### PR TITLE
[AGE-4116] fix(frontend): stop bare filename mentions in chat from linking to the wrong file

### DIFF
--- a/web/oss/src/components/Drives/chatFileRefs.test.ts
+++ b/web/oss/src/components/Drives/chatFileRefs.test.ts
@@ -1,0 +1,29 @@
+import {describe, expect, it} from "vitest"
+
+import {knownFromRecords} from "./chatFileRefs"
+
+describe("knownFromRecords", () => {
+    it("does not claim a bare basename is known just because a NESTED file shares it (#6004)", () => {
+        // The agent wrote src/README.md; a bare `README.md` mention is a different, non-existent
+        // root file, and must fall through to the verified on-demand path instead of linking here.
+        const byBasename = new Map([["README.md", ["/tmp/agenta/mounts/p/m/src/README.md"]]])
+        expect(knownFromRecords(byBasename, "README.md")).toBe(false)
+    })
+
+    it("still fast-paths a qualified mention that tail-matches a written file", () => {
+        const byBasename = new Map([["README.md", ["/tmp/agenta/mounts/p/m/src/README.md"]]])
+        expect(knownFromRecords(byBasename, "src/README.md")).toBe(true)
+    })
+
+    it("defers a bare basename to on-demand verification even when the file is at the mount root", () => {
+        // knownFromRecords never trusts a bare mention, root file or not — OnDemandFileRef verifies
+        // it with a real read instead, which is the only way to tell the two cases apart.
+        const byBasename = new Map([["README.md", ["/tmp/agenta/mounts/p/m/README.md"]]])
+        expect(knownFromRecords(byBasename, "README.md")).toBe(false)
+    })
+
+    it("is false for a mention that was never written", () => {
+        const byBasename = new Map([["README.md", ["/tmp/agenta/mounts/p/m/src/README.md"]]])
+        expect(knownFromRecords(byBasename, "src/OTHER.md")).toBe(false)
+    })
+})

--- a/web/oss/src/components/Drives/chatFileRefs.tsx
+++ b/web/oss/src/components/Drives/chatFileRefs.tsx
@@ -59,7 +59,8 @@ const recordIndexAtomFamily = atomFamily((sessionId: string) =>
 )
 
 /** True when the record log proves this mention names a written file (tail match). */
-const knownFromRecords = (byBasename: Map<string, string[]>, candidate: string): boolean => {
+export const knownFromRecords = (byBasename: Map<string, string[]>, candidate: string): boolean => {
+    if (!candidate.includes("/")) return false
     const base = candidate.split("/").pop() ?? candidate
     return Boolean(byBasename.get(base)?.some((t) => mountPathMatchesToolPath(candidate, t)))
 }


### PR DESCRIPTION
## Summary
A chat mention like `` `README.md` `` was treated as a known, linkable file whenever ANY file with that basename existed anywhere in the session, even if the real file lived in a subfolder (e.g. `notes/README.md`). Clicking the mention opened the wrong path and showed "Couldn't load this file's content" (#6004).

The root cause is in `knownFromRecords` (`chatFileRefs.tsx`): it tail-matched the raw mention text against every file the agent had written, so a bare basename always matched the first written file sharing that name, regardless of where it actually lived. The fix stops bare (no `/`) mentions from taking that unverified shortcut. They now always go through the existing on-demand path, which reads the real file at that exact location and only renders a link when it actually resolves.

## Testing
### Verified locally
- Reproduced on `localhost:3000`: created `notes/README.md`, got the agent to reference it by bare filename, confirmed the mention now renders as plain text instead of a broken link.
- Confirmed a file created directly at the mount root still links and opens correctly (no regression).

### Added or updated tests
- `chatFileRefs.test.ts`: unit tests on `knownFromRecords` covering the false-positive case (nested file, bare mention), a still-working qualified mention, a mount-root file correctly deferring to on-demand verification, and an unmatched mention.

### QA follow-up
- Markdown-link-style mentions share the same resolver but weren't separately spot-checked.

## Demo
<!-- added manually -->
<img width="871" height="555" alt="Screenshot 2026-08-13 at 1 18 39 PM" src="https://github.com/user-attachments/assets/5366c644-6479-4c72-b901-99aae84a78f7" />


## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me