### PR TITLE
[test] Catch agent turns that end with no answer and no error

### DIFF
--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -130,7 +130,9 @@ proves nothing about the durable working directory (LESSONS #16).
   while that file is broken.
 - `resources/qa_matrix_lib.py` — shared helpers (session/turn plumbing, workflow/revision REST
   calls, the multi-round approval loop) for the `matrix_w*.py` adversarial cells below. Import
-  only, no CLI.
+  only, no CLI. It also holds the two cross-cutting invariants every cell should fold into its
+  verdict — `check_no_blank_success_on_refusal` and `check_no_silent_turn` (see below). **If you
+  write a new cell, wire `check_no_silent_turn` into its PASS condition.**
 - `resources/matrix_w3.py` — **[coached, with a narrow mechanism-blind sliver]** two sessions,
   disjoint edits; session B is given a stale `base_revision_id` and ZERO coaching on recovery.
   Two-tier pass: autonomous correct recovery passes outright; a model that diagnoses the 409
@@ -206,6 +208,21 @@ proves nothing about the durable working directory (LESSONS #16).
   A reliable deterministic trigger (e.g. a genuine cold-resume stale-approval replay, or a crafted
   duplicate `toolCallId`) is an open follow-up; until then, treat any SKIP from this cell as "the
   invariant was not tested this run," never as green.
+- `qa_matrix_lib.check_no_silent_turn(turns)` — **[mechanism-level invariant; no cell of its
+  own]** no turn may come back completely bare: no text, no tool call, no approval gate, no file
+  or data payload, and no error. That combination is a swallowed provider failure (ASD-EST100) —
+  the model call is rejected, the error is dropped on the way back, and the turn is reported as a
+  clean empty finish, so the user sees a blank bubble with no reason anywhere. It matters most in
+  cells whose PASS depends on something NOT appearing (no error, no leak, no blank success): a
+  turn that produced nothing satisfies those by doing nothing at all. Its content definition
+  deliberately mirrors `content_parts_emitted` in the product's own Vercel egress
+  (`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`) — reasoning does NOT count, so a
+  turn that only thought is still a violation. Wired into `matrix_w7*.py`, `matrix_t8_saved_files.py`,
+  `matrix_b1_builtin_find.py`, `matrix_invariant_commit_auth_refusal.py`,
+  `matrix_l3_abandoned_approval.py`, `matrix_w3.py`, `matrix_w4.py` and `matrix_w5.py` as
+  `... and not silent["violations"]`; add the same conjunct to any new cell. The one thing a cell
+  must exclude itself is a turn it deliberately aborted or interrupted, which legitimately ends
+  bare — `matrix_w5.py` shows the pattern (it checks only its post-interrupt turns).
 - `resources/matrix_g1_guidance_discovery.py` — **[mechanism-blind]** does the platform guidance
   actually change what the model does? The trial prompt is Mahmoud's own verbatim phrasing from
   the live session that found the bug ("can you add gstack-autoplan skill to your skills (i saved

--- a/.agents/skills/agent-release-gate/resources/coverage.md
+++ b/.agents/skills/agent-release-gate/resources/coverage.md
@@ -177,6 +177,27 @@ I2 reports an unset `TELEGRAM_BOT_TOKEN` as a loud journey `SKIP` and makes the 
 green. The token is read from the process environment only and is never printed or stored in the
 result.
 
+## Cross-cutting invariants (fold into every cell's verdict)
+
+These are not cells. They are pure checks in `qa_matrix_lib.py` that a cell folds into its PASS
+condition, so a cell cannot report green on a run that violated one. Both exist because a cell's
+own assertions are scenario-shaped and can be satisfied for the wrong reason.
+
+| Invariant | What it pins | Wired into |
+|---|---|---|
+| `check_no_blank_success_on_refusal(turns, log_lines)` | No `tool_result` with empty output and `isError:false` may exist for a call the runner logged as `[commit-auth] refused`. A refusal must reach the wire as an error or a denial, never as a blank that reads as success. | `matrix_invariant_commit_auth_refusal.py` |
+| `check_no_silent_turn(turns)` | No turn may come back completely bare — no text, no tool call, no approval gate, no file or data payload, no error. That is a swallowed provider failure (ASD-EST100) arriving as a clean empty finish: the user sees a blank bubble with no reason anywhere. | `matrix_w7.py`, `matrix_w7_daytona.py`, `matrix_w7_per_harness.py`, `matrix_t8_saved_files.py`, `matrix_b1_builtin_find.py`, `matrix_invariant_commit_auth_refusal.py`, `matrix_l3_abandoned_approval.py`, `matrix_w3.py`, `matrix_w4.py`, `matrix_w5.py` |
+
+The silent-turn check matters most in cells whose PASS depends on something NOT appearing (no
+error, no leak, no blank success): a turn that produced nothing satisfies those by doing nothing
+at all. Its definition of content deliberately mirrors `content_parts_emitted` in the product's
+own Vercel egress, so it never fires on a turn whose only output was a file or a data payload —
+and reasoning does not count, so a turn that only thought is still a violation. A cell must
+exclude any turn it deliberately aborted or interrupted, which legitimately ends bare;
+`matrix_w5.py` shows the pattern by checking only its post-interrupt turns. When you add a cell,
+add `and not silent["violations"]` to its verdict — `resources/test_qa_matrix_lib_silent_turns.py`
+fails if a wired cell drops it.
+
 ## Optional probes (`qa_longctx.py`)
 
 Separate from the gate, these need live **Gmail and GitHub Composio connections** in the target

--- a/.agents/skills/agent-release-gate/resources/matrix_b1_builtin_find.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_b1_builtin_find.py
@@ -61,6 +61,7 @@ import uuid
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from qa_matrix_lib import (  # noqa: E402
     archive,
+    check_no_silent_turn,
     create_workflow,
     refs,
     run_until_settled,
@@ -221,11 +222,19 @@ def b1_for(harness_name: str) -> dict:
             }
         )
 
-        core_ok = not any_errors and len(found_in_tool_output) == len(expected)
+        # A silent turn inside the settled loop carries no error, so `not any_errors`
+        # alone would accept it (ASD-EST100).
+        silent = check_no_silent_turn(turns)
+        core_ok = (
+            not any_errors
+            and not silent["violations"]
+            and len(found_in_tool_output) == len(expected)
+        )
         return {
             "status": "PASS" if core_ok else "FAIL",
             "why": (
-                f"any_errors={any_errors}, expected={expected}, "
+                f"any_errors={any_errors}, silent_turns={silent['violations']}, "
+                f"expected={expected}, "
                 f"found_in_tool_output={found_in_tool_output}, "
                 f"tool_names_seen={search_tool_names}"
             ),

--- a/.agents/skills/agent-release-gate/resources/matrix_invariant_commit_auth_refusal.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_invariant_commit_auth_refusal.py
@@ -47,6 +47,7 @@ from qa_matrix_lib import (  # noqa: E402
     approval_reply,
     archive,
     check_no_blank_success_on_refusal,
+    check_no_silent_turn,
     create_workflow,
     invoke,
     latest_revision,
@@ -153,7 +154,10 @@ def invariant_cell(container: str) -> dict:
                 "since": since,
             }
 
-        core_ok = len(check["violations"]) == 0
+        # The refusal invariant is an absence check, so a turn that produced nothing at
+        # all satisfies it vacuously (ASD-EST100). Every turn here was meant to answer.
+        silent = check_no_silent_turn(turns)
+        core_ok = len(check["violations"]) == 0 and not silent["violations"]
         time.sleep(0.5)
         newest = latest_revision(wf)
         version_bumped = newest is not None and int(newest.get("version") or -1) > int(
@@ -164,6 +168,7 @@ def invariant_cell(container: str) -> dict:
             "why": (
                 f"refusals_observed={check['refusals']}, "
                 f"violations={check['violations']}, "
+                f"silent_turns={silent['violations']}, "
                 f"replay_wire_outcome={replay_outcome!r} (must be error/denied, never a blank "
                 f"available), version_bumped_once={version_bumped} (only the first, legitimate "
                 "commit should have landed)"

--- a/.agents/skills/agent-release-gate/resources/matrix_l3_abandoned_approval.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l3_abandoned_approval.py
@@ -50,6 +50,7 @@ from qa_matrix_lib import (  # noqa: E402
     LIVE_TOOLS,
     agent_config,
     archive,
+    check_no_silent_turn,
     create_workflow,
     interactions,
     invoke,
@@ -141,7 +142,16 @@ def l3():
         )
 
         agents, sandboxes = ledger_ids(session_id)
-        ok = gated and steer_ok and died_loudly and not leaked
+        # `not leaked` is an absence check: a turn that produced nothing leaks nothing,
+        # so it would satisfy it vacuously (ASD-EST100). Both turns were meant to answer.
+        silent = check_no_silent_turn([t1, t2])
+        ok = (
+            gated
+            and steer_ok
+            and died_loudly
+            and not leaked
+            and not silent["violations"]
+        )
 
         why_parts = []
         if not gated:

--- a/.agents/skills/agent-release-gate/resources/matrix_t8_saved_files.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_t8_saved_files.py
@@ -27,6 +27,7 @@ import httpx
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from qa_matrix_lib import (  # noqa: E402
     archive,
+    check_no_silent_turn,
     create_workflow,
     latest_revision,
     refs,
@@ -178,14 +179,22 @@ def t8_saved_files():
         )
         real_read = read_output is not None
 
+        # A turn that produced nothing also produced no tool error, so it would satisfy the
+        # absence check above by doing nothing at all (ASD-EST100).
+        silent = check_no_silent_turn(turns)
         core_ok = (
-            real_read and not any_real_tool_error and version_bumped and body_matches
+            real_read
+            and not any_real_tool_error
+            and not silent["violations"]
+            and version_bumped
+            and body_matches
         )
         return {
             "status": "PASS" if core_ok else "FAIL",
             "why": (
                 f"real_read (a tool output carried the real marker)={real_read}, "
                 f"any_real_tool_error={any_real_tool_error}, version_bumped={version_bumped}, "
+                f"silent_turns={silent['violations']}, "
                 f"body_matches={body_matches}. Check runner logs for 'remote agent mount active "
                 f"for artifact={wf}' separately."
             ),

--- a/.agents/skills/agent-release-gate/resources/matrix_w3.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w3.py
@@ -141,9 +141,18 @@ def w3():
 
         a_present, b_present, final = _edits_present(wf, token_a, skill_name)
         if a_present and b_present:
+            # Both edits landing says nothing about HOW the sessions got there: a session can
+            # land its edit and still hand the user a bare turn (ASD-EST100). Stage 2 folds the
+            # same invariant in, and this cell is the only one with a second PASS path -- an
+            # unguarded early return here would be a hole the gate cannot see.
+            silent = check_no_silent_turn(turns_a + turns_b)
+            stage1_ok = not silent["violations"]
             return {
-                "status": "PASS",
-                "why": "STAGE 1: session B recovered autonomously (no coaching) and both edits landed",
+                "status": "PASS" if stage1_ok else "FAIL",
+                "why": (
+                    "STAGE 1: session B recovered autonomously (no coaching) and both edits "
+                    f"landed; silent_turns={silent['violations']}"
+                ),
                 "stage": 1,
                 "workflow_id": wf,
                 "session_a": session_a,

--- a/.agents/skills/agent-release-gate/resources/matrix_w3.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w3.py
@@ -44,6 +44,7 @@ from qa_matrix_lib import (  # noqa: E402
     agent_config,
     approval_reply,
     archive,
+    check_no_silent_turn,
     create_workflow,
     invoke,
     latest_revision,
@@ -187,12 +188,16 @@ def w3():
                 break
 
         a_present2, b_present2, final2 = _edits_present(wf, token_a, skill_name)
-        ok = settled2 and a_present2 and b_present2
+        # `settled2` is satisfied by a turn with no approval and no error — which a turn
+        # that produced nothing also satisfies (ASD-EST100).
+        silent = check_no_silent_turn(turns_a + turns_b + nudge_turns)
+        ok = settled2 and a_present2 and b_present2 and not silent["violations"]
         return {
             "status": "PASS" if ok else "FAIL",
             "why": (
                 f"STAGE 2 (diagnose-and-ask, then a bare 'yes, retry' with zero mechanics "
-                f"coached): settled2={settled2}, a_present={a_present2}, b_present={b_present2}"
+                f"coached): settled2={settled2}, a_present={a_present2}, b_present={b_present2}, "
+                f"silent_turns={silent['violations']}"
             ),
             "stage": 2,
             "workflow_id": wf,

--- a/.agents/skills/agent-release-gate/resources/matrix_w4.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w4.py
@@ -30,6 +30,7 @@ from qa_matrix_lib import (  # noqa: E402
     agent_config,
     approval_reply,
     archive,
+    check_no_silent_turn,
     create_workflow,
     invoke,
     latest_revision,
@@ -156,13 +157,21 @@ def w4():
             b_skill.get("body")
         )
 
-        core_ok = conflict_seen and a_edit_present and b_edit_present
+        # Settlement here only checks that no approval is pending, which a turn that
+        # produced nothing also satisfies (ASD-EST100).
+        silent = check_no_silent_turn(turns_a + turns_b)
+        core_ok = (
+            conflict_seen
+            and a_edit_present
+            and b_edit_present
+            and not silent["violations"]
+        )
         return {
             "status": "PASS" if core_ok else "FAIL",
             "why": (
                 f"conflict_seen={conflict_seen} (execute-time base check caught the staleness "
                 f"under a pending approval), a_edit_present={a_edit_present}, "
-                f"b_edit_present={b_edit_present}. NOTE: A's recovery was explicitly coached "
+                f"b_edit_present={b_edit_present}, silent_turns={silent['violations']}. NOTE: A's recovery was explicitly coached "
                 f"(runner error-detail bug in effect)."
             ),
             "workflow_id": wf,

--- a/.agents/skills/agent-release-gate/resources/matrix_w5.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w5.py
@@ -34,6 +34,7 @@ from qa_matrix_lib import (  # noqa: E402
     LIVE_TOOLS,
     agent_config,
     archive,
+    check_no_silent_turn,
     create_workflow,
     invoke,
     latest_revision,
@@ -99,8 +100,14 @@ def w5():
             session_id, [user_msg(commit_prompt)], live_params, references
         )
 
-        post_interrupt_works = status_c["settled"] and not any(
-            t.errors for t in turns_c
+        # `turn1` is deliberately interrupted, so it legitimately ends bare and is excluded.
+        # The post-interrupt turns were meant to answer: a silent one there would read as
+        # "settled with no errors" and hide a swallowed failure (ASD-EST100).
+        silent = check_no_silent_turn(turns_c)
+        post_interrupt_works = (
+            status_c["settled"]
+            and not any(t.errors for t in turns_c)
+            and not silent["violations"]
         )
         time.sleep(1.0)
         newest = latest_revision(wf)
@@ -120,6 +127,7 @@ def w5():
             "why": (
                 f"steer_ok={steer_ok} (turn1 was interrupted, steer turn replied cleanly), "
                 f"post_interrupt_works={post_interrupt_works} (new turn on same session settled "
+                f"| silent_turns={silent['violations']} "
                 f"without wire errors), commit_landed={commit_landed}"
             ),
             "workflow_id": wf,

--- a/.agents/skills/agent-release-gate/resources/matrix_w7.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w7.py
@@ -37,6 +37,7 @@ from qa_matrix_lib import (  # noqa: E402
     LIVE_TOOLS,
     agent_config,
     archive,
+    check_no_silent_turn,
     create_workflow,
     latest_revision,
     refs,
@@ -131,9 +132,13 @@ def w7():
             ver or -1
         )
 
+        # A turn that produced nothing also produced no error and no tool error, so it would
+        # satisfy both absence checks above by doing nothing at all (ASD-EST100).
+        silent = check_no_silent_turn(turns)
         core_ok = (
             not any_errors
             and not any_tool_error
+            and not silent["violations"]
             and version_bumped
             and body_matches
             and len(manifest_frames) > 0
@@ -142,6 +147,7 @@ def w7():
             "status": "PASS" if core_ok else "FAIL",
             "why": (
                 f"rounds={len(turns)}, any_tool_error={any_tool_error}, "
+                f"silent_turns={silent['violations']}, "
                 f"version_bumped={version_bumped}, body_matches_exact_bytes={body_matches}, "
                 f"manifest_frames_found={len(manifest_frames)}, "
                 f"manifest_has_digest={digest_present}, manifest_has_bytes={bytes_present}"

--- a/.agents/skills/agent-release-gate/resources/matrix_w7_daytona.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w7_daytona.py
@@ -34,6 +34,7 @@ import uuid
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from qa_matrix_lib import (  # noqa: E402
     archive,
+    check_no_silent_turn,
     create_workflow,
     latest_revision,
     refs,
@@ -174,9 +175,13 @@ def w7_daytona() -> dict:
             ver or -1
         )
 
+        # A turn that produced nothing also produced no error and no tool error, so it would
+        # satisfy both absence checks above by doing nothing at all (ASD-EST100).
+        silent = check_no_silent_turn(turns)
         core_ok = (
             not any_errors
             and not any_tool_error
+            and not silent["violations"]
             and version_bumped
             and body_matches
             and len(manifest_frames) > 0
@@ -185,6 +190,7 @@ def w7_daytona() -> dict:
             "status": "PASS" if core_ok else "FAIL",
             "why": (
                 f"rounds={len(turns)}, any_tool_error={any_tool_error}, "
+                f"silent_turns={silent['violations']}, "
                 f"real_tool_errors={real_tool_errors}, "
                 f"version_bumped={version_bumped}, body_matches_exact_bytes={body_matches}, "
                 f"manifest_frames_found={len(manifest_frames)}, "

--- a/.agents/skills/agent-release-gate/resources/matrix_w7_per_harness.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_w7_per_harness.py
@@ -44,6 +44,7 @@ import uuid
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from qa_matrix_lib import (  # noqa: E402
     archive,
+    check_no_silent_turn,
     create_workflow,
     latest_revision,
     refs,
@@ -199,9 +200,13 @@ def w7_for(harness_name: str) -> dict:
             ver or -1
         )
 
+        # A turn that produced nothing also produced no error and no tool error, so it would
+        # satisfy both absence checks above by doing nothing at all (ASD-EST100).
+        silent = check_no_silent_turn(turns)
         core_ok = (
             not any_errors
             and not any_tool_error
+            and not silent["violations"]
             and version_bumped
             and body_matches
             and len(manifest_frames) > 0
@@ -210,6 +215,7 @@ def w7_for(harness_name: str) -> dict:
             "status": "PASS" if core_ok else "FAIL",
             "why": (
                 f"rounds={len(turns)}, any_tool_error={any_tool_error}, "
+                f"silent_turns={silent['violations']}, "
                 f"version_bumped={version_bumped}, body_matches_exact_bytes={body_matches}, "
                 f"manifest_frames_found={len(manifest_frames)}, "
                 f"manifest_has_digest={digest_present}, manifest_has_bytes={bytes_present}"

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -688,3 +688,31 @@ def check_no_blank_success_on_refusal(turns: list[Turn], log_lines: list[str]) -
                     }
                 )
     return {"refusals": refused_ids, "violations": violations}
+
+
+def check_no_silent_turn(turns: list[Turn]) -> dict:
+    """The silent-turn invariant: a turn that said nothing, did nothing, asked nothing, and
+    reported nothing must never be treated as a completed turn.
+
+    That combination is the signature of a swallowed provider failure (ASD-EST100): the model
+    call is rejected, the error is dropped on the way back, and the turn arrives as a clean
+    empty finish. The user sees a blank bubble with no reason anywhere.
+
+    A turn is NOT silent when it produced assistant text, called a tool, raised an approval gate,
+    or carried an error frame — so a parked turn (which always raises a gate) and a failed turn
+    (which carries an error) both pass. Returns {"violations": [...]}; a cell should treat any
+    non-empty `violations` as an automatic FAIL regardless of its own assertions. The one case a
+    cell must filter out itself is a turn it deliberately aborted, which legitimately ends bare.
+    """
+    violations = []
+    for index, turn in enumerate(turns):
+        if turn.reply.strip() or turn.tool_calls or turn.approvals or turn.errors:
+            continue
+        violations.append(
+            {
+                "turn": index,
+                "finishReason": turn.finish_reason,
+                "frames": list(turn.frames),
+            }
+        )
+    return {"violations": violations}

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -690,23 +690,71 @@ def check_no_blank_success_on_refusal(turns: list[Turn], log_lines: list[str]) -
     return {"refusals": refused_ids, "violations": violations}
 
 
+# Frame types that carry no content: the stream scaffolding, the model's private reasoning, and
+# the error frames. Everything else the adapter emits IS content — text, tool input/output,
+# approval requests, `file`, attachment delivery, and every `data-<name>` payload.
+#
+# This mirrors `content_parts_emitted` in the product's own egress
+# (`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py`), which counts message/message_delta,
+# tool_call, tool_result, interaction_request, data, file and attachment_delivery, and does NOT
+# count reasoning, usage, done, or error. Keep the two definitions in step: if the adapter starts
+# counting a new event as content, a turn carrying only that event stops being silent.
+#
+# It is a deny-list on purpose. `data-<name>` payloads are open-ended, so an allow-list would
+# treat an unknown-but-real content frame as silence and FAIL a healthy turn. A deny-list errs the
+# other way — an unrecognised frame reads as content — which can only ever under-report.
+_NON_CONTENT_FRAMES = frozenset(
+    {
+        "start",
+        "start-step",
+        "finish-step",
+        "finish",
+        "reasoning-start",
+        "reasoning-delta",
+        "reasoning-end",
+        "error",
+        "data-agent-error",
+    }
+)
+_TEXT_FRAMES = frozenset({"text-start", "text-delta", "text-end"})
+
+
+def _turn_produced_content(turn: Turn) -> bool:
+    """Did this turn put anything in front of the user (by the product's own definition)?"""
+    if turn.reply.strip():
+        return True
+    for frame in turn.frames:
+        if frame in _NON_CONTENT_FRAMES:
+            continue
+        # Text frames arrived but the reply is blank/whitespace: nothing was actually said.
+        if frame in _TEXT_FRAMES:
+            continue
+        return True
+    return False
+
+
 def check_no_silent_turn(turns: list[Turn]) -> dict:
     """The silent-turn invariant: a turn that said nothing, did nothing, asked nothing, and
     reported nothing must never be treated as a completed turn.
 
     That combination is the signature of a swallowed provider failure (ASD-EST100): the model
     call is rejected, the error is dropped on the way back, and the turn arrives as a clean
-    empty finish. The user sees a blank bubble with no reason anywhere.
+    empty finish. The user sees a blank bubble with no reason anywhere. It is dangerous precisely
+    in cells whose PASS depends on something NOT appearing — a turn that produced nothing also
+    produced no error, no leak, and no blank success, so it satisfies those cells by doing
+    nothing at all.
 
-    A turn is NOT silent when it produced assistant text, called a tool, raised an approval gate,
-    or carried an error frame — so a parked turn (which always raises a gate) and a failed turn
-    (which carries an error) both pass. Returns {"violations": [...]}; a cell should treat any
-    non-empty `violations` as an automatic FAIL regardless of its own assertions. The one case a
-    cell must filter out itself is a turn it deliberately aborted, which legitimately ends bare.
+    A turn is NOT silent when it produced any content frame (text, a tool call or result, an
+    approval request, a file, an attachment delivery, any `data-<name>` payload) or carried an
+    error. So a parked turn (which raises a gate) and a failed turn (which carries an error) both
+    pass. Returns {"violations": [...]}; a cell should treat any non-empty `violations` as an
+    automatic FAIL regardless of its own assertions. The one case a cell must filter out itself
+    is a turn it deliberately aborted or interrupted, which legitimately ends bare — pass only
+    the turns that were meant to answer (see `matrix_w5.py`, which excludes its interrupted turn).
     """
     violations = []
     for index, turn in enumerate(turns):
-        if turn.reply.strip() or turn.tool_calls or turn.approvals or turn.errors:
+        if _turn_produced_content(turn) or turn.errors:
             continue
         violations.append(
             {

--- a/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_silent_turns.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_silent_turns.py
@@ -1,0 +1,96 @@
+"""Unit test for the silent-turn invariant (run like the other lib tests:
+`uv run --no-sync pytest` from `api/`, or any interpreter with pytest + httpx).
+
+The trap this pins: the gate scores a cell on its own scenario assertions, so a turn that came
+back completely bare — no text, no tool call, no gate, no error — passes every check that only
+looks for the ABSENCE of something bad. That is exactly the shape a swallowed provider failure
+takes (ASD-EST100): the model call is rejected, the error is dropped, and the turn is reported
+as a clean empty finish. `check_no_silent_turn` makes that shape an automatic failure, and these
+cases pin that it does not fire on the turns that legitimately carry no assistant text.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+
+def _lib(monkeypatch):
+    monkeypatch.setenv("AGENTA_BASE", "https://qa.example")
+    monkeypatch.setenv("AGENTA_PROJECT_ID", "proj-1")
+    monkeypatch.setenv("AGENTA_API_KEY", "test-key")
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    sys.modules.pop("qa_matrix_lib", None)
+    return importlib.import_module("qa_matrix_lib")
+
+
+def _bare_turn(lib, finish_reason="stop"):
+    """The incident's turn: the stream carried a terminator and nothing else."""
+    turn = lib.Turn()
+    turn.frames = ["start", "start-step", "finish-step", "finish"]
+    turn.finish_reason = finish_reason
+    return turn
+
+
+def test_a_bare_turn_is_a_violation(monkeypatch):
+    lib = _lib(monkeypatch)
+
+    result = lib.check_no_silent_turn([_bare_turn(lib)])
+
+    assert len(result["violations"]) == 1
+    # The violation has to carry enough to debug the run it came from.
+    assert result["violations"][0]["turn"] == 0
+    assert result["violations"][0]["finishReason"] == "stop"
+    assert "finish" in result["violations"][0]["frames"]
+
+
+def test_whitespace_is_not_an_answer(monkeypatch):
+    lib = _lib(monkeypatch)
+    turn = _bare_turn(lib)
+    turn.text_parts = ["  ", "\n"]
+
+    assert len(lib.check_no_silent_turn([turn])["violations"]) == 1
+
+
+def test_a_turn_that_answered_is_clean(monkeypatch):
+    lib = _lib(monkeypatch)
+    turn = _bare_turn(lib)
+    turn.text_parts = ["The answer is 4."]
+
+    assert lib.check_no_silent_turn([turn])["violations"] == []
+
+
+def test_a_turn_that_reported_an_error_is_clean(monkeypatch):
+    lib = _lib(monkeypatch)
+    # A failed turn is loud, which is the whole point: it must not be double-reported here.
+    turn = _bare_turn(lib)
+    turn.errors = ["the model provider account has insufficient credit"]
+
+    assert lib.check_no_silent_turn([turn])["violations"] == []
+
+
+def test_a_parked_turn_is_clean(monkeypatch):
+    lib = _lib(monkeypatch)
+    # A turn paused on an approval gate carries no assistant text by design.
+    turn = _bare_turn(lib, finish_reason="other")
+    turn.tool_calls = [{"toolCallId": "tc-1", "toolName": "bash", "input": {}}]
+    turn.approvals = [{"approvalId": "a1", "toolCallId": "tc-1"}]
+
+    assert lib.check_no_silent_turn([turn])["violations"] == []
+
+
+def test_a_tool_only_turn_is_clean(monkeypatch):
+    lib = _lib(monkeypatch)
+    turn = _bare_turn(lib)
+    turn.tool_calls = [{"toolCallId": "tc-1", "toolName": "bash", "input": {}}]
+
+    assert lib.check_no_silent_turn([turn])["violations"] == []
+
+
+def test_only_the_silent_turns_of_a_session_are_reported(monkeypatch):
+    lib = _lib(monkeypatch)
+    answered = _bare_turn(lib)
+    answered.text_parts = ["hello"]
+
+    result = lib.check_no_silent_turn([answered, _bare_turn(lib), _bare_turn(lib)])
+
+    assert [v["turn"] for v in result["violations"]] == [1, 2]

--- a/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_silent_turns.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_silent_turns.py
@@ -5,30 +5,61 @@ The trap this pins: the gate scores a cell on its own scenario assertions, so a 
 back completely bare — no text, no tool call, no gate, no error — passes every check that only
 looks for the ABSENCE of something bad. That is exactly the shape a swallowed provider failure
 takes (ASD-EST100): the model call is rejected, the error is dropped, and the turn is reported
-as a clean empty finish. `check_no_silent_turn` makes that shape an automatic failure, and these
-cases pin that it does not fire on the turns that legitimately carry no assistant text.
+as a clean empty finish. `check_no_silent_turn` makes that shape an automatic failure.
+
+Three things are pinned here:
+  1. a bare turn is a violation, and the turns that legitimately carry no assistant text are not;
+  2. the content definition matches the product's own (`content_parts_emitted` in the Vercel
+     egress), so a turn whose only output is a file or a data payload is NOT reported;
+  3. the check is actually WIRED into the cells — it was dead code once, and a dead invariant is
+     worse than none because the gate looks like it covers this.
 """
 
 import importlib
+import re
 import sys
 from pathlib import Path
+
+import pytest
+
+RESOURCES = Path(__file__).resolve().parent
+
+# Every cell that both holds turns and whose verdict depends on something NOT appearing, so a
+# turn that produced nothing would satisfy it by doing nothing at all.
+WIRED_CELLS = [
+    "matrix_w7.py",
+    "matrix_w7_daytona.py",
+    "matrix_w7_per_harness.py",
+    "matrix_t8_saved_files.py",
+    "matrix_b1_builtin_find.py",
+    "matrix_invariant_commit_auth_refusal.py",
+    "matrix_l3_abandoned_approval.py",
+    "matrix_w5.py",
+    "matrix_w4.py",
+    "matrix_w3.py",
+]
 
 
 def _lib(monkeypatch):
     monkeypatch.setenv("AGENTA_BASE", "https://qa.example")
     monkeypatch.setenv("AGENTA_PROJECT_ID", "proj-1")
     monkeypatch.setenv("AGENTA_API_KEY", "test-key")
-    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    sys.path.insert(0, str(RESOURCES))
     sys.modules.pop("qa_matrix_lib", None)
     return importlib.import_module("qa_matrix_lib")
 
 
-def _bare_turn(lib, finish_reason="stop"):
-    """The incident's turn: the stream carried a terminator and nothing else."""
+def _turn(lib, *, content_frames=(), finish_reason="stop"):
+    """A turn whose stream carried the scaffolding plus `content_frames` and nothing else."""
     turn = lib.Turn()
-    turn.frames = ["start", "start-step", "finish-step", "finish"]
+    turn.frames = ["start", "start-step", *content_frames, "finish-step", "finish"]
     turn.finish_reason = finish_reason
     return turn
+
+
+def _bare_turn(lib, finish_reason="stop"):
+    """The incident's turn: the stream carried a terminator and nothing else."""
+    return _turn(lib, finish_reason=finish_reason)
 
 
 def test_a_bare_turn_is_a_violation(monkeypatch):
@@ -45,7 +76,7 @@ def test_a_bare_turn_is_a_violation(monkeypatch):
 
 def test_whitespace_is_not_an_answer(monkeypatch):
     lib = _lib(monkeypatch)
-    turn = _bare_turn(lib)
+    turn = _turn(lib, content_frames=["text-start", "text-delta", "text-end"])
     turn.text_parts = ["  ", "\n"]
 
     assert len(lib.check_no_silent_turn([turn])["violations"]) == 1
@@ -53,7 +84,7 @@ def test_whitespace_is_not_an_answer(monkeypatch):
 
 def test_a_turn_that_answered_is_clean(monkeypatch):
     lib = _lib(monkeypatch)
-    turn = _bare_turn(lib)
+    turn = _turn(lib, content_frames=["text-start", "text-delta", "text-end"])
     turn.text_parts = ["The answer is 4."]
 
     assert lib.check_no_silent_turn([turn])["violations"] == []
@@ -62,7 +93,7 @@ def test_a_turn_that_answered_is_clean(monkeypatch):
 def test_a_turn_that_reported_an_error_is_clean(monkeypatch):
     lib = _lib(monkeypatch)
     # A failed turn is loud, which is the whole point: it must not be double-reported here.
-    turn = _bare_turn(lib)
+    turn = _turn(lib, content_frames=["error"])
     turn.errors = ["the model provider account has insufficient credit"]
 
     assert lib.check_no_silent_turn([turn])["violations"] == []
@@ -71,7 +102,11 @@ def test_a_turn_that_reported_an_error_is_clean(monkeypatch):
 def test_a_parked_turn_is_clean(monkeypatch):
     lib = _lib(monkeypatch)
     # A turn paused on an approval gate carries no assistant text by design.
-    turn = _bare_turn(lib, finish_reason="other")
+    turn = _turn(
+        lib,
+        content_frames=["tool-input-available", "tool-approval-request"],
+        finish_reason="other",
+    )
     turn.tool_calls = [{"toolCallId": "tc-1", "toolName": "bash", "input": {}}]
     turn.approvals = [{"approvalId": "a1", "toolCallId": "tc-1"}]
 
@@ -80,17 +115,90 @@ def test_a_parked_turn_is_clean(monkeypatch):
 
 def test_a_tool_only_turn_is_clean(monkeypatch):
     lib = _lib(monkeypatch)
-    turn = _bare_turn(lib)
+    turn = _turn(lib, content_frames=["tool-input-available", "tool-output-available"])
     turn.tool_calls = [{"toolCallId": "tc-1", "toolName": "bash", "input": {}}]
 
     assert lib.check_no_silent_turn([turn])["violations"] == []
 
 
+@pytest.mark.parametrize(
+    "frame",
+    [
+        "file",  # the agent generated a file and said nothing
+        "data-attachment-delivery",  # it delivered an attachment
+        "data-chart",  # any generative-UI payload
+        "data-interaction",  # an interaction card
+    ],
+)
+def test_a_turn_whose_only_output_is_a_content_payload_is_clean(monkeypatch, frame):
+    """The product counts these as content (`content_parts_emitted`), so a turn carrying one has
+    put something in front of the user and must not be reported as silent."""
+    lib = _lib(monkeypatch)
+
+    assert (
+        lib.check_no_silent_turn([_turn(lib, content_frames=[frame])])["violations"]
+        == []
+    )
+
+
+def test_reasoning_alone_is_still_silent(monkeypatch):
+    """Deliberate: the product does NOT count reasoning as content, so a turn that only thought
+    renders as a blank bubble and is exactly the failure this invariant exists to catch."""
+    lib = _lib(monkeypatch)
+    turn = _turn(
+        lib, content_frames=["reasoning-start", "reasoning-delta", "reasoning-end"]
+    )
+
+    assert len(lib.check_no_silent_turn([turn])["violations"]) == 1
+
+
+def test_the_error_data_frame_is_not_counted_as_content(monkeypatch):
+    """`data-agent-error` is the paired half of an error frame, not a content payload — counting
+    it would make every swallowed-error turn look like it produced something."""
+    lib = _lib(monkeypatch)
+
+    result = lib.check_no_silent_turn([_turn(lib, content_frames=["data-agent-error"])])
+
+    assert len(result["violations"]) == 1
+
+
 def test_only_the_silent_turns_of_a_session_are_reported(monkeypatch):
     lib = _lib(monkeypatch)
-    answered = _bare_turn(lib)
+    answered = _turn(lib, content_frames=["text-delta"])
     answered.text_parts = ["hello"]
 
     result = lib.check_no_silent_turn([answered, _bare_turn(lib), _bare_turn(lib)])
 
     assert [v["turn"] for v in result["violations"]] == [1, 2]
+
+
+@pytest.mark.parametrize("cell", WIRED_CELLS)
+def test_the_invariant_is_wired_into_the_cell(cell):
+    """The check was dead code when it first landed: defined, tested, and called by nobody, so
+    the gate still PASSed a completely bare turn. This fails if a cell drops the wiring."""
+    source = (RESOURCES / cell).read_text()
+
+    assert "check_no_silent_turn" in source, f"{cell} does not call the invariant"
+    # It must feed the verdict, not just be computed and discarded.
+    assert re.search(r'not silent\["violations"\]', source), (
+        f"{cell} computes the invariant but does not let it decide the verdict"
+    )
+
+
+def test_a_bare_turn_forces_every_wired_cell_to_fail(monkeypatch):
+    """The cells all fold the invariant in as `... and not silent["violations"]`. A conjunction
+    with a False term is False, so this plus the wiring test above is what proves a bare turn
+    turns any wired cell's verdict into FAIL, whatever its own assertions concluded.
+
+    (Running a cell end-to-end additionally needs a live deployment; the two tests together pin
+    the part that can be checked without one.)
+    """
+    lib = _lib(monkeypatch)
+
+    silent = lib.check_no_silent_turn([_bare_turn(lib)])
+
+    assert not (not silent["violations"]), (
+        "a bare turn must make the cells' `not silent[...]` conjunct False"
+    )
+    for other_terms_all_passed in (True, False):
+        assert (other_terms_all_passed and not silent["violations"]) is False

--- a/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_silent_turns.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_silent_turns.py
@@ -186,40 +186,68 @@ def test_the_invariant_is_wired_into_the_cell(cell):
     )
 
 
-# The invariant's own read, in either quote style: the cells write it as `silent["violations"]`,
-# and `ast.unparse` renders it back with single quotes.
-_READS_THE_INVARIANT = re.compile(r"""silent\[['"]violations['"]\]""")
-
-
-def _names_that_carry_the_invariant(tree):
-    """Every local name whose value depends on `silent["violations"]`, directly or through
-    another such name (the cells build their verdict in steps: `post_interrupt_works` folds the
-    invariant in, `core_ok` folds `post_interrupt_works` in)."""
-    assignments = {
-        target.id: ast.unparse(node.value)
+def _assigned_expressions(tree):
+    """Every `name = <expression>` in the cell, so a verdict built in named steps
+    (`post_interrupt_works` -> `core_ok` -> the return) can be followed back to what it reads."""
+    return {
+        target.id: node.value
         for node in ast.walk(tree)
         if isinstance(node, ast.Assign)
         for target in node.targets
         if isinstance(target, ast.Name)
     }
-    carriers = set()
-    while True:
-        grown = {
-            name
-            for name, value in assignments.items()
-            if _READS_THE_INVARIANT.search(value)
-            or any(re.search(rf"\b{carrier}\b", value) for carrier in carriers)
-        }
-        if grown == carriers:
-            return carriers
-        carriers = grown
+
+
+def _reads_the_invariant(node):
+    """`silent["violations"]` — the invariant's own read, and the only atom this evaluation knows
+    the value of."""
+    return (
+        isinstance(node, ast.Subscript)
+        and isinstance(node.value, ast.Name)
+        and node.value.id == "silent"
+        and isinstance(node.slice, ast.Constant)
+        and node.slice.value == "violations"
+    )
+
+
+def _value_when_a_turn_was_silent(node, assigned, seen=()):
+    """What an expression evaluates to on the ONE assumption that a silent turn happened.
+
+    Three-valued: True, False, or None for "depends on the cell's own checks, which this cannot
+    know". `silent["violations"]` is a non-empty list under that assumption, so it is True, and
+    everything the cell asserts for itself is unknown. Answering the polarity question needs this
+    rather than a search for the invariant's NAME: `not silent["violations"]` and
+    `not (not silent["violations"])` both mention it, and only the first one is a guard.
+    """
+    if _reads_the_invariant(node):
+        return True
+    if isinstance(node, ast.UnaryOp) and isinstance(node.op, ast.Not):
+        inner = _value_when_a_turn_was_silent(node.operand, assigned, seen)
+        return None if inner is None else not inner
+    if isinstance(node, ast.BoolOp):
+        values = [
+            _value_when_a_turn_was_silent(value, assigned, seen)
+            for value in node.values
+        ]
+        # `and` keeps going on True and settles on False; `or` is the mirror image.
+        keeps_going = isinstance(node.op, ast.And)
+        if any(value is not keeps_going for value in values if value is not None):
+            return not keeps_going
+        return keeps_going if all(value is not None for value in values) else None
+    if isinstance(node, ast.Name):
+        if node.id in seen or node.id not in assigned:
+            return None  # a loop, or a name from outside the cell: nothing can be concluded.
+        return _value_when_a_turn_was_silent(
+            assigned[node.id], assigned, (*seen, node.id)
+        )
+    return None  # a call, a comparison, a subscript of something else: the cell's own business.
 
 
 def _unguarded_pass_paths(source):
-    """The `why` of every `return {...}` in the cell that can report PASS without the invariant
-    having a say. An empty list is what a fully wired cell looks like."""
+    """Every `return {...}` in the cell that can report PASS even though a turn was silent. An
+    empty list is what a fully wired cell looks like."""
     tree = ast.parse(source)
-    carriers = _names_that_carry_the_invariant(tree)
+    assigned = _assigned_expressions(tree)
     unguarded = []
     for node in ast.walk(tree):
         if not isinstance(node, ast.Return) or not isinstance(node.value, ast.Dict):
@@ -237,10 +265,20 @@ def _unguarded_pass_paths(source):
         verdict_source = ast.unparse(verdict)
         if "PASS" not in verdict_source:
             continue  # a FAIL-only early return; the invariant has nothing to add.
-        decider = ast.unparse(verdict.test) if isinstance(verdict, ast.IfExp) else ""
-        if _READS_THE_INVARIANT.search(decider) or any(
-            re.search(rf"\b{carrier}\b", decider) for carrier in carriers
-        ):
+        # PASS has to be the branch a silent turn CANNOT reach, whichever side of the conditional
+        # it is written on.
+        reaches_pass = None
+        if isinstance(verdict, ast.IfExp):
+            says_pass = (
+                "PASS" in ast.unparse(verdict.body),
+                "PASS" in ast.unparse(verdict.orelse),
+            )
+            if says_pass == (True, False):
+                reaches_pass = _value_when_a_turn_was_silent(verdict.test, assigned)
+            elif says_pass == (False, True):
+                inverted = _value_when_a_turn_was_silent(verdict.test, assigned)
+                reaches_pass = None if inverted is None else not inverted
+        if reaches_pass is False:
             continue
         unguarded.append(f"line {node.lineno}: {verdict_source}")
     return unguarded
@@ -284,6 +322,32 @@ def cell():
     assert len(unguarded) == 1
     assert "stage 1" not in unguarded[0]  # it reports the verdict, not the prose
     assert "PASS" in unguarded[0]
+
+
+def test_a_pass_that_uses_the_invariant_backwards_is_reported():
+    """Mentioning the invariant is not the same as being guarded by it. This cell reads it and
+    then inverts it, so it reports PASS in exactly the case the invariant exists to catch."""
+    cell = """
+def cell():
+    turns = run()
+    silent = check_no_silent_turn(turns)
+    core_ok = not silent["violations"]
+    return {"status": "PASS" if not core_ok else "FAIL", "why": "inverted"}
+"""
+
+    assert len(_unguarded_pass_paths(cell)) == 1
+
+
+def test_a_pass_written_on_the_other_side_of_the_conditional_is_accepted():
+    """The guard is about which branch a silent turn can reach, not about where PASS is typed."""
+    cell = """
+def cell():
+    turns = run()
+    silent = check_no_silent_turn(turns)
+    return {"status": "FAIL" if silent["violations"] else "PASS", "why": "mirrored"}
+"""
+
+    assert _unguarded_pass_paths(cell) == []
 
 
 def test_a_cell_whose_every_pass_path_consults_the_invariant_is_clean():

--- a/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_silent_turns.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_matrix_lib_silent_turns.py
@@ -15,6 +15,7 @@ Three things are pinned here:
      worse than none because the gate looks like it covers this.
 """
 
+import ast
 import importlib
 import re
 import sys
@@ -183,6 +184,123 @@ def test_the_invariant_is_wired_into_the_cell(cell):
     assert re.search(r'not silent\["violations"\]', source), (
         f"{cell} computes the invariant but does not let it decide the verdict"
     )
+
+
+# The invariant's own read, in either quote style: the cells write it as `silent["violations"]`,
+# and `ast.unparse` renders it back with single quotes.
+_READS_THE_INVARIANT = re.compile(r"""silent\[['"]violations['"]\]""")
+
+
+def _names_that_carry_the_invariant(tree):
+    """Every local name whose value depends on `silent["violations"]`, directly or through
+    another such name (the cells build their verdict in steps: `post_interrupt_works` folds the
+    invariant in, `core_ok` folds `post_interrupt_works` in)."""
+    assignments = {
+        target.id: ast.unparse(node.value)
+        for node in ast.walk(tree)
+        if isinstance(node, ast.Assign)
+        for target in node.targets
+        if isinstance(target, ast.Name)
+    }
+    carriers = set()
+    while True:
+        grown = {
+            name
+            for name, value in assignments.items()
+            if _READS_THE_INVARIANT.search(value)
+            or any(re.search(rf"\b{carrier}\b", value) for carrier in carriers)
+        }
+        if grown == carriers:
+            return carriers
+        carriers = grown
+
+
+def _unguarded_pass_paths(source):
+    """The `why` of every `return {...}` in the cell that can report PASS without the invariant
+    having a say. An empty list is what a fully wired cell looks like."""
+    tree = ast.parse(source)
+    carriers = _names_that_carry_the_invariant(tree)
+    unguarded = []
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Return) or not isinstance(node.value, ast.Dict):
+            continue
+        verdict = next(
+            (
+                value
+                for key, value in zip(node.value.keys, node.value.values)
+                if isinstance(key, ast.Constant) and key.value == "status"
+            ),
+            None,
+        )
+        if verdict is None:
+            continue
+        verdict_source = ast.unparse(verdict)
+        if "PASS" not in verdict_source:
+            continue  # a FAIL-only early return; the invariant has nothing to add.
+        decider = ast.unparse(verdict.test) if isinstance(verdict, ast.IfExp) else ""
+        if _READS_THE_INVARIANT.search(decider) or any(
+            re.search(rf"\b{carrier}\b", decider) for carrier in carriers
+        ):
+            continue
+        unguarded.append(f"line {node.lineno}: {verdict_source}")
+    return unguarded
+
+
+@pytest.mark.parametrize("cell", WIRED_CELLS)
+def test_every_pass_path_in_the_cell_is_decided_by_the_invariant(cell):
+    """Wiring the invariant into a cell's FINAL verdict is not enough when the cell can return
+    PASS earlier. W3 shipped exactly that hole: its Stage 1 ("session B recovered on its own and
+    both edits landed") returned PASS before the invariant ran, so a bare turn inside an
+    otherwise-successful W3 was invisible to the gate — while the source-level test above stayed
+    green, because Stage 2 did have the wiring.
+
+    This walks each cell's returns instead of its text, so any new early PASS path has to consult
+    the invariant too.
+    """
+    unguarded = _unguarded_pass_paths((RESOURCES / cell).read_text())
+
+    assert not unguarded, (
+        f"{cell} can return PASS without consulting the silent-turn invariant: "
+        + "; ".join(unguarded)
+    )
+
+
+def test_an_early_pass_that_skips_the_invariant_is_reported():
+    """Keeps the check above from being vacuously green. It is a static analysis, so if it ever
+    stopped finding anything it would look exactly like a perfectly wired suite. This is the W3
+    hole in miniature: an early PASS, and a final verdict that does fold the invariant in."""
+    cell = """
+def cell():
+    turns = run()
+    if edits_landed(turns):
+        return {"status": "PASS", "why": "stage 1"}
+    silent = check_no_silent_turn(turns)
+    core_ok = retried(turns) and not silent["violations"]
+    return {"status": "PASS" if core_ok else "FAIL", "why": "stage 2"}
+"""
+
+    unguarded = _unguarded_pass_paths(cell)
+
+    assert len(unguarded) == 1
+    assert "stage 1" not in unguarded[0]  # it reports the verdict, not the prose
+    assert "PASS" in unguarded[0]
+
+
+def test_a_cell_whose_every_pass_path_consults_the_invariant_is_clean():
+    """The other half of the same guard: the analysis must accept the verdict shape the cells
+    actually use, where the invariant reaches the return through a chain of named steps."""
+    cell = """
+def cell():
+    turns = run()
+    silent = check_no_silent_turn(turns)
+    settled = no_errors(turns) and not silent["violations"]
+    core_ok = settled and edits_landed(turns)
+    if early(turns):
+        return {"status": "PASS" if settled else "FAIL", "why": "stage 1"}
+    return {"status": "PASS" if core_ok else "FAIL", "why": "stage 2"}
+"""
+
+    assert _unguarded_pass_paths(cell) == []
 
 
 def test_a_bare_turn_forces_every_wired_cell_to_fail(monkeypatch):

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_silent_failure.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_silent_failure.py
@@ -1,0 +1,159 @@
+"""Pins the SSE half of the silent-turn contract (ASD-EST100): a turn that produced nothing
+must never reach the browser as a clean, empty finish, and a turn that DID fail must reach it
+carrying the real reason.
+
+The runner is being changed to fail loud on an empty turn (`{ok: false, error: ...}` where it
+used to return `{ok: true, output: ""}`). These tests pin what the adapter must do with that
+result, and — just as importantly — pin the two turns that legitimately carry no assistant text
+(a turn that only called tools, a turn parked on an approval gate) as NOT failures, so the
+zero-content backstop cannot start firing on them.
+
+The sibling `test_vercel_stream_conformance.py` covers the case where a live `error` event and a
+terminal `ok: false` describe the SAME failure (exactly one frame must go out). What is pinned
+here is the other shape: a failure that only the TERMINAL result knows about, which is what an
+acquire failure and the empty-turn guardrail both look like on the wire.
+"""
+
+from __future__ import annotations
+
+from typing import Any, AsyncIterator, Dict, List
+
+import pytest
+
+from agenta.sdk.agents.adapters.vercel.stream import (
+    agent_run_to_vercel_parts,
+    agent_stream_to_vercel_stream,
+)
+from agenta.sdk.agents.errors import AgentRunFailed
+from agenta.sdk.agents.streaming import AgentStream
+
+_NO_OUTPUT_TEXT = "The agent produced no output."
+
+# The concise message the runner puts on a failed turn, as `conciseError` renders it.
+_PROVIDER_ERROR = (
+    "pi_core: the model provider account has insufficient credit "
+    "(check the project's OpenAI key)."
+)
+
+
+async def _records(items: List[Dict[str, Any]]) -> AsyncIterator[Dict[str, Any]]:
+    for item in items:
+        yield item
+
+
+def _error_texts(parts: List[Dict[str, Any]]) -> List[str]:
+    return [p["errorText"] for p in parts if p["type"] == "error"]
+
+
+@pytest.mark.asyncio
+async def test_terminal_only_failure_carries_the_providers_message() -> None:
+    """A run whose ONLY signal is `{ok: false, error: ...}` — no live error event — must surface
+    that message. This is the wire shape of the empty-turn guardrail and of an acquire failure.
+    """
+    run = AgentStream(
+        _records(
+            [{"kind": "result", "result": {"ok": False, "error": _PROVIDER_ERROR}}]
+        )
+    )
+    parts = [part async for part in agent_run_to_vercel_parts(run)]
+
+    errors = _error_texts(parts)
+    assert len(errors) == 1, f"expected exactly one error frame, got {errors!r}"
+    # Substring, not equality: `result_from_wire` prefixes the raised failure. What must not
+    # change is that the caller's own reason reaches the browser.
+    assert _PROVIDER_ERROR in errors[0]
+    assert _NO_OUTPUT_TEXT not in errors[0], (
+        "the real reason was replaced by the generic no-output message"
+    )
+    # The failure code rides the paired data frame, so a client can branch on it.
+    data_frames = [p for p in parts if p["type"] == "data-agent-error"]
+    assert len(data_frames) == 1
+    assert data_frames[0]["data"]["code"] == AgentRunFailed.failure_code
+    assert data_frames[0]["data"]["errorText"] == errors[0]
+    # And a consumer waiting on the terminator must not hang because the turn failed.
+    types = [p["type"] for p in parts]
+    assert types[-1] == "finish"
+    assert types.index("error") < types.index("finish")
+
+
+@pytest.mark.asyncio
+async def test_live_terminal_only_failure_carries_the_providers_message() -> None:
+    """Live-routing counterpart: the failure arrives as a raise out of the event stream with no
+    error event ahead of it.
+    """
+
+    async def events() -> AsyncIterator[Dict[str, Any]]:
+        raise AgentRunFailed(_PROVIDER_ERROR)
+        yield {}  # pragma: no cover - makes this an async generator
+
+    parts = [
+        part async for part in agent_stream_to_vercel_stream(events(), trace_id="t1")
+    ]
+
+    errors = _error_texts(parts)
+    assert len(errors) == 1, f"expected exactly one error frame, got {errors!r}"
+    assert _PROVIDER_ERROR in errors[0]
+    assert _NO_OUTPUT_TEXT not in errors[0]
+    assert [p["type"] for p in parts][-1] == "finish"
+
+
+@pytest.mark.asyncio
+async def test_a_turn_with_no_events_at_all_never_finishes_silently() -> None:
+    """The bare-`done` turn from the incident: nothing streamed, nothing to render. Whatever the
+    runner reports, an empty turn must not reach the browser as a clean finish with no frame
+    explaining it.
+    """
+    run = AgentStream(
+        _records([{"kind": "result", "result": {"ok": True, "output": ""}}])
+    )
+    parts = [part async for part in agent_run_to_vercel_parts(run)]
+
+    assert _error_texts(parts), "an empty turn produced no error frame at all"
+
+
+@pytest.mark.asyncio
+async def test_a_tool_only_turn_is_not_reported_as_no_output() -> None:
+    """A turn that ran tools and ended without prose is a normal turn, not a silent failure.
+    Guards the zero-content backstop against firing on it.
+    """
+    events = [
+        {
+            "type": "tool_call",
+            "data": {"id": "c1", "name": "bash", "input": {"command": "ls"}},
+        },
+        {"type": "tool_result", "data": {"id": "c1", "output": "AGENTS.md"}},
+        {"type": "done", "data": {"stopReason": "stop"}},
+    ]
+    parts = [
+        part
+        async for part in agent_stream_to_vercel_stream(_records(events), trace_id="t2")
+    ]
+
+    # No error frame of ANY kind: stronger than checking for the generic wording, and it cannot
+    # rot if that wording changes in the adapter.
+    assert _error_texts(parts) == []
+
+
+@pytest.mark.asyncio
+async def test_a_parked_turn_is_not_reported_as_no_output() -> None:
+    """A turn paused on an approval gate carries no assistant text by design; it must not be
+    reported as a turn that produced nothing (the reported "No response" on a reloaded paused
+    turn is this exact confusion).
+    """
+    events = [
+        {
+            "type": "interaction_request",
+            "data": {
+                "id": "perm-1",
+                "kind": "user_approval",
+                "payload": {"toolCallId": "c1"},
+            },
+        },
+        {"type": "done", "data": {"stopReason": "paused"}},
+    ]
+    parts = [
+        part
+        async for part in agent_stream_to_vercel_stream(_records(events), trace_id="t3")
+    ]
+
+    assert _error_texts(parts) == []

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_silent_failure.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_silent_failure.py
@@ -113,6 +113,11 @@ async def test_a_turn_with_no_events_at_all_never_finishes_silently() -> None:
     parts = [part async for part in agent_run_to_vercel_parts(run)]
 
     assert _error_texts(parts), "an empty turn produced no error frame at all"
+    # Order, not just presence: a browser treats `finish` as terminal, so an error frame that
+    # arrives after it is an error the user never sees.
+    types = [part["type"] for part in parts]
+    assert types[-1] == "finish"
+    assert types.index("error") < types.index("finish")
 
 
 @pytest.mark.asyncio

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_silent_failure.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_silent_failure.py
@@ -27,7 +27,10 @@ from agenta.sdk.agents.adapters.vercel.stream import (
 from agenta.sdk.agents.errors import AgentRunFailed
 from agenta.sdk.agents.streaming import AgentStream
 
-_NO_OUTPUT_TEXT = "The agent produced no output."
+# The backstop's failure CODE, not its prose. Asserting the code is what keeps these tests
+# honest: the generic message's wording can be reworded at any time, and a `not in text` check
+# would then pass vacuously while the backstop was still burying the real error.
+_NO_OUTPUT_CODE = "no_output"
 
 # The concise message the runner puts on a failed turn, as `conciseError` renders it.
 _PROVIDER_ERROR = (
@@ -62,13 +65,12 @@ async def test_terminal_only_failure_carries_the_providers_message() -> None:
     # Substring, not equality: `result_from_wire` prefixes the raised failure. What must not
     # change is that the caller's own reason reaches the browser.
     assert _PROVIDER_ERROR in errors[0]
-    assert _NO_OUTPUT_TEXT not in errors[0], (
-        "the real reason was replaced by the generic no-output message"
-    )
-    # The failure code rides the paired data frame, so a client can branch on it.
+    # The failure code rides the paired data frame, so a client can branch on it. This is also
+    # the structural form of "the real reason was not replaced by the generic no-output message".
     data_frames = [p for p in parts if p["type"] == "data-agent-error"]
     assert len(data_frames) == 1
     assert data_frames[0]["data"]["code"] == AgentRunFailed.failure_code
+    assert data_frames[0]["data"]["code"] != _NO_OUTPUT_CODE
     assert data_frames[0]["data"]["errorText"] == errors[0]
     # And a consumer waiting on the terminator must not hang because the turn failed.
     types = [p["type"] for p in parts]
@@ -93,7 +95,9 @@ async def test_live_terminal_only_failure_carries_the_providers_message() -> Non
     errors = _error_texts(parts)
     assert len(errors) == 1, f"expected exactly one error frame, got {errors!r}"
     assert _PROVIDER_ERROR in errors[0]
-    assert _NO_OUTPUT_TEXT not in errors[0]
+    codes = [p["data"]["code"] for p in parts if p["type"] == "data-agent-error"]
+    assert codes == [AgentRunFailed.failure_code]
+    assert _NO_OUTPUT_CODE not in codes
     assert [p["type"] for p in parts][-1] == "finish"
 
 

--- a/services/runner/tests/unit/daytona-transcript-recovery.test.ts
+++ b/services/runner/tests/unit/daytona-transcript-recovery.test.ts
@@ -12,9 +12,10 @@
  * before teardown. These tests stand a Pi transcript up inside a fake remote sandbox and pin that
  * the error reaches the caller.
  *
- * Fixture note: an implementation that LISTS the transcript directory (rather than reading a
- * known path) will need `runProcess` in `tests/utils/silent-turn.ts` taught to answer that
- * listing.
+ * Fixture note: the fake supports both ways a reader might find the transcript — `readFsFile`
+ * serves it for any `.jsonl` path, and `runProcess` answers an `ls` on stdout the way
+ * `sandboxRelayHost.list` reads it (`src/tools/relay.ts`). So the expectations below stay
+ * implementation-neutral: they pin that the transcript is read, not how it is located.
  *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/daytona-transcript-recovery.test.ts)
  */

--- a/services/runner/tests/unit/daytona-transcript-recovery.test.ts
+++ b/services/runner/tests/unit/daytona-transcript-recovery.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Recovering a swallowed provider error from a REMOTE (Daytona) sandbox.
+ *
+ * `findSwallowedPiError` reads Pi's transcript to turn an empty turn into a real failure, but it
+ * reads the runner's own filesystem, so it is switched off on Daytona (`pi-error.ts` says so in
+ * its header, `run-turn.ts` gates it behind `!plan.isDaytona`). Cloud runs on Daytona. That makes
+ * production the one place where the safety net does not exist — every swallowed provider error
+ * there becomes a blank bubble, and the only copy of the message dies with the sandbox.
+ *
+ * The sandbox already exposes a daemon file API that other code reads through (`usage.ts` pulls
+ * the usage file, `pi-assets.ts` pulls the skill-snapshot marker), so the transcript is reachable
+ * before teardown. These tests stand a Pi transcript up inside a fake remote sandbox and pin that
+ * the error reaches the caller.
+ *
+ * Fixture note: an implementation that LISTS the transcript directory (rather than reading a
+ * known path) will need `runProcess` in `tests/utils/silent-turn.ts` taught to answer that
+ * listing.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/daytona-transcript-recovery.test.ts)
+ */
+import { afterEach, beforeEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import { findSwallowedPiError } from "../../src/engines/sandbox_agent/pi-error.ts";
+import {
+  enableDaytonaProvider,
+  piTranscriptWithError,
+  runSilentTurn,
+  seedFailedTranscript,
+  textChunk,
+} from "../utils/silent-turn.ts";
+
+const RATE_LIMIT_ERROR =
+  "Rate limit reached for gpt-5 in organization org-abc on tokens per min.";
+
+const dirs: string[] = [];
+
+beforeEach(enableDaytonaProvider);
+
+afterEach(() => {
+  for (const dir of dirs.splice(0))
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe("a Pi transcript inside a remote sandbox", () => {
+  it("is the shape the existing reader understands", async () => {
+    // Guards the fixture itself: the same bytes the fake sandbox serves must be readable by the
+    // reader that already ships, so a transcript-format change fails here and not as a confusing
+    // silence in the expectations below.
+    const cwd = mkdtempSync(join(tmpdir(), "agenta-daytona-transcript-"));
+    dirs.push(cwd);
+    seedFailedTranscript(cwd, RATE_LIMIT_ERROR);
+
+    assert.equal(findSwallowedPiError(cwd), RATE_LIMIT_ERROR);
+  });
+
+  it("does not disturb a Daytona turn that produced an answer", async () => {
+    // Guards the fake sandbox: a run through it must still complete normally, so a failure below
+    // means the empty turn, not a broken remote fixture.
+    const { result } = await runSilentTurn(
+      { harness: "pi_core", sandbox: "daytona" },
+      {
+        promptEvents: [textChunk("The answer is 4.\n")],
+        sandboxTranscript: piTranscriptWithError(
+          "/home/sandbox",
+          RATE_LIMIT_ERROR,
+        ),
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.output, "The answer is 4.");
+  });
+
+  it.fails(
+    "surfaces the provider failure on an empty turn [awaiting fix: Daytona swallowed-error reader]",
+    async () => {
+      const { result } = await runSilentTurn(
+        { harness: "pi_core", sandbox: "daytona" },
+        {
+          sandboxTranscript: piTranscriptWithError(
+            "/home/sandbox",
+            RATE_LIMIT_ERROR,
+          ),
+        },
+      );
+
+      assert.equal(result.ok, false);
+      // Asserting on the substance of THIS failure, not on wording: only a recovery that actually
+      // read the remote transcript can produce it. A generic "the agent produced no output"
+      // cannot satisfy this, which is the point.
+      assert.ok(
+        result.error?.toLowerCase().includes("rate limit"),
+        `expected the transcript's failure, got: ${result.error}`,
+      );
+    },
+  );
+
+  it.fails(
+    "reads the transcript out of the sandbox before teardown [awaiting fix: Daytona swallowed-error reader]",
+    async () => {
+      const { readFsFilePaths } = await runSilentTurn(
+        { harness: "pi_core", sandbox: "daytona" },
+        {
+          sandboxTranscript: piTranscriptWithError(
+            "/home/sandbox",
+            RATE_LIMIT_ERROR,
+          ),
+        },
+      );
+
+      // The recovery has to happen while the sandbox is still alive. Pinning the read (rather
+      // than only the message) is what stops the check being satisfied by a hard-coded string.
+      assert.ok(
+        readFsFilePaths.some((path) => path.endsWith(".jsonl")),
+        `no transcript read from the sandbox, only: ${readFsFilePaths.join(", ")}`,
+      );
+    },
+  );
+});

--- a/services/runner/tests/unit/daytona-transcript-recovery.test.ts
+++ b/services/runner/tests/unit/daytona-transcript-recovery.test.ts
@@ -37,6 +37,17 @@ import {
 const RATE_LIMIT_ERROR =
   "Rate limit reached for gpt-5 in organization org-abc on tokens per min.";
 
+/**
+ * The workspace directory the run uses inside the remote sandbox.
+ *
+ * One constant for both halves on purpose. Pi stamps the cwd on every transcript's `session`
+ * record and `findSwallowedPiError` only accepts a transcript whose stamp matches the run's
+ * workspace, so a test that seeds `/home/sandbox` while the run works somewhere else would be
+ * satisfied by a recovery that ignores transcript ownership -- i.e. one that would happily
+ * report a stale or foreign session's error as this turn's.
+ */
+const REMOTE_CWD = "/home/sandbox";
+
 const dirs: string[] = [];
 
 beforeEach(enableDaytonaProvider);
@@ -64,11 +75,9 @@ describe("a Pi transcript inside a remote sandbox", () => {
     const { result } = await runSilentTurn(
       { harness: "pi_core", sandbox: "daytona" },
       {
+        cwd: REMOTE_CWD,
         promptEvents: [textChunk("The answer is 4.\n")],
-        sandboxTranscript: piTranscriptWithError(
-          "/home/sandbox",
-          RATE_LIMIT_ERROR,
-        ),
+        sandboxTranscript: piTranscriptWithError(REMOTE_CWD, RATE_LIMIT_ERROR),
       },
     );
 
@@ -82,10 +91,8 @@ describe("a Pi transcript inside a remote sandbox", () => {
       const { result } = await runSilentTurn(
         { harness: "pi_core", sandbox: "daytona" },
         {
-          sandboxTranscript: piTranscriptWithError(
-            "/home/sandbox",
-            RATE_LIMIT_ERROR,
-          ),
+          cwd: REMOTE_CWD,
+          sandboxTranscript: piTranscriptWithError(REMOTE_CWD, RATE_LIMIT_ERROR),
         },
       );
 
@@ -106,10 +113,8 @@ describe("a Pi transcript inside a remote sandbox", () => {
       const { readFsFilePaths } = await runSilentTurn(
         { harness: "pi_core", sandbox: "daytona" },
         {
-          sandboxTranscript: piTranscriptWithError(
-            "/home/sandbox",
-            RATE_LIMIT_ERROR,
-          ),
+          cwd: REMOTE_CWD,
+          sandboxTranscript: piTranscriptWithError(REMOTE_CWD, RATE_LIMIT_ERROR),
         },
       );
 

--- a/services/runner/tests/unit/sandbox-agent-pi-error.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-error.test.ts
@@ -16,12 +16,14 @@
  */
 import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { piSessionWorkspaceDir } from "../../src/engines/sandbox_agent/pi-assets.ts";
 import { findSwallowedPiError } from "../../src/engines/sandbox_agent/pi-error.ts";
+// The transcript encoder is shared with the silent-turn suites, so the format lives in one
+// place: two hand-rolled copies could drift together and both stop matching what Pi writes.
+import { writePiTranscript as writeTranscript } from "../utils/silent-turn.ts";
 
 const dirs: string[] = [];
 
@@ -31,48 +33,36 @@ function tempDir(): string {
   return dir;
 }
 
-/**
- * Write a Pi-style .jsonl transcript into `piSessionWorkspaceDir(cwd)` (flat, like Pi does
- * when pointed at an explicit session dir). `recordCwd` overrides the cwd stamped on the
- * transcript's `session` record, to simulate a stale or copied transcript.
- */
-function writeTranscript(
-  cwd: string,
-  name: string,
-  messages: Array<Record<string, unknown>>,
-  recordCwd: string = cwd,
-): void {
-  const dir = piSessionWorkspaceDir(cwd);
-  mkdirSync(dir, { recursive: true });
-  const lines = [
-    JSON.stringify({ type: "session", version: 3, id: name, cwd: recordCwd }),
-    ...messages.map((m) => JSON.stringify(m)),
-  ];
-  writeFileSync(join(dir, `${name}.jsonl`), lines.join("\n") + "\n");
-}
-
 afterEach(() => {
-  for (const dir of dirs.splice(0)) rmSync(dir, { recursive: true, force: true });
+  for (const dir of dirs.splice(0))
+    rmSync(dir, { recursive: true, force: true });
 });
 
 describe("findSwallowedPiError", () => {
   it("returns the last assistant errorMessage from the session-workspace transcript", () => {
     const cwd = tempDir();
     writeTranscript(cwd, "sess-quota", [
-      { type: "message", message: { role: "user", content: [{ type: "text", text: "hi" }] } },
+      {
+        type: "message",
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      },
       {
         type: "message",
         message: {
           role: "assistant",
           content: [],
           stopReason: "error",
-          errorMessage: "You exceeded your current quota, please check your plan.",
+          errorMessage:
+            "You exceeded your current quota, please check your plan.",
         },
       },
     ]);
 
     const error = findSwallowedPiError(cwd);
-    assert.equal(error, "You exceeded your current quota, please check your plan.");
+    assert.equal(
+      error,
+      "You exceeded your current quota, please check your plan.",
+    );
   });
 
   it("returns undefined for a successful turn", () => {
@@ -96,7 +86,12 @@ describe("findSwallowedPiError", () => {
     writeTranscript(cwd, "sess-recovered", [
       {
         type: "message",
-        message: { role: "assistant", content: [], stopReason: "error", errorMessage: "transient" },
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: "transient",
+        },
       },
       {
         type: "message",
@@ -119,7 +114,12 @@ describe("findSwallowedPiError", () => {
       [
         {
           type: "message",
-          message: { role: "assistant", content: [], stopReason: "error", errorMessage: "nope" },
+          message: {
+            role: "assistant",
+            content: [],
+            stopReason: "error",
+            errorMessage: "nope",
+          },
         },
       ],
       "/tmp/some-other-cwd",

--- a/services/runner/tests/unit/silent-turn-contract.test.ts
+++ b/services/runner/tests/unit/silent-turn-contract.test.ts
@@ -178,6 +178,21 @@ describe("empty turns that still pass silently", () => {
     assert.equal(result.output, "The answer is 4.");
   });
 
+  it("puts a tool call in the stream (guards the expectation below)", async () => {
+    // The tool-call expectation below is `it.fails`, so its own in-body check that the tool call
+    // arrived would be satisfied by a fixture that stopped emitting one — the test would sit at
+    // "expected fail" forever, including after the fix lands. This guard is the external one.
+    const { events } = await runSilentTurn(
+      { harness: "pi_core" },
+      { promptEvents: [toolCallChunk("tool-1")] },
+    );
+
+    assert.ok(
+      types(events).includes("tool_call"),
+      `the fixture must emit a tool_call event, got: ${types(events)}`,
+    );
+  });
+
   it("strips a banner-only turn down to nothing (guards the expectation below)", async () => {
     // The premise of the banner case: after stripping, a turn that streamed only the banner is
     // indistinguishable from a turn that streamed nothing. Asserting it here rather than inside

--- a/services/runner/tests/unit/silent-turn-contract.test.ts
+++ b/services/runner/tests/unit/silent-turn-contract.test.ts
@@ -1,0 +1,265 @@
+/**
+ * The wire contract for a turn that produced nothing (ASD-EST100, the "No response" class).
+ *
+ * When a provider rejects a model call (no credit, quota, rate limit, bad key, context overflow),
+ * pi-acp maps the failure to a clean `{stopReason: "end_turn"}` with no content. The runner
+ * believes it, returns `ok: true` with an empty output, records the turn as a completed one, and
+ * the user sees a blank bubble with no error anywhere. The only copy of the real message is inside
+ * the sandbox, which is then destroyed.
+ *
+ * These tests assert the WIRE contract, never prose:
+ *   - a turn that produced no output must not come back `ok: true`
+ *   - a failed turn must emit an `error` event BEFORE the terminal `done` the API reconciles on
+ *   - a failed turn must not record continuity (recording it poisons later turns with the same
+ *     empty state, which is how one bad turn became a whole bad session)
+ *
+ * The suite is deliberately two-sided. Every fail-loud assertion is paired with a guard that a
+ * turn which legitimately produced no text (a park) or which produced a real answer keeps working,
+ * so the fail-loud fix cannot be satisfied by failing everything, and the empty-turn check cannot
+ * be satisfied by suppressing it.
+ *
+ * Tests marked `it.fails` pin behavior that is NOT implemented yet; they pass today BECAUSE the
+ * assertion fails, and turn red the moment the named fix lands, which is the signal to drop the
+ * `.fails`. The fix names are in the test titles. Note that `it.fails` is satisfied by ANY
+ * failure, including a fixture that dies before running a turn — so each one is backed by a guard
+ * test above it that proves its setup reaches a real turn.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/silent-turn-contract.test.ts)
+ */
+import { afterEach, beforeEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import type { AgentEvent } from "../../src/protocol.ts";
+import {
+  AGENT_SESSION_ID,
+  SESSION_ID,
+  enableDaytonaProvider,
+  runSilentTurn,
+  seedFailedTranscript,
+  textChunk,
+  toolCallChunk,
+} from "../utils/silent-turn.ts";
+
+const QUOTA_ERROR = "Your credit balance is too low to run this model.";
+
+// pi-acp's startup banner, which it emits as the first message chunk of a session.
+const BANNER = [
+  "pi v0.79.4\n---\n\n## Context\n- /tmp/x/AGENTS.md\n\n",
+  "New version available: v0.80.2 (installed v0.79.4).\n",
+];
+
+const dirs: string[] = [];
+
+/** A run cwd holding a Pi transcript whose last turn failed, where the reader looks for it. */
+function cwdWithFailedTranscript(): string {
+  const cwd = mkdtempSync(join(tmpdir(), "agenta-silent-turn-"));
+  dirs.push(cwd);
+  seedFailedTranscript(cwd, QUOTA_ERROR);
+  return cwd;
+}
+
+function types(events: AgentEvent[]): string[] {
+  return events.map((e) => e.type);
+}
+
+beforeEach(enableDaytonaProvider);
+
+afterEach(() => {
+  for (const dir of dirs.splice(0))
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe("a turn whose model call failed", () => {
+  it("fails loud with the provider's own message (local Pi)", async () => {
+    const cwd = cwdWithFailedTranscript();
+
+    const { result, events, store } = await runSilentTurn(
+      { harness: "pi_core" },
+      { cwd },
+    );
+
+    assert.equal(result.ok, false);
+    // The error must name THIS failure. `conciseError` classifies the provider's raw text into a
+    // curated message, so assert on the substance both forms carry ("credit"), never on wording:
+    // only actually reading the transcript can produce it.
+    assert.ok(
+      result.error?.includes("credit"),
+      `the provider's failure must reach the caller, got: ${result.error}`,
+    );
+    // The playground renders the event stream, not the result envelope: the error has to be IN
+    // the stream, and ahead of the terminal `done`, or the turn still renders as a silent blank.
+    const order = types(events);
+    assert.ok(order.includes("error"), `no error event in stream: ${order}`);
+    assert.ok(
+      order.indexOf("error") < order.lastIndexOf("done"),
+      `the error event must precede the terminal done: ${order}`,
+    );
+    // A failed turn must not be remembered as the session's last good turn.
+    assert.equal(store.get(SESSION_ID, "pi_core"), undefined);
+  });
+
+  it("returns no output and no messages when the harness itself throws", async () => {
+    const { result } = await runSilentTurn(
+      { harness: "pi_core" },
+      { promptError: new Error("fetch failed") },
+    );
+
+    assert.equal(result.ok, false);
+    assert.ok(result.error);
+    assert.equal(result.output, undefined);
+    assert.equal(result.messages, undefined);
+  });
+});
+
+describe("turns that must keep working (guards against an over-eager fail-loud)", () => {
+  it("succeeds and records continuity when the turn produced an answer", async () => {
+    const { result, events, store } = await runSilentTurn(
+      { harness: "pi_core" },
+      { promptEvents: [textChunk("The answer is 4.\n")] },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.output, "The answer is 4.");
+    assert.deepEqual(result.messages, [
+      { role: "assistant", content: "The answer is 4." },
+    ]);
+    assert.ok(
+      !types(events).includes("error"),
+      "a good turn emitted an error event",
+    );
+    assert.equal(
+      store.get(SESSION_ID, "pi_core")?.agentSessionId,
+      AGENT_SESSION_ID,
+    );
+  });
+
+  it("does not treat a parked turn as an empty failure", async () => {
+    // A turn paused on an approval gate legitimately ends with no assistant text. It is the
+    // single most likely false positive for any empty-turn check, and it is a reported symptom
+    // in its own right (a reloaded paused turn renders as "No response", issue #5542).
+    const { result, events } = await runSilentTurn(
+      { harness: "pi_core" },
+      { park: true },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.stopReason, "paused");
+    assert.ok(
+      !types(events).includes("error"),
+      "a parked turn must not emit an error event",
+    );
+  });
+});
+
+describe("empty turns that still pass silently", () => {
+  it("reaches a real turn on Daytona and closes it (guards the expectations below)", async () => {
+    // Without this, a fixture that dies during sandbox setup would satisfy every `it.fails`
+    // below forever — which is exactly how this fixture first "passed". Both assertions hold
+    // before and after the fail-loud fix, so this stays a fixture check and not a second alarm.
+    const { result, events } = await runSilentTurn({
+      harness: "pi_core",
+      sandbox: "daytona",
+    });
+
+    assert.equal(types(events).at(-1), "done");
+    assert.equal(result.output ?? "", "");
+  });
+
+  it("reaches a real turn on a non-Pi harness (guards the expectation below)", async () => {
+    const { result } = await runSilentTurn(
+      { harness: "claude" },
+      { promptEvents: [textChunk("The answer is 4.\n")] },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.output, "The answer is 4.");
+  });
+
+  it("strips a banner-only turn down to nothing (guards the expectation below)", async () => {
+    // The premise of the banner case: after stripping, a turn that streamed only the banner is
+    // indistinguishable from a turn that streamed nothing. Asserting it here rather than inside
+    // the `it.fails` means a change to the banner format shows up as a real failure.
+    const { result } = await runSilentTurn(
+      { harness: "pi_core" },
+      { promptEvents: BANNER.map(textChunk) },
+    );
+
+    assert.equal(result.output, "");
+  });
+
+  it.fails(
+    "must fail loud on Daytona, where the transcript reader is switched off [awaiting fix: fail-loud empty turn]",
+    async () => {
+      // Cloud runs on Daytona, so this is the one placement where the safety net does not exist.
+      const { result } = await runSilentTurn({
+        harness: "pi_core",
+        sandbox: "daytona",
+      });
+
+      assert.equal(result.ok, false);
+    },
+  );
+
+  it.fails(
+    "must fail loud for a non-Pi harness, whose transcript is never read [awaiting fix: fail-loud empty turn]",
+    async () => {
+      // The swallowed-error probe is Pi-only, so an empty Claude/Codex turn is silent everywhere.
+      const { result } = await runSilentTurn({ harness: "claude" });
+
+      assert.equal(result.ok, false);
+    },
+  );
+
+  it.fails(
+    "must not record continuity for an empty turn [awaiting fix: fail-loud empty turn]",
+    async () => {
+      // Recording an empty turn as the session's last good turn is what let one silent failure
+      // poison every later turn: the next turn restores that state cleanly and fails the same way.
+      const { store } = await runSilentTurn({
+        harness: "pi_core",
+        sandbox: "daytona",
+      });
+
+      assert.equal(store.get(SESSION_ID, "pi_core"), undefined);
+    },
+  );
+
+  it.fails(
+    "must fail loud when the whole answer was the startup banner [awaiting fix: fail-loud empty turn]",
+    async () => {
+      // pi-acp emits its startup banner as the first message chunk. The stripper removes it, so a
+      // turn that streamed ONLY the banner arrives at the same place as a turn that streamed
+      // nothing: empty output, `ok: true`, blank bubble.
+      const { result } = await runSilentTurn(
+        { harness: "pi_core" },
+        { promptEvents: BANNER.map(textChunk) },
+      );
+
+      assert.equal(result.ok, false);
+    },
+  );
+
+  it.fails(
+    "must surface the error when the turn called a tool and then died [awaiting fix: fail-loud empty turn]",
+    async () => {
+      // The probe is skipped whenever the turn emitted a tool call, so a turn that ran a tool and
+      // then hit the provider failure stays silent even on the local path that can read the
+      // transcript. This is the shape of issue #6102 (a turn ends after a tool call, no answer,
+      // no stated reason).
+      const cwd = cwdWithFailedTranscript();
+
+      const { result, events } = await runSilentTurn(
+        { harness: "pi_core" },
+        { cwd, promptEvents: [toolCallChunk("tool-1")] },
+      );
+
+      // The tool call really reached the stream, so this is about the empty turn after it.
+      assert.ok(types(events).includes("tool_call"));
+      assert.equal(result.ok, false);
+      assert.ok(result.error?.includes("credit"));
+    },
+  );
+});

--- a/services/runner/tests/utils/silent-turn.ts
+++ b/services/runner/tests/utils/silent-turn.ts
@@ -17,7 +17,8 @@
  *    use (`usage.ts`, `pi-assets.ts`). That is what lets a test stand a Pi transcript up inside a
  *    remote sandbox without a live Daytona.
  */
-import { mkdirSync, writeFileSync } from "node:fs";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
@@ -128,7 +129,14 @@ export async function runSilentTurn(
   const readFsFilePaths: string[] = [];
   const store = new SessionContinuityStore();
   const events: AgentEvent[] = [];
-  const cwd = options.cwd ?? "/tmp/agenta-silent-turn-cwd";
+  // A run without an explicit cwd still gets a private one. A fixed shared /tmp path would let a
+  // stray Pi transcript left by any other run (or an earlier failed one) be picked up as this
+  // turn's swallowed error — which would silently flip the empty-turn expectations and look
+  // exactly like the fix landing. Cleaned up below, since only this call knows it owns it.
+  const ownedCwd = options.cwd
+    ? undefined
+    : mkdtempSync(join(tmpdir(), "agenta-silent-turn-run-"));
+  const cwd = options.cwd ?? (ownedCwd as string);
 
   let eventHandler: ((event: unknown) => void) | undefined;
   let permissionHandler: ((request: unknown) => void) | undefined;
@@ -230,19 +238,23 @@ export async function runSilentTurn(
     sessionContinuityStore: store,
   };
 
-  const result = await runSandboxAgent(
-    {
-      harness: "pi_core",
-      messages: [{ role: "user", content: "hello" }],
-      sessionId: SESSION_ID,
-      ...request,
-    } as AgentRunRequest,
-    (event) => events.push(event),
-    undefined,
-    deps,
-  );
+  try {
+    const result = await runSandboxAgent(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        sessionId: SESSION_ID,
+        ...request,
+      } as AgentRunRequest,
+      (event) => events.push(event),
+      undefined,
+      deps,
+    );
 
-  return { result, events, readFsFilePaths, store };
+    return { result, events, readFsFilePaths, store };
+  } finally {
+    if (ownedCwd) rmSync(ownedCwd, { recursive: true, force: true });
+  }
 }
 
 /** A Pi session transcript whose last assistant turn failed with `message`. */

--- a/services/runner/tests/utils/silent-turn.ts
+++ b/services/runner/tests/utils/silent-turn.ts
@@ -1,0 +1,281 @@
+/**
+ * A fake harness for driving turns that produce NOTHING.
+ *
+ * The silent-failure class of bug (ASD-EST100) is defined by what a turn does NOT contain: no
+ * assistant text, no error, no pause. Pinning it needs a harness whose turn output is exactly
+ * what a test asks for, so `tests/unit/silent-turn-contract.test.ts` and
+ * `tests/unit/daytona-transcript-recovery.test.ts` drive `runSandboxAgent` through this.
+ *
+ * Two choices matter, and both are deliberate:
+ *
+ * 1. It wires the REAL otel run (`createSandboxAgentOtel`), not a stub that returns a canned
+ *    output string. Output has to be produced by streaming ACP updates, the way a harness
+ *    produces it, or the tests would assert against a fixture instead of against the code that
+ *    decides whether a turn was empty. It also means the banner stripper and the terminal `done`
+ *    event are the real ones, so event ORDER can be asserted.
+ * 2. The sandbox serves files through `readFsFile`, the same daemon file API the Daytona paths
+ *    use (`usage.ts`, `pi-assets.ts`). That is what lets a test stand a Pi transcript up inside a
+ *    remote sandbox without a live Daytona.
+ */
+import { mkdirSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
+import type { RelayHost } from "../../src/tools/relay.ts";
+import type { AgentEvent, AgentRunRequest } from "../../src/protocol.ts";
+import {
+  runSandboxAgent,
+  type SandboxAgentDeps,
+} from "../../src/engines/sandbox_agent.ts";
+import { piSessionWorkspaceDir } from "../../src/engines/sandbox_agent/pi-assets.ts";
+import { resetRunnerConfigCache } from "../../src/config/runner-config.ts";
+import { SessionContinuityStore } from "../../src/engines/sandbox_agent/session-continuity.ts";
+
+/** The harness's native session id, which a completed turn records for continuity. */
+export const AGENT_SESSION_ID = "agent-session-1";
+
+/** Stands in for the tool relay's file host, which these runs never start. */
+const unusedRelay = async (): Promise<never> => {
+  throw new Error("the tool relay is not wired in silent-turn tests");
+};
+const unusedRelayHost: RelayHost = {
+  list: unusedRelay,
+  read: unusedRelay,
+  write: unusedRelay,
+  rename: unusedRelay,
+  remove: unusedRelay,
+};
+
+/** The session id every run in these suites uses, so tests can read the continuity store. */
+export const SESSION_ID = "session-under-test";
+
+/** An ACP text delta, in the `{payload:{update}}` envelope `session.onEvent` delivers. */
+export function textChunk(text: string): Record<string, unknown> {
+  return {
+    payload: {
+      update: {
+        sessionUpdate: "agent_message_chunk",
+        content: { type: "text", text },
+      },
+    },
+  };
+}
+
+/** An ACP tool-call announcement, same envelope. */
+export function toolCallChunk(
+  toolCallId: string,
+  title = "bash",
+): Record<string, unknown> {
+  return {
+    payload: {
+      update: {
+        sessionUpdate: "tool_call",
+        toolCallId,
+        title,
+        status: "pending",
+      },
+    },
+  };
+}
+
+/**
+ * Enable the Daytona provider for a test, and drop the memoized config so the run plan reads the
+ * enabled set. Daytona placement is under test (it is the cloud path, and the one where the
+ * swallowed-error reader is switched off), so both suites need this in `beforeEach`.
+ */
+export function enableDaytonaProvider(): void {
+  process.env.AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS = "local,daytona";
+  process.env.AGENTA_RUNNER_DAYTONA_API_KEY = "test-key";
+  resetRunnerConfigCache();
+}
+
+export interface SilentTurnOptions {
+  /** ACP updates the harness streams before its prompt settles. Empty = a turn with no output. */
+  promptEvents?: Array<Record<string, unknown>>;
+  /** Make the prompt itself throw (the transport-failure path). */
+  promptError?: Error;
+  /** Raise a permission gate mid-prompt, then hang — the shape a parked turn has. */
+  park?: boolean;
+  /** The run's working directory; a local Pi transcript is read from under it. */
+  cwd?: string;
+  /**
+   * A Pi transcript the sandbox serves for ANY `.jsonl` path. The in-sandbox transcript
+   * directory is the reader's to choose, so a test pins that a transcript is read at all rather
+   * than hard-coding a path the fix has not picked yet.
+   */
+  sandboxTranscript?: string;
+}
+
+export interface SilentTurnRun {
+  result: Awaited<ReturnType<typeof runSandboxAgent>>;
+  /** Events the engine emitted live, in order — the stream the playground renders. */
+  events: AgentEvent[];
+  /** Every path read through the sandbox's daemon file API, in order. */
+  readFsFilePaths: string[];
+  store: SessionContinuityStore;
+}
+
+/**
+ * Run one turn against the fake harness and return the wire result plus the live event stream.
+ *
+ * `request` is merged over a minimal valid request, so a test names only what it is pinning
+ * (harness, sandbox placement).
+ */
+export async function runSilentTurn(
+  request: Partial<AgentRunRequest>,
+  options: SilentTurnOptions = {},
+): Promise<SilentTurnRun> {
+  const readFsFilePaths: string[] = [];
+  const store = new SessionContinuityStore();
+  const events: AgentEvent[] = [];
+  const cwd = options.cwd ?? "/tmp/agenta-silent-turn-cwd";
+
+  let eventHandler: ((event: unknown) => void) | undefined;
+  let permissionHandler: ((request: unknown) => void) | undefined;
+  // A parked turn's prompt never settles on its own; the managed cancel resolves it, mirroring
+  // what the sandbox-agent package does on `destroySession` (the same model `fakeHarness` in
+  // `tests/unit/sandbox-agent-orchestration.test.ts` carries — keep the two in step).
+  let resolveHungPrompt: ((value: unknown) => void) | undefined;
+
+  const session = {
+    id: "session-1",
+    agentSessionId: AGENT_SESSION_ID,
+    onEvent(handler: (event: unknown) => void) {
+      eventHandler = handler;
+    },
+    onPermissionRequest(handler: (request: unknown) => void) {
+      permissionHandler = handler;
+    },
+    async respondPermission() {},
+    async prompt() {
+      for (const event of options.promptEvents ?? []) eventHandler?.(event);
+      if (options.promptError) throw options.promptError;
+      if (options.park) {
+        permissionHandler?.({
+          id: "perm-1",
+          availableReplies: ["once", "always", "reject"],
+          toolCall: { toolCallId: "tool-1", name: "edit", title: "edit" },
+        });
+        return new Promise((resolve) => {
+          resolveHungPrompt = resolve;
+        });
+      }
+      return { stopReason: "end_turn" };
+    },
+  };
+
+  const sandbox = {
+    async mkdirFs() {},
+    // `exitCode: 0` makes the Daytona bootstrap's `test -x <pinned pi>` succeed, i.e. the image
+    // already has Pi baked in — otherwise the run dies during setup and never reaches a turn.
+    async runProcess() {
+      return { exitCode: 0 };
+    },
+    async writeFsFile() {},
+    async deleteFsEntry() {},
+    async createSession() {
+      return session;
+    },
+    async destroySession() {
+      resolveHungPrompt?.({ stopReason: "cancelled" });
+    },
+    async destroySandbox() {},
+    async dispose() {},
+    async readFsFile({ path }: { path: string }) {
+      readFsFilePaths.push(path);
+      const content = path.endsWith(".jsonl")
+        ? options.sandboxTranscript
+        : undefined;
+      if (content === undefined) throw new Error(`ENOENT: ${path}`);
+      return new TextEncoder().encode(content);
+    },
+  };
+
+  const deps: SandboxAgentDeps = {
+    log: () => {},
+    createLocalCwd: (durable?: string) => durable ?? cwd,
+    createDaytonaCwd: (durable?: string) => durable ?? cwd,
+    resolveSkillDirs: () => ({ skills: [], cleanup: () => {} }),
+    buildDaemonEnv: () => ({}),
+    resolveDaemonBinary: () => "/bin/sandbox-agent",
+    buildSandboxProvider: () => ({ provider: true }) as any,
+    createPersist: () => ({}) as any,
+    startSandboxAgent: (async () => sandbox) as any,
+    prepareWorkspace: (async () => ({ cleanup: async () => {} })) as any,
+    probeCapabilities: async () => ({
+      source: "probed",
+      capabilities: {
+        mcpTools: true,
+        toolCalls: true,
+        usage: true,
+        streamingDeltas: true,
+      },
+    }),
+    applyModel: async (_session, model) => model ?? "resolved-model",
+    createOtel: createSandboxAgentOtel,
+    startToolRelay: (() => ({ stop: async () => {} })) as any,
+    // The relay never runs (`startToolRelay` is stubbed), so these only have to satisfy the
+    // shape. An unreachable host is the honest stub: a test that starts depending on the relay
+    // fails loudly here instead of quietly reading an empty directory.
+    localRelayHost: () => unusedRelayHost,
+    sandboxRelayHost: () => unusedRelayHost,
+    responderFactory: () => ({
+      async onPermission() {
+        return { kind: options.park ? "pendingApproval" : "allow" } as const;
+      },
+      async onClientTool() {
+        return { kind: "deny" } as const;
+      },
+    }),
+    sessionContinuityStore: store,
+  };
+
+  const result = await runSandboxAgent(
+    {
+      harness: "pi_core",
+      messages: [{ role: "user", content: "hello" }],
+      sessionId: SESSION_ID,
+      ...request,
+    } as AgentRunRequest,
+    (event) => events.push(event),
+    undefined,
+    deps,
+  );
+
+  return { result, events, readFsFilePaths, store };
+}
+
+/** A Pi session transcript whose last assistant turn failed with `message`. */
+export function piTranscriptWithError(cwd: string, message: string): string {
+  return (
+    [
+      JSON.stringify({ type: "session", version: 3, id: "sess-failed", cwd }),
+      JSON.stringify({
+        type: "message",
+        message: { role: "user", content: [{ type: "text", text: "hi" }] },
+      }),
+      JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: message,
+        },
+      }),
+    ].join("\n") + "\n"
+  );
+}
+
+/**
+ * Write a failed Pi transcript into `cwd` where the reader looks for it — the local equivalent of
+ * a sandbox whose harness died on a provider rejection.
+ */
+export function seedFailedTranscript(cwd: string, message: string): void {
+  const dir = piSessionWorkspaceDir(cwd);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, "sess-failed.jsonl"),
+    piTranscriptWithError(cwd, message),
+  );
+}

--- a/services/runner/tests/utils/silent-turn.ts
+++ b/services/runner/tests/utils/silent-turn.ts
@@ -174,10 +174,20 @@ export async function runSilentTurn(
 
   const sandbox = {
     async mkdirFs() {},
-    // `exitCode: 0` makes the Daytona bootstrap's `test -x <pinned pi>` succeed, i.e. the image
-    // already has Pi baked in — otherwise the run dies during setup and never reaches a turn.
-    async runProcess() {
-      return { exitCode: 0 };
+    // Two jobs, both matching the real contract:
+    //  - `exitCode: 0` makes the Daytona bootstrap's `test -x <pinned pi>` succeed, i.e. the
+    //    image already has Pi baked in — otherwise the run dies during setup and never reaches
+    //    a turn.
+    //  - `ls` answers on STDOUT, the way `sandboxRelayHost.list` reads it in `src/tools/relay.ts`
+    //    (`String(ls?.stdout ?? "").split("\n")`). A reader that finds the transcript by LISTING
+    //    the directory has to see the file; returning a bare exit code would hand it an empty
+    //    listing, and the Daytona expectations would stay green through the fix that closes them.
+    async runProcess(input?: { command?: string }) {
+      const listing =
+        input?.command === "ls" && options.sandboxTranscript
+          ? `${TRANSCRIPT_FILENAME}\n`
+          : "";
+      return { exitCode: 0, stdout: listing };
     },
     async writeFsFile() {},
     async deleteFsEntry() {},
@@ -257,26 +267,71 @@ export async function runSilentTurn(
   }
 }
 
-/** A Pi session transcript whose last assistant turn failed with `message`. */
-export function piTranscriptWithError(cwd: string, message: string): string {
+/**
+ * Pi's transcript format, in ONE place.
+ *
+ * Every test that stands a Pi transcript up — here and in `sandbox-agent-pi-error.test.ts` —
+ * encodes it through this, so a Pi schema change cannot leave two hand-rolled copies agreeing
+ * with each other and both wrong about the format the reader parses.
+ *
+ * `recordCwd` overrides the cwd stamped on the `session` record, to simulate a stale or copied
+ * transcript (the reader matches on it).
+ */
+export function piTranscript(
+  cwd: string,
+  name: string,
+  messages: Array<Record<string, unknown>>,
+  recordCwd: string = cwd,
+): string {
   return (
     [
-      JSON.stringify({ type: "session", version: 3, id: "sess-failed", cwd }),
-      JSON.stringify({
-        type: "message",
-        message: { role: "user", content: [{ type: "text", text: "hi" }] },
-      }),
-      JSON.stringify({
-        type: "message",
-        message: {
-          role: "assistant",
-          content: [],
-          stopReason: "error",
-          errorMessage: message,
-        },
-      }),
+      JSON.stringify({ type: "session", version: 3, id: name, cwd: recordCwd }),
+      ...messages.map((message) => JSON.stringify(message)),
     ].join("\n") + "\n"
   );
+}
+
+/** Write a transcript into `piSessionWorkspaceDir(cwd)`, flat, the way Pi does. */
+export function writePiTranscript(
+  cwd: string,
+  name: string,
+  messages: Array<Record<string, unknown>>,
+  recordCwd: string = cwd,
+): void {
+  const dir = piSessionWorkspaceDir(cwd);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(
+    join(dir, `${name}.jsonl`),
+    piTranscript(cwd, name, messages, recordCwd),
+  );
+}
+
+/** The one transcript these suites stand up; also what the fake sandbox's `ls` reports. */
+const TRANSCRIPT_NAME = "sess-failed";
+export const TRANSCRIPT_FILENAME = `${TRANSCRIPT_NAME}.jsonl`;
+
+/** The messages of a session whose last assistant turn failed with `message`. */
+function failedTurnMessages(message: string): Array<Record<string, unknown>> {
+  return [
+    {
+      type: "message",
+      message: { role: "user", content: [{ type: "text", text: "hi" }] },
+    },
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [],
+        stopReason: "error",
+        errorMessage: message,
+      },
+    },
+  ];
+}
+
+/** A Pi session transcript whose last assistant turn failed with `message`. */
+export function piTranscriptWithError(cwd: string, message: string): string {
+  return piTranscript(cwd, TRANSCRIPT_NAME, failedTurnMessages(message));
 }
 
 /**
@@ -284,10 +339,5 @@ export function piTranscriptWithError(cwd: string, message: string): string {
  * a sandbox whose harness died on a provider rejection.
  */
 export function seedFailedTranscript(cwd: string, message: string): void {
-  const dir = piSessionWorkspaceDir(cwd);
-  mkdirSync(dir, { recursive: true });
-  writeFileSync(
-    join(dir, "sess-failed.jsonl"),
-    piTranscriptWithError(cwd, message),
-  );
+  writePiTranscript(cwd, TRANSCRIPT_NAME, failedTurnMessages(message));
 }

--- a/services/runner/tests/utils/silent-turn.ts
+++ b/services/runner/tests/utils/silent-turn.ts
@@ -97,7 +97,12 @@ export interface SilentTurnOptions {
   promptError?: Error;
   /** Raise a permission gate mid-prompt, then hang — the shape a parked turn has. */
   park?: boolean;
-  /** The run's working directory; a local Pi transcript is read from under it. */
+  /**
+   * The run's working directory. On a local run a Pi transcript is read from under it; on a
+   * Daytona run it is the workspace path INSIDE the sandbox, which is the cwd Pi stamps on the
+   * transcript it writes there, so a remote test must pass the same path it seeds the transcript
+   * with or the reader will (correctly) disown it.
+   */
   cwd?: string;
   /**
    * A Pi transcript the sandbox serves for ANY `.jsonl` path. The in-sandbox transcript


### PR DESCRIPTION
## Context

Users keep reporting that the agent "stops answering and says nothing" (ASD-EST100). When a provider rejects a model call (no credit, quota, rate limit, bad key), pi-acp maps the failure to a clean `{stopReason: "end_turn"}` with no content. The runner believes it, returns `ok: true` with an empty output, records the turn as a completed one, and the playground renders a blank bubble with no error anywhere. The only copy of the real message sits in Pi's transcript inside the sandbox, which is then destroyed.

No suite caught that shape. This PR adds the regression tests at each layer the failure passes through. It changes no product code.

## Changes

A swallowed provider failure on Daytona comes back today as:

```
{ok: true, output: "", messages: [], stopReason: "end_turn"}
```

with an event stream of exactly `["done"]`. That is the incident's signature verbatim, and the tests reproduce it through the real engine rather than a fixture.

The contract they assert is:

```
{ok: false, error: "<the provider's failure>"}
```

with an `error` event ahead of the terminal `done` the API reconciles on, and with no continuity recorded, because recording an empty turn as the session's last good turn is what let one silent failure poison every later turn.

Three layers are covered. `silent-turn-contract.test.ts` drives `runSandboxAgent` through a fake harness wired to the **real** otel run, so whether a turn was empty is decided by the code under test and not by a canned output string. `daytona-transcript-recovery.test.ts` stands a Pi transcript up inside a fake remote sandbox served over the daemon file API, since the transcript reader is switched off on Daytona and cloud runs on Daytona. `test_vercel_stream_silent_failure.py` pins the SSE half: a terminal-only `ok: false` must carry the caller's own reason, never the generic "produced no output" frame.

The QA release gate gets the same invariant. `check_no_silent_turn` is wired into the ten cells that hold turns and whose PASS depends on something **not** appearing, because a turn that produced nothing satisfies those cells by doing nothing at all. Its definition of content mirrors `content_parts_emitted` in the product's own Vercel egress, so a turn whose only output is a file or a data payload is not reported. Reasoning stays excluded, matching the adapter: a turn that only thought renders as a blank bubble.

Seven tests use `it.fails`. They pin contracts that are not implemented yet, so they pass today because the assertion fails, and they turn red the moment the named fix lands, which is the signal to drop the marker. Five await the fail-loud empty-turn guardrail (empty turn on Daytona, empty turn on a non-Pi harness, continuity recorded for an empty turn, a banner-only turn, a turn that called a tool and then died). Two await the Daytona swallowed-error reader.

Two properties keep the suite honest. `it.fails` is satisfied by *any* failure, including a fixture that dies before running a turn, so every one is backed by a separate guard test proving its setup reaches a real turn. And every fail-loud assertion is paired with a turn that must keep succeeding (a parked turn, a turn that answered), so the pending fix cannot be satisfied by failing everything, and the empty-turn check cannot be satisfied by suppressing it.

## Tests / notes

- Runner: 2185 passed, 7 expected-fail, `tsc --noEmit` clean.
- Release gate lib: 32 passed. SDK agent adapters: 127 passed.
- No product code is touched. The 7 expected-fail tests are the pending contracts listed above, not breakage.
- Two things surfaced while writing these, both product decisions rather than test problems. `conciseError` rewrites the provider's raw text into a curated classification, so "the real provider message" reaches the user as a classification of it. And the SDK's zero-content backstop keys only on content and error state, never on `stopReason`, so a paused turn with zero content parts would emit the generic no-output frame. Gates always emit content today, so it does not fire in practice.
- Reviewers may want to look hardest at `check_no_silent_turn`'s content definition. It is a deny-list on purpose: `data-<name>` payloads are open-ended, so an allow-list would fail healthy turns, while a deny-list can only under-report.
