### PR TITLE
[fix] Wait for a request's arguments before calling it malformed [AGE-4095]

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -563,6 +563,7 @@ const AgentMessage = ({
                             onOutput={onClientToolOutput}
                             renderMap={renderMap}
                             degradedEarlierInTurn={degradedEarlierInTurn}
+                            turnStreaming={isStreaming}
                         />
                     )
                 }

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ClientToolPart.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ClientToolPart.tsx
@@ -28,12 +28,15 @@ const ClientToolPart = ({
     onOutput,
     renderMap,
     degradedEarlierInTurn,
+    turnStreaming,
 }: {
     part: ToolUIPart
     onOutput: ClientToolOutputHandler
     renderMap?: Map<string, RenderHintLike>
     /** Retry cap: an earlier part in this turn already auto-settled as an elicitation degradation. */
     degradedEarlierInTurn?: boolean
+    /** The turn is still streaming, so the part's `input` may still be refreshed. */
+    turnStreaming?: boolean
 }) => {
     const meta = clientToolMeta(part, renderMap)
     // The handler is a STABLE module-level component picked from the registry (not created during
@@ -61,7 +64,7 @@ const ClientToolPart = ({
 
     return (
         <div data-client-tool-call-id={meta.toolCallId}>
-            {createElement(handler, {meta, settle, degradedEarlierInTurn})}
+            {createElement(handler, {meta, settle, degradedEarlierInTurn, turnStreaming})}
         </div>
     )
 }

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.degradation.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.degradation.test.tsx
@@ -1,0 +1,189 @@
+/**
+ * Degradation only judges a FINAL payload (#5949).
+ *
+ * The runner surfaces a tool call before its args and refreshes them incrementally, so a live
+ * `request_input` part passes through `null` → `{}` → partial → complete. Judging one of those
+ * mid-stream settled the card as "Couldn't render this request." and lost the question.
+ *
+ * These drive that real frame sequence through the REAL parser; only the chrome is mocked.
+ */
+import {act} from "react"
+
+import {createRoot, type Root} from "react-dom/client"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+vi.mock("@agenta/entity-ui/gatewayTool", () => ({
+    SchemaForm: () => <div />,
+    formatReviewValue: (_field: unknown, value: unknown) => String(value),
+}))
+
+vi.mock("@agenta/shared/clientTools", () => ({
+    isInteractionEndedOutput: () => false,
+    CLIENT_TOOL_NAMES: new Set(["request_connection", "request_input"]),
+}))
+
+vi.mock("@agenta/shared/hooks", () => ({
+    useModifierKey: () => "⌘",
+}))
+
+vi.mock("@agenta/ui", () => ({
+    HeightCollapse: ({children}: {children?: React.ReactNode}) => <div>{children}</div>,
+}))
+
+vi.mock("@agenta/ui/rich-chat-input", () => ({
+    ShortcutHint: () => <span />,
+}))
+
+vi.mock("@phosphor-icons/react", () => ({
+    CaretRight: () => <i />,
+    CheckCircle: () => <i />,
+    Prohibit: () => <i />,
+    Question: () => <i />,
+    Warning: () => <i />,
+    XCircle: () => <i />,
+}))
+
+vi.mock("antd", () => ({
+    Button: ({children, onClick}: {children?: React.ReactNode; onClick?: () => void}) => (
+        <button type="button" onClick={onClick}>
+            {children}
+        </button>
+    ),
+    Form: {
+        useForm: () => [{validateFields: () => Promise.resolve({}), setFieldsValue: () => {}}],
+        useWatch: () => ({}),
+    },
+    Typography: {Text: ({children}: {children?: React.ReactNode}) => <span>{children}</span>},
+}))
+
+vi.mock("../../assets/toolDisplay", () => ({
+    resolveToolDisplay: () => ({label: "Elicitation"}),
+    canonicalToolName: (raw: string) => raw,
+}))
+
+import ElicitationWidget from "./ElicitationWidget"
+import type {ClientToolMeta, SettleClientTool} from "./types"
+
+/** The complete payload, as the PR-reviewer template's first `request_input` emits it. */
+const COMPLETE_INPUT = {
+    message: "Which repository should I review?",
+    requestedSchema: {
+        type: "object",
+        "x-ag-stepper": true,
+        properties: {
+            repository: {type: "string", title: "GitHub repository"},
+        },
+        required: ["repository"],
+    },
+}
+
+/**
+ * The shapes one tool call streams through, in order. Everything before the last is a placeholder
+ * the parser rejects — `null` is the one the issue recorded ("payload is not an object").
+ */
+const STREAMED_FRAMES: unknown[] = [
+    null,
+    {},
+    {message: "Which repository should I re"},
+    COMPLETE_INPUT,
+]
+
+const metaWith = (input: unknown): ClientToolMeta => ({
+    toolCallId: "call-1",
+    toolName: "request_input",
+    renderKind: "elicitation",
+    state: "input-available",
+    input,
+    output: undefined,
+    settled: false,
+    part: {} as ClientToolMeta["part"],
+})
+
+let container: HTMLDivElement
+let root: Root
+
+const render = async (
+    input: unknown,
+    settle: SettleClientTool,
+    opts: {turnStreaming?: boolean; degradedEarlierInTurn?: boolean} = {},
+) => {
+    await act(async () => {
+        root.render(
+            <ElicitationWidget
+                meta={metaWith(input)}
+                settle={settle}
+                turnStreaming={opts.turnStreaming}
+                degradedEarlierInTurn={opts.degradedEarlierInTurn}
+            />,
+        )
+    })
+}
+
+beforeEach(() => {
+    ;(globalThis as {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+})
+
+afterEach(async () => {
+    await act(async () => {
+        root.unmount()
+    })
+    container.remove()
+    vi.clearAllMocks()
+})
+
+describe("ElicitationWidget — degradation waits for the final payload", () => {
+    it("never settles while the turn streams the args in, then renders the form", async () => {
+        const settle = vi.fn()
+        for (const frame of STREAMED_FRAMES) {
+            await render(frame, settle, {turnStreaming: true})
+            expect(settle).not.toHaveBeenCalled()
+        }
+
+        expect(container.textContent).toContain("Which repository should I review?")
+    })
+
+    it("still does not settle once the turn parks on a payload that completed", async () => {
+        const settle = vi.fn()
+        await render(null, settle, {turnStreaming: true})
+        await render(COMPLETE_INPUT, settle, {turnStreaming: true})
+        await render(COMPLETE_INPUT, settle, {turnStreaming: false})
+
+        expect(settle).not.toHaveBeenCalled()
+        expect(container.textContent).toContain("Which repository should I review?")
+    })
+
+    it("degrades once when the turn parks on a payload that never completed", async () => {
+        const settle = vi.fn()
+        await render(null, settle, {turnStreaming: true})
+        await render(null, settle, {turnStreaming: false})
+
+        expect(settle).toHaveBeenCalledTimes(1)
+        expect(settle.mock.calls[0][0]).toEqual({
+            errorText: "elicitation: unsupported payload — payload is not an object",
+        })
+    })
+
+    it("degrades a genuinely malformed payload that is absent the streaming flag", async () => {
+        const settle = vi.fn()
+        await render({message: "no schema here"}, settle)
+
+        expect(settle).toHaveBeenCalledTimes(1)
+        expect(settle.mock.calls[0][0]).toEqual({
+            errorText: "elicitation: unsupported payload — missing requestedSchema",
+        })
+    })
+
+    it("holds the parked notice until the args are final", async () => {
+        const settle = vi.fn()
+        await render(null, settle, {turnStreaming: true, degradedEarlierInTurn: true})
+        expect(container.textContent).not.toContain("needs attention")
+
+        await render(null, settle, {turnStreaming: false, degradedEarlierInTurn: true})
+        expect(container.textContent).toContain("needs attention")
+        // The retry cap still holds: a parked card notifies, it never auto-settles.
+        expect(settle).not.toHaveBeenCalled()
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.tsx
@@ -118,7 +118,12 @@ const SubmittedAnswers = ({
     )
 }
 
-const ElicitationWidget = ({meta, settle, degradedEarlierInTurn}: ClientToolHandlerProps) => {
+const ElicitationWidget = ({
+    meta,
+    settle,
+    degradedEarlierInTurn,
+    turnStreaming,
+}: ClientToolHandlerProps) => {
     const [form] = Form.useForm()
     const formRef = useRef<SchemaFormHandle>(null)
     const modifierKey = useModifierKey()
@@ -141,15 +146,19 @@ const ElicitationWidget = ({meta, settle, degradedEarlierInTurn}: ClientToolHand
     })
     const requiredReady = missingRequired.length === 0
 
+    // The runner surfaces a tool call before its args and refreshes them incrementally, so
+    // mid-stream a payload reads malformed while it is merely unfinished (#5949).
+    const inputFinal = turnStreaming !== true
+
     // Degradation: invalid payload auto-settles errorText ONCE per turn; a repeat malformed
     // emission parks instead (visible notice, no auto-settle) — no settle→resume→re-emit loop.
-    const parked = !parsed.ok && degradedEarlierInTurn === true
+    const parked = inputFinal && !parsed.ok && degradedEarlierInTurn === true
     const settledRef = useRef(false)
     useEffect(() => {
-        if (parsed.ok || parked || settledRef.current || meta.settled) return
+        if (!inputFinal || parsed.ok || parked || settledRef.current || meta.settled) return
         settledRef.current = true
         settle({errorText: buildDegradationErrorText(parsed.reason)})
-    }, [parsed, parked, meta.settled, settle])
+    }, [inputFinal, parsed, parked, meta.settled, settle])
 
     // Draft persistence: typed values live only in antd Form state, so a reload would lose them.
     const draftKey = draftKeyFor(meta.toolCallId)

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/types.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/types.ts
@@ -52,4 +52,6 @@ export interface ClientToolHandlerProps {
     /** Retry cap (elicitation): an earlier part in this turn already auto-settled as a
      * degradation — the widget PARKS (visible notice, no auto-settle) instead of looping. */
     degradedEarlierInTurn?: boolean
+    /** The turn is still streaming, so `input` is NOT final — a widget must not validate it yet. */
+    turnStreaming?: boolean
 }


### PR DESCRIPTION
## Context

When an agent asked a question mid-run, the card sometimes rendered as an amber "Couldn't render this request." chip instead of the form. The question was lost, the agent carried on as if it had been answered, and a reload replayed the same chip because the failure was already saved.

The recorded error said `payload is not an object`, yet the saved `input` held a perfectly good payload. Both were true because the parse ran before the arguments arrived.

The runner surfaces a tool call before its arguments exist and fills them in afterwards, and it does so on purpose (`services/runner/src/tracing/otel.ts`: the call "MUST surface before any approval/result for this id", so the args are refreshed later, "never by delaying this"). The args then land incrementally, as a growing partial parse. So a live `request_input` part passes through a sequence of shapes:

```
null                                     -> "payload is not an object"
{}                                       -> "missing message"
{message: "Which repository should I re"} -> "missing requestedSchema"
{message, requestedSchema: {...}}         -> the real payload
```

`ElicitationWidget` validated whichever shape it happened to mount on and auto-settled a permanent error. Whether it caught a placeholder depended on where `useChat`'s 50ms throttle boundary fell against the stream, which is why the same session could fail once and render fine the next time.

## Changes

The widget now judges the payload only once the turn stops streaming, which is the point at which the args are final. Both the degradation settle and the parked "needs attention" notice wait for it.

A narrower check does not work. Testing `input != null` misses the `{}` announce, and testing `state === "input-available"` misses every partial, because the part is already `input-available` from the first frame onward.

`turnStreaming` threads from `AgentMessage` (which already held `isStreaming`) through `ClientToolPart` to the widget, matching how the sibling `degradedEarlierInTurn` flag is already passed. The default is safe: a caller that omits it degrades exactly as before, so nothing can hang.

This also brings elicitation in line with a rule the codebase already had. `UnhandledClientTool` can only mount when the turn is not streaming, so it never auto-settles mid-stream. Elicitation was the exception.

A genuinely malformed payload still degrades the moment the turn parks.

## Tests / notes

- New `ElicitationWidget.degradation.test.tsx` drives the real frame sequence above through the real parser (only the chrome is mocked) and pins that the widget waits. I confirmed it is not vacuous: with the gate disabled, the three cases covering the fix fail and the two covering unchanged behaviour still pass.
- `pnpm vitest run src/components/AgentChatSlice`: 490 passed, 1 skipped. `pnpm lint-fix` clean.
- No runner or SDK change. The late arguments are deliberate, the tracing layer cannot know a call is a client tool when it announces it, and both `client_tool` emit sites already carry complete args. The bug was the frontend reading "not finished" as "malformed".
- This stops new occurrences only. Sessions that already degraded have the error saved in their interaction row, so they replay the same chip.
- Known gap, not fixed here: if two genuinely malformed elicitations park in the same commit, both settle instead of one settling and one parking, because `degradedEarlierInTurn` only flips once a part carries the error text. That is two error settles, not a resume loop, and fixing it properly would pull payload validation up into `AgentMessage`.
- `ConnectToolWidget` reads `meta.input` under the same assumption and does not take this flag. It degrades gracefully (a briefly wrong label, no auto-settle), so it is not broken today. It is the second widget that would want this, which is when moving `inputFinal` onto `ClientToolMeta` starts to pay off.

## What to QA

- Open the templates gallery, pick the PR reviewer template, and let the builder agent run its first turn without typing anything. The card after `discover_tools` shows the stepper form ("1. GitHub repository", "Review posture", "Risk focus"), never an amber "Couldn't render this request." chip.
- Repeat that on a few fresh sessions. The bug was timing dependent, so one clean run is not proof.
- Answer the form and continue. The agent receives the answers and the card collapses to a single line showing what you submitted.
- Click Decline on a question, then Dismiss on another. Each settles to its own chip and the run resumes.
- Regression: a connect request (an agent asking for a GitHub connection) still renders its Connect / Not now row and completes.