### PR TITLE
[5970] fix(frontend): keep advanced summary readable

### DIFF
--- a/web/oss/src/components/pages/overview/agent/AgentConfigurationCard.tsx
+++ b/web/oss/src/components/pages/overview/agent/AgentConfigurationCard.tsx
@@ -16,7 +16,7 @@ import {useAtomValue} from "jotai"
 
 import {usePlaygroundNavigation} from "@/oss/hooks/usePlaygroundNavigation"
 
-import {agentConfigSummary} from "./agentConfigSummary"
+import {agentConfigSummary, formatAdvancedSummary} from "./agentConfigSummary"
 import {agentLatestRevisionAtomFamily} from "./state"
 
 const INSTRUCTIONS_FILE = "AGENTS.md"
@@ -61,12 +61,7 @@ const AgentConfigurationCard = ({appId}: {appId: string}) => {
     const open = () => goToPlayground(undefined, {appId})
 
     const model = [summary.model, summary.harness].filter(Boolean).join(" · ")
-    const advanced = [
-        summary.sandbox && `Sandbox: ${summary.sandbox.toLowerCase()}`,
-        summary.permissions && `Permissions: ${summary.permissions.toLowerCase()}`,
-    ]
-        .filter(Boolean)
-        .join(" · ")
+    const advanced = formatAdvancedSummary(summary)
 
     // Same order and icons as the playground's config sections, so this reads as a view of that
     // panel rather than a second account of the same settings.
@@ -113,7 +108,7 @@ const AgentConfigurationCard = ({appId}: {appId: string}) => {
             key: "advanced",
             icon: <SlidersHorizontalIcon size={16} />,
             title: "Advanced",
-            ...stated(advanced || "Defaults"),
+            ...stated(advanced),
         },
     ]
 

--- a/web/oss/src/components/pages/overview/agent/agentConfigSummary.test.ts
+++ b/web/oss/src/components/pages/overview/agent/agentConfigSummary.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "vitest"
 
-import {agentConfigSummary, prettifyKind} from "./agentConfigSummary"
+import {agentConfigSummary, formatAdvancedSummary, prettifyKind} from "./agentConfigSummary"
 
 // The shape below is a real stored revision's `parameters`, trimmed.
 const parameters = {
@@ -70,5 +70,12 @@ describe("agentConfigSummary", () => {
         expect(prettifyKind("claude_code")).toBe("Claude code")
         expect(prettifyKind("some-future-kind")).toBe("Some future kind")
         expect(prettifyKind(null)).toBeNull()
+    })
+
+    it("keeps the Advanced row summary compact without dropping its values", () => {
+        expect(formatAdvancedSummary({sandbox: "Local", permissions: "Allow reads"})).toBe(
+            "Local sandbox · Allow reads",
+        )
+        expect(formatAdvancedSummary({sandbox: null, permissions: null})).toBe("Defaults")
     })
 })

--- a/web/oss/src/components/pages/overview/agent/agentConfigSummary.ts
+++ b/web/oss/src/components/pages/overview/agent/agentConfigSummary.ts
@@ -23,6 +23,16 @@ export interface AgentConfigSummary {
     permissions: string | null
 }
 
+export function formatAdvancedSummary(
+    summary: Pick<AgentConfigSummary, "sandbox" | "permissions">,
+): string {
+    return (
+        [summary.sandbox && `${summary.sandbox} sandbox`, summary.permissions]
+            .filter(Boolean)
+            .join(" · ") || "Defaults"
+    )
+}
+
 const isRecord = (value: unknown): value is Record<string, unknown> =>
     typeof value === "object" && value !== null && !Array.isArray(value)
 


### PR DESCRIPTION
## Summary
The Agent overview's Advanced row used verbose `Sandbox: ... · Permissions: ...` prefixes in a narrow rail, so the title and value could both be truncated. Format the summary as `Local sandbox · Allow reads` to preserve both values within the available width.

## Testing
### Verified locally
- `git diff --check`
- Added unit coverage for `formatAdvancedSummary`.

### Added or updated tests
`web/oss/src/components/pages/overview/agent/agentConfigSummary.test.ts`

### QA follow-up
Verify the Agent Overview configuration rail at the issue's 1600px viewport and at narrow desktop widths.

## Demo
N/A (runtime dependency installation was unavailable in this environment).

## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [ ] Relevant tests pass locally
- [ ] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me
