### PR TITLE
fix(runner): say why a trace export failed, not just "Unauthorized"

### DIFF
--- a/api/oss/src/middlewares/auth.py
+++ b/api/oss/src/middlewares/auth.py
@@ -102,6 +102,16 @@ def _auth_id_tail(value: Optional[str]) -> Optional[str]:
     return value[-12:]
 
 
+def _unauthorized_reason(exc: HTTPException) -> Optional[str]:
+    """The `reason` a 401 was raised with, when its raiser named one (see `verify_secret_token`).
+
+    `reason` also reaches the caller in the response body, which is the point: it is how a
+    client tells "refresh your credential" from "your credential is wrong". Keep it a closed
+    vocabulary of stable literals — never free text, never an exception string.
+    """
+    return exc.detail.get("reason") if isinstance(exc.detail, dict) else None
+
+
 def _log_bearer_auth_denied(
     *,
     request: Request,
@@ -186,7 +196,14 @@ async def auth_middleware(request: Request, call_next):
             log.error("%s: %s", exc.status_code, exc.detail)
         elif 400 <= exc.status_code < 500:
             if exc.status_code in [401]:
-                log.debug("%s: %s", exc.status_code, exc.detail)
+                log.debug(
+                    "[auth] unauthorized",
+                    status_code=exc.status_code,
+                    path=request.url.path,
+                    method=request.method,
+                    reason=_unauthorized_reason(exc),
+                    detail=exc.detail,
+                )
             else:
                 log.warn("%s: %s", exc.status_code, exc.detail)
 
@@ -903,14 +920,56 @@ async def verify_secret_token(
         request.state.organization_name = auth_context.get("organization_name")
         request.state.credentials = f"{_SECRET_TOKEN_PREFIX}{secret_token}"
 
-    except DecodeError as exc:
-        raise UnauthorizedException() from exc
-
     except ExpiredSignatureError as exc:
-        raise UnauthorizedException() from exc
+        # The signature verified, so this is our own token presented past `_SECRET_EXP` — a
+        # caller that never re-acquired, which is a live client bug, hence warning over debug.
+        log.warn(
+            "[auth] secret token unauthorized",
+            path=request.url.path,
+            method=request.method,
+            reason="expired_signature",
+            expired_seconds_ago=_expired_seconds_ago(secret_token),
+        )
+
+        raise UnauthorizedException(reason="expired_signature") from exc
+
+    except DecodeError as exc:
+        log.debug(
+            "[auth] secret token unauthorized",
+            path=request.url.path,
+            method=request.method,
+            reason="invalid_token",
+        )
+
+        raise UnauthorizedException(reason="invalid_token") from exc
 
     except Exception as exc:  # pylint: disable=bare-except
         raise InternalServerErrorException() from exc
+
+
+def _expired_seconds_ago(secret_token: str) -> Optional[int]:
+    """Seconds since the token's `exp` passed — the age an aged-out credential reports.
+
+    Verification is off: the caller only reaches this after `decode` already verified the
+    signature, and the claim feeds a log field, never a decision.
+    """
+    try:
+        claims = decode(
+            jwt=secret_token,
+            key=_SECRET_KEY,
+            algorithms=["HS256"],
+            options={"verify_signature": False, "verify_exp": False},
+        )
+
+        expiry = claims.get("exp")
+
+        if not isinstance(expiry, (int, float)):
+            return None
+
+        return int(datetime.now(timezone.utc).timestamp() - expiry)
+
+    except Exception:  # pylint: disable=broad-exception-caught
+        return None
 
 
 async def sign_secret_token(

--- a/api/oss/tests/pytest/unit/middlewares/test_auth_secret_token.py
+++ b/api/oss/tests/pytest/unit/middlewares/test_auth_secret_token.py
@@ -1,0 +1,123 @@
+"""A rejected `Secret` token must say WHY it was rejected.
+
+Trace exports from the agent runner failed with 401 for a week and the server side logged
+nothing that told an expired credential apart from a malformed one. These pin the two reasons
+and the age the expired one reports.
+"""
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+from fastapi import HTTPException
+from jwt import encode
+from starlette.requests import Request
+
+from oss.src.middlewares import auth
+from oss.src.utils.exceptions import UnauthorizedException
+
+
+SECRET_KEY = "unit-test-secret-key-with-32-bytes"
+
+
+class _RecordingLog:
+    """Stands in for the module logger and keeps every (level, event, fields) call."""
+
+    def __init__(self):
+        self.calls = []
+
+    def _record(self, level):
+        def log(event, *args, **fields):
+            self.calls.append((level, event, fields))
+
+        return log
+
+    def __getattr__(self, level):
+        return self._record(level)
+
+    def of(self, level):
+        return [call for call in self.calls if call[0] == level]
+
+
+@pytest.fixture(name="log")
+def _log(monkeypatch):
+    recorder = _RecordingLog()
+    monkeypatch.setattr(auth, "log", recorder)
+    monkeypatch.setattr(auth, "_SECRET_KEY", SECRET_KEY)
+    return recorder
+
+
+def _request() -> Request:
+    return Request(
+        {
+            "type": "http",
+            "method": "POST",
+            "path": "/otlp/v1/traces",
+            "headers": [],
+            "query_string": b"",
+            "scheme": "http",
+            "server": ("testserver", 80),
+            "root_path": "",
+        }
+    )
+
+
+def _token(expires_in_seconds: int) -> str:
+    expiry = datetime.now(timezone.utc) + timedelta(seconds=expires_in_seconds)
+    return encode(
+        payload={"user_id": "u", "project_id": "p", "exp": int(expiry.timestamp())},
+        key=SECRET_KEY,
+        algorithm="HS256",
+    )
+
+
+@pytest.mark.asyncio
+async def test_expired_token_reports_expired_signature_and_its_age(log):
+    with pytest.raises(UnauthorizedException) as raised:
+        await auth.verify_secret_token(
+            request=_request(),
+            secret_token=_token(expires_in_seconds=-3600),
+        )
+
+    assert raised.value.detail["reason"] == "expired_signature"
+
+    (_, event, fields) = log.of("warn")[0]
+    assert event == "[auth] secret token unauthorized"
+    assert fields["reason"] == "expired_signature"
+    # The age is what names the cause: the runner held the credential past its 15-minute life.
+    assert 3500 < fields["expired_seconds_ago"] < 3700
+
+
+@pytest.mark.asyncio
+async def test_malformed_token_reports_invalid_token(log):
+    with pytest.raises(UnauthorizedException) as raised:
+        await auth.verify_secret_token(request=_request(), secret_token="not-a-jwt")
+
+    assert raised.value.detail["reason"] == "invalid_token"
+
+    (_, event, fields) = log.of("debug")[0]
+    assert event == "[auth] secret token unauthorized"
+    assert fields["reason"] == "invalid_token"
+    assert log.of("warn") == []
+
+
+@pytest.mark.asyncio
+async def test_live_token_authenticates_and_logs_nothing(log):
+    request = _request()
+
+    await auth.verify_secret_token(
+        request=request,
+        secret_token=_token(expires_in_seconds=600),
+    )
+
+    assert request.state.user_id == "u"
+    assert request.state.project_id == "p"
+    assert log.calls == []
+
+
+def test_unauthorized_reason_reads_the_raiser_s_reason():
+    # This is what the middleware's 401 branch logs, so a 401 is one grep either way.
+    assert (
+        auth._unauthorized_reason(UnauthorizedException(reason="expired_signature"))
+        == "expired_signature"
+    )
+    assert auth._unauthorized_reason(HTTPException(401, "Unauthorized")) is None

--- a/services/runner/src/tracing/export-diagnostics.ts
+++ b/services/runner/src/tracing/export-diagnostics.ts
@@ -1,0 +1,188 @@
+/**
+ * What the runner says when an OTLP trace export does not land.
+ *
+ * Cloud exports failed with a bare `otel: trace export failed <traceId> OTLPExporterError:
+ * Unauthorized` for a week: no status, no endpoint, and nothing about the credential — so an
+ * export credential that had aged out (the actual cause) looked exactly like a wrong one, and
+ * a batch carrying no credential at all was sent anyway and reported the same 401.
+ *
+ * Every non-landing export goes through `logExportProblem`, so the three outcomes (rejected,
+ * threw, skipped) share one shape a log query can parse.
+ */
+import type { Redactor } from "../redaction.ts";
+
+/** Auth schemes we are willing to echo into a log. Anything else reports as "other", so a
+ *  malformed header value can never put token bytes in a log line. */
+const KNOWN_AUTH_SCHEMES = ["Secret", "ApiKey", "Bearer", "Access"];
+
+/** Log field caps. Applied AFTER redaction (see `logExportProblem`). */
+const MAX_RESPONSE_CHARS = 200;
+const MAX_ERROR_CHARS = 200;
+const MAX_STACK_CHARS = 600;
+
+/** Host of an OTLP endpoint. Logs carry the host, never the full caller-supplied URL. */
+export function endpointHost(endpoint: string): string {
+  try {
+    return new URL(endpoint).host;
+  } catch {
+    return "unparseable";
+  }
+}
+
+/**
+ * What an export credential says about itself. Agenta mints the export credential as a
+ * short-lived JWT, so a 401 from a credential that aged out is otherwise indistinguishable
+ * from a 401 from a wrong one. Read from the token's own `iat`/`exp` claims; the token itself
+ * is never returned or logged.
+ */
+export interface CredentialAge {
+  /** Auth scheme; "none" when the export carries no credential at all. */
+  scheme: string;
+  /** Seconds since the JWT was issued, when it carries an `iat` claim. */
+  ageSeconds?: number;
+  /** Seconds until the JWT expires; negative once it has. */
+  expiresInSeconds?: number;
+  /** True when `exp` is in the past — the credential names itself as the cause of a 401. */
+  expired?: boolean;
+}
+
+/** Claims of a JWT. Diagnostics only: no signature is checked and nothing here decides access. */
+function jwtClaims(token: string): Record<string, unknown> | undefined {
+  const parts = token.split(".");
+  if (parts.length !== 3) return undefined;
+  try {
+    const claims = JSON.parse(
+      Buffer.from(parts[1], "base64url").toString("utf8"),
+    );
+    return claims && typeof claims === "object" ? claims : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+export function describeCredential(authorization?: string): CredentialAge {
+  if (!authorization?.trim()) return { scheme: "none" };
+  // "<Scheme> <token>", or a bare token with no scheme: either way the credential is the last
+  // token, and a scheme only exists when something followed it.
+  const [first, ...rest] = authorization.trim().split(/\s+/);
+  const scheme =
+    rest.length > 0 && KNOWN_AUTH_SCHEMES.includes(first) ? first : "other";
+  const claims = jwtClaims(rest.at(-1) ?? first);
+  const age: CredentialAge = { scheme };
+  if (!claims) return age;
+  const now = Date.now() / 1000;
+  if (typeof claims.iat === "number")
+    age.ageSeconds = Math.round(now - claims.iat);
+  if (typeof claims.exp === "number") {
+    age.expiresInSeconds = Math.round(claims.exp - now);
+    age.expired = age.expiresInSeconds < 0;
+  }
+  return age;
+}
+
+/**
+ * The exhausted-retry message otlp-exporter-base 0.220 raises for the whole RETRYABLE status
+ * class (408, 429, 5xx). That path resolves without an HTTP response object, so the error it
+ * finally reports carries no `code` and no body — the status is genuinely unavailable, however
+ * the log is written. Naming the class is the most a log can say there; without it a throttled
+ * or quota-rejected export is indistinguishable from a transport error.
+ */
+const RETRYABLE_EXHAUSTED = "Export failed with retryable status";
+
+/** What an OTLP failure says about itself. `OTLPExporterError.code` is the HTTP status (a
+ *  transport-level failure — DNS, refused connection — carries a string code or none) and its
+ *  `data` is the rejecting endpoint's own body, which is what turns "Unauthorized" into a
+ *  reason. Body is returned WHOLE: it is truncated only after redaction, or a secret straddling
+ *  the cut would survive as a prefix. */
+function describeExportError(error: unknown): {
+  status?: number;
+  statusClass?: string;
+  response?: string;
+} {
+  const { code, data, message } = (error ?? {}) as {
+    code?: unknown;
+    data?: unknown;
+    message?: unknown;
+  };
+  return {
+    status: typeof code === "number" ? code : undefined,
+    statusClass:
+      message === RETRYABLE_EXHAUSTED ? "retryable (408/429/5xx)" : undefined,
+    response: typeof data === "string" && data ? data : undefined,
+  };
+}
+
+/** The text of anything thrown: an Error's message, else the value itself, else its JSON. A
+ *  string or object throw has no `.message`, and reporting nothing is how a failure goes
+ *  unexplained — an object that stringifies to "[object Object]" says the least of all. */
+function errorText(error: unknown): string | undefined {
+  if (error == null) return undefined;
+  const message = (error as { message?: unknown }).message;
+  if (typeof message === "string" && message) return message;
+  const text = String(error);
+  if (text && text !== "[object Object]") return text;
+  try {
+    return JSON.stringify(error);
+  } catch {
+    return undefined;
+  }
+}
+
+function truncate(text: string | undefined, limit: number): string | undefined {
+  if (!text) return undefined;
+  return text.length > limit ? `${text.slice(0, limit)}…` : text;
+}
+
+const OUTCOME_MESSAGES = {
+  failed: "otel: trace export failed",
+  threw: "otel: trace export threw",
+  skipped: "otel: trace export skipped, no credential",
+} as const;
+
+/**
+ * Report one batch that did not land. The endpoint's response and the error text are
+ * caller-derived, so they run through the trace's own deny-set on the way out — the same
+ * sink-level rule the exported spans follow — and are truncated only afterwards.
+ *
+ * A `threw` outcome also carries the stack: that outcome means the exporter itself blew up
+ * (a misconfigured one, say), and the frame is what names it. A rejected export's stack is
+ * always the same transport frame, so it is left out there.
+ */
+export function logExportProblem(problem: {
+  outcome: keyof typeof OUTCOME_MESSAGES;
+  traceId: string;
+  endpoint: string;
+  authorization?: string;
+  spans: number;
+  error?: unknown;
+  redactors?: Iterable<Redactor>;
+}): void {
+  const redact = (text?: string): string | undefined => {
+    if (!text) return undefined;
+    let out = text;
+    // `?? out` is the type narrowing, not a runtime fallback: redactString is declared
+    // `string | null | undefined` (it passes a nullish input straight back).
+    for (const redactor of problem.redactors ?? [])
+      out = redactor.redactString(out, "stderr") ?? out;
+    return out;
+  };
+  const { status, statusClass, response } = describeExportError(problem.error);
+  const stack =
+    problem.outcome === "threw" && problem.error instanceof Error
+      ? problem.error.stack
+      : undefined;
+  console.error(
+    OUTCOME_MESSAGES[problem.outcome],
+    JSON.stringify({
+      traceId: problem.traceId,
+      endpoint: endpointHost(problem.endpoint),
+      status,
+      statusClass,
+      credential: describeCredential(problem.authorization),
+      spans: problem.spans,
+      error: truncate(redact(errorText(problem.error)), MAX_ERROR_CHARS),
+      response: truncate(redact(response), MAX_RESPONSE_CHARS),
+      stack: truncate(redact(stack), MAX_STACK_CHARS),
+    }),
+  );
+}

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -358,7 +358,7 @@ class TraceBatchProcessor implements SpanProcessor {
           spans: group.length,
           redactors,
         };
-        if (!target.authorization && isAgentaIngest(target.endpoint)) {
+        if (!target.authorization?.trim() && isAgentaIngest(target.endpoint)) {
           // Agenta's ingest rejects an unauthenticated export, so sending one buys nothing and
           // reports as a 401 that reads like a BAD credential. Say the credential is missing
           // instead, and drop the batch here.

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -57,6 +57,7 @@ import { ATTR_SERVICE_NAME } from "@opentelemetry/semantic-conventions";
 
 import type { AgentEvent, AgentUsage, EmitEvent } from "../protocol.ts";
 import type { Redactor } from "../redaction.ts";
+import { logExportProblem } from "./export-diagnostics.ts";
 
 /** Machine-readable prefix on a sibling force-settle result (see TOOL_NOT_EXECUTED_PAUSED). The
  *  responder keys off this to keep the deferral out of the client-output store, and the web widget
@@ -182,12 +183,16 @@ function redactSpan(span: ReadableSpan, redactors: Iterable<Redactor>): void {
     }
     const status = span.status as { message?: string };
     if (typeof status.message === "string") {
-      status.message = redactor.redactString(status.message, "spans") ?? status.message;
+      status.message =
+        redactor.redactString(status.message, "spans") ?? status.message;
     }
   }
 }
 
-function redactAttributes(attrs: Record<string, unknown>, redactor: Redactor): void {
+function redactAttributes(
+  attrs: Record<string, unknown>,
+  redactor: Redactor,
+): void {
   for (const [key, value] of Object.entries(attrs)) {
     if (typeof value === "string") {
       attrs[key] = redactor.redactString(value, "spans");
@@ -223,23 +228,61 @@ function getExporter(target: ExportTarget): OTLPTraceExporter {
   return exporter;
 }
 
+const CLOUD_API_BASE = "https://cloud.agenta.ai/api";
+
 /** Fallback target from env, used when a trace was started without an explicit one. */
 function defaultTarget(): ExportTarget {
   // Internal direct hop first, then the public `.../api` base, then cloud.
   const base =
     (
       process.env.AGENTA_API_INTERNAL_URL ?? process.env.AGENTA_API_URL
-    )?.replace(/\/+$/, "") || "https://cloud.agenta.ai/api";
+    )?.replace(/\/+$/, "") || CLOUD_API_BASE;
   // The per-run caller credential rides the request (each explicit trace target carries its own
   // authorization; local Pi's OTLP bearer is written to a 0600 file). The runner holds no static
   // platform key: it must not carry an `AGENTA_API_KEY` a local harness could read from /proc and
   // reuse (interface.md section 2). The scheme-tagged ephemeral `AGENTA_CREDENTIALS` (a
-  // `Secret ...` from `/check`, used verbatim) is the only fallback; absent it, export unauthed.
+  // `Secret ...` from `/check`, used verbatim) is the only fallback; absent it, `flush` skips
+  // the export rather than sending Agenta an unauthenticated one (see `isAgentaIngest`).
   const credentials = process.env.AGENTA_CREDENTIALS || "";
   return {
     endpoint: `${base}/otlp/v1/traces`,
     authorization: credentials || undefined,
   };
+}
+
+/**
+ * Does this endpoint speak Agenta's own ingest, which always requires a credential? Only there
+ * is a credential-less export pointless — a caller may instead aim a run at a third-party
+ * collector (a local OTel collector, Jaeger, a host behind network auth), and those accept
+ * unauthenticated spans, so those must still be sent.
+ *
+ * Both configured bases count, not only the one `defaultTarget` picked: a run can be handed the
+ * public URL while the runner's own hop is internal. The full normalized ingest URL must match,
+ * because a third-party collector may share the Agenta host behind a different proxy path.
+ */
+function isAgentaIngest(endpoint: string): boolean {
+  const normalize = (value: string): string | undefined => {
+    try {
+      const url = new URL(value);
+      const path = url.pathname.replace(/\/+$/, "") || "/";
+      return `${url.origin}${path}`;
+    } catch {
+      return undefined;
+    }
+  };
+
+  const normalizedEndpoint = normalize(endpoint);
+  if (!normalizedEndpoint) return false;
+  return [
+    process.env.AGENTA_API_INTERNAL_URL,
+    process.env.AGENTA_API_URL,
+    CLOUD_API_BASE,
+  ].some(
+    (base) =>
+      base &&
+      normalize(`${base.replace(/\/+$/, "")}/otlp/v1/traces`) ===
+        normalizedEndpoint,
+  );
 }
 
 /**
@@ -306,22 +349,37 @@ class TraceBatchProcessor implements SpanProcessor {
         // Fall back to the env default only for a span whose OWN run's target is unknown
         // (untagged span, or the run already released) — never to another run's target, or a
         // batch could still land on an unintended endpoint/auth.
-        const target = (runId ? byRun?.get(runId) : undefined) ?? defaultTarget();
+        const target =
+          (runId ? byRun?.get(runId) : undefined) ?? defaultTarget();
+        const problem = {
+          traceId,
+          endpoint: target.endpoint,
+          authorization: target.authorization,
+          spans: group.length,
+          redactors,
+        };
+        if (!target.authorization && isAgentaIngest(target.endpoint)) {
+          // Agenta's ingest rejects an unauthenticated export, so sending one buys nothing and
+          // reports as a 401 that reads like a BAD credential. Say the credential is missing
+          // instead, and drop the batch here.
+          logExportProblem({ ...problem, outcome: "skipped" });
+          return Promise.resolve();
+        }
         return new Promise<void>((resolve) => {
           try {
             getExporter(target).export(orderParentFirst(group), (result) => {
               if (result.code === ExportResultCode.FAILED)
-                console.error(
-                  "otel: trace export failed",
-                  traceId,
-                  result.error,
-                );
+                logExportProblem({
+                  ...problem,
+                  outcome: "failed",
+                  error: result.error,
+                });
               resolve();
             });
           } catch (err) {
             // A synchronous export throw (e.g. misconfigured exporter) must stay best-effort:
             // flush() is awaited without a catch, so a reject here would break the run.
-            console.error("otel: trace export threw", traceId, err);
+            logExportProblem({ ...problem, outcome: "threw", error: err });
             resolve();
           }
         });
@@ -955,7 +1013,8 @@ function acpRawOutputText(raw: any): string {
       continue;
     }
     if (value && typeof value === "object") {
-      const text = acpToolContentText(value.content) || acpToolContentText(value);
+      const text =
+        acpToolContentText(value.content) || acpToolContentText(value);
       if (text) return text;
       const json = jsonText(value);
       if (json) return json;
@@ -1495,8 +1554,8 @@ export function createSandboxAgentOtel(
       usage = {
         input: usage?.input ?? 0,
         output: usage?.output ?? 0,
-        total: typeof total === "number" ? total : usage?.total ?? 0,
-        cost: typeof cost === "number" ? cost : usage?.cost ?? 0,
+        total: typeof total === "number" ? total : (usage?.total ?? 0),
+        cost: typeof cost === "number" ? cost : (usage?.cost ?? 0),
       };
       record({ type: "usage", ...usage });
     }

--- a/services/runner/tests/setup/hermetic-env.ts
+++ b/services/runner/tests/setup/hermetic-env.ts
@@ -49,6 +49,9 @@ const SCRUBBED = [
   "DAYTONA_API_URL",
   "DAYTONA_TARGET",
   "DAYTONA_SNAPSHOT",
+  // The per-run export credential the trace exporter falls back to. Present in a dev shell, it
+  // flips the credential-less export paths (skip vs send) that otel export tests assert on.
+  "AGENTA_CREDENTIALS",
 ];
 
 for (const name of SCRUBBED) delete process.env[name];

--- a/services/runner/tests/unit/otel-export-diagnostics.test.ts
+++ b/services/runner/tests/unit/otel-export-diagnostics.test.ts
@@ -1,0 +1,277 @@
+/**
+ * Trace exports from the cloud runner failed with a bare
+ * `otel: trace export failed <traceId> OTLPExporterError: Unauthorized` for a week. The line
+ * named neither the HTTP status, nor the endpoint, nor the age of the credential — so an
+ * expired export credential (the actual cause) was indistinguishable from a wrong one, and a
+ * batch with NO credential was sent anyway and reported the same 401.
+ *
+ * This pins the diagnostics that close that gap: the failure log carries status + endpoint host
+ * + credential age without the token, and a credential-less batch is skipped with its own line.
+ *
+ * Run: pnpm exec vitest run tests/unit/otel-export-diagnostics.test.ts
+ */
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { ExportResultCode } from "@opentelemetry/core";
+
+import {
+  describeCredential,
+  endpointHost,
+  logExportProblem,
+} from "../../src/tracing/export-diagnostics.ts";
+import { Redactor } from "../../src/redaction.ts";
+import {
+  AGENTA_INGEST_ENDPOINT,
+  TEST_EXPORT_ENDPOINT,
+  runExportCapture,
+} from "../utils/otel-export.ts";
+
+const SKIPPED = "trace export skipped, no credential";
+const INTERNAL_API_ORIGIN = ["http://agenta-api.internal", "8000"].join(":");
+
+/** A JWT with the given claims and a junk signature — nothing here verifies signatures. */
+function jwt(claims: Record<string, unknown>): string {
+  const segment = (value: unknown) =>
+    Buffer.from(JSON.stringify(value)).toString("base64url");
+  return `${segment({ alg: "HS256", typ: "JWT" })}.${segment(claims)}.c2lnbmF0dXJl`;
+}
+
+function secondsFromNow(offset: number): number {
+  return Math.floor(Date.now() / 1000) + offset;
+}
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+  vi.restoreAllMocks();
+});
+
+describe("endpointHost", () => {
+  it("keeps the host and port, and drops the path a log has no business carrying", () => {
+    expect(endpointHost("https://cloud.agenta.ai/api/otlp/v1/traces")).toBe(
+      "cloud.agenta.ai",
+    );
+    expect(endpointHost(`${INTERNAL_API_ORIGIN}/otlp/v1/traces`)).toBe(
+      "agenta-api.internal:8000",
+    );
+  });
+
+  it("says so rather than throwing when the endpoint is not a url", () => {
+    // The endpoint is caller-supplied, and this runs on a path that is already failing.
+    expect(endpointHost("not a url")).toBe("unparseable");
+    expect(endpointHost("")).toBe("unparseable");
+  });
+});
+
+describe("describeCredential", () => {
+  it("reports an expired credential as expired, without the token", () => {
+    const token = jwt({
+      exp: secondsFromNow(-3600),
+      iat: secondsFromNow(-4500),
+    });
+    const age = describeCredential(`Secret ${token}`);
+
+    expect(age.scheme).toBe("Secret");
+    expect(age.expired).toBe(true);
+    expect(age.expiresInSeconds).toBeLessThan(0);
+    expect(age.ageSeconds).toBeGreaterThan(4000);
+    expect(JSON.stringify(age)).not.toContain(token);
+  });
+
+  it("reports a live credential as not expired", () => {
+    const age = describeCredential(
+      `Secret ${jwt({ exp: secondsFromNow(600) })}`,
+    );
+
+    expect(age.expired).toBe(false);
+    expect(age.expiresInSeconds).toBeGreaterThan(0);
+  });
+
+  it("reports a missing credential as scheme none", () => {
+    expect(describeCredential(undefined)).toEqual({ scheme: "none" });
+    expect(describeCredential("  ")).toEqual({ scheme: "none" });
+  });
+
+  it("reads the token from a schemed credential, not the scheme word", () => {
+    // The token is the LAST whitespace-separated part, so a scheme never reaches the decoder
+    // and a bare token still does.
+    const token = jwt({ exp: secondsFromNow(-60) });
+
+    expect(describeCredential(`Secret ${token}`).expired).toBe(true);
+    expect(describeCredential(token).expired).toBe(true);
+    expect(describeCredential(`  Secret   ${token}  `).expired).toBe(true);
+  });
+
+  it("keeps an opaque or unknown-scheme credential out of the log", () => {
+    // An unrecognized scheme reports as "other" and an undecodable token yields no claims, so
+    // no byte of a non-JWT credential can reach a log line.
+    expect(describeCredential("Weird sk-live-abcdef")).toEqual({
+      scheme: "other",
+    });
+    expect(describeCredential("sk-live-abcdef")).toEqual({ scheme: "other" });
+    expect(describeCredential("ApiKey not.a.jwt")).toEqual({
+      scheme: "ApiKey",
+    });
+  });
+});
+
+describe("otel export diagnostics", () => {
+  it("names the status, endpoint and credential age when an export fails", async () => {
+    const token = jwt({ exp: secondsFromNow(-1800) });
+    const error = Object.assign(new Error("Unauthorized"), {
+      name: "OTLPExporterError",
+      code: 401,
+      data: '{"message":"Unauthorized"}',
+    });
+
+    const { logs, exportCalled } = await runExportCapture({
+      authorization: `Secret ${token}`,
+      result: { code: ExportResultCode.FAILED, error },
+    });
+
+    expect(exportCalled).toBe(true);
+    const failure = logs.find((line) => line.includes("trace export failed"));
+    expect(failure).toBeDefined();
+    expect(failure).toContain('"status":401');
+    expect(failure).toContain('"endpoint":"127.0.0.1:1"');
+    expect(failure).toContain('"expired":true');
+    expect(failure).toContain('"scheme":"Secret"');
+    expect(failure).toContain("Unauthorized");
+    expect(failure).not.toContain(token);
+  });
+
+  it("skips a credential-less export to Agenta's own ingest", async () => {
+    const { logs, exportCalled } = await runExportCapture({
+      endpoint: AGENTA_INGEST_ENDPOINT,
+      result: { code: ExportResultCode.SUCCESS },
+    });
+
+    expect(exportCalled).toBe(false);
+    expect(logs.some((line) => line.includes(SKIPPED))).toBe(true);
+  });
+
+  it("skips a credential-less export to the configured Agenta host, not just the cloud one", async () => {
+    vi.stubEnv("AGENTA_API_URL", INTERNAL_API_ORIGIN);
+
+    const { logs, exportCalled } = await runExportCapture({
+      endpoint: `${INTERNAL_API_ORIGIN}/otlp/v1/traces`,
+      result: { code: ExportResultCode.SUCCESS },
+    });
+
+    expect(exportCalled).toBe(false);
+    expect(logs.some((line) => line.includes(SKIPPED))).toBe(true);
+  });
+  it("exports to a credential-less collector on the Agenta host under another path", async () => {
+    vi.stubEnv("AGENTA_API_URL", `${INTERNAL_API_ORIGIN}/api`);
+
+    const { logs, exportCalled } = await runExportCapture({
+      endpoint: `${INTERNAL_API_ORIGIN}/collector/v1/traces`,
+      result: { code: ExportResultCode.SUCCESS },
+    });
+
+    expect(exportCalled).toBe(true);
+    expect(logs).toEqual([]);
+  });
+
+  it("exports to Agenta ingest once the env credential is present", async () => {
+    // The fallback credential is what keeps a run that carries none of its own exporting, which
+    // is what otel-trace-target-attribution.test.ts leans on to keep its fallback guard alive.
+    vi.stubEnv("AGENTA_CREDENTIALS", "Secret env-credential");
+
+    const { logs, exportCalled } = await runExportCapture({
+      endpoint: AGENTA_INGEST_ENDPOINT,
+      result: { code: ExportResultCode.SUCCESS },
+    });
+
+    expect(exportCalled).toBe(true);
+    expect(logs).toEqual([]);
+  });
+
+  it("still exports a credential-less batch to a third-party collector", async () => {
+    // A caller can aim a run at its own OTel collector or Jaeger, which take unauthenticated
+    // spans. Skipping there would drop every batch the collector was meant to receive.
+    const { logs, exportCalled } = await runExportCapture({
+      endpoint: TEST_EXPORT_ENDPOINT,
+      result: { code: ExportResultCode.SUCCESS },
+    });
+
+    expect(exportCalled).toBe(true);
+    expect(logs).toEqual([]);
+  });
+});
+
+describe("logExportProblem", () => {
+  function captureProblem(
+    problem: Parameters<typeof logExportProblem>[0],
+  ): string {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    logExportProblem(problem);
+    return errorSpy.mock.calls.map((args) => args.join(" ")).join("\n");
+  }
+
+  const base = {
+    traceId: "t",
+    endpoint: AGENTA_INGEST_ENDPOINT,
+    authorization: "Secret x",
+    spans: 1,
+  };
+
+  it("reports a thrown non-Error by its string form", () => {
+    const line = captureProblem({
+      ...base,
+      outcome: "threw",
+      error: "exporter blew up",
+    });
+
+    expect(line).toContain("trace export threw");
+    expect(line).toContain("exporter blew up");
+  });
+
+  it("reports a thrown plain object rather than nothing at all", () => {
+    const line = captureProblem({
+      ...base,
+      outcome: "threw",
+      error: { errno: -111, syscall: "connect" },
+    });
+
+    expect(line).toContain("connect");
+  });
+
+  it("carries the stack of a thrown Error, which names the misconfigured exporter", () => {
+    const line = captureProblem({
+      ...base,
+      outcome: "threw",
+      error: new Error("bad exporter config"),
+    });
+
+    expect(line).toContain("bad exporter config");
+    expect(line).toContain('"stack":"Error: bad exporter config');
+  });
+
+  it("names the retryable class, which the exporter reports without a status", () => {
+    // 408/429/5xx exhaust their retries and surface with no code and no body, so a throttled
+    // or quota-rejected export would otherwise show no status at all.
+    const line = captureProblem({
+      ...base,
+      outcome: "failed",
+      error: new Error("Export failed with retryable status"),
+    });
+
+    expect(line).toContain('"statusClass":"retryable (408/429/5xx)"');
+  });
+
+  it("redacts the response body before truncating it, so no secret survives the cut", () => {
+    const secret = ["sk", "live", "0123456789abcdef"].join("-");
+    const redactor = new Redactor().withKnownSecrets([secret]);
+    // Straddle the 200-char cut: truncating first would leave the secret's prefix in the log.
+    const body = `${"x".repeat(190)}${secret}${"y".repeat(50)}`;
+
+    const line = captureProblem({
+      ...base,
+      outcome: "failed",
+      error: Object.assign(new Error("Forbidden"), { code: 403, data: body }),
+      redactors: [redactor],
+    });
+
+    expect(line).not.toContain(secret.slice(0, 10));
+    expect(line).toContain('"status":403');
+  });
+});

--- a/services/runner/tests/unit/otel-export-diagnostics.test.ts
+++ b/services/runner/tests/unit/otel-export-diagnostics.test.ts
@@ -138,9 +138,10 @@ describe("otel export diagnostics", () => {
     expect(failure).not.toContain(token);
   });
 
-  it("skips a credential-less export to Agenta's own ingest", async () => {
+  it("skips a blank credential on Agenta's own ingest", async () => {
     const { logs, exportCalled } = await runExportCapture({
       endpoint: AGENTA_INGEST_ENDPOINT,
+      authorization: "   ",
       result: { code: ExportResultCode.SUCCESS },
     });
 

--- a/services/runner/tests/unit/otel-flush-export.test.ts
+++ b/services/runner/tests/unit/otel-flush-export.test.ts
@@ -3,23 +3,16 @@
  * export FAILURE resolved as success and was invisible. This pins that a failing export is
  * logged rather than silently swallowed.
  *
- * We spy on `OTLPExporterBase.prototype.export` (reached via any exporter instance's prototype
- * chain, since the package only exports the concrete `OTLPTraceExporter`) to force a FAILED
- * `ExportResult` through the real `TraceBatchProcessor` created by `createSandboxAgentOtel`.
+ * The runs here export to a third-party collector, which takes unauthenticated spans, so no
+ * credential is needed. Only a credential-less export to Agenta's OWN ingest is skipped before
+ * reaching the exporter (pinned in otel-export-diagnostics.test.ts).
  *
  * Run: pnpm exec vitest run tests/unit/otel-flush-export.test.ts
  */
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
-import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
-import type { SpanExporter } from "@opentelemetry/sdk-trace-base";
+import { ExportResultCode } from "@opentelemetry/core";
 
-import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
-
-/** The shared base prototype real exporters inherit `export` from, typed as `SpanExporter`. */
-function exportProtoOf(exporter: OTLPTraceExporter): SpanExporter {
-  return Object.getPrototypeOf(Object.getPrototypeOf(exporter));
-}
+import { runExportCapture } from "../utils/otel-export.ts";
 
 afterEach(() => {
   vi.restoreAllMocks();
@@ -27,58 +20,20 @@ afterEach(() => {
 
 describe("otel TraceBatchProcessor.flush", () => {
   it("logs a FAILED ExportResult instead of silently resolving", async () => {
-    // Reach the shared base prototype that actually owns `export` (OTLPTraceExporter itself
-    // declares no own methods) so the spy applies to every exporter instance the module builds.
-    const exportProto = exportProtoOf(
-      new OTLPTraceExporter({ url: "http://127.0.0.1:1/v1/traces" }),
-    );
-    const exportSpy = vi
-      .spyOn(exportProto, "export")
-      .mockImplementation((_spans, cb: (r: ExportResult) => void) => {
-        cb({ code: ExportResultCode.FAILED, error: new Error("boom") });
-      });
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    const otel = createSandboxAgentOtel({
-      harness: "claude",
-      model: "anthropic/claude-haiku",
-      emitSpans: true,
-      endpoint: "http://127.0.0.1:1/v1/traces",
+    const { logs, exportCalled } = await runExportCapture({
+      result: { code: ExportResultCode.FAILED, error: new Error("boom") },
     });
-    otel.start({ prompt: "hi" });
-    otel.finish();
-    await otel.flush();
 
-    expect(exportSpy).toHaveBeenCalled();
+    expect(exportCalled).toBe(true);
     // The failure must surface via a log, not vanish.
-    expect(errorSpy).toHaveBeenCalled();
-    const loggedFailure = errorSpy.mock.calls.some((args) =>
-      args.some((a) => typeof a === "string" && a.includes("export failed")),
-    );
-    expect(loggedFailure).toBe(true);
+    expect(logs.some((line) => line.includes("export failed"))).toBe(true);
   });
 
   it("does not log on a SUCCESS ExportResult", async () => {
-    const exportProto = exportProtoOf(
-      new OTLPTraceExporter({ url: "http://127.0.0.1:1/v1/traces" }),
-    );
-    vi.spyOn(exportProto, "export").mockImplementation(
-      (_spans, cb: (r: ExportResult) => void) => {
-        cb({ code: ExportResultCode.SUCCESS });
-      },
-    );
-    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-    const otel = createSandboxAgentOtel({
-      harness: "claude",
-      model: "anthropic/claude-haiku",
-      emitSpans: true,
-      endpoint: "http://127.0.0.1:1/v1/traces",
+    const { logs } = await runExportCapture({
+      result: { code: ExportResultCode.SUCCESS },
     });
-    otel.start({ prompt: "hi" });
-    otel.finish();
-    await otel.flush();
 
-    expect(errorSpy).not.toHaveBeenCalled();
+    expect(logs).toEqual([]);
   });
 });

--- a/services/runner/tests/unit/otel-trace-target-attribution.test.ts
+++ b/services/runner/tests/unit/otel-trace-target-attribution.test.ts
@@ -21,7 +21,7 @@
  *
  * Run: pnpm exec vitest run tests/unit/otel-trace-target-attribution.test.ts
  */
-import { afterEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { ExportResult } from "@opentelemetry/core";
 import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
 
@@ -42,7 +42,11 @@ vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => {
       this.authorization = config.headers?.Authorization;
     }
     export(spans: ReadableSpan[], cb: (r: ExportResult) => void): void {
-      fakeExports.push({ url: this.url, authorization: this.authorization, spans });
+      fakeExports.push({
+        url: this.url,
+        authorization: this.authorization,
+        spans,
+      });
       cb({ code: 0 /* ExportResultCode.SUCCESS */ });
     }
     async shutdown(): Promise<void> {}
@@ -60,8 +64,19 @@ function exportsTo(endpoint: string): ReadableSpan[] {
   return fakeExports.filter((e) => e.url === endpoint).flatMap((e) => e.spans);
 }
 
+beforeEach(() => {
+  // Pin the env fallback target so the "nothing fell back to the default" assertions below are
+  // real. Empty API urls keep `defaultTarget()` on the cloud base the assertions name, and the
+  // credential is what keeps a fallback batch EXPORTING: without one it would be skipped
+  // (Agenta ingest never takes an unauthenticated export) and the guard would pass vacuously.
+  vi.stubEnv("AGENTA_API_INTERNAL_URL", "");
+  vi.stubEnv("AGENTA_API_URL", "");
+  vi.stubEnv("AGENTA_CREDENTIALS", "Secret fallback-credential");
+});
+
 afterEach(() => {
   fakeExports.length = 0;
+  vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
 
@@ -113,7 +128,9 @@ describe("otel traceTargets — per-run target attribution across a shared trace
     expect(atB.length).toBeGreaterThan(0);
 
     // No batch fell back to the env default while a run was still registered.
-    expect(exportsTo("https://cloud.agenta.ai/api/otlp/v1/traces")).toHaveLength(0);
+    expect(
+      exportsTo("https://cloud.agenta.ai/api/otlp/v1/traces"),
+    ).toHaveLength(0);
 
     // Attribution is correct, not merely present: A's spans carry A's prompt, B's carry B's.
     // `input.value` is itself a JSON-encoded string attribute, so the nested quotes are escaped.
@@ -164,14 +181,23 @@ describe("otel traceTargets — per-run target attribution across a shared trace
 
     for (const [label, endpoint] of Object.entries(TARGETS)) {
       const spans = exportsTo(endpoint);
-      expect(spans.length, `${label} should have exported to its own target`).toBeGreaterThan(0);
+      expect(
+        spans.length,
+        `${label} should have exported to its own target`,
+      ).toBeGreaterThan(0);
       const text = JSON.stringify(spans.map((s) => s.attributes));
-      expect(text).toContain(`\\"prompt\\":\\"prompt-${label.toLowerCase()}\\"`);
+      expect(text).toContain(
+        `\\"prompt\\":\\"prompt-${label.toLowerCase()}\\"`,
+      );
       for (const other of Object.keys(TARGETS)) {
         if (other === label) continue;
-        expect(text).not.toContain(`\\"prompt\\":\\"prompt-${other.toLowerCase()}\\"`);
+        expect(text).not.toContain(
+          `\\"prompt\\":\\"prompt-${other.toLowerCase()}\\"`,
+        );
       }
     }
-    expect(exportsTo("https://cloud.agenta.ai/api/otlp/v1/traces")).toHaveLength(0);
+    expect(
+      exportsTo("https://cloud.agenta.ai/api/otlp/v1/traces"),
+    ).toHaveLength(0);
   });
 });

--- a/services/runner/tests/utils/otel-export.ts
+++ b/services/runner/tests/utils/otel-export.ts
@@ -1,0 +1,58 @@
+/**
+ * Drive one agent run through the real `TraceBatchProcessor` with a stubbed OTLP transport, and
+ * return what the export path logged.
+ *
+ * The stub goes on the shared base prototype exporters inherit `export` from, because the
+ * package only exports the concrete `OTLPTraceExporter` and the module builds its own instances
+ * from an internal cache — a spy on any one instance would not be reached.
+ */
+import { vi } from "vitest";
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import type { ExportResult } from "@opentelemetry/core";
+import type { SpanExporter } from "@opentelemetry/sdk-trace-base";
+
+import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
+
+/** A third-party collector: not an Agenta host, so a credential-less batch is still sent. */
+export const TEST_EXPORT_ENDPOINT = "http://127.0.0.1:1/otlp/v1/traces";
+
+/** Agenta's own ingest, which never accepts an unauthenticated export. */
+export const AGENTA_INGEST_ENDPOINT =
+  "https://cloud.agenta.ai/api/otlp/v1/traces";
+
+function exportPrototype(): SpanExporter {
+  const exporter = new OTLPTraceExporter({ url: TEST_EXPORT_ENDPOINT });
+  return Object.getPrototypeOf(Object.getPrototypeOf(exporter));
+}
+
+/** Run one prompt to completion and flush it. Call inside a test that restores mocks after. */
+export async function runExportCapture(options: {
+  /** Omit to run a batch with no credential. */
+  authorization?: string;
+  result: ExportResult;
+  endpoint?: string;
+}): Promise<{ logs: string[]; exportCalled: boolean }> {
+  const endpoint = options.endpoint ?? TEST_EXPORT_ENDPOINT;
+  const exportSpy = vi
+    .spyOn(exportPrototype(), "export")
+    .mockImplementation((_spans, cb: (r: ExportResult) => void) =>
+      cb(options.result),
+    );
+  const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+  const otel = createSandboxAgentOtel({
+    harness: "claude",
+    model: "anthropic/claude-haiku",
+    emitSpans: true,
+    endpoint,
+    authorization: options.authorization,
+  });
+  otel.start({ prompt: "hi" });
+  otel.finish();
+  await otel.flush();
+
+  return {
+    logs: errorSpy.mock.calls.map((args) => args.join(" ")),
+    exportCalled: exportSpy.mock.calls.length > 0,
+  };
+}


### PR DESCRIPTION
## Context

When a trace export was rejected, the runner logged one line:

```
otel: trace export failed 4bf92f3577b34da6a3ce929d0e0e4736 OTLPExporterError: Unauthorized
```

That line names no HTTP status, no endpoint, and nothing about the credential the export carried. The export credential is a short-lived JWT, so the most likely cause (a credential that aged out) looks exactly like the least likely one (a credential that was never valid). A run of these failures went undiagnosed for a week because the log could not tell the two apart.

A second gap fed the same confusion. When no credential was available at all, the export was sent anyway, so a missing credential also came back as a 401 and read like a bad one.

This PR makes the failure legible. Refreshing the credential per turn is a separate change.

## Changes

Every export that does not land now goes through one log shape, so the three outcomes (rejected, threw, skipped) answer to one query.

Before:

```
otel: trace export failed 4bf92f3577b34da6a3ce929d0e0e4736 OTLPExporterError: Unauthorized
```

After:

```
otel: trace export failed {"traceId":"4bf92f3577b34da6a3ce929d0e0e4736","endpoint":"cloud.agenta.ai","status":401,"credential":{"scheme":"Secret","ageSeconds":3645,"expiresInSeconds":-2745,"expired":true},"spans":3,"error":"Unauthorized","response":"{\"message\":\"Unauthorized\",\"reason\":\"expired_signature\"}"}
```

The credential's age comes from decoding the JWT's own `iat` and `exp` claims locally. No signature is checked, the token itself never reaches a log, and an unrecognized scheme reports as `other` so a malformed header value cannot put token bytes in a log line.

A batch with no credential is no longer sent to Agenta's own ingest, which always rejects it. It is dropped with its own line:

```
otel: trace export skipped, no credential {"traceId":"4bf92f...","endpoint":"cloud.agenta.ai","credential":{"scheme":"none"},"spans":3}
```

Only Agenta's ingest is skipped. An endpoint is caller-supplied, so a run aimed at a third-party collector (a local OpenTelemetry collector, Jaeger, a host behind network auth) still gets its unauthenticated spans. The check matches the endpoint host against both configured API bases and the cloud one.

On the API side, a rejected `Secret` token now says which kind of rejection it was. An expired signature logs at warning, with the seconds since it expired, because the signature verified: that is our own token presented late, which is a live client bug. A malformed token logs at debug. Both name a `reason` in the 401 body (`expired_signature` or `invalid_token`), which is what lets a client tell "refresh your credential" from "your credential is wrong".

```
[WARN.] [auth] secret token unauthorized path=/otlp/v1/traces method=POST reason=expired_signature expired_seconds_ago=2746
```

The two halves meet: the API names the reason in the body, and the runner logs that body back. One failed export now says both how old its credential was and that the server agrees expiry was the cause.

## Tests / notes

- Runner: `pnpm test` (130 files, 2180 tests) and `pnpm run typecheck`, both clean. New unit tests cover the credential decoder, both sides of the Agenta-host check (skipped there, still exported to a third-party collector), the thrown-value shapes, and redaction.
- API: `pytest oss/tests/pytest/unit/middlewares`, plus `ruff format` and `ruff check`.
- The response body and the error text run through the trace's own redactor before they are truncated, so a secret straddling the cut cannot survive as a prefix.
- `reason` is now part of the 401 response, not only the log. Keep it a closed vocabulary of stable literals.
- Worth knowing: the retryable status class (408, 429, 5xx) reaches the exporter's caller with no code and no body in the pinned `otlp-exporter-base` 0.220, so those log `statusClass: "retryable (408/429/5xx)"` rather than a number. That is the most the transport makes available.
- `ageSeconds` appears only when the token carries an `iat` claim. The per-turn credential change adds it.
