### PR TITLE
fix(tracing): record readable agent stream output

### DIFF
--- a/sdks/python/agenta/sdk/agents/fold.py
+++ b/sdks/python/agenta/sdk/agents/fold.py
@@ -128,6 +128,23 @@ def fold(
     }
 
 
+def assistant_text(events: Iterable[FoldedEvent]) -> str:
+    """Return the human-readable assistant text from one agent event stream.
+
+    Reasoning, tool, usage, and terminal events remain available in the streamed response
+    and session records. They are transport details rather than the workflow's output.
+    Reuse ``fold`` so this projection follows the same message-boundary rules as batch
+    execution and Vercel egress.
+    """
+    folded = fold(events)
+    return "".join(
+        message.get("content", "")
+        for message in folded["messages"]
+        if message.get("role") == "assistant"
+        and isinstance(message.get("content"), str)
+    )
+
+
 def _is_trailing_tool_unit(message: Message) -> bool:
     return message.get("role") == "tool"
 

--- a/sdks/python/agenta/sdk/decorators/tracing.py
+++ b/sdks/python/agenta/sdk/decorators/tracing.py
@@ -55,6 +55,7 @@ class instrument:  # pylint: disable=invalid-name
         redact: Optional[Callable[..., Any]] = None,
         redact_on_error: Optional[bool] = True,
         max_depth: Optional[int] = 2,
+        stream_output: Optional[Callable[[List[Any]], Any]] = None,
         # DEPRECATING
         kind: str = "task",
         spankind: Optional[str] = "TASK",
@@ -67,6 +68,7 @@ class instrument:  # pylint: disable=invalid-name
         self.redact = redact
         self.redact_on_error = redact_on_error
         self.max_depth = max_depth
+        self.stream_output = stream_output
 
     @staticmethod
     def _warn_if_not_initialized(handler_name: str) -> None:
@@ -340,10 +342,15 @@ class instrument:  # pylint: disable=invalid-name
 
         self.kind = parse_span_kind(self.type)
 
-    @staticmethod
-    def _join_stream(chunks: list):
+    def _join_stream(self, chunks: list):
         """Collapse accumulated stream chunks the way the generator wrappers do:
-        all-str -> joined string, all-bytes -> joined bytes, else the list."""
+        all-str -> joined string, all-bytes -> joined bytes, else the list.
+
+        A caller may opt into a domain-specific projection for a structured stream. The
+        wire chunks still pass through unchanged; only the span output is translated.
+        """
+        if self.stream_output is not None:
+            return self.stream_output(chunks)
         if all(isinstance(r, str) for r in chunks):
             return "".join(chunks)
         if all(isinstance(r, bytes) for r in chunks):

--- a/sdks/python/oss/tests/pytest/integration/observability/test_returned_generator_instrument.py
+++ b/sdks/python/oss/tests/pytest/integration/observability/test_returned_generator_instrument.py
@@ -18,7 +18,9 @@ These tests are RED before the fix, GREEN after. Uses the in-memory exporter (no
 
 import pytest
 
+from agenta.sdk.agents.fold import assistant_text
 from agenta.sdk.decorators.running import workflow
+from agenta.sdk.decorators.tracing import instrument
 from agenta.sdk.models.workflows import WorkflowServiceStreamResponse
 
 from oss.tests.pytest.integration.observability.test_workflow_instrument_programmatic import (  # noqa: E501
@@ -84,6 +86,38 @@ async def test_async_def_returning_event_gen_records_event_list(in_memory_tracin
     assert isinstance(captured, list), f"expected drained list, got {captured!r}"
     assert captured[0]["type"] == "message_start"
     assert captured[-1]["type"] == "done"
+
+
+@pytest.mark.asyncio
+async def test_returned_agent_event_stream_records_assistant_text(in_memory_tracing):
+    async def _events():
+        yield {"type": "thought_delta", "data": {"id": "r1", "delta": "private"}}
+        yield {"type": "message_start", "data": {"id": "m1"}}
+        yield {"type": "message_delta", "data": {"id": "m1", "delta": "Hello"}}
+        yield {"type": "message_delta", "data": {"id": "m1", "delta": " world"}}
+        yield {"type": "message_end", "data": {"id": "m1"}}
+        yield {"type": "usage", "data": {"total": 42}}
+        yield {"type": "done", "data": {"stopReason": "end_turn"}}
+
+    @workflow()
+    @instrument(stream_output=assistant_text)
+    async def wf(value: str):
+        return _events()
+
+    response = await wf.invoke(request=_request())
+    items = await _collect(response)
+    assert [event["type"] for event in items] == [
+        "thought_delta",
+        "message_start",
+        "message_delta",
+        "message_delta",
+        "message_end",
+        "usage",
+        "done",
+    ]
+
+    root = _roots(in_memory_tracing.finished_spans())[0]
+    assert _attr(root, "ag.data.outputs.__default__") == "Hello world"
 
 
 # --------------------------------------------------------------------------- #

--- a/services/oss/src/agent/app.py
+++ b/services/oss/src/agent/app.py
@@ -23,6 +23,7 @@ from agenta.sdk.agents import (
     SandboxNotAllowedError,
 )
 
+from agenta.sdk.agents.fold import assistant_text
 from agenta.sdk.agents.handler import (
     AgentComposition,
     make_agent_handler,
@@ -153,7 +154,10 @@ def create_agent_app():
     # copies of the conversation under `ag.data.inputs` (inputs.messages, request.data.
     # inputs.messages) plus a duplicate of `ag.data.parameters`. Only `messages` is signal.
     register_handler(
-        instrument(ignore_inputs=["request", "inputs", "parameters"])(_agent),
+        instrument(
+            ignore_inputs=["request", "inputs", "parameters"],
+            stream_output=assistant_text,
+        )(_agent),
         uri=AGENT_URI,
     )
     register_interface(


### PR DESCRIPTION
## Context

An agent trace records the `_agent` workflow output as the complete streamed event list. A person opening the span sees hundreds of `thought_delta`, `message_delta`, usage, and terminal objects instead of the assistant's reply.

The workflow instrumentation already drains the stream before it closes the span. The missing step was translating this known agent event format into its user-facing output.

## Change

Instrumentation now accepts an optional `stream_output` translator. It changes only the value written to the span. The original chunks still stream to the client unchanged.

The built-in agent enables that translator and reuses the existing agent-event fold. Before:

```json
[
  {"type": "message_delta", "data": {"delta": "Hello"}},
  {"type": "message_delta", "data": {"delta": " world"}},
  {"type": "usage", "data": {"total": 42}}
]
```

After:

```text
Hello world
```

Reasoning, tools, usage, and terminal events remain in the live response and session records. Generic structured streams keep their previous list output unless their caller explicitly supplies a translator.

## Tests

- Focused returned-generator integration suite: 5 passed.
- Tracing decorator regression suite: 30 passed.
- Ruff formatting and lint checks pass on every changed file.
- `git diff --check` passes.

## How to review

1. Read `assistant_text` in `agents/fold.py`. It reuses the existing event fold and selects assistant messages.
2. Read the opt-in hook in `decorators/tracing.py`. Confirm that it affects recorded output only.
3. Read the built-in agent registration in `services/oss/src/agent/app.py`.
4. Read the integration test. It proves the raw stream is unchanged while the span output becomes plain text.
