### PR TITLE
fix(runner): increase tool timeout defaults

### DIFF
--- a/docs/docs/self-host/reference/01-configuration.mdx
+++ b/docs/docs/self-host/reference/01-configuration.mdx
@@ -427,9 +427,9 @@ provider.
 | Variable | Role | Default | Secret | Helm |
 |---|---|---|---|---|
 | `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS` | Hard deadline for one run, measured from the first message | `2700000` (45 minutes) | no | `agentRunner.env.AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS` |
-| `AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS` | Longest gap between two progress events before the run is abandoned | `300000` (5 minutes) | no | `agentRunner.env.AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS` |
+| `AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS` | Longest gap between two progress events before the run is abandoned | `1800000` (30 minutes) | no | `agentRunner.env.AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS` |
 | `AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS` | Longest wait for the first response after the run starts | `120000` (2 minutes) | no | `agentRunner.env.AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS` |
-| `AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS` | Longest a single tool call may take | `300000` (5 minutes) | no | `agentRunner.env.AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS` |
+| `AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS` | Longest a single tool call may take | `1800000` (30 minutes) | no | `agentRunner.env.AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS` |
 
 Three rules govern how they interact:
 

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -111,12 +111,12 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # --- Run limits (per run; a run paused on a human approval is exempt from all four) ---
 # 45 min.
 # AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=2700000
-# 5 min without a progress event. Must stay below the total.
-# AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=300000
+# 30 min without a progress event. Must stay below the total.
+# AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=1800000
 # 2 min to the first response.
 # AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS=120000
-# 5 min per tool call.
-# AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=300000
+# 30 min per tool call.
+# AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=1800000
 
 # --- Session history: last-message-only turns ---
 # The client sends only the newest user message and the runner rebuilds the earlier turns

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -115,12 +115,12 @@ AGENTA_RUNNER_TOKEN=replace-me
 # --- Run limits (per run; a run paused on a human approval is exempt from all four) ---
 # 45 min.
 # AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=2700000
-# 5 min without a progress event. Must stay below the total.
-# AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=300000
+# 30 min without a progress event. Must stay below the total.
+# AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=1800000
 # 2 min to the first response.
 # AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS=120000
-# 5 min per tool call.
-# AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=300000
+# 30 min per tool call.
+# AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=1800000
 
 # --- Session history: last-message-only turns ---
 # The client sends only the newest user message and the runner rebuilds the earlier turns

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -111,12 +111,12 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # --- Run limits (per run; a run paused on a human approval is exempt from all four) ---
 # 45 min.
 # AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=2700000
-# 5 min without a progress event. Must stay below the total.
-# AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=300000
+# 30 min without a progress event. Must stay below the total.
+# AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=1800000
 # 2 min to the first response.
 # AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS=120000
-# 5 min per tool call.
-# AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=300000
+# 30 min per tool call.
+# AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=1800000
 
 # --- Session history: last-message-only turns ---
 # The client sends only the newest user message and the runner rebuilds the earlier turns

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -115,12 +115,12 @@ AGENTA_RUNNER_TOKEN=replace-me
 # --- Run limits (per run; a run paused on a human approval is exempt from all four) ---
 # 45 min.
 # AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=2700000
-# 5 min without a progress event. Must stay below the total.
-# AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=300000
+# 30 min without a progress event. Must stay below the total.
+# AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=1800000
 # 2 min to the first response.
 # AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS=120000
-# 5 min per tool call.
-# AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=300000
+# 30 min per tool call.
+# AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS=1800000
 
 # --- Session history: last-message-only turns ---
 # The client sends only the newest user message and the runner rebuilds the earlier turns

--- a/services/runner/src/engines/sandbox_agent/run-limits.ts
+++ b/services/runner/src/engines/sandbox_agent/run-limits.ts
@@ -30,9 +30,9 @@ export const TTFB_TIMEOUT_ENV = "AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS";
 export const TOOL_CALL_TIMEOUT_ENV = "AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS";
 
 export const DEFAULT_TOTAL_DEADLINE_MS = 45 * 60_000; // 45 min
-export const DEFAULT_IDLE_TIMEOUT_MS = 5 * 60_000; // 5 min
+export const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60_000; // 30 min
 export const DEFAULT_TTFB_TIMEOUT_MS = 2 * 60_000; // 2 min
-export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 5 * 60_000; // 5 min
+export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 30 * 60_000; // 30 min
 
 /** Every field is a usable timer delay (integer ms, at least 1, within Node's timer range) —
  *  `resolveRunLimits` guarantees it, so callers can arm any of them without re-checking. */


### PR DESCRIPTION
Tool calls that produce no intermediate progress currently stop after five minutes. This interrupts legitimate long-running commands and external operations.

This change raises both limits that can stop a quiet tool call:

- The per-tool-call timeout increases from 300,000 ms (5 minutes) to 1,800,000 ms (30 minutes).
- The no-progress timeout increases from 300,000 ms (5 minutes) to 1,800,000 ms (30 minutes).

The 45-minute overall run deadline remains unchanged. Deployments can still override every limit through the existing environment variables. The Docker Compose examples and self-hosting reference now show the new defaults.

## Validation

- `pnpm test`: 125 test files and 2,133 tests passed.
- `pnpm run typecheck`: passed.
- `git diff --check`: passed.

## How to review

1. Review `services/runner/src/engines/sandbox_agent/run-limits.ts` for the runtime defaults.
2. Review the four Docker Compose environment examples for matching values and comments.
3. Review the self-hosting configuration table for the public defaults.
