### PR TITLE
fix(observability): report failure rate as a percentage

### DIFF
--- a/web/oss/src/services/tracing/lib/helpers.test.ts
+++ b/web/oss/src/services/tracing/lib/helpers.test.ts
@@ -1,0 +1,26 @@
+import {describe, expect, it} from "vitest"
+
+import {analyticsToGeneration} from "./helpers"
+
+const TRACE_TYPE_PATH = "attributes.ag.type.trace"
+const ERRORS_PATH = "attributes.ag.metrics.errors.cumulative"
+
+describe("analyticsToGeneration", () => {
+    it("reports the failure rate as a percentage", () => {
+        const analytics = {
+            buckets: [
+                {
+                    timestamp: "2026-08-12T10:00:00Z",
+                    metrics: {
+                        [TRACE_TYPE_PATH]: {count: 6},
+                        [ERRORS_PATH]: {sum: 1},
+                    },
+                },
+            ],
+        }
+
+        const result = analyticsToGeneration(analytics, "24_hours")
+
+        expect(result.failure_rate).toBeCloseTo(16.67, 2)
+    })
+})

--- a/web/oss/src/services/tracing/lib/helpers.ts
+++ b/web/oss/src/services/tracing/lib/helpers.ts
@@ -157,7 +157,7 @@ export function analyticsToGeneration(
     return {
         data,
         total_count: totalCount,
-        failure_rate: totalCount ? errorCount / totalCount : 0,
+        failure_rate: totalCount ? (errorCount / totalCount) * 100 : 0,
         total_cost: totalCost,
         avg_cost: totalCount ? totalCost / totalCount : 0,
         avg_latency: totalDurationCount ? totalDurationMs / totalDurationCount : 0, // ms


### PR DESCRIPTION
## Summary

Closes #5967.

The usage card treated the failure rate as a ratio even though the UI appends `%`, so 1 failed request out of 6 displayed as `0.17%`. The analytics transform now returns a percentage, so the card displays `16.67%`.

## Testing
### Verified locally

- `pnpm --filter @agenta/oss exec vitest run src/services/tracing/lib/helpers.test.ts`
- Full OSS unit suite: 575 passed, 1 skipped
- OSS and EE TypeScript checks
- Formatting and linting

### Added or updated tests

Added a regression test for 1 failure in 6 requests, expecting `16.67`.

### QA follow-up

Confirm the Requests card shows `16.67%` for 1 failed request out of 6.

## Demo

<img width="760" height="500" alt="Agenta Requests card showing a 16.67% failure rate" src="https://github.com/user-attachments/assets/696f9860-6614-4fc8-afeb-daed277e9c28" />

## Checklist
- [x] I have included a screenshot for this UI change
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
