### PR TITLE
fix(frontend): Make the sidebar banner and switcher menu fit the rail

### DIFF
--- a/web/oss/src/components/Sidebar/components/ProjectOrgSwitcher/index.tsx
+++ b/web/oss/src/components/Sidebar/components/ProjectOrgSwitcher/index.tsx
@@ -39,6 +39,9 @@ const ITEM_ROW_CLASS = "shrink-0"
 const CAPTION_CLASS =
     "px-2 pt-1.5 pb-1 text-xs font-medium text-[var(--ag-colorTextTertiary)] truncate"
 
+/** px-[3px] + the card's 1px border + ROW_CLASS's px-2 = 12px, the nav rows' icon column. */
+const PANEL_CLASS = "flex flex-col px-[3px] py-1"
+
 /** Capped scroll list (3 h-8 rows) with the scrollbar hidden. */
 const SCROLL_LIST_CLASS =
     "flex max-h-24 flex-col overflow-y-auto [&::-webkit-scrollbar]:hidden [scrollbar-width:none]"
@@ -168,7 +171,7 @@ const ProjectOrgSwitcher = ({collapsed}: ProjectOrgSwitcherProps) => {
 
     const projectPanel = useMemo(
         () => (
-            <div className="flex flex-col p-1">
+            <div className={PANEL_CLASS}>
                 <div className={CAPTION_CLASS}>Projects in {orgLabel}</div>
                 <div className={SCROLL_LIST_CLASS}>
                     {projectsForOrg.map((proj) => {
@@ -231,7 +234,7 @@ const ProjectOrgSwitcher = ({collapsed}: ProjectOrgSwitcherProps) => {
 
     const orgPanel = useMemo(
         () => (
-            <div className="flex flex-col p-1">
+            <div className={PANEL_CLASS}>
                 <div className="flex items-center justify-between">
                     <Row
                         className="!w-auto flex-1 font-medium"
@@ -316,8 +319,16 @@ const ProjectOrgSwitcher = ({collapsed}: ProjectOrgSwitcherProps) => {
                 destroyOnHidden
                 styles={{root: {zIndex: 2000}}}
                 popupRender={() => (
-                    // Fixed width matching the expanded trigger (sidebar 236px − 14px wrapper padding).
-                    <div className="w-[220px] overflow-hidden rounded-lg border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorBgElevated)] shadow-md">
+                    // antd pins the popup root's min-width to the trigger width, so w-full makes the
+                    // panel exactly as wide as the trigger at any rail width — never wider. Collapsed
+                    // the trigger is icon-sized, so the panel falls back to a readable fixed width.
+                    // box-border because preflight is off: w-full + a border would otherwise overflow 2px.
+                    <div
+                        className={clsx(
+                            "box-border overflow-hidden rounded-lg border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorBgElevated)] shadow-md",
+                            collapsed ? "w-[220px]" : "w-full",
+                        )}
+                    >
                         {panel === "projects" ? projectPanel : orgPanel}
                     </div>
                 )}
@@ -328,7 +339,8 @@ const ProjectOrgSwitcher = ({collapsed}: ProjectOrgSwitcherProps) => {
                     className={clsx(
                         // Borderless at rest; the hover fill is the affordance.
                         "flex items-center rounded-md border-0 bg-transparent cursor-pointer transition-colors hover:bg-[var(--ag-colorFillTertiary)]",
-                        collapsed ? "h-8 w-8 justify-center p-1" : "w-full gap-2 px-1.5 py-1.5",
+                        // px-3 puts the avatar on the nav rows' icon column instead of 6px inside it.
+                        collapsed ? "h-8 w-8 justify-center p-1" : "w-full gap-2 px-3 py-1.5",
                     )}
                     title={`${projectLabel} · ${orgLabel}`}
                 >

--- a/web/oss/src/components/Sidebar/scopes/mainScope.tsx
+++ b/web/oss/src/components/Sidebar/scopes/mainScope.tsx
@@ -22,7 +22,7 @@ const MainSidebarHeader = ({collapsed}: SidebarSlotContext) => <SidebarLogo coll
 
 const MainSidebarFooter = ({collapsed}: SidebarSlotContext) =>
     collapsed ? null : (
-        <div className="mx-auto">
+        <div className="w-full">
             <SidePanelSubscriptionInfo />
         </div>
     )

--- a/web/oss/src/components/SidebarBanners/SidebarBanner.tsx
+++ b/web/oss/src/components/SidebarBanners/SidebarBanner.tsx
@@ -11,6 +11,11 @@ interface SidebarBannerProps {
     onDismiss?: () => void
 }
 
+// The rail ground is warm, so the card needs its own surface + the shell hairline to read as a card.
+// px-[11px] = 12px nav-item padding − the 1px card border, so the text starts on the nav icon column.
+const bannerClassName =
+    "px-[11px] py-3 rounded-lg flex flex-col gap-2 relative bg-colorBgElevated border border-solid border-[var(--ag-shell-line)]"
+
 const SidebarBanner = ({banner, onDismiss}: SidebarBannerProps) => {
     const router = useRouter()
 
@@ -29,7 +34,7 @@ const SidebarBanner = ({banner, onDismiss}: SidebarBannerProps) => {
     // If custom content is provided, render it instead
     if (banner.customContent) {
         return (
-            <section className="p-4 rounded-lg flex flex-col gap-2 bg-[var(--ag-c-F5F7FA)] relative">
+            <section className={bannerClassName}>
                 {banner.dismissible && onDismiss && (
                     <button
                         onClick={onDismiss}
@@ -45,7 +50,7 @@ const SidebarBanner = ({banner, onDismiss}: SidebarBannerProps) => {
     }
 
     return (
-        <section className="p-4 rounded-lg flex flex-col gap-2 bg-[var(--ag-c-F5F7FA)] relative">
+        <section className={bannerClassName}>
             {banner.dismissible && onDismiss && (
                 <button
                     onClick={onDismiss}
@@ -58,7 +63,7 @@ const SidebarBanner = ({banner, onDismiss}: SidebarBannerProps) => {
             <Typography.Text className="text-sm leading-5 font-semibold pr-10 text-gray-900">
                 {banner.title}
             </Typography.Text>
-            <Typography.Text className="text-[13px] leading-5 text-[var(--ag-c-586673)]">
+            <Typography.Text className="text-[12px] leading-5 text-[var(--ag-c-586673)]">
                 {banner.description}
             </Typography.Text>
             {banner.action && (

--- a/web/oss/src/components/SidebarBanners/SidebarBanner.tsx
+++ b/web/oss/src/components/SidebarBanners/SidebarBanner.tsx
@@ -16,6 +16,10 @@ interface SidebarBannerProps {
 const bannerClassName =
     "px-[11px] py-3 rounded-lg flex flex-col gap-2 relative bg-colorBgElevated border border-solid border-[var(--ag-shell-line)]"
 
+// Semantic fill, not black/5: a 5% black wash is invisible on the dark elevated surface.
+const dismissClassName =
+    "absolute right-3 top-3 grid h-7 w-7 place-items-center rounded-md border-0 bg-transparent text-colorText transition-colors hover:bg-colorFillTertiary focus:outline-none focus-visible:bg-colorFillTertiary focus-visible:outline-none"
+
 const SidebarBanner = ({banner, onDismiss}: SidebarBannerProps) => {
     const router = useRouter()
 
@@ -38,7 +42,7 @@ const SidebarBanner = ({banner, onDismiss}: SidebarBannerProps) => {
                 {banner.dismissible && onDismiss && (
                     <button
                         onClick={onDismiss}
-                        className="absolute right-3 top-3 grid h-7 w-7 place-items-center rounded-md border-0 bg-transparent text-gray-900 transition-colors hover:bg-black/5 focus:outline-none focus-visible:bg-black/5 focus-visible:outline-none"
+                        className={dismissClassName}
                         aria-label="Dismiss banner"
                     >
                         <X size={16} />
@@ -54,13 +58,13 @@ const SidebarBanner = ({banner, onDismiss}: SidebarBannerProps) => {
             {banner.dismissible && onDismiss && (
                 <button
                     onClick={onDismiss}
-                    className="absolute right-3 top-3 grid h-7 w-7 place-items-center rounded-md border-0 bg-transparent text-gray-900 transition-colors hover:bg-black/5 focus:outline-none focus-visible:bg-black/5 focus-visible:outline-none"
+                    className={dismissClassName}
                     aria-label="Dismiss banner"
                 >
                     <X size={16} />
                 </button>
             )}
-            <Typography.Text className="text-sm leading-5 font-semibold pr-10 text-gray-900">
+            <Typography.Text className="text-sm leading-5 font-semibold pr-10 text-colorText">
                 {banner.title}
             </Typography.Text>
             <Typography.Text className="text-[12px] leading-5 text-[var(--ag-c-586673)]">

--- a/web/oss/src/components/SidebarBanners/index.tsx
+++ b/web/oss/src/components/SidebarBanners/index.tsx
@@ -24,9 +24,10 @@ const SidebarBanners = () => {
         }
     }
 
-    // px-2 matches the nav items' 8px inline margin so the card shares their edges.
+    // box-border is explicit because preflight is off; the app only gets border-box from
+    // antd's `.ant-layout *` reset, which does not reach portalled trees.
     return (
-        <div className="w-full shrink-0 px-[19px]">
+        <div className="box-border w-full shrink-0 px-[19px]">
             <SidebarBanner
                 banner={topBanner}
                 onDismiss={topBanner.dismissible ? handleDismiss : undefined}

--- a/web/oss/src/components/SidebarBanners/index.tsx
+++ b/web/oss/src/components/SidebarBanners/index.tsx
@@ -24,8 +24,9 @@ const SidebarBanners = () => {
         }
     }
 
+    // px-2 matches the nav items' 8px inline margin so the card shares their edges.
     return (
-        <div className="w-[215px] shrink-0">
+        <div className="w-full shrink-0 px-[19px]">
             <SidebarBanner
                 banner={topBanner}
                 onDismiss={topBanner.dismissible ? handleDismiss : undefined}


### PR DESCRIPTION
## Context

Two problems in the sidebar rail, both from hardcoded widths and a stale colour token.

The "Star Agenta" banner had no visible edge. It painted itself with `--ag-c-F5F7FA`, and the warm recolour repointed that legacy token at `#f6f5f3`, which is the exact value of `--ag-shell-rail-bg`. The card and the ground behind it were the same colour, so the card read as loose text on the rail.

The project switcher menu ignored the rail entirely. It was a fixed 220px panel anchored to a trigger whose width follows the resizable rail, so on a narrow rail the menu hung out over the content area, and on a wide rail it stopped well short of the button it belongs to.

## Changes

The banner card now uses `colorBgElevated` plus the `--ag-shell-line` hairline. That is the same "white card on warm ground" language the rail already uses for its selected nav pill, and it costs nothing in dark mode, where the old token already resolved to `colorBgElevated`. Its container was a fixed 215px box centred with `mx-auto`, which drifted further from the nav rows the wider the rail got. It is now full width with an inset, so it tracks the rail at any size.

The switcher menu takes its width from the trigger. antd pins the popup root's `min-width` to the trigger width, so `w-full` on the panel makes it exactly as wide as the button, never wider. Collapsed, the trigger is icon sized, so the panel falls back to a fixed readable width.

The panel also needed `box-border`. Preflight is off in this repo (`oss/tailwind.config.ts:443`), so `box-sizing` is not `border-box` by default and `w-full` plus a 1px border overflowed its container by 2px.

Two padding fixes put the switcher on the same column as the nav icons. The trigger's own `px-1.5` was stacking on its wrapper's `px-2`, landing the avatar at 14px while every nav icon sits at 20px. The menu's rows had the same problem one pixel out, from the panel padding sitting inside the card's border.

Measured on the running app, rail at 302px:

| | before | after |
|---|---|---|
| switcher avatar | 14 | 20 (nav icon column) |
| menu panel | 8 to 228, past a 200px rail | 8 to 294, exactly the trigger |
| menu row icons | 21 | 20 |

## Tests / notes

- Verified in the browser against the live DOM rather than by eye. Every number above is a `getBoundingClientRect()` reading, checked at several rail widths to confirm nothing is pinned to one size.
- Dark mode is unchanged in fill. `--ag-c-F5F7FA` already mapped to `colorBgElevated` there, so the only difference is the added hairline.
- `pnpm eslint --fix` and prettier on the four touched files. `tsc --noEmit` is clean for them.
- The banner card sits inset from the nav rows rather than flush with them. That is deliberate, not a leftover from the fixed-width version.

## What to QA

- Open any page with the sidebar expanded. The "Star Agenta" banner reads as a card with a visible border, not as text floating on the rail.
- Drag the rail wider and narrower. The banner keeps its inset on both sides at every width, with no fixed-width jump.
- Click the project switcher at the bottom of the rail. The menu is exactly as wide as the button and stays inside the rail. Drag the rail to a narrow width and open it again. It still does not spill over the content area.
- Check the left column. The switcher avatar, the menu's project avatars, and the menu's row icons line up with the Home and Settings icons above them.
- Collapse the rail and open the switcher. The menu is still wide enough to read.
- Regression: switch the theme to dark from the same menu. The banner and the menu both keep a visible edge against the rail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
