### PR TITLE
[docs] Update demo video to the new recording

### DIFF
--- a/docs/blog/entries/agenta-is-now-a-workspace-for-building-agents.mdx
+++ b/docs/blog/entries/agenta-is-now-a-workspace-for-building-agents.mdx
@@ -12,7 +12,7 @@ description: "Agenta is now a workspace for building and running agents: assista
   <iframe
     width="100%"
     height="400"
-    src="https://www.youtube.com/embed/Y5l2BPRkKC8"
+    src="https://www.youtube.com/embed/7Wfvtv428Fs"
     title="Agenta Is Now a Workspace for Building Agents"
     frameBorder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
@@ -34,7 +34,7 @@ Agenta started as a platform for managing and evaluating prompts. With this rele
   <iframe
     width="100%"
     height="400"
-    src="https://www.youtube.com/embed/Y5l2BPRkKC8"
+    src="https://www.youtube.com/embed/7Wfvtv428Fs"
     title="Agenta Is Now a Workspace for Building Agents"
     frameBorder="0"
     allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"

--- a/docs/docs/getting-started/01-introduction.mdx
+++ b/docs/docs/getting-started/01-introduction.mdx
@@ -23,7 +23,7 @@ Watch this short video to see Agenta in action.
 <iframe
   width="100%"
   height="400"
-  src="https://www.youtube.com/embed/Y5l2BPRkKC8"
+  src="https://www.youtube.com/embed/7Wfvtv428Fs"
   title="Introduction to Agenta"
   frameBorder="0"
   allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"


### PR DESCRIPTION
## Context

The demo video was re-recorded, so the old recording (`Y5l2BPRkKC8`) is out of date everywhere it is embedded. PR #6036 swapped it in the four README files. The docs site still played the old video.

## Changes

Three YouTube embeds now point at the new recording (`7Wfvtv428Fs`):

- `docs/docs/getting-started/01-introduction.mdx` (the "Watch this short video" embed on the docs landing page)
- `docs/blog/entries/agenta-is-now-a-workspace-for-building-agents.mdx` (both embeds: the summary card and the body)

Each page embeds the video with a plain `<iframe src="https://www.youtube.com/embed/<id>">`, so only the id changed. The docs pages never used the GitHub thumbnail asset that the READMEs do, so there is no image to swap here. Nothing else in the pages moved.

## Notes

A repo-wide grep for the old video id and the old thumbnail asset id now returns nothing outside `.git`, so this completes the swap PR #6036 started.
