### PR TITLE
[fix] Fail closed with a visible error when the Pi agent dir is unwritable

### DIFF
--- a/services/runner/src/engines/sandbox_agent/environment-setup.ts
+++ b/services/runner/src/engines/sandbox_agent/environment-setup.ts
@@ -302,6 +302,12 @@ export async function prepareEnvironmentSetup(
     !plan.isDaytona &&
     piExtEnv[PI_MODEL_PROVIDER_OVERRIDE_ENV] !== undefined &&
     !localPiAssets.extensionInstalled;
+  // Fail closed: a subscription run whose operator-mounted Pi agent dir failed the write probe
+  // cannot start — Pi dies at startup on the unwritable dir with zero output, which the user sees
+  // as a session that silently hangs. Recorded here (the probe ran above) and thrown inside the
+  // engine try, like the three gates above, so it becomes a visible error frame.
+  const localPiAgentDirUnwritable =
+    plan.isPi && !plan.isDaytona && !localPiAssets.agentDirWritable;
 
   // A local Claude subscription run reads and writes the operator's read-write mounted login
   // DIRECTLY: `buildDaemonEnv` already carried `CLAUDE_CONFIG_DIR` (the mount) into the daemon env,
@@ -431,6 +437,7 @@ export async function prepareEnvironmentSetup(
     logger,
     localModelConfigUnwritable,
     localModelOverrideUnenforceable,
+    localPiAgentDirUnwritable,
     mcpAbort,
     piExtEnv,
     piModelConfig,

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -458,6 +458,11 @@ export async function acquireEnvironment(
     if (piModelConfigError) {
       throw piModelConfigError;
     }
+    // Surface the root cause before extension-derived gates: an unwritable subscription mount can
+    // also prevent extension installation, but rebuilding the image cannot repair mount ownership.
+    if (localPiAgentDirUnwritable) {
+      throw new Error(PI_AGENT_DIR_UNWRITABLE_MESSAGE);
+    }
     // Fail closed before any sandbox/mount infra spins up: a local Pi run whose policy could gate a
     // built-in tool cannot proceed without the permission extension installed (Decision 2).
     if (localBuiltinGatingUnenforceable) {
@@ -473,12 +478,6 @@ export async function acquireEnvironment(
     // endpoint with the wrong credentials.
     if (localModelOverrideUnenforceable) {
       throw new Error(PI_MODEL_OVERRIDE_EXTENSION_UNAVAILABLE_MESSAGE);
-    }
-    // Fail closed: a subscription run cannot start when the operator-mounted Pi agent dir failed
-    // the write probe — Pi dies at startup on the unwritable dir with zero output, so without this
-    // gate the turn ends instantly and the UI shows a silently stuck session.
-    if (localPiAgentDirUnwritable) {
-      throw new Error(PI_AGENT_DIR_UNWRITABLE_MESSAGE);
     }
     // Structural + SSRF validation of user MCP servers BEFORE any sandbox (or Daytona Secret) is
     // created, so an invalid credentialed server never triggers remote side effects.

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -77,6 +77,7 @@ import {
   type MountCredentials,
 } from "./mount.ts";
 import {
+  PI_AGENT_DIR_UNWRITABLE_MESSAGE,
   PI_MODEL_CONFIG_WRITE_FAILED_MESSAGE,
   PI_MODEL_OVERRIDE_EXTENSION_UNAVAILABLE_MESSAGE,
   PI_PERMISSION_EXTENSION_UNAVAILABLE_MESSAGE,
@@ -308,6 +309,7 @@ export async function acquireEnvironment(
     localBuiltinGatingUnenforceable,
     localModelConfigUnwritable,
     localModelOverrideUnenforceable,
+    localPiAgentDirUnwritable,
     logger,
     mcpAbort,
     piExtEnv,
@@ -471,6 +473,12 @@ export async function acquireEnvironment(
     // endpoint with the wrong credentials.
     if (localModelOverrideUnenforceable) {
       throw new Error(PI_MODEL_OVERRIDE_EXTENSION_UNAVAILABLE_MESSAGE);
+    }
+    // Fail closed: a subscription run cannot start when the operator-mounted Pi agent dir failed
+    // the write probe — Pi dies at startup on the unwritable dir with zero output, so without this
+    // gate the turn ends instantly and the UI shows a silently stuck session.
+    if (localPiAgentDirUnwritable) {
+      throw new Error(PI_AGENT_DIR_UNWRITABLE_MESSAGE);
     }
     // Structural + SSRF validation of user MCP servers BEFORE any sandbox (or Daytona Secret) is
     // created, so an invalid credentialed server never triggers remote side effects.

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -315,6 +315,19 @@ export const PI_MODEL_OVERRIDE_EXTENSION_UNAVAILABLE_MESSAGE =
   "default endpoint. Ask your deployment operator to rebuild and republish the runner image.";
 
 /**
+ * Thrown (via the engine's named-message pattern) when a local subscription run's Pi agent dir —
+ * the operator's mounted login — is not writable by the runner user. Pi persists its session
+ * rollouts and OAuth refresh into that dir, so an unwritable mount makes the harness die at
+ * startup with no output at all: the turn ends instantly and the UI shows nothing (the exact
+ * "session looks stuck, user retries forever" failure). Fail closed with a visible error instead.
+ * Single line so `conciseError` surfaces it verbatim.
+ */
+export const PI_AGENT_DIR_UNWRITABLE_MESSAGE =
+  "The agent could not use the mounted Pi login directory: it is not writable by the runner's " +
+  "user, so the harness cannot persist its session or refresh its login. The run was stopped. " +
+  "Ask your deployment operator to make the mounted Pi agent directory writable by the runner's uid.";
+
+/**
  * Write the Pi `models.json` into a local (throwaway) agent dir with mode `0600` via an atomic
  * temp-file-plus-rename. THROWS on failure so the caller can make materialization terminal — a
  * managed custom run must never fall through to a default provider (design Decision 6). The file
@@ -623,6 +636,40 @@ export interface PrepareLocalPiAssetsResult {
    * when this is false (materialization is terminal — design Decision 6).
    */
   modelConfigWritten: boolean;
+  /**
+   * False only for a subscription run whose operator-mounted agent dir failed the write probe. Pi
+   * persists session rollouts and its OAuth refresh into that dir, so an unwritable mount makes
+   * the harness die at startup with zero output; the caller fails the run closed with
+   * `PI_AGENT_DIR_UNWRITABLE_MESSAGE` instead. Always true for the per-run-dir paths (the dir is
+   * created by the runtime user) and for non-local-Pi runs.
+   */
+  agentDirWritable: boolean;
+}
+
+/**
+ * Probe whether the runner user can actually write into a Pi agent dir: create `sessions/` when
+ * missing and round-trip a probe file inside it. Pi needs exactly these writes at startup
+ * (session rollout persistence), and its failure mode on EACCES is an instant silent exit.
+ */
+export function probePiAgentDirWritable(
+  agentDir: string,
+  log: Log = () => {},
+): boolean {
+  const probe = join(agentDir, "sessions", `.agenta-write-probe-${randomUUID()}`);
+  try {
+    mkdirSync(join(agentDir, "sessions"), { recursive: true });
+    writeFileSync(probe, "", "utf-8");
+    rmSync(probe, { force: true });
+    return true;
+  } catch (err) {
+    try {
+      rmSync(probe, { force: true });
+    } catch {
+      // the probe file was never created; nothing to clean up
+    }
+    log(`pi agent dir write probe failed: ${(err as Error).message}`);
+    return false;
+  }
 }
 
 /**
@@ -658,6 +705,7 @@ export function prepareLocalPiAssets({
       dir: undefined,
       extensionInstalled: true,
       modelConfigWritten: true,
+      agentDirWritable: true,
     };
 
   // buildRunPlan already rejected a local runtime_provided run with no configured
@@ -677,6 +725,7 @@ export function prepareLocalPiAssets({
           describePiModelsJsonPlan(piModelConfig),
       );
     }
+    const agentDirWritable = probePiAgentDirWritable(agentDir, log);
     const extensionInstalled = installPiExtensionLocal(agentDir, log);
     if (plan.prompt.hasSystemPrompt) {
       writeSystemPromptLocal(
@@ -688,7 +737,12 @@ export function prepareLocalPiAssets({
     }
     env.PI_CODING_AGENT_DIR = agentDir;
     // Deliberately NOT returned as a throwaway: this is the operator's login, not a temp dir.
-    return { dir: undefined, extensionInstalled, modelConfigWritten: true };
+    return {
+      dir: undefined,
+      extensionInstalled,
+      modelConfigWritten: true,
+      agentDirWritable,
+    };
   }
 
   // Managed / none: always route through a throwaway per-run dir the runtime user owns, so the
@@ -724,7 +778,12 @@ export function prepareLocalPiAssets({
     }
   }
   env.PI_CODING_AGENT_DIR = runAgentDir;
-  return { dir: runAgentDir, extensionInstalled, modelConfigWritten };
+  return {
+    dir: runAgentDir,
+    extensionInstalled,
+    modelConfigWritten,
+    agentDirWritable: true,
+  };
 }
 
 /** Upload materialized skill dirs into a Daytona sandbox's Pi `skills/` user scope. */

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -647,25 +647,33 @@ export interface PrepareLocalPiAssetsResult {
 }
 
 /**
- * Probe whether the runner user can actually write into a Pi agent dir: create `sessions/` when
- * missing and round-trip a probe file inside it. Pi needs exactly these writes at startup
- * (session rollout persistence), and its failure mode on EACCES is an instant silent exit.
+ * Probe whether the runner user can write to both Pi state targets: the agent-dir root for login
+ * refreshes and extension assets, plus `sessions/` for transcript rollouts. A partially writable
+ * mount is still unusable, and Pi fails on EACCES with an instant silent exit.
  */
 export function probePiAgentDirWritable(
   agentDir: string,
   log: Log = () => {},
 ): boolean {
-  const probe = join(agentDir, "sessions", `.agenta-write-probe-${randomUUID()}`);
+  const sessionsDir = join(agentDir, "sessions");
+  const probes = [
+    join(agentDir, `.agenta-write-probe-${randomUUID()}`),
+    join(sessionsDir, `.agenta-write-probe-${randomUUID()}`),
+  ];
   try {
-    mkdirSync(join(agentDir, "sessions"), { recursive: true });
-    writeFileSync(probe, "", "utf-8");
-    rmSync(probe, { force: true });
+    mkdirSync(sessionsDir, { recursive: true });
+    for (const probe of probes) {
+      writeFileSync(probe, "", "utf-8");
+      rmSync(probe, { force: true });
+    }
     return true;
   } catch (err) {
-    try {
-      rmSync(probe, { force: true });
-    } catch {
-      // the probe file was never created; nothing to clean up
+    for (const probe of probes) {
+      try {
+        rmSync(probe, { force: true });
+      } catch {
+        // the probe file was never created; nothing to clean up
+      }
     }
     log(`pi agent dir write probe failed: ${(err as Error).message}`);
     return false;

--- a/services/runner/tests/unit/pi-permission-failclosed.test.ts
+++ b/services/runner/tests/unit/pi-permission-failclosed.test.ts
@@ -17,13 +17,24 @@
  */
 import { describe, it, afterEach } from "vitest";
 import assert from "node:assert/strict";
+import {
+  chmodSync,
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+} from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import type { AgentRunRequest } from "../../src/protocol.ts";
 import type { SandboxAgentDeps } from "../../src/engines/sandbox_agent.ts";
 import { acquireEnvironment } from "../../src/engines/sandbox_agent.ts";
-import { PI_PERMISSION_EXTENSION_UNAVAILABLE_MESSAGE } from "../../src/engines/sandbox_agent/pi-assets.ts";
+import {
+  PI_AGENT_DIR_UNWRITABLE_MESSAGE,
+  PI_MODEL_OVERRIDE_EXTENSION_UNAVAILABLE_MESSAGE,
+  PI_PERMISSION_EXTENSION_UNAVAILABLE_MESSAGE,
+} from "../../src/engines/sandbox_agent/pi-assets.ts";
 import { resetRunnerConfigCache } from "../../src/config/runner-config.ts";
 
 const MISSING_BUNDLE = join(tmpdir(), "agenta-missing-extension-bundle.js");
@@ -81,6 +92,65 @@ describe("acquireEnvironment fail-closed on a missing Pi permission extension", 
     // install was correctly treated as harmless under an allow-everything policy.
     assert.match(result.error, new RegExp(SENTINEL));
     assert.notEqual(result.error, PI_PERMISSION_EXTENSION_UNAVAILABLE_MESSAGE);
+  });
+
+  it("surfaces mount writability before a custom-endpoint extension failure", async () => {
+    forceFailedInstall();
+
+    const mount = mkdtempSync(join(tmpdir(), "agenta-pi-subscription-mount-"));
+    const authFile = join(mount, "auth.json");
+    const sessionsDir = join(mount, "sessions");
+    writeFileSync(authFile, "{\"token\":\"live\"}", "utf-8");
+    mkdirSync(sessionsDir);
+    chmodSync(sessionsDir, 0o755);
+    chmodSync(authFile, 0o444);
+    chmodSync(mount, 0o555);
+
+    const previousPiAgentDir = process.env.PI_CODING_AGENT_DIR;
+    process.env.PI_CODING_AGENT_DIR = mount;
+    resetRunnerConfigCache();
+
+    try {
+      const result = await acquireEnvironment(
+        {
+          harness: "pi_core",
+          messages: [{ role: "user", content: "hello" }],
+          modelConnection: {
+            provider: "openai",
+            deployment: "direct",
+            endpoint: { baseUrl: "https://proxy.example.test/v1" },
+            credentialMode: "runtime_provided",
+            credentials: [],
+          },
+          permissions: { default: "allow" },
+        } as AgentRunRequest,
+        {},
+      );
+
+      assert.equal(result.ok, false);
+      if (result.ok) return;
+      if (typeof process.getuid === "function" && process.getuid() === 0) {
+        // root bypasses the mount mode bits, so only the forced extension failure is observable.
+        assert.equal(
+          result.error,
+          PI_MODEL_OVERRIDE_EXTENSION_UNAVAILABLE_MESSAGE,
+        );
+        return;
+      }
+      assert.equal(result.error, PI_AGENT_DIR_UNWRITABLE_MESSAGE);
+      assert.notEqual(
+        result.error,
+        PI_MODEL_OVERRIDE_EXTENSION_UNAVAILABLE_MESSAGE,
+      );
+    } finally {
+      if (previousPiAgentDir === undefined)
+        delete process.env.PI_CODING_AGENT_DIR;
+      else process.env.PI_CODING_AGENT_DIR = previousPiAgentDir;
+      resetRunnerConfigCache();
+      chmodSync(mount, 0o755);
+      chmodSync(authFile, 0o644);
+      rmSync(mount, { recursive: true, force: true });
+    }
   });
 });
 

--- a/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -875,9 +875,16 @@ describe("prepareLocalPiAssets (runtime_provided runs out of the mount, read-wri
    * unwritable mount it dies at startup with zero output, which the user sees as a silently
    * stuck session. The probe must report it so the engine can fail closed with a visible error.
    */
-  it("reports agentDirWritable=false when the mount is not writable by the runner user", () => {
+  it("reports agentDirWritable=false when only sessions/ is writable", () => {
     const mount = tempDir("agenta-pi-subscription-mount-");
-    writeFileSync(join(mount, "auth.json"), '{"token":"live"}', "utf-8");
+    const authFile = join(mount, "auth.json");
+    const sessionsDir = join(mount, "sessions");
+    writeFileSync(authFile, '{"token":"live"}', "utf-8");
+    mkdirSync(sessionsDir);
+    // Preserve the incomplete-mount shape from the regression: Pi can write a rollout under
+    // sessions/, but it cannot write at the agent-dir root to refresh auth.json.
+    chmodSync(sessionsDir, 0o755);
+    chmodSync(authFile, 0o444);
     chmodSync(mount, 0o555);
     try {
       const { agentDirWritable } = prepareLocalPiAssets({
@@ -892,6 +899,7 @@ describe("prepareLocalPiAssets (runtime_provided runs out of the mount, read-wri
       }
     } finally {
       chmodSync(mount, 0o755);
+      chmodSync(authFile, 0o644);
     }
   });
 

--- a/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -6,6 +6,7 @@
 import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
 import {
+  chmodSync,
   existsSync,
   mkdirSync,
   mkdtempSync,
@@ -852,6 +853,61 @@ describe("prepareLocalPiAssets (runtime_provided runs out of the mount, read-wri
     assert.notEqual(runDir, source);
     assert.equal(env.PI_CODING_AGENT_DIR, runDir);
     dirs.push(runDir as string);
+  });
+
+  it("reports agentDirWritable=true and prepares sessions/ on a writable mount", () => {
+    const mount = tempDir("agenta-pi-subscription-mount-");
+    writeFileSync(join(mount, "auth.json"), '{"token":"live"}', "utf-8");
+
+    const { agentDirWritable } = prepareLocalPiAssets({
+      plan: subscriptionPlan(mount) as never,
+      env: {},
+    });
+
+    assert.equal(agentDirWritable, true);
+    // The probe's side effect is exactly what Pi needs at startup; no probe file survives.
+    assert.ok(existsSync(join(mount, "sessions")));
+    assert.equal(readdirSync(join(mount, "sessions")).length, 0);
+  });
+
+  /**
+   * Pi persists session rollouts and its OAuth refresh into the mounted agent dir; on an
+   * unwritable mount it dies at startup with zero output, which the user sees as a silently
+   * stuck session. The probe must report it so the engine can fail closed with a visible error.
+   */
+  it("reports agentDirWritable=false when the mount is not writable by the runner user", () => {
+    const mount = tempDir("agenta-pi-subscription-mount-");
+    writeFileSync(join(mount, "auth.json"), '{"token":"live"}', "utf-8");
+    chmodSync(mount, 0o555);
+    try {
+      const { agentDirWritable } = prepareLocalPiAssets({
+        plan: subscriptionPlan(mount) as never,
+        env: {},
+      });
+      if (typeof process.getuid === "function" && process.getuid() === 0) {
+        // root bypasses mode bits, so the probe cannot fail in a root test run
+        assert.equal(agentDirWritable, true);
+      } else {
+        assert.equal(agentDirWritable, false);
+      }
+    } finally {
+      chmodSync(mount, 0o755);
+    }
+  });
+
+  it("managed runs always report agentDirWritable=true (per-run dir is runtime-owned)", () => {
+    const source = tempDir("agenta-pi-managed-source-");
+    writeFileSync(join(source, "auth.json"), '{"token":"managed"}', "utf-8");
+
+    const result = prepareLocalPiAssets({
+      plan: subscriptionPlan(source, {
+        credentials: { credentialMode: "env" },
+      }) as never,
+      env: {},
+    });
+
+    assert.equal(result.agentDirWritable, true);
+    if (result.dir) dirs.push(result.dir);
   });
 
 });


### PR DESCRIPTION
## Context

A Pi subscription session on a deployment whose mounted Pi agent directory is not writable by the runner user looks frozen. You send a message, the turn starts, the sandbox builds, and then nothing: no agent frame, no error, the spinner just ends. On the bighetzner deployment the user re-sent the same message four times believing the platform was stuck (session `3402da56-...`, issue #6089).

What actually happens, stepping through the turn: `prepareLocalPiAssets` points `PI_CODING_AGENT_DIR` at the operator's mounted login (correct: Pi must refresh its OAuth token in place). The extension installs, the system-prompt write fails with EACCES but is logged as "skipped" (best effort by design), the harness session is created, and then Pi itself dies at startup because it cannot persist its session rollouts into the unwritable dir. Pi exits with zero output, so the engine sees a turn that simply ended. The runner log's only trace:

```
[sandbox-agent] system prompt write skipped: EACCES: permission denied, open '/agenta/harness/pi/APPEND_SYSTEM.md'
[sandbox-agent] [timing] stage=create_session ms=805 ... mode=create
[sessions/alive] heartbeat OK ... running=false        <- turn over, no frames
```

The neighboring failure modes already fail closed with a visible frame (`PI_PERMISSION_EXTENSION_UNAVAILABLE_MESSAGE`, `PI_MODEL_CONFIG_WRITE_FAILED_MESSAGE`, `PI_MODEL_OVERRIDE_EXTENSION_UNAVAILABLE_MESSAGE`). This one had no gate.

## Changes

`prepareLocalPiAssets` now probes the operator-mounted agent dir for writability on the subscription path (`probePiAgentDirWritable`: create `sessions/` if missing, round-trip a probe file inside it — exactly the writes Pi needs at startup) and reports `agentDirWritable` in its result. `prepareEnvironmentSetup` records the flag and `acquireEnvironment` throws the new named single-line message inside the engine try, like the three existing gates, so the engine's own catch turns it into `{ ok: false, error }` and a visible error frame:

> The agent could not use the mounted Pi login directory: it is not writable by the runner's user, so the harness cannot persist its session or refresh its login. The run was stopped. Ask your deployment operator to make the mounted Pi agent directory writable by the runner's uid.

Stepping through the same turn after the fix: the probe fails before any sandbox or mount spins up, the run stops with that frame in the transcript, and the user knows within one turn what to tell their operator, instead of retrying a silently dying session.

The per-run-dir paths (managed/none) always report `agentDirWritable: true`: their dir is created by the runtime user, and their existing failure modes already have their own gates.

## Tradeoffs and notes

- The probe leaves `sessions/` behind on a writable mount. That is deliberate: Pi creates the same directory itself at startup, so the probe's side effect is a subset of normal operation, and probing the real target (not a sibling temp path) is what makes the answer trustworthy.
- The probe adds one mkdir + one file round-trip per subscription run, before sandbox spin-up. Negligible next to sandbox creation, and only on the local subscription path.
- The system-prompt write stays best-effort. With the probe in front of it, the only way it can still fail is a file-level anomaly on an otherwise writable dir; failing the whole run for that would be harsher than the current behavior. The gate covers the case that actually kills the harness.

## Tests

- `tests/unit/sandbox-agent-pi-assets.test.ts`: writable mount reports `agentDirWritable: true` with `sessions/` prepared and no probe residue; a chmod-0555 mount reports `false` (root-run guard included, since root bypasses mode bits); managed runs always report `true`.
- Full runner suite in the pinned Node 24 image: 130 files, 2217 tests, all passing.
- The live incident that motivated this (`3402da56-...`) was verified both ways on the bighetzner deployment: unwritable dir reproduced the silent death; after fixing the mount ownership the same session ran normally.

## What to QA

- On a stack where the pi mount is writable: run a Pi subscription session. Behavior unchanged.
- Make the mounted pi dir read-only for the runner user, send a message to a Pi session: the turn ends with the "could not use the mounted Pi login directory" error frame visible in the transcript, not a silent stop.
- Regression: managed (API-key) Pi runs and Claude/Codex sessions are untouched by the probe.

Closes #6089

https://claude.ai/code/session_01AxbkMmS2VvpaxhXPAWzTbH
