### PR TITLE
[5999] fix(docker): Copy oss/scripts into the OSS dev web image

### DIFF
--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -57,6 +57,7 @@ services:
             #
             - ../../../web/oss/src:/app/oss/src
             - ../../../web/oss/public:/app/oss/public
+            - ../../../web/oss/scripts:/app/oss/scripts
             - ../../../web/packages:/app/packages
             - nextjs-oss-cache:/app/oss/.next/cache
             - turbo-oss-cache:/app/.turbo

--- a/web/oss/docker/Dockerfile.dev
+++ b/web/oss/docker/Dockerfile.dev
@@ -95,6 +95,7 @@ COPY --chown=agenta:agenta packages/agenta-chat/tsconfig.json ./packages/agenta-
 
 COPY --chown=agenta:agenta oss/src ./oss/src
 COPY --chown=agenta:agenta oss/public ./oss/public
+COPY --chown=agenta:agenta oss/scripts ./oss/scripts
 COPY --chown=agenta:agenta oss/tsconfig.json ./oss
 
 COPY --chown=agenta:agenta oss/postcss.config.mjs ./oss/postcss.config.mjs


### PR DESCRIPTION
## Summary
A fresh OSS dev web container dies on boot with `Cannot find module '/app/oss/scripts/copy-pdf-worker.mjs'`. `pnpm dev` (via `dev-oss`) runs `node scripts/copy-pdf-worker.mjs` before Next.js, but `Dockerfile.dev` only copied `oss/src` and `oss/public`, and compose did not mount `oss/scripts`.

This copies `oss/scripts` into the image next to the existing `oss/src` copy, and bind-mounts it in `docker-compose.dev.yml` the same way `src` and `public` are mounted. GH images are unchanged (`Dockerfile.gh` already copies all of `oss/`). EE is unchanged (its `dev` script does not run the worker copy).

Fixes #5999

## Testing
### Verified locally
- Confirmed `web/oss/package.json` `dev` starts with `node scripts/copy-pdf-worker.mjs`.
- Built `web/oss/docker/Dockerfile.dev` as `agenta-oss-dev-web:latest`.
- Ran the image without a compose mount. The script is in the image and the boot command succeeds:

```
$ docker run --rm --entrypoint sh agenta-oss-dev-web:latest -c \
    'ls -la /app/oss/scripts && cd /app/oss && node scripts/copy-pdf-worker.mjs'

-rw-r--r-- 1 agenta agenta 1205 copy-pdf-worker.mjs
[copy-pdf-worker] pdfjs worker → public/pdf.worker.min.mjs
```

- Rendered `docker compose --profile with-web -f docker-compose.dev.yml config` with `env.oss.dev.example`: the `web` service bind-mounts `web/oss/scripts` to `/app/oss/scripts`.

### Added or updated tests
N/A. Docker build/compose config only. No application code.

### QA follow-up
On a clean host: `load-env hosting/docker-compose/oss/.env.oss.dev` then `bash hosting/docker-compose/run.sh --oss --dev --build`. The web container should stay up and logs should show `[copy-pdf-worker] pdfjs worker → public/pdf.worker.min.mjs` instead of the missing-module crash.

## Demo
Not a UI change. Screenshot of the OSS dev web image after the fix: `copy-pdf-worker.mjs` is present and the boot step succeeds.

![OSS dev web image contains copy-pdf-worker.mjs and the boot script runs](https://gist.githubusercontent.com/Abdelkaderbzz/395966e33bb424af4e9ec46b67076a8a/raw/513b273e1498fa9c20731218292714b8b1f44367/agenta-5999-demo.png)

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)