### PR TITLE
chore(docker): include oss/scripts in OSS dev build

### DIFF
--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -57,6 +57,7 @@ services:
             #
             - ../../../web/oss/src:/app/oss/src
             - ../../../web/oss/public:/app/oss/public
+            - ../../../web/oss/scripts:/app/oss/scripts
             - ../../../web/packages:/app/packages
             - nextjs-oss-cache:/app/oss/.next/cache
             - turbo-oss-cache:/app/.turbo

--- a/web/oss/docker/Dockerfile.dev
+++ b/web/oss/docker/Dockerfile.dev
@@ -95,6 +95,7 @@ COPY --chown=agenta:agenta packages/agenta-chat/tsconfig.json ./packages/agenta-
 
 COPY --chown=agenta:agenta oss/src ./oss/src
 COPY --chown=agenta:agenta oss/public ./oss/public
+COPY --chown=agenta:agenta oss/scripts ./oss/scripts
 COPY --chown=agenta:agenta oss/tsconfig.json ./oss
 
 COPY --chown=agenta:agenta oss/postcss.config.mjs ./oss/postcss.config.mjs


### PR DESCRIPTION
## Description
The dev script runs `node scripts/copy-pdf-worker.mjs` on startup, but `Dockerfile.dev` never copied `oss/scripts/` into the image, and the dev compose did not mount it. This caused fresh OSS dev builds to fail with:



## Summary
**What changed?** Added the missing `oss/scripts/` directory to the OSS dev Docker image and compose mount.

**Why was this change needed?** The `dev` script in `web/oss/package.json` executes `node scripts/copy-pdf-worker.mjs` on startup. Since `Dockerfile.dev` only copied `oss/src/` and `oss/public/`, the script was absent from fresh builds, causing the container to exit immediately.

**What problem does it solve?** Fixes the OSS dev web container failing to boot on from-scratch builds since 2026-07-15.

**How the change addresses the root cause:** By copying `oss/scripts/` into the image during build and mounting it in dev compose, the `copy-pdf-worker.mjs` script is present both in fresh images and during live development.

## Changes
- **Dockerfile.dev**: Added `COPY --chown=agenta:agenta oss/scripts ./oss/scripts`
- **docker-compose.dev.yml**: Added volume mount `../../../web/oss/scripts:/app/oss/scripts`

## Testing
### Verified locally
- [x] Reproduced the failure with `bash hosting/docker-compose/run.sh --oss --dev --build` on a clean host
- [x] Verified `copy-pdf-worker.mjs` exists inside the container at `/app/oss/scripts/` (see Demo)
- [x] Verified the web container stays running (`Up 2 minutes`) without restarting
- [x] Verified the dev server starts its dependency resolution sequence without module errors

### Added or updated tests
N/A — This is a Docker build configuration fix with no application code changes.

### QA follow-up
N/A — The fix is self-contained and verified by the container boot sequence itself.

## Demo
**Before fix:** Container failed with `Cannot find module '/app/oss/scripts/copy-pdf-worker.mjs'`

**After fix:**

<img width="934" height="294" alt="image" src="https://github.com/user-attachments/assets/18f04f5a-a9b8-4d08-8f4a-0deda081b565" />
 — the `ls -la /app/oss/scripts/` showing `copy-pdf-worker.mjs`]*

<img width="644" height="472" alt="image" src="https://github.com/user-attachments/assets/b2522e80-0c5d-4e61-8c0d-ab9968afcd5f" />
 — `docker ps` showing `agenta-oss-dev-web-1` as `Up 2 minutes`]*

<img width="779" height="322" alt="image" src="https://github.com/user-attachments/assets/6fecc0c3-d2ba-43a8-b172-beff7c44d697" /> — `docker compose logs web` showing successful pnpm resolution/dev start]*

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

Fixes #5999