### PR TITLE
fix(entity-ui): default missing harness to pi_core

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/agentTemplateUtils.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/agentTemplateUtils.ts
@@ -30,3 +30,8 @@ export function cloneItem(item: unknown): Record<string, unknown> {
     if (!item || typeof item !== "object") return {}
     return JSON.parse(JSON.stringify(item)) as Record<string, unknown>
 }
+
+/** Resolve the effective harness kind, matching the execution layer's default. */
+export function effectiveHarnessValue(harness: Record<string, unknown>): string {
+    return typeof harness.kind === "string" ? harness.kind : "pi_core"
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -49,7 +49,7 @@ import {HarnessSelectControl} from "../HarnessSelectControl"
 import {PiPermissionsControl} from "../PiPermissionsControl"
 import {SandboxPermissionControl} from "../SandboxPermissionControl"
 
-import {enumLabel} from "./agentTemplateUtils"
+import {effectiveHarnessValue, enumLabel} from "./agentTemplateUtils"
 import {CatalogUnavailableNotice} from "./CatalogUnavailableNotice"
 import {PermissionPolicySelect} from "./PermissionPolicySelect"
 import ProviderCredentialsSection from "./ProviderCredentialsSection"
@@ -165,7 +165,7 @@ export function useModelHarness({
     // carries through extra keys (e.g. `extras`) so a form edit never silently drops them. The picker
     // is harness-filtered: selecting a model sets BOTH the model id and its provider, fed by the
     // `/inspect` capability map below.
-    const harnessValue = typeof harness.kind === "string" ? (harness.kind as string) : null
+    const harnessValue = effectiveHarnessValue(harness)
     const isPiHarness = harnessValue === "pi_core" || harnessValue === "pi_agenta"
     const llm = config.llm
     const modelId = useMemo(() => modelIdFromConfig(llm), [llm])

--- a/web/packages/agenta-entity-ui/tests/unit/agentTemplateUtils.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/agentTemplateUtils.test.ts
@@ -1,0 +1,20 @@
+import {describe, expect, it} from "vitest"
+
+import {effectiveHarnessValue} from "../../src/DrillInView/SchemaControls/agentTemplate/agentTemplateUtils"
+
+describe("effectiveHarnessValue", () => {
+    it("defaults to pi_core when harness kind is missing", () => {
+        expect(effectiveHarnessValue({})).toBe("pi_core")
+        expect(effectiveHarnessValue({kind: null})).toBe("pi_core")
+    })
+
+    it("preserves an explicitly selected harness", () => {
+        expect(effectiveHarnessValue({kind: "pi_core"})).toBe("pi_core")
+        expect(effectiveHarnessValue({kind: "pi_agenta"})).toBe("pi_agenta")
+        expect(effectiveHarnessValue({kind: "claude"})).toBe("claude")
+    })
+
+    it("defaults to pi_core for a non-string kind", () => {
+        expect(effectiveHarnessValue({kind: 123})).toBe("pi_core")
+    })
+})


### PR DESCRIPTION
## Summary

Fixes #5661 

The execution layer already defaults a missing harness to `pi_core`, but the Entity UI previously resolved the missing value to `null`. This caused Pi-specific controls, including the Permissions section, to be hidden when the harness was omitted from the configuration.

## Changes

- Added `effectiveHarnessValue()` to centralize the `pi_core` fallback.
- Updated `useModelHarness` to use the effective harness value.
- Added regression tests covering:
  - missing harness
  - explicit `pi_core`
  - explicit `pi_agenta`
  - explicit `claude`
  - non-string harness values

## Testing

- `pnpm exec tsc --noEmit`
- `pnpm exec eslint src/DrillInView/SchemaControls/agentTemplate/agentTemplateUtils.ts src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx tests/unit/agentTemplateUtils.test.ts`
- `pnpm exec vitest run tests/unit/piPermissions.test.ts tests/unit/agentTemplateUtils.test.ts`
- `git diff --check`

All relevant tests pass.
Demo: With agent.harness omitted from the configuration, the Entity UI still resolves the effective harness to pi_core, so the Pi-specific Permissions controls remain available.
[Screen Recording 2026-08-17 002153.zip](https://github.com/user-attachments/files/31121880/Screen.Recording.2026-08-17.002153.zip)
