### PR TITLE
fix(observability): keep usage chart labels visible

### DIFF
--- a/web/oss/src/components/pages/observability/dashboard/CustomAreaChart.test.tsx
+++ b/web/oss/src/components/pages/observability/dashboard/CustomAreaChart.test.tsx
@@ -1,0 +1,67 @@
+import {renderToStaticMarkup} from "react-dom/server"
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+const captures = vi.hoisted(() => ({
+    areaChartProps: [] as unknown[],
+}))
+
+vi.mock("antd", () => ({
+    theme: {
+        useToken: () => ({
+            token: {
+                colorTextSecondary: "#667085",
+                colorBorderSecondary: "#d0d5dd",
+                colorBgElevated: "#ffffff",
+                colorBorder: "#d0d5dd",
+                borderRadius: 6,
+                boxShadowSecondary: "none",
+                colorText: "#101828",
+            },
+        }),
+    },
+}))
+
+vi.mock("@/oss/lib/hooks/useChartSeries", () => ({
+    useChartSeries: () => ["#1677ff", "#52c41a"],
+}))
+
+vi.mock("recharts", async () => {
+    const React = await import("react")
+
+    return {
+        ResponsiveContainer: ({children}: {children?: React.ReactNode}) => <div>{children}</div>,
+        AreaChart: (props: {children?: React.ReactNode}) => {
+            captures.areaChartProps.push(props)
+            return <svg>{props.children}</svg>
+        },
+        Area: () => null,
+        CartesianGrid: () => null,
+        Tooltip: () => null,
+        XAxis: () => null,
+        YAxis: () => null,
+    }
+})
+
+const {default: CustomAreaChart} = await import("./CustomAreaChart")
+
+beforeEach(() => {
+    captures.areaChartProps.length = 0
+})
+
+describe("CustomAreaChart", () => {
+    it("keeps the chart inside the SVG so wide y-axis labels are not clipped", () => {
+        renderToStaticMarkup(
+            <CustomAreaChart
+                data={[{timestamp: "2026-08-12", latency: 20000}]}
+                categories={["latency"]}
+                index="timestamp"
+                valueFormatter={(value) => `${value}ms`}
+            />,
+        )
+
+        expect(captures.areaChartProps).toHaveLength(1)
+        expect(captures.areaChartProps[0]).toMatchObject({
+            margin: {top: 5, right: 5, left: 0, bottom: 0},
+        })
+    })
+})

--- a/web/oss/src/components/pages/observability/dashboard/CustomAreaChart.tsx
+++ b/web/oss/src/components/pages/observability/dashboard/CustomAreaChart.tsx
@@ -44,7 +44,7 @@ const CustomAreaChart: React.FC<CustomAreaChartProps> = ({
     return (
         <div className={`w-full ${className}`}>
             <ResponsiveContainer width="100%" height="100%">
-                <ReAreaChart data={data} margin={{top: 5, right: 5, left: -20, bottom: 0}}>
+                <ReAreaChart data={data} margin={{top: 5, right: 5, left: 0, bottom: 0}}>
                     <defs>
                         {categories.map((category, idx) => {
                             const color = resolveColor(idx)


### PR DESCRIPTION
## Summary

Fixes #5968.

Usage charts were using a negative left margin, which pushed wider y-axis labels outside the SVG clip. This keeps the left chart margin at zero so labels like `20Kms` and `$4.00` stay visible.

## Testing
### Verified locally

- `pnpm --filter @agenta/oss exec vitest run src/components/pages/observability/dashboard/CustomAreaChart.test.tsx`
- `pnpm exec eslint oss/src/components/pages/observability/dashboard/CustomAreaChart.tsx oss/src/components/pages/observability/dashboard/CustomAreaChart.test.tsx`
- `pnpm --filter @agenta/oss exec tsc --noEmit`
- `git diff --check`

### Added or updated tests

Added a regression test for the chart margin used by the observability usage charts.

### QA follow-up

Verify the expanded Usage card with latency and cost values wide enough to produce labels such as `20Kms` or `$4.00`.

## Demo

Draft PR: demo recording pending before ready-for-review.

## Checklist
- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
