### PR TITLE
[5967] fix(frontend): format usage failure rate as percentage

### DIFF
--- a/web/oss/src/components/pages/observability/dashboard/AnalyticsDashboard.tsx
+++ b/web/oss/src/components/pages/observability/dashboard/AnalyticsDashboard.tsx
@@ -1,6 +1,11 @@
 import {useMemo, type ComponentProps} from "react"
 
-import {formatCompactNumber, formatCurrency, formatNumber} from "@agenta/shared/utils"
+import {
+    formatCompactNumber,
+    formatCurrency,
+    formatNumber,
+    formatPercent,
+} from "@agenta/shared/utils"
 import {ChartLineIcon} from "@phosphor-icons/react"
 import {Spin} from "antd"
 import {useAtom} from "jotai"
@@ -99,9 +104,7 @@ const AnalyticsDashboard = ({
                                 <div className={`${statTextClass} danger`}>
                                     <span className="label">Failed:</span>
                                     <span className="value">
-                                        {data?.failure_rate
-                                            ? `${formatNumber(data?.failure_rate)}%`
-                                            : "-"}
+                                        {data?.failure_rate ? formatPercent(data.failure_rate) : "-"}
                                     </span>
                                 </div>
                             )


### PR DESCRIPTION
## Summary
The observability dashboard receives `failure_rate` as a decimal ratio (e.g. 1 / 6 = 0.1667), but the UI formatted that ratio as a number and appended `%`. Use the existing shared `formatPercent` helper so the displayed value is 16.7%, not 0.17%.

## Testing
### Verified locally
- `git diff --check`
- Shared `formatPercent` unit coverage already covers decimal-to-percentage formatting.

### Added or updated tests
N/A; the change reuses the existing tested formatter.

### QA follow-up
Verify the Requests card with a non-zero failure rate in the observability dashboard.

## Demo
N/A (runtime dependency installation was unavailable in this environment).

## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [ ] Relevant tests pass locally
- [ ] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me
