### PR TITLE
[AGE-4111] fix(frontend): open absolute file paths in Files

### DIFF
--- a/services/runner/src/engines/sandbox_agent/platform-guidance.ts
+++ b/services/runner/src/engines/sandbox_agent/platform-guidance.ts
@@ -141,6 +141,24 @@ export function instructionsSourceAppendix(): SystemPromptAppendix {
 }
 
 /**
+ * The path format the chat file-link resolver can identify without guessing.
+ *
+ * THE OBSERVED FAILURE. A model names only `README.md` after working on a nested file. The client
+ * cannot know which file it means when several directories contain that basename. Guessing linked
+ * to the wrong file (#6004), while treating an absolute sandbox path as a web href navigated away
+ * from chat (#5983). The client now understands the full path, so the model must preserve it.
+ */
+export function fileCitationAppendix(): SystemPromptAppendix {
+  return {
+    id: "file-citations",
+    text:
+      "When you mention a local file in your response, use a clickable Markdown link whose " +
+      "target is the file's full absolute path. Do not cite only a basename such as `README.md`. " +
+      "If you do not know the full path, find it before citing the file.",
+  };
+}
+
+/**
  * Codex only: its OWN bundled skills document the wrong workflow, and prose alone loses to them.
  *
  * THE STRUCTURAL PROBLEM, measured. Codex materializes system skills into `CODEX_HOME` at startup,
@@ -244,6 +262,7 @@ export function platformGuidanceAppendix(
   const skillsReadPath = input.skillsPath
     ? skillsReadPathAppendix(input.skillsPath)
     : undefined;
+  const fileCitations = fileCitationAppendix();
   const mount = mountGuidanceServedElsewhere(input)
     ? undefined
     : input.agentMountedPath
@@ -263,6 +282,7 @@ export function platformGuidanceAppendix(
     skills,
     skillsReadPath,
     codexSkills,
+    fileCitations,
     mount,
   ]);
 }

--- a/services/runner/tests/unit/agent-mount-guidance.test.ts
+++ b/services/runner/tests/unit/agent-mount-guidance.test.ts
@@ -22,6 +22,10 @@ import {
   claudeSystemPromptMeta,
   composeSystemPromptAppendix,
 } from "../../src/engines/sandbox_agent/system-prompt-appendix.ts";
+import {
+  fileCitationAppendix,
+  platformGuidanceAppendix,
+} from "../../src/engines/sandbox_agent/platform-guidance.ts";
 
 const MOUNT = "/home/sandbox/agenta/mounts/proj-1/sandbox-1-agent";
 
@@ -87,5 +91,27 @@ describe("the delivery channels carry either statement unchanged", () => {
       appendToSystemPrompt("author text", agentMountUnavailableGuidance()),
       `author text\n\n${agentMountUnavailableGuidance()}`,
     );
+  });
+});
+
+describe("file citation guidance", () => {
+  it("requires a clickable full absolute path and rejects a bare basename", () => {
+    const text = fileCitationAppendix().text;
+    assert.match(text, /clickable Markdown link/);
+    assert.match(text, /full absolute path/);
+    assert.match(text, /Do not cite only a basename/);
+  });
+
+  it("is included for every harness through the rendered instructions file", () => {
+    for (const acpAgent of ["pi", "claude", "codex"]) {
+      const text = platformGuidanceAppendix({
+        acpAgent,
+        isPi: acpAgent === "pi",
+        agentMountedPath: undefined,
+        agentMountSkipped: false,
+        toolNames: [],
+      });
+      assert.match(text ?? "", /full absolute path/);
+    }
   });
 });

--- a/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
@@ -195,7 +195,14 @@ const ExternalLink = ({href, title, className, children}: AnchorProps) => (
 const DriveLink = ({href, ...rest}: AnchorProps) => {
     const sessionId = useDriveSessionId()
     const link = useAtomValue(chatFileLinkAtomFamily(sessionId ?? ""))
-    const fallback = <ExternalLink href={href} {...rest} />
+    // A slash-prefixed href is a local sandbox path, not a browser-relative web URL. If the drive
+    // cannot prove it names a file, keep its label inert instead of navigating to
+    // `https://<agenta-host>/tmp/...` (#5983).
+    const fallback = href?.startsWith("/") ? (
+        <>{rest.children}</>
+    ) : (
+        <ExternalLink href={href} {...rest} />
+    )
     if (link && href) return <>{link.renderCode(href, fallback)}</>
     return fallback
 }

--- a/web/oss/src/components/Drives/chatFileRefs.test.ts
+++ b/web/oss/src/components/Drives/chatFileRefs.test.ts
@@ -1,6 +1,18 @@
 import {describe, expect, it} from "vitest"
 
-import {knownFromRecords} from "./chatFileRefs"
+import {fileCandidate, knownFromRecords} from "./chatFileRefs"
+
+describe("fileCandidate", () => {
+    it("preserves an absolute sandbox path for mount-tail resolution (#5983)", () => {
+        expect(fileCandidate("/tmp/agenta/mounts/p/m/src/README.md")).toBe(
+            "/tmp/agenta/mounts/p/m/src/README.md",
+        )
+    })
+
+    it("still normalizes an explicitly relative path", () => {
+        expect(fileCandidate("./src/README.md")).toBe("src/README.md")
+    })
+})
 
 describe("knownFromRecords", () => {
     it("does not claim a bare basename is known just because a NESTED file shares it (#6004)", () => {
@@ -13,6 +25,12 @@ describe("knownFromRecords", () => {
     it("still fast-paths a qualified mention that tail-matches a written file", () => {
         const byBasename = new Map([["README.md", ["/tmp/agenta/mounts/p/m/src/README.md"]]])
         expect(knownFromRecords(byBasename, "src/README.md")).toBe(true)
+    })
+
+    it("fast-paths the full absolute path of a written file", () => {
+        const path = "/tmp/agenta/mounts/p/m/src/README.md"
+        const byBasename = new Map([["README.md", [path]]])
+        expect(knownFromRecords(byBasename, path)).toBe(true)
     })
 
     it("defers a bare basename to on-demand verification even when the file is at the mount root", () => {

--- a/web/oss/src/components/Drives/chatFileRefs.tsx
+++ b/web/oss/src/components/Drives/chatFileRefs.tsx
@@ -35,8 +35,12 @@ import {AGENT_FILES_DIR} from "./useSessionDrive"
  * letter-led trailing extension (`.ts`, `.tar.gz`). A bare `/[./]/` matched any dotted token —
  * decimals (`3.14`), abbreviations (`e.g.`), and dotted identifiers (`user.name`) — each firing a
  * guaranteed-404 on-demand read once scrolled into view; the shape test drops those. */
-const fileCandidate = (text: string): string | null => {
-    const t = text.trim().replace(/^\.?\/+/, "")
+export const fileCandidate = (text: string): string | null => {
+    const trimmed = text.trim()
+    // Keep the leading slash on an absolute sandbox path. The Quick Look host uses the complete
+    // tool-path tail to match the mount-relative file, while removing it turns `/tmp/...` into an
+    // unrelated drive-relative path and loses the information needed for that match (#5983).
+    const t = trimmed.startsWith("./") ? trimmed.slice(2) : trimmed
     return t && /\/|\.[A-Za-z][A-Za-z0-9]{0,7}$/.test(t) ? t : null
 }
 


### PR DESCRIPTION
An agent could provide the correct absolute path, such as `/tmp/agenta/mounts/.../notes/README.md`, but clicking it could navigate the browser to that path on the Agenta host instead of opening Files. Agents also often shortened references to `README.md`, which leaves the client unable to identify the intended file.

This follow-up preserves the leading slash so the Files pane can match the complete tool path against the mount-relative file. If an absolute local path cannot be resolved, its label stays inert instead of becoming browser navigation.

The runner now appends one platform instruction after the authored instructions for every harness:

> When you mention a local file in your response, use a clickable Markdown link whose target is the file's full absolute path.

The instruction uses the existing fenced platform-guidance block. It does not modify or persist into the user's authored `AGENTS.md`.

Before:

```markdown
[README](/tmp/agenta/mounts/project/session/notes/README.md)
```

An unresolved path opened `https://<agenta-host>/tmp/agenta/mounts/...`.

After:

The same path opens the matching file in Files when records prove the match. An unresolved absolute path no longer navigates away from chat.

## Tests

- `cd web && pnpm lint-fix`
- `cd web && pnpm --filter @agenta/oss exec tsc --noEmit`
- `cd services/runner && pnpm exec vitest run tests/unit/agent-mount-guidance.test.ts`
- `cd services/runner && pnpm run typecheck`
- The focused frontend Vitest file currently fails during dependency import with the repository test-environment error `jsxDEV is not a function`; it collects zero tests.

## How to review

1. Review `chatFileRefs.tsx` and its tests for preservation of absolute paths.
2. Review `markdown.tsx` for the unresolved-local-path fallback.
3. Review `platform-guidance.ts` and the runner test for the cross-harness instruction.

Stacked on #6008. Addresses #5983.
