### PR TITLE
fix(channels): stop dropping every top-level Slack message

### DIFF
--- a/api/oss/src/core/channels/adapters/slack/adapter.py
+++ b/api/oss/src/core/channels/adapters/slack/adapter.py
@@ -257,8 +257,13 @@ class SlackAdapter(ChannelAdapterInterface):
 
         text = event.get("text") or ""
         agent, command, _arg = extract_sigils(text)
-        thread_ts = event.get("thread_ts")
         event_ts = event.get("ts") or ""
+        # A top-level message carries no thread_ts; per Slack's own threading
+        # model it roots a thread keyed by its own ts. Without this fallback
+        # the THREAD key composition raises ChannelLocatorIncomplete and every
+        # non-threaded channel message dies in dispatch (and the reply could
+        # not thread under the message it answers anyway).
+        thread_ts = event.get("thread_ts") or event_ts or None
 
         locator = build_locator(team=team_id, channel=channel_id, thread_ts=thread_ts)
 

--- a/api/oss/tests/pytest/unit/channels/slack/test_slack_adapter.py
+++ b/api/oss/tests/pytest/unit/channels/slack/test_slack_adapter.py
@@ -361,7 +361,14 @@ async def test_parse_event_classifies_each_container_kind(event_extra, expected)
     assert parsed.space_kind == expected
 
 
-async def test_threaded_message_and_channel_message_resolve_different_units():
+async def test_a_top_level_message_and_replies_threaded_under_it_resolve_one_unit():
+    """Slack's threading model: a top-level message roots the thread its
+    replies live in — a reply's thread_ts IS the parent's ts. The previous
+    expectation (no thread_ts on a top-level message) was a shape the THREAD
+    key composition could not consume anyway: the field is declared required,
+    so it raised ChannelLocatorIncomplete and every non-threaded channel
+    message died in dispatch."""
+
     adapter = SlackAdapter()
 
     threaded = await adapter.parse_event(
@@ -375,12 +382,12 @@ async def test_threaded_message_and_channel_message_resolve_different_units():
             }
         )
     )
-    untethered = await adapter.parse_event(
+    parent = await adapter.parse_event(
         body=_event_callback({"channel": "C1", "user": "U1", "text": "hi", "ts": "1.1"})
     )
 
     assert threaded.external_locator["thread_ts"] == "1.1"
-    assert "thread_ts" not in untethered.external_locator
+    assert parent.external_locator["thread_ts"] == "1.1"
 
 
 async def test_two_distinct_threads_compose_to_distinct_external_keys():
@@ -964,3 +971,39 @@ async def test_revoke_installation_still_returns_a_notice_if_slack_rejects_the_c
     notice = await adapter.revoke_installation(connection=_hosted_connection())
 
     assert notice is not None
+
+
+async def test_parse_event_top_level_message_roots_its_own_thread():
+    """A top-level message carries no thread_ts. Slack's own threading model
+    keys the thread it starts by the message's own ts — without that fallback
+    the THREAD key composition raised ChannelLocatorIncomplete and every
+    non-threaded channel message died in dispatch (and the reply could not
+    thread under the message it answers)."""
+
+    adapter = SlackAdapter()
+    body = _event_callback(
+        {"channel": "C1", "user": "U1", "text": "hello", "ts": "42.1"}
+    )
+
+    event = await adapter.parse_event(body=body)
+
+    assert event is not None
+    assert event.external_locator["thread_ts"] == "42.1"
+
+
+async def test_parse_event_threaded_reply_keeps_the_parent_thread_ts():
+    adapter = SlackAdapter()
+    body = _event_callback(
+        {
+            "channel": "C1",
+            "user": "U1",
+            "text": "reply",
+            "ts": "43.9",
+            "thread_ts": "42.1",
+        }
+    )
+
+    event = await adapter.parse_event(body=body)
+
+    assert event is not None
+    assert event.external_locator["thread_ts"] == "42.1"


### PR DESCRIPTION
## Context
Mentioning the bot with a plain, top-level channel message produced nothing in Slack: no reply, no error. The dispatch worker crashed on every such message with `ChannelLocatorIncomplete: Locator for slack is missing declared thread key field: thread_ts`. Slack only puts `thread_ts` on messages inside a thread; a top-level message has none, and the THREAD key composition declares the field required. Only messages typed inside an existing thread ever worked.

## Changes
`parse_event` now falls back to the message's own `ts` when `thread_ts` is absent. This is Slack's own threading model: a top-level message roots the thread its replies live in, and a reply's `thread_ts` is the parent's `ts`. It also means the agent's answer lands as a thread reply under the mention it answers.

Before: `{"team": "T1", "channel": "C1"}` (no thread key, dispatch raises)
After: `{"team": "T1", "channel": "C1", "thread_ts": "<the message's own ts>"}`

One existing test pinned the old shape (`thread_ts` absent on a top-level message). That shape was one the rest of the system could not consume. The test now pins the new semantics: a parent and the replies threaded under it resolve to one unit.

## Tests
- New: a top-level message roots its own thread; a threaded reply keeps its parent's `thread_ts`.
- Full channels unit tier passes (645 tests).
- Verified live: a real mention in a real workspace now runs the agent and gets a threaded reply (finding F4 of the deployment field report).
