### PR TITLE
fix(channels): deliver the first reply on a thread

### DIFF
--- a/api/oss/src/tasks/asyncio/channels/outbox.py
+++ b/api/oss/src/tasks/asyncio/channels/outbox.py
@@ -129,6 +129,7 @@ class ChannelsOutboxWorker:
             connection=connection,
             capabilities=capabilities,
             item=item,
+            thread=thread,
         )
 
     # --- turn ended ---------------------------------------------------------#
@@ -193,6 +194,7 @@ class ChannelsOutboxWorker:
                 connection=connection,
                 capabilities=capabilities,
                 item=item,
+                thread=thread,
             )
 
     # --- send: post or edit, then record the receipt ------------------------#
@@ -205,6 +207,7 @@ class ChannelsOutboxWorker:
         connection: ChannelConnection,
         capabilities: ChannelCapabilities,
         item: RenderItem,
+        thread: ChannelThread,
     ) -> None:
         content = [part.model_dump(exclude_none=True) for part in item.parts]
 
@@ -234,9 +237,13 @@ class ChannelsOutboxWorker:
                 idempotency_key=idempotency_key,
             )
         else:
+            # First post for this item: no receipt exists yet, so the target
+            # comes from the THREAD's locator (team/channel/thread_ts). An
+            # empty locator here KeyError'd inside the Slack adapter and the
+            # first-ever reply on any thread silently never reached Slack.
             receipt = await adapter.post_message(
                 connection=connection,
-                locator={},
+                locator=thread.data.external_locator or {},
                 content=content,
                 idempotency_key=idempotency_key,
             )

--- a/api/oss/tests/pytest/unit/channels/test_channels_outbox_worker.py
+++ b/api/oss/tests/pytest/unit/channels/test_channels_outbox_worker.py
@@ -72,13 +72,15 @@ class FakeChannelsDAO(ChannelsDAOInterface):
         self.spaces[space.id] = space
         return space
 
-    def seed_thread(self, *, space_id: UUID, session_id: str) -> ChannelThread:
+    def seed_thread(
+        self, *, space_id: UUID, session_id: str, external_locator=None
+    ) -> ChannelThread:
         thread = ChannelThread(
             id=uuid4(),
             space_id=space_id,
             agent_id=uuid4(),
             session_id=session_id,
-            data=ChannelThreadData(),
+            data=ChannelThreadData(external_locator=external_locator),
         )
         self.threads[thread.id] = thread
         return thread
@@ -919,3 +921,53 @@ class TestChannelsOutboxStreamWorker:
 
         assert total == 0
         assert processed_ids == []
+
+
+class _PostLocatorSpy(WellBehavedFakeAdapter):
+    """Records the locator each post_message receives; delegates otherwise."""
+
+    def __init__(self):
+        super().__init__()
+        self.post_locators: List[Dict] = []
+
+    async def post_message(self, *, connection, locator, content, idempotency_key):
+        self.post_locators.append(locator)
+        return await super().post_message(
+            connection=connection,
+            locator=locator,
+            content=content,
+            idempotency_key=idempotency_key,
+        )
+
+
+@pytest.mark.asyncio
+async def test_the_first_post_of_a_turn_targets_the_thread_s_locator():
+    """No receipt exists before the first post, so its target can only come
+    from the THREAD's locator. An empty locator here KeyError'd inside the
+    Slack adapter (`locator["channel"]`) and the first answer on any thread
+    was silently never delivered."""
+
+    channels_dao = FakeChannelsDAO()
+    spy = _PostLocatorSpy()
+    service = ChannelsService(
+        channels_dao=channels_dao,
+        adapter_registry=ChannelAdapterRegistry(adapters={"fake": spy}),
+    )
+    worker = ChannelsOutboxWorker(
+        channels_service=service,
+        turns_service=SessionTurnsService(turns_dao=FakeTurnsDAO()),
+        records_service=RecordsService(FakeRecordsDAO()),
+    )
+    connection = channels_dao.seed_connection(channel="fake")
+    space = channels_dao.seed_space(connection_id=connection.id)
+    thread = channels_dao.seed_thread(
+        space_id=space.id,
+        session_id="s-locator",
+        external_locator={"channel": "C1", "thread_ts": "42.1"},
+    )
+
+    await worker.on_turn_started(
+        project_id=PROJECT_ID, thread=thread, turn_id="turn-locator"
+    )
+
+    assert spy.post_locators == [{"channel": "C1", "thread_ts": "42.1"}]


### PR DESCRIPTION
## Context
The agent ran and answered, the playground showed the reply, and Slack showed "Working…" forever. The delivery worker crashed with `KeyError: 'channel'` inside the Slack adapter. The first post for an outbox item has no receipt yet, and that branch of `_send` passed an empty locator, although the thread row holds the full target (team, channel, thread timestamp). The first-ever answer on any thread could never be delivered.

## Changes
`_send` now takes the thread and uses `thread.data.external_locator` for the no-receipt post. Later posts and edits keep using the stored receipt, unchanged.

This is the same defect class the branch's ledger records for the bridge adapter (F63): a read with no writer, which survived because test fixtures seeded the receipt directly and never exercised the first post.

## Tests
- New: the first post of a turn targets the thread's own locator (spy adapter records what `post_message` receives).
- Full channels unit tier passes (645 tests).
- Verified live: first replies now land in the Slack thread (finding F6 of the deployment field report).
