### PR TITLE
[fix] Align select trigger labels left and pin the chevron right

### DIFF
--- a/web/packages/agenta-ui/src/components/ui/select.tsx
+++ b/web/packages/agenta-ui/src/components/ui/select.tsx
@@ -29,10 +29,14 @@ const selectTriggerVariants = cva(
     [
         // CONTROL_RESET — see button.tsx (preflight is off app-wide for antd's sake).
         "box-border border-solid font-[inherit]",
-        "flex w-full items-center justify-between gap-1 border text-foreground outline-none transition-colors",
+        // text-left: preflight is off, so the UA's `button { text-align: center }` would centre
+        // the selected label on the button-based triggers (Select, and every consumer of this variant).
+        "flex w-full items-center justify-between gap-1 border text-left text-foreground outline-none transition-colors",
         // Radix's Value span doesn't take a className, so shrink it from here — without this a
-        // long selected label overflows the trigger and pushes the chevron out.
-        "[&>span]:min-w-0 [&>span]:flex-1",
+        // long selected label overflows the trigger and pushes the chevron out. Scoped to the value
+        // slot: a bare `[&>span]` also stretched the trailing adornment span (Combobox/Cascader wrap
+        // their chevron + clear in one), floating the chevron mid-trigger instead of at its edge.
+        "[&>[data-slot=select-value]]:min-w-0 [&>[data-slot=select-value]]:flex-1",
         "cursor-pointer disabled:cursor-not-allowed disabled:bg-disabled-bg disabled:text-disabled disabled:border-disabled-border",
         // antd greys only the placeholder TEXT; the root keeps the foreground colour.
         "[&[data-placeholder]_[data-slot=select-value]]:text-placeholder",


### PR DESCRIPTION
## Context

Two layout bugs in the shared select trigger, both visible in the agent config drawer. The "Policy" select rendered its selected label centered instead of at the left edge, and the sandbox environment picker parked its chevron in the middle of the control instead of at the right edge.

Both come from `selectTriggerVariants`, the base class set that Select, Combobox, Cascader, `SelectLLMProvider`, and the schema/trigger form controls all share.

1. Tailwind preflight is off app-wide (for antd's sake), so the browser default `button { text-align: center }` still applies. Every button-based trigger centered its label.
2. The base carried `[&>span]:min-w-0 [&>span]:flex-1`, which exists only for Radix's `SelectValue` span (Radix gives it no `className`). Combobox and Cascader wrap their chevron and clear button in a trailing `<span>`, so that span also got `flex: 1 1 0%` and grew to half the trigger. `shrink-0` on it does not help, because the problem is grow, not shrink.

## Changes

Added `text-left` to the base variant, and scoped the grow rule to the value slot:

Before:

```
"[&>span]:min-w-0 [&>span]:flex-1"
```

After:

```
"[&>[data-slot=select-value]]:min-w-0 [&>[data-slot=select-value]]:flex-1"
```

The other consumers of the variant already own their content layout, so narrowing the selector costs them nothing. Combobox and Cascader put `min-w-0 flex-1` on their content div, `SourceField` on its inner button, and the multi-select chip box in `schemaFormControls` is `flex-wrap justify-start`, where a `flex-1` on each chip was wrong to begin with. `ScheduleBuilderField`'s summary span loses `flex-1`, but `justify-between` still pins its chevron to the right.

`SelectLLMProviderBase` already patched the centering with its own local `text-left`. That is now redundant, but harmless, so it stays.

## Tests

- `tsc --noEmit` on `@agenta/ui` is clean.
- CSS-only change, no unit tests touch these classes.
- I did not verify it in a running app. Worth an eyeball in the agent config drawer.

## What to QA

- Open an agent's config drawer, Permissions section. The "Policy" select shows "Allow reads" at the left edge of the field, not centered.
- Same drawer, Execution environment section. The sandbox picker shows "Local" at the left and its chevron flush against the right edge.
- Regression: open a searchable select (Combobox) with a long selected label, and a Cascader. The label still truncates instead of overflowing, and the clear button still appears on hover over the chevron.
- Regression: the model picker (`SelectLLMProvider`) and the multi-select chip fields in the tool schema form still lay out as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
