### PR TITLE
feat(frontend): Open agent-mentioned files in the side pane

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/filePathExtension.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/filePathExtension.test.ts
@@ -1,0 +1,86 @@
+import {createElement, type ReactNode} from "react"
+
+import {XMarkdown} from "@ant-design/x-markdown"
+import {renderToStaticMarkup} from "react-dom/server"
+import {describe, expect, it} from "vitest"
+
+import {
+    FILE_PATH_TAG,
+    filePathExtension,
+    matchSandboxPath,
+    nextPathIndex,
+} from "./filePathExtension"
+
+const MOUNT = "/tmp/agenta/mounts/proj-1/mount-1"
+
+/** Render markdown through the real XMarkdown pipeline (marked extension → DOMPurify → components),
+ * with the file-path element mapped to a marker so a surviving token is visible in the output. */
+const render = (content: string): string =>
+    renderToStaticMarkup(
+        createElement(XMarkdown, {
+            content,
+            config: {extensions: [filePathExtension]},
+            components: {
+                [FILE_PATH_TAG]: ({children}: {children?: ReactNode}) =>
+                    createElement("mark", null, children),
+            },
+        }),
+    )
+
+describe("matchSandboxPath", () => {
+    it("matches a sandbox path at the start of the input", () => {
+        expect(matchSandboxPath(`${MOUNT}/README.md rest`)).toBe(`${MOUNT}/README.md`)
+    })
+
+    it("leaves trailing sentence punctuation out of the path", () => {
+        expect(matchSandboxPath(`${MOUNT}/README.md.`)).toBe(`${MOUNT}/README.md`)
+        expect(matchSandboxPath(`${MOUNT}/README.md).`)).toBe(`${MOUNT}/README.md`)
+        expect(matchSandboxPath(`${MOUNT}/src/`)).toBe(`${MOUNT}/src`)
+    })
+
+    it("keeps a non-ASCII filename whole", () => {
+        expect(matchSandboxPath(`${MOUNT}/résumé.md rest`)).toBe(`${MOUNT}/résumé.md`)
+    })
+
+    it("ignores paths outside the mounts and non-paths", () => {
+        expect(matchSandboxPath("/etc/hosts")).toBeNull()
+        expect(matchSandboxPath("/tmp")).toBeNull()
+        expect(matchSandboxPath("//cloud.agenta.ai/x")).toBeNull()
+        expect(matchSandboxPath("README.md")).toBeNull()
+    })
+})
+
+describe("nextPathIndex", () => {
+    it("finds a path that follows a word boundary", () => {
+        const src = `I updated ${MOUNT}/README.md for you`
+        expect(nextPathIndex(src)).toBe(src.indexOf(MOUNT))
+    })
+
+    it("skips slashes inside words and URLs", () => {
+        expect(nextPathIndex("and/or, 12/25/2026")).toBeUndefined()
+        expect(nextPathIndex(`https://cloud.agenta.ai${MOUNT}/README.md`)).toBeUndefined()
+    })
+})
+
+describe("filePathExtension", () => {
+    it("wraps a bare path in prose, and the element survives sanitization", () => {
+        expect(render(`I updated ${MOUNT}/README.md for you`)).toContain(
+            `<mark>${MOUNT}/README.md</mark>`,
+        )
+    })
+
+    it("leaves inline code and fenced blocks untouched", () => {
+        expect(render(`\`${MOUNT}/README.md\``)).not.toContain("<mark>")
+        expect(render(`\`\`\`\n${MOUNT}/README.md\n\`\`\``)).not.toContain("<mark>")
+    })
+
+    it("leaves a link destination untouched", () => {
+        const html = render(`[README](${MOUNT}/README.md)`)
+        expect(html).toContain(`href="${MOUNT}/README.md"`)
+        expect(html).not.toContain("<mark>")
+    })
+
+    it("leaves prose without a sandbox path alone", () => {
+        expect(render("See /etc/hosts and and/or")).not.toContain("<mark>")
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/filePathExtension.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/filePathExtension.ts
@@ -1,17 +1,9 @@
 /**
- * A marked extension that tokenizes a sandbox file path written as BARE PROSE — "I updated
- * /tmp/agenta/mounts/…/README.md for you" — into a `<agenta-file-path>` element the chat renderer
- * resolves against the session drive (see `markdown.tsx`). Backticked and markdown-linked mentions
- * already had a path there; this closes the third way an agent names a file.
- *
- * Running as a marked extension (rather than a pass over the rendered text) is what makes it safe:
- * marked tokenizes fenced blocks, inline code, and link destinations first, so none of those are
- * rewritten.
- *
- * Scope is deliberately narrow — an absolute path INSIDE the session/agent mounts. A bare relative
- * mention ("see README.md") is indistinguishable from ordinary prose, and an absolute path outside
- * the mounts (`/etc/hosts`) can never resolve to a drive file, so tokenizing either would only buy
- * speculative lookups that always miss.
+ * Tokenizes a sandbox path written as BARE PROSE ("I updated /tmp/agenta/mounts/…/README.md") into
+ * an `<agenta-file-path>` element the chat renderer resolves against the session drive. Running as
+ * a marked extension is what makes it safe: fenced blocks, inline code, and link destinations are
+ * already claimed by the time it runs. Only paths inside the mounts match — nothing else can
+ * resolve to a drive file.
  */
 import {isSandboxPath} from "@agenta/entities/session"
 import type {TokenizerAndRendererExtension} from "marked"
@@ -31,40 +23,45 @@ const isPathChar = (char: string): boolean =>
     char === "~" ||
     char.charCodeAt(0) > 127
 
-/** Sentence punctuation that trails a path rather than belonging to it ("…/README.md."). */
-const TRAILING = new Set([".", ",", ";", ":", "!", "?", ")", "]", "}", ">", "'", '"'])
+/** Trailing characters that punctuate a path rather than belong to it ("…/README.md.", "…/src/"). */
+const TRAILING = new Set([".", ",", ";", ":", "!", "?", ")", "]", "}", ">", "'", '"', "/"])
 
 /** Longest plausible mention — a guard against a pathological token, not a real limit. */
 const MAX_LENGTH = 512
 
+/** The one segment every mount path contains, whatever the base dir or store namespace. */
+const MOUNTS_MARKER = "/mounts/"
+
 /**
- * The sandbox path at the START of `src`, or null. Hand-scanned rather than matched with a nested
+ * The sandbox path starting at `from`, or null. Hand-scanned rather than matched with a nested
  * quantifier, which is the polynomial-ReDoS shape CodeQL flags on this kind of input.
  */
-export function matchSandboxPath(src: string): string | null {
-    if (src.charAt(0) !== "/" || src.charAt(1) === "/") return null
-    let end = 1
-    while (end < src.length && end < MAX_LENGTH) {
+export function matchSandboxPath(src: string, from = 0): string | null {
+    if (src.charAt(from) !== "/" || src.charAt(from + 1) === "/") return null
+    const limit = Math.min(src.length, from + MAX_LENGTH)
+    let end = from + 1
+    while (end < limit) {
         const char = src.charAt(end)
         if (char !== "/" && !isPathChar(char)) break
         end++
     }
-    while (end > 0 && (TRAILING.has(src.charAt(end - 1)) || src.charAt(end - 1) === "/")) end--
-    const path = src.slice(0, end)
+    while (end > from && TRAILING.has(src.charAt(end - 1))) end--
+    const path = src.slice(from, end)
     return isSandboxPath(path) ? path : null
 }
 
-/** May a path start at this index — i.e. is the slash a word boundary and not part of `://`? */
-const startsHere = (src: string, index: number): boolean => {
-    const before = index > 0 ? src.charAt(index - 1) : ""
-    if (before && (isPathChar(before) || before === ":" || before === "/")) return false
-    return matchSandboxPath(src.slice(index)) !== null
-}
-
-/** The index where the next bare path begins, for marked's inline scanner. */
+/**
+ * The index where the next bare path begins, for marked's inline scanner. marked calls this once
+ * per inline run over the whole remaining source, so the miss case — no mount path in the text at
+ * all — has to cost one native substring search, not a walk of every slash in the paragraph.
+ */
 export function nextPathIndex(src: string): number | undefined {
+    if (src.indexOf(MOUNTS_MARKER) === -1) return undefined
     for (let i = src.indexOf("/"); i !== -1; i = src.indexOf("/", i + 1)) {
-        if (startsHere(src, i)) return i
+        const before = i > 0 ? src.charAt(i - 1) : ""
+        // A slash mid-word ("and/or") or in a scheme ("https://") never starts a path.
+        if (before && (isPathChar(before) || before === ":" || before === "/")) continue
+        if (matchSandboxPath(src, i)) return i
     }
     return undefined
 }
@@ -75,7 +72,7 @@ export const FILE_PATH_TAG = "agenta-file-path"
 export const filePathExtension: TokenizerAndRendererExtension = {
     name: "agentaFilePath",
     level: "inline",
-    start: (src) => nextPathIndex(src),
+    start: nextPathIndex,
     tokenizer(src) {
         const path = matchSandboxPath(src)
         if (!path) return undefined

--- a/web/oss/src/components/AgentChatSlice/assets/filePathExtension.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/filePathExtension.ts
@@ -1,0 +1,85 @@
+/**
+ * A marked extension that tokenizes a sandbox file path written as BARE PROSE — "I updated
+ * /tmp/agenta/mounts/…/README.md for you" — into a `<agenta-file-path>` element the chat renderer
+ * resolves against the session drive (see `markdown.tsx`). Backticked and markdown-linked mentions
+ * already had a path there; this closes the third way an agent names a file.
+ *
+ * Running as a marked extension (rather than a pass over the rendered text) is what makes it safe:
+ * marked tokenizes fenced blocks, inline code, and link destinations first, so none of those are
+ * rewritten.
+ *
+ * Scope is deliberately narrow — an absolute path INSIDE the session/agent mounts. A bare relative
+ * mention ("see README.md") is indistinguishable from ordinary prose, and an absolute path outside
+ * the mounts (`/etc/hosts`) can never resolve to a drive file, so tokenizing either would only buy
+ * speculative lookups that always miss.
+ */
+import {isSandboxPath} from "@agenta/entities/session"
+import type {TokenizerAndRendererExtension} from "marked"
+
+/** Characters a path segment may contain: an allowlist of ASCII plus everything above it (an
+ * accented or CJK filename is a path like any other). Excludes `<`, `>`, `&`, and quotes, so a
+ * matched token is inert HTML and the renderer below can emit it without escaping. */
+const isPathChar = (char: string): boolean =>
+    (char >= "a" && char <= "z") ||
+    (char >= "A" && char <= "Z") ||
+    (char >= "0" && char <= "9") ||
+    char === "." ||
+    char === "_" ||
+    char === "-" ||
+    char === "+" ||
+    char === "@" ||
+    char === "~" ||
+    char.charCodeAt(0) > 127
+
+/** Sentence punctuation that trails a path rather than belonging to it ("…/README.md."). */
+const TRAILING = new Set([".", ",", ";", ":", "!", "?", ")", "]", "}", ">", "'", '"'])
+
+/** Longest plausible mention — a guard against a pathological token, not a real limit. */
+const MAX_LENGTH = 512
+
+/**
+ * The sandbox path at the START of `src`, or null. Hand-scanned rather than matched with a nested
+ * quantifier, which is the polynomial-ReDoS shape CodeQL flags on this kind of input.
+ */
+export function matchSandboxPath(src: string): string | null {
+    if (src.charAt(0) !== "/" || src.charAt(1) === "/") return null
+    let end = 1
+    while (end < src.length && end < MAX_LENGTH) {
+        const char = src.charAt(end)
+        if (char !== "/" && !isPathChar(char)) break
+        end++
+    }
+    while (end > 0 && (TRAILING.has(src.charAt(end - 1)) || src.charAt(end - 1) === "/")) end--
+    const path = src.slice(0, end)
+    return isSandboxPath(path) ? path : null
+}
+
+/** May a path start at this index — i.e. is the slash a word boundary and not part of `://`? */
+const startsHere = (src: string, index: number): boolean => {
+    const before = index > 0 ? src.charAt(index - 1) : ""
+    if (before && (isPathChar(before) || before === ":" || before === "/")) return false
+    return matchSandboxPath(src.slice(index)) !== null
+}
+
+/** The index where the next bare path begins, for marked's inline scanner. */
+export function nextPathIndex(src: string): number | undefined {
+    for (let i = src.indexOf("/"); i !== -1; i = src.indexOf("/", i + 1)) {
+        if (startsHere(src, i)) return i
+    }
+    return undefined
+}
+
+/** The element the chat markdown renderer maps to its drive-aware file reference. */
+export const FILE_PATH_TAG = "agenta-file-path"
+
+export const filePathExtension: TokenizerAndRendererExtension = {
+    name: "agentaFilePath",
+    level: "inline",
+    start: (src) => nextPathIndex(src),
+    tokenizer(src) {
+        const path = matchSandboxPath(src)
+        if (!path) return undefined
+        return {type: "agentaFilePath", raw: path, text: path}
+    },
+    renderer: (token) => `<${FILE_PATH_TAG}>${token.text}</${FILE_PATH_TAG}>`,
+}

--- a/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
@@ -1,5 +1,6 @@
 import {memo, type ReactNode} from "react"
 
+import {isSandboxPath} from "@agenta/entities/session"
 import {CopyButton} from "@agenta/ui/components/presentational"
 import {XMarkdown} from "@ant-design/x-markdown"
 import Latex from "@ant-design/x-markdown/plugins/Latex"
@@ -11,6 +12,8 @@ import {oneDark} from "react-syntax-highlighter/dist/esm/styles/prism"
 import {useDriveSessionId} from "@/oss/components/Drives/driveSessionContext"
 
 import {chatFileLinkAtomFamily} from "../state/fileLinks"
+
+import {FILE_PATH_TAG, filePathExtension} from "./filePathExtension"
 
 // Dark-mode-aware markdown styling. `min-w-0` + `max-w-full` + the per-element width guards
 // keep long lines / code blocks from widening their container; code blocks scroll within their
@@ -65,8 +68,8 @@ export const MD_CLASS =
     // Trim the outer edges so the bubble padding isn't doubled by leading/trailing margins.
     "[&>:first-child]:!mt-0 [&>:last-child]:!mb-0"
 
-/** Math support ($…$ / $$…$$) via KaTeX — registered once as a marked extension. */
-const LATEX_CONFIG = {extensions: Latex()}
+/** Marked extensions: math ($…$ / $$…$$) via KaTeX, plus bare sandbox paths in prose. */
+const MARKED_CONFIG = {extensions: [...Latex(), filePathExtension]}
 
 /** Chat content must never restyle the app document, so forbid document-affecting tags.
  * A pasted HTML doc's <style>/<link> would otherwise mount into the live document and
@@ -195,7 +198,14 @@ const ExternalLink = ({href, title, className, children}: AnchorProps) => (
 const DriveLink = ({href, ...rest}: AnchorProps) => {
     const sessionId = useDriveSessionId()
     const link = useAtomValue(chatFileLinkAtomFamily(sessionId ?? ""))
-    const fallback = <ExternalLink href={href} {...rest} />
+    // A sandbox path is a FILE path, never a URL. When it doesn't resolve to a drive file, showing
+    // the label as plain text beats an anchor to `<app-origin>/tmp/agenta/mounts/…` (issue #5983).
+    const fallback =
+        href && isSandboxPath(href) ? (
+            <span title={href}>{rest.children}</span>
+        ) : (
+            <ExternalLink href={href} {...rest} />
+        )
     if (link && href) return <>{link.renderCode(href, fallback)}</>
     return fallback
 }
@@ -204,9 +214,22 @@ const DriveLink = ({href, ...rest}: AnchorProps) => {
 const Anchor = (props: AnchorProps) =>
     isExternalHref(props.href) ? <ExternalLink {...props} /> : <DriveLink {...props} />
 
+/** A bare sandbox path in prose (see `filePathExtension`). Same resolver as the code-span and link
+ * paths; unresolved, it renders as the plain text it already was. */
+const BareFilePath = ({children}: {children?: ReactNode}) => {
+    const sessionId = useDriveSessionId()
+    const link = useAtomValue(chatFileLinkAtomFamily(sessionId ?? ""))
+    const text = childrenToText(children).trim()
+    const fallback = <>{text}</>
+    if (link && text) return <>{link.renderCode(text, fallback)}</>
+    return fallback
+}
+
 /** Stable `components` map: a fresh object literal per render churns XMarkdown's prop identity, and
- * this renderer re-renders on every throttled streaming token — so hoist it to a module constant. */
-const MD_COMPONENTS = {code: CodeBlock, pre: PreUnwrap, a: Anchor}
+ * this renderer re-renders on every throttled streaming token — so hoist it to a module constant.
+ * Every key here is also allowed through XMarkdown's DOMPurify pass, which is what lets the custom
+ * `agenta-file-path` element survive sanitization. */
+const MD_COMPONENTS = {code: CodeBlock, pre: PreUnwrap, a: Anchor, [FILE_PATH_TAG]: BareFilePath}
 
 /** Shared markdown renderer for the slice — used by message bubbles and the composer live
  * preview, so both render identically. `className` appends to `MD_CLASS` so callers can tweak
@@ -220,7 +243,7 @@ const Markdown = ({content, className}: {content: string; className?: string}) =
     <XMarkdown
         className={className ? `${MD_CLASS} ${className}` : MD_CLASS}
         content={content}
-        config={LATEX_CONFIG}
+        config={MARKED_CONFIG}
         dompurifyConfig={DOMPURIFY_CONFIG}
         components={MD_COMPONENTS}
     />

--- a/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
@@ -89,22 +89,35 @@ const childrenToText = (children: ReactNode): string => {
 }
 
 /**
- * Inline code chip. When the active conversation has published a file-link resolver and this span's
- * text names a real drive file, it renders as a compact inline file reference (icon + name, opens
- * Quick Look) that flows within the sentence — the heavy block file card is reserved for the tool
- * step that wrote the file. Otherwise it's a plain code chip.
+ * The active conversation's file-link resolver: renders `text` as a drive reference when it names a
+ * real file, else `fallback`. Resolution is async (records + an on-demand check) and the Drives
+ * layer owns both outcomes; no resolver mounted → `fallback`.
+ *
+ * Reads the session from the ambient drive context, so a backgrounded pane's mentions never resolve
+ * against another mounted session.
  */
-const InlineCode = ({className, children}: {className?: string; children?: ReactNode}) => {
-    // Resolve against THIS conversation's session (from the ambient drive context), so a
-    // backgrounded pane's file mentions don't read another mounted session's resolver.
+const useDriveFileRef = () => {
     const sessionId = useDriveSessionId()
     const link = useAtomValue(chatFileLinkAtomFamily(sessionId ?? ""))
-    const text = childrenToText(children).trim()
-    const fallback = <code className={className}>{children}</code>
-    // The Drives resolver decides link-vs-plain (async: records + on-demand single-file check) and
-    // owns the fallback; no resolver mounted → plain code.
-    if (link && text) return <>{link.renderCode(text, fallback)}</>
-    return fallback
+    return (text: string | undefined, fallback: ReactNode): ReactNode =>
+        link && text ? <>{link.renderCode(text, fallback)}</> : fallback
+}
+
+/**
+ * Inline code chip. When this span's text names a real drive file it renders as a compact inline
+ * file reference (icon + name, opens Quick Look) that flows within the sentence — the heavy block
+ * file card is reserved for the tool step that wrote the file. Otherwise it's a plain code chip.
+ */
+const InlineCode = ({className, children}: {className?: string; children?: ReactNode}) => {
+    const renderRef = useDriveFileRef()
+    return (
+        <>
+            {renderRef(
+                childrenToText(children).trim(),
+                <code className={className}>{children}</code>,
+            )}
+        </>
+    )
 }
 
 /**
@@ -196,33 +209,28 @@ const ExternalLink = ({href, title, className, children}: AnchorProps) => (
  * uses ({@link InlineCode}), so a markdown link and a code-span mention of the same file behave
  * identically (issue #5481: nested / `NN-name/` paths get emitted as links and bypassed it). */
 const DriveLink = ({href, ...rest}: AnchorProps) => {
-    const sessionId = useDriveSessionId()
-    const link = useAtomValue(chatFileLinkAtomFamily(sessionId ?? ""))
-    // A sandbox path is a FILE path, never a URL. When it doesn't resolve to a drive file, showing
-    // the label as plain text beats an anchor to `<app-origin>/tmp/agenta/mounts/…` (issue #5983).
+    const renderRef = useDriveFileRef()
+    // A sandbox path is a FILE path, never a URL: unresolved, plain text beats an anchor to
+    // `<app-origin>/tmp/agenta/mounts/…` (issue #5983).
     const fallback =
         href && isSandboxPath(href) ? (
             <span title={href}>{rest.children}</span>
         ) : (
             <ExternalLink href={href} {...rest} />
         )
-    if (link && href) return <>{link.renderCode(href, fallback)}</>
-    return fallback
+    return <>{renderRef(href, fallback)}</>
 }
 
 /** Split so an ordinary URL costs nothing: only a relative href subscribes to the drive resolver. */
 const Anchor = (props: AnchorProps) =>
     isExternalHref(props.href) ? <ExternalLink {...props} /> : <DriveLink {...props} />
 
-/** A bare sandbox path in prose (see `filePathExtension`). Same resolver as the code-span and link
- * paths; unresolved, it renders as the plain text it already was. */
+/** A bare sandbox path in prose (see `filePathExtension`); unresolved, it stays the plain text it
+ * already was. */
 const BareFilePath = ({children}: {children?: ReactNode}) => {
-    const sessionId = useDriveSessionId()
-    const link = useAtomValue(chatFileLinkAtomFamily(sessionId ?? ""))
+    const renderRef = useDriveFileRef()
     const text = childrenToText(children).trim()
-    const fallback = <>{text}</>
-    if (link && text) return <>{link.renderCode(text, fallback)}</>
-    return fallback
+    return <>{renderRef(text, text)}</>
 }
 
 /** Stable `components` map: a fresh object literal per render churns XMarkdown's prop identity, and

--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -61,6 +61,7 @@ export function DriveExplorer({
     explicitFiles,
     scope = "session",
     initialPath,
+    initialIsFolder,
     onClose,
     driveIds,
     expanded: drawerExpanded = false,
@@ -78,6 +79,9 @@ export function DriveExplorer({
     explicitFiles?: MountFile[]
     scope?: DriveScope
     initialPath?: string | null
+    /** The opener already PROVED `initialPath`'s kind — use it instead of guessing from the name
+     * while the tree level loads. */
+    initialIsFolder?: boolean
     /** When provided, the explorer renders its OWN single header (breadcrumb + node + actions + this
      * close button) + the shared search/filters toolbar. Always provided by {@link FilesDrawer}. */
     onClose?: () => void
@@ -192,15 +196,14 @@ export function DriveExplorer({
         setShowGitignored,
     })
     const selectedNode = selectedPath != null ? nodeByPath.get(selectedPath) : undefined
-    // The root and any node flagged a folder render the grid; everything else the preview. In lazy
-    // mode a not-yet-loaded selection falls back to the NAME (the same heuristic `useDriveTreeData`
-    // subscribes by), so an initial file target shows its preview immediately instead of a wrong
-    // "empty folder" flash — and an initial FOLDER target doesn't show a broken file preview until
-    // its level lands.
+    // Backend `is_folder` once the level loads; before that, the opener's proven kind if it had one,
+    // else the name (the same heuristic `useDriveTreeData` subscribes by).
     const selectedIsFolder =
         selectedPath != null &&
-        (selectedPath === "" ||
-            (selectedNode ? selectedNode.isFolder === true : !looksLikeFilePath(selectedPath)))
+        (selectedNode?.isFolder ??
+            (selectedPath === initialPath && initialIsFolder != null
+                ? initialIsFolder
+                : !looksLikeFilePath(selectedPath)))
 
     // Where an upload lands: the selection when it's a folder, else the selected file's folder.
     const currentFolder = selectedIsFolder

--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -193,9 +193,14 @@ export function DriveExplorer({
     })
     const selectedNode = selectedPath != null ? nodeByPath.get(selectedPath) : undefined
     // The root and any node flagged a folder render the grid; everything else the preview. In lazy
-    // mode a not-yet-loaded selection is treated as a FILE (the preview reads by path), so an initial
-    // file target shows its preview immediately instead of a wrong "empty folder" flash.
-    const selectedIsFolder = selectedPath === "" || selectedNode?.isFolder === true
+    // mode a not-yet-loaded selection falls back to the NAME (the same heuristic `useDriveTreeData`
+    // subscribes by), so an initial file target shows its preview immediately instead of a wrong
+    // "empty folder" flash — and an initial FOLDER target doesn't show a broken file preview until
+    // its level lands.
+    const selectedIsFolder =
+        selectedPath != null &&
+        (selectedPath === "" ||
+            (selectedNode ? selectedNode.isFolder === true : !looksLikeFilePath(selectedPath)))
 
     // Where an upload lands: the selection when it's a folder, else the selected file's folder.
     const currentFolder = selectedIsFolder

--- a/web/oss/src/components/Drives/DriveFileCard.tsx
+++ b/web/oss/src/components/Drives/DriveFileCard.tsx
@@ -32,8 +32,7 @@ const OP_META: Record<FileActivityOp, {label: string; color?: string}> = {
  * The heavy block {@link DriveFileCard} is reserved for the tool step that actually wrote the file,
  * so a mention in the reply never breaks the paragraph with a full card.
  *
- * `isFolder` swaps the kind glyph for the tree's folder icon — a mentioned directory opens the
- * explorer ON that folder, so the chip has to read as one.
+ * `isFolder` swaps the glyph and travels with the open request, so the explorer doesn't re-guess.
  */
 export function DriveFileInlineRef({path, isFolder}: {path: string; isFolder?: boolean}) {
     const sessionId = useDriveSessionId()
@@ -42,7 +41,7 @@ export function DriveFileInlineRef({path, isFolder}: {path: string; isFolder?: b
     return (
         <button
             type="button"
-            onClick={() => openQuickLook({path})}
+            onClick={() => openQuickLook({path, isFolder})}
             title={path}
             className="mx-px inline-flex max-w-full cursor-pointer items-center gap-1 rounded border border-solid border-colorBorderSecondary bg-colorFillTertiary px-1 py-0 align-baseline font-mono text-[0.9em] leading-[1.4] text-colorText transition-colors hover:border-colorBorder hover:bg-colorFillSecondary"
         >

--- a/web/oss/src/components/Drives/DriveFileCard.tsx
+++ b/web/oss/src/components/Drives/DriveFileCard.tsx
@@ -6,7 +6,7 @@
  * listing; deletes render struck-through with no actions.
  */
 import {mountPathMatchesToolPath, type FileActivityOp} from "@agenta/entities/session"
-import {DownloadSimple} from "@phosphor-icons/react"
+import {DownloadSimple, FolderSimple} from "@phosphor-icons/react"
 import {Button, Tag, Tooltip, Typography} from "antd"
 import {useSetAtom} from "jotai"
 
@@ -31,8 +31,11 @@ const OP_META: Record<FileActivityOp, {label: string; color?: string}> = {
  * subtle inline chip (icon + name) that flows within the sentence and opens Quick Look on click.
  * The heavy block {@link DriveFileCard} is reserved for the tool step that actually wrote the file,
  * so a mention in the reply never breaks the paragraph with a full card.
+ *
+ * `isFolder` swaps the kind glyph for the tree's folder icon — a mentioned directory opens the
+ * explorer ON that folder, so the chip has to read as one.
  */
-export function DriveFileInlineRef({path}: {path: string}) {
+export function DriveFileInlineRef({path, isFolder}: {path: string; isFolder?: boolean}) {
     const sessionId = useDriveSessionId()
     const openQuickLook = useSetAtom(driveQuickLookAtomFamily(sessionId ?? ""))
     const name = path.split("/").pop() ?? path
@@ -44,7 +47,11 @@ export function DriveFileInlineRef({path}: {path: string}) {
             className="mx-px inline-flex max-w-full cursor-pointer items-center gap-1 rounded border border-solid border-colorBorderSecondary bg-colorFillTertiary px-1 py-0 align-baseline font-mono text-[0.9em] leading-[1.4] text-colorText transition-colors hover:border-colorBorder hover:bg-colorFillSecondary"
         >
             <span className="flex shrink-0 items-center">
-                {driveFileIcon(path, 11, "text-current")}
+                {isFolder ? (
+                    <FolderSimple size={11} className="text-current" />
+                ) : (
+                    driveFileIcon(path, 11, "text-current")
+                )}
             </span>
             <span className="min-w-0 truncate">{name}</span>
         </button>

--- a/web/oss/src/components/Drives/SessionFilesDrawer.tsx
+++ b/web/oss/src/components/Drives/SessionFilesDrawer.tsx
@@ -9,6 +9,7 @@
  */
 import {useMemo} from "react"
 
+import {toolPathToDrivePath} from "@agenta/entities/session"
 import {atom, useAtom} from "jotai"
 import {atomFamily} from "jotai/utils"
 
@@ -34,6 +35,24 @@ export const filesDrawerStagedAtomFamily = atomFamily((_sessionId: string) =>
 export const matchesTail = (filePath: string, requested: string): boolean =>
     filePath === requested || requested.endsWith(`/${filePath}`)
 
+/**
+ * The drive path a quick-look request names. A sandbox path (an opener may pass the raw tool path)
+ * maps to its drive path first; then an exact listing hit wins outright, else the LONGEST tail match
+ * — a request for `…/src/README.md` suffix-matches both `README.md` and `src/README.md`, and the
+ * deeper one is the file that was actually asked for. Unknown to the listing → the mapped path (the
+ * explorer selects it directly).
+ */
+export const resolveDrivePath = (files: {path: string}[], requested: string): string => {
+    const target = toolPathToDrivePath(requested) ?? requested
+    let best: string | null = null
+    for (const file of files) {
+        if (file.path === target) return file.path
+        if (!matchesTail(file.path, target)) continue
+        if (best === null || file.path.length > best.length) best = file.path
+    }
+    return best ?? target
+}
+
 export function SessionFilesDrawer({sessionId}: {sessionId: string}) {
     const [gridOpen, setGridOpen] = useAtom(filesDrawerOpenAtomFamily(sessionId))
     const [quickLook, setQuickLook] = useAtom(driveQuickLookAtomFamily(sessionId))
@@ -49,11 +68,10 @@ export function SessionFilesDrawer({sessionId}: {sessionId: string}) {
     )
 
     // Resolve the quick-look path (possibly a tail) to the presented drive path the tree selects by.
-    const initialPath = useMemo(() => {
-        if (!quickLook) return null
-        const hit = drive.recents.find((f) => matchesTail(f.path, quickLook.path))
-        return hit?.path ?? quickLook.path
-    }, [quickLook, drive.recents])
+    const initialPath = useMemo(
+        () => (quickLook ? resolveDrivePath(drive.recents, quickLook.path) : null),
+        [quickLook, drive.recents],
+    )
 
     const driveIds = useMemo(
         () =>

--- a/web/oss/src/components/Drives/SessionFilesDrawer.tsx
+++ b/web/oss/src/components/Drives/SessionFilesDrawer.tsx
@@ -35,13 +35,8 @@ export const filesDrawerStagedAtomFamily = atomFamily((_sessionId: string) =>
 export const matchesTail = (filePath: string, requested: string): boolean =>
     filePath === requested || requested.endsWith(`/${filePath}`)
 
-/**
- * The drive path a quick-look request names. A sandbox path (an opener may pass the raw tool path)
- * maps to its drive path first; then an exact listing hit wins outright, else the LONGEST tail match
- * — a request for `…/src/README.md` suffix-matches both `README.md` and `src/README.md`, and the
- * deeper one is the file that was actually asked for. Unknown to the listing → the mapped path (the
- * explorer selects it directly).
- */
+/** The drive path a quick-look request names: map a sandbox path, then take an exact listing hit,
+ * else the LONGEST tail match (`…/src/README.md` suffix-matches a root `README.md` too). */
 export const resolveDrivePath = (files: {path: string}[], requested: string): string => {
     const target = toolPathToDrivePath(requested) ?? requested
     let best: string | null = null

--- a/web/oss/src/components/Drives/SessionFilesPane.tsx
+++ b/web/oss/src/components/Drives/SessionFilesPane.tsx
@@ -97,6 +97,7 @@ export function SessionFilesPane({sessionId}: {sessionId: string}) {
                 drive={drive}
                 scope="session"
                 initialPath={initialPath}
+                initialIsFolder={quickLook?.isFolder}
                 onClose={close}
                 closeVariant="collapse"
                 mirrored

--- a/web/oss/src/components/Drives/SessionFilesPane.tsx
+++ b/web/oss/src/components/Drives/SessionFilesPane.tsx
@@ -22,7 +22,7 @@ import {DriveExplorerSkeleton} from "./DriveExplorerSkeleton"
 import {useDriveArtifactId} from "./driveSessionContext"
 import {useDriveGeneration} from "./FilesDrawer"
 import {driveQuickLookAtomFamily} from "./quickLook"
-import {filesDrawerStagedAtomFamily, matchesTail} from "./SessionFilesDrawer"
+import {filesDrawerStagedAtomFamily, resolveDrivePath} from "./SessionFilesDrawer"
 import {useSessionDriveSummary} from "./useSessionDrive"
 
 // Heavy body — loaded lazily on first open (the split unmounts the pane while collapsed).
@@ -74,11 +74,10 @@ export function SessionFilesPane({sessionId}: {sessionId: string}) {
     )
 
     // Resolve the quick-look path (possibly a tail) to the presented drive path the tree selects by.
-    const initialPath = useMemo(() => {
-        if (!quickLook) return null
-        const hit = drive.recents.find((f) => matchesTail(f.path, quickLook.path))
-        return hit?.path ?? quickLook.path
-    }, [quickLook, drive.recents])
+    const initialPath = useMemo(
+        () => (quickLook ? resolveDrivePath(drive.recents, quickLook.path) : null),
+        [quickLook, drive.recents],
+    )
 
     const driveIds = useMemo(
         () =>

--- a/web/oss/src/components/Drives/chatFileRefs.tsx
+++ b/web/oss/src/components/Drives/chatFileRefs.tsx
@@ -5,9 +5,10 @@
  *
  *   1. RECORDS pre-seed (free): the session records already carry every path the agent WROTE/edited,
  *      so a mention that tail-matches one is a known file — zero network.
- *   2. On-demand single-file check (anything else, e.g. a file the agent only READ): when the span
+ *   2. On-demand single-item check (anything else, e.g. a file the agent only READ): when the span
  *      scrolls INTO VIEW, read just that ONE path; a 200 means it exists → link (and that read IS
- *      the Quick Look content, so opening it is instant). A 404 leaves it as plain code.
+ *      the Quick Look content, so opening it is instant). A 404 leaves it as plain code. A mention
+ *      that names a DIRECTORY is checked with a one-level listing of that path instead.
  *
  * Never lists the tree; the on-demand read is viewport-gated and deduped per path. Markdown stays
  * decoupled from Drives — it just calls {@link chatFileResolver}.renderCode.
@@ -15,11 +16,13 @@
 import {type ReactNode, useCallback, useEffect, useRef, useState} from "react"
 
 import {
+    mountDirQueryFamily,
     mountFileContentQueryFamily,
     mountPathMatchesToolPath,
     pickCwdMount,
     sessionMountsQueryFamily,
     sessionRecordFileRecencyAtomFamily,
+    toolPathToDrivePath,
     type Mount,
 } from "@agenta/entities/session"
 import {atom, useAtomValue} from "jotai"
@@ -29,15 +32,34 @@ import {agentMountQueryFamily} from "./agentDrive"
 import {DriveFileInlineRef} from "./DriveFileCard"
 import {useDriveArtifactId, useDriveSessionId} from "./driveSessionContext"
 import {cleanPath} from "./driveTree"
+import {looksLikeFilePath} from "./driveTreeView"
 import {AGENT_FILES_DIR} from "./useSessionDrive"
 
-/** A span that could NAME a file; strip a leading `./` and require a path-ish shape: a slash, or a
- * letter-led trailing extension (`.ts`, `.tar.gz`). A bare `/[./]/` matched any dotted token —
- * decimals (`3.14`), abbreviations (`e.g.`), and dotted identifiers (`user.name`) — each firing a
- * guaranteed-404 on-demand read once scrolled into view; the shape test drops those. */
-const fileCandidate = (text: string): string | null => {
-    const t = text.trim().replace(/^\.?\/+/, "")
-    return t && /\/|\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(t) ? t : null
+/** A resolvable mention: the drive-presented path it names, plus whether it looks like a folder. */
+interface FileCandidate {
+    path: string
+    isFolder: boolean
+}
+
+/** Which existence check to run. Shares the drive's own name heuristic, so a dot-DIRECTORY
+ * (`.claude`, `.git`) is read as a folder here exactly as the tree reads it. */
+const looksLikeFolder = (path: string): boolean => !looksLikeFilePath(path)
+
+/** A span that could NAME a file or folder. A sandbox-absolute path (`/tmp/agenta/mounts/…`) is one
+ * by construction, so it only needs mapping to its drive path. Anything else must strip a leading
+ * `./` and look path-ish: a slash, or a letter-led trailing extension (`.ts`, `.tar.gz`). A bare
+ * `/[./]/` matched any dotted token — decimals (`3.14`), abbreviations (`e.g.`), and dotted
+ * identifiers (`user.name`) — each firing a guaranteed-404 on-demand read once scrolled into view;
+ * the shape test drops those. */
+const fileCandidate = (text: string): FileCandidate | null => {
+    const raw = text.trim()
+    const drivePath = toolPathToDrivePath(raw)
+    // A sandbox path that maps to the mount ROOT names the drive itself, not an item in it.
+    if (drivePath !== null)
+        return drivePath ? {path: drivePath, isFolder: looksLikeFolder(drivePath)} : null
+    const t = raw.replace(/^\.?\/+/, "")
+    if (!t || !/\/|\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(t)) return null
+    return {path: t, isFolder: looksLikeFolder(t)}
 }
 
 /** Basenames of every file the agent wrote/edited (from records) → the tool paths sharing them, for
@@ -81,6 +103,18 @@ function useMountResolver(sessionId: string, artifactId?: string | null) {
     )
 }
 
+/** The path once it has stopped changing. A streaming reply grows a bare path mention prefix by
+ * prefix (`/tmp/ag`, `/tmp/agenta/mo`, …) and every prefix is a path in its own right — checking
+ * each one would fire a burst of guaranteed misses for a single mention. */
+function useSettledPath(path: string, ms = 400): string {
+    const [settled, setSettled] = useState("")
+    useEffect(() => {
+        const timer = window.setTimeout(() => setSettled(path), ms)
+        return () => window.clearTimeout(timer)
+    }, [path, ms])
+    return settled
+}
+
 /** Latch true once the element scrolls near the viewport (never resets — the link stays). */
 function useInView() {
     const ref = useRef<HTMLSpanElement>(null)
@@ -101,22 +135,36 @@ function useInView() {
     return [ref, inView] as const
 }
 
-/** A mention NOT already known from records: read that ONE path when it scrolls into view — a hit
- * links it (and warms Quick Look), a miss stays plain code. */
-function OnDemandFileRef({candidate, fallback}: {candidate: string; fallback: ReactNode}) {
+/** A mention NOT already known from records: check that ONE path when it scrolls into view — a hit
+ * links it (and, for a file, warms Quick Look), a miss stays plain code. A file is checked by
+ * reading it; a folder by listing its one level, since reading a directory always misses. Only the
+ * matching query is ever enabled — the other is keyed empty, which disables it. */
+function OnDemandFileRef({candidate, fallback}: {candidate: FileCandidate; fallback: ReactNode}) {
     const sessionId = useDriveSessionId() ?? ""
     const artifactId = useDriveArtifactId()
     const resolveMount = useMountResolver(sessionId, artifactId)
     const [ref, inView] = useInView()
-    const resolved = resolveMount(candidate)
-    const enabled = inView && Boolean(resolved?.mount?.id)
-    const query = useAtomValue(
+    const settledPath = useSettledPath(candidate.path)
+    const resolved = resolveMount(candidate.path)
+    const enabled = inView && settledPath === candidate.path && Boolean(resolved?.mount?.id)
+    const mountId = enabled ? (resolved?.mount.id ?? "") : ""
+    const path = enabled ? (resolved?.path ?? "") : ""
+    const content = useAtomValue(
         mountFileContentQueryFamily({
-            mountId: enabled ? (resolved?.mount.id ?? "") : "",
-            path: enabled ? (resolved?.path ?? "") : "",
+            mountId: candidate.isFolder ? "" : mountId,
+            path: candidate.isFolder ? "" : path,
         }),
     )
-    if (typeof query.data === "string") return <DriveFileInlineRef path={candidate} />
+    const listing = useAtomValue(
+        mountDirQueryFamily({
+            mountId: candidate.isFolder ? mountId : "",
+            path: candidate.isFolder ? path : "",
+        }),
+    )
+    const exists = candidate.isFolder
+        ? (listing.data?.length ?? 0) > 0
+        : typeof content.data === "string"
+    if (exists) return <DriveFileInlineRef path={candidate.path} isFolder={candidate.isFolder} />
     // Plain code inside a ref'd span so the observer can watch it scroll into view.
     return <span ref={ref}>{fallback}</span>
 }
@@ -127,7 +175,10 @@ function ChatFileCode({text, fallback}: {text: string; fallback: ReactNode}) {
     const index = useAtomValue(recordIndexAtomFamily(sessionId))
     const candidate = fileCandidate(text)
     if (!candidate) return <>{fallback}</>
-    if (knownFromRecords(index, candidate)) return <DriveFileInlineRef path={candidate} />
+    // Records hold TOOL paths, which tail-match the mention AS WRITTEN (`mountPathMatchesToolPath`
+    // strips the leading slash itself) — so this asks with the raw text, not the mapped drive path.
+    if (knownFromRecords(index, text.trim().replace(/^\.\/+/, "")))
+        return <DriveFileInlineRef path={candidate.path} />
     return <OnDemandFileRef candidate={candidate} fallback={fallback} />
 }
 

--- a/web/oss/src/components/Drives/chatFileRefs.tsx
+++ b/web/oss/src/components/Drives/chatFileRefs.tsx
@@ -13,9 +13,10 @@
  * Never lists the tree; the on-demand read is viewport-gated and deduped per path. Markdown stays
  * decoupled from Drives — it just calls {@link chatFileResolver}.renderCode.
  */
-import {type ReactNode, useCallback, useEffect, useRef, useState} from "react"
+import {type ReactNode, useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import {
+    AGENT_FILES_DIR,
     mountDirQueryFamily,
     mountFileContentQueryFamily,
     mountPathMatchesToolPath,
@@ -33,34 +34,36 @@ import {DriveFileInlineRef} from "./DriveFileCard"
 import {useDriveArtifactId, useDriveSessionId} from "./driveSessionContext"
 import {cleanPath} from "./driveTree"
 import {looksLikeFilePath} from "./driveTreeView"
-import {AGENT_FILES_DIR} from "./useSessionDrive"
 
-/** A resolvable mention: the drive-presented path it names, plus whether it looks like a folder. */
+/** A resolvable mention, normalized once: the drive path it names, whether it reads as a folder
+ * (which existence check to run), and the mention as written (what the record index matches on). */
 interface FileCandidate {
     path: string
     isFolder: boolean
+    mention: string
 }
 
-/** Which existence check to run. Shares the drive's own name heuristic, so a dot-DIRECTORY
- * (`.claude`, `.git`) is read as a folder here exactly as the tree reads it. */
-const looksLikeFolder = (path: string): boolean => !looksLikeFilePath(path)
+const LEADING_DOT_SLASH = /^\.?\/+/
 
-/** A span that could NAME a file or folder. A sandbox-absolute path (`/tmp/agenta/mounts/…`) is one
- * by construction, so it only needs mapping to its drive path. Anything else must strip a leading
- * `./` and look path-ish: a slash, or a letter-led trailing extension (`.ts`, `.tar.gz`). A bare
- * `/[./]/` matched any dotted token — decimals (`3.14`), abbreviations (`e.g.`), and dotted
- * identifiers (`user.name`) — each firing a guaranteed-404 on-demand read once scrolled into view;
- * the shape test drops those. */
+/** A span that could NAME a file or folder. A sandbox path is one by construction and only needs
+ * mapping; anything else must look path-ish — a slash, or a letter-led trailing extension. Without
+ * that shape test every dotted token (`3.14`, `e.g.`, `user.name`) would fire a guaranteed-404 read
+ * once scrolled into view. */
 const fileCandidate = (text: string): FileCandidate | null => {
     const raw = text.trim()
+    const mention = raw.replace(LEADING_DOT_SLASH, "")
     const drivePath = toolPathToDrivePath(raw)
-    // A sandbox path that maps to the mount ROOT names the drive itself, not an item in it.
-    if (drivePath !== null)
-        return drivePath ? {path: drivePath, isFolder: looksLikeFolder(drivePath)} : null
-    const t = raw.replace(/^\.?\/+/, "")
-    if (!t || !/\/|\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(t)) return null
-    return {path: t, isFolder: looksLikeFolder(t)}
+    // A sandbox path mapping to the mount ROOT names the drive itself, not an item in it.
+    if (drivePath !== null) return drivePath ? candidate(drivePath, mention) : null
+    if (!mention || !/\/|\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(mention)) return null
+    return candidate(mention, mention)
 }
+
+const candidate = (path: string, mention: string): FileCandidate => ({
+    path,
+    isFolder: !looksLikeFilePath(path),
+    mention,
+})
 
 /** Basenames of every file the agent wrote/edited (from records) → the tool paths sharing them, for
  * a cheap "does a written file tail-match this mention" test (records paths are tool paths — absolute
@@ -103,16 +106,16 @@ function useMountResolver(sessionId: string, artifactId?: string | null) {
     )
 }
 
-/** The path once it has stopped changing. A streaming reply grows a bare path mention prefix by
- * prefix (`/tmp/ag`, `/tmp/agenta/mo`, …) and every prefix is a path in its own right — checking
- * each one would fire a burst of guaranteed misses for a single mention. */
-function useSettledPath(path: string, ms = 400): string {
+/** True once `path` has held still. A streaming mention grows a segment at a time and each prefix
+ * is its own path, so checking every one fires a burst of misses. `""` arms nothing. */
+function useSettled(path: string, ms = 400): boolean {
     const [settled, setSettled] = useState("")
     useEffect(() => {
+        if (!path) return
         const timer = window.setTimeout(() => setSettled(path), ms)
         return () => window.clearTimeout(timer)
     }, [path, ms])
-    return settled
+    return Boolean(path) && settled === path
 }
 
 /** Latch true once the element scrolls near the viewport (never resets — the link stays). */
@@ -135,20 +138,19 @@ function useInView() {
     return [ref, inView] as const
 }
 
-/** A mention NOT already known from records: check that ONE path when it scrolls into view — a hit
- * links it (and, for a file, warms Quick Look), a miss stays plain code. A file is checked by
- * reading it; a folder by listing its one level, since reading a directory always misses. Only the
- * matching query is ever enabled — the other is keyed empty, which disables it. */
+/** A mention NOT already known from records: check that ONE path once it scrolls into view — a file
+ * by reading it (which also warms Quick Look), a folder by listing its one level, since reading a
+ * directory always misses. The check that doesn't apply is keyed empty, which disables it. */
 function OnDemandFileRef({candidate, fallback}: {candidate: FileCandidate; fallback: ReactNode}) {
     const sessionId = useDriveSessionId() ?? ""
     const artifactId = useDriveArtifactId()
     const resolveMount = useMountResolver(sessionId, artifactId)
     const [ref, inView] = useInView()
-    const settledPath = useSettledPath(candidate.path)
-    const resolved = resolveMount(candidate.path)
-    const enabled = inView && settledPath === candidate.path && Boolean(resolved?.mount?.id)
-    const mountId = enabled ? (resolved?.mount.id ?? "") : ""
-    const path = enabled ? (resolved?.path ?? "") : ""
+    // Gated on `inView` so an offscreen mention arms no timer and forces no extra render.
+    const settled = useSettled(inView ? candidate.path : "")
+    const resolved = settled ? resolveMount(candidate.path) : null
+    const mountId = resolved?.mount.id ?? ""
+    const path = resolved?.path ?? ""
     const content = useAtomValue(
         mountFileContentQueryFamily({
             mountId: candidate.isFolder ? "" : mountId,
@@ -173,11 +175,10 @@ function OnDemandFileRef({candidate, fallback}: {candidate: FileCandidate; fallb
 function ChatFileCode({text, fallback}: {text: string; fallback: ReactNode}) {
     const sessionId = useDriveSessionId() ?? ""
     const index = useAtomValue(recordIndexAtomFamily(sessionId))
-    const candidate = fileCandidate(text)
+    const candidate = useMemo(() => fileCandidate(text), [text])
     if (!candidate) return <>{fallback}</>
-    // Records hold TOOL paths, which tail-match the mention AS WRITTEN (`mountPathMatchesToolPath`
-    // strips the leading slash itself) — so this asks with the raw text, not the mapped drive path.
-    if (knownFromRecords(index, text.trim().replace(/^\.\/+/, "")))
+    // Records hold tool paths — match the mention as written, not the mapped drive path.
+    if (knownFromRecords(index, candidate.mention))
         return <DriveFileInlineRef path={candidate.path} />
     return <OnDemandFileRef candidate={candidate} fallback={fallback} />
 }

--- a/web/oss/src/components/Drives/quickLook.tsx
+++ b/web/oss/src/components/Drives/quickLook.tsx
@@ -13,5 +13,7 @@ import {atom} from "jotai"
 import {atomFamily} from "jotai/utils"
 
 export const driveQuickLookAtomFamily = atomFamily((_sessionId: string) =>
-    atom<{path: string; hideTree?: boolean} | null>(null),
+    // `isFolder` is for an opener that already PROVED the kind (a chat mention resolved by listing
+    // it); the explorer otherwise guesses from the name until the tree level lands.
+    atom<{path: string; isFolder?: boolean; hideTree?: boolean} | null>(null),
 )

--- a/web/oss/src/components/Drives/resolveDrivePath.test.ts
+++ b/web/oss/src/components/Drives/resolveDrivePath.test.ts
@@ -1,0 +1,38 @@
+import {describe, expect, it} from "vitest"
+
+import {resolveDrivePath} from "./SessionFilesDrawer"
+
+const files = (...paths: string[]) => paths.map((path) => ({path}))
+
+describe("resolveDrivePath", () => {
+    it("prefers an exact listing hit", () => {
+        expect(resolveDrivePath(files("README.md", "src/README.md"), "src/README.md")).toBe(
+            "src/README.md",
+        )
+    })
+
+    it("resolves a tool-path tail to the drive path", () => {
+        expect(resolveDrivePath(files("notes/a.md"), "/tmp/agenta/mounts/p/m/notes/a.md")).toBe(
+            "notes/a.md",
+        )
+    })
+
+    it("picks the deepest match when several paths share a suffix", () => {
+        expect(
+            resolveDrivePath(
+                files("README.md", "src/README.md"),
+                "/tmp/agenta/mounts/p/m/src/README.md",
+            ),
+        ).toBe("src/README.md")
+    })
+
+    it("returns the request unchanged when the listing does not know it", () => {
+        expect(resolveDrivePath(files("README.md"), "src/other.md")).toBe("src/other.md")
+    })
+
+    it("maps a sandbox path even when the listing does not hold it", () => {
+        expect(resolveDrivePath(files("other.md"), "/tmp/agenta/mounts/p/m/deep/x.md")).toBe(
+            "deep/x.md",
+        )
+    })
+})

--- a/web/oss/src/components/Drives/useSessionDrive.ts
+++ b/web/oss/src/components/Drives/useSessionDrive.ts
@@ -441,11 +441,8 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
     }, [mountsQuery, cwdCount, rootQuery, agentMountQuery, agentCount, agentRootQuery, artifactId])
 
     const data = useMemo(() => {
-        // Newest write/edit per path. Record paths are TOOL paths (sandbox-absolute on harnesses
-        // that require it) and every consumer matches them against the mount-relative tree, so map
-        // them first — otherwise `agents/…` plumbing slips past the listable filter and nothing
-        // selects. Re-dedupe after mapping: two tool paths for one file (absolute from one tool,
-        // cwd-relative from another) collapse to the same drive path, and these rows are keyed by it.
+        // Record paths are TOOL paths; map before filtering or `agents/…` plumbing slips through.
+        // Re-dedupe after: two tool paths for one file collapse to the drive path these rows key by.
         const newestByPath = new Map<string, number>()
         for (const [toolPath, at] of recordRecency) {
             const path = toolPathToDrivePath(toolPath) ?? cleanPath(toolPath)

--- a/web/oss/src/components/Drives/useSessionDrive.ts
+++ b/web/oss/src/components/Drives/useSessionDrive.ts
@@ -1,6 +1,7 @@
 import {useCallback, useMemo} from "react"
 
 import {
+    AGENT_FILES_DIR,
     latestMountFilesQueryFamily,
     mountFilesQueryFamily,
     mountRootQueryFamily,
@@ -8,6 +9,7 @@ import {
     sessionFileActivityAtomFamily,
     sessionMountsQueryFamily,
     sessionRecordFileRecencyAtomFamily,
+    toolPathToDrivePath,
     type Mount,
     type MountFile,
 } from "@agenta/entities/session"
@@ -19,7 +21,7 @@ import {cleanPath, driveFileStats, isInternalDrivePath, relativeTime} from "./dr
 /** The agent's durable mount is symlinked into the session cwd under this name (runner:
  * `AGENT_FILES_LINK_NAME`). Its files live in a SEPARATE mount/prefix, so the drive folds them in
  * under this path — matching how the agent sees them on disk. */
-export const AGENT_FILES_DIR = "agent-files"
+export {AGENT_FILES_DIR}
 
 /** Where a presented drive path comes from: the durable per-agent mount (`agent-files/…`, shared
  * across the agent's sessions) or the ephemeral session cwd. Drives it visually + the grid filter. */
@@ -439,9 +441,18 @@ export function useSessionDriveSummary(sessionId: string, artifactId?: string): 
     }, [mountsQuery, cwdCount, rootQuery, agentMountQuery, agentCount, agentRootQuery, artifactId])
 
     const data = useMemo(() => {
-        // Newest write/edit per path (the map already dedups by path, keeping the latest timestamp).
-        const recordRecents: DriveRecentFile[] = [...recordRecency.entries()]
-            .map(([toolPath, at]) => ({path: cleanPath(toolPath), touchedAt: at}))
+        // Newest write/edit per path. Record paths are TOOL paths (sandbox-absolute on harnesses
+        // that require it) and every consumer matches them against the mount-relative tree, so map
+        // them first — otherwise `agents/…` plumbing slips past the listable filter and nothing
+        // selects. Re-dedupe after mapping: two tool paths for one file (absolute from one tool,
+        // cwd-relative from another) collapse to the same drive path, and these rows are keyed by it.
+        const newestByPath = new Map<string, number>()
+        for (const [toolPath, at] of recordRecency) {
+            const path = toolPathToDrivePath(toolPath) ?? cleanPath(toolPath)
+            if (at > (newestByPath.get(path) ?? 0)) newestByPath.set(path, at)
+        }
+        const recordRecents: DriveRecentFile[] = [...newestByPath.entries()]
+            .map(([path, touchedAt]) => ({path, touchedAt}))
             .filter((f) => isListableDrivePath(f.path))
             .sort((a, b) =>
                 b.touchedAt !== a.touchedAt

--- a/web/packages/agenta-entities/src/session/core/sandboxPaths.ts
+++ b/web/packages/agenta-entities/src/session/core/sandboxPaths.ts
@@ -1,12 +1,8 @@
 /**
- * Sandbox path → drive path. The runner mounts a session's durable cwd at
- * `<base>/agenta/mounts/<project_id>/<mount_id>` (`/tmp/…` locally, `/home/sandbox/…` on Daytona)
- * and the agent's own mount at the `-agent` sibling of that directory, which the drive presents
- * folded under `agent-files/`.
- *
- * An agent names files by their SANDBOX path, so every surface that resolves a mention against a
- * mount listing has to map one to the other first — a listing path is mount-root-relative, and a
- * sandbox path compared to it resolves to nothing.
+ * Sandbox path → drive path. Agents name files by their sandbox path, but a mount listing is
+ * mount-root-relative, so the two never match until one is mapped. The runner mounts the session
+ * cwd at `<base>/agenta/[<namespace>/]mounts/<project_id>/<mount_id>` and the agent's own mount at
+ * that directory's `-agent` sibling, which the drive folds under `agent-files/`.
  */
 import {stripTrailingSlashes} from "./pathUtils"
 
@@ -17,24 +13,25 @@ export const AGENT_FILES_DIR = "agent-files"
 const AGENT_MOUNT_SUFFIX = "-agent"
 
 /**
- * The drive-presented path a sandbox-absolute path names, or `null` when it isn't one — a path
- * outside the mounts (`/etc/hosts`) and a relative mention both return `null`, since neither needs
- * mapping. The mount root itself maps to `""`.
+ * The drive-presented path a sandbox-absolute path names, or `null` when it isn't one (`/etc/hosts`
+ * and relative mentions need no mapping). The mount root itself maps to `""`.
  *
- * Segment-walked rather than matched with a regex: the mount prefix is backend-supplied and an
- * end-anchored quantifier over it backtracks quadratically (the polynomial-ReDoS the sibling path
- * helpers already avoid).
+ * Segment-walked, not regex-matched: an end-anchored quantifier over a backend-supplied prefix
+ * backtracks quadratically (the polynomial-ReDoS the sibling path helpers avoid). `mounts` is
+ * located rather than assumed to follow `agenta`, because a deploy-time store namespace sits
+ * between the two (api `MountsService._storage_key`).
  */
 export function toolPathToDrivePath(toolPath: string): string | null {
     if (!toolPath.startsWith("/")) return null
     const segments = stripTrailingSlashes(toolPath).split("/")
-    for (let i = 0; i + 3 < segments.length; i++) {
-        if (segments[i] !== "agenta" || segments[i + 1] !== "mounts") continue
-        const rest = segments.slice(i + 4).join("/")
-        if (!segments[i + 3].endsWith(AGENT_MOUNT_SUFFIX)) return rest
-        return rest ? `${AGENT_FILES_DIR}/${rest}` : AGENT_FILES_DIR
-    }
-    return null
+    const agenta = segments.indexOf("agenta")
+    if (agenta === -1) return null
+    const mounts = segments.indexOf("mounts", agenta + 1)
+    // Needs a project AND a mount segment after `mounts` to name a drive.
+    if (mounts === -1 || mounts + 2 >= segments.length) return null
+    const rest = segments.slice(mounts + 3).join("/")
+    if (!segments[mounts + 2].endsWith(AGENT_MOUNT_SUFFIX)) return rest
+    return rest ? `${AGENT_FILES_DIR}/${rest}` : AGENT_FILES_DIR
 }
 
 /** Does this path point inside the session cwd / agent mount the drive shows? */

--- a/web/packages/agenta-entities/src/session/core/sandboxPaths.ts
+++ b/web/packages/agenta-entities/src/session/core/sandboxPaths.ts
@@ -1,0 +1,41 @@
+/**
+ * Sandbox path → drive path. The runner mounts a session's durable cwd at
+ * `<base>/agenta/mounts/<project_id>/<mount_id>` (`/tmp/…` locally, `/home/sandbox/…` on Daytona)
+ * and the agent's own mount at the `-agent` sibling of that directory, which the drive presents
+ * folded under `agent-files/`.
+ *
+ * An agent names files by their SANDBOX path, so every surface that resolves a mention against a
+ * mount listing has to map one to the other first — a listing path is mount-root-relative, and a
+ * sandbox path compared to it resolves to nothing.
+ */
+import {stripTrailingSlashes} from "./pathUtils"
+
+/** The agent mount's fold point inside the session cwd (runner: `AGENT_FILES_LINK_NAME`). */
+export const AGENT_FILES_DIR = "agent-files"
+
+/** The directory suffix the runner gives the agent mount (`<cwd>-agent`). */
+const AGENT_MOUNT_SUFFIX = "-agent"
+
+/**
+ * The drive-presented path a sandbox-absolute path names, or `null` when it isn't one — a path
+ * outside the mounts (`/etc/hosts`) and a relative mention both return `null`, since neither needs
+ * mapping. The mount root itself maps to `""`.
+ *
+ * Segment-walked rather than matched with a regex: the mount prefix is backend-supplied and an
+ * end-anchored quantifier over it backtracks quadratically (the polynomial-ReDoS the sibling path
+ * helpers already avoid).
+ */
+export function toolPathToDrivePath(toolPath: string): string | null {
+    if (!toolPath.startsWith("/")) return null
+    const segments = stripTrailingSlashes(toolPath).split("/")
+    for (let i = 0; i + 3 < segments.length; i++) {
+        if (segments[i] !== "agenta" || segments[i + 1] !== "mounts") continue
+        const rest = segments.slice(i + 4).join("/")
+        if (!segments[i + 3].endsWith(AGENT_MOUNT_SUFFIX)) return rest
+        return rest ? `${AGENT_FILES_DIR}/${rest}` : AGENT_FILES_DIR
+    }
+    return null
+}
+
+/** Does this path point inside the session cwd / agent mount the drive shows? */
+export const isSandboxPath = (path: string): boolean => toolPathToDrivePath(path) !== null

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -130,6 +130,7 @@ export {
     type FileActivity,
     type FileActivityOp,
 } from "./core/fileActivity"
+export {AGENT_FILES_DIR, isSandboxPath, toolPathToDrivePath} from "./core/sandboxPaths"
 export {
     sessionFileActivityAtomFamily,
     latestSessionFileActivityAtomFamily,

--- a/web/packages/agenta-entities/tests/unit/session-sandbox-paths.test.ts
+++ b/web/packages/agenta-entities/tests/unit/session-sandbox-paths.test.ts
@@ -16,6 +16,15 @@ describe("toolPathToDrivePath", () => {
         )
     })
 
+    it("tolerates a deploy-time store namespace before the mounts segment", () => {
+        expect(toolPathToDrivePath("/tmp/agenta/staging/mounts/proj-1/mount-1/README.md")).toBe(
+            "README.md",
+        )
+        expect(
+            toolPathToDrivePath("/tmp/agenta/staging/mounts/proj-1/mount-1-agent/SKILL.md"),
+        ).toBe("agent-files/SKILL.md")
+    })
+
     it("folds the agent mount under agent-files/", () => {
         expect(toolPathToDrivePath("/tmp/agenta/mounts/proj-1/mount-1-agent/SKILL.md")).toBe(
             "agent-files/SKILL.md",

--- a/web/packages/agenta-entities/tests/unit/session-sandbox-paths.test.ts
+++ b/web/packages/agenta-entities/tests/unit/session-sandbox-paths.test.ts
@@ -1,0 +1,49 @@
+import {describe, expect, it} from "vitest"
+
+import {isSandboxPath, toolPathToDrivePath} from "../../src/session/core/sandboxPaths"
+
+describe("toolPathToDrivePath", () => {
+    it("maps a local session cwd path to its mount-relative path", () => {
+        expect(toolPathToDrivePath("/tmp/agenta/mounts/proj-1/mount-1/README.md")).toBe("README.md")
+        expect(toolPathToDrivePath("/tmp/agenta/mounts/proj-1/mount-1/src/lib/index.ts")).toBe(
+            "src/lib/index.ts",
+        )
+    })
+
+    it("maps a Daytona sandbox path the same way", () => {
+        expect(toolPathToDrivePath("/home/sandbox/agenta/mounts/proj-1/mount-1/notes/a.md")).toBe(
+            "notes/a.md",
+        )
+    })
+
+    it("folds the agent mount under agent-files/", () => {
+        expect(toolPathToDrivePath("/tmp/agenta/mounts/proj-1/mount-1-agent/SKILL.md")).toBe(
+            "agent-files/SKILL.md",
+        )
+        expect(toolPathToDrivePath("/tmp/agenta/mounts/proj-1/mount-1-agent")).toBe("agent-files")
+    })
+
+    it("maps the mount root itself to the drive root", () => {
+        expect(toolPathToDrivePath("/tmp/agenta/mounts/proj-1/mount-1")).toBe("")
+        expect(toolPathToDrivePath("/tmp/agenta/mounts/proj-1/mount-1/")).toBe("")
+    })
+
+    it("leaves a path that is already drive-relative alone", () => {
+        expect(toolPathToDrivePath("README.md")).toBeNull()
+        expect(toolPathToDrivePath("src/lib/index.ts")).toBeNull()
+        expect(toolPathToDrivePath("agent-files/SKILL.md")).toBeNull()
+    })
+
+    it("ignores absolute paths outside the mounts", () => {
+        expect(toolPathToDrivePath("/etc/hosts")).toBeNull()
+        expect(toolPathToDrivePath("/home/sandbox/scratch/a.md")).toBeNull()
+        // The prefix must be a real mount root: `agenta/mounts` needs a project AND a mount segment.
+        expect(toolPathToDrivePath("/tmp/agenta/mounts/proj-1")).toBeNull()
+    })
+
+    it("reports membership through isSandboxPath", () => {
+        expect(isSandboxPath("/tmp/agenta/mounts/proj-1/mount-1/README.md")).toBe(true)
+        expect(isSandboxPath("/etc/hosts")).toBe(false)
+        expect(isSandboxPath("README.md")).toBe(false)
+    })
+})


### PR DESCRIPTION
Closes #5983

## Context

When an agent named a file in Chat or Playground, the path became a web link. Clicking it left the app for `https://cloud.agenta.ai/tmp/agenta/mounts/.../README.md`, a URL that does not exist.

The chat already knows how to resolve a mention against the session drive and open it in the Files side pane. It just never recognised the path. Agents name files by their sandbox path, and the runner mounts the session cwd at `<base>/agenta/mounts/<project_id>/<mount_id>` while the drive lists files relative to the mount root. The resolver compared the two directly, found nothing, and fell back to rendering an anchor. Files the agent had written in the same session still resolved (the record log tail-matches those), so the failure only showed up for files it had read.

## Changes

A new pure helper, `toolPathToDrivePath`, maps a sandbox path to the path the drive presents. It also handles the agent's own mount, which lives at the `-agent` sibling directory and appears in the drive under `agent-files/`.

```
/tmp/agenta/mounts/<p>/<m>/src/README.md   ->  src/README.md
/home/sandbox/agenta/mounts/<p>/<m>/a.md   ->  a.md
/tmp/agenta/mounts/<p>/<m>-agent/SKILL.md  ->  agent-files/SKILL.md
/etc/hosts                                 ->  null (not in the mounts)
```

Every way an agent can name a file now resolves through that helper:

- A backticked span and a markdown link map the path before resolving it.
- A bare path in prose is new. A marked extension tokenizes it into an element the renderer resolves, so fenced blocks, inline code, and link destinations are never rewritten. It only matches paths inside the mounts, since nothing else can resolve to a drive file.

A mention that resolves renders as a chip that opens the file in the side pane. A sandbox path that does not resolve renders as plain text rather than a dead link to our own origin.

Three smaller fixes came out of the same area:

- A mention that names a directory is checked with a one-level listing instead of a file read, and opens the explorer on that folder. The explorer used to assume any not-yet-loaded selection was a file, which showed a broken file preview for a nested folder until its level loaded.
- Quick-look requests resolve to the deepest matching drive path. Asking for `.../src/README.md` used to be able to land on a root `README.md`.
- Record-log paths are normalized once at the source, so the recents list holds drive paths. Every consumer already matched them against the mount-relative tree, and the internal-file filter (`agents/...` runner plumbing) only works on a drive path.

## Tests

- Unit tests for the path helper, the prose tokenizer, and quick-look resolution. The tokenizer test renders through the real XMarkdown pipeline, so it also covers the custom element surviving sanitization.
- `pnpm vitest` green across `Drives` and `AgentChatSlice` (409) and `@agenta/entities` (981). `tsc --noEmit` and eslint clean.
- Not yet run against a live session. The checks below are the ones worth doing by hand.

## What to QA

- Ask an agent to read a file it did not write, then mention it. The path renders as a chip and opens the file in the Files pane. You stay in Chat.
- Same check in the Playground. Both hosts share the chat panel, so the behaviour should match.
- Ask it to mention a folder (a plain one and a dot-folder like `.claude`). The chip carries a folder icon and opens the explorer on that folder, not a broken preview.
- Have it mention a path outside the mounts, for example `/etc/hosts`. It stays plain text and nothing navigates.
- Regression: click a file card in the tool activity of an older session. It still opens the right file in the pane.
- Regression: check a reply with fenced code containing a path. The code block is untouched.
