### PR TITLE
[fix] Runner image: FUSE mounts work under any user: uid

### DIFF
--- a/services/runner/docker/Dockerfile.dev
+++ b/services/runner/docker/Dockerfile.dev
@@ -21,13 +21,18 @@ WORKDIR /app
 # ripgrep/fd-find/jq/procps/file/tree are the same bet on habit: `rg` and `fd` are the first
 # commands every harness reaches for when searching a tree, and Debian ships fd as `fdfind`,
 # so the symlink below is what makes the command agents actually type resolve.
+# libnss-unknown + the nsswitch edit: keep dev parity with Dockerfile.gh — the documented
+# subscription self-host scheme runs the container as the operator's uid, and fusermount aborts
+# ("could not determine username") for a uid with no passwd entry, killing every geesefs mount.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates git python3 python-is-python3 unzip zip fuse curl \
-        ripgrep fd-find jq procps file tree \
+        ripgrep fd-find jq procps file tree libnss-unknown \
     && ln -s "$(which fdfind)" /usr/local/bin/fd \
     && rm -rf /var/lib/apt/lists/* \
-    && echo "user_allow_other" >> /etc/fuse.conf
+    && echo "user_allow_other" >> /etc/fuse.conf \
+    && sed -i -E "s/^(passwd|group):(.*)/\1:\2 unknown/" /etc/nsswitch.conf \
+    && grep -E "^(passwd|group):.* unknown$" /etc/nsswitch.conf
 
 # geesefs static binary (FUSE-over-S3) for the durable cwd. Pinned release; arch-matched.
 ARG GEESEFS_VERSION=v0.43.0

--- a/services/runner/docker/Dockerfile.gh
+++ b/services/runner/docker/Dockerfile.gh
@@ -31,13 +31,20 @@ WORKDIR /app
 # ripgrep/fd-find/jq/procps/file/tree are the same bet on habit: `rg` and `fd` are the first
 # commands every harness reaches for when searching a tree, and Debian ships fd as `fdfind`,
 # so the symlink below is what makes the command agents actually type resolve.
+# libnss-unknown + the nsswitch edit: the documented subscription self-host scheme runs this
+# container as the OPERATOR's uid (`user: "<id -u>:<id -g>"`), which usually has no /etc/passwd
+# entry in the image. fusermount calls getpwuid() and aborts with "could not determine username"
+# for a nameless uid, killing every geesefs workspace mount. libnss-unknown synthesizes an entry
+# for unknown uids so any `user:` override works.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
         ca-certificates git python3 python-is-python3 unzip zip fuse curl \
-        ripgrep fd-find jq procps file tree \
+        ripgrep fd-find jq procps file tree libnss-unknown \
     && ln -s "$(which fdfind)" /usr/local/bin/fd \
     && rm -rf /var/lib/apt/lists/* \
-    && echo "user_allow_other" >> /etc/fuse.conf
+    && echo "user_allow_other" >> /etc/fuse.conf \
+    && sed -i -E "s/^(passwd|group):(.*)/\1:\2 unknown/" /etc/nsswitch.conf \
+    && grep -E "^(passwd|group):.* unknown$" /etc/nsswitch.conf
 
 # geesefs static binary (FUSE-over-S3) for the durable cwd. Pinned release; arch-matched.
 ARG GEESEFS_VERSION=v0.43.0


### PR DESCRIPTION
## Context

Following the subscription self-host guide (`01-use-your-own-subscription.mdx`) with any operator uid other than 1000 kills every agent session. The guide instructs `user: "<id -u>:<id -g>"` on the runner service, but the image's `/etc/passwd` only knows `root` and `node` (1000). `fusermount` calls `getpwuid()` for the current uid and aborts for a nameless one:

```
fusermount: could not determine username
geesefs stderr: main.FATAL Mounting file system: ... running /usr/bin/fusermount: exit status 1
```

Every geesefs workspace mount fails, so every session dies before its first frame. This took down a whole self-hosted stack (bighetzner, 2026-08-17) after a runner recreate with `user: "1004:1004"`; the documented example uid 1001 hits it identically.

## Changes

Both runner Dockerfiles (`Dockerfile.gh`, `Dockerfile.dev`) now install `libnss-unknown` and register it in `/etc/nsswitch.conf` (`passwd`/`group` lines get the `unknown` fallback). The NSS module synthesizes an entry for any uid that has no passwd row, so `getpwuid()` always resolves and `fusermount` proceeds regardless of the `user:` override.

Before, as uid 1004 in the image:

```
$ whoami
whoami: cannot find name for user ID 1004
$ fusermount -u /tmp/mnt
fusermount: could not determine username
```

After:

```
$ whoami
uid-1004
$ fusermount -u /tmp/mnt
fusermount: entry for /tmp/mnt not found in /etc/mtab   (the normal "nothing mounted" error)
```

The Railway image wraps the GHCR image, so it inherits the fix. A `grep` guard in the same RUN layer fails the build if a future base image changes the nsswitch format and the sed stops matching.

## Tests / notes

- Verified in `node:24-slim` (the image base): installed the package, applied the sed, and ran `whoami`/`getent`/`fusermount` as uid 1004 with `--cap-add SYS_ADMIN --device /dev/fuse`. The username failure is gone; fusermount proceeds to normal mount logic.
- No behavior change for uid 1000/root: `files` stays first in nsswitch, so existing entries win; `unknown` only answers lookups that would otherwise fail.
- The same nameless-uid scheme also leaves harness mounts owned by other uids unwritable (pi agent dir). That is a separate failure mode with its own issue and fix (silent pi run death), not covered here.

## What to QA

- Build the runner image from `Dockerfile.gh`, run the stack with `user:` set to any uid not in the image (e.g. 1234), start an agent session. The workspace mounts and the session streams frames.
- Regression: run without a `user:` override (default node/1000). Sessions behave as before.

Closes #6087

https://claude.ai/code/session_01AxbkMmS2VvpaxhXPAWzTbH
