### PR TITLE
fix(org): gate single-org query until the id is verifiably resolvable

### DIFF
--- a/web/oss/src/state/org/selectors/org.ts
+++ b/web/oss/src/state/org/selectors/org.ts
@@ -333,6 +333,22 @@ export const resolvePreferredWorkspaceId = (userId: string | null, orgs?: Org[])
     return anyOrg?.id ?? null
 }
 
+/**
+ * True only if `id` can currently be resolved to a real organization id — either
+ * directly (it's already a known org), via a cached workspace→org mapping, or via
+ * a projectId we can look up asynchronously. If none apply (e.g. a brand-new
+ * signup where nothing has been cached yet and no project is known), the id is
+ * an unverified workspace id and must not be sent to /api/organizations/{id}.
+ */
+const canResolveOrgId = (id: string, get: (a: any) => any): boolean => {
+    const orgs = get(orgsAtom) as Org[]
+    if (Array.isArray(orgs) && orgs.some((org) => org.id === id)) return true
+    if (Object.values(readWorkspaceOrgMap()).includes(id)) return true
+    if (resolveOrgId(id)) return true
+    const {projectId} = get(appIdentifiersAtom)
+    return Boolean(projectId)
+}
+
 export const selectedOrgQueryAtom = atomWithQuery<OrgDetails | null>((get) => {
     const snapshot = get(appStateSnapshotAtom)
     const queryOrgId = snapshot.query["organization_id"]
@@ -345,7 +361,9 @@ export const selectedOrgQueryAtom = atomWithQuery<OrgDetails | null>((get) => {
         snapshot.routeLayer === "project" ||
         snapshot.routeLayer === "app"
     const isAcceptRoute = snapshot.pathname.startsWith("/workspaces/accept")
-    const enabled = !!id && get(sessionExistsAtom) && jwtReady && isWorkspaceRoute && !isAcceptRoute
+    const idResolvable = !!id && canResolveOrgId(id, get)
+    const enabled =
+        idResolvable && get(sessionExistsAtom) && jwtReady && isWorkspaceRoute && !isAcceptRoute
 
     return {
         queryKey: ["selectedOrg", id],


### PR DESCRIPTION
Fixes #6029

## Summary
During first-account signup, the app briefly calls the single-organization
endpoint with the workspace id instead of the organization id, producing
a 403 and a misleading console error before the app self-recovers.

## Root cause
`normalizeOrgIdentifier()`'s final fallback returns the raw, unverified id
as the organization id whenever it can't resolve one — no direct org match,
no cached workspace→org mapping, and no `projectId` yet to look up. That's
exactly the state right after a brand-new signup: nothing has been cached
for a workspace that was just created, and `projectId` hasn't propagated
into state yet. `selectedOrgQueryAtom` then fires with that unverified id,
hitting `/api/organizations/{workspace_id}` and getting a 403.

## Fix
Added `canResolveOrgId()`, which checks the same three signals
`normalizeOrgIdentifier` already checks (direct org match, cached
workspace→org mapping, resolvable via a known `projectId`) synchronously,
and gated `selectedOrgQueryAtom`'s `enabled` flag on it. The query now
simply doesn't fire until the id can actually be verified as resolvable to
a real org, instead of firing immediately and guessing. Since the checked
signals (`orgsAtom`, `appIdentifiersAtom`) are read reactively in the
atom's sync config function, the query naturally re-evaluates and fires
correctly once the org list or projectId becomes available a moment later.

## Testing
Traced the full call chain by hand (`selectedOrgQueryAtom` →
`normalizeOrgIdentifier` → the exact fallback branch) against the issue's
own reproduction steps and request sequence. I wasn't able to get a
type-check or the local dev server to complete in my session tonight to
produce a live before/after recording — happy to add one, or if a
maintainer can verify visually in the meantime.