### PR TITLE
fix(frontend): Sort sidebar agents by last used

### DIFF
--- a/web/oss/src/components/AgentChatSlice/state/sessions.localActivity.test.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.localActivity.test.ts
@@ -1,0 +1,47 @@
+/**
+ * Local usage stamps behind the sidebar's "agents by last used" ordering.
+ *
+ * The trap these pin: opening an agent's playground seeds a blank tab, so counting every stored
+ * session would rank an agent you merely visited above one you actually ran.
+ */
+import {createStore} from "jotai"
+import {describe, expect, it, vi} from "vitest"
+
+vi.mock("@agenta/entities/session", () => ({
+    deleteSessionRemote: vi.fn(async () => true),
+    archiveSessionRemote: vi.fn(async () => true),
+    unarchiveSessionRemote: vi.fn(async () => true),
+    setSessionHeader: vi.fn(async () => true),
+}))
+
+const {addSessionAtomFamily, bumpSessionActivityAtomFamily, localAgentActivityAtom} =
+    await import("./sessions")
+
+const AGENT = "33333333-3333-4333-8333-333333333333"
+
+// A fresh store per test is the isolation here — the persisted atoms start from their defaults.
+describe("localAgentActivityAtom", () => {
+    it("ignores a seeded blank tab", () => {
+        const store = createStore()
+        store.set(addSessionAtomFamily(AGENT))
+
+        expect(store.get(localAgentActivityAtom)[AGENT]).toBeUndefined()
+    })
+
+    it("stamps the agent once a turn settles", () => {
+        const store = createStore()
+        const id = store.set(addSessionAtomFamily(AGENT)) as string
+        store.set(bumpSessionActivityAtomFamily(AGENT), id)
+
+        expect(store.get(localAgentActivityAtom)[AGENT]).toBeGreaterThan(0)
+    })
+
+    // `__global__`, `drawer:<id>` and `onboarding` scopes name no agent.
+    it("skips scopes that are not an app id", () => {
+        const store = createStore()
+        const id = store.set(addSessionAtomFamily("__global__")) as string
+        store.set(bumpSessionActivityAtomFamily("__global__"), id)
+
+        expect(store.get(localAgentActivityAtom)).toEqual({})
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -4,7 +4,7 @@ import {
     setSessionHeader,
     unarchiveSessionRemote,
 } from "@agenta/entities/session"
-import {generateId} from "@agenta/shared/utils"
+import {generateId, isValidUUID} from "@agenta/shared/utils"
 import type {UIMessage} from "ai"
 import {atom, type Getter, type Setter} from "jotai"
 import {atomFamily, atomWithStorage, createJSONStorage, selectAtom} from "jotai/utils"
@@ -230,6 +230,49 @@ export const archivedSessionHistoryAtomFamily = atomFamily((key: string) =>
         return [...list].sort((a, b) => sessionActivity(b) - sessionActivity(a))
     }),
 )
+
+/** Session ids that hold at least one persisted message. Derived from the message map so a turn
+ * appending to a session already known to have messages doesn't invalidate consumers below that
+ * only need message PRESENCE, not the messages themselves. */
+const sessionIdsWithMessagesAtom = selectAtom(
+    sessionMessagesAtom,
+    (messages) => {
+        const ids = new Set<string>()
+        for (const [id, list] of Object.entries(messages)) {
+            if (list.length) ids.add(id)
+        }
+        return ids
+    },
+    (a, b) => a.size === b.size && [...a].every((id) => b.has(id)),
+)
+
+/**
+ * Newest local activity per agent, keyed by app id — the sidebar's recency ordering reads it
+ * alongside the server's session window, which lags behind a stale time.
+ *
+ * Husks don't count: opening a playground seeds a blank tab, and "visited" is not "used". Nor do
+ * scopes that name no agent (`__global__`, `drawer:<id>`, `onboarding`).
+ */
+export const localAgentActivityAtom = atom<Record<string, number>>((get) => {
+    const withMessages = get(sessionIdsWithMessagesAtom)
+    const activity: Record<string, number> = {}
+    for (const [key, sessions] of Object.entries(get(sessionsByAppAtom))) {
+        if (!isValidUUID(key)) continue
+        let newest = 0
+        for (const s of sessions) {
+            // Used, not merely visited. Mirrors `!isSessionHusk`, with message presence read from
+            // the narrowed set above so an ongoing turn's appends don't invalidate this atom.
+            const used =
+                s.lastMessageAt ||
+                s.serverKnown ||
+                Boolean(s.title?.trim()) ||
+                withMessages.has(s.id)
+            if (used) newest = Math.max(newest, sessionActivity(s))
+        }
+        if (newest > 0) activity[key] = newest
+    }
+    return activity
+})
 
 /** Sessions shown as tabs for a scope, in tab order. Archived sessions are hidden even if a stale
  * open-tab id lingers (e.g. archived on another device — the reconciler flips the flag). */

--- a/web/oss/src/components/Sidebar/dynamic/agentsSource.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/agentsSource.test.ts
@@ -1,0 +1,90 @@
+import type {SessionStream} from "@agenta/entities/session"
+import type {Workflow} from "@agenta/entities/workflow"
+import {describe, expect, it} from "vitest"
+
+import {agentLastUsed, sortAgentsByLastUsed} from "./agentsSource"
+
+// `sessionAgentId` only accepts UUID references, so session-derived tests need real ones.
+const ALPHA = "11111111-1111-4111-8111-111111111111"
+
+const agent = (id: string, stamps: Partial<Workflow> = {}): Workflow =>
+    ({id, name: id, ...stamps}) as Workflow
+
+const session = (agentId: string | null, activity: string | null): SessionStream =>
+    ({
+        session_id: `session-${agentId}-${activity}`,
+        references: agentId ? [{id: agentId, key: "workflow"}] : [],
+        updated_at: activity,
+    }) as SessionStream
+
+const ids = (workflows: readonly Workflow[]) => workflows.map((workflow) => workflow.id)
+
+describe("agentLastUsed", () => {
+    it("keeps the newest activity per agent, and the local stamp when it leads", () => {
+        const lastUsed = agentLastUsed(
+            [session(ALPHA, "2026-08-01T10:00:00Z"), session(ALPHA, "2026-08-03T10:00:00Z")],
+            {[ALPHA]: Date.parse("2026-08-04T10:00:00Z")},
+        )
+
+        expect(lastUsed.get(ALPHA)).toBe(Date.parse("2026-08-04T10:00:00Z"))
+    })
+
+    // A session with no turns names no agent, so it is activity for nobody.
+    it("ignores rows with no agent or no usable stamp", () => {
+        expect(agentLastUsed([session(null, "2026-08-05T10:00:00Z")]).size).toBe(0)
+        expect(agentLastUsed([session(ALPHA, "not-a-date")]).has(ALPHA)).toBe(false)
+    })
+})
+
+describe("sortAgentsByLastUsed", () => {
+    it("orders by session activity, newest first", () => {
+        const sorted = sortAgentsByLastUsed(
+            [agent("old"), agent("new"), agent("mid")],
+            new Map([
+                ["old", 1],
+                ["new", 3],
+                ["mid", 2],
+            ]),
+        )
+
+        expect(ids(sorted)).toEqual(["new", "mid", "old"])
+    })
+
+    // Creating an agent counts as using it, so a fresh one opens above agents that ran earlier.
+    it("falls back to the agent's own stamp when it has no usage", () => {
+        const sorted = sortAgentsByLastUsed(
+            [
+                agent("used", {created_at: "2026-07-01T10:00:00Z"}),
+                agent("brand-new", {created_at: "2026-08-10T10:00:00Z"}),
+                agent("edited", {updated_at: "2026-08-09T10:00:00Z"}),
+                agent("undated"),
+            ],
+            new Map([["used", Date.parse("2026-08-08T10:00:00Z")]]),
+        )
+
+        expect(ids(sorted)).toEqual(["brand-new", "edited", "used", "undated"])
+    })
+
+    it("keeps the source order for equal timestamps", () => {
+        const sorted = sortAgentsByLastUsed(
+            [agent("first"), agent("second"), agent("third")],
+            new Map([
+                ["first", 7],
+                ["second", 7],
+                ["third", 7],
+            ]),
+        )
+
+        expect(ids(sorted)).toEqual(["first", "second", "third"])
+    })
+
+    // The group renders `refs.slice(0, maxItems)`, so the cut must land on a sorted list.
+    it("leaves the five most recent agents in the sidebar's visible slots", () => {
+        const workflows = Array.from({length: 8}, (_, index) => agent(`agent-${index}`))
+        const lastUsed = new Map(workflows.map((workflow, index) => [workflow.id, index]))
+
+        const visible = sortAgentsByLastUsed(workflows, lastUsed).slice(0, 5)
+
+        expect(ids(visible)).toEqual(["agent-7", "agent-6", "agent-5", "agent-4", "agent-3"])
+    })
+})

--- a/web/oss/src/components/Sidebar/dynamic/agentsSource.ts
+++ b/web/oss/src/components/Sidebar/dynamic/agentsSource.ts
@@ -1,0 +1,67 @@
+import type {SessionStream} from "@agenta/entities/session"
+import type {ListQueryState} from "@agenta/entities/shared"
+import {agentWorkflowsListQueryStateAtom, type Workflow} from "@agenta/entities/workflow"
+import {sessionAgentId} from "@agenta/sessions/row"
+import {atom} from "jotai"
+import {selectAtom} from "jotai/utils"
+
+import {localAgentActivityAtom} from "@/oss/components/AgentChatSlice/state/sessions"
+
+import {sidebarSessionRowsAtom} from "./sessionsSource"
+
+/** Epoch ms, or 0 when the stamp is missing or unparsable. */
+const at = (value?: string | null): number => Date.parse(value ?? "") || 0
+
+/** Newest activity per agent, from the fetched session rows plus this browser's local usage. */
+export const agentLastUsed = (
+    rows: readonly SessionStream[],
+    local: Record<string, number> = {},
+): Map<string, number> => {
+    const lastUsed = new Map(Object.entries(local))
+    for (const row of rows) {
+        const agentId = sessionAgentId(row)
+        if (!agentId) continue
+        const activity = at(row.updated_at ?? row.created_at)
+        if (activity > (lastUsed.get(agentId) ?? 0)) lastUsed.set(agentId, activity)
+    }
+    return lastUsed
+}
+
+/** Last used, else the agent's own stamp — so an agent you just created still opens at the top. */
+const rank = (workflow: Workflow, lastUsed: ReadonlyMap<string, number>): number =>
+    lastUsed.get(workflow.id) ?? at(workflow.updated_at ?? workflow.created_at)
+
+/** Newest first. Ranks are computed once per agent (not inside the comparator), and `Array#sort`
+ * is stable, so agents with equal keys keep the source order. */
+export const sortAgentsByLastUsed = (
+    workflows: readonly Workflow[],
+    lastUsed: ReadonlyMap<string, number>,
+): Workflow[] =>
+    workflows
+        .map((workflow) => ({workflow, key: rank(workflow, lastUsed)}))
+        .sort((a, b) => b.key - a.key)
+        .map(({workflow}) => workflow)
+
+const sortedSidebarAgentsAtom = atom((get) => {
+    const {data} = get(agentWorkflowsListQueryStateAtom)
+    const lastUsed = agentLastUsed(get(sidebarSessionRowsAtom), get(localAgentActivityAtom))
+    return sortAgentsByLastUsed(data, lastUsed)
+})
+
+/**
+ * Holds the sorted array reference steady while the order is unchanged. A settled chat turn
+ * rewrites the activity map and re-runs the sort, but if the resulting order matches the last one
+ * the previous array is returned — so the Agents group does not re-render on every turn.
+ */
+const stableSortedSidebarAgentsAtom = selectAtom(
+    sortedSidebarAgentsAtom,
+    (agents) => agents,
+    (a, b) => a.length === b.length && a.every((workflow, index) => workflow === b[index]),
+)
+
+/** The agents list, most recently used first — sorted so the order lands before the group's
+ * five-item cut in `resolveChildren`, with the full list left for the "Show all" count. */
+export const sidebarAgentsListAtom = atom<ListQueryState<Workflow>>((get) => {
+    const query = get(agentWorkflowsListQueryStateAtom)
+    return {...query, data: get(stableSortedSidebarAgentsAtom)}
+})

--- a/web/oss/src/components/Sidebar/dynamic/registry.ts
+++ b/web/oss/src/components/Sidebar/dynamic/registry.ts
@@ -2,7 +2,6 @@ import {createElement} from "react"
 
 // import {testsetsListAtom} from "@agenta/entities/testset"
 import {
-    agentWorkflowsListQueryStateAtom,
     // evaluatorsListQueryAtom,
     // nonArchivedEvaluatorsAtom,
     promptWorkflowsListQueryStateAtom,
@@ -17,6 +16,7 @@ import {pendingSessionOpenAtom} from "@/oss/components/AgentChatSlice/state/pend
 
 import {MAIN_SIDEBAR_SCOPE_ID, SESSIONS_SIDEBAR_KEY} from "../scopes/constants"
 
+import {sidebarAgentsListAtom} from "./agentsSource"
 import {SIDEBAR_SESSION_VISIBLE_LIMIT} from "./sessionOptions"
 import SessionRowActions from "./SessionRowActions"
 import {sidebarSessionsListAtom, type SessionSidebarRef} from "./sessionsSource"
@@ -128,7 +128,8 @@ const ENTITIES: SidebarEntity[] = [
                 size: 14,
                 fallback: createElement(RobotIcon, {size: 14}),
             }),
-        listAtom: agentWorkflowsListQueryStateAtom,
+        // Ordered by last used, ahead of the `maxItems` cut below.
+        listAtom: sidebarAgentsListAtom,
         getLabel: (workflow) => workflow.name || workflow.slug || "Untitled agent",
         childPath: (workflow) => `/apps/${workflow.id}/overview`,
         // Stays highlighted across all of the agent's pages, not just the one it links to.

--- a/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
+++ b/web/oss/src/components/Sidebar/dynamic/sessionsSource.ts
@@ -72,6 +72,18 @@ const sidebarPinnedSessionsQueryAtom = atomWithQuery<SessionStream[] | null>((ge
     }
 })
 
+/**
+ * Every session row the sidebar has fetched — the recent window plus the pins it excludes.
+ *
+ * For consumers that need per-agent activity rather than rendered rows (the Agents group's recency
+ * ordering). Reading it from another group shares these query keys instead of adding a second
+ * window request.
+ */
+export const sidebarSessionRowsAtom = atom<SessionStream[]>((get) => [
+    ...(get(sidebarPinnedSessionsQueryAtom).data ?? []),
+    ...(get(sidebarSessionsQueryAtom).data ?? []),
+])
+
 /** Null when the row has no open target yet (no turns) — the sidebar drops it rather than
  * rendering a link to `/apps/null`. */
 const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRef | null => {


### PR DESCRIPTION
## Context
Opening the Agents group in the sidebar showed five agents in what looked like a random order. The group rendered the first five records from the shared workflow list, whose order follows creation, so the agents on screen had no relation to the ones you actually work with.

## Changes
The Agents group now sorts by last used before the five-item cut, so the top of the list is the agents you touched most recently.

"Last used" is the agent's newest session activity. It comes from the session rows the sidebar already fetches for the Sessions group (same query keys, so no extra request), overlaid with this browser's local playground store so a session you just started reorders the list immediately, ahead of the server window's stale time.

An agent with no session history falls back to `updated_at ?? created_at`. That is one ranking key, not two tiers, so a freshly created agent carries the newest timestamp in the list and opens at the top.

Sorting lives in a new list atom the registry points at, so the order lands before `resolveChildren` slices the visible five, and the full list stays intact for the "Show all" overflow count.

Before: first five workflow records, creation order.
After: five most recently used agents, newest first.

## Tests / notes
- `agentsSource.test.ts` covers ordering, the created/updated fallback, a brand-new agent ranking on top, ties keeping source order, and the sort-before-limit guarantee.
- `sessions.localActivity.test.ts` pins the local overlay: a seeded blank tab does not count as usage (opening a playground seeds an empty tab, so "visited" must not read as "used"), a settled turn does, and non-app scopes are skipped.
- `pnpm test:unit` green on all touched suites, `tsc` and `pnpm lint-fix` clean.
- Automation-only agents (scheduled runs, never a human session) fall back to their workflow timestamp. The sidebar's session policy is `exclude-trigger`, and counting trigger sessions would need a separate query key (a second request per sidebar open), so it was left out on purpose.
- Stacked on `feat/agent-icon-picker` (#6062), which also edits `registry.ts`. Base this PR on that branch; it should merge first.

## What to QA
- Use a few agents in a known order, then open the Agents group. The list is newest-used first.
- Start a new session on an agent low in the list. It jumps to the top without a reload.
- Create a new agent. It appears at the top of the group.
- Regression: with the Sessions group also open, check the Network tab shows no second session-list request.
