### PR TITLE
[5968] fix(frontend): unclip wide y-axis labels on usage charts

### DIFF
--- a/web/oss/src/components/pages/observability/dashboard/CustomAreaChart.tsx
+++ b/web/oss/src/components/pages/observability/dashboard/CustomAreaChart.tsx
@@ -44,7 +44,7 @@ const CustomAreaChart: React.FC<CustomAreaChartProps> = ({
     return (
         <div className={`w-full ${className}`}>
             <ResponsiveContainer width="100%" height="100%">
-                <ReAreaChart data={data} margin={{top: 5, right: 5, left: -20, bottom: 0}}>
+                <ReAreaChart data={data} margin={{top: 5, right: 5, left: 0, bottom: 0}}>
                     <defs>
                         {categories.map((category, idx) => {
                             const color = resolveColor(idx)


### PR DESCRIPTION
Closes #5968

## Summary

The Usage card's Latency and Cost charts clip the leading digit of wide y-axis labels (`20Kms` renders as `0Kms`, `15Kms` as `5Kms`), because `CustomAreaChart` offsets the entire plot area — Y axis included — 20px past the left edge of the SVG with a negative margin.

## Root cause

`web/oss/src/components/pages/observability/dashboard/CustomAreaChart.tsx`:

```tsx
<ReAreaChart data={data} margin={{top: 5, right: 5, left: -20, bottom: 0}}>
```

Recharts lays the Y axis inside the plot area, so `left: -20` shifts it left of the SVG origin. Labels wider than ~4 characters then start at negative x and get clipped by the card's overflow boundary — exactly the negative x coordinates measured in the issue report (`10Kms` −5, `15Kms` −5, `20Kms` −8). The `-20` is a leftover visual nudge from the commit that introduced the component (`60c2b4c4`) with no comment explaining it.

## Fix

One line: `left: -20` → `left: 0`. The chart keeps its layout otherwise unchanged; the widest label measured in the issue sits at x=−8, so removing the offset recovers all 20px with slack to spare.

## Verification

I reproduced this component in a minimal React + recharts (2.15.4) harness — the same `margin`, `tickCount`, and `valueFormatter` (`${formatCompactNumber(value)}ms`) as the app — and measured each y-axis tick label's left edge relative to the chart container in a headless browser:

| margin | 0ms | 5Kms | 10Kms | 15Kms | 20Kms |
|---|---|---|---|---|---|
| `left: -20` (before) | +10px | +3px | **−3px** | **−3px** | **−3px** |
| `left: 0` (after) | +30px | +23px | +17px | +17px | +17px |

Negative = outside the clipping boundary → leading digit cut off. After the fix every label is fully visible.

## Demo

Before (labels clipped):

![before](https://raw.githubusercontent.com/Kirtofu/agenta/assets/y-axis-demo/assets/y-axis-demo/before.png)

After (labels legible):

![after](https://raw.githubusercontent.com/Kirtofu/agenta/assets/y-axis-demo/assets/y-axis-demo/after.png)

## Testing

- The change is a single numeric value; no imports, components, or styles were added.
- I could not run `pnpm lint-fix` locally (no full monorepo checkout available in this environment) — CI lint should be unaffected, but flagging it per the contributor guide.
- Manual QA suggestion: open Home → Usage → Expand and confirm `20Kms`/`15Kms`/`10Kms` render in full.

## Checklist

- [x] I have included a screenshot for this UI change
- [ ] Relevant tests pass locally — n/a for this change; minimal harness verification above
- [ ] Relevant linting and formatting pass locally — not runnable in this environment; flagging for CI
- [x] PR title follows the `[issue-id] fix(frontend): ...` convention
- [ ] CLA — will sign when the bot prompts
