### PR TITLE
fix(frontend): render deferred elicitations as waiting instead of failing

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/toolDisplay.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolDisplay.test.ts
@@ -105,6 +105,7 @@ describe("canonicalToolName", () => {
 
     it("unwraps the Codex dot form of the same server", () => {
         expect(canonicalToolName("mcp.agenta-tools.commit_revision")).toBe("commit_revision")
+        expect(canonicalToolName("mcp.agenta-tools.request_input")).toBe("request_input")
     })
 
     it("leaves another server's tool wrapped, so it cannot collide with a platform tool", () => {
@@ -129,10 +130,42 @@ describe("resolveToolDisplay under an MCP wrapper", () => {
         )
     })
 
+    it("applies the override under the Codex dot wrapper too", () => {
+        const summary = resolveToolDisplay("mcp.agenta-tools.commit_revision").summary
+        expect(summary?.({workflow_revision: {message: "Add the skill."}}, null)).toBe(
+            "Add the skill.",
+        )
+    })
+
     it("still presents it as an MCP tool, and keeps the raw name reachable", () => {
         const display = resolveToolDisplay("mcp__agenta-tools__commit_revision")
 
         expect(display.kind).toBe("mcp")
         expect(display.raw).toBe("mcp__agenta-tools__commit_revision")
+    })
+})
+
+// Regression #6106: the Codex mcp.<server>.<tool> form title-cased raw, producing
+// "Mcp.agenta tools.request input" instead of the mcp__ form's "Request input" header.
+describe("resolveToolDisplay name shapes", () => {
+    it("renders the Claude mcp__ form as tool from 'Server · MCP'", () => {
+        const display = resolveToolDisplay("mcp__agenta-tools__request_input")
+        expect(display.label).toBe("Request input")
+        expect(display.source).toBe("Agenta tools · MCP")
+        expect(display.kind).toBe("mcp")
+    })
+
+    it("renders the Codex mcp. form identically to the mcp__ form", () => {
+        const codex = resolveToolDisplay("mcp.agenta-tools.request_input")
+        const claude = resolveToolDisplay("mcp__agenta-tools__request_input")
+        expect(codex.label).toBe(claude.label)
+        expect(codex.source).toBe(claude.source)
+        expect(codex.kind).toBe("mcp")
+    })
+
+    it("treats mcp. as an MCP wrapper only with server AND tool segments", () => {
+        const display = resolveToolDisplay("mcp.something")
+        expect(display.kind).not.toBe("mcp")
+        expect(display.source).toBeUndefined()
     })
 })

--- a/web/oss/src/components/AgentChatSlice/assets/toolDisplay.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/toolDisplay.ts
@@ -82,6 +82,18 @@ const parseNameShape = (raw: string): {label: string; source?: string; kind: Too
             kind: "mcp",
         }
     }
+    // Codex wraps the same tools as mcp.{server}.{tool}. Only with both server and tool segments —
+    // a bare "mcp.something" is not an MCP wrapper and title-cases like any other name.
+    if (raw.startsWith("mcp.")) {
+        const parts = raw.split(".").filter(Boolean)
+        if (parts.length >= 3) {
+            return {
+                label: parseGatewayToolName(parts[parts.length - 1]).label,
+                source: `${parseGatewayToolName(parts[1]).label} · MCP`,
+                kind: "mcp",
+            }
+        }
+    }
     const parsed = parseGatewayToolName(raw)
     return {...parsed, kind: parsed.source ? "gateway" : "platform"}
 }

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptBuilderParity.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptBuilderParity.test.ts
@@ -13,15 +13,15 @@
  */
 import {transcriptToMessages as pkgTranscriptToMessages} from "@agenta/chat/assets"
 import type {SessionRecord} from "@agenta/entities/session"
+import {
+    APPROVED_EXECUTION_RESULT_UNKNOWN,
+    APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX,
+} from "@agenta/shared/utils"
 import type {UIMessage} from "ai"
 import {describe, expect, it} from "vitest"
 
 import {GOLDEN_SESSIONS} from "./__fixtures__/goldenSessions"
-import {
-    APPROVED_EXECUTION_RESULT_UNKNOWN,
-    APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX,
-    transcriptToMessages as ossTranscriptToMessages,
-} from "./transcriptToMessages"
+import {transcriptToMessages as ossTranscriptToMessages} from "./transcriptToMessages"
 
 type AnyPart = Record<string, unknown>
 

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.test.ts
@@ -4,10 +4,11 @@ import type {
     SessionRecord,
 } from "@agenta/entities/session"
 import {CLIENT_TOOL_INTERACTION_ENDED_OUTPUT} from "@agenta/shared/clientTools"
+import {APPROVED_EXECUTION_RESULT_UNKNOWN} from "@agenta/shared/utils"
 import {describe, expect, it} from "vitest"
 
 import abandonedFormSession from "./__fixtures__/abandonedFormSession.json"
-import {APPROVED_EXECUTION_RESULT_UNKNOWN, transcriptToMessages} from "./transcriptToMessages"
+import {transcriptToMessages} from "./transcriptToMessages"
 
 const record = (id: string, payload: Record<string, unknown>, sender = "agent"): SessionRecord => ({
     id,

--- a/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/transcriptToMessages.ts
@@ -4,6 +4,7 @@ import type {
     SessionRecord,
 } from "@agenta/entities/session"
 import {CLIENT_TOOL_INTERACTION_ENDED_OUTPUT} from "@agenta/shared/clientTools"
+import {APPROVED_EXECUTION_RESULT_UNKNOWN, DEFERRED_NOT_EXECUTED_PREFIX} from "@agenta/shared/utils"
 import type {UIMessage} from "ai"
 
 import {attachmentContentUrl} from "./attachmentMedia"
@@ -24,15 +25,6 @@ import {attachmentContentUrl} from "./attachmentMedia"
  */
 
 type Part = Record<string, unknown>
-
-// Mirrors services/runner/src/tracing/otel.ts; park sentinels report skipped or unobserved work, not final results.
-export const DEFERRED_NOT_EXECUTED_PREFIX = "DEFERRED_NOT_EXECUTED"
-export const APPROVED_EXECUTION_RESULT_UNKNOWN =
-    "APPROVED_EXECUTION_RESULT_UNKNOWN: the approved call started but its result was not observed before the pause ended the turn; do not assume it failed and do not retry a side-effecting call."
-export const APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX = APPROVED_EXECUTION_RESULT_UNKNOWN.slice(
-    0,
-    APPROVED_EXECUTION_RESULT_UNKNOWN.indexOf(":"),
-)
 
 interface DraftMessage {
     id: string

--- a/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx
@@ -1,6 +1,10 @@
 import {memo} from "react"
 
 import {detectFileActivity, type FileActivity} from "@agenta/entities/session"
+import {
+    APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX,
+    DEFERRED_NOT_EXECUTED_PREFIX,
+} from "@agenta/shared/utils"
 import {HeightCollapse} from "@agenta/ui"
 import {
     CaretRight,
@@ -25,10 +29,6 @@ import {
     type ToolDisplay,
 } from "../assets/toolDisplay"
 import {formatToolValue, stripFence} from "../assets/toolFormat"
-import {
-    APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX,
-    DEFERRED_NOT_EXECUTED_PREFIX,
-} from "../assets/transcriptToMessages"
 import {
     expandedValueAtomFamily,
     setExpandedAtom,

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
@@ -10,6 +10,7 @@
  * re-ask — the settled part itself can't be re-resolved).
  */
 import {isInteractionEndedOutput} from "@agenta/shared/clientTools"
+import {DEFERRED_NOT_EXECUTED_PREFIX} from "@agenta/shared/utils"
 import {
     ArrowClockwise,
     CheckCircle,
@@ -24,14 +25,6 @@ import type {ClientToolHandlerProps} from "./types"
 import {settledFailureChip, useConnectFlow, type ConnectOutput} from "./useConnectFlow"
 
 const {Text} = Typography
-
-/**
- * The runner parks only ONE interaction per turn; a second `request_connection` in the same step is
- * force-settled with this sentinel and RE-REQUESTED next turn (services/runner otel.ts
- * `TOOL_NOT_EXECUTED_PAUSED`). It is a deferral, not a failure — render it quietly with no Retry, so
- * the user waits for the agent's re-ask instead of starting a flow that races it.
- */
-const DEFERRED_SENTINEL = "DEFERRED_NOT_EXECUTED"
 
 const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
     const {
@@ -48,12 +41,12 @@ const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
     } = useConnectFlow(meta, settle)
 
     // A runner-deferred sibling settles as an error carrying the deferral sentinel (not a real
-    // connection failure); see DEFERRED_SENTINEL.
+    // connection failure); the agent RE-REQUESTS it next turn, so render quietly with no Retry.
     const partErrorText = (meta.part as {errorText?: unknown}).errorText
     const deferredByRunner =
         meta.state === "output-error" &&
         typeof partErrorText === "string" &&
-        partErrorText.startsWith(DEFERRED_SENTINEL)
+        partErrorText.startsWith(DEFERRED_NOT_EXECUTED_PREFIX)
 
     // ── Connecting: a post-settle manual retry's popup is open ───────────────────────────────────
     if (phase === "connecting") {

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.deferred.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.deferred.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Deferred vs degraded elicitation replay (#6106).
+ *
+ * A runner pause sentinel on the part's errorText means the call was deferred behind another
+ * approval and the model will re-issue it — the card must show the request read-only with the
+ * "Waiting on another approval" wording, never the "Couldn't render this request" chip. A genuine
+ * errorText stays a degradation chip. Uses the REAL @agenta/shared/utils (state derivation and
+ * payload parsing are the code under test); only the chrome is mocked.
+ */
+import {act} from "react"
+
+import {createRoot, type Root} from "react-dom/client"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+vi.mock("@agenta/entity-ui/gatewayTool", () => ({
+    SchemaForm: ({disabled}: {disabled?: boolean}) => (
+        <div data-testid="schema-form" data-disabled={disabled ? "true" : "false"} />
+    ),
+    formatReviewValue: (_field: unknown, value: unknown) => String(value),
+}))
+
+vi.mock("@agenta/shared/hooks", () => ({
+    useModifierKey: () => "⌘",
+}))
+
+vi.mock("@agenta/ui", () => ({
+    HeightCollapse: ({children}: {children?: React.ReactNode}) => <div>{children}</div>,
+}))
+
+vi.mock("@agenta/ui/rich-chat-input", () => ({
+    ShortcutHint: () => <span />,
+}))
+
+vi.mock("@phosphor-icons/react", () => ({
+    CaretRight: () => <i />,
+    CheckCircle: () => <i />,
+    Clock: () => <i />,
+    Prohibit: () => <i />,
+    Question: () => <i />,
+    Warning: () => <i />,
+    XCircle: () => <i />,
+}))
+
+vi.mock("antd", () => {
+    const Button = ({
+        children,
+        onClick,
+        disabled,
+    }: {
+        children?: React.ReactNode
+        onClick?: () => void
+        disabled?: boolean
+    }) => (
+        <button type="button" onClick={onClick} disabled={disabled}>
+            {children}
+        </button>
+    )
+    return {
+        Button,
+        Form: {
+            useForm: () => [{validateFields: () => Promise.resolve({})}],
+            useWatch: () => ({}),
+        },
+        Typography: {Text: ({children}: {children?: React.ReactNode}) => <span>{children}</span>},
+    }
+})
+
+vi.mock("../../assets/toolDisplay", () => ({
+    resolveToolDisplay: () => ({label: "Request input"}),
+}))
+
+import ElicitationWidget from "./ElicitationWidget"
+import type {ClientToolMeta, SettleClientTool} from "./types"
+
+const DEFERRED_ERROR_TEXT =
+    "DEFERRED_NOT_EXECUTED: paused for another approval; retry the same call if still required."
+
+const metaWithError = (errorText: string): ClientToolMeta => ({
+    toolCallId: "call-1",
+    toolName: "mcp.agenta-tools.request_input",
+    renderKind: "elicitation",
+    state: "output-error",
+    input: {
+        message: "Which channels should the digest go to?",
+        requestedSchema: {
+            type: "object",
+            properties: {
+                channels: {
+                    type: "array",
+                    title: "Channels",
+                    items: {type: "string", enum: ["slack", "email"]},
+                },
+            },
+            required: ["channels"],
+        },
+    },
+    output: undefined,
+    settled: true,
+    part: {errorText} as unknown as ClientToolMeta["part"],
+})
+
+let container: HTMLDivElement
+let root: Root
+
+const render = async (meta: ClientToolMeta, settle: SettleClientTool) => {
+    await act(async () => {
+        root.render(<ElicitationWidget meta={meta} settle={settle} />)
+    })
+}
+
+beforeEach(() => {
+    ;(globalThis as {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+})
+
+afterEach(async () => {
+    await act(async () => {
+        root.unmount()
+    })
+    container.remove()
+    vi.clearAllMocks()
+})
+
+describe("ElicitationWidget — runner-deferred part", () => {
+    it("renders the request read-only with the waiting wording, not the fallback chip", async () => {
+        const settle = vi.fn()
+        await render(metaWithError(DEFERRED_ERROR_TEXT), settle)
+
+        expect(container.textContent).toContain("Which channels should the digest go to?")
+        expect(container.textContent).toContain("Waiting on another approval")
+        expect(container.textContent).not.toContain("Couldn’t render this request")
+
+        const form = container.querySelector('[data-testid="schema-form"]')
+        expect(form).not.toBeNull()
+        expect(form?.getAttribute("data-disabled")).toBe("true")
+
+        // Nothing to answer: no submit path, and no settle fires.
+        expect(container.querySelectorAll("button")).toHaveLength(0)
+        expect(settle).not.toHaveBeenCalled()
+    })
+
+    it("keeps a genuine errorText on the degradation chip with no form", async () => {
+        const settle = vi.fn()
+        await render(metaWithError("boom: the tool blew up"), settle)
+
+        expect(container.textContent).toContain("Couldn’t render this request")
+        expect(container.textContent).not.toContain("Waiting on another approval")
+        expect(container.querySelector('[data-testid="schema-form"]')).toBeNull()
+        expect(settle).not.toHaveBeenCalled()
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ElicitationWidget.tsx
@@ -30,7 +30,15 @@ import {
 } from "@agenta/shared/utils"
 import {HeightCollapse} from "@agenta/ui"
 import {ShortcutHint} from "@agenta/ui/rich-chat-input"
-import {CaretRight, CheckCircle, Prohibit, Question, Warning, XCircle} from "@phosphor-icons/react"
+import {
+    CaretRight,
+    CheckCircle,
+    Clock,
+    Prohibit,
+    Question,
+    Warning,
+    XCircle,
+} from "@phosphor-icons/react"
 import {Button, Form, Typography} from "antd"
 import dayjs from "dayjs"
 
@@ -210,6 +218,37 @@ const ElicitationWidget = ({meta, settle, degradedEarlierInTurn}: ClientToolHand
         output: meta.output,
         errorText: (meta.part as {errorText?: string}).errorText,
     })
+
+    // Runner deferral (paused on another approval): nothing to answer — show the request read-only.
+    if (partState === "deferred") {
+        if (!parsed.ok)
+            return (
+                <Chip icon={<Clock size={13} className="shrink-0 text-colorTextTertiary" />}>
+                    Waiting on another approval
+                </Chip>
+            )
+        return (
+            <div className="flex min-w-0 flex-col gap-2 rounded-lg border border-solid border-colorBorderSecondary p-3 my-1 max-w-2xl">
+                <div className="flex items-start gap-2">
+                    <Clock size={14} className="shrink-0 mt-0.5 text-colorTextTertiary" />
+                    <div className="flex min-w-0 flex-col">
+                        <Text className="!text-xs">{parsed.payload.message}</Text>
+                        <Text type="secondary" className="!text-xs">
+                            Asked by {resolveToolDisplay(meta.toolName).label} · Waiting on another
+                            approval
+                        </Text>
+                    </div>
+                </div>
+                <SchemaForm
+                    schema={parsed.payload.requestedSchema as unknown as Record<string, unknown>}
+                    form={form}
+                    formats
+                    openEnums
+                    disabled
+                />
+            </div>
+        )
+    }
 
     // Settled replays: chip copy comes from the envelope (`humanFriendlyMessage`), never re-resolved.
     if (partState !== "pending") {

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/meta.test.ts
@@ -158,6 +158,21 @@ describe("resolveClientToolHandler", () => {
         )
     })
 
+    it("resolves harness-wrapped request_input names when no render hint arrived", () => {
+        for (const wrapped of [
+            "mcp__agenta-tools__request_input",
+            "mcp.agenta-tools.request_input",
+        ]) {
+            const part = toolPart({type: `tool-${wrapped}`, state: "input-available"})
+            expect(resolveClientToolHandler(clientToolMeta(part))).toBe(ElicitationWidget)
+        }
+    })
+
+    it("does NOT unwrap a third-party MCP tool onto a platform widget", () => {
+        const part = toolPart({type: "tool-mcp__github__request_input", state: "input-available"})
+        expect(resolveClientToolHandler(clientToolMeta(part))).toBeNull()
+    })
+
     it("leaves an unknown client tool to the fallback", () => {
         const part = toolPart({type: "tool-mysteryTool", state: "input-available"})
         expect(resolveClientToolHandler(clientToolMeta(part))).toBeNull()

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/registry.tsx
@@ -29,6 +29,8 @@ import type {ComponentType} from "react"
 
 import {CLIENT_TOOL_DESCRIPTORS} from "@agenta/shared/clientTools"
 
+import {canonicalToolName} from "../../assets/toolDisplay"
+
 import ConnectToolWidget from "./ConnectToolWidget"
 import ElicitationWidget from "./ElicitationWidget"
 import type {ClientToolHandlerProps, ClientToolMeta} from "./types"
@@ -49,10 +51,12 @@ const BY_TOOL_NAME: Record<string, ClientToolHandler> = {
     [CLIENT_TOOL_DESCRIPTORS.elicitation.toolName]: ElicitationWidget,
 }
 
-/** Resolve the widget for a client tool, or `null` when none is registered. */
+/** Resolve the widget for a client tool, or `null` when none is registered. The name lookup
+ * unwraps harness MCP wrappers (`mcp__agenta-tools__request_input`, `mcp.agenta-tools.…`) via
+ * `canonicalToolName`, so a wrapped call still dispatches when the render hint is missing. */
 export const resolveClientToolHandler = (meta: ClientToolMeta): ClientToolHandler | null =>
     (meta.renderKind ? BY_RENDER_KIND[meta.renderKind] : undefined) ??
-    BY_TOOL_NAME[meta.toolName] ??
+    BY_TOOL_NAME[canonicalToolName(meta.toolName)] ??
     null
 
 /** Whether this client tool has a dedicated widget (used to route known tools in every state). */

--- a/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
+++ b/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
@@ -16,6 +16,10 @@ import type {
 } from "@agenta/entities/session"
 import {getAgentaApiUrl} from "@agenta/shared/api"
 import {CLIENT_TOOL_INTERACTION_ENDED_OUTPUT} from "@agenta/shared/clientTools"
+import {
+    APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX,
+    DEFERRED_NOT_EXECUTED_PREFIX,
+} from "@agenta/shared/utils"
 import type {UIMessage} from "ai"
 
 /**
@@ -41,14 +45,13 @@ export function attachmentContentUrl(sessionId: string, attachmentId: string): s
     return `${getAgentaApiUrl()}/sessions/attachments/${encodeURIComponent(attachmentId)}/content?${params.toString()}`
 }
 
-// Mirrors services/runner/src/tracing/otel.ts; park sentinels report skipped or unobserved work, not final results.
-export const DEFERRED_NOT_EXECUTED_PREFIX = "DEFERRED_NOT_EXECUTED"
-export const APPROVED_EXECUTION_RESULT_UNKNOWN =
-    "APPROVED_EXECUTION_RESULT_UNKNOWN: the approved call started but its result was not observed before the pause ended the turn; do not assume it failed and do not retry a side-effecting call."
-export const APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX = APPROVED_EXECUTION_RESULT_UNKNOWN.slice(
-    0,
-    APPROVED_EXECUTION_RESULT_UNKNOWN.indexOf(":"),
-)
+// Park sentinels (@agenta/shared mirror of services/runner/src/tracing/otel.ts) report skipped
+// or unobserved work, not final results.
+export {
+    APPROVED_EXECUTION_RESULT_UNKNOWN,
+    APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX,
+    DEFERRED_NOT_EXECUTED_PREFIX,
+} from "@agenta/shared/utils"
 
 interface DraftMessage {
     id: string

--- a/web/packages/agenta-shared/src/utils/elicitation.ts
+++ b/web/packages/agenta-shared/src/utils/elicitation.ts
@@ -14,6 +14,7 @@
  * ride platform-owned flows whose data path bypasses the chat wire, never schema-driven forms.
  * Full design: docs/design/agent-chat-interaction-kinds/decisions.md
  */
+import {isDeferredToolSentinel} from "./toolSentinels"
 
 /** Wire value for `render.kind` on elicitation interactions (REQUIRED on emissions). */
 export const ELICITATION_RENDER_KIND = "elicitation"
@@ -294,19 +295,28 @@ export function buildDegradationErrorText(reason: string): string {
     return `elicitation: unsupported payload — ${reason}`
 }
 
-export type ElicitationPartState = "pending" | "submitted" | "declined" | "cancelled" | "degraded"
+export type ElicitationPartState =
+    | "pending"
+    | "deferred"
+    | "submitted"
+    | "declined"
+    | "cancelled"
+    | "degraded"
 
 /**
  * Derive the replayable card state from an AI SDK tool part. Mirrors the ClientToolPart settle
- * semantics: `output-error`/`errorText` is degradation only; user actions land in `output`.
- * An output with no recognizable action replays as submitted (tolerant reader).
+ * semantics: `output-error`/`errorText` is degradation only — except a runner pause sentinel,
+ * which means the call was deferred (the runner told the model to re-issue it), not that it
+ * failed. User actions land in `output`; an output with no recognizable action replays as
+ * submitted (tolerant reader).
  */
 export function deriveElicitationPartState(part: {
     state?: string
     output?: unknown
     errorText?: string
 }): ElicitationPartState {
-    if (part.state === "output-error" || typeof part.errorText === "string") return "degraded"
+    if (part.state === "output-error" || typeof part.errorText === "string")
+        return isDeferredToolSentinel(part.errorText) ? "deferred" : "degraded"
     if (part.state !== "output-available") return "pending"
     const action = isRecord(part.output) ? part.output.action : undefined
     if (action === "decline") return "declined"

--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -241,6 +241,14 @@ export {
     type ElicitationResult,
 } from "./elicitation"
 
+// Runner pause sentinels on tool results (mirrors services/runner/src/tracing/otel.ts)
+export {
+    APPROVED_EXECUTION_RESULT_UNKNOWN,
+    APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX,
+    DEFERRED_NOT_EXECUTED_PREFIX,
+    isDeferredToolSentinel,
+} from "./toolSentinels"
+
 // Polling utilities
 export {shortPoll} from "./shortPoll"
 

--- a/web/packages/agenta-shared/src/utils/toolSentinels.ts
+++ b/web/packages/agenta-shared/src/utils/toolSentinels.ts
@@ -1,0 +1,26 @@
+/**
+ * Runner pause sentinels, mirrored from `services/runner/src/tracing/otel.ts`. When a turn pauses
+ * on an approval, the runner force-settles the sibling tool calls with an error-shaped result
+ * whose text starts with one of these codes. They report skipped or unobserved work — never a
+ * final failure — so renderers treat them as non-terminal.
+ */
+
+export const DEFERRED_NOT_EXECUTED_PREFIX = "DEFERRED_NOT_EXECUTED"
+
+export const APPROVED_EXECUTION_RESULT_UNKNOWN =
+    "APPROVED_EXECUTION_RESULT_UNKNOWN: the approved call started but its result was not observed before the pause ended the turn; do not assume it failed and do not retry a side-effecting call."
+
+export const APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX = APPROVED_EXECUTION_RESULT_UNKNOWN.slice(
+    0,
+    APPROVED_EXECUTION_RESULT_UNKNOWN.indexOf(":"),
+)
+
+/** True when a tool result's errorText is a runner pause sentinel (deferred or unobserved work),
+ * not a real failure. Prefix match: the code is the contract, the prose after the colon isn't. */
+export function isDeferredToolSentinel(errorText: unknown): boolean {
+    return (
+        typeof errorText === "string" &&
+        (errorText.startsWith(DEFERRED_NOT_EXECUTED_PREFIX) ||
+            errorText.startsWith(APPROVED_EXECUTION_RESULT_UNKNOWN_PREFIX))
+    )
+}

--- a/web/packages/agenta-shared/tests/unit/elicitation.test.ts
+++ b/web/packages/agenta-shared/tests/unit/elicitation.test.ts
@@ -18,6 +18,11 @@ import {
     partitionElicitationDraft,
     serializeElicitationContent,
 } from "../../src/utils/elicitation"
+import {
+    APPROVED_EXECUTION_RESULT_UNKNOWN,
+    DEFERRED_NOT_EXECUTED_PREFIX,
+    isDeferredToolSentinel,
+} from "../../src/utils/toolSentinels"
 
 const fixture = (name: string) =>
     JSON.parse(readFileSync(join(__dirname, "..", "fixtures", name), "utf-8"))
@@ -673,5 +678,49 @@ describe("deriveElicitationPartState", () => {
                 errorText: buildDegradationErrorText("missing message"),
             }),
         ).toBe("degraded")
+    })
+
+    it("treats a runner pause sentinel as deferred, not degraded (both sentinels)", () => {
+        // Verbatim runner settle for a call parked behind another approval (otel.ts
+        // TOOL_NOT_EXECUTED_PAUSED) — the #6106 "Couldn't render this request" regression.
+        expect(
+            deriveElicitationPartState({
+                state: "output-error",
+                errorText: `${DEFERRED_NOT_EXECUTED_PREFIX}: paused for another approval; retry the same call if still required.`,
+            }),
+        ).toBe("deferred")
+        expect(
+            deriveElicitationPartState({
+                state: "output-error",
+                errorText: APPROVED_EXECUTION_RESULT_UNKNOWN,
+            }),
+        ).toBe("deferred")
+    })
+
+    it("keeps a genuine errorText degraded", () => {
+        expect(
+            deriveElicitationPartState({
+                state: "output-error",
+                errorText: buildDegradationErrorText("missing message"),
+            }),
+        ).toBe("degraded")
+        expect(
+            deriveElicitationPartState({state: "output-error", errorText: "boom"}),
+        ).toBe("degraded")
+    })
+})
+
+describe("isDeferredToolSentinel", () => {
+    it("matches both sentinel codes by prefix", () => {
+        expect(isDeferredToolSentinel(`${DEFERRED_NOT_EXECUTED_PREFIX}: paused`)).toBe(true)
+        expect(isDeferredToolSentinel(APPROVED_EXECUTION_RESULT_UNKNOWN)).toBe(true)
+        expect(isDeferredToolSentinel("APPROVED_EXECUTION_RESULT_UNKNOWN: and more")).toBe(true)
+    })
+
+    it("rejects real errors and non-strings", () => {
+        expect(isDeferredToolSentinel("connection refused")).toBe(false)
+        expect(isDeferredToolSentinel(buildDegradationErrorText("missing message"))).toBe(false)
+        expect(isDeferredToolSentinel(undefined)).toBe(false)
+        expect(isDeferredToolSentinel(null)).toBe(false)
     })
 })


### PR DESCRIPTION
## Context

When an agent asks two interactive questions in one turn (for example a Reddit OAuth connect, then a multi-select question), the runner pauses the turn on the first request and settles the second with the sentinel result `DEFERRED_NOT_EXECUTED: paused for another approval; retry the same call if still required.`, marked as an error. The generic tool card already treats this sentinel as "waiting on another approval", but the elicitation widget treated any error text as terminal and fell back to **"Couldn't render this request"**, even though the question and its multi-select schema were fully renderable. The same card also showed the header "Mcp.agenta tools.request input" because the Codex-style wire name `mcp.agenta-tools.request_input` was title-cased raw instead of being prettified like the `mcp__server__tool` form.

## Changes

- New `toolSentinels.ts` in `@agenta/shared` holds the runner's pause-sentinel prefixes (`DEFERRED_NOT_EXECUTED`, `APPROVED_EXECUTION_RESULT_UNKNOWN`) and an `isDeferredToolSentinel` helper. The OSS and `@agenta/chat` transcript builders, `ToolActivity`, and `ConnectToolWidget` now import these strings instead of keeping local copies. The two transcript builders' deliberately different matching logic is unchanged and stays pinned by the parity test.
- `deriveElicitationPartState` returns a new explicit `deferred` state when the error text is a deferral sentinel. Genuine errors still return `degraded`.
- `ElicitationWidget` renders a deferred request read-only: the question message and its form, disabled, with "Waiting on another approval". Nothing is submittable, because the runner tells the agent to re-issue the call after the pause; the re-issued card is the interactive one.

Before: fallback chip "Couldn't render this request" plus the raw request JSON.
After: the question with its (disabled) multi-select and a "Waiting on another approval" note.

- `canonicalToolName` now unwraps Codex-style `mcp.<server>.<tool>` the same way as `mcp__server__tool`, so the header reads "Request input". Only the internal `agenta-tools` server is unwrapped; a third-party server's `request_input` stays wrapped and is not routed into the Agenta widget (pinned by test).
- The client-tool registry looks up widgets by the canonical name, so wrapped names dispatch correctly even when the render hint is missing.

## Tests

- `@agenta/shared`: 342 passed. The elicitation suite covers both sentinels mapping to `deferred` and genuine errors staying `degraded`.
- web/oss AgentChatSlice suite: 35 files, 382 passed, 1 pre-existing skip. Includes a new component test pinning the deferred rendering (form disabled, no Accept/Decline buttons, waiting wording, no settle) and the genuine-error fallback, plus additive `toolDisplay`/registry tests for the Codex name form.
- `@agenta/chat`: 271 passed. `tsc --noEmit` clean for shared, chat, oss, and ee; `pnpm lint-fix` clean.
- A fresh-context review found no must-fix issues; its two should-fix items (sentinel dedup in `ConnectToolWidget`, the component-level deferred test) are included here.
- Not verified against a live deployment: the running OSS stack uses a prebuilt image without code mounts. The repro data comes from session `2618bed2-4a8a-4345-8460-0dc4e37cafa8` in that stack's database.

## What to QA

- In an agent session, get the agent to request an OAuth connection and ask a `request_input` question in the same turn (the daily-news-digest agent does this). The question card shows the message with a disabled form and "Waiting on another approval", not "Couldn't render this request".
- Resolve the first request and let the agent re-ask. The fresh card is interactive and submits normally.
- Regression: a client tool call that genuinely fails still shows the "Couldn't render this request" fallback.
- Regression: in a Codex-harness session, tool headers show "Request input" for `mcp.agenta-tools.request_input`; Claude-harness `mcp__...` headers are unchanged.

Closes #6106.
