### PR TITLE
fix(channels): resolve the migration id collision with v0.112.1

### DIFF
--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000022_add_channels.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000022_add_channels.py
@@ -1,7 +1,7 @@
 """add channels
 
-Revision ID: oss000000021
-Revises: oss000000020
+Revision ID: oss000000022
+Revises: oss000000021
 Create Date: 2026-08-07 00:00:00.000000
 
 Every channels table lands in this one revision, `channel_identity_links`
@@ -18,8 +18,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import JSONB
 
 
-revision: str = "oss000000021"
-down_revision: Union[str, None] = "oss000000020"
+revision: str = "oss000000022"
+down_revision: Union[str, None] = "oss000000021"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 


### PR DESCRIPTION
## Context
Deploying `feat/add-channels` on a fresh stack failed before the API could start. Alembic stopped with "multiple head revisions": this branch's `add_channels` migration and the release's `add_session_streams_references` both claim revision id `oss000000021`. The collision arrived when the branch merged v0.112.1. Until this is fixed, no deployment of the branch can migrate any database that includes the release.

## Changes
The channels migration is renumbered to `oss000000022`, on top of the release migration. Nothing inside the migration changed; only the id, the down revision, and the filename.

Before: `oss000000020 -> {oss000000021 add_session_streams_references, oss000000021 add_channels}` (two heads, duplicate id)
After: `oss000000020 -> oss000000021 add_session_streams_references -> oss000000022 add_channels`

## Tests / notes
- A fresh EE database migrates cleanly through the whole chain (verified on the live channels test stack; the deploy that found this now runs).
- Caveat for dev databases that already applied the old id: bump the `alembic_version_oss` row from the channels `oss000000021` to `oss000000022` by hand, or the runner will try to re-apply the channels DDL.

Found while deploying the branch against a real Slack workspace (finding F1 of that deployment's field report).
