### PR TITLE
runner: park sandbox on tool-call timeout, not delete

### DIFF
--- a/services/runner/src/engines/sandbox_agent/engine.ts
+++ b/services/runner/src/engines/sandbox_agent/engine.ts
@@ -61,7 +61,9 @@ export async function runSandboxAgent(
         ? "clean-resumable"
         : signal?.aborted
           ? "aborted"
-          : "failed-turn",
+          : result?.failureKind === "tool-timeout"
+            ? "tool-timeout"
+            : "failed-turn",
     });
   }
 }

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -153,11 +153,15 @@ export async function runTurn(
   );
   let runLimitTrip: (() => void) | undefined;
   let runLimitReason: string | undefined;
+  // Set when a per-tool-call timer fires: the daemon and filesystem are intact (only one tool
+  // overran its clock), so the teardown path should park rather than delete the sandbox.
+  let runLimitWasToolTimeout = false;
   const runLimitTripped = new Promise<void>((resolve) => {
     runLimitTrip = resolve;
   });
   runLimits.onTrip((reason) => {
     runLimitReason = reason;
+    runLimitWasToolTimeout = reason.startsWith("tool call ");
     runLimitTrip?.();
   });
 
@@ -1180,7 +1184,10 @@ export async function runTurn(
       otel?.finish();
     } catch {}
     await otel?.flush().catch(() => {});
-    return { ok: false, error };
+    // A per-tool-call timeout leaves the sandbox daemon and filesystem intact; tag the result
+    // so the teardown path can park instead of delete. See teardown.ts "tool-timeout".
+    const failureKind = runLimitWasToolTimeout ? "tool-timeout" : undefined;
+    return { ok: false, error, ...(failureKind ? { failureKind } : {}) };
   } finally {
     // Release every run-limits timer (idempotent, never re-arms on a late event) on EVERY path.
     runLimits.dispose();

--- a/services/runner/src/engines/sandbox_agent/teardown.ts
+++ b/services/runner/src/engines/sandbox_agent/teardown.ts
@@ -14,6 +14,10 @@
  *                            installed credentials are all sound, so park it.
  *  - `continuity-invalid`    The CONVERSATION is wrong. An example is an edited transcript. This
  *                            says nothing about the environment, so park it.
+ *  - `tool-timeout`          A per-tool-call deadline tripped mid-turn. The sandbox daemon is
+ *                            healthy -- only the one tool call overran its clock. Installed
+ *                            dependencies, credentials, and the filesystem are all intact.
+ *                            Park it so the next turn inherits that disk state.
  *  - `runtime-incompatible`  Something baked into the DAEMON is stale. Examples are model or MCP
  *                            credentials, the process environment, and Pi's runtime assets. A
  *                            parked sandbox would resume with that stale material installed.
@@ -37,6 +41,7 @@ export type TeardownReason =
   | "runtime-incompatible"
   | "sandbox-incompatible"
   | "continuity-invalid"
+  | "tool-timeout"
   | "clean-resumable"
   | "idle-expiry"
   | "capacity-eviction"
@@ -64,6 +69,9 @@ const PARKABLE_REASONS: ReadonlySet<TeardownReason> = new Set<TeardownReason>([
   // The two incompatibilities whose daemon is still sound. See the module comment.
   "session-incompatible",
   "continuity-invalid",
+  // A per-tool-call timeout: only one tool overran its clock; the daemon and the filesystem are
+  // intact. Park so the next turn can reuse all installed dependencies. See module comment.
+  "tool-timeout",
 ]);
 
 export function teardownDisposition(

--- a/services/runner/src/lifecycle/session-coordinator.ts
+++ b/services/runner/src/lifecycle/session-coordinator.ts
@@ -556,7 +556,9 @@ export async function runWithKeepalive(
       ? "clean-resumable"
       : signal?.aborted || clientGone?.()
         ? "aborted"
-        : "failed-turn";
+        : result.failureKind === "tool-timeout"
+          ? "tool-timeout"
+          : "failed-turn";
 
   /**
    * Turn a dispatch mismatch label into the teardown reason that names the FAILING LAYER.

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -717,6 +717,12 @@ export interface AgentRunResult {
   /** Trace id of the run (the caller's trace when a traceparent was passed). */
   traceId?: string;
   error?: string;
+  /**
+   * Machine-readable classification of a failed turn (present only when `ok` is false and the
+   * runner knows why it failed). `"tool-timeout"` means a per-tool-call deadline tripped; the
+   * sandbox daemon and filesystem are intact. Callers may use this to park instead of delete.
+   */
+  failureKind?: string;
 }
 
 /**

--- a/services/runner/tests/unit/session-lifecycle-characterization.test.ts
+++ b/services/runner/tests/unit/session-lifecycle-characterization.test.ts
@@ -376,6 +376,13 @@ describe("(b) teardown reasons name the failing layer", () => {
     }
   });
 
+  it("a tool-timeout PARKS the sandbox because only the tool overran its clock", () => {
+    // The daemon, credentials, and filesystem are all intact after a per-tool-call deadline. The
+    // next turn should inherit the disk state (installed deps, /tmp contents, etc.) rather than
+    // rebuilding from a bare sandbox. See teardown.ts "tool-timeout".
+    assert.equal(teardownDisposition("tool-timeout"), "stop");
+  });
+
   it("the parkable set is an ALLOWLIST, so a new reason deletes by default", () => {
     // The invariant that keeps this safe as the union grows. A denylist would make a newly added
     // reason park by accident, which is how stale credentials survive into a resumed daemon.
@@ -386,6 +393,7 @@ describe("(b) teardown reasons name the failing layer", () => {
       "shutdown-idle",
       "session-incompatible",
       "continuity-invalid",
+      "tool-timeout",
     ];
     const everyReason: TeardownReason[] = [
       "kill",
@@ -396,13 +404,14 @@ describe("(b) teardown reasons name the failing layer", () => {
       "runtime-incompatible",
       "sandbox-incompatible",
       "continuity-invalid",
+      "tool-timeout",
       "clean-resumable",
       "idle-expiry",
       "capacity-eviction",
       "shutdown-in-flight",
       "shutdown-idle",
     ];
-    assert.equal(everyReason.length, 13, "the TeardownReason union has 13 members");
+    assert.equal(everyReason.length, 14, "the TeardownReason union has 14 members");
     for (const reason of everyReason) {
       assert.equal(
         teardownDisposition(reason),


### PR DESCRIPTION
## Summary

- A per-tool-call deadline that trips mid-turn leaves the sandbox daemon healthy and the filesystem intact. Only the one tool overran its clock. Deleting the sandbox forces the next turn to rebuild all installed state (deps, /tmp contents, build output) from scratch, costing real time and money.
- Adds a new tool-timeout teardown reason to the parkable allowlist in teardown.ts. Other run-limit failures (total deadline, idle timeout, TTFB) still delete, because those may indicate a genuinely wedged process.
- run-turn.ts detects when a per-tool-call timer fired and sets failureKind: tool-timeout on the failed result. Both the keep-alive dispatch (session-coordinator.ts) and the cold path (engine.ts) map that to the tool-timeout reason, which parks instead of deletes.

Fixes #6103

## Demo

This is a pure backend teardown-logic fix in the TypeScript runner with no UI change.

Before: when a per-tool-call deadline trips, the sandbox is deleted. Installed packages, /tmp contents, and build output are lost. The next turn rebuilds from a bare sandbox.

After: the same event parks the sandbox instead of deleting it. The next turn reconnects and finds its disk state intact (no 180 MB Chromium re-download, no repeated pnpm install).

## Test plan

- [x] 21 tests pass in session-lifecycle-characterization, including new tool-timeout parks test
- [x] 12 tests pass in run-limits
- [x] Pre-existing failures unchanged