### PR TITLE
fix(channels): close the bot-echo cascade and the empty-answer delivery path

### DIFF
--- a/api/oss/src/core/channels/adapters/slack/adapter.py
+++ b/api/oss/src/core/channels/adapters/slack/adapter.py
@@ -40,6 +40,9 @@ from oss.src.core.channels.types import (
     ChannelSignatureInvalid,
 )
 from oss.src.utils.env import env
+from oss.src.utils.logging import get_module_logger
+
+log = get_module_logger(__name__)
 
 _SLACK_API_BASE = "https://slack.com/api"
 
@@ -248,6 +251,17 @@ class SlackAdapter(ChannelAdapterInterface):
             return None
 
         event = payload.get("event") or {}
+
+        # Edits and deletions arrive as message subtypes whose author lives in
+        # the NESTED event["message"], not on the outer event. Our own
+        # indicator edit ("Working…" -> answer, chat.update) therefore read as
+        # authorless human input, rooted a phantom thread off the edit's
+        # synthetic ts, and ran a real turn whose post was edited in turn -- a
+        # self-sustaining bot-echo cascade. No edit-processing path exists, so
+        # drop these subtypes outright (QA finding, 2026-08-17).
+        if event.get("subtype") in ("message_changed", "message_deleted"):
+            return None
+
         team_id = payload.get("team_id") or ""
         channel_id = event.get("channel") or ""
 
@@ -289,7 +303,7 @@ class SlackAdapter(ChannelAdapterInterface):
         text, blocks = _render_content(content)
         receipts = []
         for chunk in split_for_max_chars(text, max_chars=MAX_CHARS) or [""]:
-            response = await self._call(
+            response = await self._call_with_blocks_fallback(
                 connection,
                 "chat.postMessage",
                 {
@@ -312,7 +326,7 @@ class SlackAdapter(ChannelAdapterInterface):
         idempotency_key: UUID,
     ) -> Dict[str, Any]:
         text, blocks = _render_content(content)
-        response = await self._call(
+        response = await self._call_with_blocks_fallback(
             connection,
             "chat.update",
             {
@@ -423,6 +437,28 @@ class SlackAdapter(ChannelAdapterInterface):
         )
 
     # --- internals --- #
+
+    async def _call_with_blocks_fallback(
+        self, connection: ChannelConnection, method: str, params: Dict[str, Any]
+    ) -> Dict[str, Any]:
+        """Last-resort guard: deliver the text without blocks rather than lose
+        the answer, and log the rejected payload verbatim. The one rejection
+        cause observed so far was OURS (an empty mrkdwn section from an empty
+        fold -- now prevented upstream), not Slack flakiness; this fallback
+        stays for whatever rejection shape shows up next, and the log line is
+        what makes that diagnosable (QA, 2026-08-17)."""
+
+        try:
+            return await self._call(connection, method, params)
+        except _SlackApiError as e:
+            if e.error != "invalid_blocks" or not params.get("blocks"):
+                raise
+            log.warning(
+                "[slack] %s rejected blocks; retrying text-only. blocks=%s",
+                method,
+                json.dumps(params.get("blocks"))[:3000],
+            )
+            return await self._call(connection, method, {**params, "blocks": None})
 
     async def _call(
         self, connection: ChannelConnection, method: str, params: Dict[str, Any]
@@ -567,7 +603,10 @@ def _render_content(content: List[Dict[str, Any]]) -> tuple:
     text = "\n".join(t for t in texts if t)
     blocks: List[Dict[str, Any]] = []
 
-    if texts:
+    # `if texts:` let an all-empty text list emit a section with empty mrkdwn,
+    # which Slack rejects wholesale as invalid_blocks -- the fallback `" "`
+    # below guards only the text field, not the blocks (QA, 2026-08-17).
+    if text:
         blocks.append({"type": "section", "text": {"type": "mrkdwn", "text": text}})
 
     if buttons:

--- a/api/oss/src/core/channels/adapters/slack/mapping.py
+++ b/api/oss/src/core/channels/adapters/slack/mapping.py
@@ -96,6 +96,14 @@ def is_bot_authored(event: Dict[str, Any], *, bot_user_id: Optional[str]) -> boo
         return True
     if bot_user_id and event.get("user") == bot_user_id:
         return True
+    # Subtypes like message_changed nest the authored message one level down;
+    # authorship must be visible there too, or our own edits read as human.
+    nested = event.get("message")
+    if isinstance(nested, dict):
+        if nested.get("bot_id"):
+            return True
+        if bot_user_id and nested.get("user") == bot_user_id:
+            return True
     return False
 
 

--- a/api/oss/src/tasks/asyncio/channels/outbox.py
+++ b/api/oss/src/tasks/asyncio/channels/outbox.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timezone
 from typing import Dict, List, Optional, Tuple
 from uuid import UUID
@@ -29,6 +30,12 @@ from oss.src.tasks.asyncio.shared.consumer import StreamConsumer
 from oss.src.utils.logging import get_module_logger
 
 log = get_module_logger(__name__)
+
+# One read plus two re-reads, 0.8s apart: enough to cover the ~150ms commit
+# race measured live with room to spare, and short enough that a genuinely
+# empty turn still reports within two seconds.
+_EMPTY_FOLD_ATTEMPTS = 3
+_EMPTY_FOLD_BACKOFF_SECONDS = 0.8
 
 
 class ChannelsOutboxWorker:
@@ -148,19 +155,52 @@ class ChannelsOutboxWorker:
             project_id=project_id, thread=thread
         )
 
-        records = await self.records_service.get_records(
-            project_id=project_id, session_id=session_id
-        )
-        # The answer is what the agent said. The inbound user turn is persisted
-        # into the same log, and fold() labels every message record `assistant`,
-        # so without this the reply repeats the user back to themselves.
-        turn_events = [
-            {"type": record.record_type, "data": record.attributes}
-            for record in records
-            if record.turn_id == turn_id and record.record_source == "agent"
-        ]
+        # The turn-ended event can outrun the final record commit (measured
+        # ~150ms live): reading too early folds to an EMPTY answer, which used
+        # to render an empty section Slack rejects, orphaning the indicator.
+        # A bounded re-read absorbs the race; the real ordering guarantee is a
+        # design question (QA, 2026-08-17).
+        folded: Dict = {}
+        has_answer = False
+        for attempt in range(_EMPTY_FOLD_ATTEMPTS):
+            records = await self.records_service.get_records(
+                project_id=project_id, session_id=session_id
+            )
+            # The answer is what the agent said. The inbound user turn is
+            # persisted into the same log, and fold() labels every message
+            # record `assistant`, so without this the reply repeats the user
+            # back to themselves.
+            turn_events = [
+                {"type": record.record_type, "data": record.attributes}
+                for record in records
+                if record.turn_id == turn_id and record.record_source == "agent"
+            ]
 
-        folded = fold(turn_events, stop_reason=None)
+            folded = fold(turn_events, stop_reason=None)
+            has_answer = bool(
+                any(
+                    (message.get("content") or "") != ""
+                    for message in (folded.get("messages") or [])
+                    if message.get("role") == "assistant"
+                )
+                or folded.get("pending_interaction")
+            )
+            if has_answer or attempt == _EMPTY_FOLD_ATTEMPTS - 1:
+                break
+            await asyncio.sleep(_EMPTY_FOLD_BACKOFF_SECONDS)
+
+        # Still empty after the bounded re-reads: leave the indicator in place
+        # and fail LOUDLY rather than edit in a blank bubble. A silent empty
+        # delivery marks the row SENT and erases the only signal that the
+        # answer was lost (DM-wave finding, 2026-08-17).
+        if not has_answer:
+            log.error(
+                "[SESSIONS-OUTBOX] answer still empty after re-reads; leaving "
+                "indicator un-edited turn=%s session=%s",
+                turn_id,
+                session_id,
+            )
+            return
 
         items = render_turn_result(capabilities=capabilities, folded=folded)
 

--- a/api/oss/tests/pytest/unit/channels/slack/test_slack_adapter.py
+++ b/api/oss/tests/pytest/unit/channels/slack/test_slack_adapter.py
@@ -10,6 +10,8 @@ import pytest
 
 from oss.src.core.channels.adapters.slack.adapter import (
     SlackAdapter,
+    _render_content,
+    _SlackApiError,
 )
 from oss.src.core.channels.dtos import (
     ChannelConnection,
@@ -339,6 +341,49 @@ async def test_parse_event_unaddressed_message_marks_addressed_false():
 
     assert event is not None
     assert event.addressed is False
+
+
+async def test_parse_event_ignores_our_own_indicator_edit():
+    """The bot-echo cascade. Editing "Working…" into the answer comes back as
+    a `message_changed` whose author sits in the NESTED message, so the outer
+    event read as authorless human input: the adapter rooted a phantom thread
+    off the edit's synthetic ts, ran a real turn, posted, edited that post,
+    and went round again (observed four deep, one paid run every ~14s)."""
+
+    connection = _connection(bot_user_id="UBOT1")
+    adapter = SlackAdapter()
+    body = _event_callback(
+        {
+            "channel": "C1",
+            "subtype": "message_changed",
+            "ts": "2.2",
+            "message": {"user": "UBOT1", "text": "the answer", "ts": "1.1"},
+        }
+    )
+
+    assert await adapter.parse_event(body=body, connection=connection) is None
+
+
+@pytest.mark.parametrize("subtype", ["message_changed", "message_deleted"])
+async def test_parse_event_drops_edit_and_delete_subtypes(subtype):
+    """No path processes an edit or a deletion, so even a human's edit must
+    not enter as fresh input — it would re-run a turn already answered."""
+
+    adapter = SlackAdapter()
+    body = _event_callback(
+        {
+            "channel": "C1",
+            "subtype": subtype,
+            "ts": "2.2",
+            "message": {
+                "user": "U1",
+                "text": "<@UBOT1> rethought question",
+                "ts": "1.1",
+            },
+        }
+    )
+
+    assert await adapter.parse_event(body=body) is None
 
 
 @pytest.mark.parametrize(
@@ -811,6 +856,76 @@ async def test_content_over_max_chars_splits_into_multiple_posts():
     )
 
     assert len(transport.requests) == 2
+
+
+def test_empty_text_emits_no_section_block():
+    """Slack rejects a section whose mrkdwn text is empty, and rejects the
+    whole payload with it. The guard used to be `if texts:` — a list holding
+    one empty string is truthy, so an empty fold rendered exactly the block
+    Slack refuses. The fallback text keeps its `" "`; the blocks go away."""
+
+    text, blocks = _render_content([{"type": "text", "text": ""}])
+
+    assert blocks == []
+    assert text == " "
+
+
+async def test_post_message_with_no_answer_text_sends_no_blocks():
+    adapter, transport = _adapter_with_stub([{"ok": True, "channel": "C1", "ts": "1"}])
+
+    await adapter.post_message(
+        connection=_connection(),
+        locator={"channel": "C1"},
+        content=[{"type": "text", "text": ""}],
+        idempotency_key=uuid4(),
+    )
+
+    assert not json.loads(transport.requests[0].content).get("blocks")
+
+
+async def test_a_blocks_rejection_retries_the_same_message_text_only():
+    """Last-resort guard: an answer is worth more than its formatting. The
+    rejected payload is logged verbatim, because a rejection we cannot see the
+    shape of is a rejection we cannot fix."""
+
+    adapter, transport = _adapter_with_stub(
+        [
+            {"ok": False, "error": "invalid_blocks"},
+            {"ok": True, "channel": "C1", "ts": "1"},
+        ]
+    )
+
+    receipt = await adapter.post_message(
+        connection=_connection(),
+        locator={"channel": "C1"},
+        content=[{"type": "text", "text": "the answer"}],
+        idempotency_key=uuid4(),
+    )
+
+    assert receipt == {"channel": "C1", "ts": "1"}
+    assert len(transport.requests) == 2
+    retried = json.loads(transport.requests[1].content)
+    assert "blocks" not in retried  # _call drops None params
+    assert retried["text"] == "the answer"
+
+
+async def test_a_rejection_that_is_not_about_blocks_is_not_retried():
+    """The fallback must not turn every Slack error into a second call —
+    `channel_not_found` fails the same way twice and hides the real cause."""
+
+    adapter, transport = _adapter_with_stub(
+        [{"ok": False, "error": "channel_not_found"}]
+    )
+
+    with pytest.raises(_SlackApiError):
+        await adapter.post_message(
+            connection=_connection(),
+            locator={"channel": "C1"},
+            content=[{"type": "text", "text": "the answer"}],
+            idempotency_key=uuid4(),
+        )
+
+    assert len(transport.requests) == 1
 
 
 # --- fetch_history / backfill refusal ---------------------------------------- #

--- a/api/oss/tests/pytest/unit/channels/slack/test_slack_mapping.py
+++ b/api/oss/tests/pytest/unit/channels/slack/test_slack_mapping.py
@@ -97,6 +97,29 @@ def test_message_from_a_human_is_not_bot_authored():
     assert is_bot_authored({"user": "U1"}, bot_user_id="U999") is False
 
 
+def test_a_nested_edited_message_carries_its_authorship_one_level_down():
+    """`message_changed` puts the authored message in `event["message"]` and
+    leaves the outer event authorless. Reading only the outer event made our
+    own "Working…" -> answer edit look like human input, which is how the
+    bot-echo cascade started."""
+
+    event = {"subtype": "message_changed", "message": {"bot_id": "B123"}}
+
+    assert is_bot_authored(event, bot_user_id=None) is True
+
+
+def test_a_nested_message_from_our_own_bot_user_id_is_bot_authored():
+    event = {"subtype": "message_changed", "message": {"user": "U999"}}
+
+    assert is_bot_authored(event, bot_user_id="U999") is True
+
+
+def test_a_nested_message_from_a_human_is_still_not_bot_authored():
+    event = {"subtype": "message_changed", "message": {"user": "U1"}}
+
+    assert is_bot_authored(event, bot_user_id="U999") is False
+
+
 # --- outbound: splitting, button degradation, approval cards --------------- #
 
 

--- a/api/oss/tests/pytest/unit/channels/test_channels_outbox_worker.py
+++ b/api/oss/tests/pytest/unit/channels/test_channels_outbox_worker.py
@@ -971,3 +971,119 @@ async def test_the_first_post_of_a_turn_targets_the_thread_s_locator():
     )
 
     assert spy.post_locators == [{"channel": "C1", "thread_ts": "42.1"}]
+
+
+class _LateCommitRecordsDAO(FakeRecordsDAO):
+    """Answers the first `empty_reads` reads with nothing, then with whatever
+    was seeded — the live race where the turn-ended event outran the final
+    record commit (~150ms measured)."""
+
+    def __init__(self, *, empty_reads: int):
+        super().__init__()
+        self._empty_reads = empty_reads
+        self.reads = 0
+
+    async def get_records(self, *, project_id, session_id):
+        self.reads += 1
+        if self.reads <= self._empty_reads:
+            return []
+        return await super().get_records(project_id=project_id, session_id=session_id)
+
+
+def _worker_over(channels_dao, records_dao) -> ChannelsOutboxWorker:
+    return ChannelsOutboxWorker(
+        channels_service=ChannelsService(
+            channels_dao=channels_dao,
+            adapter_registry=ChannelAdapterRegistry(
+                adapters={"fake": WellBehavedFakeAdapter()}
+            ),
+        ),
+        turns_service=SessionTurnsService(turns_dao=FakeTurnsDAO()),
+        records_service=RecordsService(records_dao),
+    )
+
+
+def _delivered_text(channels_dao) -> str:
+    return " ".join(
+        part.get("text") or ""
+        for row in channels_dao.outbox.values()
+        for part in (row.data.processed or {}).get("content", [])
+    )
+
+
+@pytest.mark.asyncio
+async def test_an_empty_fold_is_re_read_before_it_is_rendered(monkeypatch):
+    """The turn-ended event can arrive before the agent's last record is
+    committed. Folding that early read yields an EMPTY answer, which rendered
+    an empty Slack section (rejected as invalid_blocks) and orphaned the
+    indicator on "Working…". The read is retried before anything renders."""
+
+    monkeypatch.setattr(
+        "oss.src.tasks.asyncio.channels.outbox._EMPTY_FOLD_BACKOFF_SECONDS", 0
+    )
+
+    channels_dao = FakeChannelsDAO()
+    records_dao = _LateCommitRecordsDAO(empty_reads=1)
+    worker = _worker_over(channels_dao, records_dao)
+    _, thread = await _seed_connection_and_thread(channels_dao, "sess-race")
+
+    await worker.on_turn_started(
+        project_id=PROJECT_ID, thread=thread, turn_id="turn-race"
+    )
+    records_dao.seed(
+        session_id="sess-race",
+        turn_id="turn-race",
+        record_type="message",
+        attributes={"text": "the answer that was still committing"},
+    )
+
+    await worker.on_turn_ended(
+        project_id=PROJECT_ID,
+        thread=thread,
+        turn_id="turn-race",
+        session_id="sess-race",
+    )
+
+    assert records_dao.reads == 2  # the early read, then the one that won
+    assert "the answer that was still committing" in _delivered_text(channels_dao)
+
+
+@pytest.mark.asyncio
+async def test_a_fold_still_empty_after_the_re_reads_leaves_the_indicator_alone(
+    monkeypatch, caplog
+):
+    """A blank bubble is worse than no bubble: editing the indicator into an
+    empty answer marks the row SENT and erases the only signal that the answer
+    was lost. When the re-reads run out, the indicator stays and the worker
+    fails loudly instead."""
+
+    monkeypatch.setattr(
+        "oss.src.tasks.asyncio.channels.outbox._EMPTY_FOLD_BACKOFF_SECONDS", 0
+    )
+
+    channels_dao = FakeChannelsDAO()
+    records_dao = _LateCommitRecordsDAO(empty_reads=99)  # nothing ever commits
+    worker = _worker_over(channels_dao, records_dao)
+    _, thread = await _seed_connection_and_thread(channels_dao, "sess-empty")
+
+    await worker.on_turn_started(
+        project_id=PROJECT_ID, thread=thread, turn_id="turn-empty"
+    )
+    indicator = _delivered_text(channels_dao)
+    assert indicator  # the indicator did post, and is what must survive
+
+    with caplog.at_level("ERROR"):
+        await worker.on_turn_ended(
+            project_id=PROJECT_ID,
+            thread=thread,
+            turn_id="turn-empty",
+            session_id="sess-empty",
+        )
+
+    assert records_dao.reads == 3  # bounded: one read plus two re-reads
+    assert len(channels_dao.outbox) == 1
+    assert _delivered_text(channels_dao) == indicator  # never edited to blank
+    assert any(
+        "empty" in record.message and record.levelname == "ERROR"
+        for record in caplog.records
+    )


### PR DESCRIPTION
## Context

Two days of live QA against a real Slack workspace (`#agenta-channels-qa`, bot `@Agenta`) and, on day two, a real Telegram bridge. Three delivery-path defects were found, hotfixed on the running stack, and then carried for the rest of the day across every remaining wave — Slack channels, DMs, multi-agent routing, grants, long answers, and the bridge round trip. This PR brings those three fixes back with the tests they were missing.

They are recorded as **F82** (the cascade) and **F85** (the empty-answer path) in the findings ledger, [#6074](https://github.com/Agenta-AI/agenta/pull/6074).

Stacked on [#6072](https://github.com/Agenta-AI/agenta/pull/6072) — `outbox.py` is the same function that PR touches, so basing here keeps both diffs clean. Merge #6072 first.

## Changes

**The bot answered its own edits.** Editing the "Working…" indicator into the answer (`chat.update`) comes back to us as a `message_changed` event. Slack puts the authored message one level down, in `event["message"]`, and leaves the outer event authorless — so `is_bot_authored` saw no `bot_id` and no matching `user`, and the adapter treated our own edit as fresh human input. It carries a synthetic `ts`, so the event rooted a *phantom* thread, minted a fresh session, ran a real turn, posted an answer, edited that post, and came round again. Observed four deep at roughly one paid run every 14 seconds, and it also explains the stray top-level posts from earlier manual testing.

Two changes close it: `parse_event` drops `message_changed` and `message_deleted` outright (no path processes an edit, so admitting one can only re-run an answered turn), and `is_bot_authored` reads authorship from the nested message too.

**A blank answer took the whole delivery down.** The race, in order:

1. The turn ends and the turn-ended event reaches the outbox worker.
2. The agent's final record is still committing — measured at about 150 ms behind.
3. `on_turn_ended` reads records, finds none for the turn, and folds to an empty answer.
4. `_render_content` emitted a section block with empty `mrkdwn` text, because the guard was `if texts:` and a list holding one empty string is truthy.
5. Slack rejects the whole payload as `invalid_blocks`, the edit never lands, and the indicator sits on "Working…" forever.

Intermittent by timing, not by content: the same answer replayed two minutes later went through. Four changes, each at a different depth:

- `on_turn_ended` re-reads the records up to twice more, 0.8 s apart, when the fold comes back empty.
- If it is *still* empty, the worker leaves the indicator un-edited and logs an ERROR, rather than editing in a blank bubble — a silent empty delivery marks the row SENT and erases the only evidence the answer was lost.
- `_render_content` never emits a section block for empty text.
- A blocks rejection retries the same message text-only and logs the rejected payload verbatim, so the next rejection shape is diagnosable instead of invisible.

The ordering guarantee itself — why a turn-ended event may precede the record it describes — is a design question and stays open on F85.

## Tests

`api/oss/tests/pytest/unit/channels/` — 655 pass. Each new test was run against the unfixed code first and fails there.

- `test_slack_adapter.py`: our own indicator edit parses to `None`; both edit/delete subtypes drop; empty text emits no section block, and no blocks reach the wire; a blocks rejection retries text-only; a `channel_not_found` rejection does *not* retry.
- `test_slack_mapping.py`: nested authorship is seen for both `bot_id` and our own `bot_user_id`, and a nested human message is still not bot-authored.
- `test_channels_outbox_worker.py`: a records DAO that answers empty then non-empty proves the re-read delivers the answer; one that never commits proves the indicator survives untouched, the reads stay bounded at three, and the ERROR is logged.
