### PR TITLE
fix(frontend): tidy the files pane chrome in the agent playground

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/RightPanel/RightPanelSplit.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/RightPanel/RightPanelSplit.tsx
@@ -43,6 +43,11 @@ const DRIVEN_SLIDE_CLASS =
 const BAR_INSET_CLASS =
     "[&>.ant-splitter-bar]:!h-[calc(100%-var(--agent-bar-inset,0px))] [&>.ant-splitter-bar]:!self-end " +
     "[&>.ant-splitter-bar]:[transition:height_240ms_cubic-bezier(0.4,0,0.2,1)]"
+// A COLLAPSED panel draws no divider: these splits nest (Inspector inside the Files split's chat
+// column), so a closed one's hairline lands ~1px from the open one's and reads as a double border.
+// `visibility` (not display) keeps the bar's box, so the open panel's slide isn't disturbed; held
+// until the close slide finishes so the line leaves with the pane, not before it.
+const BAR_HIDDEN_CLASS = "[&>.ant-splitter-bar]:invisible"
 
 /**
  * Nested resizable split: [chat | right panel]. The Splitter (and thus the chat column) stays
@@ -133,7 +138,7 @@ const RightPanelSplit = ({
         // playground-splitter classes: this divider renders EXACTLY like the config pane's (2px
         // hairline + centered grip) instead of antd's default bar, so all vertical seams match.
         <Splitter
-            className={`h-full min-h-0 w-full flex-1 playground-splitter playground-splitter-agent ${FILL_PANE_CLASS} ${BAR_INSET_CLASS} ${animate ? DRIVEN_SLIDE_CLASS : ""}`}
+            className={`h-full min-h-0 w-full flex-1 playground-splitter playground-splitter-agent ${FILL_PANE_CLASS} ${BAR_INSET_CLASS} ${animate ? DRIVEN_SLIDE_CLASS : ""} ${!open && !closing ? BAR_HIDDEN_CLASS : ""}`}
             onResizeStart={() => setDragging(true)}
             onResize={(sizes) => {
                 if (open) setLive(clampWidth(sizes[1], sizes[0] + sizes[1], min, max))

--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -255,8 +255,12 @@ export function DriveExplorer({
     // it falls through and renders the tree; its retry rides the existing header (see DriveHeader's
     // `partialErrored` slot), NOT a new banner row that would shove the content down.
     let body: ReactNode
+    // Search/filters/tree toggle only earn their row when there IS a tree — a terminal state has
+    // nothing to search or filter, and the row's own borders make an empty pane look broken.
+    let showToolbar = true
     if (drive.errored && drive.fileCount === 0) {
         body = <DriveErrorState drive={drive} />
+        showToolbar = false
     } else if (drive.isLoading || (drive.mount && lazyTree.rootLoading)) {
         // The right pane will be a FILE preview if we're opening onto a file, else the browse GRID.
         // Nothing is loaded yet, so the name is all we have to go on.
@@ -270,6 +274,7 @@ export function DriveExplorer({
         )
     } else if (drive.fileCount === 0) {
         body = <DriveEmptyState scope={scope} />
+        showToolbar = false
     } else {
         // What shows for the current selection: the folder's children (as a tile grid) or a file's
         // preview. The right pane of the tree navigator (and the whole body when the tree is hidden).
@@ -422,23 +427,25 @@ export function DriveExplorer({
                     {/* Pending uploads render as tiles in the grid + a pinned group in the tree (both
                         drawer-global), so no separate header banner here — a banner that mounts/unmounts
                         shoved the toolbar + panes on every upload state change. */}
-                    <DriveToolbar
-                        mirrored={mirrored}
-                        search={search}
-                        setSearch={setSearch}
-                        searchActive={searchActive}
-                        showTree={showTree}
-                        treeVisible={treeVisible}
-                        toggleTree={toggleTree}
-                        showOrigin={showOrigin}
-                        originFilter={originFilter}
-                        setOriginFilter={setOriginFilter}
-                        showHidden={showHidden}
-                        setShowHidden={setShowHidden}
-                        inGitScope={inGitScope}
-                        showGitignored={showGitignored}
-                        setShowGitignored={setShowGitignored}
-                    />
+                    {showToolbar ? (
+                        <DriveToolbar
+                            mirrored={mirrored}
+                            search={search}
+                            setSearch={setSearch}
+                            searchActive={searchActive}
+                            showTree={showTree}
+                            treeVisible={treeVisible}
+                            toggleTree={toggleTree}
+                            showOrigin={showOrigin}
+                            originFilter={originFilter}
+                            setOriginFilter={setOriginFilter}
+                            showHidden={showHidden}
+                            setShowHidden={setShowHidden}
+                            inGitScope={inGitScope}
+                            showGitignored={showGitignored}
+                            setShowGitignored={setShowGitignored}
+                        />
+                    ) : null}
                     <div className="flex min-h-0 flex-1 flex-col">{body}</div>
                 </div>
             ) : (

--- a/web/oss/src/components/Drives/DriveExplorerStates.tsx
+++ b/web/oss/src/components/Drives/DriveExplorerStates.tsx
@@ -1,34 +1,29 @@
 /**
- * DriveExplorerStates — the explorer body's two terminal states: the total-failure banner (with its
- * retry) and the empty drive. Split out so DriveExplorer's body branch reads as a three-line switch;
+ * DriveExplorerStates — the explorer body's two terminal states: the total failure (with its retry)
+ * and the empty drive. Split out so DriveExplorer's body branch reads as a three-line switch;
  * the loading state is {@link DriveExplorerSkeleton}.
  */
-import {Tray} from "@phosphor-icons/react"
-import {Alert} from "antd"
+import {Tray, WarningCircle} from "@phosphor-icons/react"
 
 import {DriveRetryButton} from "./DriveFileRow"
 import {type DriveScope} from "./driveTypes"
 import {type SessionDriveData} from "./useSessionDrive"
 
+// Same centred icon + two lines as the empty state — the sibling terminal state in this slot; only
+// the glyph carries the warning tone, so a failed drive doesn't shout a full alert box at the user.
 export function DriveErrorState({drive}: {drive: SessionDriveData}) {
     return (
-        <div className="w-full p-4">
-            <Alert
-                type="warning"
-                showIcon
-                message="Couldn't load this drive"
-                description={
-                    <span className="text-xs">
-                        The file store may not be configured on this deployment.
-                        {drive.retry ? (
-                            <>
-                                {" "}
-                                <DriveRetryButton onRetry={drive.retry} busy={drive.isFetching} />
-                            </>
-                        ) : null}
-                    </span>
-                }
-            />
+        <div className="flex min-h-0 w-full flex-1 flex-col items-center justify-center gap-1 p-8 text-center">
+            <WarningCircle size={20} weight="fill" className="text-colorWarning" />
+            <div className="text-xs font-medium">Couldn&apos;t load this drive</div>
+            <div className="text-xs text-colorTextTertiary">
+                The file store may not be configured on this deployment.
+            </div>
+            {drive.retry ? (
+                <div className="mt-1">
+                    <DriveRetryButton onRetry={drive.retry} busy={drive.isFetching} />
+                </div>
+            ) : null}
         </div>
     )
 }

--- a/web/oss/src/components/Drives/DriveHeader.tsx
+++ b/web/oss/src/components/Drives/DriveHeader.tsx
@@ -4,6 +4,7 @@ import {
     ArrowsIn,
     ArrowsOut,
     CaretDoubleRight,
+    Copy,
     DotsThree,
     DownloadSimple,
     GitBranch,
@@ -97,14 +98,12 @@ export const DriveHeader = ({
     // (transient null before the root auto-selects) → no toggle.
     const hasDetails = isFolder ? isRepo : selectedPath != null
     const overflow: MenuProps["items"] = [
+        // Label only — the raw uuid under it made every item two lines tall and stretched the menu to
+        // the width of a uuid; the value goes to the clipboard, which is the whole point of the item.
         ...ids.map((id) => ({
             key: id.key,
-            label: (
-                <div className="flex flex-col gap-0.5 py-0.5">
-                    <span className="text-xs font-medium">Copy {id.label}</span>
-                    <span className="font-mono text-[12px] text-colorTextTertiary">{id.value}</span>
-                </div>
-            ),
+            label: `Copy ${id.label}`,
+            icon: <Copy size={14} />,
         })),
         // Only a separator when there IS something above it — a host without drive ids (the ids
         // resolve async, and the local-file drive never has any) otherwise opens on a stray rule.

--- a/web/oss/src/components/Drives/SessionFilesPane.tsx
+++ b/web/oss/src/components/Drives/SessionFilesPane.tsx
@@ -11,11 +11,12 @@
  */
 import {useCallback, useEffect, useMemo} from "react"
 
-import {atom, useAtom} from "jotai"
+import {atom, useAtom, useAtomValue} from "jotai"
 import {atomFamily} from "jotai/utils"
 import dynamic from "next/dynamic"
 
 import {useChatScopeKey} from "@/oss/components/AgentChatSlice/state/scope"
+import {playgroundInspectorEnabledAtom} from "@/oss/state/settings/featureFlags"
 
 import {type DriveId} from "./DriveExplorer"
 import {DriveExplorerSkeleton} from "./DriveExplorerSkeleton"
@@ -80,13 +81,20 @@ export function SessionFilesPane({sessionId}: {sessionId: string}) {
         return hit?.path ?? quickLook.path
     }, [quickLook, drive.recents])
 
+    // Raw ids are a DEBUGGING affordance (wiring an SDK call, filing a bug), so they ride the same
+    // switch as the rest of the inspection surface — off, the overflow menu is just "Download all".
+    const inspectorEnabled = useAtomValue(playgroundInspectorEnabledAtom)
     const driveIds = useMemo(
         () =>
-            [
-                drive.mount?.id ? {key: "mount", label: "Drive ID", value: drive.mount.id} : null,
-                sessionId ? {key: "owner", label: "Session ID", value: sessionId} : null,
-            ].filter(Boolean) as DriveId[],
-        [drive.mount?.id, sessionId],
+            !inspectorEnabled
+                ? []
+                : ([
+                      drive.mount?.id
+                          ? {key: "mount", label: "Drive ID", value: drive.mount.id}
+                          : null,
+                      sessionId ? {key: "owner", label: "Session ID", value: sessionId} : null,
+                  ].filter(Boolean) as DriveId[]),
+        [inspectorEnabled, drive.mount?.id, sessionId],
     )
 
     const driveGeneration = useDriveGeneration(drive.mount?.id)


### PR DESCRIPTION
## Context

Three things made the docked Files pane in the agent playground read as unfinished chrome.

A drive that fails to load rendered a full antd Alert. It was a bordered amber box stretched across a pane about 350px wide, and the only Alert anywhere in the Drives surface, so a routine "no file store configured" shouted louder than anything else on screen. The search and filter toolbar stayed mounted in that state and in the empty-drive state, offering search over nothing and leaving a stray bottom border under an empty pane.

The seam beside the pane painted two hairlines about 1px apart. `RightPanelSplit` nests: the Inspector split sits inside the Files split's chat column. A collapsed panel is 0px wide but its divider bar kept painting, so the closed Inspector's line landed right next to the open Files pane's line.

The overflow menu printed each id's raw uuid on a second line under its label, which made every item two lines tall and stretched the menu to the width of a uuid.

## Changes

**Error state.** `DriveErrorState` now uses the same shape as `DriveEmptyState`, its sibling in the same slot: a centred 20px glyph, an `text-xs` title, a tertiary subline, and the existing retry below it. Only the icon carries the warning tone.

**Toolbar.** `DriveExplorer` renders `DriveToolbar` only when there is a tree to browse. It is hidden for the error and empty states, and kept during loading, where the skeleton means content is still coming and dropping it would only add a shift.

**Divider.** A collapsed panel hides its splitter bar. It uses `visibility` rather than `display` so the box stays and the open panel's slide is undisturbed, and it holds until the 240ms close slide finishes so the line leaves with the pane instead of ahead of it.

**Overflow menu.** Each id item is a single line with a copy glyph, matching "Download all" beside it. The uuid still reaches the clipboard on click, which is the item's whole job. The ids are a debugging affordance, so they now ride the same `playgroundInspectorEnabledAtom` switch as `InspectSessionButton` and the turn inspector, gated in `SessionFilesPane` so the shared Drives header stays free of agent-chat state.

Before, per id:

```
Copy Drive ID
019ffb3a-20c2-7922-a6a6-837671d487f8
```

After, with the inspector preference on:

```
⧉ Copy Drive ID
```

With it off, the menu is just "Download all", and the header drops the divider it would otherwise open on.

## Tests / notes

- Verified each change in the running local app against a session whose drive fails to load: the error pane, the single seam, and the menu contents in both states of the preference.
- `eslint --fix` clean on all five files.
- The gate is the user preference in Settings then Preferences, not an env var. Nothing changes for anyone who has it on today.
- Checked `release/v0.112.1`: none of these are fixed there, and its one commit touching Drives (`7f35d2f406`) only edits `chatFileRefs` and `markdown`, so nothing overlaps.

## What to QA

- Open a session whose drive cannot load, then open the Files pane. You get a centred warning icon, the two lines, and "Try again". No amber box, and no search toolbar above it.
- Same check on a session with an empty drive. The empty state shows with no toolbar. The header keeps its collapse, upload, and overflow controls.
- Open the Files pane on a session that has files. The toolbar is back, search and filters work, and the seam between the chat and the pane is a single line. Drag it, then collapse the pane with the "»" and confirm the divider leaves with the pane rather than snapping out early.
- Open the pane's overflow menu with Settings then Preferences then "Playground inspector" off. You should see only "Download all", with no divider above it. Turn the preference on, reopen: "Copy Drive ID" and "Copy Session ID" are back as single lines, and clicking each copies the uuid.
- Regression: open the Inspector (the same preference) alongside the Files pane. Both dividers show while both panes are open, and each disappears when its own pane collapses.
