### PR TITLE
[parked] feat(frontend): edit text files inline in the Files drawer

### DIFF
--- a/docs/design/file-drawer-edit-mode/CONTEXT.md
+++ b/docs/design/file-drawer-edit-mode/CONTEXT.md
@@ -1,0 +1,192 @@
+# File drawer edit mode — shared context brief
+
+**Read this first. Every fact below was verified against the code on 2026-08-04. Do not
+re-derive it. Do verify anything you intend to contradict.**
+
+## Where you are working
+
+- **Worktree:** `/home/mahmoud/code/agenta-2-editmode` (an isolated `git worktree`, NOT the
+  user's main checkout). Everything happens here. Never touch `/home/mahmoud/code/agenta-2`.
+- **Branch:** `feat/file-drawer-edit-mode`, based on `origin/release/v0.109.0`.
+- **PR base when the time comes:** `release/v0.109.0`. Never open a PR against `main`.
+- `web/node_modules` is installed in this worktree.
+
+## The goal
+
+Let a user open a text file in the Files drawer, click **Edit**, change it in place, and
+save it back to the mount. The agent picks the change up because the sandbox FUSE-mounts the
+same object-store prefix.
+
+The design is fully specified. Do not invent interaction design.
+
+- **Design spec:** `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html`
+  It is a `.dc.html` prototype. The meaningful parts are (a) the markup, which shows layout
+  and copy, and (b) the `<script type="text/x-dc">` block at the bottom, which holds a
+  `STATES` list and a `NOTES` object spelling out every state, its trigger, and its rules.
+  Read the script block first, then the markup. Strip inline styles when reading:
+  `python3 -c "import re;print(re.sub(r' style=\"[^\"]*\"','',open('<path>').read()))"`.
+
+The spec's design-system CSS is explicitly derived from the app's own antd tokens, so use
+the existing theme tokens (`colorText`, `colorBorderSecondary`, and so on). Do not
+hard-code the hex values from the spec.
+
+### The twelve states the spec defines
+
+`read` (viewing, Edit offered) · `clean` (buffer open, Save off) · `dirty` · `preview`
+(rendered markdown) · `saving` · `saved` · `error` (save failed, buffer preserved) ·
+`conflict` (agent wrote underneath) · `confirm` (discard guard) · `code` (codeOnly, no
+markdown toggle) · `locked` (image/PDF/binary — Edit not rendered) · `capped` (text but over
+the size cap — Edit rendered but disabled with a tooltip).
+
+## Verified facts about the existing code
+
+### Backend — already complete, no API work needed
+
+- `PUT /mounts/{mount_id}/files?path=...` writes raw request-body bytes.
+  Handler `write_mount_file` at `api/oss/src/apis/fastapi/mounts/router.py:570`,
+  registered at line 283, guarded by `Permission.EDIT_MOUNTS`.
+- Service: `api/oss/src/core/mounts/service.py:1476` → `put_object` into the mount's prefix.
+- Response model `MountFileWrittenResponse` (`api/oss/src/apis/fastapi/mounts/models.py:102`)
+  returns **only `path` and `size`. There is no `mtime` in the response.** The spec assumes
+  mtime comes back from the write. It does not. Solve this on the client (for example, mark
+  the just-written path as self-authored and suppress the conflict banner for it) rather
+  than changing the backend. A backend change would drag in Fern regeneration and turn a
+  frontend PR into a cross-stack one. If you conclude a backend change is unavoidable, say
+  so explicitly in the plan instead of doing it silently.
+- The Fern client already exposes it: `mounts.writeMountFile` in
+  `web/packages/agenta-api-client/src/generated/api/resources/mounts/client/Client.ts:1065`.
+  Reach it through a per-resource accessor from `@agenta/sdk/resources` (see
+  `web/AGENTS.md`), never the `@agenta/sdk` root barrel.
+- The agent sees saved bytes with no extra sync: the sandbox geesefs-mounts the same
+  prefix (`services/runner/src/engines/sandbox_agent/mount.ts`).
+
+### Frontend — the Drives area
+
+All paths below are under `web/oss/src/components/Drives/`.
+
+| File | What it is |
+|---|---|
+| `DriveExplorer.tsx` | Two-pane shell (tree + preview) and the one header |
+| `DriveHeader.tsx` | Breadcrumb, name, action cluster. Spec: takes an `editing` flag and swaps the cluster for Cancel / Save |
+| `DriveToolbar.tsx` | Search, origin filter, visibility toggles. Spec: replaced wholesale by the edit bar while editing |
+| `DriveFilePreview.tsx` | Right pane. Header band (or headerless in "chrome mode") over the content viewer |
+| `DriveFileContentViewer.tsx` | Kind-keyed crossfade wrapper around `DriveFileBody` |
+| `renderers.tsx` | The renderer registry. `TextBody` at line 129, `CodeBody` at ~line 172, `TEXT_KINDS` at line 587, `DriveFileBody` switch at ~line 625 |
+| `driveKinds.ts` | `resolveDriveFileKind(path)` and `driveCodeLanguage(path)` — the single extension→kind resolver. Use it; do not add a second extension list |
+| `driveFileSource.tsx` | `useDriveFileText(mount, path)` reads content (local blob or mount query) |
+| `driveMedia.ts` | `uploadMountFile` (multipart, used by drag-drop), download helpers |
+| `FilesDrawer.tsx` | The antd drawer shell; body is lazily imported |
+
+Content reads go through `mountFileContentQueryFamily` and invalidate on
+`mountFileContentQueryKey` (both in
+`web/packages/agenta-entities/src/session/state/mounts.ts`).
+
+`TEXT_CAP = 1.5 * 1024 * 1024` in `renderers.tsx` is the existing inline-text size cap. The
+spec's `capped` state must reuse this constant, not a new one.
+
+### The editor components the spec says to reuse — all confirmed to exist
+
+- **`SharedEditor`** — `web/packages/agenta-ui/src/SharedEditor/`. Props confirmed present:
+  `header`, `footer`, `editorType: "border" | "borderless"`,
+  `state: "default" | "filled" | "disabled" | "readOnly" | "focus" | "typing"`,
+  `initialValue`, `value`, `handleChange`, `editorProps`, `disableDebounce`,
+  `onFocusChange`, `maxPasteChars`. Read `web/packages/agenta-ui/src/SharedEditor/README.md`.
+- **`SimpleSharedEditor`** — `web/oss/src/components/EditorViews/SimpleSharedEditor/` is the
+  app-level wrapper most call sites use (Playground, evaluators, session drawer). Look at how
+  `web/oss/src/components/SharedDrawers/SessionDrawer/components/SessionMessagePanel/index.tsx`
+  uses it before writing anything new.
+- **Markdown source ↔ preview** — `markdownViewAtom(id)`, `TOGGLE_MARKDOWN_VIEW`,
+  `SET_MARKDOWN_VIEW`, all exported from `@agenta/ui` (see
+  `web/packages/agenta-ui/src/Editor/index.ts:56,77`). Working example:
+  `web/packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx` — note its
+  comment that setting the atom alone is not enough, you must also dispatch the command.
+- **codeOnly mode** — `EditorProps` with `codeOnly: true` plus a `language`. See
+  `web/packages/agenta-ui/src/Editor/README.md`.
+- **`DiffView`** — exported from `@agenta/ui/editor` (`Editor/index.ts:41`). Powers the
+  conflict banner's "View diff".
+
+### Conflict detection
+
+- `mountFileSchema` **does** carry `mtime` (epoch ms) —
+  `web/packages/agenta-entities/src/session/core/schema.ts:145`.
+- There is an existing per-session file-activity signal:
+  `web/packages/agenta-entities/src/session/state/fileActivity.ts`. Entries carry
+  `resolved: {mountId, path}`, an `effect` (`created`/`modified`/…), and sometimes the
+  previous cached body. This is the "file-activity signal that already exists" the spec
+  refers to. Use it.
+
+### Things the spec assumes that are NOT true today — resolve these in the plan
+
+1. **No mtime on the write response** (see above).
+2. **There is no read-only-mount flag.** `mountSchema` has only `id`, `slug`, `name`,
+   `session_id`. The spec's "read-only mounts hide Edit entirely" has nothing to read.
+   Decide: gate on the `EDIT_MOUNTS` permission if the frontend can see it, otherwise
+   treat every mount as writable and note the gap. Do not invent a schema field.
+
+## Constraint: the antd migration branch
+
+PR #5643 (`fe-refactor/migration-away-from-antd`) migrates `@agenta/ui` off antd onto Radix
++ cva. It is **641 files, ~55k insertions, targeting `main`, not yet merged anywhere**, and
+it is expected to land within hours.
+
+What this means for you, verified:
+
+- **Textual conflict risk in Drives is tiny.** That branch touches exactly three files under
+  `Drives/`, one line each — `DriveFilePreview.tsx`, `DriveHeader.tsx`, `FolderView.tsx`,
+  all changing a shared `CopyButton`'s `size="small"` to `size="icon-sm"`. **Do not touch
+  those three lines.** If you leave them alone the merge is clean.
+- **The forward-compat cost is real.** That branch rewrites `import {Button} from "antd"` to
+  `import {Button} from "@agenta/ui/ui"` across the app. `@agenta/ui/ui` **does not exist on
+  `release/v0.109.0`**, so you cannot write forward-compatible imports today. Therefore:
+  **keep raw antd imports few and concentrated in as few new files as possible**, so the
+  post-merge fixup is a short mechanical pass. Prefer `SharedEditor` /
+  `SimpleSharedEditor` / existing shared components over raw antd wherever there is a
+  choice.
+- Do not attempt to rebase onto or merge that branch. Just stay out of its way.
+
+## Repo conventions you must follow
+
+Read `AGENTS.md` at the repo root and `web/AGENTS.md`. The ones that bite hardest here:
+
+- **State:** Jotai atoms. `atomWithQuery` for data. Never `useEffect` + manual state for
+  fetching. Avoid prop drilling; use atoms for state shared across the tree.
+- **Styling:** Tailwind utility classes, semantic antd theme tokens
+  (`bg-colorBgContainer`, `text-colorText`, `border-colorBorderSecondary`). No raw hex, no
+  CSS-in-JS, no inline `style={{}}`. **Implement and check both light and dark themes.**
+- **API calls:** Fern client via `@agenta/sdk/resources`, `{queryParams: {...}}` not
+  axios `params`, zod validation at the boundary with `safeParseWithLogging`.
+- **Comments:** at most ONE short line per comment. No multi-line prose blocks. This repo
+  has an unusually high existing comment density in `Drives/` — match the terse style of the
+  newer files, do not imitate the long header essays.
+- **Before committing:** run `pnpm lint-fix` inside `web/`.
+- **Package placement:** the `agenta-package-practices` skill decides app-layer versus
+  `@agenta/*` package. This feature is Drives-specific, so it almost certainly belongs in
+  the app layer under `web/oss/src/components/Drives/`. Only promote something to a package
+  if it is genuinely reused.
+
+## Tests
+
+- Frontend unit tests in this area use vitest. There is a working local example:
+  `web/oss/src/components/Drives/dropEntries.test.ts`. Run with the web test script (check
+  `web/package.json` for the exact command).
+- Test the **state machine and the pure helpers** hard: dirty tracking, save-enabled logic,
+  kind→editable decision, size-cap decision, conflict detection, guard routing. Those are
+  where the bugs live and they are cheap to test.
+- Do not write brittle snapshot tests of the rendered drawer.
+
+## The QA matrix the user asked for
+
+Live QA must cover editing and saving: `.txt`, `.csv`, `.md`, `.env`, `.json`. Note that
+`.env` has no extension-based kind today — check what `resolveDriveFileKind` returns for it
+and make sure it lands in a text kind rather than falling through to the download card.
+`.csv` currently renders as a parsed table, so decide explicitly what editing a CSV does
+(the spec lists `csv` among the editable text kinds, so it must become a source buffer while
+editing).
+
+## Working agreement
+
+- Stay inside the worktree. Do not run `git push`, do not open a PR, do not merge. The
+  orchestrator does that at the end.
+- Commit as you go with clear messages so later phases can see what changed.
+- If you hit something that makes the plan wrong, write it down in
+  `docs/design/file-drawer-edit-mode/open-questions.md` rather than silently improvising.

--- a/docs/design/file-drawer-edit-mode/README.md
+++ b/docs/design/file-drawer-edit-mode/README.md
@@ -1,0 +1,51 @@
+# File drawer edit mode
+
+Let a user open a text file in the Files drawer, click Edit, change it in place, and save it
+back to the mount. The agent picks the change up with no extra sync, because its sandbox
+mounts the same object-store prefix.
+
+## Reading order
+
+Read these in order. Each answers a different question.
+
+| File | Question it answers |
+|---|---|
+| `CONTEXT.md` | What is already true in the code? Verified facts, worktree rules, the QA matrix. Written before this plan and kept as-is. |
+| `context.md` | Why does this work exist, what is in scope, what is out? |
+| `research.md` | What did reading the code change about the brief? Every place the spec or `CONTEXT.md` is wrong, with the file and line that proves it. |
+| `plan.md` | How is it built? State machine, file-by-file changes, editor API, save path, conflict detection, tests. |
+| `status.md` | Where is it now? Progress, open decisions, what the next session should pick up. |
+| `design/edit-mode-spec.html` | What does it look like and what does the copy say? Authoritative for interaction and wording. |
+
+`CONTEXT.md` and `context.md` are two different files. On a case-insensitive filesystem they
+collide, so refer to them by their full names in commit messages and never rename one to match
+the other.
+
+Read `research.md` before `plan.md`. The plan depends on three corrections that only make sense
+once you have seen the evidence.
+
+## Terms used across these files
+
+- **Drive**: the file tree the Files drawer shows. One drive folds one or two mounts together.
+- **Mount**: a durable object-store prefix bound to a session or an artifact. Files live here.
+  A mount has an id, a slug, and a name, and nothing else the frontend can read.
+- **Kind**: the file category the drawer resolves from the extension (`markdown`, `text`,
+  `code`, `json`, `csv`, `html`, `image`, `pdf`, `audio`, `video`, `other`). One resolver owns
+  it: `resolveDriveFileKind` in `web/oss/src/components/Drives/driveKinds.ts`.
+- **Buffer**: the in-memory copy of one file's text while the user edits it. The drawer holds
+  at most one buffer at a time.
+- **Original**: the bytes as read when the buffer opened. Dirty means draft differs from
+  original.
+- **File-activity signal**: the per-session log of write-shaped tool calls the chat records
+  while a turn streams. Lives in
+  `web/packages/agenta-entities/src/session/state/fileActivity.ts`.
+- **Affordance**: whether the header offers Edit for the selected file, and in what condition
+  (`offer`, `capped`, `hidden`).
+
+## Scope of the change
+
+Frontend only. The backend write endpoint, its permission check, and its object-store path all
+already exist and are unchanged. No Fern regeneration. No new API.
+
+Everything new lives in the app layer under `web/oss/src/components/Drives/`. Nothing is
+promoted into a `@agenta/*` package, because nothing here is reused outside the drive surfaces.

--- a/docs/design/file-drawer-edit-mode/context.md
+++ b/docs/design/file-drawer-edit-mode/context.md
@@ -1,0 +1,75 @@
+# Why this work exists
+
+## What a user sees today
+
+Open the Files drawer, pick a file, and you get a read-only preview. Markdown renders. Code
+highlights. CSV becomes a table. Images and PDFs display. Anything the drawer cannot render
+offers a Download button.
+
+There is no way to change a file. To fix one line in a document the agent wrote, the user
+downloads it, edits it locally, and drags it back in as an upload. The upload path exists and
+works, so the round trip is possible, just slow and easy to get wrong (wrong folder, wrong
+name, a stale copy).
+
+The drawer has no answer for the other half of the problem either. The agent writes to these
+mounts constantly while a turn runs. A user who edited a file in another tab and re-uploaded it
+would silently overwrite whatever the agent wrote in between, with no warning and no diff.
+
+## What we are building
+
+Inline editing in the drawer. Select a text file, click Edit, change it, click Save. The file
+is written back to the same mount at the same path. The agent's sandbox mounts that prefix, so
+the next tool call reads the new bytes with no sync step.
+
+The design is fully specified in `design/edit-mode-spec.html`. That file is authoritative for
+layout, copy, and interaction. This plan does not re-open interaction design.
+
+The shape of the interaction, in one paragraph: entering edit mode takes over the drawer's two
+header rows. The header's action cluster becomes Cancel and Save. The filter toolbar underneath
+is replaced by an edit bar. The tree stays visible but stops responding, so its scroll position
+and expanded folders survive the round trip. One file is editable at a time. Every exit route
+(closing the drawer, picking another file, changing a filter, Escape, browser unload) runs
+through one discard guard.
+
+## Goals
+
+- Edit and save the five extensions the user will test by hand: `.txt`, `.csv`, `.md`, `.env`,
+  `.json`. Bytes round-trip without silent reformatting.
+- Never lose a buffer. A failed save keeps every character and offers a retry.
+- Never silently overwrite the agent. When the file changed underneath an open buffer, say so
+  before the write lands, and offer a diff.
+- Reuse the editor components the app already ships. No textarea, no second editor, no second
+  list of file extensions.
+- Keep the change small enough to merge cleanly next to the in-flight antd migration branch.
+
+## Non-goals
+
+- No backend change. Not the write endpoint, not its response body, not the OpenAPI spec, not
+  Fern regeneration. If something forces one, it goes in `status.md` as a blocker rather than
+  being done quietly.
+- No new file, no rename, no delete. Creating files stays the upload path's job.
+- No multi-file editing, no tabs, no split view. One buffer.
+- No editing of images, PDFs, audio, video, or unrecognised binaries.
+- No collaborative or operational-transform merge. Conflict resolution is three explicit
+  choices: look at the diff, take theirs, or overwrite.
+- No autosave. Saving is always an explicit act.
+
+## Constraints that shape the design
+
+**The write response carries no modification time.** `MountFileWrittenResponse` returns `path`
+and `size`. Conflict detection needs a modification time, so the client derives one after the
+fact rather than reading one off the write. `plan.md` covers how.
+
+**There is no read-only-mount flag.** `mountSchema` has `id`, `slug`, `name`, `session_id`.
+The spec's "read-only mounts hide Edit" has no field to read. The drawer already answers the
+same question for uploads with `canUpload`, and edit mode reuses that answer.
+
+**The antd migration branch lands soon.** PR #5643 rewrites `import {Button} from "antd"` to
+`import {Button} from "@agenta/ui/ui"` across the app, and `@agenta/ui/ui` does not exist on
+`release/v0.109.0`. So this work cannot write forward-compatible imports. It concentrates raw
+antd imports into as few new files as possible instead, and it does not touch the three lines
+in `Drives/` that branch changes.
+
+**The drawer is mounted by two different hosts.** The chat pane wraps it in a
+`DriveSessionProvider`; the config panel does not. Anything that depends on the session id has
+to degrade cleanly when there is no session.

--- a/docs/design/file-drawer-edit-mode/design/edit-mode-spec.html
+++ b/docs/design/file-drawer-edit-mode/design/edit-mode-spec.html
@@ -1,0 +1,637 @@
+<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<script src="./support.js"></script>
+</head>
+<body>
+<x-dc>
+<helmet>
+<link rel="stylesheet" href="_ds/agenta-design-system-0263eb0f-a904-4476-a73b-7afca7b6d749/colors_and_type.css">
+<link rel="stylesheet" href="_ds/agenta-design-system-0263eb0f-a904-4476-a73b-7afca7b6d749/ui_kits/web/kit.css">
+<script src="_ds/agenta-design-system-0263eb0f-a904-4476-a73b-7afca7b6d749/_ds_bundle.js"></script>
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+<style>
+  body { margin:0; background:#f5f7fa; font-family:Inter, system-ui, sans-serif; -webkit-font-smoothing:antialiased; }
+  a { color:#1c2c3d; text-decoration:none; }
+  a:hover { color:#394857; }
+  @keyframes spin { to { transform: rotate(360deg); } }
+</style>
+</helmet>
+
+<div style="min-height:100vh; padding:32px 32px 64px; color:#1c2c3d; font-family:Inter, system-ui, sans-serif;">
+
+  <div style="display:flex; flex-direction:column; gap:6px; margin-bottom:24px; max-width:900px;">
+    <div style="font-size:12px; font-weight:500; letter-spacing:0.06em; text-transform:uppercase; color:#758391;">Files drawer · inline editing</div>
+    <div style="font-size:28px; font-weight:600; line-height:1.2;">Edit takes over the toolbar</div>
+    <div style="font-size:14px; line-height:1.6; color:#586673; text-wrap:pretty;">Direction 1a, at fidelity. Entering edit swaps <span style="font-family:'JetBrains Mono',monospace; font-size:13px;">DriveToolbar</span> (search + origin filter + visibility toggles) for the edit bar, and the header's action cluster for Cancel / Save. Every state below is a real state the implementation has to handle — pick one from the rail to see it.</div>
+  </div>
+
+  <div style="display:flex; gap:24px; align-items:flex-start;">
+
+    <div style="width:224px; flex-shrink:0; position:sticky; top:32px; display:flex; flex-direction:column; gap:4px;">
+      <div style="font-size:11px; font-weight:500; letter-spacing:0.06em; text-transform:uppercase; color:#758391; padding:0 8px 8px;">States</div>
+      <sc-for list="{{ states }}" as="s" hint-placeholder-count="11">
+        <div onClick="{{ s.select }}" style="{{ s.style }}" style-hover="background:rgba(5,23,41,0.04);">
+          <div style="font-size:13px; font-weight:500;">{{ s.label }}</div>
+          <div style="font-size:11px; color:#758391; margin-top:2px;">{{ s.hint }}</div>
+        </div>
+      </sc-for>
+    </div>
+
+    <div style="display:flex; flex-direction:column; gap:20px; min-width:0;">
+
+      <!-- ============ DRAWER ============ -->
+      <div style="width:960px; background:#fff; border:1px solid #eaeff5; border-radius:8px; box-shadow:0 1px 3px 0 rgb(0 0 0 / 0.1); overflow:hidden; position:relative;">
+
+        <!-- header row 1 — DriveHeader -->
+        <div style="display:flex; align-items:center; gap:8px; padding:8px 12px; border-bottom:1px solid #eaeff5;">
+          <div style="width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:#586673; flex-shrink:0;" style-hover="background:rgba(5,23,41,0.04);">
+            <span style="width:16px; height:16px; flex-shrink:0; background:#586673; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/x.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/x.svg) center/contain no-repeat;"></span>
+          </div>
+          <div style="width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:#586673; flex-shrink:0;" style-hover="background:rgba(5,23,41,0.04);">
+            <span style="width:16px; height:16px; flex-shrink:0; background:#586673; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/arrows-out.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/arrows-out.svg) center/contain no-repeat;"></span>
+          </div>
+
+          <div style="display:flex; align-items:center; gap:8px; min-width:0; flex:1;">
+            <div style="display:flex; align-items:center; gap:6px; min-width:0; font-family:'JetBrains Mono', monospace; font-size:12px; color:#758391; white-space:nowrap;">
+              <span>root</span><span style="color:#bdc7d1;">/</span><span>agent-files</span><span style="color:#bdc7d1;">/</span><span style="color:#1c2c3d; font-weight:500;">{{ fileName }}</span>
+            </div>
+            <span style="font-size:11px; color:#758391; flex-shrink:0;">{{ fileSize }}</span>
+            <span style="display:inline-flex; align-items:center; height:18px; padding:0 6px; border:1px solid #eaeff5; background:#fafafa; border-radius:4px; font-size:10px; color:#586673; flex-shrink:0;">Agent</span>
+
+            <sc-if value="{{ dirty }}" hint-placeholder-val="{{ false }}">
+              <span style="display:inline-flex; align-items:center; gap:5px; height:20px; padding:0 8px 0 6px; border-radius:10px; background:#fffbe6; border:1px solid #ffe58f; flex-shrink:0;">
+                <span style="width:6px; height:6px; border-radius:50%; background:#faad14;"></span>
+                <span style="font-size:11px; color:#8c6d1f; white-space:nowrap;">Unsaved</span>
+              </span>
+            </sc-if>
+            <sc-if value="{{ saved }}" hint-placeholder-val="{{ false }}">
+              <span style="display:inline-flex; align-items:center; gap:5px; height:20px; padding:0 8px; border-radius:10px; background:#f6ffed; border:1px solid #b7eb8f; flex-shrink:0;">
+                <span style="font-size:11px; color:#389e0d; white-space:nowrap;">Saved</span>
+              </span>
+            </sc-if>
+          </div>
+
+          <!-- view-mode actions -->
+          <sc-if value="{{ browsing }}" hint-placeholder-val="{{ true }}">
+            <div style="display:flex; align-items:center; gap:2px; flex-shrink:0;">
+              <div style="width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:#586673;" style-hover="background:rgba(5,23,41,0.04);">
+                <span style="width:16px; height:16px; flex-shrink:0; background:#586673; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/upload-simple.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/upload-simple.svg) center/contain no-repeat;"></span>
+              </div>
+              <div style="width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:#758391;" style-hover="background:rgba(5,23,41,0.04);">
+                <span style="width:16px; height:16px; flex-shrink:0; background:#758391; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/copy.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/copy.svg) center/contain no-repeat;"></span>
+              </div>
+              <div style="width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:#758391;" style-hover="background:rgba(5,23,41,0.04);">
+                <span style="width:16px; height:16px; flex-shrink:0; background:#758391; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/info.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/info.svg) center/contain no-repeat;"></span>
+              </div>
+              <sc-if value="{{ canEdit }}" hint-placeholder-val="{{ true }}">
+                <div style="height:28px; padding:0 12px; margin-left:4px; display:flex; align-items:center; gap:6px; border:1px solid #bdc7d1; border-radius:6px; font-size:12px; font-weight:500; color:#1c2c3d; white-space:nowrap; cursor:pointer;" style-hover="border-color:#394857;" onClick="{{ startEdit }}">
+                  <span style="width:13px; height:13px; flex-shrink:0; background:currentColor; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/pencil-simple.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/pencil-simple.svg) center/contain no-repeat;"></span>
+                  Edit
+                </div>
+              </sc-if>
+              <sc-if value="{{ editBlocked }}" hint-placeholder-val="{{ false }}">
+                <div title="Only text files can be edited" style="height:28px; padding:0 12px; margin-left:4px; display:flex; align-items:center; gap:6px; border:1px solid #eaeff5; border-radius:6px; font-size:12px; font-weight:500; color:#bdc7d1; white-space:nowrap; cursor:not-allowed;">
+                  <span style="width:13px; height:13px; flex-shrink:0; background:currentColor; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/pencil-simple.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/pencil-simple.svg) center/contain no-repeat;"></span>
+                  Edit
+                </div>
+              </sc-if>
+              <div style="height:28px; padding:0 12px; display:flex; align-items:center; gap:6px; border:1px solid #bdc7d1; border-radius:6px; font-size:12px; color:#1c2c3d; white-space:nowrap;" style-hover="border-color:#394857;">
+                <span style="width:13px; height:13px; flex-shrink:0; background:currentColor; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/download-simple.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/download-simple.svg) center/contain no-repeat;"></span>
+                Download
+              </div>
+              <div style="width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center;" style-hover="background:rgba(5,23,41,0.04);"><span style="width:18px; height:18px; flex-shrink:0; background:#758391; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/dots-three.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/dots-three.svg) center/contain no-repeat;"></span></div>
+            </div>
+          </sc-if>
+
+          <!-- edit-mode actions -->
+          <sc-if value="{{ editing }}" hint-placeholder-val="{{ false }}">
+            <div style="display:flex; align-items:center; gap:8px; flex-shrink:0;">
+              <div onClick="{{ cancel }}" style="height:28px; padding:0 12px; display:flex; align-items:center; border:1px solid #bdc7d1; border-radius:6px; font-size:12px; color:#586673; white-space:nowrap; cursor:pointer;" style-hover="border-color:#394857; color:#1c2c3d;">Cancel</div>
+              <sc-if value="{{ saveEnabled }}" hint-placeholder-val="{{ false }}">
+                <div onClick="{{ save }}" style="height:28px; padding:0 12px; display:flex; align-items:center; gap:7px; background:#1c2c3d; color:#fff; border-radius:6px; font-size:12px; font-weight:500; white-space:nowrap; cursor:pointer;" style-hover="background:#394857;">Save<span style="opacity:0.55; font-size:11px;">⌘S</span></div>
+              </sc-if>
+              <sc-if value="{{ saving }}" hint-placeholder-val="{{ false }}">
+                <div style="height:28px; padding:0 12px; display:flex; align-items:center; gap:7px; background:#394857; color:#fff; border-radius:6px; font-size:12px; font-weight:500; white-space:nowrap;">
+                  <span style="width:11px; height:11px; border:1.5px solid rgba(255,255,255,0.35); border-top-color:#fff; border-radius:50%; display:inline-block; animation:spin 0.7s linear infinite;"></span>
+                  Saving
+                </div>
+              </sc-if>
+              <sc-if value="{{ saveDisabled }}" hint-placeholder-val="{{ true }}">
+                <div style="height:28px; padding:0 12px; display:flex; align-items:center; gap:7px; background:#f0f3f7; color:#bdc7d1; border-radius:6px; font-size:12px; font-weight:500; white-space:nowrap; cursor:not-allowed;">Save<span style="font-size:11px;">⌘S</span></div>
+              </sc-if>
+            </div>
+          </sc-if>
+        </div>
+
+        <!-- header row 2 — DriveToolbar / edit bar -->
+        <sc-if value="{{ browsing }}" hint-placeholder-val="{{ true }}">
+          <div style="display:flex; align-items:center; gap:8px; padding:7px 12px; border-bottom:1px solid #eaeff5;">
+            <div style="width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:#1c2c3d; flex-shrink:0;" style-hover="background:rgba(5,23,41,0.04);">
+              <span style="width:16px; height:16px; flex-shrink:0; background:#1c2c3d; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/sidebar-simple.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/sidebar-simple.svg) center/contain no-repeat;"></span>
+            </div>
+            <div style="width:220px; height:28px; border:1px solid #d6dee6; border-radius:6px; display:flex; align-items:center; gap:7px; padding:0 9px; flex-shrink:0;">
+              <span style="width:12px; height:12px; flex-shrink:0; background:#bdc7d1; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/magnifying-glass.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/magnifying-glass.svg) center/contain no-repeat;"></span>
+              <span style="font-size:12px; color:#bdc7d1;">Search files</span>
+            </div>
+            <div style="display:flex; gap:2px; padding:2px; background:#f5f7fa; border-radius:6px; flex-shrink:0;">
+              <div style="padding:3px 12px; font-size:12px; font-weight:500; background:#fff; border-radius:4px; box-shadow:0 1px 2px 0 rgb(0 0 0 / 0.05);">All</div>
+              <div style="padding:3px 12px; font-size:12px; color:#586673;">Agent</div>
+              <div style="padding:3px 12px; font-size:12px; color:#586673;">Session</div>
+            </div>
+            <div style="flex:1;"></div>
+            <div style="width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:#1c2c3d;" style-hover="background:rgba(5,23,41,0.04);">
+              <span style="width:16px; height:16px; flex-shrink:0; background:#1c2c3d; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/eye.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/eye.svg) center/contain no-repeat;"></span>
+            </div>
+            <div style="width:28px; height:28px; border-radius:6px; display:flex; align-items:center; justify-content:center; color:#758391;" style-hover="background:rgba(5,23,41,0.04);">
+              <span style="width:16px; height:16px; flex-shrink:0; background:#758391; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/file-dashed.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/file-dashed.svg) center/contain no-repeat;"></span>
+            </div>
+          </div>
+        </sc-if>
+
+        <sc-if value="{{ editing }}" hint-placeholder-val="{{ false }}">
+          <div style="display:flex; align-items:center; gap:10px; padding:7px 12px; border-bottom:1px solid #eaeff5; background:#f5f7fa;">
+            <div style="font-size:12px; font-weight:500; color:#1c2c3d; flex-shrink:0;">Editing</div>
+            <div style="width:1px; height:16px; background:#d6dee6; flex-shrink:0;"></div>
+
+            <sc-if value="{{ isMarkdown }}" hint-placeholder-val="{{ true }}">
+              <div style="display:flex; gap:2px; padding:2px; background:#fff; border:1px solid #d6dee6; border-radius:6px; flex-shrink:0;">
+                <div onClick="{{ showSource }}" style="{{ sourceTabStyle }}">Source</div>
+                <div onClick="{{ showPreview }}" style="{{ previewTabStyle }}">Preview</div>
+              </div>
+              <div style="display:flex; align-items:center; gap:1px; flex-shrink:0;">
+                <div style="width:26px; height:26px; border-radius:4px; display:flex; align-items:center; justify-content:center; font-size:12px; font-weight:600; color:#586673;" style-hover="background:rgba(5,23,41,0.04);">B</div>
+                <div style="width:26px; height:26px; border-radius:4px; display:flex; align-items:center; justify-content:center;" style-hover="background:rgba(5,23,41,0.04);"><span style="width:14px; height:14px; background:#586673; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/text-italic.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/text-italic.svg) center/contain no-repeat;"></span></div>
+                <div style="width:26px; height:26px; border-radius:4px; display:flex; align-items:center; justify-content:center; font-size:11px; font-weight:600; color:#586673;" style-hover="background:rgba(5,23,41,0.04);">H2</div>
+                <div style="width:1px; height:14px; background:#eaeff5; margin:0 4px;"></div>
+                <div style="width:26px; height:26px; border-radius:4px; display:flex; align-items:center; justify-content:center; color:#586673;" style-hover="background:rgba(5,23,41,0.04);">
+                  <span style="width:14px; height:14px; flex-shrink:0; background:#586673; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/list-bullets.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/list-bullets.svg) center/contain no-repeat;"></span>
+                </div>
+                <div style="width:26px; height:26px; border-radius:4px; display:flex; align-items:center; justify-content:center; color:#586673;" style-hover="background:rgba(5,23,41,0.04);">
+                  <span style="width:14px; height:14px; flex-shrink:0; background:#586673; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/code.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/code.svg) center/contain no-repeat;"></span>
+                </div>
+              </div>
+            </sc-if>
+
+            <sc-if value="{{ isCode }}" hint-placeholder-val="{{ false }}">
+              <div style="display:flex; align-items:center; gap:8px; flex-shrink:0;">
+                <div style="height:24px; padding:0 8px; display:flex; align-items:center; gap:6px; border:1px solid #d6dee6; background:#fff; border-radius:4px; font-size:11px; color:#586673;">Python<span style="color:#bdc7d1;">▾</span></div>
+                <div style="font-size:11px; color:#758391;">Syntax highlighting only — no markdown toggle</div>
+              </div>
+            </sc-if>
+
+            <div style="flex:1;"></div>
+            <div style="font-size:11px; color:#758391; white-space:nowrap; flex-shrink:0;">Esc to cancel · filters resume after saving</div>
+          </div>
+        </sc-if>
+
+        <!-- banners -->
+        <sc-if value="{{ conflict }}" hint-placeholder-val="{{ false }}">
+          <div style="display:flex; align-items:center; gap:10px; padding:9px 12px; background:#fffbe6; border-bottom:1px solid #ffe58f;">
+            <span style="width:15px; height:15px; flex-shrink:0; background:#faad14; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/fill/warning-circle-fill.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/fill/warning-circle-fill.svg) center/contain no-repeat;"></span>
+            <div style="font-size:12px; color:#8c6d1f; line-height:1.5;">The agent wrote to <span style="font-family:'JetBrains Mono',monospace;">INDEX.md</span> while you were editing. Saving now overwrites its version.</div>
+            <div style="flex:1;"></div>
+            <div style="display:flex; gap:6px; flex-shrink:0;">
+              <div style="height:24px; padding:0 10px; display:flex; align-items:center; border:1px solid #ffe58f; background:#fff; border-radius:4px; font-size:11px; color:#8c6d1f; white-space:nowrap;">View diff</div>
+              <div style="height:24px; padding:0 10px; display:flex; align-items:center; border:1px solid #ffe58f; background:#fff; border-radius:4px; font-size:11px; color:#8c6d1f; white-space:nowrap;">Reload theirs</div>
+            </div>
+          </div>
+        </sc-if>
+
+        <sc-if value="{{ error }}" hint-placeholder-val="{{ false }}">
+          <div style="display:flex; align-items:center; gap:10px; padding:9px 12px; background:#fff2f0; border-bottom:1px solid #ffccc7;">
+            <span style="width:15px; height:15px; flex-shrink:0; background:#d61010; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/fill/warning-circle-fill.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/fill/warning-circle-fill.svg) center/contain no-repeat;"></span>
+            <div style="font-size:12px; color:#a8071a; line-height:1.5;">Couldn't save — the mount rejected the write. Your changes are still here.</div>
+            <div style="flex:1;"></div>
+            <div style="height:24px; padding:0 10px; display:flex; align-items:center; border:1px solid #ffccc7; background:#fff; border-radius:4px; font-size:11px; color:#a8071a; white-space:nowrap; flex-shrink:0;">Try again</div>
+          </div>
+        </sc-if>
+
+        <!-- body -->
+        <div style="display:flex; height:440px;">
+          <div style="{{ treeStyle }}">
+            <div style="display:flex; flex-direction:column; font-size:12px; color:#586673;">
+
+              <div style="white-space:nowrap; display:flex; align-items:center; gap:6px; padding:4px 12px 4px 6px; border-radius:4px;" style-hover="background:rgba(5,23,41,0.02);">
+                <span style="width:16px; display:flex; align-items:center; justify-content:center; flex-shrink:0;"><span style="width:10px; height:10px; background:#bdc7d1; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/caret-right.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/caret-right.svg) center/contain no-repeat;"></span></span>
+                <span style="width:14px; height:14px; flex-shrink:0; background:#faad14; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/folder-simple.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/folder-simple.svg) center/contain no-repeat;"></span>
+                <span style="font-family:'JetBrains Mono', monospace;">.codex</span>
+                <span style="display:inline-flex; align-items:center; height:16px; padding:0 4px; border:1px solid #eaeff5; border-radius:4px; font-size:10px; font-weight:500; color:#758391; flex-shrink:0;">Session</span>
+              </div>
+
+              <div style="white-space:nowrap; display:flex; align-items:center; gap:6px; padding:4px 12px 4px 6px; border-radius:4px;" style-hover="background:rgba(5,23,41,0.02);">
+                <span style="width:16px; display:flex; align-items:center; justify-content:center; flex-shrink:0;"><span style="width:10px; height:10px; background:#bdc7d1; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/caret-down.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/caret-down.svg) center/contain no-repeat;"></span></span>
+                <span style="width:14px; height:14px; flex-shrink:0; background:#faad14; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/folder-simple.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/folder-simple.svg) center/contain no-repeat;"></span>
+                <span style="font-family:'JetBrains Mono', monospace; color:#1c2c3d;">agent-files</span>
+                <span style="display:inline-flex; align-items:center; height:16px; padding:0 4px; border:1px solid #13c2c2; border-radius:4px; font-size:10px; font-weight:500; color:#13c2c2; flex-shrink:0;">Agent</span>
+              </div>
+
+              <div style="white-space:nowrap; display:flex; align-items:center; gap:6px; padding:4px 12px 4px 20px; border-radius:4px;" style-hover="background:rgba(5,23,41,0.02);">
+                <span style="width:16px; display:flex; align-items:center; justify-content:center; flex-shrink:0;"><span style="width:10px; height:10px; background:#bdc7d1; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/caret-right.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/caret-right.svg) center/contain no-repeat;"></span></span>
+                <span style="width:14px; height:14px; flex-shrink:0; background:#faad14; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/folder-simple.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/folder-simple.svg) center/contain no-repeat;"></span>
+                <span style="font-family:'JetBrains Mono', monospace;">_archive</span>
+              </div>
+
+              <div style="white-space:nowrap; display:flex; align-items:center; gap:6px; padding:4px 12px 4px 20px; border-radius:4px;" style-hover="background:rgba(5,23,41,0.02);">
+                <span style="width:16px; display:flex; align-items:center; justify-content:center; flex-shrink:0;"><span style="width:10px; height:10px; background:#bdc7d1; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/caret-right.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/caret-right.svg) center/contain no-repeat;"></span></span>
+                <span style="width:14px; height:14px; flex-shrink:0; background:#faad14; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/folder-simple.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/folder-simple.svg) center/contain no-repeat;"></span>
+                <span style="font-family:'JetBrains Mono', monospace;">00-product</span>
+              </div>
+
+              <div style="white-space:nowrap; display:flex; align-items:center; gap:6px; padding:4px 12px 4px 20px; border-radius:4px;" style-hover="background:rgba(5,23,41,0.02);">
+                <span style="width:16px; display:flex; align-items:center; justify-content:center; flex-shrink:0;"><span style="width:10px; height:10px; background:#bdc7d1; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/caret-right.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/caret-right.svg) center/contain no-repeat;"></span></span>
+                <span style="width:14px; height:14px; flex-shrink:0; background:#faad14; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/folder-simple.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/folder-simple.svg) center/contain no-repeat;"></span>
+                <span style="font-family:'JetBrains Mono', monospace;">06-measurement</span>
+              </div>
+
+              <div style="white-space:nowrap; display:flex; align-items:center; gap:6px; padding:4px 12px 4px 36px; border-radius:4px; opacity:0.6;" style-hover="background:rgba(5,23,41,0.02);">
+                <span style="width:14px; height:14px; flex-shrink:0; background:#758391; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/file.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/file.svg) center/contain no-repeat;"></span>
+                <span style="font-family:'JetBrains Mono', monospace;">.env</span>
+                <span style="font-size:11px; color:#bdc7d1; flex-shrink:0;">257 B</span>
+              </div>
+
+              <div style="white-space:nowrap; display:flex; align-items:center; gap:6px; padding:4px 12px 4px 36px; border-radius:4px;" style-hover="background:rgba(5,23,41,0.02);">
+                <span style="width:14px; height:14px; flex-shrink:0; background:#4fd1b5; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/file-text.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/file-text.svg) center/contain no-repeat;"></span>
+                <span style="font-family:'JetBrains Mono', monospace;">AGENT-OPERATING-RULES.md</span>
+              </div>
+
+              <div style="white-space:nowrap; display:flex; align-items:center; gap:6px; padding:4px 12px 4px 36px; border-radius:4px; background:#eef2f6; box-shadow:inset 0 0 0 1px #1c2c3d;">
+                <span style="{{ selectedIconStyle }}"></span>
+                <span style="font-family:'JetBrains Mono', monospace; color:#1c2c3d;">{{ fileName }}</span>
+                <span style="font-size:11px; color:#bdc7d1; flex-shrink:0;">{{ fileSize }}</span>
+                <sc-if value="{{ dirty }}" hint-placeholder-val="{{ false }}">
+                  <span style="width:6px; height:6px; border-radius:50%; background:#faad14; flex-shrink:0;"></span>
+                </sc-if>
+              </div>
+
+              <div style="white-space:nowrap; display:flex; align-items:center; gap:6px; padding:4px 12px 4px 36px; border-radius:4px;" style-hover="background:rgba(5,23,41,0.02);">
+                <span style="width:14px; height:14px; flex-shrink:0; background:#4fd1b5; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/file-text.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/file-text.svg) center/contain no-repeat;"></span>
+                <span style="font-family:'JetBrains Mono', monospace;">README.md</span>
+                <span style="font-size:11px; color:#bdc7d1; flex-shrink:0;">293 B</span>
+              </div>
+
+              <div style="white-space:nowrap; display:flex; align-items:center; gap:6px; padding:4px 12px 4px 36px; border-radius:4px;" style-hover="background:rgba(5,23,41,0.02);">
+                <span style="width:14px; height:14px; flex-shrink:0; background:#4fd1b5; -webkit-mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/file-text.svg) center/contain no-repeat; mask:url(https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/file-text.svg) center/contain no-repeat;"></span>
+                <span style="font-family:'JetBrains Mono', monospace;">trello-main-board.md</span>
+                <span style="font-size:11px; color:#bdc7d1; flex-shrink:0;">153 B</span>
+              </div>
+            </div>
+          </div>
+
+          <div style="flex:1; min-width:0; display:flex; flex-direction:column; position:relative;">
+
+            <sc-if value="{{ showSourcePane }}" hint-placeholder-val="{{ false }}">
+              <div style="{{ sourcePaneStyle }}">
+                <div style="font-family:'JetBrains Mono', monospace; font-size:12px; line-height:1.9; color:#1c2c3d;">
+                  <div><span style="color:#758391;"># </span>Agenta GTM — folder index</div>
+                  <div style="height:23px;"></div>
+                  <div><span style="color:#758391;">**</span>Updated:<span style="color:#758391;">**</span> 2026-08-01 <span style="color:#758391;">**</span>Status:<span style="color:#758391;">**</span> live — this IS the durable agent-folder root.</div>
+                  <div style="height:23px;"></div>
+                  <div><span style="color:#758391;">## </span>How this folder works</div>
+                  <div style="height:23px;"></div>
+                  <div><span style="color:#758391;">- </span>Numbered folders follow GTM funnel order: product → research → positioning.</div>
+                  <div><span style="color:#758391;">- </span><span style="background:#f0f2f5; padding:1px 4px; border-radius:3px;">_archive/</span> = superseded material, kept with self-describing names.</div>
+                  <div><span style="color:#758391;">- </span>Provenance tags: original, recovered verbatim, recovered (synthesis).<span style="{{ caretStyle }}"></span></div>
+                </div>
+              </div>
+            </sc-if>
+
+            <sc-if value="{{ showPreviewPane }}" hint-placeholder-val="{{ false }}">
+              <div style="flex:1; padding:20px 24px; overflow:hidden;">
+                <div style="font-size:19px; font-weight:600; margin-bottom:10px;">Agenta GTM — folder index</div>
+                <div style="font-size:13px; line-height:1.7; color:#586673; margin-bottom:16px;"><strong style="color:#1c2c3d; font-weight:600;">Updated:</strong> 2026-08-01 <strong style="color:#1c2c3d; font-weight:600;">Status:</strong> live — this IS the durable agent-folder root.</div>
+                <div style="font-size:15px; font-weight:600; margin-bottom:8px;">How this folder works</div>
+                <div style="display:flex; flex-direction:column; gap:6px; font-size:13px; line-height:1.7; color:#586673;">
+                  <div>· Numbered folders follow GTM funnel order: product → research → positioning.</div>
+                  <div>· <span style="font-family:'JetBrains Mono',monospace; font-size:12px; background:#f0f2f5; padding:1px 5px; border-radius:3px;">_archive/</span> = superseded material, kept with self-describing names.</div>
+                  <div>· Provenance tags: original, recovered verbatim, recovered (synthesis).</div>
+                </div>
+              </div>
+            </sc-if>
+
+            <sc-if value="{{ showCodePane }}" hint-placeholder-val="{{ false }}">
+              <div style="flex:1; display:flex; overflow:hidden;">
+                <div style="width:44px; padding:16px 0; display:flex; flex-direction:column; align-items:flex-end; gap:0; background:#fcfdfe; border-right:1px solid #eaeff5; flex-shrink:0;">
+                  <div style="font-family:'JetBrains Mono',monospace; font-size:11px; line-height:23px; color:#bdc7d1; padding-right:10px;">1<br>2<br>3<br>4<br>5<br>6<br>7<br>8</div>
+                </div>
+                <div style="flex:1; padding:16px 18px; font-family:'JetBrains Mono', monospace; font-size:12px; line-height:23px; color:#1c2c3d;">
+                  <div><span style="color:#758391;">#!/usr/bin/env python3</span></div>
+                  <div><span style="color:#758391;">"""Export public X engagement profiles."""</span></div>
+                  <div style="height:23px;"></div>
+                  <div><span style="color:#722ed1;">from</span> __future__ <span style="color:#722ed1;">import</span> annotations</div>
+                  <div style="height:23px;"></div>
+                  <div><span style="color:#722ed1;">def</span> <span style="color:#096dd9;">main</span>() -&gt; <span style="color:#722ed1;">None</span>:</div>
+                  <div>&nbsp;&nbsp;&nbsp;&nbsp;profiles = fetch_profiles()</div>
+                  <div>&nbsp;&nbsp;&nbsp;&nbsp;write_csv(profiles)<span style="display:inline-block; width:1px; height:13px; background:#1c2c3d; vertical-align:-2px; margin-left:1px;"></span></div>
+                </div>
+              </div>
+            </sc-if>
+
+            <sc-if value="{{ showImagePane }}" hint-placeholder-val="{{ false }}">
+              <div style="flex:1; display:flex; flex-direction:column; align-items:center; justify-content:center; gap:10px; background:#fcfdfe;">
+                <div style="width:180px; height:120px; border:1px solid #eaeff5; border-radius:6px; background:#f5f7fa;"></div>
+                <div style="font-size:12px; color:#758391;">Preview only — Edit is hidden for images, PDFs and binaries.</div>
+              </div>
+            </sc-if>
+
+            <sc-if value="{{ editing }}" hint-placeholder-val="{{ false }}">
+              <div style="display:flex; align-items:center; gap:14px; padding:6px 14px; border-top:1px solid #eaeff5; background:#f5f7fa; font-size:11px; color:#758391;">
+                <span>{{ language }}</span>
+                <span>UTF-8</span>
+                <span>{{ cursor }}</span>
+                <div style="flex:1;"></div>
+                <span>{{ savedAt }}</span>
+              </div>
+            </sc-if>
+          </div>
+        </div>
+
+        <!-- discard dialog -->
+        <sc-if value="{{ confirm }}" hint-placeholder-val="{{ false }}">
+          <div style="position:absolute; inset:0; background:rgba(5,23,41,0.45); display:flex; align-items:center; justify-content:center;">
+            <div style="width:420px; background:#fff; border-radius:8px; box-shadow:0 12px 28px 0 rgba(0,0,0,0.2); padding:20px; display:flex; flex-direction:column; gap:10px;">
+              <div style="font-size:15px; font-weight:600;">Discard unsaved changes?</div>
+              <div style="font-size:13px; line-height:1.6; color:#586673;"><span style="font-family:'JetBrains Mono',monospace; font-size:12px;">INDEX.md</span> has changes that haven't been saved. Leaving now discards them.</div>
+              <div style="display:flex; justify-content:flex-end; gap:8px; margin-top:6px;">
+                <div onClick="{{ keepEditing }}" style="height:30px; padding:0 12px; display:flex; align-items:center; border:1px solid #bdc7d1; border-radius:6px; font-size:12px; color:#586673; white-space:nowrap; cursor:pointer;" style-hover="border-color:#394857;">Keep editing</div>
+                <div onClick="{{ discard }}" style="height:30px; padding:0 12px; display:flex; align-items:center; border:1px solid #bdc7d1; border-radius:6px; font-size:12px; color:#586673; white-space:nowrap; cursor:pointer;" style-hover="border-color:#394857;">Discard</div>
+                <div onClick="{{ save }}" style="height:30px; padding:0 12px; display:flex; align-items:center; background:#1c2c3d; color:#fff; border-radius:6px; font-size:12px; font-weight:500; white-space:nowrap; cursor:pointer;" style-hover="background:#394857;">Save and continue</div>
+              </div>
+            </div>
+          </div>
+        </sc-if>
+      </div>
+
+      <!-- ============ NOTES FOR THE CURRENT STATE ============ -->
+      <div style="width:960px; border:1px solid #eaeff5; background:#fff; border-radius:8px; padding:18px 20px; display:flex; flex-direction:column; gap:10px;">
+        <div style="display:flex; align-items:baseline; gap:10px;">
+          <div style="font-size:15px; font-weight:600;">{{ stateTitle }}</div>
+          <div style="font-size:12px; color:#758391;">{{ stateTrigger }}</div>
+        </div>
+        <div style="display:flex; flex-direction:column; gap:7px;">
+          <sc-for list="{{ notes }}" as="n" hint-placeholder-count="4">
+            <div style="display:flex; gap:9px; font-size:13px; line-height:1.6; color:#586673;">
+              <span style="color:#bdc7d1; flex-shrink:0;">—</span>
+              <span style="text-wrap:pretty;">{{ n }}</span>
+            </div>
+          </sc-for>
+        </div>
+      </div>
+
+      <!-- ============ IMPLEMENTATION MAP ============ -->
+      <div style="width:960px; border:1px solid #eaeff5; background:#fff; border-radius:8px; padding:18px 20px; display:flex; flex-direction:column; gap:14px;">
+        <div style="font-size:15px; font-weight:600;">What this reuses</div>
+
+        <div style="display:grid; grid-template-columns:230px 1fr; gap:10px 18px; font-size:13px; line-height:1.6; color:#586673;">
+          <div style="font-family:'JetBrains Mono',monospace; font-size:12px; color:#1c2c3d;">SharedEditor</div>
+          <div>Same wrapper the prompt fields use: <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">header</span> / <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">footer</span> slots, <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">editorType="borderless"</span> inside the pane, and its <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">state</span> union (<span style="font-family:'JetBrains Mono',monospace; font-size:12px;">filled · focus · typing · readOnly · disabled</span>) maps 1:1 onto the states in the rail. Set <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">disableDebounce</span> — a file buffer wants keystroke-accurate dirty tracking, not the 300ms prompt debounce.</div>
+
+          <div style="font-family:'JetBrains Mono',monospace; font-size:12px; color:#1c2c3d;">Editor + markdownPlugin</div>
+          <div>Source ↔ Preview is <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">TOGGLE_MARKDOWN_VIEW</span> / <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">SET_MARKDOWN_VIEW</span> with <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">markdownViewAtom(id)</span> — already built for the prompt editor. The segmented control in the edit bar is a bigger, explicit surface for the same command; the hover toggle stays out of this pane.</div>
+
+          <div style="font-family:'JetBrains Mono',monospace; font-size:12px; color:#1c2c3d;">Editor codeOnly</div>
+          <div>Non-markdown text files use <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">editorProps</span> with <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">codeOnly: true</span> and a <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">language</span>, with language resolved from <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">resolveDriveFileKind(path)</span> and the existing <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">editorLanguage</span> util. Markdown toggle is hidden there.</div>
+
+          <div style="font-family:'JetBrains Mono',monospace; font-size:12px; color:#1c2c3d;">DiffView</div>
+          <div>Powers "View diff" in the conflict banner — <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">original</span> = the mount's current bytes, <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">modified</span> = the local buffer.</div>
+
+          <div style="font-family:'JetBrains Mono',monospace; font-size:12px; color:#1c2c3d;">DriveHeader / DriveToolbar</div>
+          <div>Both take an <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">editing</span> flag. DriveHeader swaps its action cluster for Cancel / Save; DriveToolbar is replaced by the edit bar, so the origin filter, search and visibility toggles can't be touched mid-edit. The tree pane stays mounted but goes <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">inert</span>, so its scroll position and expansion survive.</div>
+
+          <div style="font-family:'JetBrains Mono',monospace; font-size:12px; color:#1c2c3d;">Mount write API</div>
+          <div>Save posts the buffer and expects <span style="font-family:'JetBrains Mono',monospace; font-size:12px;">MountFileWrittenResponse</span>; the response's size/mtime refresh the header chip and the tree row without a full drive refetch. Read-only mounts hide Edit entirely.</div>
+        </div>
+
+        <div style="height:1px; background:#eaeff5;"></div>
+
+        <div style="display:flex; flex-direction:column; gap:7px;">
+          <div style="font-size:13px; font-weight:500;">Rules</div>
+          <div style="font-size:13px; line-height:1.7; color:#586673;">Edit is offered only for text kinds (<span style="font-family:'JetBrains Mono',monospace; font-size:12px;">markdown · text · code · json · csv · html</span>) on a writable mount, and only below the size cap the viewer already enforces. ⌘S saves, Esc cancels (routing through the guard when dirty). One file is editable at a time — the drawer never holds two buffers. Closing the drawer, switching origin filter, switching file, and the browser's own unload all hit the same guard. Session-scoped files warn on first edit that the session may be torn down.</div>
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>
+
+</x-dc>
+<script type="text/x-dc" data-dc-script data-props="{&quot;$preview&quot;:{&quot;width&quot;:1280,&quot;height&quot;:900}}">
+const STATES = [
+  {id:"read", label:"Viewing", hint:"Read-only, Edit offered"},
+  {id:"clean", label:"Editing — clean", hint:"Buffer opened, Save off"},
+  {id:"dirty", label:"Editing — dirty", hint:"Unsaved changes"},
+  {id:"preview", label:"Editing — preview", hint:"Rendered markdown"},
+  {id:"saving", label:"Saving", hint:"Write in flight"},
+  {id:"saved", label:"Saved", hint:"Confirmation, then exit"},
+  {id:"error", label:"Save failed", hint:"Buffer preserved"},
+  {id:"conflict", label:"Changed on disk", hint:"Agent wrote underneath"},
+  {id:"confirm", label:"Discard confirm", hint:"Leaving while dirty"},
+  {id:"code", label:"Code file", hint:"codeOnly, no toggle"},
+  {id:"locked", label:"Not editable", hint:"Image / PDF / binary"},
+  {id:"capped", label:"Over size cap", hint:"Text, but too large"},
+];
+
+const NOTES = {
+  read: {
+    title: "Viewing",
+    trigger: "Default — a text file selected in the tree",
+    notes: [
+      "Edit sits between the icon actions and Download: a bordered secondary button, never primary. Download stays the loudest thing a reader can do.",
+      "Edit is absent (not disabled) when the mount is read-only or the kind isn't text — a disabled button on every image would train people to ignore it.",
+      "Nothing else about this state changes. The pane is still headerless; the header is still the one header.",
+    ],
+  },
+  clean: {
+    title: "Editing — clean",
+    trigger: "Edit clicked, or ⌘E",
+    notes: [
+      "The toolbar row is replaced, not augmented: search, the All/Agent/Session segmented and the visibility toggles are gone for the duration, which is the whole point of this direction.",
+      "Save is disabled until the buffer differs from what was read — an untouched open-and-close must not write a new mtime.",
+      "The tree stays visible but inert; its scroll and expanded folders survive the round trip.",
+      "Focus lands in the editor with the cursor at the start of the document, not the end.",
+    ],
+  },
+  dirty: {
+    title: "Editing — unsaved changes",
+    trigger: "First keystroke",
+    notes: [
+      "Two dirty affordances, one dot each: the 'Unsaved' chip next to the breadcrumb and a dot on the file's tree row.",
+      "Save becomes primary. ⌘S fires it from anywhere in the drawer.",
+      "The chip is the anchor for the guard dialog's copy — same file name, same wording.",
+    ],
+  },
+  preview: {
+    title: "Editing — preview",
+    trigger: "Preview segment, or the markdown toggle command",
+    notes: [
+      "Preview is a view of the buffer, not an exit from edit mode: Cancel and Save stay in the header, and the dirty chip persists.",
+      "Rendered with the same Markdown component the viewer uses, so nothing shifts between preview and the read-only view after save.",
+      "The formatting controls stay visible but disabled in preview — their absence would reflow the bar on every toggle.",
+    ],
+  },
+  saving: {
+    title: "Saving",
+    trigger: "Save or ⌘S",
+    notes: [
+      "The editor goes readOnly for the duration rather than blocking with an overlay; typing into a buffer that's mid-flight is the bug this prevents.",
+      "Cancel stays live and aborts the request — a slow mount shouldn't trap anyone.",
+      "No skeleton, no layout change. Only the button swaps to the spinner.",
+    ],
+  },
+  saved: {
+    title: "Saved",
+    trigger: "Write acknowledged",
+    notes: [
+      "The dirty chip becomes a green 'Saved' chip for about two seconds, then the drawer returns to the viewing state with the file re-rendered.",
+      "Header size chip and tree row update from the write response — no drive refetch, no flash back to skeleton.",
+      "If the user has already typed again during the write, stay in edit mode and go straight back to dirty.",
+    ],
+  },
+  error: {
+    title: "Save failed",
+    trigger: "Write rejected or the request failed",
+    notes: [
+      "Never lose the buffer. The banner is the only new chrome; the editor keeps every character.",
+      "Retry re-posts the same buffer. Cancel still routes through the guard.",
+      "Uses the same banner slot as the conflict case, so only one can ever be shown.",
+    ],
+  },
+  conflict: {
+    title: "Changed on disk",
+    trigger: "The mount's mtime moved while the buffer was open",
+    notes: [
+      "This is the case the current drawer has no answer for: the agent writes constantly, and a naive save silently clobbers it.",
+      "Detected on the file-activity signal that already exists, and re-checked immediately before every write.",
+      "Three ways out: View diff (DiffView, mount bytes vs. buffer), Reload theirs (discards the buffer through the guard), or Save anyway — which overwrites, and says so.",
+    ],
+  },
+  confirm: {
+    title: "Discard confirm",
+    trigger: "Closing, switching file, switching origin filter, or Esc while dirty",
+    notes: [
+      "One dialog for every exit, including the browser's own beforeunload.",
+      "Three actions in escalating order: Keep editing, Discard, Save and continue — the last one completes the action that was interrupted, so switching files still lands on the file you clicked.",
+      "Discard is not destructive-red: this is a scratch buffer, not a deletion.",
+    ],
+  },
+  code: {
+    title: "Code file",
+    trigger: "A non-markdown text kind is selected",
+    notes: [
+      "Same shell, different body: codeOnly with the language resolved from the extension, plus line numbers.",
+      "No Source/Preview segmented — there's nothing to preview. The bar shows the language instead, so the space doesn't read as broken.",
+      "Everything else — dirty tracking, guard, conflict, save — is identical. One state machine for all text kinds.",
+    ],
+  },
+  locked: {
+    title: "Not editable",
+    trigger: "Image, PDF, or anything over the size cap",
+    notes: [
+      "Edit is not rendered at all; Download stays.",
+      "For a text file past the size cap, Edit IS rendered but disabled, with a tooltip naming the cap — that one is a limit, not a category.",
+      "The viewer's existing kind resolver decides this; no second list of extensions to keep in sync.",
+    ],
+  },
+};
+
+class Component extends DCLogic {
+  state = {s: "read"};
+
+  set(id) { this.setState({s: id}); }
+
+  componentDidMount() {
+    this._key = (e) => {
+      if ((e.metaKey || e.ctrlKey) && e.key.toLowerCase() === "s") { e.preventDefault(); this.set("saved"); }
+      if (e.key === "Escape") this.set(this.dirtyIn(this.state.s) ? "confirm" : "read");
+    };
+    window.addEventListener("keydown", this._key);
+  }
+  componentWillUnmount() { window.removeEventListener("keydown", this._key); }
+
+  dirtyIn(s) { return ["dirty", "preview", "error", "conflict", "confirm"].includes(s); }
+
+  renderVals() {
+    const s = this.state.s;
+    const editing = !["read", "locked"].includes(s);
+    const dirty = this.dirtyIn(s);
+    const isCode = s === "code";
+    const isMarkdown = editing && !isCode;
+    const note = NOTES[s];
+
+    const tab = (on) => "padding:3px 12px; font-size:12px; border-radius:4px; cursor:pointer; white-space:nowrap;" +
+      (on ? " font-weight:500; background:#eef2f6; color:#1c2c3d;" : " color:#586673;");
+
+    return {
+      states: STATES.map((st) => ({
+        label: st.label,
+        hint: st.hint,
+        select: () => this.set(st.id),
+        style: "padding:8px 10px; border-radius:6px; cursor:pointer; border:1px solid " +
+          (st.id === s ? "#d6dee6; background:#fff; box-shadow:0 1px 2px 0 rgb(0 0 0 / 0.05);" : "transparent; background:transparent;"),
+      })),
+
+      selectedIconStyle: (() => {
+        const icon = isCode ? "file-code" : s === "locked" ? "image-square" : "file-text";
+        const tint = isCode ? "#1c2c3d" : s === "locked" ? "#7fb0ff" : "#4fd1b5";
+        const url = "https://unpkg.com/@phosphor-icons/core@2.1.1/assets/regular/" + icon + ".svg";
+        return "width:14px; height:14px; flex-shrink:0; background:" + tint +
+          "; -webkit-mask:url(" + url + ") center/contain no-repeat; mask:url(" + url + ") center/contain no-repeat;";
+      })(),
+
+      fileName: isCode ? "x-engagement-export.py" : s === "locked" ? "launch-frame.png" : "INDEX.md",
+      fileSize: isCode ? "10.1 KB" : s === "locked" ? "412 KB" : "41.2 KB",
+
+      browsing: !editing,
+      editing,
+      dirty,
+      saved: s === "saved",
+      saving: s === "saving",
+      error: s === "error",
+      conflict: s === "conflict",
+      confirm: s === "confirm",
+      canEdit: s === "read",
+      editBlocked: s === "locked",
+      saveEnabled: dirty && s !== "saving",
+      saveDisabled: editing && !dirty && s !== "saving",
+
+      isMarkdown,
+      isCode,
+      showSourcePane: (s === "read" || (editing && !isCode && s !== "preview")),
+      showPreviewPane: s === "preview",
+      showCodePane: isCode,
+      showImagePane: s === "locked",
+
+      sourcePaneStyle: "flex:1; padding:18px 22px; overflow:hidden;" + (s === "saving" ? " opacity:0.6;" : ""),
+      caretStyle: editing && s !== "saving"
+        ? "display:inline-block; width:1px; height:13px; background:#1c2c3d; vertical-align:-2px; margin-left:2px;"
+        : "display:none;",
+      treeStyle: "width:250px; flex-shrink:0; border-right:1px solid #eaeff5; padding:10px 8px; overflow:hidden;" +
+        (editing ? " opacity:0.45; pointer-events:none;" : ""),
+
+      sourceTabStyle: tab(s !== "preview"),
+      previewTabStyle: tab(s === "preview"),
+      showSource: () => this.set("dirty"),
+      showPreview: () => this.set("preview"),
+      startEdit: () => this.set("clean"),
+      cancel: () => this.set(dirty ? "confirm" : "read"),
+      save: () => this.set("saved"),
+      discard: () => this.set("read"),
+      keepEditing: () => this.set("dirty"),
+
+      language: isCode ? "Python" : "Markdown",
+      cursor: isCode ? "Ln 8, Col 25" : "Ln 8, Col 62",
+      savedAt: s === "saved" ? "Saved just now" : "Last saved 13:41",
+
+      stateTitle: note.title,
+      stateTrigger: note.trigger,
+      notes: note.notes,
+    };
+  }
+}
+</script>
+</body>
+</html>

--- a/docs/design/file-drawer-edit-mode/open-questions.md
+++ b/docs/design/file-drawer-edit-mode/open-questions.md
@@ -1,0 +1,14 @@
+# Implementation divergences
+
+## `queryMountDir` needs a public export
+
+The plan says the pre-write check should call the same `queryMountDir` fetcher as
+`mountDirQueryFamily`, but it only lists `mountDirQueryKey` among the new session-package barrel
+exports. The fetcher is public in
+`web/packages/agenta-entities/src/session/api/api.ts:636`, while the package's only public session
+barrel does not export it beside the other mount reads
+(`web/packages/agenta-entities/src/session/index.ts:22-26`).
+
+The implementation also exports `queryMountDir` from `@agenta/entities/session`. This keeps the
+pre-write check on the existing validated Fern boundary instead of duplicating the request in the
+app layer or importing an unexported package-internal path.

--- a/docs/design/file-drawer-edit-mode/open-questions.md
+++ b/docs/design/file-drawer-edit-mode/open-questions.md
@@ -12,3 +12,26 @@ barrel does not export it beside the other mount reads
 The implementation also exports `queryMountDir` from `@agenta/entities/session`. This keeps the
 pre-write check on the existing validated Fern boundary instead of duplicating the request in the
 app layer or importing an unexported package-internal path.
+
+## A drive swap must preserve the old explorer when the user keeps editing
+
+The plan says a drive swap should remount `DriveExplorer` and show the guard above that boundary.
+After that remount, however, **Keep editing** has no valid editor surface: the new drive cannot
+resolve the old buffer's mount and path, and the mismatch effect would reopen the same guard.
+
+`FilesDrawer` therefore holds the last displayed drive while the dirty-buffer guard is unresolved
+(`web/oss/src/components/Drives/FilesDrawer.tsx:107-119`). Discarding, cancelling, closing, or a
+successful save clears the buffer and releases the incoming drive; keeping the edit leaves the old
+explorer mounted. The one-shot drive-swap intent is owned by `useDriveEditGuard`
+(`web/oss/src/components/Drives/editMode/useDriveEditController.ts:385-420`).
+
+## Edit availability also waits for the parent listing
+
+The plan derives Edit availability only from the loaded content and reads `baseMtime` with
+`queryClient.getQueryData` on click. Content can finish before the independent directory listing,
+which would open a buffer with an accidental null baseline and silently disable the mtime check.
+
+The controller now subscribes to the existing `mountDirQueryFamily` and keeps Edit loading until
+that listing resolves (`web/oss/src/components/Drives/editMode/useDriveEditController.ts:122-147`).
+A genuinely omitted `mtime` still uses the plan's documented null-baseline degradation; a listing
+that simply has not arrived no longer does.

--- a/docs/design/file-drawer-edit-mode/open-questions.md
+++ b/docs/design/file-drawer-edit-mode/open-questions.md
@@ -35,3 +35,17 @@ The controller now subscribes to the existing `mountDirQueryFamily` and keeps Ed
 that listing resolves (`web/oss/src/components/Drives/editMode/useDriveEditController.ts:122-147`).
 A genuinely omitted `mtime` still uses the plan's documented null-baseline degradation; a listing
 that simply has not arrived no longer does.
+
+## A small edit-open snapshot race remains
+
+Edit is disabled while either the file-content query or its parent-listing query is fetching. This
+closes the observed stale-content/new-mtime window, but the two queries still settle independently.
+A write that lands after both fetches settle and before the buffer opens can still produce a mixed
+snapshot. A fully coherent open would require the deferred listing -> content -> listing retry loop.
+
+## Listing invalidation remains project-wide
+
+`invalidateMountListings` now lives beside the canonical mount query keys in the non-React session
+state module, so saves no longer import the upload hook dependency graph. Its behavior is unchanged:
+it invalidates all active mount-listing roots in the project, not only the mount that was written.
+Narrowing those keys is deferred because this pass must preserve the existing upload behavior.

--- a/docs/design/file-drawer-edit-mode/plan.md
+++ b/docs/design/file-drawer-edit-mode/plan.md
@@ -1,285 +1,341 @@
 # Implementation plan
 
-Read `research.md` first. Three of its corrections change the API this plan calls.
+Read `research.md` first. Several of its corrections change the API this plan calls.
 
 Everything lives under `web/oss/src/components/Drives/`. Paths below are relative to that
 directory unless they start with `web/`.
 
-## 1. The state machine
+## 1. What this PR ships
 
-### The twelve names and what they actually are
+Open a text file in the Files drawer, click **Edit**, change it, save it back to the mount.
+Every write is guarded by a pre-write modification-time check, every exit from a dirty buffer
+is guarded by a dialog, and a failed write never loses a character.
 
-The spec lists twelve states. They are not twelve values of one variable. Three of them describe
-the file before any editing starts, two describe how the buffer is rendered, and one is a
-pending exit. Storing them as a flat enum produces an unreachable-combination mess (a file can
-be dirty and in preview and in conflict at the same time).
+Deliberately deferred, with the reason in `status.md`: the side-by-side conflict diff, the
+agent-activity early conflict warning, Save-and-continue from the guard dialog, the editor
+status footer, new/rename/delete, and `.env.local`-style multi-dot config files.
 
-So the stored state is a small record, and the twelve spec names are a **derived label**
-computed from it. The derived label exists so the code and the spec share one vocabulary, and so
-the state machine can be unit-tested against the spec name by name.
+## 2. The state model
 
-Stored record, one per open buffer:
+### One buffer, one atom
 
 ```ts
-// driveEditState.ts
+// editMode/state.ts
+export const driveEditBufferAtom = atom<DriveEditBuffer | null>(null)
+```
+
+A single module-level atom, not an atom family. The spec's rule is "one file is editable at a
+time — the drawer never holds two buffers", and a single nullable value enforces that with the
+type rather than a check. It also means the action atoms need no key, and closing a buffer
+releases its two potentially 1.5 MB strings instead of pinning them per mount for the module
+lifetime.
+
+Module-level (not provider-scoped) because the drawer uses `destroyOnClose`, and because
+`FilesDrawer` remounts `DriveExplorer` under a new `key` when the host swaps one real drive for
+another (`useDriveGeneration`, `FilesDrawer.tsx:35-56`). A buffer must survive both. The guard
+dialog is therefore rendered by `FilesDrawer`, above that remount boundary.
+
+### The record
+
+```ts
 export interface DriveEditBuffer {
-    mountId: string
-    /** Mount-relative path. The write target. */
-    path: string
-    /** Presented path with any `agent-files/` prefix. Breadcrumb, tree row, dialog copy. */
+    /** Identity for this open buffer. Late save completions are matched against it. */
+    bufferId: string
+    /** The drawer slot that opened it: the primary drive's mount id. */
+    driveKey: string
+    /** The mount actually written to. NOT driveKey — `agent-files/x` resolves to the agent mount. */
+    targetMountId: string
+    /** Path relative to targetMountId's root. The write target. */
+    targetPath: string
+    /** Presented path, including any `agent-files/` prefix. Breadcrumb, tree row, dialog copy. */
     displayPath: string
+    scope: DriveScope
     /** Bytes as read when the buffer opened. Dirty is measured against this. */
     original: string
     draft: string
-    /** mtime of the file when the buffer opened; null when the store omitted it. */
+    /** mtime from the directory listing when the buffer opened; null when the store omitted it. */
     baseMtime: number | null
-    phase: "clean" | "dirty" | "saving" | "saved"
-    view: "source" | "preview"
-    banner: EditBanner | null
-    pendingExit: ExitIntent | null
-    /** Set by "Save anyway". Skips the pre-write mtime check for exactly one attempt. */
-    forceNextSave: boolean
-    /** When the save landed. Drives the two-second Saved chip. */
-    savedAt: number | null
-    /** Aborts an in-flight save when Cancel is pressed during `saving`. */
-    abort: AbortController | null
+    mode: "markdown" | "code"
+    language: CodeLanguage
+    editorView: "source" | "preview"
+    saveStatus: "idle" | "saving"
+    /** Identity of the in-flight write. Completions that do not match are dropped. */
+    inflightRequestId: string | null
+    /** One banner slot. Setting either kind replaces the other. */
+    issue: EditIssue | null
+    pendingNavigation: NavigationIntent | null
+    /** Set by Overwrite. Skips the pre-write check for exactly one attempt. */
+    skipConflictCheckOnce: boolean
+    /** The session-teardown notice has been shown for this buffer. */
+    teardownWarned: boolean
 }
 
-export type EditBanner =
+export type EditIssue =
     | {kind: "error"; message: string}
-    | {kind: "conflict"; theirMtime: number | null}
+    | {kind: "conflict"; reason: "changed" | "missing"; theirMtime: number | null}
 
-export type ExitIntent =
+export type NavigationIntent =
     | {kind: "cancel"}
     | {kind: "close"}
-    | {kind: "select"; path: string}
-    | {kind: "filter"; run: () => void}
-    | {kind: "reload-theirs"}
+    | {kind: "select"; path: string | null}
+    | {kind: "reload"}
 ```
 
-The three pre-edit names come from a pure function over the selected file, not from the record:
+Four separate names for what a looser model would call "mount id" and "path". `agent-files/`
+paths fold a second mount into one presented tree (`useSessionDrive.ts:180-194`,
+`resolveMount`), so the display path, the write path, the write mount, and the drawer slot are
+four different values. Collapsing any two of them produces a wrong query key or a write to the
+wrong mount.
+
+Dirty is derived, never stored: `draft !== original`.
+
+### No twelve-state label
+
+The spec's twelve state names are a vocabulary for the design, not a variable. Six of them are
+orthogonal to the other six (a buffer can be dirty and in preview and in conflict), so any
+first-match table that flattens them loses information — and a `code` label that no
+function can ever return makes a "one assertion per spec name" test impossible to write.
+
+The state is read as orthogonal facets instead:
 
 ```ts
-// driveEdit.ts
-export type DriveEditAffordance = "offer" | "capped" | "hidden"
+export interface DriveEditFacets {
+    editing: boolean
+    dirty: boolean
+    saving: boolean
+    mode: "markdown" | "code"
+    editorView: "source" | "preview"
+    issue: EditIssue | null
+    guardOpen: boolean
+}
 ```
 
-Derived label:
+Each spec state maps onto a combination of those, and each facet is independently testable.
 
-| Spec name | Condition |
+### Actions
+
+Every action atom is pure state manipulation with no I/O, so the whole reducer tests against a
+bare `createStore()` with no React. Actions that need something to happen in the world **return
+a value the controller interprets**; they never call into the app themselves.
+
+| Atom | Effect |
 |---|---|
-| `read` | no buffer, affordance `offer` |
-| `locked` | no buffer, affordance `hidden` |
-| `capped` | no buffer, affordance `capped` |
-| `confirm` | `pendingExit != null` |
-| `conflict` | `banner?.kind === "conflict"` |
-| `error` | `banner?.kind === "error"` |
-| `saving` | `phase === "saving"` |
-| `saved` | `phase === "saved"` |
-| `preview` | `view === "preview"` |
-| `clean` | `phase === "clean"` |
-| `dirty` | `phase === "dirty"` |
-| `code` | buffer mode is `code` (orthogonal, reported alongside the label) |
+| `openEditBufferAtom(input)` | no buffer → a clean buffer |
+| `setEditDraftAtom(text)` | updates `draft`; ignored while `saveStatus === "saving"` |
+| `setEditorViewAtom(view)` | swaps source/preview, nothing else |
+| `requestNavigationAtom(intent)` | clean: clears the buffer, returns `{run: intent}`. Dirty or with an issue: sets `pendingNavigation`, returns `{run: null}` |
+| `resolveNavigationAtom("keep")` | clears `pendingNavigation` |
+| `resolveNavigationAtom("discard")` | returns the intent to run; clears the buffer unless the intent is `reload` |
+| `startEditSaveAtom(requestId)` | `saveStatus = "saving"`, clears `issue` and `skipConflictCheckOnce` |
+| `editSaveSucceededAtom(requestId)` | no-op unless `requestId === inflightRequestId`; otherwise clears the buffer |
+| `editSaveFailedAtom({requestId, message})` | no-op on mismatch; otherwise `saveStatus = "idle"`, `issue = {kind:"error"}`, draft untouched |
+| `markEditConflictAtom({requestId, reason, theirMtime})` | no-op on mismatch; sets the conflict issue |
+| `overwriteNextSaveAtom()` | clears the issue, sets `skipConflictCheckOnce` |
+| `replaceBufferFromRemoteAtom({content, mtime})` | replaces `original`, `draft`, `baseMtime`; clears the issue; buffer stays open and clean |
+| `markTeardownWarnedAtom()` | sets `teardownWarned` |
+| `closeEditBufferAtom()` | clears the buffer |
 
-`deriveEditStatus(buffer, affordance)` evaluates that table top to bottom and returns the first
-match. The precedence is deliberate and matches the spec's own rendering rules: the guard dialog
-sits over everything; the banner slot holds exactly one banner ("uses the same banner slot as
-the conflict case, so only one can ever be shown"); phase beats view.
+Two rules that are one line each in the reducer and remove whole classes of bug:
 
-`code` is not returned by `deriveEditStatus`. It is a second value, `driveEditBufferMode(path)`
-returning `"markdown" | "code"`, because the spec's own note says everything else about the
-`code` state is identical: "One state machine for all text kinds."
+**Every completion carries the request id it belongs to.** A save started against file A can
+settle after the drawer closed and a buffer for file B opened. Matching `inflightRequestId`
+makes that completion a no-op instead of marking B saved or moving B's baseline. An
+`AbortController` does not prevent this: aborting the client request does not prove the server
+did not write, and a queued completion can still land.
 
-### Where the state lives
+**A successful save exits edit mode.** The write response carries no modification time
+(`MountFileWrittenResponse` is `path` and `size` only), so a buffer that stays open after a save
+has no trustworthy baseline: any mtime fetched afterwards might belong to an agent write that
+landed in between, and adopting it would arm the next save to overwrite that agent write without
+a conflict. Exiting means the baseline is always established by a fresh read at Edit time. The
+header shows a transient "Saved" tag for about two seconds, owned by the controller hook and
+cleared on unmount or on the next edit.
 
-```ts
-// driveEditState.ts
-export const driveEditBufferAtomFamily = atomFamily(
-    (_driveKey: string) => atom<DriveEditBuffer | null>(null),
-)
-```
-
-**Keyed by the drive's mount id** (`drive.mount?.id ?? ""`), the same key
-`driveSelectionAtomFamily` already uses in `useDriveSelection.ts`. Reasons:
-
-- The value is a single nullable buffer, never a map. One drive therefore cannot hold two
-  buffers. That is the "one file at a time" rule enforced by the type, not by a check.
-- Module-level, so it survives the drawer's `destroyOnClose` remount the same way the persisted
-  selection does. A user who accidentally closes the drawer does not silently lose a buffer,
-  though the guard should have caught them first.
-- Scoped per drive, so the chat host and the config host cannot fight over one slot if both
-  ever mount at once.
-
-Derived read atoms in the same file:
-
-```ts
-export const driveEditDirtyAtomFamily      // buffer != null && draft !== original
-export const driveEditStatusAtomFamily     // deriveEditStatus(...) for display and tests
-export const driveEditPathAtomFamily       // the display path, or null. Read by DriveTreeRow
-                                           // for the dirty dot, so the dot needs no prop drilling.
-```
-
-Write-only action atoms, one per transition. Every one of them is pure state manipulation with
-no I/O, so the whole machine tests with a bare `createStore()` and no React:
-
-| Atom | From | To |
-|---|---|---|
-| `openEditBufferAtom({mountId, path, displayPath, original, baseMtime})` | no buffer | `clean` |
-| `setEditDraftAtom(text)` | `clean` or `dirty` | `dirty`, or back to `clean` when text equals `original` |
-| `setEditViewAtom("source" \| "preview")` | any | same phase, new `view` |
-| `requestEditExitAtom(intent)` | `clean` | runs the intent, clears the buffer |
-| | `dirty` / banner set | sets `pendingExit`, renders the guard |
-| `resolveEditExitAtom("keep")` | `pendingExit` set | clears `pendingExit`, phase unchanged |
-| `resolveEditExitAtom("discard")` | `pendingExit` set | runs the intent, clears the buffer |
-| `resolveEditExitAtom("save")` | `pendingExit` set | starts a save; the intent runs on success |
-| `startEditSaveAtom(abort)` | `clean` / `dirty` | `saving`, clears any banner |
-| `editSaveSucceededAtom({size, mtime})` | `saving` | `saved` if draft unchanged during the write, otherwise `dirty` |
-| `editSaveFailedAtom(message)` | `saving` | `dirty`, `banner = {kind:"error"}`, draft untouched |
-| `markEditConflictAtom(theirMtime)` | any open buffer | `banner = {kind:"conflict"}` |
-| `forceNextEditSaveAtom()` | `conflict` banner | clears the banner, sets `forceNextSave` |
-| `adoptTheirsAtom({content, mtime})` | any open buffer | replaces `original`, `draft`, `baseMtime`; phase `clean`; clears the banner |
-| `closeEditBufferAtom()` | any | no buffer |
-
-Setting either banner clears the other. That is one line in the reducer and it is what makes the
-"only one banner can ever be shown" rule impossible to violate.
-
-`editSaveSucceededAtom` returning to `dirty` instead of `saved` when the draft moved during the
-write is the spec's rule: "If the user has already typed again during the write, stay in edit
-mode and go straight back to dirty."
+Because the editor is genuinely disabled during the write (section 5) and Cancel is disabled
+with it, the draft cannot move while a save is in flight. The spec's "if the user has already
+typed again during the write" branch is therefore unreachable and is not implemented.
 
 ### Exit routes that must run through the guard
 
-The spec names five, and they all call `requestEditExitAtom`:
-
 | Route | Where it is intercepted |
 |---|---|
-| Cancel button | `DriveHeader` edit cluster |
-| Escape | drawer-level `keydown` in `useDriveEdit` |
-| Closing the drawer | `DriveExplorer` wraps the `onClose` it passes to `DriveHeader` |
-| Selecting another file or folder | `DriveExplorer` wraps `select` before handing it to the tree, the breadcrumb, the folder grid, and `DriveFilePreview` |
-| Changing a filter | not reachable: the edit bar replaces the toolbar, so search, origin, and the visibility toggles are unmounted while editing. The intent kind stays in the union for the browser-unload case and for any future control that survives the swap. |
-| Browser unload | `beforeunload` listener in `useDriveEdit`, registered only while dirty. The browser shows its own dialog; ours cannot run there. |
+| Cancel button | `DriveHeader` edit cluster → controller |
+| Escape | drawer-level `keydown` in the controller |
+| Drawer close: header button, mask click, antd Escape | `FilesDrawer` wraps the host `onClose` **before** giving it to `EnhancedDrawer`. Wrapping only the callback passed to `DriveHeader` leaves mask and keyboard dismissal unguarded — antd receives the raw callback (`FilesDrawer.tsx:95-104`, `EnhancedDrawer.tsx:71-80`) |
+| Selecting another file or folder | `DriveExplorer` wraps `select` before the tree, breadcrumb, folder grid, and preview |
+| A changed `initialPath` | `useDriveSelection` re-selects from its own effect (`useDriveSelection.ts:84-90`), which a wrapper around the returned `select` cannot intercept. `FilesDrawer` holds the incoming `initialPath` while a dirty buffer is open and passes the previous value down; Discard releases it |
+| Drag spring-navigation | `useDriveDrop` calls `onNavigate` from a 700 ms timer (`useDriveDrop.ts:94-105`). Pass `enabled: canUpload && !editing` so drop and its timers are off entirely — CSS `pointer-events-none` does not stop a timer that has already started |
+| Browser unload | `beforeunload` registered only while dirty. The browser shows its own dialog; ours cannot run there, so this route does not use `NavigationIntent` |
+| Drive swap under an open drawer | The host changes `drive.mount.id`, `useDriveGeneration` bumps, and React replaces `DriveExplorer`. A child cannot stop its parent remounting it, so the buffer survives in the module atom and `FilesDrawer` shows the guard on the next mount. The buffer carries its own `targetMountId`, so Save still writes to the right place |
 
-## 2. Files that change and how
+The spec's fifth route, changing a filter, is not reachable: the edit bar replaces the toolbar,
+so search, origin, and the visibility toggles are unmounted while editing. No intent kind for it.
 
-### Existing files
+## 3. Files that change
+
+### Package changes (`web/packages/agenta-entities/src/session/`)
+
+- `core/schema.ts`: add `mountFileWrittenResponseSchema` — `{path: z.string(), size: z.number()}`.
+  `size` is required. The backend always sends an integer, and falling back to `content.length`
+  would report a UTF-16 character count as a byte count.
+- `api/api.ts`: add `writeMountFile` beside the existing `readMountFile`. The write boundary
+  belongs where the mount reads and their validation already live; splitting the schema into the
+  package and the call into the app is the worst of both.
+- `index.ts`: export `writeMountFile`, `mountFileWrittenResponseSchema`, and `mountDirQueryKey`.
+  The last one exists in `state/mounts.ts:42` but is not in the barrel today, and the package
+  exposes only the `./session` subpath, so the pre-write check cannot reach it otherwise.
+
+### Existing Drives files
 
 **`driveKinds.ts`**: move `TEXT_CAP` here from `renderers.tsx` and export it. This module is
-deliberately React-free and renderer-free so light consumers can import it; the edit gate is
-exactly such a consumer and must not pull the Shiki and Markdown graph in to read a number. Add
-nothing else.
+deliberately React-free so light consumers can import it; the edit gate must not pull the Shiki
+and Markdown graph in to read a number. Also export `CODE_LANGS` as a `Readonly<Record<...>>` so
+the language mapper's test can iterate it — today it is module-private.
 
-**`renderers.tsx`**: one line: `export {TEXT_CAP} from "./driveKinds"` and import it from there
-for the existing cap checks. One definition, both readers. No other change to this file.
+**`renderers.tsx`**: `export {TEXT_CAP} from "./driveKinds"` and import it from there for the
+existing cap checks. One definition, both readers. No other change.
 
-**`DriveHeader.tsx`**: add one optional prop group:
+**`FilesDrawer.tsx`**: owns the guarded close, the held `initialPath`, and renders
+`DriveEditGuardModal` above the `key`-remount boundary. This is the shell that antd actually
+talks to, so it is the only place a close guard can be complete.
+
+**`DriveHeader.tsx`**: one optional prop group.
 
 ```ts
 edit?: {
-    affordance: DriveEditAffordance
+    availability: DriveEditAvailability
     editing: boolean
     dirty: boolean
-    saved: boolean
     saving: boolean
+    justSaved: boolean
     onEdit: () => void
     onCancel: () => void
     onSave: () => void
 }
 ```
 
-Three changes inside:
-
 1. In the browsing cluster, between the details toggle and `DriveFileDownloadButton`, render an
-   Edit button when `affordance === "offer"`, or a disabled Edit button with a tooltip naming the
-   cap when `affordance === "capped"`. Render nothing when `hidden`. Secondary style, never
-   primary: Download stays the loudest action for a reader.
-2. When `edit.editing`, replace the whole right-hand cluster (upload, copy, details, download,
-   overflow) with Cancel and Save. Save is `type="primary"` and disabled unless dirty; during
-   `saving` it shows the antd `loading` spinner and reads "Saving". Cancel stays enabled during
-   `saving` so a slow mount does not trap anyone.
-3. Next to the origin `Tag`, render an "Unsaved" `Tag` when dirty, or a success-toned "Saved"
-   `Tag` when `saved`. Both reuse the already-imported `Tag`.
+   Edit button when `availability === "enabled"`, or a disabled Edit button with an explanatory
+   tooltip when it is `"too-large"`, `"loading"`, or `"unreadable"`. Render nothing when
+   `"unavailable"`. Secondary style, never primary: Download stays the loudest action for a reader.
+2. While editing, replace the whole right-hand cluster (upload, copy, details, download, overflow)
+   with Cancel and Save. Save is `type="primary"`, disabled unless dirty, and shows the antd
+   `loading` spinner reading "Saving" during the write. Cancel is disabled during the write.
+3. Next to the origin `Tag`, an "Unsaved" `Tag` when dirty, or a success-toned "Saved" `Tag`
+   while `justSaved`. Both reuse the already-imported `Tag`.
+4. An `aria-live="polite"` region carrying the current status text (Saving, Saved, the error
+   message, the conflict message), so the asynchronous state changes are announced.
 
 Do not touch the `CopyButton size="small"` line. The antd migration branch changes it.
 
-**`DriveToolbar.tsx`**: unchanged. `DriveExplorer` chooses between it and `DriveEditBar`. Adding
-an `editing` flag to `DriveToolbar` would mean threading every filter prop through a component
-that renders none of them while editing, and would grow that file's antd surface for no gain.
+**`DriveToolbar.tsx`**: unchanged. `DriveExplorer` chooses between it and `DriveEditBar`.
 
-**`DriveFilePreview.tsx`**: when a buffer is open for this file, render `DriveFileEditor`
-instead of `DriveFileContentViewer`. The meta band above it is unchanged and still obeys
-`detailsOpen`. Do not touch its `CopyButton size="small"` line.
+**`DriveFilePreview.tsx`**: when a buffer is open for this file, render `DriveFileEditor` instead
+of `DriveFileContentViewer`. The meta band above is unchanged. Do not touch its `CopyButton` line.
 
-**`DriveFileContentViewer.tsx`**: unchanged.
+**`DriveTreePane.tsx`**: add an `interactive` prop (default true). When false it sets `inert` on
+the tree scroll container and the resize handle and drops `onTreeKeyDown`. The pane has no such
+seam today, and the resize handle is a sibling of the tree element, so opacity on the tree alone
+would leave both keyboard focus and resizing live.
 
-**`DriveTreeRow.tsx`**: read `driveEditPathAtomFamily` and render a small dot on the row whose
-path matches. The spec asks for exactly two dirty affordances, one dot each: this one and the
-header chip.
+**`DriveTreeList.tsx` / `DriveTreeRow.tsx`**: `DriveTreeList` takes a `dirtyPath: string | null`
+and passes a boolean to the matching row, which renders the dot. One subscription at the list,
+not one per virtualized row — and `DriveTreeRow` receives no drive identity, so it could not
+select a keyed atom member anyway.
 
-**`DriveExplorer.tsx`**: the composition work:
+**`useMountUpload.ts`**: export its `refreshListing` body as
+`invalidateMountListings(queryClient, projectId)`. It invalidates `files`, `files-latest`,
+`files-root`, and `files-dir` — every root the drawer's header, recents, and tree actually read.
+The save reuses it rather than inventing a narrower policy that leaves the header size stale.
 
-- call `useDriveEdit({drive, selectedPath, select, onClose, canUpload})`
+**`DriveExplorer.tsx`**: composition only.
+
+- call `useDriveEditController(...)`
 - swap `<DriveToolbar/>` for `<DriveEditBar/>` while editing
-- pass the `edit` prop group to `DriveHeader`
-- pass the guarded `select` to the tree, the breadcrumb, the folder grid, and the preview
-- render `<DriveEditBanner/>` between the second header row and the body, in the one banner slot
-- render `<DriveEditGuardModal/>` and `<DriveEditDiffModal/>` at the end of the chrome branch
-- while editing, give the tree pane `pointer-events-none opacity-45` and `inert`, so its scroll
-  position and expanded folders survive
+- pass the `edit` prop group to `DriveHeader` and `dirtyPath` to `DriveTreeList`
+- pass the guarded `select` to the tree, breadcrumb, folder grid, and preview
+- pass `enabled: canUpload && !editing` into `useDriveUploads`
+- pass `interactive={!editing}` to `DriveTreePane`
+- render `<DriveEditBanner/>` between the second header row and the body
 
-### New files
+### New files, under `editMode/`
 
 | File | Contents | React? | antd? |
 |---|---|---|---|
-| `driveEdit.ts` | Pure helpers: `EDIT_KINDS`, `driveEditAffordance`, `driveEditBufferMode`, `driveEditorLanguage`, `isEditDirty`, `deriveEditStatus`, `conflictFromActivity` | no | no |
-| `driveEditState.ts` | The atom family and every action atom above | no | no |
-| `driveEditSave.ts` | The Fern call, the pre-write mtime re-check, cache invalidation | no | no |
-| `useDriveEdit.ts` | Wires atoms to the drawer: reads the original bytes, runs the save, subscribes to file activity, binds the keys | hook | no |
-| `DriveEditBar.tsx` | Header row 2 while editing: "Editing" label, Source/Preview segmented for markdown, language chip for code, the hint line | yes | `Segmented`, `Button`, `Tooltip` |
-| `DriveFileEditor.tsx` | The editor pane: `SharedEditor` in an `EditorProvider`, the markdown synchroniser, the preview pane, the status footer | yes | no |
-| `DriveEditBanner.tsx` | The one banner slot: error with Try again, conflict with View diff / Reload theirs / Save anyway | yes | `Alert`, `Button` |
-| `DriveEditGuardModal.tsx` | Discard dialog. `EnhancedModal` from `@agenta/ui/components` | yes | no |
-| `DriveEditDiffModal.tsx` | View diff. `computeTextDiffLines` list, or `DiffView` for the `json` kind | yes | no |
-| `driveEdit.test.ts` | Unit tests for the pure helpers | no | no |
-| `driveEditState.test.ts` | Unit tests for the transitions | no | no |
+| `model.ts` | `EDIT_KINDS`, `driveEditAvailability`, `driveEditBufferMode`, `driveEditorLanguage`, `isEditDirty`, `conflictFromListing` | no | no |
+| `state.ts` | `driveEditBufferAtom`, the facets selector, every action atom | no | no |
+| `api.ts` | `saveDriveFile`: pre-write check, the package write call, cache seeding, invalidation | no | no |
+| `useDriveEditController.ts` | The drawer-level controller, plus `useDriveEditGuard` for `FilesDrawer` | hook | no |
+| `components/DriveEditBar.tsx` | Header row 2 while editing: "Editing" label, Source/Preview segmented for markdown, language chip for code, hint line, session-teardown notice | yes | `Segmented`, `Button`, `Tooltip` |
+| `components/DriveFileEditor.tsx` | `SharedEditor` in an `EditorProvider`, plus the markdown preview pane | yes | no |
+| `components/DriveEditBanner.tsx` | The one banner slot: error with Try again, conflict with Reload from disk / Overwrite | yes | `Alert`, `Button` |
+| `components/DriveEditGuardModal.tsx` | Discard dialog, `EnhancedModal` from `@agenta/ui/components` | yes | no |
+| `model.test.ts`, `state.test.ts`, `controller.test.ts` | see section 8 | no | no |
 
-## 3. Reusing the editor components
+A directory rather than eleven more flat files in an already large module: `driveEdit.ts`,
+`driveEditState.ts`, `driveEditSave.ts`, and `useDriveEdit.ts` are indistinguishable in an import
+list and reveal no hierarchy.
 
-### Which wrapper, and why not the other one
+## 4. The controller
 
-Use `SharedEditor` from `@agenta/ui/shared-editor`, wrapped in our own `EditorProvider` from
-`@agenta/ui/editor`.
+```ts
+useDriveEditController({
+    driveKey,          // drive.mount?.id ?? ""
+    resolveMountPath,  // (displayPath) => {mount, path} | null — folds agent-files/
+    selectedPath,
+    scope,
+    canEditMountFiles,
+    includeGitignored, // part of every directory query key
+    select,
+    close,
+})
+```
 
-Do **not** use `SimpleSharedEditor`. It sniffs the content on every render and forces the editor
-into JSON, YAML, or HTML mode when the text happens to parse as one
-(`SimpleSharedEditor/index.tsx:288-311`). A `.txt` file containing a single JSON object would
-silently become a JSON code editor with a format dropdown. It also renders its own header with
-Format, Copy, and Minimize controls, which duplicates what the edit bar owns. Its value is the
-prompt-field use case, not a file buffer.
+It owns everything the reducer cannot: reading the original bytes, resolving `baseMtime`,
+running the save, executing returned navigation intents, the key bindings (⌘E to open, ⌘S to
+save, Escape to exit), the `beforeunload` registration, the `AbortController` (in a ref, as
+`useMountUpload` already does — not in the atom), and the "Saved" tag timer.
 
-The right precedent to copy is `ChatMessageEditor.tsx` in `@agenta/ui`: same `EditorProvider` +
-`SharedEditor` + `noProvider` shape, and it already solves the markdown-view dispatch race.
+Opening a buffer requires all of:
 
-### The editor call
+- a resolved `{mount, path}` from the drive's own resolver, so the write target is right for
+  `agent-files/`
+- raw content that has actually loaded. `useDriveFileText` returns `{data, isPending}` and
+  represents a failed read as non-pending `undefined` (`driveFileSource.tsx:63-84`), so
+  `isPending` means loading and `!isPending && data === undefined` means unreadable. Edit is
+  disabled in both cases with a tooltip saying which
+- a length re-check against `TEXT_CAP` on the loaded string. The listing size can be stale or
+  unknown, and `driveTree.ts` converts a null size to `0`, so the listing snapshot alone is not
+  a cap
+- `baseMtime` read from the raw directory listing for the file's parent
+  (`mountDirQueryKey(projectId, targetMountId, parentDir, includeGitignored)`), not from the
+  tree node — `DriveTreeNode` discards `mtime`
+
+`canEditMountFiles` is derived from the drawer's existing `canUpload`
+(`isAgentFileUploadsEnabled() && !explicitFiles && !!drive.mount`). It is a capability proxy, not
+proof the backend will accept the write: `mountSchema` has no read-only flag and we do not invent
+one. The name says "can edit", not "mount is writable".
+
+## 5. The editor
+
+### Every editable kind is `codeOnly`, including markdown
 
 ```tsx
-// DriveFileEditor.tsx
-const mode = driveEditBufferMode(path)          // "markdown" | "code"
-const language = driveEditorLanguage(path)      // CodeLanguage, only used when mode === "code"
-const editorId = `drive-edit-${mountId}-${path}`
+const editorId = `drive-edit-${bufferId}`
 
 <EditorProvider
-    codeOnly={mode === "code"}
-    language={mode === "code" ? language : undefined}
+    codeOnly
+    language={language}
     enableTokens={false}
     showToolbar={false}
-    disabled={phase === "saving"}
+    disabled={saving}
     id={editorId}
 >
     <SharedEditor
         id={editorId}
         editorType="borderless"
-        state={phase === "saving" ? "readOnly" : "filled"}
+        state={saving ? "readOnly" : "filled"}
+        disabled={saving}
         initialValue={original}
         value={draft}
         handleChange={onDraftChange}
@@ -287,69 +343,76 @@ const editorId = `drive-edit-${mountId}-${path}`
         noProvider
         autoFocus
         editorProps={{
-            codeOnly: mode === "code",
-            language: mode === "code" ? language : undefined,
+            codeOnly: true,
+            language,
             noProvider: true,
             showToolbar: false,
             enableTokens: false,
         }}
-        footer={<DriveEditStatusBar mode={mode} language={language} savedAt={savedAt} />}
-        className={view === "preview" ? "hidden" : undefined}
+        className={editorView === "preview" ? "hidden" : undefined}
     />
-    {mode === "markdown" ? <MarkdownSourceSynchronizer editorId={editorId} /> : null}
 </EditorProvider>
 ```
 
-Prop-by-prop, with the reason each value is what it is:
+**Markdown is edited as source through `codeOnly`, never through the rich-text markdown mode.**
+This is a correctness requirement, not a preference. In rich mode the editor emits changes by
+serializing the Lexical document and then running `stripBackslashEscapes`
+(`Editor.tsx:282-299`), which removes every backslash that precedes another character
+(`plugins/markdown/utils/textCleanup.ts:146-177`). Worse, the first `SET_MARKDOWN_VIEW(true)`
+does not inject the original file text: it serializes the rich tree it hydrated
+(`markdownPlugin.tsx:151-168`), so the file can be reformatted before the user types anything.
+`ChatMessageEditor` is not a precedent here — it edits a semantic chat message and never promises
+byte preservation.
 
-- `editorType="borderless"`: the pane already draws the inset border. A second border reads as a
-  nested box.
-- `state`: `"readOnly"` while saving. The spec chose this over an overlay: "typing into a buffer
-  that's mid-flight is the bug this prevents." The other five values in the union are not used;
-  `filled` covers every other phase and focus is handled by the component's own tracking.
-- `disableDebounce`: required. The default is a 300 ms `useDebounceInput` window
-  (`SharedEditor.tsx:76-81`). Dirty tracking has to be keystroke-accurate, or Save stays disabled
-  for a third of a second after the first keystroke and the guard can miss a change typed
-  immediately before Escape.
-- `initialValue` + `value`: `SharedEditor` uses `initialValue` for the mount-time Lexical seed
-  and `value` for the controlled sync (`SharedEditor.tsx:71-73`). Pass `original` and `draft`.
-  Do not pass `syncWithInitialValueChanges`: it would re-seed the buffer when the underlying
-  query refetches, which is exactly the overwrite we are trying to prevent.
-- `noProvider` on both the wrapper and `editorProps`: we own the provider, as `ChatMessageEditor`
-  does.
-- `autoFocus`: the spec wants focus in the editor on open, cursor at the start of the document.
-- `footer`: the status bar (language, `UTF-8`, cursor position, last-saved). Uses the slot rather
-  than a sibling so it sits inside the editor's border.
+`codeOnly` also means `MarkdownPlugin` is not mounted at all
+(`plugins/index.tsx: singleLine || codeOnly ? null : <MarkdownPlugin/>`), so there is no
+`SET_MARKDOWN_VIEW` command to pin, no `markdownViewAtom` to write, and no synchronizer
+component. The whole markdown-view mechanism drops out of this feature.
 
-### Source and preview for markdown
+**`disabled` goes on `SharedEditor`, not only on the provider.** `SharedEditor.state` only
+changes container classes and cursor styling; editability comes from the `disabled` prop it
+forwards to `Editor` (`SharedEditor.tsx:216-235`), which reaches `EditorInner`, where it defaults
+to `false` and calls `editor.setEditable(!disabled)` (`Editor.tsx:455-457`). A provider-only
+`disabled` is re-enabled by that inner effect and the user can type into a buffer mid-write.
+`state="readOnly"` stays for the visual treatment.
 
-Two separate mechanisms, and it is easy to conflate them.
+**The buffer owns `original` and `draft`; the editor's props are outputs, not the source of
+truth.** `SharedEditor` prefers `value` over `initialValue` for its controlled value
+(`SharedEditor.tsx:71-80`), and in code mode the plugin seeds its initial content from
+`value !== undefined ? value : initialValue` (`plugins/index.tsx:149-160`). So `initialValue`
+is not a separate mount-time channel. Never infer the save baseline from it. Do not pass
+`syncWithInitialValueChanges`: it would re-seed the buffer on a background refetch, which is the
+overwrite this feature exists to prevent.
 
-**The buffer is always raw markdown source.** `MarkdownSourceSynchronizer` pins
-`SET_MARKDOWN_VIEW` to `true` for the life of a markdown buffer, and sets `markdownViewAtom(editorId)`
-to `true` so the CSS flag agrees with the node state. It is a direct copy of
-`MarkdownViewSynchronizer` from `ChatMessageEditor.tsx:88-104`, including both dispatches:
-a `useLayoutEffect` for the steady state, and a `requestAnimationFrame` in a `useEffect` for the
-mount race where the layout effect fires before `MarkdownPlugin` registers the command. Setting
-the atom alone does nothing; the comment in `ChatMessageEditorProps.markdownView` says so and the
-plugin confirms it. Editing markdown as rich text would round-trip the file through the markdown
-serialiser on every keystroke and reflow formatting the user never touched.
+`disableDebounce` is required. The default is a 300 ms window (`SharedEditor.tsx:76-81`), which
+would leave Save disabled for a third of a second after the first keystroke and let the guard
+miss a change typed immediately before Escape.
 
-**Preview is a separate pane.** The Source/Preview segmented in the edit bar sets
-`buffer.view`. In `preview`, the `SharedEditor` gets `className="hidden"` (it stays mounted, so
-cursor position and undo history survive the round trip) and we render the existing `Markdown`
-component from `@/oss/components/AgentChatSlice/assets/markdown` over `draft`, inside the same
-scroll container `TextBody` uses (`renderers.tsx:153-160`). That satisfies the spec's requirement
-that nothing shifts between preview and the read-only view after save, because it is literally
-the same component.
+`autoFocus` mounts Lexical's `AutoFocusPlugin`, which focuses but does not promise the caret is
+at the start of the document. Verify that in QA; if the caret lands at the end, add a small
+select-start plugin through `editorProps.additionalCodePlugins`.
 
-Preview is offered only when `mode === "markdown"`. For `code` the edit bar shows the language
-chip instead, so the bar does not reflow.
+### Markdown source and preview
 
-### codeOnly and the language mapper
+The Source/Preview segmented in the edit bar sets `editorView`. In `preview` the `SharedEditor`
+gets `className="hidden"` — `SharedEditor` merges the caller's className onto its outer node, so
+the class reaches the right subtree — and we render the existing `Markdown` component from
+`@/oss/components/AgentChatSlice/assets/markdown` over `draft`, inside the same scroll container
+`TextBody` uses (`renderers.tsx:153-160`). Same component as the read view, so nothing shifts
+between preview and viewing after save.
+
+Keeping the editor mounted avoids a remount and preserves undo history. Whether the caret
+position survives the round trip is untested and is not claimed; nothing in the code restores a
+selection across the toggle.
+
+Preview is offered only when `mode === "markdown"`. For `code` the bar shows the language chip
+instead, so it does not reflow. The spec's "formatting controls stay visible but disabled in
+preview" does not apply: `codeOnly` has no rich-text toolbar to disable.
+
+### The language mapper
 
 `driveEditorLanguage(path)` maps the Shiki id from `driveCodeLanguage(path)` into the six-value
-`CodeLanguage` union (see `research.md` correction 4):
+`CodeLanguage` union (`plugins/code/types.ts`, see `research.md` correction 4):
 
 ```
 json, yaml            -> "json" / "yaml"
@@ -359,321 +422,280 @@ typescript, tsx       -> "typescript"
 everything else       -> "code"
 ```
 
-`"code"` is the union's generic highlighter and is the honest answer for shell, Rust, Go, CSV,
-plain text, and `.env`. A unit test asserts every value in `CODE_LANGS` maps into the union, so
-adding a language to `driveKinds.ts` later cannot produce a type error at a call site far away.
+`"code"` is the union's generic highlighter and is the honest answer for markdown, shell, Rust,
+Go, CSV, plain text, and `.env`.
 
-### DiffView and the conflict diff
-
-`DriveEditDiffModal.tsx` shows the mount's current bytes against the buffer.
-
-- kind `json`: `<DiffView language="json" original={theirs} modified={draft} />`. This is the one
-  case `DiffView` handles correctly.
-- every other kind: `computeTextDiffLines(theirs, draft, {contextLines: 3, enableFolding: true,
-  foldThreshold: 5})` from `@agenta/ui/diff`, rendered as a list of lines coloured by
-  `line.type`. `DiffView` cannot be used here; `research.md` correction 2 has the evidence.
-
-## 4. The save path
+## 6. The save path
 
 ```ts
-// driveEditSave.ts
-import {getMountsClient, projectScopedRequest} from "@agenta/entities/session"
-
-export async function writeDriveFile({
-    mountId, path, content, projectId, signal,
-}): Promise<{ok: true; size: number} | {ok: false; message: string}> {
-    const name = path.split("/").pop() || "file"
-    const file = new File([content], name, {type: "text/plain"})
-    try {
-        const written = await getMountsClient().uploadMountFile(
-            {mount_id: mountId, path, file},
-            projectScopedRequest(projectId, undefined, signal, 0),
-        )
-        const parsed = safeParseWithLogging(
-            mountFileWrittenResponseSchema, written, "[writeDriveFile]",
-        )
-        return {ok: true, size: parsed?.size ?? content.length}
-    } catch (error) {
-        if (isAbortError(error)) throw error
-        return {ok: false, message: toWriteErrorMessage(error)}
-    }
-}
+// packages/agenta-entities/src/session/api/api.ts
+export async function writeMountFile({
+    projectId, mountId, path, content, signal,
+}): Promise<{ok: true; size: number} | {ok: false; message: string}>
 ```
 
-Notes on each choice:
+- `uploadMountFile`, not the generated `writeMountFile`. The generated raw-body method sends no
+  body and would truncate the file. Both endpoints reach the same `MountsService.write_file`,
+  with the same `EDIT_MOUNTS` check and the same full `put_object` overwrite. `research.md`
+  correction 1.
+- The full mount-relative `path` in the query. `upload_mount_file` uses it verbatim unless it is
+  empty or ends in `/` (`api/oss/src/apis/fastapi/mounts/utils.py:79-83`), so it overwrites
+  exactly that object and the multipart filename is irrelevant.
+- `projectScopedRequest(projectId, undefined, signal, 0)`. `maxRetries: 0`: a retried PUT after a
+  timeout can land after the user has edited again.
+- Not `callFern` — it turns every failure into `null` and the error banner needs the message.
+  Aborts are rethrown.
+- `safeParseWithLogging(mountFileWrittenResponseSchema, ...)` at the boundary.
+- An explicit request timeout, so a hung mount surfaces as an error banner with the buffer intact
+  rather than a permanently disabled Cancel.
 
-- `uploadMountFile`, not `writeMountFile`. The generated `writeMountFile` sends no body and would
-  truncate the file. Both endpoints call the same `MountsService.write_file`. `research.md`
-  correction 1 has the proof.
-- `path` is the full mount-relative path. `upload_mount_file` uses the query `path` verbatim
-  unless it is empty or ends in `/` (`api/oss/src/apis/fastapi/mounts/utils.py:79-83`), so a
-  full path overwrites exactly that object.
-- `projectScopedRequest(..., signal, 0)`. `maxRetries: 0` because a write must never be retried
-  transparently: a retried PUT after a timeout can land after the user has already edited again.
-- Not `callFern`. It converts every failure into `null` and the error state needs the message.
-  Aborts are rethrown so Cancel during `saving` unwinds cleanly.
-- A zod parse at the boundary, per `web/AGENTS.md`. Add `mountFileWrittenResponseSchema` to
-  `packages/agenta-entities/src/session/core/schema.ts` next to the existing mount schemas
-  (`{path: z.string(), size: z.number().nullish()}`), since none exists yet.
+### After a successful write
 
-### What is invalidated after a successful write
+1. `queryClient.setQueryData(mountFileContentQueryKey(projectId, targetMountId, targetPath), draft)`
+   — the drawer returns to the read view with the saved bytes already rendered, no refetch, no
+   skeleton flash.
+2. `invalidateMountListings(queryClient, projectId)` — the same four roots the upload path
+   invalidates. The header prefers `drive.recents` over the tree node's size
+   (`DriveExplorer.tsx:180-193`), and recents come from `files-latest`/`files-root`, so a
+   directory-only invalidation leaves the visible size stale.
 
-In order, and deliberately narrow:
+Do **not** call `revalidateSessionMountsAtom`: it invalidates every mount in the project plus
+every cached body, which is right after an agent turn and far too wide for a one-file save.
 
-1. `queryClient.setQueryData(mountFileContentQueryKey(projectId, mountId, path), draft)`:
-   seed the cache with the bytes we just wrote. This is what lets the drawer return to the
-   read-only view with the saved text already rendered, with no refetch and no skeleton flash.
-2. `queryClient.invalidateQueries({queryKey: mountDirQueryKey(projectId, mountId, parentDir)})`:
-   the file's own directory level. This refreshes `size` and `mtime` for the tree row and the
-   header chip, and it is how we learn the post-write mtime the response does not carry.
-3. `queryClient.invalidateQueries({queryKey: ["mounts", "files", projectId, mountId]})`: the
-   whole-mount listing, used by the recents and the search view.
+## 7. Conflict detection
 
-Do **not** call `revalidateSessionMountsAtom`. It invalidates every mount in the project plus
-every cached body (`mounts.ts:219-247`), which is right for a finished agent turn and far too
-wide for a one-file save.
+One trigger: the pre-write modification-time check. Before every write, unless
+`skipConflictCheckOnce` is set:
 
-## 5. Conflict detection
+1. `queryClient.fetchQuery` on
+   `mountDirQueryKey(projectId, targetMountId, parentDir, includeGitignored)` with `staleTime: 0`,
+   using the same fetcher `mountDirQueryFamily` uses. `includeGitignored` is part of the key; a
+   check against the wrong listing variant would look at a listing the file is absent from.
+2. **No entry for the path → conflict, `reason: "missing"`.** The agent deleted the file. Treating
+   a missing entry as "no mtime to compare, proceed" would silently recreate a deleted file,
+   because the write is an unconditional `put_object`.
+3. Entry present, both mtimes non-null and different → conflict, `reason: "changed"`.
+4. Entry present, either mtime null → cannot compare; proceed. A silent degradation, recorded in
+   `status.md` rather than hidden.
 
-Two independent triggers. Neither is sufficient alone.
+There is no self-write grace window and no agent-activity trigger.
 
-### Trigger one: the file-activity signal
+A grace window that suppresses the check for N seconds after a save is a correctness bug: an
+agent write inside the window is overwritten silently, and the "next save catches it" claim is
+false because the next save can fall inside the same window. Its stated purpose — stopping our
+own invalidation from raising a conflict against our own bytes — does not exist either: file
+activity is appended from detected agent tool calls, and a frontend save appends nothing
+(`fileActivity.ts:75-139`). Exiting edit mode on save (section 2) removes the problem the window
+was invented for.
 
-`useDriveEdit` subscribes to `latestSessionFileActivityAtomFamily(sessionId)` with
-`sessionId = useDriveSessionId()`. A pure predicate decides:
+The activity trigger is cut because it usually cannot fire. `fileActivity` resolves a tool path
+only by scanning cached queries under the full-listing prefix `["mounts", "files", projectId]`
+(`fileActivity.ts:86-99`), and the drawer loads per-directory `files-dir` queries, fetching the
+full listing only while search is active (`useLazyDriveTree.tsx:117-138`). An open drawer
+normally gets an entry with no `resolved` mount/path. It is worth adding later, once it can
+resolve `files-dir` entries; it only ever made the warning arrive earlier, and the pre-write check
+is what actually prevents data loss.
 
-```ts
-// driveEdit.ts
-export function conflictFromActivity(
-    entry: SessionFileActivityEntry | null,
-    buffer: DriveEditBuffer | null,
-    selfWriteUntil: number,
-): boolean {
-    if (!entry || !buffer) return false
-    if (entry.resolved?.mountId !== buffer.mountId) return false
-    if (entry.resolved?.path !== buffer.path) return false
-    if (entry.at <= buffer.openedAt) return false
-    if (entry.at <= selfWriteUntil) return false
-    return true
-}
-```
+### The two ways out of a conflict
 
-Limitation, stated plainly: the config-panel host does not mount `DriveSessionProvider`, so
-`useDriveSessionId()` returns null there and this trigger never fires. Trigger two covers that
-host. This is not worth fixing by threading a session id through the config host, because the
-pre-write check is the one that actually prevents data loss; the activity signal only makes the
-warning arrive earlier.
+- **Reload from disk** — when dirty this routes through the guard with a `reload` intent; on
+  Discard the content query is invalidated, refetched, and `replaceBufferFromRemoteAtom` swaps
+  `original`, `draft`, and `baseMtime` in place. The buffer stays open and clean. It does not
+  close the buffer and then adopt into it.
+- **Overwrite** — `overwriteNextSaveAtom()` then save. The flag clears on the next
+  `startEditSaveAtom`, so a second conflict is caught normally. The button copy says it
+  overwrites.
 
-### Trigger two: the pre-write modification-time check
+Seeing what changed before choosing is deferred: the diff needs a fresh content read, a modal,
+and its own async lifecycle, and `DiffView` cannot render it — its props are restricted to JSON
+and YAML and its extension parses the strings before diffing, so a file that is mid-edit and not
+yet valid JSON renders nothing (`DiffView.tsx:178-199`,
+`plugins/code/extensions/diffHighlight.tsx:385-425,526-529`). When it lands it should use
+`computeTextDiffLines` for every kind, including `.json`, because the product compares raw file
+bytes, not parsed data structures.
 
-The spec requires the conflict be "re-checked immediately before every write". Before calling
-`writeDriveFile`, and unless `forceNextSave` is set:
-
-1. `await queryClient.fetchQuery({queryKey: mountDirQueryKey(projectId, mountId, parentDir), ...})`
-   with `staleTime: 0`, so it goes to the network.
-2. Find the entry whose `path` matches and read its `mtime`.
-3. If both `mtime` and `buffer.baseMtime` are non-null and differ, do not write. Call
-   `markEditConflictAtom(theirMtime)` and stop. Otherwise proceed.
-
-A null on either side means the object store did not report a time, and the check cannot fire.
-That is a silent degradation, so it is recorded in `status.md` rather than hidden.
-
-`baseMtime` at open comes from the directory listing already cached for the file's folder
-(`mountDirQueryFamily`), falling back to the drive's `recents` entry, falling back to null.
-
-### The write response has no modification time
-
-`MountFileWrittenResponse` returns `path` and `size` only. Handled in two parts, neither of which
-touches the backend:
-
-**Self-write suppression.** On a successful save, set a module-level
-`selfWriteUntil = Date.now() + SELF_WRITE_GRACE_MS` (5000) for that `(mountId, path)`.
-`conflictFromActivity` ignores any activity entry inside that window, and the pre-write check is
-skipped for the same window. Without this, the invalidation we fire ourselves in step 2 above
-would return a new mtime and raise a conflict against our own bytes.
-
-**Adopt the real mtime one refetch later.** The directory invalidation lands within the grace
-window. When it does, and the buffer is still open (the user kept editing after saving), read the
-fresh entry's mtime and write it into `buffer.baseMtime`. The window closes and conflict
-detection is armed again against a true value.
-
-The effect is that "no mtime on the write response" costs one extra listing refetch we were
-already firing, and a five-second window in which a conflict raised by someone else would be
-missed. That window is acceptable: the pre-write check on the *next* save still catches it, and
-the alternative is a backend change that turns a frontend PR into a cross-stack one.
-
-### The three ways out of a conflict
-
-- **View diff** opens `DriveEditDiffModal` with the freshly-fetched mount bytes as original and
-  the draft as modified.
-- **Reload theirs** routes through the guard when dirty (it discards the buffer), then invalidates
-  and refetches `mountFileContentQueryKey`, then calls `adoptTheirsAtom({content, mtime})`.
-- **Save anyway** calls `forceNextEditSaveAtom()` and then saves. The flag clears after one
-  attempt, so a second conflict is caught normally. The button copy says it overwrites.
-
-## 6. Which files can be edited
-
-### The rule
+## 8. Which files can be edited
 
 ```ts
-// driveEdit.ts
+// editMode/model.ts
 export const EDIT_KINDS = new Set<DriveFileKind>([
     "markdown", "text", "code", "json", "csv", "html",
 ])
 
-export function driveEditAffordance({kind, size, canWrite}): DriveEditAffordance {
-    if (!canWrite) return "hidden"
-    if (!EDIT_KINDS.has(kind)) return "hidden"
-    if (size != null && size > TEXT_CAP) return "capped"
-    return "offer"
+export type DriveEditAvailability =
+    | "enabled" | "loading" | "unreadable" | "too-large" | "unavailable"
+
+export function driveEditAvailability({kind, listingSize, contentLength, isPending, canEdit}) {
+    if (!canEdit) return "unavailable"
+    if (!EDIT_KINDS.has(kind)) return "unavailable"
+    if (listingSize != null && listingSize > TEXT_CAP) return "too-large"
+    if (isPending) return "loading"
+    if (contentLength == null) return "unreadable"
+    if (contentLength > TEXT_CAP) return "too-large"
+    return "enabled"
 }
 ```
 
 `kind` comes from `resolveDriveFileKind(path)`. There is no second extension list anywhere in
-this feature. `TEXT_CAP` is the existing 1.5 MB constant, moved to `driveKinds.ts` and imported
-here. `canWrite` is the drawer's existing `canUpload`
-(`isAgentFileUploadsEnabled() && !explicitFiles && !!drive.mount`), which is the closest thing to
-a writable-mount answer the frontend has. `mountSchema` has no read-only flag to read and we do
-not invent one.
-
-`hidden` renders no Edit button at all. `capped` renders it disabled with a tooltip naming the
-cap. The spec's reasoning: a category is not a limit, and a disabled Edit on every image would
-train people to ignore the button.
+this feature. `unavailable` renders no Edit button at all — a category is not a limit, and a
+disabled Edit on every image would train people to ignore the button. The other three render it
+disabled with a tooltip that says which.
 
 ### The five extensions the user will QA
 
-| Extension | `resolveDriveFileKind` | Affordance | Buffer mode | Read view today | What editing does |
-|---|---|---|---|---|---|
-| `.txt` | `text` | offer | `code`, language `code` | `TextBody`, a `<pre>` | plain source buffer, verbatim round trip |
-| `.csv` | `csv` | offer | `code`, language `code` | `CsvBody`, a parsed table | swaps to a plain source buffer over the raw text; the table returns after save |
-| `.md` | `markdown` | offer | `markdown` | `TextBody` rendering `Markdown` | raw markdown source, with a Preview pane using the same `Markdown` component |
-| `.env` | `text` | offer | `code`, language `code` | `TextBody`, a `<pre>` | same as `.txt` |
-| `.json` | `json` | offer | `code`, language `json` | `CodeBody`, pretty-printed | source buffer seeded from the **raw** content, not from the pretty print |
+| Extension | Kind | Buffer mode | Read view today | What editing does |
+|---|---|---|---|---|
+| `.txt` | `text` | `code`, language `code` | `TextBody`, a `<pre>` | plain source buffer, verbatim round trip |
+| `.csv` | `csv` | `code`, language `code` | `CsvBody`, a parsed table | plain source buffer over the raw text; the table returns after save |
+| `.md` | `markdown` | `code`, language `code` | `TextBody` rendering `Markdown` | raw markdown source, with a Preview pane using the same `Markdown` component |
+| `.env` | `text` | `code`, language `code` | `TextBody`, a `<pre>` | same as `.txt` |
+| `.json` | `json` | `code`, language `json` | `CodeBody`, pretty-printed | source buffer seeded from the **raw** content, not from the pretty print |
 
-Three of these carry a trap worth stating:
+Three traps worth stating:
 
 **`.json` must not be seeded from the read view.** `CodeBody` runs
-`JSON.stringify(JSON.parse(content), null, 2)` before displaying
-(`renderers.tsx:178-186`). Seeding the buffer from that reformats the entire file the moment the
-user changes one line. Seed from `useDriveFileText` directly, which returns the raw content
-string.
+`JSON.stringify(JSON.parse(content), null, 2)` before displaying (`renderers.tsx:178-186`).
+Seeding from that reformats the whole file the moment the user changes one line. Seed from
+`useDriveFileText`, which returns the raw string.
 
 **`.csv` becomes text while editing.** The spec lists `csv` among the editable kinds and there is
-no cell editor here. The table is a read view only.
+no cell editor here. The table is a read view only. `csv` is not in `TEXT_KINDS` but the renderer
+already applies `TEXT_CAP` to it (`renderers.tsx:585-638`), so the cap behaviour matches.
 
 **`.env` works, `.env.local` does not.** `resolveDriveFileKind(".env")` returns `text` because
-the pattern `/\.(txt|log|env)$/i` matches a leading dot. `.env.local` matches nothing and lands on
-`other`, which shows the download card and offers no Edit. Widening the resolver would change the
-read-only viewer's behaviour for every host, so it stays out of this PR and is logged in
-`status.md`. Also note `.env` is a dotfile: it appears only with the hidden-files toggle on, which
-is its default (`useDriveFilters.ts:16`).
+`/\.(txt|log|env)$/i` matches a leading dot. `.env.local` matches nothing and lands on `other`,
+the download card. Widening the resolver would change the read-only viewer for every host, so it
+stays out of this PR and is logged in `status.md`. `.env` is a dotfile and appears only with the
+hidden-files toggle on, which is its default (`useDriveFilters.ts:16`).
 
-For completeness on the non-QA kinds: `.html` is editable as a `code` buffer (its read view has
-its own Preview/Source toggle, which is unrelated and untouched); `image`, `pdf`, `audio`,
-`video`, and `other` are `hidden`.
+`.html` is editable as a `code` buffer; `image`, `pdf`, `audio`, `video`, and `other` are
+`unavailable`.
 
-## 7. Test plan
+## 9. Session-scoped files warn on first edit
+
+The spec's rules require it: a session's files can be torn down with the session. On the first
+keystroke in a buffer whose `scope === "session"`, the edit bar shows a one-line inline notice and
+`markTeardownWarnedAtom` fires so it does not repeat for that buffer. A line in the bar, not a
+modal — it is a caveat, not a decision.
+
+## 10. Test plan
 
 Vitest, colocated, following `dropEntries.test.ts`. No snapshot tests of the rendered drawer.
 
-### `driveEdit.test.ts` (pure helpers)
+### `model.test.ts`
 
-- `resolveDriveFileKind` for `.txt`, `.csv`, `.md`, `.env`, `.json`, plus `agent-files/.env`,
-  `.env.local`, `.png`, `.pdf`, `README`. This locks the dotfile behaviour that the whole `.env`
-  story rests on.
-- `driveEditAffordance` across the matrix: every kind, times `{size under cap, size exactly cap,
-  size over cap, size null}`, times `{canWrite true, canWrite false}`. Assert `capped` only ever
-  appears for a kind in `EDIT_KINDS`, and that `size == null` never produces `capped`.
-- `driveEditBufferMode`: `markdown` only for markdown extensions, `code` for everything else.
-- `driveEditorLanguage`: every key of `CODE_LANGS` maps into the six-value `CodeLanguage` union,
-  and `.json` maps to `json`, `.yaml` to `yaml`, `.py` to `python`, `.sh` to `code`.
+- `resolveDriveFileKind` for `.txt`, `.csv`, `.md`, `.env`, `.json`, `agent-files/.env`,
+  `.env.local`, `.png`, `.pdf`, `README`. Locks the dotfile behaviour the `.env` story rests on.
+- `driveEditAvailability` across the matrix: every kind × `{under cap, exactly cap, over cap,
+  null listing size}` × `{pending, loaded, unreadable}` × `{canEdit true/false}`. Assert
+  `too-large` only ever appears for a kind in `EDIT_KINDS`, that a null listing size still gets
+  capped once the content length is known, and that a failed read never reports `enabled`.
+- `driveEditBufferMode`: `markdown` only for markdown extensions, `code` otherwise.
+- `driveEditorLanguage`: every value in the now-exported `CODE_LANGS` maps into the six-value
+  union; `.json`→`json`, `.yaml`→`yaml`, `.py`→`python`, `.sh`→`code`, `.md`→`code`.
 - `isEditDirty`: differs, identical, identical after retyping, trailing-newline difference,
   empty original.
-- `deriveEditStatus`: one assertion per spec name, twelve in total, each with the minimal record
-  that produces it. Plus the precedence cases: dirty and in preview returns `preview`; dirty with
-  a conflict banner returns `conflict`; conflict with a pending exit returns `confirm`.
-- `conflictFromActivity`: matching path and mount, wrong mount, wrong path, entry timestamped
-  before the buffer opened, entry inside the self-write grace window, null entry, null buffer.
+- `conflictFromListing`: entry missing → conflict; mtime changed → conflict; mtime equal → none;
+  either mtime null → none.
 
-### `driveEditState.test.ts` (transitions)
+### `state.test.ts` (bare `createStore()`, no React)
 
-Uses a bare jotai `createStore()`. No React, no rendering.
+- open puts the machine in a clean buffer with Save disabled; one edit makes it dirty; editing
+  back to the original text makes it clean again.
+- `requestNavigationAtom` on a clean buffer returns the intent and clears the buffer; on a dirty
+  buffer it returns nothing and sets `pendingNavigation`.
+- `resolveNavigationAtom("keep")` clears `pendingNavigation` and touches nothing else.
+- `resolveNavigationAtom("discard")` returns the intent; it clears the buffer for `close`,
+  `cancel`, and `select`, and keeps it for `reload`.
+- `setEditDraftAtom` is ignored while saving.
+- a completion whose `requestId` does not match `inflightRequestId` is a no-op — assert this for
+  success, failure, and conflict, including the case where the buffer was replaced in between.
+- `editSaveSucceededAtom` clears the buffer (edit mode exits).
+- `editSaveFailedAtom` leaves a character-identical draft and an error issue.
+- `markEditConflictAtom` replaces an error issue and vice versa; the two never coexist.
+- `overwriteNextSaveAtom` clears the conflict and sets the flag; `startEditSaveAtom` clears it.
+- `replaceBufferFromRemoteAtom` replaces original, draft, and `baseMtime` and leaves the buffer
+  open and clean.
+- opening a second file while a buffer is open goes through `requestNavigationAtom`; the atom
+  still holds exactly one buffer and the new selection does not apply until the guard resolves.
 
-- open puts the machine in `clean` with Save disabled.
-- one edit gives `dirty`; editing back to the original text returns to `clean`.
-- `clean` plus `requestEditExitAtom` runs the intent immediately, with no guard.
-- `dirty` plus `requestEditExitAtom` sets `pendingExit` and does not run the intent.
-- `resolveEditExitAtom("keep")` clears `pendingExit` and leaves the phase and the draft alone.
-- `resolveEditExitAtom("discard")` runs the intent and clears the buffer.
-- `resolveEditExitAtom("save")` starts a save and runs the intent only after success. A failed
-  save leaves the intent unrun and the buffer alive.
-- `saving` then `editSaveSucceededAtom` gives `saved`. `saving`, then an edit, then
-  `editSaveSucceededAtom` gives `dirty`, not `saved`.
-- `editSaveFailedAtom` gives `dirty` with an error banner and a character-identical draft.
-- `markEditConflictAtom` while an error banner is showing replaces it, and the reverse. Assert
-  the two banners never coexist.
-- `forceNextEditSaveAtom` clears the conflict banner and sets `forceNextSave`; the flag is
-  cleared by the next `startEditSaveAtom`.
-- `adoptTheirsAtom` replaces original, draft, and `baseMtime`, and returns the phase to `clean`.
-- opening a second file while a buffer is open: `requestEditExitAtom({kind:"select"})` is what
-  runs, the atom value is still exactly one object, and the new selection does not apply until
-  the guard resolves.
+### `controller.test.ts` (the seams that actually break)
 
-### What is deliberately not unit-tested
+Thin fakes for the query client and the write call; no Lexical.
 
-The Lexical editor itself, the `SET_MARKDOWN_VIEW` dispatch timing, and the antd rendering. Those
-are covered by the live QA matrix in `CONTEXT.md`, which is where the markdown source toggle and
-the two themes actually get checked.
+- a drawer close from the shell (mask/Escape path) routes through the guard.
+- a changed `initialPath` while dirty routes through the guard and does not re-select underneath.
+- a missing directory entry produces a conflict rather than recreating a deleted file.
+- the pre-write fetch key carries the active `includeGitignored` value.
+- a late success from file A does not mutate a buffer for file B.
+- `agent-files/x.md` writes to the agent mount with path `x.md`, and its content-cache seed and
+  directory fetch use that mount id.
+- a successful save seeds the content cache with the exact draft and invalidates all four
+  listing roots.
+- the write goes out as multipart with the full path and `maxRetries: 0`.
 
-## 8. The antd migration constraint
+### Deliberately not unit-tested
+
+The Lexical editor itself and the antd rendering. Byte fidelity is instead structural: markdown
+never enters rich mode, so there is no serializer in the path. A test asserts
+`driveEditBufferMode` never produces a non-`codeOnly` editor configuration, and QA checks the
+bytes.
+
+## 11. The antd migration constraint
 
 PR #5643 rewrites `import {X} from "antd"` to `import {X} from "@agenta/ui/ui"` across the app.
-`@agenta/ui/ui` does not exist on `release/v0.109.0`, so nothing here can be written
-forward-compatible. The goal is instead to make the post-merge fixup mechanical and short.
-
-**antd imports this feature adds, in full:**
+`@agenta/ui/ui` does not exist on `release/v0.109.0`, so nothing here can be forward-compatible.
+The goal is to make the post-merge fixup mechanical.
 
 | File | antd imports | Why here |
 |---|---|---|
-| `DriveEditBar.tsx` | `Segmented`, `Button`, `Tooltip` | The Source/Preview control is a segmented control by the spec's own drawing, and `Segmented` is what `DriveToolbar` and `renderers.tsx` already use for the same shape. |
-| `DriveEditBanner.tsx` | `Alert`, `Button` | `Alert` is already used elsewhere in `Drives/` and carries the error and warning tones the two banners need. |
+| `components/DriveEditBar.tsx` | `Segmented`, `Button`, `Tooltip` | The Source/Preview control is a segmented control in the spec's drawing, and `Segmented` is what `DriveToolbar` and `renderers.tsx` already use for that shape |
+| `components/DriveEditBanner.tsx` | `Alert`, `Button` | `Alert` is already used in `Drives/` and carries both tones |
 
 **Zero new antd import lines in existing files.** `DriveHeader.tsx` already imports `Button`,
-`Tooltip`, and `Tag`, which is everything its Edit / Cancel / Save / chip additions need.
+`Tooltip`, and `Tag`. `DriveEditGuardModal` uses `EnhancedModal` from `@agenta/ui/components`,
+which `web/AGENTS.md` requires over raw antd `Modal`. `DriveFileEditor` uses `SharedEditor`,
+`EditorProvider`, and the existing `Markdown` component. `model.ts`, `state.ts`, `api.ts`, and
+the controller have no React and no antd by construction.
 
-**Files that avoid antd entirely and why:**
-
-- `DriveEditGuardModal.tsx` and `DriveEditDiffModal.tsx` use `EnhancedModal` from
-  `@agenta/ui/components`. `web/AGENTS.md` requires it over raw antd `Modal`, and it keeps the two
-  dialogs out of the migration's path.
-- `DriveFileEditor.tsx` uses `SharedEditor`, `EditorProvider`, and the existing `Markdown`
-  component. No antd.
-- `driveEdit.ts`, `driveEditState.ts`, `driveEditSave.ts`, `useDriveEdit.ts` have no React and no
-  antd by construction.
-
-So the whole feature concentrates raw antd into two new files. After #5643 merges, the fixup is
-two import lines.
+After #5643 merges the fixup is two import lines.
 
 **Lines not to touch:** the `CopyButton size="small"` occurrences in `DriveFilePreview.tsx`,
-`DriveHeader.tsx`, and `FolderView.tsx`. #5643 changes each of them to `size="icon-sm"`. Leaving
-them alone keeps the merge clean.
+`DriveHeader.tsx`, and `FolderView.tsx`. #5643 changes each to `size="icon-sm"`.
 
-## 9. Build order
+## 12. Accessibility
+
+- The header's `aria-live="polite"` region announces Saving, Saved, save errors, and conflicts.
+- `DriveTreePane`'s `interactive={false}` sets `inert` so the tree's focusable row buttons and
+  the focusable resize separator leave the tab order — pointer-events alone is not an interaction
+  boundary.
+- The guard modal returns focus to the editor on Keep editing.
+- Both light and dark themes are checked for every new state, not only the happy-path editor:
+  the error banner, the conflict banner, the disabled Edit tooltip, the saving spinner, the
+  Unsaved and Saved tags, and the guard modal.
+
+## 13. Build order
 
 Each step leaves the tree building and testable.
 
-1. `driveKinds.ts` gets `TEXT_CAP`; `renderers.tsx` re-exports it. No behaviour change.
-2. `driveEdit.ts` plus `driveEdit.test.ts`. Pure, no UI.
-3. `driveEditState.ts` plus `driveEditState.test.ts`. Pure, no UI.
-4. `driveEditSave.ts` and the `mountFileWrittenResponseSchema` addition. Verify the write against
-   the local stack with a scratch call before any UI exists.
-5. `DriveFileEditor.tsx` and `DriveEditBar.tsx`, wired into `DriveFilePreview` and
-   `DriveExplorer`. At the end of this step a `.txt` file edits and saves, with no guard, no
-   banner, and no conflict handling.
-6. `useDriveEdit.ts`: the guard, `DriveEditGuardModal`, the key bindings, the tree pane going
-   inert, the header chips, the tree-row dot.
-7. `DriveEditBanner.tsx`, the pre-write check, self-write suppression, the activity subscription,
-   `DriveEditDiffModal.tsx`.
-8. Markdown Source/Preview.
-9. Both themes, then the five-extension QA matrix.
-10. `pnpm lint-fix` inside `web/`.
+1. `driveKinds.ts` gets `TEXT_CAP` and exports `CODE_LANGS`; `renderers.tsx` re-exports the cap.
+   No behaviour change.
+2. Package: `mountFileWrittenResponseSchema`, `writeMountFile`, and the three barrel exports.
+   Verify the write against the local stack with a scratch call before any UI exists.
+3. `editMode/model.ts` + `model.test.ts`. Pure, no UI.
+4. `editMode/state.ts` + `state.test.ts`. Pure, no UI.
+5. `editMode/api.ts` and `invalidateMountListings`.
+6. `DriveFileEditor` and `DriveEditBar`, wired through `DriveFilePreview` and `DriveExplorer`.
+   At the end of this step a `.txt` file edits and saves, with no guard and no conflict handling.
+7. The controller: guard modal owned by `FilesDrawer`, the held `initialPath`, the guarded
+   `select`, drop disabled while editing, `DriveTreePane` inertness, key bindings, header chips,
+   tree-row dot.
+8. `DriveEditBanner`, the pre-write check, Reload from disk, Overwrite.
+9. Markdown Source/Preview, the session-teardown notice, the `aria-live` region.
+10. `controller.test.ts`.
+11. Both themes, then the five-extension QA matrix.
+12. `pnpm lint-fix` inside `web/`.
+
+Keep the reasoning in this document. Implementation comments are one short line each
+(`web/AGENTS.md`); the only two that earn a line are the multipart-body constraint and the
+stale-request check.

--- a/docs/design/file-drawer-edit-mode/plan.md
+++ b/docs/design/file-drawer-edit-mode/plan.md
@@ -1,0 +1,679 @@
+# Implementation plan
+
+Read `research.md` first. Three of its corrections change the API this plan calls.
+
+Everything lives under `web/oss/src/components/Drives/`. Paths below are relative to that
+directory unless they start with `web/`.
+
+## 1. The state machine
+
+### The twelve names and what they actually are
+
+The spec lists twelve states. They are not twelve values of one variable. Three of them describe
+the file before any editing starts, two describe how the buffer is rendered, and one is a
+pending exit. Storing them as a flat enum produces an unreachable-combination mess (a file can
+be dirty and in preview and in conflict at the same time).
+
+So the stored state is a small record, and the twelve spec names are a **derived label**
+computed from it. The derived label exists so the code and the spec share one vocabulary, and so
+the state machine can be unit-tested against the spec name by name.
+
+Stored record, one per open buffer:
+
+```ts
+// driveEditState.ts
+export interface DriveEditBuffer {
+    mountId: string
+    /** Mount-relative path. The write target. */
+    path: string
+    /** Presented path with any `agent-files/` prefix. Breadcrumb, tree row, dialog copy. */
+    displayPath: string
+    /** Bytes as read when the buffer opened. Dirty is measured against this. */
+    original: string
+    draft: string
+    /** mtime of the file when the buffer opened; null when the store omitted it. */
+    baseMtime: number | null
+    phase: "clean" | "dirty" | "saving" | "saved"
+    view: "source" | "preview"
+    banner: EditBanner | null
+    pendingExit: ExitIntent | null
+    /** Set by "Save anyway". Skips the pre-write mtime check for exactly one attempt. */
+    forceNextSave: boolean
+    /** When the save landed. Drives the two-second Saved chip. */
+    savedAt: number | null
+    /** Aborts an in-flight save when Cancel is pressed during `saving`. */
+    abort: AbortController | null
+}
+
+export type EditBanner =
+    | {kind: "error"; message: string}
+    | {kind: "conflict"; theirMtime: number | null}
+
+export type ExitIntent =
+    | {kind: "cancel"}
+    | {kind: "close"}
+    | {kind: "select"; path: string}
+    | {kind: "filter"; run: () => void}
+    | {kind: "reload-theirs"}
+```
+
+The three pre-edit names come from a pure function over the selected file, not from the record:
+
+```ts
+// driveEdit.ts
+export type DriveEditAffordance = "offer" | "capped" | "hidden"
+```
+
+Derived label:
+
+| Spec name | Condition |
+|---|---|
+| `read` | no buffer, affordance `offer` |
+| `locked` | no buffer, affordance `hidden` |
+| `capped` | no buffer, affordance `capped` |
+| `confirm` | `pendingExit != null` |
+| `conflict` | `banner?.kind === "conflict"` |
+| `error` | `banner?.kind === "error"` |
+| `saving` | `phase === "saving"` |
+| `saved` | `phase === "saved"` |
+| `preview` | `view === "preview"` |
+| `clean` | `phase === "clean"` |
+| `dirty` | `phase === "dirty"` |
+| `code` | buffer mode is `code` (orthogonal, reported alongside the label) |
+
+`deriveEditStatus(buffer, affordance)` evaluates that table top to bottom and returns the first
+match. The precedence is deliberate and matches the spec's own rendering rules: the guard dialog
+sits over everything; the banner slot holds exactly one banner ("uses the same banner slot as
+the conflict case, so only one can ever be shown"); phase beats view.
+
+`code` is not returned by `deriveEditStatus`. It is a second value, `driveEditBufferMode(path)`
+returning `"markdown" | "code"`, because the spec's own note says everything else about the
+`code` state is identical: "One state machine for all text kinds."
+
+### Where the state lives
+
+```ts
+// driveEditState.ts
+export const driveEditBufferAtomFamily = atomFamily(
+    (_driveKey: string) => atom<DriveEditBuffer | null>(null),
+)
+```
+
+**Keyed by the drive's mount id** (`drive.mount?.id ?? ""`), the same key
+`driveSelectionAtomFamily` already uses in `useDriveSelection.ts`. Reasons:
+
+- The value is a single nullable buffer, never a map. One drive therefore cannot hold two
+  buffers. That is the "one file at a time" rule enforced by the type, not by a check.
+- Module-level, so it survives the drawer's `destroyOnClose` remount the same way the persisted
+  selection does. A user who accidentally closes the drawer does not silently lose a buffer,
+  though the guard should have caught them first.
+- Scoped per drive, so the chat host and the config host cannot fight over one slot if both
+  ever mount at once.
+
+Derived read atoms in the same file:
+
+```ts
+export const driveEditDirtyAtomFamily      // buffer != null && draft !== original
+export const driveEditStatusAtomFamily     // deriveEditStatus(...) for display and tests
+export const driveEditPathAtomFamily       // the display path, or null. Read by DriveTreeRow
+                                           // for the dirty dot, so the dot needs no prop drilling.
+```
+
+Write-only action atoms, one per transition. Every one of them is pure state manipulation with
+no I/O, so the whole machine tests with a bare `createStore()` and no React:
+
+| Atom | From | To |
+|---|---|---|
+| `openEditBufferAtom({mountId, path, displayPath, original, baseMtime})` | no buffer | `clean` |
+| `setEditDraftAtom(text)` | `clean` or `dirty` | `dirty`, or back to `clean` when text equals `original` |
+| `setEditViewAtom("source" \| "preview")` | any | same phase, new `view` |
+| `requestEditExitAtom(intent)` | `clean` | runs the intent, clears the buffer |
+| | `dirty` / banner set | sets `pendingExit`, renders the guard |
+| `resolveEditExitAtom("keep")` | `pendingExit` set | clears `pendingExit`, phase unchanged |
+| `resolveEditExitAtom("discard")` | `pendingExit` set | runs the intent, clears the buffer |
+| `resolveEditExitAtom("save")` | `pendingExit` set | starts a save; the intent runs on success |
+| `startEditSaveAtom(abort)` | `clean` / `dirty` | `saving`, clears any banner |
+| `editSaveSucceededAtom({size, mtime})` | `saving` | `saved` if draft unchanged during the write, otherwise `dirty` |
+| `editSaveFailedAtom(message)` | `saving` | `dirty`, `banner = {kind:"error"}`, draft untouched |
+| `markEditConflictAtom(theirMtime)` | any open buffer | `banner = {kind:"conflict"}` |
+| `forceNextEditSaveAtom()` | `conflict` banner | clears the banner, sets `forceNextSave` |
+| `adoptTheirsAtom({content, mtime})` | any open buffer | replaces `original`, `draft`, `baseMtime`; phase `clean`; clears the banner |
+| `closeEditBufferAtom()` | any | no buffer |
+
+Setting either banner clears the other. That is one line in the reducer and it is what makes the
+"only one banner can ever be shown" rule impossible to violate.
+
+`editSaveSucceededAtom` returning to `dirty` instead of `saved` when the draft moved during the
+write is the spec's rule: "If the user has already typed again during the write, stay in edit
+mode and go straight back to dirty."
+
+### Exit routes that must run through the guard
+
+The spec names five, and they all call `requestEditExitAtom`:
+
+| Route | Where it is intercepted |
+|---|---|
+| Cancel button | `DriveHeader` edit cluster |
+| Escape | drawer-level `keydown` in `useDriveEdit` |
+| Closing the drawer | `DriveExplorer` wraps the `onClose` it passes to `DriveHeader` |
+| Selecting another file or folder | `DriveExplorer` wraps `select` before handing it to the tree, the breadcrumb, the folder grid, and `DriveFilePreview` |
+| Changing a filter | not reachable: the edit bar replaces the toolbar, so search, origin, and the visibility toggles are unmounted while editing. The intent kind stays in the union for the browser-unload case and for any future control that survives the swap. |
+| Browser unload | `beforeunload` listener in `useDriveEdit`, registered only while dirty. The browser shows its own dialog; ours cannot run there. |
+
+## 2. Files that change and how
+
+### Existing files
+
+**`driveKinds.ts`**: move `TEXT_CAP` here from `renderers.tsx` and export it. This module is
+deliberately React-free and renderer-free so light consumers can import it; the edit gate is
+exactly such a consumer and must not pull the Shiki and Markdown graph in to read a number. Add
+nothing else.
+
+**`renderers.tsx`**: one line: `export {TEXT_CAP} from "./driveKinds"` and import it from there
+for the existing cap checks. One definition, both readers. No other change to this file.
+
+**`DriveHeader.tsx`**: add one optional prop group:
+
+```ts
+edit?: {
+    affordance: DriveEditAffordance
+    editing: boolean
+    dirty: boolean
+    saved: boolean
+    saving: boolean
+    onEdit: () => void
+    onCancel: () => void
+    onSave: () => void
+}
+```
+
+Three changes inside:
+
+1. In the browsing cluster, between the details toggle and `DriveFileDownloadButton`, render an
+   Edit button when `affordance === "offer"`, or a disabled Edit button with a tooltip naming the
+   cap when `affordance === "capped"`. Render nothing when `hidden`. Secondary style, never
+   primary: Download stays the loudest action for a reader.
+2. When `edit.editing`, replace the whole right-hand cluster (upload, copy, details, download,
+   overflow) with Cancel and Save. Save is `type="primary"` and disabled unless dirty; during
+   `saving` it shows the antd `loading` spinner and reads "Saving". Cancel stays enabled during
+   `saving` so a slow mount does not trap anyone.
+3. Next to the origin `Tag`, render an "Unsaved" `Tag` when dirty, or a success-toned "Saved"
+   `Tag` when `saved`. Both reuse the already-imported `Tag`.
+
+Do not touch the `CopyButton size="small"` line. The antd migration branch changes it.
+
+**`DriveToolbar.tsx`**: unchanged. `DriveExplorer` chooses between it and `DriveEditBar`. Adding
+an `editing` flag to `DriveToolbar` would mean threading every filter prop through a component
+that renders none of them while editing, and would grow that file's antd surface for no gain.
+
+**`DriveFilePreview.tsx`**: when a buffer is open for this file, render `DriveFileEditor`
+instead of `DriveFileContentViewer`. The meta band above it is unchanged and still obeys
+`detailsOpen`. Do not touch its `CopyButton size="small"` line.
+
+**`DriveFileContentViewer.tsx`**: unchanged.
+
+**`DriveTreeRow.tsx`**: read `driveEditPathAtomFamily` and render a small dot on the row whose
+path matches. The spec asks for exactly two dirty affordances, one dot each: this one and the
+header chip.
+
+**`DriveExplorer.tsx`**: the composition work:
+
+- call `useDriveEdit({drive, selectedPath, select, onClose, canUpload})`
+- swap `<DriveToolbar/>` for `<DriveEditBar/>` while editing
+- pass the `edit` prop group to `DriveHeader`
+- pass the guarded `select` to the tree, the breadcrumb, the folder grid, and the preview
+- render `<DriveEditBanner/>` between the second header row and the body, in the one banner slot
+- render `<DriveEditGuardModal/>` and `<DriveEditDiffModal/>` at the end of the chrome branch
+- while editing, give the tree pane `pointer-events-none opacity-45` and `inert`, so its scroll
+  position and expanded folders survive
+
+### New files
+
+| File | Contents | React? | antd? |
+|---|---|---|---|
+| `driveEdit.ts` | Pure helpers: `EDIT_KINDS`, `driveEditAffordance`, `driveEditBufferMode`, `driveEditorLanguage`, `isEditDirty`, `deriveEditStatus`, `conflictFromActivity` | no | no |
+| `driveEditState.ts` | The atom family and every action atom above | no | no |
+| `driveEditSave.ts` | The Fern call, the pre-write mtime re-check, cache invalidation | no | no |
+| `useDriveEdit.ts` | Wires atoms to the drawer: reads the original bytes, runs the save, subscribes to file activity, binds the keys | hook | no |
+| `DriveEditBar.tsx` | Header row 2 while editing: "Editing" label, Source/Preview segmented for markdown, language chip for code, the hint line | yes | `Segmented`, `Button`, `Tooltip` |
+| `DriveFileEditor.tsx` | The editor pane: `SharedEditor` in an `EditorProvider`, the markdown synchroniser, the preview pane, the status footer | yes | no |
+| `DriveEditBanner.tsx` | The one banner slot: error with Try again, conflict with View diff / Reload theirs / Save anyway | yes | `Alert`, `Button` |
+| `DriveEditGuardModal.tsx` | Discard dialog. `EnhancedModal` from `@agenta/ui/components` | yes | no |
+| `DriveEditDiffModal.tsx` | View diff. `computeTextDiffLines` list, or `DiffView` for the `json` kind | yes | no |
+| `driveEdit.test.ts` | Unit tests for the pure helpers | no | no |
+| `driveEditState.test.ts` | Unit tests for the transitions | no | no |
+
+## 3. Reusing the editor components
+
+### Which wrapper, and why not the other one
+
+Use `SharedEditor` from `@agenta/ui/shared-editor`, wrapped in our own `EditorProvider` from
+`@agenta/ui/editor`.
+
+Do **not** use `SimpleSharedEditor`. It sniffs the content on every render and forces the editor
+into JSON, YAML, or HTML mode when the text happens to parse as one
+(`SimpleSharedEditor/index.tsx:288-311`). A `.txt` file containing a single JSON object would
+silently become a JSON code editor with a format dropdown. It also renders its own header with
+Format, Copy, and Minimize controls, which duplicates what the edit bar owns. Its value is the
+prompt-field use case, not a file buffer.
+
+The right precedent to copy is `ChatMessageEditor.tsx` in `@agenta/ui`: same `EditorProvider` +
+`SharedEditor` + `noProvider` shape, and it already solves the markdown-view dispatch race.
+
+### The editor call
+
+```tsx
+// DriveFileEditor.tsx
+const mode = driveEditBufferMode(path)          // "markdown" | "code"
+const language = driveEditorLanguage(path)      // CodeLanguage, only used when mode === "code"
+const editorId = `drive-edit-${mountId}-${path}`
+
+<EditorProvider
+    codeOnly={mode === "code"}
+    language={mode === "code" ? language : undefined}
+    enableTokens={false}
+    showToolbar={false}
+    disabled={phase === "saving"}
+    id={editorId}
+>
+    <SharedEditor
+        id={editorId}
+        editorType="borderless"
+        state={phase === "saving" ? "readOnly" : "filled"}
+        initialValue={original}
+        value={draft}
+        handleChange={onDraftChange}
+        disableDebounce
+        noProvider
+        autoFocus
+        editorProps={{
+            codeOnly: mode === "code",
+            language: mode === "code" ? language : undefined,
+            noProvider: true,
+            showToolbar: false,
+            enableTokens: false,
+        }}
+        footer={<DriveEditStatusBar mode={mode} language={language} savedAt={savedAt} />}
+        className={view === "preview" ? "hidden" : undefined}
+    />
+    {mode === "markdown" ? <MarkdownSourceSynchronizer editorId={editorId} /> : null}
+</EditorProvider>
+```
+
+Prop-by-prop, with the reason each value is what it is:
+
+- `editorType="borderless"`: the pane already draws the inset border. A second border reads as a
+  nested box.
+- `state`: `"readOnly"` while saving. The spec chose this over an overlay: "typing into a buffer
+  that's mid-flight is the bug this prevents." The other five values in the union are not used;
+  `filled` covers every other phase and focus is handled by the component's own tracking.
+- `disableDebounce`: required. The default is a 300 ms `useDebounceInput` window
+  (`SharedEditor.tsx:76-81`). Dirty tracking has to be keystroke-accurate, or Save stays disabled
+  for a third of a second after the first keystroke and the guard can miss a change typed
+  immediately before Escape.
+- `initialValue` + `value`: `SharedEditor` uses `initialValue` for the mount-time Lexical seed
+  and `value` for the controlled sync (`SharedEditor.tsx:71-73`). Pass `original` and `draft`.
+  Do not pass `syncWithInitialValueChanges`: it would re-seed the buffer when the underlying
+  query refetches, which is exactly the overwrite we are trying to prevent.
+- `noProvider` on both the wrapper and `editorProps`: we own the provider, as `ChatMessageEditor`
+  does.
+- `autoFocus`: the spec wants focus in the editor on open, cursor at the start of the document.
+- `footer`: the status bar (language, `UTF-8`, cursor position, last-saved). Uses the slot rather
+  than a sibling so it sits inside the editor's border.
+
+### Source and preview for markdown
+
+Two separate mechanisms, and it is easy to conflate them.
+
+**The buffer is always raw markdown source.** `MarkdownSourceSynchronizer` pins
+`SET_MARKDOWN_VIEW` to `true` for the life of a markdown buffer, and sets `markdownViewAtom(editorId)`
+to `true` so the CSS flag agrees with the node state. It is a direct copy of
+`MarkdownViewSynchronizer` from `ChatMessageEditor.tsx:88-104`, including both dispatches:
+a `useLayoutEffect` for the steady state, and a `requestAnimationFrame` in a `useEffect` for the
+mount race where the layout effect fires before `MarkdownPlugin` registers the command. Setting
+the atom alone does nothing; the comment in `ChatMessageEditorProps.markdownView` says so and the
+plugin confirms it. Editing markdown as rich text would round-trip the file through the markdown
+serialiser on every keystroke and reflow formatting the user never touched.
+
+**Preview is a separate pane.** The Source/Preview segmented in the edit bar sets
+`buffer.view`. In `preview`, the `SharedEditor` gets `className="hidden"` (it stays mounted, so
+cursor position and undo history survive the round trip) and we render the existing `Markdown`
+component from `@/oss/components/AgentChatSlice/assets/markdown` over `draft`, inside the same
+scroll container `TextBody` uses (`renderers.tsx:153-160`). That satisfies the spec's requirement
+that nothing shifts between preview and the read-only view after save, because it is literally
+the same component.
+
+Preview is offered only when `mode === "markdown"`. For `code` the edit bar shows the language
+chip instead, so the bar does not reflow.
+
+### codeOnly and the language mapper
+
+`driveEditorLanguage(path)` maps the Shiki id from `driveCodeLanguage(path)` into the six-value
+`CodeLanguage` union (see `research.md` correction 4):
+
+```
+json, yaml            -> "json" / "yaml"
+python                -> "python"
+javascript, jsx, mjs  -> "javascript"
+typescript, tsx       -> "typescript"
+everything else       -> "code"
+```
+
+`"code"` is the union's generic highlighter and is the honest answer for shell, Rust, Go, CSV,
+plain text, and `.env`. A unit test asserts every value in `CODE_LANGS` maps into the union, so
+adding a language to `driveKinds.ts` later cannot produce a type error at a call site far away.
+
+### DiffView and the conflict diff
+
+`DriveEditDiffModal.tsx` shows the mount's current bytes against the buffer.
+
+- kind `json`: `<DiffView language="json" original={theirs} modified={draft} />`. This is the one
+  case `DiffView` handles correctly.
+- every other kind: `computeTextDiffLines(theirs, draft, {contextLines: 3, enableFolding: true,
+  foldThreshold: 5})` from `@agenta/ui/diff`, rendered as a list of lines coloured by
+  `line.type`. `DiffView` cannot be used here; `research.md` correction 2 has the evidence.
+
+## 4. The save path
+
+```ts
+// driveEditSave.ts
+import {getMountsClient, projectScopedRequest} from "@agenta/entities/session"
+
+export async function writeDriveFile({
+    mountId, path, content, projectId, signal,
+}): Promise<{ok: true; size: number} | {ok: false; message: string}> {
+    const name = path.split("/").pop() || "file"
+    const file = new File([content], name, {type: "text/plain"})
+    try {
+        const written = await getMountsClient().uploadMountFile(
+            {mount_id: mountId, path, file},
+            projectScopedRequest(projectId, undefined, signal, 0),
+        )
+        const parsed = safeParseWithLogging(
+            mountFileWrittenResponseSchema, written, "[writeDriveFile]",
+        )
+        return {ok: true, size: parsed?.size ?? content.length}
+    } catch (error) {
+        if (isAbortError(error)) throw error
+        return {ok: false, message: toWriteErrorMessage(error)}
+    }
+}
+```
+
+Notes on each choice:
+
+- `uploadMountFile`, not `writeMountFile`. The generated `writeMountFile` sends no body and would
+  truncate the file. Both endpoints call the same `MountsService.write_file`. `research.md`
+  correction 1 has the proof.
+- `path` is the full mount-relative path. `upload_mount_file` uses the query `path` verbatim
+  unless it is empty or ends in `/` (`api/oss/src/apis/fastapi/mounts/utils.py:79-83`), so a
+  full path overwrites exactly that object.
+- `projectScopedRequest(..., signal, 0)`. `maxRetries: 0` because a write must never be retried
+  transparently: a retried PUT after a timeout can land after the user has already edited again.
+- Not `callFern`. It converts every failure into `null` and the error state needs the message.
+  Aborts are rethrown so Cancel during `saving` unwinds cleanly.
+- A zod parse at the boundary, per `web/AGENTS.md`. Add `mountFileWrittenResponseSchema` to
+  `packages/agenta-entities/src/session/core/schema.ts` next to the existing mount schemas
+  (`{path: z.string(), size: z.number().nullish()}`), since none exists yet.
+
+### What is invalidated after a successful write
+
+In order, and deliberately narrow:
+
+1. `queryClient.setQueryData(mountFileContentQueryKey(projectId, mountId, path), draft)`:
+   seed the cache with the bytes we just wrote. This is what lets the drawer return to the
+   read-only view with the saved text already rendered, with no refetch and no skeleton flash.
+2. `queryClient.invalidateQueries({queryKey: mountDirQueryKey(projectId, mountId, parentDir)})`:
+   the file's own directory level. This refreshes `size` and `mtime` for the tree row and the
+   header chip, and it is how we learn the post-write mtime the response does not carry.
+3. `queryClient.invalidateQueries({queryKey: ["mounts", "files", projectId, mountId]})`: the
+   whole-mount listing, used by the recents and the search view.
+
+Do **not** call `revalidateSessionMountsAtom`. It invalidates every mount in the project plus
+every cached body (`mounts.ts:219-247`), which is right for a finished agent turn and far too
+wide for a one-file save.
+
+## 5. Conflict detection
+
+Two independent triggers. Neither is sufficient alone.
+
+### Trigger one: the file-activity signal
+
+`useDriveEdit` subscribes to `latestSessionFileActivityAtomFamily(sessionId)` with
+`sessionId = useDriveSessionId()`. A pure predicate decides:
+
+```ts
+// driveEdit.ts
+export function conflictFromActivity(
+    entry: SessionFileActivityEntry | null,
+    buffer: DriveEditBuffer | null,
+    selfWriteUntil: number,
+): boolean {
+    if (!entry || !buffer) return false
+    if (entry.resolved?.mountId !== buffer.mountId) return false
+    if (entry.resolved?.path !== buffer.path) return false
+    if (entry.at <= buffer.openedAt) return false
+    if (entry.at <= selfWriteUntil) return false
+    return true
+}
+```
+
+Limitation, stated plainly: the config-panel host does not mount `DriveSessionProvider`, so
+`useDriveSessionId()` returns null there and this trigger never fires. Trigger two covers that
+host. This is not worth fixing by threading a session id through the config host, because the
+pre-write check is the one that actually prevents data loss; the activity signal only makes the
+warning arrive earlier.
+
+### Trigger two: the pre-write modification-time check
+
+The spec requires the conflict be "re-checked immediately before every write". Before calling
+`writeDriveFile`, and unless `forceNextSave` is set:
+
+1. `await queryClient.fetchQuery({queryKey: mountDirQueryKey(projectId, mountId, parentDir), ...})`
+   with `staleTime: 0`, so it goes to the network.
+2. Find the entry whose `path` matches and read its `mtime`.
+3. If both `mtime` and `buffer.baseMtime` are non-null and differ, do not write. Call
+   `markEditConflictAtom(theirMtime)` and stop. Otherwise proceed.
+
+A null on either side means the object store did not report a time, and the check cannot fire.
+That is a silent degradation, so it is recorded in `status.md` rather than hidden.
+
+`baseMtime` at open comes from the directory listing already cached for the file's folder
+(`mountDirQueryFamily`), falling back to the drive's `recents` entry, falling back to null.
+
+### The write response has no modification time
+
+`MountFileWrittenResponse` returns `path` and `size` only. Handled in two parts, neither of which
+touches the backend:
+
+**Self-write suppression.** On a successful save, set a module-level
+`selfWriteUntil = Date.now() + SELF_WRITE_GRACE_MS` (5000) for that `(mountId, path)`.
+`conflictFromActivity` ignores any activity entry inside that window, and the pre-write check is
+skipped for the same window. Without this, the invalidation we fire ourselves in step 2 above
+would return a new mtime and raise a conflict against our own bytes.
+
+**Adopt the real mtime one refetch later.** The directory invalidation lands within the grace
+window. When it does, and the buffer is still open (the user kept editing after saving), read the
+fresh entry's mtime and write it into `buffer.baseMtime`. The window closes and conflict
+detection is armed again against a true value.
+
+The effect is that "no mtime on the write response" costs one extra listing refetch we were
+already firing, and a five-second window in which a conflict raised by someone else would be
+missed. That window is acceptable: the pre-write check on the *next* save still catches it, and
+the alternative is a backend change that turns a frontend PR into a cross-stack one.
+
+### The three ways out of a conflict
+
+- **View diff** opens `DriveEditDiffModal` with the freshly-fetched mount bytes as original and
+  the draft as modified.
+- **Reload theirs** routes through the guard when dirty (it discards the buffer), then invalidates
+  and refetches `mountFileContentQueryKey`, then calls `adoptTheirsAtom({content, mtime})`.
+- **Save anyway** calls `forceNextEditSaveAtom()` and then saves. The flag clears after one
+  attempt, so a second conflict is caught normally. The button copy says it overwrites.
+
+## 6. Which files can be edited
+
+### The rule
+
+```ts
+// driveEdit.ts
+export const EDIT_KINDS = new Set<DriveFileKind>([
+    "markdown", "text", "code", "json", "csv", "html",
+])
+
+export function driveEditAffordance({kind, size, canWrite}): DriveEditAffordance {
+    if (!canWrite) return "hidden"
+    if (!EDIT_KINDS.has(kind)) return "hidden"
+    if (size != null && size > TEXT_CAP) return "capped"
+    return "offer"
+}
+```
+
+`kind` comes from `resolveDriveFileKind(path)`. There is no second extension list anywhere in
+this feature. `TEXT_CAP` is the existing 1.5 MB constant, moved to `driveKinds.ts` and imported
+here. `canWrite` is the drawer's existing `canUpload`
+(`isAgentFileUploadsEnabled() && !explicitFiles && !!drive.mount`), which is the closest thing to
+a writable-mount answer the frontend has. `mountSchema` has no read-only flag to read and we do
+not invent one.
+
+`hidden` renders no Edit button at all. `capped` renders it disabled with a tooltip naming the
+cap. The spec's reasoning: a category is not a limit, and a disabled Edit on every image would
+train people to ignore the button.
+
+### The five extensions the user will QA
+
+| Extension | `resolveDriveFileKind` | Affordance | Buffer mode | Read view today | What editing does |
+|---|---|---|---|---|---|
+| `.txt` | `text` | offer | `code`, language `code` | `TextBody`, a `<pre>` | plain source buffer, verbatim round trip |
+| `.csv` | `csv` | offer | `code`, language `code` | `CsvBody`, a parsed table | swaps to a plain source buffer over the raw text; the table returns after save |
+| `.md` | `markdown` | offer | `markdown` | `TextBody` rendering `Markdown` | raw markdown source, with a Preview pane using the same `Markdown` component |
+| `.env` | `text` | offer | `code`, language `code` | `TextBody`, a `<pre>` | same as `.txt` |
+| `.json` | `json` | offer | `code`, language `json` | `CodeBody`, pretty-printed | source buffer seeded from the **raw** content, not from the pretty print |
+
+Three of these carry a trap worth stating:
+
+**`.json` must not be seeded from the read view.** `CodeBody` runs
+`JSON.stringify(JSON.parse(content), null, 2)` before displaying
+(`renderers.tsx:178-186`). Seeding the buffer from that reformats the entire file the moment the
+user changes one line. Seed from `useDriveFileText` directly, which returns the raw content
+string.
+
+**`.csv` becomes text while editing.** The spec lists `csv` among the editable kinds and there is
+no cell editor here. The table is a read view only.
+
+**`.env` works, `.env.local` does not.** `resolveDriveFileKind(".env")` returns `text` because
+the pattern `/\.(txt|log|env)$/i` matches a leading dot. `.env.local` matches nothing and lands on
+`other`, which shows the download card and offers no Edit. Widening the resolver would change the
+read-only viewer's behaviour for every host, so it stays out of this PR and is logged in
+`status.md`. Also note `.env` is a dotfile: it appears only with the hidden-files toggle on, which
+is its default (`useDriveFilters.ts:16`).
+
+For completeness on the non-QA kinds: `.html` is editable as a `code` buffer (its read view has
+its own Preview/Source toggle, which is unrelated and untouched); `image`, `pdf`, `audio`,
+`video`, and `other` are `hidden`.
+
+## 7. Test plan
+
+Vitest, colocated, following `dropEntries.test.ts`. No snapshot tests of the rendered drawer.
+
+### `driveEdit.test.ts` (pure helpers)
+
+- `resolveDriveFileKind` for `.txt`, `.csv`, `.md`, `.env`, `.json`, plus `agent-files/.env`,
+  `.env.local`, `.png`, `.pdf`, `README`. This locks the dotfile behaviour that the whole `.env`
+  story rests on.
+- `driveEditAffordance` across the matrix: every kind, times `{size under cap, size exactly cap,
+  size over cap, size null}`, times `{canWrite true, canWrite false}`. Assert `capped` only ever
+  appears for a kind in `EDIT_KINDS`, and that `size == null` never produces `capped`.
+- `driveEditBufferMode`: `markdown` only for markdown extensions, `code` for everything else.
+- `driveEditorLanguage`: every key of `CODE_LANGS` maps into the six-value `CodeLanguage` union,
+  and `.json` maps to `json`, `.yaml` to `yaml`, `.py` to `python`, `.sh` to `code`.
+- `isEditDirty`: differs, identical, identical after retyping, trailing-newline difference,
+  empty original.
+- `deriveEditStatus`: one assertion per spec name, twelve in total, each with the minimal record
+  that produces it. Plus the precedence cases: dirty and in preview returns `preview`; dirty with
+  a conflict banner returns `conflict`; conflict with a pending exit returns `confirm`.
+- `conflictFromActivity`: matching path and mount, wrong mount, wrong path, entry timestamped
+  before the buffer opened, entry inside the self-write grace window, null entry, null buffer.
+
+### `driveEditState.test.ts` (transitions)
+
+Uses a bare jotai `createStore()`. No React, no rendering.
+
+- open puts the machine in `clean` with Save disabled.
+- one edit gives `dirty`; editing back to the original text returns to `clean`.
+- `clean` plus `requestEditExitAtom` runs the intent immediately, with no guard.
+- `dirty` plus `requestEditExitAtom` sets `pendingExit` and does not run the intent.
+- `resolveEditExitAtom("keep")` clears `pendingExit` and leaves the phase and the draft alone.
+- `resolveEditExitAtom("discard")` runs the intent and clears the buffer.
+- `resolveEditExitAtom("save")` starts a save and runs the intent only after success. A failed
+  save leaves the intent unrun and the buffer alive.
+- `saving` then `editSaveSucceededAtom` gives `saved`. `saving`, then an edit, then
+  `editSaveSucceededAtom` gives `dirty`, not `saved`.
+- `editSaveFailedAtom` gives `dirty` with an error banner and a character-identical draft.
+- `markEditConflictAtom` while an error banner is showing replaces it, and the reverse. Assert
+  the two banners never coexist.
+- `forceNextEditSaveAtom` clears the conflict banner and sets `forceNextSave`; the flag is
+  cleared by the next `startEditSaveAtom`.
+- `adoptTheirsAtom` replaces original, draft, and `baseMtime`, and returns the phase to `clean`.
+- opening a second file while a buffer is open: `requestEditExitAtom({kind:"select"})` is what
+  runs, the atom value is still exactly one object, and the new selection does not apply until
+  the guard resolves.
+
+### What is deliberately not unit-tested
+
+The Lexical editor itself, the `SET_MARKDOWN_VIEW` dispatch timing, and the antd rendering. Those
+are covered by the live QA matrix in `CONTEXT.md`, which is where the markdown source toggle and
+the two themes actually get checked.
+
+## 8. The antd migration constraint
+
+PR #5643 rewrites `import {X} from "antd"` to `import {X} from "@agenta/ui/ui"` across the app.
+`@agenta/ui/ui` does not exist on `release/v0.109.0`, so nothing here can be written
+forward-compatible. The goal is instead to make the post-merge fixup mechanical and short.
+
+**antd imports this feature adds, in full:**
+
+| File | antd imports | Why here |
+|---|---|---|
+| `DriveEditBar.tsx` | `Segmented`, `Button`, `Tooltip` | The Source/Preview control is a segmented control by the spec's own drawing, and `Segmented` is what `DriveToolbar` and `renderers.tsx` already use for the same shape. |
+| `DriveEditBanner.tsx` | `Alert`, `Button` | `Alert` is already used elsewhere in `Drives/` and carries the error and warning tones the two banners need. |
+
+**Zero new antd import lines in existing files.** `DriveHeader.tsx` already imports `Button`,
+`Tooltip`, and `Tag`, which is everything its Edit / Cancel / Save / chip additions need.
+
+**Files that avoid antd entirely and why:**
+
+- `DriveEditGuardModal.tsx` and `DriveEditDiffModal.tsx` use `EnhancedModal` from
+  `@agenta/ui/components`. `web/AGENTS.md` requires it over raw antd `Modal`, and it keeps the two
+  dialogs out of the migration's path.
+- `DriveFileEditor.tsx` uses `SharedEditor`, `EditorProvider`, and the existing `Markdown`
+  component. No antd.
+- `driveEdit.ts`, `driveEditState.ts`, `driveEditSave.ts`, `useDriveEdit.ts` have no React and no
+  antd by construction.
+
+So the whole feature concentrates raw antd into two new files. After #5643 merges, the fixup is
+two import lines.
+
+**Lines not to touch:** the `CopyButton size="small"` occurrences in `DriveFilePreview.tsx`,
+`DriveHeader.tsx`, and `FolderView.tsx`. #5643 changes each of them to `size="icon-sm"`. Leaving
+them alone keeps the merge clean.
+
+## 9. Build order
+
+Each step leaves the tree building and testable.
+
+1. `driveKinds.ts` gets `TEXT_CAP`; `renderers.tsx` re-exports it. No behaviour change.
+2. `driveEdit.ts` plus `driveEdit.test.ts`. Pure, no UI.
+3. `driveEditState.ts` plus `driveEditState.test.ts`. Pure, no UI.
+4. `driveEditSave.ts` and the `mountFileWrittenResponseSchema` addition. Verify the write against
+   the local stack with a scratch call before any UI exists.
+5. `DriveFileEditor.tsx` and `DriveEditBar.tsx`, wired into `DriveFilePreview` and
+   `DriveExplorer`. At the end of this step a `.txt` file edits and saves, with no guard, no
+   banner, and no conflict handling.
+6. `useDriveEdit.ts`: the guard, `DriveEditGuardModal`, the key bindings, the tree pane going
+   inert, the header chips, the tree-row dot.
+7. `DriveEditBanner.tsx`, the pre-write check, self-write suppression, the activity subscription,
+   `DriveEditDiffModal.tsx`.
+8. Markdown Source/Preview.
+9. Both themes, then the five-extension QA matrix.
+10. `pnpm lint-fix` inside `web/`.

--- a/docs/design/file-drawer-edit-mode/qa.md
+++ b/docs/design/file-drawer-edit-mode/qa.md
@@ -1,0 +1,261 @@
+# Live QA script — file drawer edit mode
+
+Manual walkthrough for a human, run against a deployed stack with a live agent session.
+Every step states the expected result. Anything that does not match is a bug — record it
+with the file type and step number.
+
+## 0. Setup
+
+1. Deploy the branch (`feat/file-drawer-edit-mode`) and open an agent session in the chat
+   view.
+2. Create the fixture files locally:
+
+   ```bash
+   mkdir -p /tmp/qa-edit && cd /tmp/qa-edit
+   printf 'hello world\nsecond line\n'                     > notes.txt
+   printf 'name,role\nada,eng\ngrace,eng\n'                > people.csv
+   printf '# Title\n\nSome *markdown* body.\n'             > readme.md
+   printf 'API_KEY=abc123\nDEBUG=false\n'                  > .env
+   printf '{\n  "mode": "fast",\n  "retries": 2\n}\n'      > config.json
+   head -c 2000000 /dev/urandom | base64 | head -c 1700000 > huge.txt   # ~1.7 MB, over the cap
+   # any small PNG/JPG works for the non-editable case
+   ```
+3. Open the session's **Files** drawer and drag all seven files into it. Wait until each
+   appears in the tree with a size.
+
+   **Expected:** all seven upload; the drawer header shows the drive breadcrumb; no error
+   toasts.
+
+Reference for the whole run:
+
+- The **Edit** button (pencil icon) sits in the drawer header's right-hand action cluster,
+  next to Download and the ⋯ overflow.
+- While editing, the header's action cluster gains **Cancel** and **Save**; an "Editing"
+  bar replaces the toolbar above the content.
+- **Save** is disabled until the buffer is dirty. Keyboard, with focus inside the drawer:
+  `Cmd/Ctrl+E` enters edit mode, `Cmd/Ctrl+S` saves, `Esc` cancels.
+- The size cap is 1.5 MB (1,572,864 bytes).
+
+---
+
+## 1. `.txt` — `notes.txt`
+
+1. Click `notes.txt` in the tree.
+   **Expected:** the right pane shows the plain-text body `hello world / second line`. The
+   header shows the file name and an enabled **Edit** button.
+2. Click **Edit**.
+   **Expected:** the content pane swaps to an editor with the file's text and a focused
+   caret. The toolbar row is replaced by an "Editing" bar showing a `Plain text` chip
+   (hover it: "Syntax highlighting only") and "Esc to cancel" on the right. The header now
+   shows **Cancel** and a **disabled** **Save**. No "Unsaved" tag yet.
+3. Append a line: `edited by qa`.
+   **Expected:** an orange **Unsaved** tag appears next to the file name; **Save** becomes
+   enabled.
+4. Click **Save**.
+   **Expected:** the button reads "Saving" briefly, then edit mode exits, the pane returns
+   to the read-only text view showing the new content, and a green **Saved** tag shows
+   next to the name. No error banner.
+5. Select a different file, then click `notes.txt` again.
+   **Expected:** the body still contains `edited by qa`.
+6. Close the drawer, reopen it, and open `notes.txt`.
+   **Expected:** `edited by qa` is still there — the change persisted to the mount, not
+   just to the client cache.
+
+---
+
+## 2. `.csv` — `people.csv`
+
+1. Click `people.csv`.
+   **Expected:** the read view renders a **parsed table** (columns `name`, `role`), not raw
+   text. **Edit** is enabled.
+2. Click **Edit**.
+   **Expected:** the table is replaced by a **raw source buffer** showing
+   `name,role / ada,eng / grace,eng`. The "Editing" bar shows the `Plain text` chip (no
+   Source/Preview toggle — that is markdown-only).
+3. Add a row: `linus,eng`.
+   **Expected:** **Unsaved** tag; **Save** enabled.
+4. Click **Save**.
+   **Expected:** edit mode exits and the pane returns to the **table** view, now with three
+   data rows including `linus`. **Saved** tag shown.
+5. Reopen the drawer and click `people.csv`.
+   **Expected:** the table still has the `linus` row.
+
+---
+
+## 3. `.md` — `readme.md`
+
+1. Click `readme.md`.
+   **Expected:** rendered markdown (a heading and italic text). **Edit** enabled.
+2. Click **Edit**.
+   **Expected:** a **source** buffer showing the raw markdown. The "Editing" bar shows a
+   **Source / Preview** segmented control with **Source** selected (this control appears
+   only for markdown).
+3. Change the heading to `# Title edited` and add a bullet list.
+   **Expected:** **Unsaved** tag; **Save** enabled.
+4. Click **Preview** in the Editing bar.
+   **Expected:** the pane renders the *draft* markdown, including the edit you just made
+   and the bullet list. The **Unsaved** tag stays; **Save** stays enabled.
+5. Click **Source**.
+   **Expected:** back to the raw buffer with the draft intact — nothing lost in the round
+   trip.
+6. Press `Cmd+S` (macOS) or `Ctrl+S`.
+   **Expected:** the file saves without touching the mouse; edit mode exits; the pane shows
+   the rendered markdown with your change; **Saved** tag.
+7. Reopen the drawer and click `readme.md`.
+   **Expected:** the rendered markdown still shows `Title edited` and the bullet list.
+
+---
+
+## 4. `.env` — `.env`
+
+1. Turn on hidden/dotfiles in the drawer toolbar if `.env` is not visible, then click it.
+   **Expected:** `.env` is treated as a **text** file — a plain-text body showing
+   `API_KEY=abc123`, **not** a "download this file" card. **Edit** enabled.
+   *(If `.env` renders as a download card, that is a bug: `resolveDriveFileKind` should map
+   it to the `text` kind.)*
+2. Click **Edit** and change `DEBUG=false` to `DEBUG=true`; add `REGION=eu`.
+   **Expected:** **Unsaved** tag; **Save** enabled.
+3. Click **Save**.
+   **Expected:** saves cleanly; read view shows the new values; **Saved** tag.
+4. Reopen the drawer and click `.env`.
+   **Expected:** `DEBUG=true` and `REGION=eu` persisted.
+
+---
+
+## 5. `.json` — `config.json`
+
+1. Click `config.json`.
+   **Expected:** a syntax-highlighted JSON body. **Edit** enabled.
+2. Click **Edit**.
+   **Expected:** a code buffer with JSON highlighting; the "Editing" bar shows a **JSON**
+   chip instead of `Plain text`; no Source/Preview toggle.
+3. Change `"retries": 2` to `"retries": 5` and add `"timeout": 30`.
+   **Expected:** **Unsaved** tag; **Save** enabled.
+4. Click **Save**.
+   **Expected:** saves; read view shows the new JSON. **Saved** tag.
+   *(Note: invalid JSON is still saved — the editor does not validate or reformat. Saving
+   deliberately broken JSON and getting the exact broken bytes back is correct behavior.)*
+5. Reopen the drawer and click `config.json`.
+   **Expected:** `"retries": 5` and `"timeout": 30` persisted, with whitespace exactly as
+   you typed it.
+
+---
+
+## 6. The unsaved-changes guard
+
+1. Open `notes.txt`, click **Edit**, and type something. Do **not** save.
+   **Expected:** **Unsaved** tag visible.
+2. Try to close the drawer (the drawer's close X, or click the mask outside it).
+   **Expected:** the drawer does **not** close. A modal appears titled **"Discard unsaved
+   changes?"** with body text naming the file ("`notes.txt` has changes that haven't been
+   saved. Leaving now discards them.") and two buttons: **Keep editing** and **Discard**.
+   The modal cannot be dismissed by clicking its mask or pressing Escape.
+3. Click **Keep editing**.
+   **Expected:** the modal closes, the drawer stays open, and your draft text is still in
+   the editor, unchanged, still marked **Unsaved**.
+4. Try to close the drawer again, and this time click **Discard**.
+   **Expected:** the modal closes, the drawer closes, and the edit is dropped.
+5. Reopen the drawer and click `notes.txt`.
+   **Expected:** the discarded text is **not** there — the file still holds the content
+   from walkthrough 1.
+6. Repeat with the two other exits, expecting the same modal each time:
+   - Edit, type, then click a **different file** in the tree. **Keep editing** must leave
+     you on the original file with the draft intact; **Discard** must move you to the file
+     you clicked.
+   - Edit, type, then press **Esc** (Cancel). **Keep editing** keeps the draft; **Discard**
+     returns the pane to the read-only view with the saved content.
+7. Edit, type, then click **Cancel** with **no** changes made (clean buffer).
+   **Expected:** no modal at all — a clean buffer exits straight to the read view.
+8. Edit, type, then reload the browser tab (`Cmd/Ctrl+R`).
+   **Expected:** the browser's own "Leave site? Changes you made may not be saved" prompt
+   appears. Cancelling it keeps the draft; confirming it drops the draft (the file is
+   unchanged on reload).
+
+---
+
+## 7. Over the size cap
+
+1. Click `huge.txt` (~1.7 MB, over the 1.5 MB cap).
+   **Expected:** the read view shows the existing over-cap card ("too large to preview" /
+   download affordance) rather than inline text.
+2. Look at the header action cluster.
+   **Expected:** the **Edit** button is **rendered but disabled** (greyed out, not
+   clickable).
+3. Hover **Edit**.
+   **Expected:** a tooltip reads **"Files larger than 1.5 MB can't be edited"**.
+4. Click it anyway.
+   **Expected:** nothing happens — no editor opens, no error.
+5. While the file's content is still loading (open a fresh drawer and click a large-ish but
+   under-cap text file immediately).
+   **Expected:** **Edit** is briefly disabled with the tooltip "File content is still
+   loading", then becomes enabled once the content and the directory listing have both
+   arrived. It must never be enabled while content is still in flight.
+
+---
+
+## 8. A non-editable file (image)
+
+1. Click the uploaded PNG/JPG.
+   **Expected:** the image preview renders.
+2. Look at the header action cluster.
+   **Expected:** there is **no Edit button at all** — not a disabled one. Download and the
+   ⋯ overflow are unaffected.
+3. Repeat with any binary/PDF file you have handy.
+   **Expected:** same — no Edit button.
+
+---
+
+## 9. Conflict handling (worth doing if you have an agent handy)
+
+1. Open a text file, click **Edit**, and type a change. Leave the buffer open and dirty.
+2. In the chat, ask the agent to modify that same file (e.g. "append a line to notes.txt").
+   Wait for it to finish.
+3. Click **Save**.
+   **Expected:** the save is refused. A **warning banner** appears above the editor:
+   "`<path>` changed while you were editing. Overwriting will replace that version." with
+   **Reload from disk** and **Overwrite** buttons. Your draft is still in the editor.
+4. Click **Reload from disk**.
+   **Expected:** the buffer is replaced by the agent's version; your draft is gone; the
+   banner clears.
+5. Repeat steps 1-3, then click **Overwrite** instead.
+   **Expected:** the save goes through, your version wins, edit mode exits, **Saved** tag.
+6. Repeat step 1, then have the agent **delete** the file, then click **Save**.
+   **Expected:** the banner reads "…was deleted while you were editing. Overwriting will
+   recreate it." with only an **Overwrite** button (no Reload). Overwrite recreates the
+   file with your content.
+
+---
+
+## 10. Save failure
+
+1. Open a text file, click **Edit**, make a change.
+2. Kill the network (devtools offline, or stop the API) and click **Save**.
+   **Expected:** a **red banner** appears: "Couldn't save this file. `<reason>`. Your
+   changes are still here." with a **Try again** button. The editor still holds every
+   character you typed. Edit mode does **not** exit.
+3. Restore the network and click **Try again**.
+   **Expected:** the save succeeds, the banner clears, edit mode exits, **Saved** tag.
+
+---
+
+## 11. Themes
+
+Run walkthrough 1 once in **light** theme and once in **dark** theme.
+
+**Expected:** the editor, the "Editing" bar, the Unsaved/Saved tags, the guard modal, and
+the warning/error banners all use theme colors — no white-on-white, no black-on-black, no
+hard-coded panel that ignores the theme.
+
+---
+
+## Known limits (not bugs)
+
+- **Read-only mounts:** there is no read-only flag on a mount today. Edit is gated on the
+  same permission that gates upload, so any drive you can upload to shows Edit.
+- **No side-by-side diff** on a conflict — only Reload / Overwrite.
+- **No "Save and continue"** from the guard modal — Keep editing or Discard only.
+- **No new / rename / delete** from the drawer. Editing existing files only.
+- **Multi-dot config files** (`.env.local`, `foo.test.json`) may resolve to a different
+  kind than their single-dot form; only the plain forms above are in scope.
+- **Saving invalidates mount listings project-wide**, so an unrelated open drive may
+  refetch its listing after a save. Expected for now.

--- a/docs/design/file-drawer-edit-mode/research.md
+++ b/docs/design/file-drawer-edit-mode/research.md
@@ -1,0 +1,207 @@
+# What reading the code changed
+
+Everything below was read in the worktree at `/home/mahmoud/code/agenta-2-editmode` on
+2026-08-04. Where the design spec or `CONTEXT.md` says one thing and the code says another, the
+code wins and the correction is stated here with the file and line that proves it.
+
+## Corrections
+
+### 1. The Fern `writeMountFile` sends no request body
+
+`CONTEXT.md` and the spec both route the save through `mounts.writeMountFile`. That method
+cannot carry the file contents.
+
+`web/packages/agenta-api-client/src/generated/api/resources/mounts/client/Client.ts:1065`
+builds the request with `queryParameters` only and passes no `body` to `core.fetcher`. Its
+request type confirms it:
+
+```ts
+// packages/agenta-api-client/src/generated/api/resources/mounts/client/requests/WriteMountFileRequest.ts
+export interface WriteMountFileRequest {
+    mount_id: string;
+    path: string;
+}
+```
+
+The backend handler reads `content = await request.body()`
+(`api/oss/src/apis/fastapi/mounts/router.py:579`). A body-less PUT therefore writes zero bytes.
+Calling this method would truncate every file it touched. The OpenAPI spec never described the
+raw body, so Fern generated a method that silently drops it.
+
+**What we do instead.** `mounts.uploadMountFile` is generated correctly: it builds a multipart
+form, appends the file, and sends it
+(`.../mounts/client/Client.ts:822-866`). Its request type carries the payload:
+
+```ts
+export interface BodyUploadMountFile {
+    mount_id: string;
+    path?: string | null;
+    file: core.file.Uploadable;
+}
+```
+
+Both endpoints land on the same service method. `upload_mount_file`
+(`api/oss/src/apis/fastapi/mounts/utils.py:66-91`) reads the upload and calls
+`mounts_service.write_file(project_id, mount_id, path, content)`, which is the exact call
+`write_mount_file` makes. `write_file` (`api/oss/src/core/mounts/service.py:1476-1492`) does a
+plain `put_object`: full overwrite, no collision renaming, same `EDIT_MOUNTS` permission check
+on both routes, same `MountFileWrittenResponse` shape back.
+
+So the multipart route is not a detour around the intended endpoint. It is the same write,
+reached through the one generated method that can carry bytes. This keeps the change frontend-only
+and needs no Fern regeneration.
+
+### 2. `DiffView` cannot show a diff of arbitrary text
+
+The spec assigns "View diff" to `DiffView`. `DiffView` handles JSON and YAML and nothing else.
+
+`web/packages/agenta-ui/src/Editor/DiffView.tsx:117-123`:
+
+```ts
+function detectLanguage(content: string): "json" | "yaml" {
+    const detected = getContentLanguage(content)
+    // DiffView only supports json/yaml, default to json for text
+    return detected === "text" ? "json" : detected
+}
+```
+
+Its props type declares `language?: "json" | "yaml"`, and `normalizeContent` /
+`convertContent` re-serialise through `JSON.parse` or `yaml.load`, falling back to `"{}"` when
+parsing fails. Handed a markdown or CSV file it produces an empty or mangled diff.
+
+**What we do instead.** `computeTextDiffLines(original, modified, options)` is exported from
+`@agenta/ui/diff` (`Editor/utils/diffUtils.ts:481`) and returns `ExtendedDiffLine[]` with
+`type: "context" | "added" | "removed" | "fold"` plus line numbers. It is already used this way
+by `packages/agenta-entities/src/workflow/commitDiff/classify.ts:167`. The conflict diff renders
+that list. `DiffView` is still used, but only for the `json` kind, where its language handling
+is correct.
+
+### 3. `SharedEditor`'s README describes props that do not exist
+
+`packages/agenta-ui/src/SharedEditor/README.md` documents `containerVariant: "bordered" |
+"borderless" | "textarea"` and `state: "filled" | "default"`. Neither matches `types.ts`:
+
+```ts
+// packages/agenta-ui/src/SharedEditor/types.ts
+editorType?: "border" | "borderless"
+state?: "default" | "filled" | "disabled" | "readOnly" | "focus" | "typing"
+```
+
+There is no `containerVariant` prop. Write against `types.ts` and `SharedEditor.tsx`, not the
+README.
+
+### 4. `EditorProps.language` is a six-value union, not a Shiki language id
+
+`driveCodeLanguage(path)` returns Shiki ids: `python`, `shellscript`, `rust`, `go`, `plaintext`,
+and about twenty more (`driveKinds.ts:24-61`). The editor accepts far fewer:
+
+```ts
+// packages/agenta-ui/src/Editor/plugins/code/types.ts
+export type CodeLanguage = "json" | "yaml" | "code" | "python" | "javascript" | "typescript"
+```
+
+Passing `"shellscript"` type-errors. `SimpleSharedEditor` works around this today by casting
+(`"html" as string as CodeLanguage`, `SimpleSharedEditor/index.tsx:95`). We add a small pure
+mapper instead, and unit-test that every entry in `CODE_LANGS` maps into the union.
+
+### 5. `SET_MARKDOWN_VIEW(true)` means raw markdown source, not preview
+
+The command's meaning is the reverse of what the segmented control's labels suggest.
+`markdownPlugin.tsx:279` states it plainly, and the handler at line 230 confirms it: when
+`nextMarkdownView` is true the root's first child becomes a `CodeNode` with language
+`"markdown"`; when false it is rich text.
+
+`markdownViewAtom(id)` is only an `atomWithStorage` CSS flag
+(`Editor/state/assets/atoms.ts:7-9`). Setting it does not swap the Lexical nodes. The working
+pattern is `MarkdownViewSynchronizer` in
+`packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx:88-104`: dispatch
+`SET_MARKDOWN_VIEW` from a `useLayoutEffect`, then dispatch it again from a deferred
+`requestAnimationFrame` to cover the mount race where the effect runs before `MarkdownPlugin`
+has registered the command.
+
+This matters for correctness, not just for the toggle. A markdown file edited in rich-text mode
+round-trips through the markdown serialiser on every keystroke, which reflows the user's
+original formatting. So a markdown buffer pins `SET_MARKDOWN_VIEW` to `true` for its whole life.
+
+### 6. `mountFileSchema.mtime` is populated, despite a comment saying it is not
+
+`useSessionDrive.ts:68-73` says the listing carries no mtime and calls it a backend ask. That
+comment is stale. The backend sets it in every listing path:
+`service.py:1145`, `:1262`, `:1315` all construct `MountFile(path=..., size=..., mtime=obj.mtime)`,
+and `MountFile.mtime` is `Optional[int]`, "Object-store LastModified as epoch milliseconds"
+(`api/oss/src/core/mounts/dtos.py:63-74`). `mountFileSchema` parses it
+(`packages/agenta-entities/src/session/core/schema.ts:145`).
+
+So conflict detection has a real modification time to compare, and it comes from the directory
+listing rather than from the write response.
+
+### 7. `.env` already resolves to a text kind
+
+`CONTEXT.md` asked us to check. `resolveDriveFileKind(".env")` returns `"text"`: the pattern is
+`/\.(txt|log|env)$/i` (`driveKinds.ts:65`) and the leading dot of a dotfile satisfies the `\.`.
+Verified against the actual regex:
+
+| path | matches `/\.(txt|log|env)$/i` |
+|---|---|
+| `.env` | yes |
+| `agent-files/.env` | yes |
+| `.env.local` | **no** |
+| `notes.txt` | yes |
+
+`.env.local` falls through every pattern and lands on `"other"`, which is the download card and
+is not editable. That is a real gap and it is recorded in `status.md` rather than fixed here,
+because widening the resolver changes the read-only viewer's behaviour too.
+
+`.env` is a dotfile, so it only shows when the toolbar's hidden-files toggle is on. It defaults
+to on (`useDriveFilters.ts:16`, `useState(true)`), so it is visible by default.
+
+## Facts confirmed, no correction needed
+
+- **The backend write path is complete.** `PUT /mounts/{mount_id}/files` at
+  `router.py:570`, registered at `:283`, guarded by `Permission.EDIT_MOUNTS`. Response model
+  `MountFileWrittenResponse` returns `path` and `size` only
+  (`apis/fastapi/mounts/models.py:102-105`). No `mtime`, as `CONTEXT.md` said.
+- **`TEXT_CAP = 1.5 * 1024 * 1024`** is module-private in `renderers.tsx:41`. It gates the text
+  bodies at `renderers.tsx:611-619`, where the `csv` kind is checked alongside `TEXT_KINDS`
+  rather than being in it (`TEXT_KINDS` is `markdown, text, code, json, html`,
+  `renderers.tsx:587`).
+- **`CodeBody` pretty-prints JSON before display** (`renderers.tsx:178-186`:
+  `JSON.stringify(JSON.parse(content), null, 2)`). The read view is therefore not the file. A
+  buffer seeded from it would reformat the file on save.
+- **`useDriveFileText(mount, path)`** (`driveFileSource.tsx:64`) returns the raw content string
+  from `mountFileContentQueryFamily`, or a local blob's text when a `DriveFileSourceContext`
+  provides one. Local-blob mode has no mount and cannot be written to.
+- **`canUpload` is the existing writable-drive answer**: `isAgentFileUploadsEnabled() &&
+  !explicitFiles && !!drive.mount` (`useDriveUploads.ts:67`). It already gates the header upload
+  button, drag-and-drop, and the staged inbox.
+- **The Drives area already talks to the backend through axios**, not Fern
+  (`driveMedia.ts` uses `@/oss/lib/api/assets/axiosConfig` throughout, including
+  `uploadMountFile` at `:168`). We do not follow that precedent, because Fern has a working
+  method for this call and `web/AGENTS.md` requires Fern for new code.
+- **`callFern` swallows failures.** It logs and returns `null` for anything that is not an abort
+  (`packages/agenta-entities/src/session/api/client.ts:96-105`). A save needs to tell a failure
+  from a success, so it does not use `callFern`.
+- **`projectScopedRequest(projectId, appId?, abortSignal?, maxRetries?)`** puts `project_id` on
+  `queryParams` and threads the abort signal (same file, `:47-63`). Fern repackages aborts as
+  `AgentaApiError`; `isAbortError` unwraps them.
+- **`useDriveSessionId()`** (`driveSessionContext.tsx:31`) returns the enclosing conversation's
+  session id, and `null` outside a conversation. The config-panel host does not mount the
+  provider.
+- **Query keys and families** in `packages/agenta-entities/src/session/state/mounts.ts`:
+  `mountFileContentQueryKey(projectId, mountId, path)` at `:38`,
+  `mountDirQueryKey(projectId, mountId, path, includeGitignored)` at `:42`,
+  `mountFilesQueryKey(projectId, mountId, includeGitignored)` at `:30`.
+  `revalidateSessionMountsAtom` at `:219` invalidates every mount in the project, which is far
+  wider than a single-file save needs.
+- **Vitest is the test runner** for this area: `oss/package.json` `test:unit` is `vitest run`,
+  and `Drives/dropEntries.test.ts` is a working local example that mocks the axios module.
+
+## Places the code disagrees with itself
+
+Worth knowing, not worth fixing in this PR:
+
+- `useSessionDrive.ts:68-73` claims mount listings carry no mtime. They do (correction 6).
+- `SharedEditor/README.md` documents a prop name the component does not have (correction 3).
+- `renderers.tsx:5-6` says matching is extension-based because "the listing carries no
+  content-type (same backend gap as mtime)". The mtime half of that sentence is stale for the
+  same reason.

--- a/docs/design/file-drawer-edit-mode/research.md
+++ b/docs/design/file-drawer-edit-mode/research.md
@@ -72,9 +72,14 @@ parsing fails. Handed a markdown or CSV file it produces an empty or mangled dif
 **What we do instead.** `computeTextDiffLines(original, modified, options)` is exported from
 `@agenta/ui/diff` (`Editor/utils/diffUtils.ts:481`) and returns `ExtendedDiffLine[]` with
 `type: "context" | "added" | "removed" | "fold"` plus line numbers. It is already used this way
-by `packages/agenta-entities/src/workflow/commitDiff/classify.ts:167`. The conflict diff renders
-that list. `DiffView` is still used, but only for the `json` kind, where its language handling
-is correct.
+by `packages/agenta-entities/src/workflow/commitDiff/classify.ts:167`.
+
+`DiffView` is not used at all, not even for `json`. Its diff extension parses the strings with
+YAML or JSON5 before computing the diff and logs-and-bails on a parse failure
+(`plugins/code/extensions/diffHighlight.tsx:385-425,526-529`), and a file with a `.json` suffix
+is routinely mid-edit and not yet valid. The product compares raw file bytes, not parsed data
+structures. The conflict diff is deferred out of the first PR; when it lands it uses
+`computeTextDiffLines` for every kind.
 
 ### 3. `SharedEditor`'s README describes props that do not exist
 
@@ -88,7 +93,21 @@ state?: "default" | "filled" | "disabled" | "readOnly" | "focus" | "typing"
 ```
 
 There is no `containerVariant` prop. Write against `types.ts` and `SharedEditor.tsx`, not the
-README.
+README. Two semantics the prop list does not reveal:
+
+- **`state` is visual only.** It changes container classes and cursor styling
+  (`SharedEditor.tsx:114-178`). Editability comes from the separate `disabled` prop, forwarded to
+  `Editor` (`:216-235`) and on to `EditorInner`, which defaults it to `false` and calls
+  `editor.setEditable(!disabled)` (`Editor.tsx:455-457`). Disabling only the provider is undone by
+  that inner effect.
+- **`value` wins over `initialValue` immediately.** `controlledValue = value ?? initialValue`
+  (`SharedEditor.tsx:71-80`), and in code mode the plugin seeds from
+  `value !== undefined ? value : initialValue` (`plugins/index.tsx:149-160`). There is no
+  two-phase "seed from one, sync from the other". The buffer must own its own baseline.
+
+`EditorProviderProps` in `Editor/types.d.ts:19-26` is also stale — it declares only HTML props,
+`children`, and `dimensions`, while the component is typed `EditorProps & {children}`
+(`Editor.tsx:816-847`). The JSX call still type-checks off the inferred signature.
 
 ### 4. `EditorProps.language` is a six-value union, not a Shiki language id
 
@@ -102,7 +121,8 @@ export type CodeLanguage = "json" | "yaml" | "code" | "python" | "javascript" | 
 
 Passing `"shellscript"` type-errors. `SimpleSharedEditor` works around this today by casting
 (`"html" as string as CodeLanguage`, `SimpleSharedEditor/index.tsx:95`). We add a small pure
-mapper instead, and unit-test that every entry in `CODE_LANGS` maps into the union.
+mapper instead, and unit-test that every entry in `CODE_LANGS` maps into the union. `CODE_LANGS`
+is module-private today, so the plan exports it — a test cannot import its subject otherwise.
 
 ### 5. `SET_MARKDOWN_VIEW(true)` means raw markdown source, not preview
 
@@ -119,9 +139,21 @@ pattern is `MarkdownViewSynchronizer` in
 `requestAnimationFrame` to cover the mount race where the effect runs before `MarkdownPlugin`
 has registered the command.
 
-This matters for correctness, not just for the toggle. A markdown file edited in rich-text mode
-round-trips through the markdown serialiser on every keystroke, which reflows the user's
-original formatting. So a markdown buffer pins `SET_MARKDOWN_VIEW` to `true` for its whole life.
+Pinning that command is nonetheless **not** enough to make a markdown buffer byte-preserving, and
+this feature does not use it. Two reasons, both verified:
+
+- The first `SET_MARKDOWN_VIEW(true)` does not inject the original file text. Unless its source
+  cache is already reusable it produces the source by serializing the rich tree it just hydrated
+  (`markdownPlugin.tsx:151-168`), so the file can be reformatted before the user types.
+- Rich-mode change emission serializes the document and then runs `stripBackslashEscapes`
+  (`Editor.tsx:282-299`), which strips every backslash preceding another character
+  (`plugins/markdown/utils/textCleanup.ts:146-177`).
+
+`ChatMessageEditor` is not a precedent for a file editor: it edits a semantic chat message and
+never promises byte preservation. Markdown is therefore edited as source through `codeOnly`, like
+every other kind. `codeOnly` does not mount `MarkdownPlugin` at all
+(`plugins/index.tsx: singleLine || codeOnly ? null : <MarkdownPlugin/>`), so there is no command
+to pin, no `markdownViewAtom` to write, and no synchronizer component.
 
 ### 6. `mountFileSchema.mtime` is populated, despite a comment saying it is not
 

--- a/docs/design/file-drawer-edit-mode/reviews/impl-review-claude.md
+++ b/docs/design/file-drawer-edit-mode/reviews/impl-review-claude.md
@@ -1,0 +1,307 @@
+# Implementation review — file drawer edit mode
+
+**Reviewer:** Claude (senior frontend pass)
+**Date:** 2026-08-04
+**Diff reviewed:** `git diff origin/release/v0.109.0...HEAD` (commits `af1d33c29a`, `2d7220ae5b`, `8301888ee8`)
+**Verified:** `npx vitest run src/components/Drives` — 70 tests, 4 files, all pass.
+
+The shape of the thing is right. The reducer is genuinely pure and genuinely tested, the
+request-id discipline is correct, the four identity fields are carried through to the write,
+the pre-write listing check fails closed, and `codeOnly` really is used for every kind so the
+byte-fidelity argument holds. Every defect below is in the seams between the reducer and the
+rest of the app, not in the reducer.
+
+Findings are ranked most severe first.
+
+---
+
+## 1. The buffer outlives the drawer — nothing clears it on deactivate or unmount
+
+**Files:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:312-325`
+(controller unmount effect), `:386-393` (the guard's `!active` branch),
+`web/oss/src/components/Drives/FilesDrawer.tsx:537-548`
+
+`driveEditBufferAtom` is module-level by design, but nothing ever clears it except a user
+action routed through the guard. The controller's unmount effect aborts the in-flight save and
+clears the "Saved" timer; it does not touch the buffer. `useDriveEditGuard` has no cleanup at
+all, and its `!active` branch explicitly *skips* resetting when a buffer exists. So any route to
+`open === false` that does not go through `guardedClose` orphans the buffer.
+
+Those routes exist. `SessionFilesDrawer.tsx:41` computes
+`open = gridOpen || quickLook != null || staged.length > 0` from three atoms that
+`RuntimeLens`, `ContextRail`, and `DriveFileCard` all write; and `SessionFilesDrawer` is mounted
+per session by `AgentConversation`, so a session switch unmounts the host outright.
+
+**Failure scenario.** In session A, open the Files drawer, click Edit on `INDEX.md`, type one
+character. Switch to session B in the sidebar. `AgentConversation`(A) unmounts, the drawer
+never calls `onClose`, and the dirty buffer stays in the module atom. Now open the Files drawer
+in session B. `facets.editing` is `true`, so `DriveExplorer` replaces `DriveToolbar` with
+`DriveEditBar`, `DriveTreePane` renders `inert`, and `DriveHeader` shows Cancel/Save — but
+`DriveFilePreview:57-62` refuses to render `DriveFileEditor` because `targetMountId`/`targetPath`
+don't match session B's mount, so there is no editor on screen. Search and the origin filter are
+gone, the tree is dead, and `openEditBufferAtom:80` early-returns so Edit does nothing.
+Escape → onCancel → the discard modal names a file from another session.
+
+Two smaller consequences of the same root cause: `DriveEditBanner` (rendered unconditionally in
+`DriveExplorer`) will show session A's conflict banner in session B's drawer; and if two
+sessions' drawers are open at once (antd Tabs keeps inactive panes mounted), two
+`useDriveEditController` instances register competing global `keydown` handlers over one shared
+buffer.
+
+**Fix direction:** clear the buffer when the guard goes inactive with no pending navigation, or
+scope the atom to the drawer instance and let the drive-swap case be handled by the held drive.
+
+---
+
+## 2. "Reload from disk" silently does nothing if the user types during the fetch
+
+**File:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:456-498`
+
+`canAdoptReload()` requires `live.draft === discardedDraft`. Between `resolveNavigation("discard")`
+and the `fetchQuery` resolving, the buffer is `saveStatus: "idle"` and the editor is fully
+enabled — `DriveFileEditor` only disables on `saveStatus === "saving"` — and nothing renders a
+spinner or a pending state. A single keystroke in that window makes `canAdoptReload()` false, and
+both the `.then` and the `.catch` return without touching state.
+
+**Failure scenario.** Agent writes the file underneath you. Conflict banner appears. Click
+"Reload from disk" → the discard modal → Discard. The read takes 400 ms on a cold mount. You
+type one character while waiting. The read lands, `canAdoptReload()` fails, and the function
+returns. The banner still shows Reload / Overwrite, the buffer still holds your old content, and
+there is no indication the reload was dropped. Click Reload again and you can hit the same window
+again.
+
+---
+
+## 3. Reload and a missing-file conflict can permanently disarm conflict detection
+
+**Files:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:180-181` and `:495`,
+`web/oss/src/components/Drives/editMode/model.ts:86`
+
+`conflictFromListing` returns `null` (proceed) whenever `baseMtime == null`. That degradation is
+documented in the plan for the case where the store omits mtime, but two code paths *manufacture*
+a null baseline for a buffer that had a good one:
+
+- `:495` — `const mtime = current.issue?.kind === "conflict" ? current.issue.theirMtime : null`.
+  For `reason: "missing"` the conflict carries `theirMtime: null` (`model.ts:84`), so a successful
+  reload after a missing-then-recreated file leaves `baseMtime: null` and every subsequent save
+  from that buffer is an unconditional overwrite with no check.
+- `:180-181` — `listingQuery.data.find(...)?.mtime ?? null` opens a buffer with a null baseline
+  whenever the file is absent from the parent listing (e.g. a gitignored file opened while the
+  `include_gitignored` variant in the cache says otherwise).
+
+Also at `:495`: even in the `changed` case the new baseline is the mtime observed *at conflict
+detection time*, not the mtime of the bytes actually fetched a moment later. If the agent wrote
+again in between, the buffer now holds content newer than its own baseline.
+
+**Failure scenario.** Agent deletes `notes.md` while you edit it; you save; conflict `missing`.
+Agent recreates it. You click Reload → Discard; the read now succeeds, `replaceBufferFromRemoteAtom`
+sets `baseMtime: null`. You keep editing for ten minutes while the agent writes the file three
+more times. Every save you make overwrites all of it, and the conflict banner never appears again
+for that buffer.
+
+---
+
+## 4. Unmount aborts the PUT and reports failure for a write that may have landed
+
+**File:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:312-325`
+
+The cleanup calls `controller.abort()` and then writes
+`editSaveFailedAtom({message: "Save was interrupted"})`. Aborting the client request proves
+nothing about the server — the plan says exactly this at §2 and then the implementation does it
+anyway. Since the buffer survives unmount (finding 1), the user comes back to a dirty buffer with
+an error banner for a write that already succeeded.
+
+**Failure scenario.** Save a 900 KB file on a slow mount. The host flips the drawer closed
+(quick-look cleared from a chat card, or a session switch) while the PUT is in flight. The write
+lands server-side. Reopen the drawer: the buffer is still there, banner says "Save was
+interrupted. Your changes are still here." Click "Try again" → the pre-write check reads the mtime
+*your own aborted write* produced, sees it differs from `baseMtime`, and reports "changed while
+you were editing". Choosing "Reload from disk" now discards your edits in favour of your edits.
+
+At minimum the interrupted-save message should say the outcome is unknown, and the buffer should
+not be left in a state where the next check misattributes a self-write to the agent.
+
+---
+
+## 5. The tree is `inert` but looks completely live
+
+**File:** `web/oss/src/components/Drives/DriveTreePane.tsx:65, 83`
+
+The spec's `clean` note is "the tree stays visible but inert", and the prototype dims it
+(`treeStyle` carries `opacity:0.45` while editing). The implementation sets `inert` and adds no
+visual treatment whatsoever, so the tree renders at full contrast with hover styles intact.
+
+**Failure scenario.** While editing, click another file in the tree. Nothing happens — no
+selection, no discard dialog, no cursor change, no feedback of any kind, because `inert` swallows
+the click before `edit.select` (the guarded path) can ever run. The user clicks three more times
+and concludes the drawer is broken. The plan's "every exit routes through the guard" story
+depends on tree clicks reaching `guardedSelect`; making the tree inert removes that route rather
+than guarding it.
+
+Either dim the tree (spec behaviour, at least signals "not now"), or drop `inert` on the rows and
+let `guardedSelect` do its job.
+
+---
+
+## 6. Blocking on `saving` is silent everywhere, and the guard modal can deadlock for 30 s
+
+**Files:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:268` and `:427`,
+`web/oss/src/components/Drives/editMode/components/DriveEditGuardModal.tsx:26-29`
+
+`onCancel` and `guardedClose` both `return` early while `saveStatus === "saving"` with no
+feedback. The Escape handler `preventDefault()`s first, so Escape is swallowed too. With
+`timeoutInSeconds: 30` on the write, a hung mount means the drawer's X, the mask, and Escape are
+all dead for half a minute with nothing on screen explaining why.
+
+Worse: the drive-swap effect (`:408-419`) fires regardless of save status, so it can open the
+guard modal *during* a save — and that modal has `closable={false}`, `maskClosable={false}`, and
+both buttons disabled while saving. There is no way out of it until the write settles.
+
+---
+
+## 7. Every keystroke re-renders the entire drawer
+
+**Files:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:101-102, 373`,
+`web/oss/src/components/Drives/editMode/components/DriveFileEditor.tsx:56`
+
+`useDriveEditGuard` (in `FilesDrawer`) and `useDriveEditController` (in `DriveExplorer`) both
+`useAtomValue(driveEditBufferAtom)`. `setEditDraftAtom` produces a new buffer object per
+character, and `disableDebounce` (correctly required for the guard) means one write per character.
+So each keystroke re-renders `FilesDrawer`, which recreates the `<DriveExplorer>` element, which
+re-renders the header, the toolbar row, the virtualized tree list, and the preview.
+
+**Failure scenario.** Open a mount with a few thousand files (the tree the drawer is built for),
+edit a `.md`, and hold down a key. Every character walks `flatRows` and re-renders the tree list.
+`FilesDrawer` needs only `pendingNavigation` / `displayPath` / `saveStatus`; the controller needs
+only `displayPath` and `saveStatus` outside `onSave`. Selecting those narrowly (or reading the
+draft only inside `DriveFileEditor`) removes the whole class.
+
+---
+
+## 8. Availability reports a directory-listing failure as an unreadable file
+
+**File:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:138-145`
+
+When the content loaded fine but the parent `mountDirQueryFamily` is pending or returned `null`,
+availability collapses to `"loading"` / `"unreadable"`, and `DriveHeader.tsx:271-277` renders the
+tooltip "This file couldn't be read".
+
+**Failure scenario.** A folder listing 404s or times out (the `git_aware` listing does fail on
+some mounts — `DriveHeader` already has a `partialErrored` path for exactly this). The file
+renders perfectly in the preview, and Edit is greyed out claiming the file can't be read. The
+user has no way to connect the message to the real cause.
+
+---
+
+## 9. The size-cap copy is hard-coded away from the constant it describes
+
+**File:** `web/oss/src/components/Drives/DriveHeader.tsx:275`
+
+`"Files larger than 1.5 MB can’t be edited"` duplicates `TEXT_CAP` (`driveKinds.ts:22`), which
+this PR deliberately moved into one place so the cap has one definition. Change `TEXT_CAP` and the
+tooltip lies. Derive the string from the constant (`humanSize` is already imported in
+`DriveHeader`).
+
+---
+
+## 10. The session-teardown notice is permanent, and the flag that hides it is what shows it
+
+**Files:** `web/oss/src/components/Drives/editMode/components/DriveEditBar.tsx:42-46`,
+`web/oss/src/components/Drives/editMode/components/DriveFileEditor.tsx:18-24`
+
+`teardownWarned` means "we have already warned"; the bar renders the notice *while* it is true. So
+the notice appears on the first keystroke and then never leaves for the life of the buffer, which
+is the opposite of the plan's "shows a one-line inline notice and `markTeardownWarnedAtom` fires so
+it does not repeat". It works, but the next reader will invert it.
+
+Related: the notice is squeezed onto the same flex row as the language chip and the right-aligned
+hint (`Esc to cancel · filters resume after saving`, itself invented copy — the filters also
+resume after Cancel). At the drawer's normal width, three text spans plus a segmented control on
+one 44 px row will collide before they wrap.
+
+---
+
+## 11. Reload errors are rendered by pushing the save state machine through a fake save
+
+**File:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:491-492, 502-503`
+
+`startSave(requestId)` followed immediately by `saveFailed({requestId, ...})` is used purely to get
+an error into the `issue` slot. React batches the two writes inside the promise callback so nothing
+flashes today, but it means a reload failure moves `saveStatus` to `"saving"`, mints an
+`inflightRequestId` that no request owns, and clears `skipConflictCheckOnce` as a side effect. One
+`setIssueAtom` action would be honest and would not couple reload errors to the save reducer.
+
+---
+
+## 12. `saveDriveFile` hands the save's abort signal to a shared directory query
+
+**File:** `web/oss/src/components/Drives/editMode/api.ts:61-69`
+
+`abortSignal: signal ?? querySignal` overrides react-query's own signal with the save's. The
+pre-write `fetchQuery` writes into `mountDirQueryKey(...)` — the exact key the tree's
+`mountDirQueryFamily` observes. Aborting the save (unmount, or a second `onSave`) therefore
+cancels a fetch that another live observer is waiting on. Prefer `querySignal` and let react-query
+own cancellation, or chain the two signals.
+
+---
+
+## 13. Test quality: the controller — the risky half — is never mounted
+
+**File:** `web/oss/src/components/Drives/editMode/controller.test.ts`
+
+`state.test.ts` (20 tests) and `model.test.ts` (31 tests) are genuinely good: the request-id
+no-ops, the one-issue-slot rule, the reload-keeps-the-buffer rule, and the full availability matrix
+are all covered. But `controller.test.ts` exercises only `saveDriveFile` (a pure function) and
+`useDriveEditGuard`. **`useDriveEditController` is never rendered in any test.** Untested, in
+descending risk:
+
+- the key bindings (Escape / ⌘S / ⌘E), including the `pendingNavigation` early-return that keeps
+  Escape from reaching the drawer while the modal is open
+- the unmount abort + `editSaveFailedAtom` path (finding 4)
+- `beforeunload` registration and, more to the point, its *de*registration
+- `guardedSelect` and the `path === selectedPath` short-circuit
+- `onSave`'s request-id plumbing through the real `saveDriveFile` (state.test.ts covers the atoms,
+  which the plan's list item "a late success from file A does not mutate a buffer for file B"
+  already had; the controller wiring is the part that could get it wrong)
+- the "Saved" timer and `justSavedPath === selectedPath`
+
+Two cheap gaps in `saveDriveFile`'s own tests as well: no test that a `null` listing fails closed
+(`api.ts:72-74`, the fail-closed behaviour the whole design rests on), and no test that
+`skipConflictCheck: true` skips the directory fetch entirely (that is the Overwrite contract).
+
+---
+
+## Spec fidelity — states not implemented as written
+
+Documented deviations from `status.md` (not defects, listed so QA does not re-raise them): Cancel
+is disabled during a save rather than aborting it (`saving`); "View diff" is absent from the
+conflict banner (`conflict`); "Save and continue" is absent from the guard (`confirm`); there is no
+status footer.
+
+Undocumented gaps:
+
+- **`clean`** — "the tree stays visible but inert" is implemented without the spec's dimming
+  (finding 5). "Focus lands in the editor with the cursor at the start of the document" is
+  unverified: `autoFocus` mounts Lexical's `AutoFocusPlugin`, which makes no claim about caret
+  position. The plan flagged this as a QA item; it is still open.
+- **`saved`** — "Header size chip and tree row update from the write response" is done by
+  invalidating four listing roots instead, so there is a refetch round trip where the spec wanted
+  none. `MountFileWrittenResponse` does carry `size`, and `writeMountFile` already returns it, but
+  `saveDriveFile:90` throws it away at the call site. Acceptable, worth noting.
+- **`error`** — the banner reads `${message}. Your changes are still here.` where `message` is a
+  raw Fern/axios error string (`api.ts:719-722` in the package). "Request failed with status code
+  403. Your changes are still here." is what a permission failure will actually render.
+
+## Repo conventions
+
+Clean overall. Checked and passing: no `@agenta/sdk` root-barrel import (the Fern call sits in
+`agenta-entities/session/api/api.ts` beside `readMountFile` and reaches the client through
+`./client`); zod validation at the boundary via `safeParseWithLogging`; `{queryParams}` not axios
+`params`; semantic antd tokens throughout the new components with no raw hex, no inline `style`,
+no CSS-in-JS; comments are one line each; antd imports confined to `DriveEditBar` and
+`DriveEditBanner` as the plan promised, with `EnhancedModal` used for the guard; the three
+`CopyButton size="small"` lines are untouched. `inert={true}` is valid — this app is on React 19.
+
+Two nits: `driveKinds.ts` now exports `CODE_LANGS` solely so a test can iterate it, which is a
+test-only widening of a module's public surface; and `renderers.tsx` both re-exports `TEXT_CAP`
+and imports it, so there are now two import paths for one constant.

--- a/docs/design/file-drawer-edit-mode/reviews/impl-review-codex.md
+++ b/docs/design/file-drawer-edit-mode/reviews/impl-review-codex.md
@@ -1,0 +1,173 @@
+# Codex review of the file-drawer edit-mode implementation
+
+- **Reviewer:** OpenAI Codex CLI, `gpt-5.6-sol`, high reasoning effort, read-only sandbox
+- **Date:** 2026-08-04
+- **Reviewed:** `git diff origin/release/v0.109.0...HEAD` on `feat/file-drawer-edit-mode`
+  (three implementation commits: `af1d33c29a`, `2d7220ae5b`, `8301888ee8`)
+- **Brief:** skeptical staff engineer; weighted toward code organization, naming, layering,
+  state-machine correctness, the save path, and duplication of what the repo already had.
+  Praise was explicitly excluded, so the absence of it here is the brief, not the verdict.
+- **Raw log:** `/tmp/claude-1000/-home-mahmoud-code-agenta-2/8f46ac2c-617d-4f0c-a875-dafc5d4c34fc/scratchpad/codex-runs/implreview.log`
+
+## Orchestrator spot-checks
+
+Three of the four blocking findings were verified against source before filing:
+
+- **B1 confirmed.** `web/packages/agenta-ui/src/Editor/plugins/code/utils/editorCodeUtils.ts:121,145`
+  converts tab nodes to two spaces and returns `result.trimEnd()`;
+  `web/packages/agenta-ui/src/Editor/plugins/code/index.tsx:128-136` pretty-prints compact JSON
+  on hydration. Byte fidelity for `.json`, and for any file with trailing whitespace or a
+  trailing blank line, is not currently achieved.
+- **B2 confirmed.** `useDriveEditController.ts` `onOverwrite` calls `overwriteNextSave()` then
+  `onSave()`, and `onSave` returns early on `current.draft === current.original`, leaving
+  `skipConflictCheckOnce` armed on the buffer.
+- **B3 structurally confirmed.** `state.ts:63` is a module-global `atom<DriveEditBuffer | null>(null)`
+  with no drawer scoping; `driveKey` is stored on the buffer but not used to scope consumers.
+  Whether two Files drawers actually co-mount today was not verified.
+
+B4 and the S/N findings were not independently verified.
+
+---
+
+## Verdict
+
+Not mergeable as-is. The current implementation can silently rewrite untouched bytes, permanently bypass conflict detection after a no-op overwrite, and leak one drawer’s edit state into other mounted drawers. Those correctness defects require fixes before the structural cleanup and missing tests can be evaluated.
+
+## Blocking
+
+### B1. The selected editor is not byte-preserving
+
+- **Where:** `web/oss/src/components/Drives/editMode/components/DriveFileEditor.tsx:40`, `web/packages/agenta-ui/src/Editor/plugins/code/utils/editorCodeUtils.ts:121`, `web/packages/agenta-ui/src/Editor/plugins/code/utils/editorCodeUtils.ts:145`, `web/packages/agenta-ui/src/Editor/plugins/code/index.tsx:128`
+- **What is wrong:** `DriveFileEditor` uses the default custom code-node path. Its serializer converts tab nodes to two spaces and calls `trimEnd()`, while compact JSON is pretty-printed during hydration.
+- **What breaks:** Editing one character in a file ending with newlines or trailing spaces removes those bytes; compact JSON can be reformatted wholesale. The claimed `.txt`, `.md`, `.env`, `.csv`, and `.json` byte fidelity is false.
+- **Fix:** Use a byte-preserving editor path—the existing native code-node mode is the smallest candidate—and add an editor-to-Blob test covering trailing newlines, trailing spaces, tabs, CRLF, non-ASCII, and empty content.
+
+### B2. Overwrite can leave conflict detection permanently bypassed
+
+- **Where:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:207`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:213`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:276`, `web/oss/src/components/Drives/editMode/state.ts:206`
+- **What is wrong:** `onOverwrite` arms `skipConflictCheckOnce` before calling `onSave`, but `onSave` can return without starting a request when the draft equals the original.
+- **What breaks:** After a conflict, revert the draft to its original value and click Overwrite. The conflict disappears and the bypass remains armed; the next real edit skips the pre-write check and silently overwrites the external version.
+- **Fix:** Pass `skipConflictCheck: true` directly to a validated save invocation. Do not persist the bypass in buffer state unless a request has actually started.
+
+### B3. The module-global buffer contaminates independent drawers
+
+- **Where:** `web/oss/src/components/Drives/editMode/state.ts:63`, `web/oss/src/components/Drives/DriveExplorer.tsx:118`, `web/oss/src/components/Drives/editMode/components/DriveEditBar.tsx:16`, `web/oss/src/components/Drives/editMode/components/DriveEditBanner.tsx:15`, `web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx:249`
+- **What is wrong:** Every Files drawer shares one unscoped atom. `DriveEditBuffer.driveKey` is written but never read to scope any consumer, while inactive conversation panes can remain mounted.
+- **What breaks:** Editing in session A can make session B’s tree inert, display A’s banner or guard modal, and route B’s navigation through A’s buffer. A config drawer or attachment drawer can exhibit the same contamination.
+- **Fix:** Give each `FilesDrawer` its own Jotai store/provider outside the `DriveExplorer` remount boundary, or key every atom and consumer by a stable drawer identity.
+
+### B4. Content and `baseMtime` can describe different file versions
+
+- **Where:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:123`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:131`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:180`, `web/packages/agenta-entities/src/session/state/mounts.ts:193`
+- **What is wrong:** Edit can open from cached content while the content query is refetching because only `isPending` is exposed. The independent directory query may already contain the new mtime.
+- **What breaks:** An agent write invalidates both queries; the listing refetch finishes first, then Edit captures old content with the new mtime. The pre-write check sees that same new mtime and permits overwriting the agent’s content without a conflict.
+- **Fix:** Disable Edit while either query is fetching and establish a coherent snapshot with listing → fresh content → listing, retrying when the two listing mtimes differ.
+
+## Should fix before merge
+
+### S1. Selecting a known oversized text file still downloads it
+
+- **Where:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:117`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:123`, `web/oss/src/components/Drives/editMode/model.ts:38`
+- **What is wrong:** `resolved` is created and `useDriveFileText` subscribes before the known listing size is used to reject editing.
+- **What breaks:** Selecting a 100 MB log triggers the content request even though both preview and Edit are capped at 1.5 MB.
+- **Fix:** Pass an empty mount/path to the content query when the known byte size exceeds `TEXT_CAP`.
+
+### S2. The fallback cap compares UTF-16 units with a byte limit
+
+- **Where:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:134`, `web/oss/src/components/Drives/editMode/model.ts:41`
+- **What is wrong:** `content.length` is not the UTF-8 byte size represented by `TEXT_CAP`.
+- **What breaks:** With a missing or stale listing size, multibyte content substantially over 1.5 MB remains editable.
+- **Fix:** Compare `new Blob([content]).size` or `TextEncoder` byte length.
+
+### S3. “Reload from disk” is an impossible action for a deleted file
+
+- **Where:** `web/oss/src/components/Drives/editMode/components/DriveEditBanner.tsx:36`, `web/oss/src/components/Drives/editMode/components/DriveEditBanner.tsx:48`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:490`
+- **What is wrong:** A `missing` conflict still offers Reload even though no remote body exists.
+- **What breaks:** Reload always fails, replaces the specific deletion conflict with a generic error, and leaves the user in a retry loop.
+- **Fix:** Hide Reload for `reason === "missing"`, or define an explicit deleted-file resolution that preserves the conflict.
+
+### S4. Drawer shortcuts are registered against the entire window
+
+- **Where:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:281`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:301`
+- **What is wrong:** The handler does not verify that focus or the event target is inside this drawer.
+- **What breaks:** With a drawer open, Cmd/Ctrl+E, Cmd/Ctrl+S, or Escape typed in the chat composer or another surface can open, save, or cancel the file editor. Multiple mounted drawers register competing handlers.
+- **Fix:** Attach the handler to the drawer root or reject events outside that root.
+
+### S5. A clean buffer with an old issue gets a false unsaved-changes dialog
+
+- **Where:** `web/oss/src/components/Drives/editMode/state.ts:117`, `web/oss/src/components/Drives/editMode/components/DriveEditGuardModal.tsx:21`
+- **What is wrong:** Any error or conflict activates the discard guard even when `draft === original`, but the modal always claims unsaved changes exist.
+- **What breaks:** Revert the draft after a failed or conflicting save, then Cancel: the user is warned that clean content will be discarded.
+- **Fix:** Guard only dirty buffers, or introduce issue-specific exit copy and behavior.
+
+### S6. The tests avoid the two failing production seams
+
+- **Where:** `web/oss/src/components/Drives/editMode/controller.test.ts:71`, `web/oss/src/components/Drives/editMode/controller.test.ts:178`, `web/oss/src/components/Drives/editMode/controller.test.ts:223`
+- **What is wrong:** The file tests the pure save helper, package transport, and `useDriveEditGuard`; it never mounts `useDriveEditController` or `DriveFileEditor`.
+- **What breaks:** Editor normalization, the persistent overwrite bypass, global shortcut scope, stale open snapshots, and multi-drawer contamination all pass the 70-test suite.
+- **Fix:** Add tests for actual editor emissions and controller transitions, including conflict → revert → overwrite → edit → save and two simultaneous drawer scopes.
+
+## Structure and naming
+
+### N1. The controller file is four unrelated boundaries joined together
+
+- **Where:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:73`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:164`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:207`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:355`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:470`
+- **What is wrong:** One file owns availability queries, save mutation orchestration, DOM focusing, global shortcuts, unload handling, transient confirmation timing, shell navigation, drive swapping, and remote reload.
+- **What breaks:** Reload errors already have to impersonate save failures, and controller behavior remains largely untestable without mounting the entire composition root.
+- **Fix:** Separate the edit-session controller, shell navigation guard, and reload operation; replace the DOM selector with an editor ref/focus callback.
+
+### N2. Reload errors abuse the save state machine
+
+- **Where:** `web/oss/src/components/Drives/editMode/useDriveEditController.ts:490`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:502`
+- **What is wrong:** A failed read calls `startEditSaveAtom` followed by `editSaveFailedAtom` solely to manufacture an error issue.
+- **What breaks:** Request identity and `saving` no longer describe writes, making later concurrency changes unsafe and tests misleading.
+- **Fix:** Add an honest reload-error action or a general `setEditIssueAtom`.
+
+### N3. The facets read model is partially dead and causes broad subscriptions
+
+- **Where:** `web/oss/src/components/Drives/editMode/state.ts:53`, `web/oss/src/components/Drives/editMode/state.ts:65`, `web/oss/src/components/Drives/DriveExplorer.tsx:118`, `web/oss/src/components/Drives/editMode/useDriveEditController.ts:101`
+- **What is wrong:** `mode`, `editorView`, and `guardOpen` have no production reader through this atom. The atom creates a new object for every draft update, while the controller also subscribes to the entire buffer.
+- **What breaks:** Every keystroke rerenders the `DriveExplorer` composition root and recomputes tree/query/controller work unrelated to the changed text.
+- **Fix:** Remove the unused facets and expose narrow `selectAtom` selectors with equality for editing, dirty, saving, issue, and dirty path.
+
+### N4. Cache invalidation lives in a React upload hook and is project-wide
+
+- **Where:** `web/oss/src/components/Drives/useMountUpload.ts:69`, `web/oss/src/components/Drives/editMode/api.ts:10`, `web/oss/src/components/Drives/editMode/api.ts:89`
+- **What is wrong:** A supposedly non-React save module imports a hook module that itself imports React, upload transport, media code, and UI dependencies. The helper also hand-codes query-key strings and omits `mountId`.
+- **What breaks:** Saving one file invalidates active listings for every mount in the project and couples the edit save bundle to the upload module’s dependency graph.
+- **Fix:** Move the helper beside the canonical mount query keys, accept `mountId`, and invalidate the four same-mount prefixes only.
+
+### N5. `mode: "markdown"` lies about the editor mode
+
+- **Where:** `web/oss/src/components/Drives/editMode/state.ts:28`, `web/oss/src/components/Drives/editMode/model.ts:45`, `web/oss/src/components/Drives/editMode/components/DriveFileEditor.tsx:40`
+- **What is wrong:** Every file uses `codeOnly`; `"markdown"` means only “offer rendered preview.”
+- **What breaks:** A later caller can reasonably use `mode` to configure the editor and accidentally reintroduce rich-mode serialization.
+- **Fix:** Rename it to `supportsMarkdownPreview` or a similarly literal capability.
+
+### N6. Dirty state has both a global atom channel and a drilled prop channel
+
+- **Where:** `web/oss/src/components/Drives/DriveExplorer.tsx:340`, `web/oss/src/components/Drives/DriveTreeList.tsx:31`, `web/oss/src/components/Drives/DriveTreeList.tsx:137`, `web/oss/src/components/Drives/DriveTreeRow.tsx:20`
+- **What is wrong:** Feature state is global for banners/editor/controller but is threaded through `DriveExplorer → DriveTreeList → TreeRow` for the row marker.
+- **What breaks:** Scoping the buffer correctly now requires repairing two independent state-delivery mechanisms.
+- **Fix:** Let `DriveTreeList` read a drawer-scoped dirty-path selector and pass only the row-local boolean to `TreeRow`.
+
+### N7. Package transport tests are owned by the app feature
+
+- **Where:** `web/oss/src/components/Drives/editMode/controller.test.ts:178`, `web/packages/agenta-entities/src/session/api/api.ts:694`
+- **What is wrong:** The `@agenta/entities/session` write API is tested only from an app-level file named `controller.test.ts`.
+- **What breaks:** The package’s own test suite does not protect its public transport contract, and the app test mixes three ownership layers.
+- **Fix:** Move the transport test under `web/packages/agenta-entities/tests/unit/` and split the app tests into `api.test.ts`, guard tests, and actual controller tests.
+
+## Non-blocking nits
+
+- `web/oss/src/components/Drives/editMode/components/DriveEditBanner.tsx:25` blindly appends a period to backend messages, producing doubled punctuation.
+- `web/oss/src/components/Drives/editMode/model.ts:6` exports a mutable `Set`; expose it as `ReadonlySet` or keep it module-private.
+- `docs/design/file-drawer-edit-mode/status.md:10` says no implementation or tests exist, contradicting the implementation checkpoint at `status.md:163`.
+
+## Questions the author must answer
+
+- `web/oss/src/components/Drives/DriveExplorer.tsx:221` — Why is permission to edit coupled to the upload feature flag instead of an edit-specific capability?
+- `web/oss/src/components/Drives/editMode/components/DriveEditGuardModal.tsx:19` — Who approved omitting the authoritative Save-and-continue action, and how is interrupted navigation supposed to complete after saving?
+- `web/oss/src/components/Drives/DriveHeader.tsx:313` — Who approved disabling Cancel during saving despite the authoritative interaction requiring it to remain live?
+- `web/oss/src/components/Drives/editMode/components/DriveFileEditor.tsx:59` — What evidence confirms `autoFocus` places the caret at the start rather than merely focusing the editor?
+- `docs/design/file-drawer-edit-mode/status.md:177` — Why is this being considered pre-merge-ready when byte round-trip, conflict, guard-route, caret, and theme QA are still unrun?

--- a/docs/design/file-drawer-edit-mode/reviews/plan-review-codex.md
+++ b/docs/design/file-drawer-edit-mode/reviews/plan-review-codex.md
@@ -1,0 +1,965 @@
+# Codex review of `plan.md`
+
+**Reviewer:** OpenAI Codex (gpt-5.6-sol, high reasoning effort), read-only sandbox.
+**Date:** 2026-08-04 · **Worktree:** `/home/mahmoud/code/agenta-2-editmode` @ `2dae645c4c`
+**Brief:** skeptical senior-frontend verification of `plan.md`, `research.md`, `CONTEXT.md`,
+and `design/edit-mode-spec.html` against the real code. Every claim is cited `path:line`.
+
+## Verdict
+
+The plan is not implementable as written. The transport choice, most prop names, the six-value language mapping, `mtime`, CSV handling, and `.env` research are real; the central correctness claims are not. Markdown editing is not byte-preserving, saving does not make the proposed editor read-only, the buffer cannot distinguish a save snapshot from subsequent typing, the mount-id key is wrong for folded agent files, several drawer exits bypass the guard, and the conflict grace window creates both silent-overwrite and false-conflict races. This needs a smaller first PR and a rewritten controller/state design before implementation. `docs/design/file-drawer-edit-mode/plan.md:23-46` `web/packages/agenta-ui/src/Editor/Editor.tsx:282-299` `web/oss/src/components/Drives/FilesDrawer.tsx:95-125` `docs/design/file-drawer-edit-mode/plan.md:489-503`
+
+## 1. Is the editor reuse real, or invented?
+
+### Blockers
+
+#### 1.1 `state="readOnly"` does not make this editor read-only
+
+The plan passes `disabled={phase === "saving"}` to the outer `EditorProvider`, but passes no `disabled` prop to `SharedEditor`; it passes only the visual `state="readOnly"`. `docs/design/file-drawer-edit-mode/plan.md:271-298`
+
+`SharedEditor.state` changes container classes and cursor/background styling only. It is not forwarded as editor editability. `web/packages/agenta-ui/src/SharedEditor/SharedEditor.tsx:114-178`
+
+`SharedEditor` separately forwards its `disabled` prop to the inner `Editor`; in the proposed call that value is `undefined`. `web/packages/agenta-ui/src/SharedEditor/SharedEditor.tsx:216-235`
+
+The no-provider `Editor` then supplies its own `disabled` value to `EditorInner`. `web/packages/agenta-ui/src/Editor/Editor.tsx:1117-1149`
+
+`EditorInner` defaults `disabled` to `false` and calls `editor.setEditable(!disabled)`. That inner effect can therefore re-enable the editor created by the disabled provider. `web/packages/agenta-ui/src/Editor/Editor.tsx:142-176` `web/packages/agenta-ui/src/Editor/Editor.tsx:455-457`
+
+Failing sequence:
+
+1. Edit a file.
+2. Click Save.
+3. The provider is rendered with `disabled=true`.
+4. The inner editor receives `disabled=undefined`, defaults it to `false`, and calls `setEditable(true)`.
+5. The user can keep typing during the write, contrary to the saving-state rule. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:476-483` `web/packages/agenta-ui/src/Editor/Editor.tsx:455-457`
+
+The fix is not subtle: pass `disabled={phase === "saving"}` to `SharedEditor` as the chat precedent does. `web/packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx:183-216`
+
+#### 1.2 The proposed markdown editor is not a verbatim file editor
+
+Research correction 5 is narrowly correct: `SET_MARKDOWN_VIEW(true)` means markdown source, and `false` means rich text. The plugin says so explicitly. `web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx:220-259` `web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx:279-289`
+
+The plan’s stronger conclusion—“the buffer is always raw markdown source”—is false. On first switching from rich nodes to source, the plugin obtains the source by serializing the rich document unless its source cache is already reusable. `docs/design/file-drawer-edit-mode/plan.md:328-336` `web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx:151-168`
+
+That first serialization can normalize the file before the user edits it. The command does not inject the original raw file string directly into a markdown `CodeNode`; it serializes the current rich-text tree. `web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx:151-160`
+
+Rich-mode change emission is also explicitly lossy: it serializes the document and then calls `stripBackslashEscapes`. `web/packages/agenta-ui/src/Editor/Editor.tsx:282-299`
+
+`stripBackslashEscapes` removes every backslash that precedes another character, not merely a display-only escape. `web/packages/agenta-ui/src/Editor/plugins/markdown/utils/textCleanup.ts:146-177`
+
+Failing sequence:
+
+1. Open a markdown file containing a meaningful backslash escape.
+2. The editor initially hydrates rich nodes.
+3. The synchronizer dispatches `SET_MARKDOWN_VIEW(true)`.
+4. The plugin serializes those nodes into source.
+5. A subsequent rich-path emission strips backslashes.
+6. Save writes bytes different from those originally read, even if the user changed an unrelated line. `web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx:151-168` `web/packages/agenta-ui/src/Editor/Editor.tsx:282-299`
+
+The chat editor is not a valid precedent for a byte-sensitive file editor. It edits a semantic chat-message value, and it deliberately uses the same `text` for both `initialValue` and `value`; it does not promise exact source preservation. `web/packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx:158-186`
+
+The first PR should use `codeOnly` for markdown source as well. Rendered markdown preview can remain a separate component, but the editable source must bypass the rich-text markdown transforms. `web/packages/agenta-ui/src/Editor/Editor.tsx:249-266` `web/oss/src/components/Drives/renderers.tsx:153-159`
+
+#### 1.3 `initialValue={original}` plus `value={draft}` does not behave as described
+
+All proposed `SharedEditor` props exist, but the behavioral explanation is wrong. `SharedEditor` chooses `value` over `initialValue` immediately for its controlled value. `web/packages/agenta-ui/src/SharedEditor/SharedEditor.tsx:71-80`
+
+In code mode, the code plugin likewise chooses `value` over `initialValue` when constructing its initial content. `web/packages/agenta-ui/src/Editor/plugins/index.tsx:149-160`
+
+Therefore `initialValue={original}` is not the mount-time source while `value={draft}` is the later controlled source in the clean two-phase sense claimed by the plan. `docs/design/file-drawer-edit-mode/plan.md:314-317`
+
+For rich mode, controlled-value hydration is deferred while focused, which is another behavioral constraint the plan does not model. `web/packages/agenta-ui/src/Editor/Editor.tsx:741-755`
+
+The buffer must own its exact original and draft independently of Lexical. Do not infer the save baseline from the editor’s `initialValue` behavior. `docs/design/file-drawer-edit-mode/plan.md:31-35` `web/packages/agenta-ui/src/SharedEditor/SharedEditor.tsx:71-105`
+
+#### 1.4 The editor cannot implement “typed during save” with the proposed record
+
+The design says saving is read-only, but also specifies that if the user has already typed again during the write, the state should return to dirty. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:485-492`
+
+The record has no `savingDraft`, revision counter, request id, or buffer id. `docs/design/file-drawer-edit-mode/plan.md:23-46`
+
+`editSaveSucceededAtom({size, mtime})` therefore cannot know which exact string was sent or whether the current draft changed after that snapshot. `docs/design/file-drawer-edit-mode/plan.md:135-148`
+
+Comparing the current `draft` to `original` is insufficient because `original` is still the pre-save content. A successful save of a changed draft would remain dirty unless success updates `original`, but success cannot safely update it to the current draft if the current draft moved after the request began. `docs/design/file-drawer-edit-mode/plan.md:31-36` `docs/design/file-drawer-edit-mode/plan.md:136-148`
+
+The state needs at least `saveRequest: {id, content}` or `savedRevision`, and the completion action must carry the buffer identity it belongs to. `docs/design/file-drawer-edit-mode/plan.md:125-141`
+
+### Should-fix
+
+#### 1.5 Prop audit: the props exist, but the exported provider type is stale
+
+`EditorProvider` really accepts `codeOnly`, `language`, `enableTokens`, `showToolbar`, `disabled`, and `id` because its implementation is typed as `EditorProps & {children}`. `web/packages/agenta-ui/src/Editor/Editor.tsx:816-847`
+
+The separately exported `EditorProviderProps` interface declares only HTML props, `children`, and `dimensions`. It does not describe the actual component. `web/packages/agenta-ui/src/Editor/types.d.ts:19-26`
+
+This does not invalidate the JSX call because the component’s inferred signature is broader, but it is another documentation/type export inconsistency the plan failed to notice. `web/packages/agenta-ui/src/Editor/index.ts:51-52`
+
+`SharedEditor` really accepts:
+
+- `noProvider`. `web/packages/agenta-ui/src/SharedEditor/types.ts:55`
+- `className`, inherited from `HTMLProps`. `web/packages/agenta-ui/src/SharedEditor/types.ts:20-23`
+- `autoFocus`, also inherited from `HTMLProps` and destructured explicitly. `web/packages/agenta-ui/src/SharedEditor/SharedEditor.tsx:40-69`
+- `id`, `footer`, `disableDebounce`, `initialValue`, and `value`. `web/packages/agenta-ui/src/SharedEditor/types.ts:27-37` `web/packages/agenta-ui/src/SharedEditor/types.ts:63-65`
+
+There are no nonexistent props in the plan’s concrete `<EditorProvider>` or `<SharedEditor>` calls. The failures are semantic, not syntactic. `docs/design/file-drawer-edit-mode/plan.md:265-300`
+
+#### 1.6 Research correction 3 is right
+
+The README documents nonexistent `debounceDelay` and `containerVariant` props and gives an incomplete two-value `state` union. `web/packages/agenta-ui/src/SharedEditor/README.md:36-47`
+
+The real props use `editorType: "border" | "borderless"` and a six-value `state`. `web/packages/agenta-ui/src/SharedEditor/types.ts:27-41`
+
+The plan is right to distrust this README. `docs/design/file-drawer-edit-mode/research.md:79-91`
+
+#### 1.7 `className="hidden"` is forwarded, but cursor preservation is asserted without an implementation
+
+`SharedEditor` merges the caller’s `className` onto its outer DOM node, so the `hidden` class reaches the correct subtree. `web/packages/agenta-ui/src/SharedEditor/SharedEditor.tsx:114-167`
+
+The editor remains mounted, and its `HistoryPlugin` remains mounted, so retaining the Lexical history object is plausible. `web/packages/agenta-ui/src/Editor/plugins/index.tsx:144-145`
+
+There is no selection capture or restoration code around the preview toggle. `AutoFocusPlugin` runs as a mounted plugin, not as a view-transition restorer. `web/packages/agenta-ui/src/Editor/plugins/index.tsx:144-146`
+
+The plan may claim that hiding avoids a remount. It cannot claim that cursor position survives the round trip without testing that exact toggle. `docs/design/file-drawer-edit-mode/plan.md:338-344` `docs/design/file-drawer-edit-mode/plan.md:622-626`
+
+#### 1.8 `autoFocus` does not establish “cursor at the start”
+
+The plan passes the boolean `autoFocus` and says that satisfies the requirement to place the cursor at the start. `docs/design/file-drawer-edit-mode/plan.md:320-321`
+
+The editor merely mounts Lexical’s `AutoFocusPlugin`; the call contains no explicit start-selection command. `web/packages/agenta-ui/src/Editor/plugins/index.tsx:144-146`
+
+The design explicitly requires the start, not merely focus somewhere in the editor. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:448-456`
+
+#### 1.9 The synchronizer is not literally a direct copy
+
+The chat synchronizer dispatches `SET_MARKDOWN_VIEW` in a layout effect and again in a request-animation-frame effect. `web/packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx:79-104`
+
+It does not directly set `markdownViewAtom`. The plugin sets that atom when it applies the node transformation. `web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx:130-168`
+
+The plan says its synchronizer both copies the precedent and directly sets the atom. Those are different implementations. `docs/design/file-drawer-edit-mode/plan.md:328-334`
+
+The atom is persistent `atomWithStorage`, keyed by editor id, so directly writing it also creates stored UI state with a path-derived id. `web/packages/agenta-ui/src/Editor/state/assets/atoms.ts:1-9`
+
+#### 1.10 Research correction 4 and the mapper are right, with one broken test proposal
+
+`CodeLanguage` really has exactly six values: `json`, `yaml`, `code`, `python`, `javascript`, and `typescript`. `web/packages/agenta-ui/src/Editor/plugins/code/types.ts:1-3`
+
+`driveCodeLanguage` returns many other ids, including `tsx`, `jsx`, `shellscript`, `go`, `rust`, and `plaintext`. `web/oss/src/components/Drives/driveKinds.ts:24-61`
+
+The plan’s mapper covers every current return by mapping known families and using `"code"` as the fallback. `docs/design/file-drawer-edit-mode/plan.md:349-364`
+
+The proposed test cannot iterate “every key of `CODE_LANGS`” because `CODE_LANGS` is module-private, and the plan’s stated `driveKinds.ts` change exports only `TEXT_CAP`. `web/oss/src/components/Drives/driveKinds.ts:24-54` `docs/design/file-drawer-edit-mode/plan.md:167-170` `docs/design/file-drawer-edit-mode/plan.md:588-589`
+
+Either test public extension cases or intentionally export a read-only language map. Do not add a test that cannot import its subject. `web/oss/src/components/Drives/driveKinds.ts:24-61`
+
+#### 1.11 The diff imports exist, but `DiffView` is unsafe even for a malformed `.json`
+
+`@agenta/ui/editor` exports `DiffView` and `computeTextDiffLines`. `web/packages/agenta-ui/src/Editor/index.ts:40-49`
+
+`@agenta/ui/diff` directly exports the diff utility file. `web/packages/agenta-ui/package.json:15-22`
+
+Both import paths proposed by the plan therefore exist. `docs/design/file-drawer-edit-mode/plan.md:366-374`
+
+Research correction 2 is correct that the rendered `DiffView` supports JSON/YAML only: its prop type is restricted to those languages, and its diff extension parses with YAML or JSON5 before computing the diff. `web/packages/agenta-ui/src/Editor/DiffView.tsx:178-199` `web/packages/agenta-ui/src/Editor/plugins/code/extensions/diffHighlight.tsx:385-425`
+
+On parse failure the extension logs the exception and does not construct diff content. `web/packages/agenta-ui/src/Editor/plugins/code/extensions/diffHighlight.tsx:526-529`
+
+A file with a `.json` suffix is not guaranteed to contain valid JSON while the user or agent is editing it. The plan’s claim that JSON is “the one case `DiffView` handles correctly” is too broad. `docs/design/file-drawer-edit-mode/plan.md:368-374`
+
+Use `computeTextDiffLines` for every file in this feature, including `.json`, because the product is comparing raw file contents rather than parsed data structures. `web/packages/agenta-ui/src/Editor/utils/diffUtils.ts:474-502`
+
+#### 1.12 Rejecting `SimpleSharedEditor` is justified, but the reasoning is slightly inaccurate
+
+`SimpleSharedEditor` detects JSON, YAML, and HTML from content and forces code mode for those detected values. `web/oss/src/components/EditorViews/SimpleSharedEditor/index.tsx:291-323`
+
+It also owns format, copy, and minimize controls in its header. `web/oss/src/components/EditorViews/SimpleSharedEditor/index.tsx:185-287`
+
+The plan is right that this is the wrong semantic wrapper for an extension-authoritative file editor. `docs/design/file-drawer-edit-mode/plan.md:248-258`
+
+It does not “sniff on every render”; the checks are memoized against `value` and `initialValue`. `web/oss/src/components/EditorViews/SimpleSharedEditor/index.tsx:291-308`
+
+That imprecision is a nit. The rejection itself is correct. `web/oss/src/components/EditorViews/SimpleSharedEditor/index.tsx:310-323`
+
+## 2. Is the state machine complete and are the transitions sound?
+
+### Blockers
+
+#### 2.1 The state machine has no loaded-original state
+
+`useDriveFileText` is asynchronous and returns `data: undefined` while pending. It also discards the query’s explicit error state and represents a failed read as non-pending undefined content. `web/oss/src/components/Drives/driveFileSource.tsx:63-84`
+
+The current renderer distinguishes pending content from failed content. `web/oss/src/components/Drives/renderers.tsx:138-169`
+
+The plan’s edit affordance uses only kind, listing size, and write capability. It does not require content to be loaded successfully. `docs/design/file-drawer-edit-mode/plan.md:518-529`
+
+`openEditBufferAtom` requires a concrete `original: string`, but neither the record nor the hook signature represents “loading original” or “read failed.” `docs/design/file-drawer-edit-mode/plan.md:23-35` `docs/design/file-drawer-edit-mode/plan.md:127` `docs/design/file-drawer-edit-mode/plan.md:221-237`
+
+Failing sequence:
+
+1. Select a text file.
+2. Click Edit before its content query completes, or after the query failed.
+3. `useDriveFileText` supplies `undefined`.
+4. `openEditBufferAtom` expects a string.
+5. The implementation must either lie with `""`, crash/type-error, or silently edit an empty replacement. `web/oss/src/components/Drives/driveFileSource.tsx:63-84` `docs/design/file-drawer-edit-mode/plan.md:127`
+
+Edit must be disabled until the raw content is a loaded string, with a distinct failure affordance. `web/oss/src/components/Drives/renderers.tsx:141-148`
+
+#### 2.2 The family key is not the write mount id for folded agent files
+
+Selection is keyed by the primary drive’s mount id. `web/oss/src/components/Drives/useDriveSelection.ts:18-35`
+
+A displayed `agent-files/foo.md` path resolves to a different agent mount id and the mount-relative path `foo.md`. `web/oss/src/components/Drives/useSessionDrive.ts:188-194`
+
+The proposed buffer family is keyed by `drive.mount?.id`, while the buffer’s `mountId` is the write target. Those values differ for agent files. `docs/design/file-drawer-edit-mode/plan.md:95-103` `docs/design/file-drawer-edit-mode/plan.md:125-128`
+
+The state model needs separate names and responsibilities:
+
+- `driveKey`: identifies the open drawer/controller slot.
+- `targetMountId`: identifies the backend object store mount.
+- `displayPath`: identifies the folded UI path.
+- `targetPath`: identifies the mount-relative write path. `web/oss/src/components/Drives/useSessionDrive.ts:75-83` `web/oss/src/components/Drives/useSessionDrive.ts:188-194`
+
+Calling all of these “mount id” and “path” guarantees a wrong query key or wrong write target later. `docs/design/file-drawer-edit-mode/plan.md:25-35`
+
+#### 2.3 The action atoms do not identify which family instance to mutate
+
+The family is parameterized by drive key, but the action signatures shown in the transition table contain no drive key except the target `mountId` in `openEditBufferAtom`. `docs/design/file-drawer-edit-mode/plan.md:95-103` `docs/design/file-drawer-edit-mode/plan.md:125-141`
+
+`setEditDraftAtom(text)`, `startEditSaveAtom(abort)`, and the success/failure actions cannot know which `driveEditBufferAtomFamily(key)` instance to update without hidden global coupling or a second layer of atom families. `docs/design/file-drawer-edit-mode/plan.md:128-141`
+
+The plan calls these concrete action atoms, not factory functions or per-key families. As specified, the state code cannot be written. `docs/design/file-drawer-edit-mode/plan.md:122-141`
+
+#### 2.4 `openedAt` is referenced but never declared
+
+`conflictFromActivity` compares `entry.at` with `buffer.openedAt`. `docs/design/file-drawer-edit-mode/plan.md:445-457`
+
+`DriveEditBuffer` has no `openedAt` field. `docs/design/file-drawer-edit-mode/plan.md:23-46`
+
+The tests also require an entry “timestamped before the buffer opened,” but the proposed fixture type cannot contain the needed timestamp. `docs/design/file-drawer-edit-mode/plan.md:595-596`
+
+#### 2.5 Other fields and identities are missing
+
+`editSaveSucceededAtom({size, mtime})` references an `mtime` result that the write response does not provide. `docs/design/file-drawer-edit-mode/plan.md:136` `docs/design/file-drawer-edit-mode/plan.md:484-498`
+
+The record has no `size`, even though success receives `size` and the design requires size UI updates. `docs/design/file-drawer-edit-mode/plan.md:23-46` `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:485-492`
+
+The record has no saved-request content, revision, request id, or buffer id, although the success transition depends on whether the draft moved during the request. `docs/design/file-drawer-edit-mode/plan.md:23-46` `docs/design/file-drawer-edit-mode/plan.md:146-148`
+
+The record has no explicit “guard save continuation” state, although `resolveEditExitAtom("save")` must save and then run a specific interrupted action. `docs/design/file-drawer-edit-mode/plan.md:132-137`
+
+The record has no “reload theirs in flight” state, although reload requires a content invalidation and asynchronous refetch before a new baseline exists. `docs/design/file-drawer-edit-mode/plan.md:507-510`
+
+#### 2.6 “Pure action atoms” conflicts with executable exit intents
+
+The plan says every action atom performs pure state manipulation with no I/O. `docs/design/file-drawer-edit-mode/plan.md:122-123`
+
+The same table says exit actions “run the intent.” `docs/design/file-drawer-edit-mode/plan.md:130-137`
+
+Only the filter intent contains a callable `run`; close, selection, cancel, and reload contain descriptions rather than executable continuations. `docs/design/file-drawer-edit-mode/plan.md:52-58`
+
+A bare Jotai store cannot close a drawer or invoke the real selection callback from `{kind: "select"; path}` unless the atom imports app effects or stores callbacks. `docs/design/file-drawer-edit-mode/plan.md:52-58` `docs/design/file-drawer-edit-mode/plan.md:600-620`
+
+Keep the reducer pure and let a controller interpret a returned continuation, or store an opaque intent and have the hook execute it after observing a successful terminal action. Do not pretend the atom both remains pure and performs UI effects. `web/AGENTS.md:184-209`
+
+#### 2.7 `Reload theirs` clears the object it later tries to adopt into
+
+The plan says reload routes through the dirty guard, which discards the buffer, then refetches and calls `adoptTheirsAtom`. `docs/design/file-drawer-edit-mode/plan.md:507-510`
+
+The discard transition clears the buffer. `docs/design/file-drawer-edit-mode/plan.md:132-134`
+
+`adoptTheirsAtom` is defined to operate on an open buffer. `docs/design/file-drawer-edit-mode/plan.md:140`
+
+After discard there is no buffer to adopt into. The described transition is internally contradictory. `docs/design/file-drawer-edit-mode/plan.md:132-140`
+
+Reload should either replace the existing buffer after confirmation or close edit mode and return to the normal viewer after invalidating content. It cannot do both. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:503-510`
+
+#### 2.8 Saving cancellation has no coherent transition
+
+The design says Cancel during saving aborts the request. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:476-483`
+
+The record stores an `AbortController`, but the transition table has no `abortEditSaveAtom`, no saving-to-dirty transition for an abort, and no rule deciding whether Cancel closes, guards, or merely cancels the request. `docs/design/file-drawer-edit-mode/plan.md:43-45` `docs/design/file-drawer-edit-mode/plan.md:125-141`
+
+The generic `requestEditExitAtom` rules discuss only clean versus dirty/banner states, not saving. `docs/design/file-drawer-edit-mode/plan.md:130-134`
+
+The UI plan keeps Cancel enabled while saving, so this is reachable immediately. `docs/design/file-drawer-edit-mode/plan.md:196-201`
+
+#### 2.9 Late save completion can mutate a replacement buffer
+
+The family holds one nullable buffer per drive and deliberately survives drawer unmounts. `docs/design/file-drawer-edit-mode/plan.md:95-111`
+
+A save completion carries no buffer id, file path, or request id—only size and mtime. `docs/design/file-drawer-edit-mode/plan.md:136`
+
+Failing sequence:
+
+1. Save file A.
+2. Close or abort the drawer.
+3. Reopen the same drive and edit file B.
+4. File A’s request settles after file B replaced the family value.
+5. `editSaveSucceededAtom({size, mtime})` applies to the current slot and can mark B saved or alter B’s baseline. `docs/design/file-drawer-edit-mode/plan.md:95-111` `docs/design/file-drawer-edit-mode/plan.md:125-141`
+
+An `AbortController` does not prove the server did not write, and it does not make a previously queued completion impossible. The reducer must reject completions whose request id and buffer id do not match the active state. `web/packages/agenta-entities/src/session/api/client.ts:65-91`
+
+#### 2.10 `saved -> read` is unspecified
+
+The design requires an approximately two-second Saved chip and then a return to viewing. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:485-492`
+
+The transition table has a success transition into `saved`, but no action that exits `saved`. `docs/design/file-drawer-edit-mode/plan.md:125-141`
+
+The record contains `savedAt`, but no timer owner, timer cancellation rule, or transition atom. `docs/design/file-drawer-edit-mode/plan.md:42-45`
+
+If the timer lives in `useDriveEdit`, it must be cancelled when the buffer closes, the drawer unmounts, the drive generation changes, or a new edit starts. None of those rules is planned. `web/oss/src/components/Drives/FilesDrawer.tsx:35-56` `web/oss/src/components/Drives/FilesDrawer.tsx:95-125`
+
+#### 2.11 Storing `AbortController` in the Jotai value is legal but structurally wrong here
+
+Jotai does not require atom values to be serializable; non-serializability alone is not a blocker. The proposed atom is a normal in-memory atom, not storage-backed. `docs/design/file-drawer-edit-mode/plan.md:95-100`
+
+The problem is lifecycle and mutation: an `AbortController` is a mutable imperative resource, while the module-level atom intentionally outlives the component that created it. `docs/design/file-drawer-edit-mode/plan.md:43-45` `docs/design/file-drawer-edit-mode/plan.md:105-111`
+
+Existing upload code keeps abort controllers in hook refs and keeps serializable upload status in React state. `web/oss/src/components/Drives/useMountUpload.ts:68-83`
+
+Follow that precedent: keep the controller in the owning hook, and put only request identity/status in the reducer state. `web/oss/src/components/Drives/useMountUpload.ts:73-79`
+
+### State-by-state audit of the authoritative `NOTES`
+
+| State | Verdict |
+|---|---|
+| `read` | Expressible through `affordance`, but “read-only mount” is approximated by `canUpload`, not verified permission or mount capability. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:438-446` `docs/design/file-drawer-edit-mode/plan.md:524-537` |
+| `clean` | Partly expressible. The plan omits the `⌘E` trigger, does not guarantee cursor-at-start, and proposes `inert` on a component that has no such prop. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:448-456` `docs/design/file-drawer-edit-mode/plan.md:219-228` `web/oss/src/components/Drives/DriveTreePane.tsx:13-30` |
+| `dirty` | Draft inequality can express dirty, and the header chip is straightforward; the tree dot cannot be implemented from `DriveTreeRow` without supplying a family key or context. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:458-465` `docs/design/file-drawer-edit-mode/plan.md:115-120` `web/oss/src/components/Drives/DriveTreeRow.tsx:15-50` |
+| `preview` | The record can remain dirty while `view="preview"`, but the plan omits the spec’s visible-but-disabled formatting controls entirely. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:467-474` `docs/design/file-drawer-edit-mode/plan.md:238-240` |
+| `saving` | Not sound: `state="readOnly"` is visual, and no abort transition exists. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:476-483` `web/packages/agenta-ui/src/SharedEditor/SharedEditor.tsx:132-150` `docs/design/file-drawer-edit-mode/plan.md:125-141` |
+| `saved` | Not expressible correctly because there is no save snapshot, no timer transition, and the response has no mtime. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:485-492` `docs/design/file-drawer-edit-mode/plan.md:23-46` `api/oss/src/apis/fastapi/mounts/models.py:102-104` |
+| `error` | Buffer preservation is expressible, but retry semantics are not defined against a specific failed save snapshot. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:494-501` `docs/design/file-drawer-edit-mode/plan.md:137` |
+| `conflict` | The banner is expressible; reliable detection and the reload transition are not. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:503-510` `docs/design/file-drawer-edit-mode/plan.md:436-512` |
+| `confirm` | `pendingExit` expresses the dialog, but the plan cannot execute most intent variants from a pure atom, and browser unload necessarily uses the browser dialog rather than the same modal. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:512-519` `docs/design/file-drawer-edit-mode/plan.md:52-58` `docs/design/file-drawer-edit-mode/plan.md:150-161` |
+| `code` | The orthogonal mode is sound, and the mapper covers current languages. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:521-528` `docs/design/file-drawer-edit-mode/plan.md:349-364` |
+| `locked` | Kind-based hiding is expressible; actual read-only mount status is not present in `mountSchema`. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:530-537` `web/packages/agenta-entities/src/session/core/schema.ts:171-177` |
+| `capped` | `STATES` contains it, but `NOTES` has no `capped` entry at all. Selecting it makes `note` undefined and then dereferences `note.title`; the authoritative prototype itself is broken here. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:423-436` `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:438-539` `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:557-563` `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:629-631` |
+
+### Should-fix
+
+#### 2.12 Preview precedence is lossy, though dirty remains derivable
+
+The first-match table returns `preview` before `dirty`. `docs/design/file-drawer-edit-mode/plan.md:69-84`
+
+The plan then incorrectly says “phase beats view”; the table does the opposite for clean/dirty versus preview. `docs/design/file-drawer-edit-mode/plan.md:84-87`
+
+The UI can still know it is dirty through the separate `driveEditDirtyAtomFamily`, so the dirty chip need not disappear in preview. `docs/design/file-drawer-edit-mode/plan.md:113-120`
+
+The derived label itself cannot tell whether preview is clean or dirty. That makes it a poor state API and a poor test oracle. `docs/design/file-drawer-edit-mode/plan.md:79-82` `docs/design/file-drawer-edit-mode/plan.md:592-594`
+
+Return orthogonal facets—`mode`, `view`, `saveStatus`, `dirty`, `blockingDialog`, `banner`—or remove the 12-name label entirely. The record already contains those dimensions. `docs/design/file-drawer-edit-mode/plan.md:23-46`
+
+#### 2.13 The claimed 12-label test is impossible
+
+The plan says `deriveEditStatus` will have one assertion per spec name, twelve total. `docs/design/file-drawer-edit-mode/plan.md:592-594`
+
+It explicitly says `code` is never returned by that function. `docs/design/file-drawer-edit-mode/plan.md:89-91`
+
+A function that cannot return `code` cannot have a producing test case for all twelve names. `docs/design/file-drawer-edit-mode/plan.md:69-91`
+
+#### 2.14 The module-level family retains large buffers indefinitely
+
+Mount file query bodies have an explicit one-minute garbage-collection time because they can be roughly 1.5 MB strings. `web/packages/agenta-entities/src/session/state/mounts.ts:193-209`
+
+The proposed atom family stores both `original` and `draft`, intentionally survives unmount, and has no removal policy. `docs/design/file-drawer-edit-mode/plan.md:23-35` `docs/design/file-drawer-edit-mode/plan.md:95-111`
+
+Every distinct mount key can therefore retain two large strings for the module lifetime after drawer churn. `docs/design/file-drawer-edit-mode/plan.md:95-111`
+
+Use an explicit cleanup/removal policy or keep the draft in a provider scoped to the drawer shell that owns the guard. `web/oss/src/components/Drives/FilesDrawer.tsx:95-125`
+
+#### 2.15 The session-teardown warning is missing
+
+The design’s rules require a first-edit warning for session-scoped files because the session can be torn down. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:411-414`
+
+No field, action, UI component, or implementation step handles that warning. `docs/design/file-drawer-edit-mode/plan.md:23-245`
+
+## 3. Layer, seam, file organization, naming
+
+### Blockers
+
+#### 3.1 Guard ownership belongs above `DriveExplorer`
+
+`FilesDrawer` owns the actual antd `EnhancedDrawer`, its controlled `open`, its real `onClose`, and `destroyOnClose`. `web/oss/src/components/Drives/FilesDrawer.tsx:76-125`
+
+The plan wraps only the `onClose` passed down to `DriveHeader`. `docs/design/file-drawer-edit-mode/plan.md:154-160`
+
+Antd receives the original host `onClose` directly from `FilesDrawer`, so mask-click and keyboard dismissal bypass the child wrapper. `web/oss/src/components/Drives/FilesDrawer.tsx:95-104` `web/packages/agenta-ui/src/drawer/EnhancedDrawer.tsx:71-80`
+
+The edit boundary must own or wrap `FilesDrawer.onClose`, not merely the header button callback. `web/oss/src/components/Drives/DriveHeader.tsx:122-130`
+
+#### 3.2 `DriveTreeRow` cannot read the proposed keyed atom directly
+
+`DriveTreeRow` receives a node and UI callbacks; it receives neither primary drive id nor target mount id. `web/oss/src/components/Drives/DriveTreeRow.tsx:15-50`
+
+`DriveTreeList` also receives no drive key. `web/oss/src/components/Drives/DriveTreeList.tsx:22-69`
+
+The plan’s claim that the row can call `driveEditPathAtomFamily` with “no prop drilling” omits the parameter required to select the atom-family member. `docs/design/file-drawer-edit-mode/plan.md:115-120` `docs/design/file-drawer-edit-mode/plan.md:215-217`
+
+Do not subscribe every virtualized row to a large edit atom family. Pass one `dirtyPath` to `DriveTreeList`, use a small scoped context, or cut the dot from the first PR. `web/oss/src/components/Drives/DriveTreeList.tsx:115-158`
+
+#### 3.3 The proposed `useDriveEdit` signature lacks the data it needs
+
+The plan calls `useDriveEdit({drive, selectedPath, select, onClose, canUpload})`. `docs/design/file-drawer-edit-mode/plan.md:219-223`
+
+Opening safely also needs:
+
+- Resolved target mount and mount-relative path, because `agent-files/` maps to another mount. `web/oss/src/components/Drives/useSessionDrive.ts:188-194`
+- Raw content query state, including pending and failure. `web/oss/src/components/Drives/driveFileSource.tsx:63-84`
+- The selected listing record’s `mtime`, which `DriveTreeNode` discards. `web/oss/src/components/Drives/driveTree.ts:10-21` `web/oss/src/components/Drives/driveTree.ts:160-176`
+- The active `includeGitignored` value, because it is part of every directory query key. `web/packages/agenta-entities/src/session/state/mounts.ts:42-47`
+- A shell-level close continuation, because the child `onClose` is not authoritative. `web/oss/src/components/Drives/FilesDrawer.tsx:95-125`
+
+The hook interface is under-specified before implementation begins. `docs/design/file-drawer-edit-mode/plan.md:219-237`
+
+### Should-fix
+
+#### 3.4 Four logic files are defensible; eleven flat files are not
+
+Separating pure model logic, reducer state, transport, and a controller hook is a reasonable boundary. Their current names—`driveEdit.ts`, `driveEditState.ts`, `driveEditSave.ts`, and `useDriveEdit.ts`—are too similar in an import list and reveal no hierarchy. `docs/design/file-drawer-edit-mode/plan.md:230-245`
+
+The frontend conventions call for module-local components, hooks, assets, and types to be organized within a feature module. `web/AGENTS.md:165-182`
+
+Use an `editMode/` directory:
+
+- `model.ts`
+- `state.ts`
+- `api.ts`
+- `useDriveEditController.ts`
+- `components/EditBar.tsx`
+- `components/EditGuardModal.tsx`
+- focused colocated tests. `web/AGENTS.md:170-180`
+
+This is progressive organization inside the existing Drives module, not a package extraction or broad refactor. `web/AGENTS.md:178-182`
+
+#### 3.5 The header prop group is acceptable; the inconsistency is the unscoped tree atom
+
+A one-level prop group of config and callbacks is permitted when the parent owns the state. `web/AGENTS.md:207-209`
+
+Therefore an `edit` object passed from the composition root to `DriveHeader` is not inherently wrong. `docs/design/file-drawer-edit-mode/plan.md:175-188`
+
+The inconsistency is claiming atom-first sharing for a deeply nested tree row without providing atom scope, while using explicit props for the direct child. `docs/design/file-drawer-edit-mode/plan.md:115-120` `docs/design/file-drawer-edit-mode/plan.md:175-188`
+
+Choose one coherent seam:
+
+- A scoped `DriveEditProvider` around the drawer chrome for header, banner, body, and guard.
+- Or explicit controller props to direct children plus a single `dirtyPath` passed through the tree list. `web/AGENTS.md:184-209`
+
+#### 3.6 `DriveExplorer` is already the composition root; it should not own all modal and lifecycle behavior
+
+`DriveExplorer` already coordinates filters, selection, uploads, tree data, header state, folder/file content, toolbar, and tree pane. `web/oss/src/components/Drives/DriveExplorer.tsx:90-210` `web/oss/src/components/Drives/DriveExplorer.tsx:235-328` `web/oss/src/components/Drives/DriveExplorer.tsx:332-415`
+
+The plan adds a controller hook, toolbar swap, header prop group, four guarded selection consumers, a banner, two modals, keyboard listeners, `beforeunload`, and tree inertness. `docs/design/file-drawer-edit-mode/plan.md:219-228` `docs/design/file-drawer-edit-mode/plan.md:230-245`
+
+Keep `DriveExplorer` as the declarative composition point, but put the behavior in one `DriveEditBoundary` or controller object. The real close guard must still be owned by `FilesDrawer`. `web/oss/src/components/Drives/FilesDrawer.tsx:95-125`
+
+#### 3.7 `DriveTreePane` has no inert seam
+
+`DriveTreePane` accepts geometry, key handling, drop props, rows, and children. It has no `inert`, editing, or class-name prop. `web/oss/src/components/Drives/DriveTreePane.tsx:13-30`
+
+Its resize handle is a sibling of the tree motion element, so applying inertness only to the tree pane would not automatically disable resizing. `web/oss/src/components/Drives/DriveTreePane.tsx:45-92`
+
+Drop handlers are spread onto the scroll container separately. `web/oss/src/components/Drives/DriveTreePane.tsx:61-70`
+
+The plan must explicitly change `DriveTreePane` or place an edit boundary around all navigation and drag surfaces. `docs/design/file-drawer-edit-mode/plan.md:219-228`
+
+#### 3.8 App-layer placement is correct; the proposed API/schema split is not
+
+The edit UI and its drawer-specific controller belong under `web/oss/src/components/Drives/` because they are currently used by one feature. `web/AGENTS.md:431-442`
+
+The transport wrapper and schema are split awkwardly: the plan adds the response schema to `@agenta/entities/session/core/schema.ts` but keeps the Fern call in an app file. `docs/design/file-drawer-edit-mode/plan.md:378-417`
+
+The frontend API convention says Fern access, response validation, and schema boundary should live together, using `@agenta/sdk/resources` and `safeParseWithLogging`. `web/AGENTS.md:28-84`
+
+The session package already centralizes mount reads and their validation. `web/packages/agenta-entities/src/session/api/api.ts:634-689`
+
+Either:
+
+- Add `writeMountFileContent` beside `readMountFile`, export its schema and function through `@agenta/entities/session`.
+- Or keep the entire write boundary in the app and import the accessor from `@agenta/sdk/resources` plus the public shared parser. `web/AGENTS.md:74-84`
+
+The current half-package, half-app split is the worst of both. `docs/design/file-drawer-edit-mode/plan.md:378-417`
+
+#### 3.9 The plan uses a query-key helper that is not publicly exported
+
+`mountDirQueryKey` exists in the internal state module. `web/packages/agenta-entities/src/session/state/mounts.ts:42-47`
+
+The public `@agenta/entities/session` barrel exports the directory query family but not `mountDirQueryKey`. `web/packages/agenta-entities/src/session/index.ts:81-93`
+
+The package exposes only the `./session` subpath, not arbitrary internal files. `web/packages/agenta-entities/package.json:31-49`
+
+The proposed app-layer `driveEditSave.ts` therefore cannot import that helper through the sanctioned public export unless the barrel changes. `docs/design/file-drawer-edit-mode/plan.md:419-430`
+
+#### 3.10 Naming changes
+
+- `driveEditAffordance` should be `getDriveEditAvailability`; `"offer" | "capped" | "hidden"` should be `"enabled" | "too-large" | "unavailable"` because “offer” describes presentation, not capability. `docs/design/file-drawer-edit-mode/plan.md:60-65`
+- `phase` should be `saveStatus` if its values remain `clean | dirty | saving | saved`, although dirty is better derived separately. `docs/design/file-drawer-edit-mode/plan.md:31-38`
+- `view` is acceptable as `editorView`; bare `view` is too generic beside drawer and preview views. `docs/design/file-drawer-edit-mode/plan.md:36-38`
+- `banner` should be `blockingIssue` or separate `saveError` and `conflict`; overwriting one error with another destroys information. `docs/design/file-drawer-edit-mode/plan.md:38-50` `docs/design/file-drawer-edit-mode/plan.md:143-144`
+- `pendingExit` should be `pendingNavigation` or `exitRequest`; “exit” does not reveal that selection and reload are included. `docs/design/file-drawer-edit-mode/plan.md:39` `docs/design/file-drawer-edit-mode/plan.md:52-58`
+- `forceNextSave` should be `skipConflictCheckOnce`; the current name does not say what is forced or what safety check is bypassed. `docs/design/file-drawer-edit-mode/plan.md:40-41`
+- `adoptTheirsAtom` should be `replaceBufferFromRemoteAtom`; “theirs” becomes unclear outside conflict-dialog copy. `docs/design/file-drawer-edit-mode/plan.md:140`
+
+### Nit
+
+#### 3.11 `canUpload` is an expedient capability proxy, not proof of a writable mount
+
+The current upload gate is feature flag plus non-local mode plus a present primary mount. `web/oss/src/components/Drives/useDriveUploads.ts:62-68`
+
+`mountSchema` has no read-only flag, so the plan is right not to invent one. `web/packages/agenta-entities/src/session/core/schema.ts:171-177`
+
+Call the local value `canEditMountFiles` only after deriving it deliberately from the upload capability; do not document it as actual backend writability. `docs/design/file-drawer-edit-mode/plan.md:532-537`
+
+## 4. What will actually break
+
+### Blockers
+
+#### 4.1 The five-second conflict grace window creates a silent overwrite
+
+The plan skips both activity detection and the pre-write mtime check for five seconds after a successful save. `docs/design/file-drawer-edit-mode/plan.md:489-503`
+
+Failing sequence:
+
+1. User saves version U1.
+2. The agent writes version A1 to the same path one second later.
+3. User edits to U2 and saves two seconds later.
+4. Both conflict triggers are suppressed.
+5. U2 silently overwrites A1. `docs/design/file-drawer-edit-mode/plan.md:489-503`
+
+The status document acknowledges that an agent write in the window is missed but claims the next save catches it. The next save can itself occur inside the same window, so that claim is false. `docs/design/file-drawer-edit-mode/status.md:43-47`
+
+#### 4.2 The same grace window can create a false conflict
+
+The write response contains no mtime. `api/oss/src/apis/fastapi/mounts/models.py:102-104`
+
+The plan depends on a later directory refetch to adopt the new mtime. `docs/design/file-drawer-edit-mode/plan.md:495-498`
+
+Failing sequence:
+
+1. User saves.
+2. Directory refetch fails, is cancelled, or never produces the edited entry.
+3. `baseMtime` remains the pre-save value.
+4. Five seconds elapse.
+5. User saves again.
+6. The pre-write listing sees the user’s first write mtime and reports it as an external conflict. `docs/design/file-drawer-edit-mode/plan.md:467-498`
+
+There is no “baseline refresh failed” state to prevent this. `docs/design/file-drawer-edit-mode/plan.md:23-46`
+
+#### 4.3 Adopting the “real mtime” can adopt an agent write without adopting its content
+
+Failing sequence:
+
+1. User saves U1.
+2. Agent writes A1 before the directory refetch resolves.
+3. Refetch returns A1’s mtime.
+4. The plan writes that mtime into `baseMtime` but leaves the buffer/cache content as U1.
+5. User saves U2.
+6. Pre-write mtime matches the adopted A1 mtime, so U2 overwrites A1 without conflict. `docs/design/file-drawer-edit-mode/plan.md:495-503`
+
+An mtime fetched after a write is not proof that it belongs to that write. The design needs a server-supplied version/etag/mtime or it must exit edit mode after a successful save and reopen against a fresh read. `api/oss/src/apis/fastapi/mounts/models.py:102-104`
+
+#### 4.4 The activity trigger usually cannot resolve a lazy-drawer path
+
+File activity resolves tool paths only by scanning cached queries under the full-listing prefix `["mounts", "files", projectId]`. `web/packages/agenta-entities/src/session/state/fileActivity.ts:86-99`
+
+The drawer normally loads per-directory `files-dir` queries and fetches the full `files` query only while search is active. `web/oss/src/components/Drives/useLazyDriveTree.tsx:1-11` `web/oss/src/components/Drives/useLazyDriveTree.tsx:117-138`
+
+Therefore a normal open drawer can receive an activity entry with no `resolved` mount/path, causing `conflictFromActivity` to reject it. `web/packages/agenta-entities/src/session/state/fileActivity.ts:121-130` `docs/design/file-drawer-edit-mode/plan.md:447-457`
+
+This trigger is not merely absent in the config host; it is unreliable in the chat host too. `docs/design/file-drawer-edit-mode/plan.md:461-465`
+
+#### 4.5 Self-invalidation does not create file activity
+
+File activity is recorded from detected agent tool calls and then triggers revalidation. `web/packages/agenta-entities/src/session/state/fileActivity.ts:1-15` `web/packages/agenta-entities/src/session/state/fileActivity.ts:75-139`
+
+A frontend upload/save invalidation does not itself append an activity entry. `web/packages/agenta-entities/src/session/state/fileActivity.ts:121-138`
+
+The grace window’s stated reason—preventing the feature’s own invalidation from creating an activity conflict—is based on a nonexistent feedback path. `docs/design/file-drawer-edit-mode/plan.md:489-493`
+
+#### 4.6 Deletion is treated as permission to recreate the file
+
+The pre-write check only conflicts when both mtimes are non-null and unequal. `docs/design/file-drawer-edit-mode/plan.md:472-478`
+
+If the agent deletes the file, the directory entry is absent, so `theirMtime` is null/undefined and the plan proceeds. `docs/design/file-drawer-edit-mode/plan.md:472-478`
+
+The multipart upload then writes a new object at the same path, recreating the deleted file. `api/oss/src/apis/fastapi/mounts/utils.py:79-91` `api/oss/src/core/mounts/service.py:1476-1493`
+
+Missing entry must be a conflict, not “mtime unavailable.” `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:503-510`
+
+#### 4.7 Drawer mask click and antd Escape bypass the guard
+
+`FilesDrawer` gives the host `onClose` directly to `EnhancedDrawer`. `web/oss/src/components/Drives/FilesDrawer.tsx:95-104`
+
+`EnhancedDrawer` spreads that callback into antd’s `Drawer`. `web/packages/agenta-ui/src/drawer/EnhancedDrawer.tsx:71-80`
+
+The plan only wraps the callback passed to `DriveHeader`. `docs/design/file-drawer-edit-mode/plan.md:154-160`
+
+Failing sequence:
+
+1. Edit and dirty a file.
+2. Click the drawer mask or press Escape handled by antd.
+3. Antd invokes the shell’s raw `onClose`.
+4. The host sets `open=false`.
+5. `destroyOnClose` unmounts the editor without the proposed guard. `web/oss/src/components/Drives/FilesDrawer.tsx:95-125`
+
+A second window-level Escape listener inside `useDriveEdit` does not establish ordering or prevent antd from also closing. `docs/design/file-drawer-edit-mode/plan.md:154-161`
+
+#### 4.8 Changed `initialPath` bypasses a wrapped selection callback
+
+`useDriveSelection` handles changed `initialPath` internally by calling its own `select` inside an effect. `web/oss/src/components/Drives/useDriveSelection.ts:84-90`
+
+Wrapping the returned `select` after the hook call does not intercept that internal effect. `web/oss/src/components/Drives/DriveExplorer.tsx:103-106`
+
+Failing sequence:
+
+1. Dirty a file opened from chat.
+2. Another chat link updates quick-look `initialPath`.
+3. `useDriveSelection` calls raw `select(initialPath)`.
+4. Selection changes behind the edit buffer without a guard. `web/oss/src/components/Drives/SessionFilesDrawer.tsx:50-55` `web/oss/src/components/Drives/useDriveSelection.ts:84-90`
+
+The guard must be integrated into selection ownership, not wrapped only at consumer props. `docs/design/file-drawer-edit-mode/plan.md:158-160`
+
+#### 4.9 Drive/session replacement remounts the editor without a guard
+
+`FilesDrawer` intentionally changes the `DriveExplorer` React key when one real mount is replaced by another. `web/oss/src/components/Drives/FilesDrawer.tsx:35-56`
+
+The config host can change its resolved session when the active tab disappears and falls back to another session. `web/oss/src/components/Drives/configDrive.ts:35-59`
+
+Failing sequence:
+
+1. Dirty a file in the config drawer.
+2. The active session changes underneath the panel.
+3. `drive.mount.id` changes.
+4. `useDriveGeneration` increments.
+5. React unmounts the old `DriveExplorer` with no edit guard. `web/oss/src/components/Drives/FilesDrawer.tsx:93-114`
+
+A child-level guard cannot prevent its parent from replacing its key. `web/oss/src/components/Drives/FilesDrawer.tsx:112-124`
+
+#### 4.10 Drag spring-navigation bypasses the wrapped consumers
+
+`useDriveUploads` is currently created before any proposed wrapper and receives the raw `select`. `web/oss/src/components/Drives/DriveExplorer.tsx:123-137`
+
+It passes that selection callback to `useDriveDrop`. `web/oss/src/components/Drives/useDriveUploads.ts:87-93`
+
+Hovering a dragged file over a folder invokes `onNavigate(path)` after a timer. `web/oss/src/components/Drives/useDriveDrop.ts:94-105`
+
+Failing sequence:
+
+1. Dirty a file.
+2. Drag a file over a folder in any still-active drop target.
+3. Wait 700 ms.
+4. Spring navigation calls raw `select`.
+5. Selection changes without the guard. `web/oss/src/components/Drives/useDriveDrop.ts:94-105`
+
+The proposed visual `pointer-events-none` is not a substitute for disabling controller-level navigation and outstanding timers. `docs/design/file-drawer-edit-mode/plan.md:227-228`
+
+#### 4.11 Unmount while saving leaves an identity and cleanup race
+
+The drawer uses `destroyOnClose`. `web/oss/src/components/Drives/FilesDrawer.tsx:95-104`
+
+The buffer and `AbortController` intentionally survive the unmount in a module-level atom family. `docs/design/file-drawer-edit-mode/plan.md:95-111`
+
+No cleanup step aborts on shell unmount, clears the controller, or marks the request stale. `docs/design/file-drawer-edit-mode/plan.md:125-141`
+
+Failing sequence:
+
+1. Start saving.
+2. Parent route navigation or host state unmounts the drawer.
+3. The request continues.
+4. The component that would own cache updates and timer effects is gone.
+5. The completion can later mutate a retained or replacement atom-family buffer. `docs/design/file-drawer-edit-mode/plan.md:95-111` `docs/design/file-drawer-edit-mode/plan.md:135-141`
+
+#### 4.12 The proposed directory query can check the wrong listing variant
+
+`mountDirQueryKey` includes `includeGitignored`. `web/packages/agenta-entities/src/session/state/mounts.ts:42-47`
+
+The plan’s fetch and invalidation examples omit that argument, which defaults to false. `docs/design/file-drawer-edit-mode/plan.md:426-430` `docs/design/file-drawer-edit-mode/plan.md:472-478`
+
+If the user enabled “show git-ignored files” and edits one of those entries, the pre-write fetch can query the filtered listing where the file is absent. `web/oss/src/components/Drives/useDriveFilters.ts:14-17` `web/packages/agenta-entities/src/session/state/mounts.ts:157-190`
+
+That absent entry then falls into the plan’s “no comparable mtime, proceed” path. `docs/design/file-drawer-edit-mode/plan.md:472-479`
+
+### Should-fix
+
+#### 4.13 The explicit tree, breadcrumb, folder, and preview consumers can be wrapped
+
+`DriveExplorer` passes `select` to `FolderView`, `DriveFilePreview`, `DriveTreeList`, and `DriveHeader`. `web/oss/src/components/Drives/DriveExplorer.tsx:250-323` `web/oss/src/components/Drives/DriveExplorer.tsx:337-371`
+
+Those explicit paths can use a guarded callback. The plan is right about those consumers. `docs/design/file-drawer-edit-mode/plan.md:158-160`
+
+The missed routes are the shell, internal `initialPath` effect, drive remount, drag spring-navigation, and parent unmount. `web/oss/src/components/Drives/FilesDrawer.tsx:35-56` `web/oss/src/components/Drives/useDriveSelection.ts:84-90` `web/oss/src/components/Drives/useDriveDrop.ts:94-105`
+
+#### 4.14 The filter route is currently unreachable, as the plan says
+
+The toolbar owns search, origin, hidden-file, and gitignored controls. `web/oss/src/components/Drives/DriveExplorer.tsx:393-408`
+
+Replacing the toolbar during editing removes those controls. `docs/design/file-drawer-edit-mode/plan.md:205-207`
+
+That specific conclusion is correct. Keeping `{kind:"filter"; run}` in the union is still unnecessary first-PR machinery. `docs/design/file-drawer-edit-mode/plan.md:52-58`
+
+#### 4.15 CSV inclusion is correct
+
+`csv` is not in `TEXT_KINDS`, but the renderer explicitly applies the text cap to `csv` and dispatches it to `CsvBody`. `web/oss/src/components/Drives/renderers.tsx:585-638`
+
+`CsvBody` reads the raw string and parses it for display. `web/oss/src/components/Drives/renderers.tsx:205-215`
+
+Editing CSV as a raw source buffer and returning to a table after save is consistent with the existing read view and the design’s editable-kind list. `docs/design/file-drawer-edit-mode/plan.md:545-562` `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:411-414`
+
+Research is right here. `docs/design/file-drawer-edit-mode/research.md:164-167`
+
+#### 4.16 `.env` works end to end in the existing browser
+
+The resolver regex includes `env`, and a leading dot satisfies the extension separator. `web/oss/src/components/Drives/driveKinds.ts:63-82`
+
+Hidden paths are detected by dot-prefixed path segments but are not classified as internal. `web/oss/src/components/Drives/driveTree.ts:42-55`
+
+Hidden files are shown by default. `web/oss/src/components/Drives/useDriveFilters.ts:10-17`
+
+The tree dims hidden rows rather than removing them when the filter allows them. `web/oss/src/components/Drives/DriveTreeRow.tsx:52-80`
+
+The breadcrumb displays the path segments verbatim and allows ancestor navigation. `web/oss/src/components/Drives/DriveBreadcrumb.tsx:21-64`
+
+Research correction 7 is correct for resolver, visibility, tree, and breadcrumb. `.env.local` remains `other`. `web/oss/src/components/Drives/driveKinds.ts:63-82`
+
+#### 4.17 The size cap compares backend bytes, but later fallbacks mix units
+
+The existing cap is documented and applied as bytes from the listing. `web/oss/src/components/Drives/renderers.tsx:40-42` `web/oss/src/components/Drives/renderers.tsx:590-628`
+
+That is the right unit for controlling object size. The editable buffer is a JavaScript string, so `content.length` is not a byte count. `docs/design/file-drawer-edit-mode/plan.md:382-395`
+
+The plan falls back to `content.length` if response parsing fails or size is absent, then treats that as the written size. `docs/design/file-drawer-edit-mode/plan.md:392-395`
+
+The backend response already defines `size` as an integer defaulting to zero, so the frontend schema should require a number and reject malformed responses instead of inventing a character-count byte size. `api/oss/src/apis/fastapi/mounts/models.py:102-104`
+
+#### 4.18 Unknown or stale listing size can bypass the cap
+
+The cap deliberately skips unknown size. `web/oss/src/components/Drives/renderers.tsx:590-612`
+
+The tree builder converts `null` size to `0`, losing the distinction between empty and unknown. `web/oss/src/components/Drives/driveTree.ts:160-176`
+
+The proposed affordance similarly offers Edit when `size == null`. `docs/design/file-drawer-edit-mode/plan.md:524-529`
+
+A stale small listing can also offer Edit even if the file grew before the raw content read. The content query has no independent cap. `web/packages/agenta-entities/src/session/state/mounts.ts:193-209`
+
+At minimum, enforce the cap again after the string loads and before save; do not rely solely on the listing snapshot. `docs/design/file-drawer-edit-mode/plan.md:518-529`
+
+#### 4.19 Header size can remain stale after the proposed invalidation
+
+The header prefers `drive.recents` size over the current tree node size. `web/oss/src/components/Drives/DriveExplorer.tsx:180-193`
+
+The plan invalidates the directory and the whole `files` listing, but the lightweight summary’s recents may come from record data or root/latest queries rather than that full listing. `docs/design/file-drawer-edit-mode/plan.md:419-430` `web/oss/src/components/Drives/useSessionDrive.ts:321-369`
+
+Existing upload refresh invalidates `files`, `files-latest`, `files-root`, and `files-dir`. `web/oss/src/components/Drives/useMountUpload.ts:85-90`
+
+The save invalidation should use the same relevant roots or update the exact visible data source deliberately. `docs/design/file-drawer-edit-mode/plan.md:421-434`
+
+#### 4.20 Correction 1 is correct: multipart reaches the same write service
+
+Generated `writeMountFile` sends query parameters and no body. `web/packages/agenta-api-client/src/generated/api/resources/mounts/client/Client.ts:1072-1102`
+
+Its request type contains only `mount_id` and `path`. `web/packages/agenta-api-client/src/generated/api/resources/mounts/client/requests/WriteMountFileRequest.ts:10-13`
+
+The backend raw-write handler reads the request body, so that generated call would write empty bytes. `api/oss/src/apis/fastapi/mounts/router.py:570-587`
+
+Generated `uploadMountFile` constructs multipart form data and appends the file. `web/packages/agenta-api-client/src/generated/api/resources/mounts/client/Client.ts:822-865`
+
+Its request type contains `mount_id`, optional `path`, and `file`. `web/packages/agenta-api-client/src/generated/api/resources/mounts/client/requests/BodyUploadMountFile.ts:12-15`
+
+The Python upload helper uses a full non-trailing `path` verbatim, reads all uploaded bytes, and calls the same `write_file` service. `api/oss/src/apis/fastapi/mounts/utils.py:66-91`
+
+The service validates the path and performs a full `put_object` overwrite with no rename or collision suffixing. `api/oss/src/core/mounts/service.py:1476-1493`
+
+Filename is relevant only when `path` is absent or ends in `/`; the plan supplies a full path. `api/oss/src/apis/fastapi/mounts/utils.py:76-85`
+
+Content type is ignored by the Python helper, and empty files or trailing newlines are delivered as uploaded bytes. `api/oss/src/apis/fastapi/mounts/utils.py:85-90`
+
+The multipart route is not the problem. The lossy UTF-8 read and editor transformations are the problems. `api/oss/src/core/mounts/service.py:1461-1474` `web/packages/agenta-ui/src/Editor/Editor.tsx:282-299`
+
+#### 4.21 Correction 6 is correct: listings carry mtime
+
+The frontend schema parses nullable `mtime`. `web/packages/agenta-entities/src/session/core/schema.ts:142-154`
+
+The backend DTO defines epoch-millisecond mtime. `api/oss/src/core/mounts/dtos.py:63-74`
+
+All three listing construction paths populate it from object metadata. `api/oss/src/core/mounts/service.py:1135-1145` `api/oss/src/core/mounts/service.py:1254-1263` `api/oss/src/core/mounts/service.py:1305-1315`
+
+The stale comment in `useSessionDrive` is wrong. `web/oss/src/components/Drives/useSessionDrive.ts:68-72`
+
+The plan’s actual problem is obtaining and retaining the correct raw listing entry; `DriveTreeNode` discards mtime. `web/oss/src/components/Drives/driveTree.ts:10-21` `web/oss/src/components/Drives/driveTree.ts:160-176`
+
+## 5. What is over-built and should be cut from the first PR?
+
+### Blockers to cut
+
+1. **Cut the two-trigger conflict system.** Keep one pre-write listing check; activity resolution depends on a full-listing cache the lazy drawer usually does not have. Lost: an early warning before Save. `web/packages/agenta-entities/src/session/state/fileActivity.ts:86-99` `web/oss/src/components/Drives/useLazyDriveTree.tsx:117-138`
+
+2. **Cut the self-write grace window.** It creates a documented silent-overwrite interval and a false-conflict path when baseline refresh fails. Lost: nothing worth preserving. `docs/design/file-drawer-edit-mode/plan.md:489-503`
+
+3. **Cut the `DiffView` modal.** A first conflict dialog can offer Reload and explicit Overwrite; the modal adds a fresh read, parsed-diff failure modes, and another async lifecycle. Lost: side-by-side conflict inspection. `docs/design/file-drawer-edit-mode/plan.md:366-374` `web/packages/agenta-ui/src/Editor/plugins/code/extensions/diffHighlight.tsx:409-429`
+
+4. **Cut rich-mode markdown editing.** Use `codeOnly` for raw markdown source or do not ship markdown edit in the first PR. Lost: rich source editing, which the design does not require. `web/packages/agenta-ui/src/Editor/Editor.tsx:249-266` `web/packages/agenta-ui/src/Editor/Editor.tsx:282-299`
+
+5. **Cut Save-and-continue from the first guard.** Keep Keep Editing and Discard; save continuation requires request identity and delayed navigation that the proposed reducer cannot represent. Lost: one-click save-and-navigate convenience. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:512-519` `docs/design/file-drawer-edit-mode/plan.md:132-137`
+
+### Candidate-by-candidate judgment
+
+- **Diff modal — cut.** It is a second async feature layered on an already incorrect conflict controller. `docs/design/file-drawer-edit-mode/plan.md:240-242` `docs/design/file-drawer-edit-mode/plan.md:505-512`
+- **Two-trigger conflict detection — simplify.** Use only a pre-write check in the first PR; add activity-based early warning only after it can resolve `files-dir` cache entries. `web/packages/agenta-entities/src/session/state/fileActivity.ts:86-99`
+- **Self-write grace window — cut.** A timer that disables the last-write-wins check is a correctness bug. `docs/design/file-drawer-edit-mode/plan.md:489-503`
+- **Preview pane — cut from the first PR.** It is separable from edit-and-save and carries hidden-editor selection claims that are untested. Lost: rendered markdown while editing. `docs/design/file-drawer-edit-mode/plan.md:338-347`
+- **Derived 12-name label table — cut.** It is lossy, contradicts its own precedence explanation, and cannot return all twelve names. `docs/design/file-drawer-edit-mode/plan.md:69-91`
+- **Tree-row dirty dot — cut.** The header chip is enough for the first PR, and the row lacks the family key needed by the proposed atom read. Lost: the second dirty indicator. `docs/design/file-drawer-edit-mode/plan.md:215-217` `web/oss/src/components/Drives/DriveTreeRow.tsx:15-50`
+- **`beforeunload` — keep, simplified.** Register only while dirty and rely on the browser-native prompt; do not route it through `ExitIntent`. `docs/design/file-drawer-edit-mode/plan.md:150-161`
+- **Abort-during-save — simplify.** For the first PR disable Cancel while a write is in flight, or keep the controller in a hook ref with request identity; do not store it in the buffer. Lost: escape from a slow save. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:476-483` `web/oss/src/components/Drives/useMountUpload.ts:73-79`
+- **Saved-chip timer — cut.** On success update the exact content cache, invalidate listings, and return directly to read mode. Lost: two seconds of confirmation chrome. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:485-492`
+- **Status footer — cut.** Language is already present in the edit bar, `UTF-8` is misleading after replacement decoding, and cursor position needs selection plumbing absent from the plan. `docs/design/file-drawer-edit-mode/plan.md:296-321` `api/oss/src/core/mounts/service.py:1461-1474`
+- **Formatting controls in preview — cut with preview.** The plan currently omits them despite the spec requiring them to remain visible. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:467-474`
+- **Tree inertness — keep, but implement as capability disabling.** Disable selection, breadcrumb navigation, drop spring timers, folder drop, and resize explicitly; CSS opacity alone is not an interaction boundary. `web/oss/src/components/Drives/DriveTreePane.tsx:45-92` `web/oss/src/components/Drives/useDriveDrop.ts:94-105`
+- **Error banner with Retry — keep.** Preserving the exact draft after write failure is core data safety. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:494-501`
+- **Conflict overwrite confirmation — keep, simplified.** The first PR still needs a pre-write mismatch/missing-file barrier before overwriting. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:503-510`
+- **Session-scoped first-edit warning — keep or explicitly defer in status.** It is an authoritative design rule currently missing from the plan. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:411-414`
+
+### Smallest version I would merge
+
+- Edit only after raw content has loaded successfully and the resolved target mount/path is known. `web/oss/src/components/Drives/driveFileSource.tsx:63-84` `web/oss/src/components/Drives/useSessionDrive.ts:188-194`
+- Use one shell-level edit controller owned above `DriveExplorer`, with a stable buffer id and request id. `web/oss/src/components/Drives/FilesDrawer.tsx:95-125`
+- Store `{driveKey, targetMountId, targetPath, displayPath, original, draft, baseMtime, bufferId}` and derive dirty from `draft !== original`. `docs/design/file-drawer-edit-mode/plan.md:23-46`
+- Use `SharedEditor` in `codeOnly` mode for every editable kind, including markdown. `web/packages/agenta-ui/src/Editor/Editor.tsx:249-266`
+- Pass `disabled` to both `EditorProvider` and `SharedEditor` while saving. `web/packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx:262-279` `web/packages/agenta-ui/src/ChatMessage/components/ChatMessageEditor.tsx:183-216`
+- Save through one validated session API wrapper around `uploadMountFile`, with an explicit full path and no transparent retries. `web/packages/agenta-api-client/src/generated/api/resources/mounts/client/Client.ts:822-865` `api/oss/src/apis/fastapi/mounts/utils.py:76-91`
+- Immediately before save, fetch the exact directory variant and treat changed mtime or missing entry as conflict. `web/packages/agenta-entities/src/session/state/mounts.ts:42-47`
+- Offer Reload and explicit Overwrite on conflict; no activity trigger, diff modal, or grace timer. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:503-510`
+- On success, seed the exact saved draft into the content cache, invalidate the relevant listing roots, and close edit mode immediately. `web/packages/agenta-entities/src/session/state/mounts.ts:38-47` `web/oss/src/components/Drives/useMountUpload.ts:85-90`
+- Guard the real drawer close, explicit selection, changed `initialPath`, and dirty browser unload. `web/oss/src/components/Drives/FilesDrawer.tsx:95-125` `web/oss/src/components/Drives/useDriveSelection.ts:84-90`
+- Disable all tree/drop navigation during edit instead of relying on a wrapped subset of callbacks. `web/oss/src/components/Drives/useDriveUploads.ts:87-93` `web/oss/src/components/Drives/useDriveDrop.ts:94-105`
+- Defer preview, diff, tree dot, saved timer, cursor footer, activity-based early conflict, and Save-and-continue. `docs/design/file-drawer-edit-mode/plan.md:230-245`
+- Add controller/integration tests for shell close, changed `initialPath`, missing-file conflict, ignored-file query keys, late save completion, and exact markdown backslash preservation. `docs/design/file-drawer-edit-mode/plan.md:575-626`
+
+## Other findings
+
+### Blockers
+
+#### O.1 The plan’s public import surface does not compile as described
+
+The new schema would need to be exported from `@agenta/entities/session`; the current barrel exports only existing mount schemas and types. `web/packages/agenta-entities/src/session/index.ts:43-61`
+
+`mountDirQueryKey` is also missing from that public barrel. `web/packages/agenta-entities/src/session/index.ts:81-93`
+
+The code snippet uses `safeParseWithLogging`, `mountFileWrittenResponseSchema`, `isAbortError`, and `toWriteErrorMessage` without showing sanctioned imports or defining the last helper. `docs/design/file-drawer-edit-mode/plan.md:378-400`
+
+The plan must specify the package export changes or relocate the write boundary beside the existing session API. `web/packages/agenta-entities/src/session/api/api.ts:634-689`
+
+#### O.2 Exact-byte round-trip QA cannot rescue a structurally lossy editor
+
+The QA matrix requires markdown bytes to round-trip without reformatting. `docs/design/file-drawer-edit-mode/status.md:79-84`
+
+The plan explicitly excludes Lexical markdown timing and behavior from automated testing. `docs/design/file-drawer-edit-mode/plan.md:622-626`
+
+The rich editor serializes markdown and strips backslash escapes. `web/packages/agenta-ui/src/Editor/Editor.tsx:282-299` `web/packages/agenta-ui/src/Editor/plugins/markdown/utils/textCleanup.ts:146-177`
+
+This needs an automated regression test or a raw code editor, not faith in live QA. `docs/design/file-drawer-edit-mode/status.md:79-84`
+
+### Should-fix
+
+#### O.3 Test coverage targets pure helpers and misses the failure-prone seams
+
+The test plan covers helpers and action atoms but deliberately excludes component/editor behavior. `docs/design/file-drawer-edit-mode/plan.md:575-626`
+
+Missing high-value tests include:
+
+- Raw markdown input preserving backslashes, blank final lines, and trailing newline. `web/packages/agenta-ui/src/Editor/Editor.tsx:282-299`
+- `SharedEditor` becoming genuinely non-editable during save. `web/packages/agenta-ui/src/Editor/Editor.tsx:455-457`
+- Mask/Escape drawer close routing through the guard. `web/oss/src/components/Drives/FilesDrawer.tsx:95-125`
+- Changed `initialPath` routing through the guard. `web/oss/src/components/Drives/useDriveSelection.ts:84-90`
+- Late success from file A not mutating file B. `docs/design/file-drawer-edit-mode/plan.md:125-141`
+- Deleted file producing conflict rather than recreation. `docs/design/file-drawer-edit-mode/plan.md:472-478`
+- `includeGitignored=true` being present in the pre-write query key. `web/packages/agenta-entities/src/session/state/mounts.ts:42-47`
+- Multipart request shape and exact target path. `web/packages/agenta-api-client/src/generated/api/resources/mounts/client/Client.ts:829-865`
+- Content-cache and all visible listing invalidations after save. `web/oss/src/components/Drives/useMountUpload.ts:85-90`
+
+#### O.4 The API-call placement only partially follows `web/AGENTS.md`
+
+The plan correctly uses Fern rather than adding new axios code. `docs/design/file-drawer-edit-mode/plan.md:378-417` `web/AGENTS.md:28-32`
+
+The convention says to use a per-resource accessor from `@agenta/sdk/resources` and perform Zod validation at the boundary. `web/AGENTS.md:74-84`
+
+Importing the accessor and request helper from `@agenta/entities/session` is defensible only if the write itself becomes a session API function; exposing low-level client helpers to an app-local API module weakens that boundary. `web/packages/agenta-entities/src/session/index.ts:36-42`
+
+#### O.5 Cache invalidation is too narrow for the actual drawer data model
+
+The plan invalidates one directory and the full `files` listing. `docs/design/file-drawer-edit-mode/plan.md:419-434`
+
+The drawer summary and header also use `files-latest` and `files-root` queries. `web/oss/src/components/Drives/useSessionDrive.ts:355-369`
+
+The existing upload mutation invalidates all four listing roots. `web/oss/src/components/Drives/useMountUpload.ts:85-90`
+
+Reuse that mutation invalidation policy unless there is a tested reason to narrow it. `web/oss/src/components/Drives/useMountUpload.ts:85-90`
+
+#### O.6 Accessibility requirements are absent from the plan
+
+Saving, Saved, errors, and conflicts are asynchronous status changes, but the plan does not specify an `aria-live` status region. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:476-510` `docs/design/file-drawer-edit-mode/plan.md:190-201`
+
+Tree inertness must remove descendants from keyboard interaction as well as pointer interaction; the current tree contains focusable row buttons and a focusable resize separator. `web/oss/src/components/Drives/DriveTreeRow.tsx:61-72` `web/oss/src/components/Drives/DriveTreePane.tsx:77-90`
+
+The guard should restore focus to the triggering control after Keep Editing; no focus-return behavior is planned. `docs/design/file-drawer-edit-mode/plan.md:150-161` `docs/design/file-drawer-edit-mode/plan.md:241-242`
+
+`EnhancedModal` is the correct shared modal choice, but using it does not replace testing the edit-specific focus flow. `web/AGENTS.md:419-429`
+
+#### O.7 `⌘E` is omitted
+
+The authoritative clean-state trigger is “Edit clicked, or ⌘E.” `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:448-456`
+
+The plan discusses Escape, Cmd/Ctrl-S, and browser unload but never adds an edit shortcut. `docs/design/file-drawer-edit-mode/plan.md:150-161` `docs/design/file-drawer-edit-mode/plan.md:575-626`
+
+Either implement and test Cmd/Ctrl-E or record a deliberate design deviation. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:448-456`
+
+#### O.8 Theme validation exists only as live QA
+
+The repo requires light and dark interaction states for changed UI. `web/AGENTS.md:321-333`
+
+The status file asks for both themes in live QA. `docs/design/file-drawer-edit-mode/status.md:79-84`
+
+There is no component-level or visual test for error, conflict, disabled, saving, or saved colors. `docs/design/file-drawer-edit-mode/plan.md:575-626`
+
+At minimum, all implementation classes must use semantic tokens, and QA must cover every new banner/modal state rather than only the happy-path editor. `web/AGENTS.md:321-348`
+
+#### O.9 Copy and i18n surface are larger than acknowledged
+
+The plan introduces Edit, Saving, Unsaved, Saved, editing hints, cap tooltip, retry, conflict actions, overwrite copy, guard actions, footer labels, and modal content. `docs/design/file-drawer-edit-mode/plan.md:190-201` `docs/design/file-drawer-edit-mode/plan.md:238-242`
+
+No copy ownership or localization approach is specified. Existing Drives code contains English UI, so this is not a unique violation, but the first PR should avoid multiplying copy through optional diff/footer/preview states. `web/oss/src/components/Drives/DriveHeader.tsx:114-160`
+
+#### O.10 The plan is likely to violate the comment-density rule if implemented literally
+
+The frontend rule allows at most one short line per comment, with longer prose reserved for genuinely surprising constraints. `web/AGENTS.md:412-417`
+
+The proposed plan contains extensive prop-by-prop and race explanations that should stay in design docs, not be copied into implementation comments. `docs/design/file-drawer-edit-mode/plan.md:303-336` `docs/design/file-drawer-edit-mode/plan.md:403-417`
+
+Use names and tests to express the state transitions; reserve one-line comments for the multipart-body and stale-request constraints. `web/AGENTS.md:412-417`
+
+#### O.11 The design’s `capped` prototype state is broken
+
+`capped` exists in `STATES`. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:423-436`
+
+There is no `NOTES.capped`. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:438-539`
+
+The renderer treats every state except `read` and `locked` as editing, so `capped` also incorrectly enters editing layout. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:557-563`
+
+It then dereferences the missing note. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:629-631`
+
+The plan’s interpretation—disabled Edit with a cap tooltip—is supported by the `locked` notes, but the prototype should be corrected before anyone treats all 12 rendered states as authoritative. `docs/design/file-drawer-edit-mode/design/edit-mode-spec.html:530-537`
+
+### Research correction audit
+
+1. **Correction 1 — correct.** Generated `writeMountFile` has no body; generated multipart upload carries the file and reaches the same `write_file` service. `web/packages/agenta-api-client/src/generated/api/resources/mounts/client/Client.ts:1072-1102` `web/packages/agenta-api-client/src/generated/api/resources/mounts/client/Client.ts:829-865` `api/oss/src/apis/fastapi/mounts/utils.py:66-91`
+
+2. **Correction 2 — correct, but the plan still overstates JSON safety.** `DiffView` is JSON/YAML-only and its extension parses the strings; malformed JSON can still render no diff. `web/packages/agenta-ui/src/Editor/DiffView.tsx:178-199` `web/packages/agenta-ui/src/Editor/plugins/code/extensions/diffHighlight.tsx:409-429`
+
+3. **Correction 3 — correct.** The README documents `containerVariant` and `debounceDelay`, while the real component does not accept them. `web/packages/agenta-ui/src/SharedEditor/README.md:36-47` `web/packages/agenta-ui/src/SharedEditor/types.ts:27-70`
+
+4. **Correction 4 — correct.** The editor has a six-value language union and the drive resolver returns broader Shiki ids. `web/packages/agenta-ui/src/Editor/plugins/code/types.ts:1-3` `web/oss/src/components/Drives/driveKinds.ts:24-61`
+
+5. **Correction 5 — correct only about command polarity.** `true` means source, but pinning that command does not make first hydration or later change emission byte-preserving. `web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx:151-168` `web/packages/agenta-ui/src/Editor/Editor.tsx:282-299`
+
+6. **Correction 6 — correct.** Listing schemas and backend construction paths carry mtime. `web/packages/agenta-entities/src/session/core/schema.ts:145-153` `api/oss/src/core/mounts/service.py:1135-1145`
+
+7. **Correction 7 — correct.** `.env` resolves as text, hidden files default visible, the tree dims rather than removes it, and the breadcrumb preserves it. `web/oss/src/components/Drives/driveKinds.ts:63-82` `web/oss/src/components/Drives/useDriveFilters.ts:10-17` `web/oss/src/components/Drives/DriveTreeRow.tsx:52-80` `web/oss/src/components/Drives/DriveBreadcrumb.tsx:21-64`

--- a/docs/design/file-drawer-edit-mode/status.md
+++ b/docs/design/file-drawer-edit-mode/status.md
@@ -323,3 +323,25 @@ moved out of the React upload hook into `agenta-entities/session/state/mounts.ts
 
 Still unverified and still owed: manual QA of the caret position under `autoFocus`, the theme
 pass, and the guard-route walkthrough in a live stack.
+
+## Final gate (2026-08-04)
+
+Run from the worktree, against the full branch:
+
+- `cd web/oss && pnpm exec vitest run src/components/Drives` — **6 files, 92 tests, all pass**.
+- `cd web/oss && pnpm exec vitest run` (whole OSS suite) — **31 files, 241 tests, all pass**.
+- `cd web/packages/agenta-entities && pnpm exec vitest run` — **67 files, 939 tests, all pass**
+  (run because this branch touches the session package).
+- `cd web && pnpm type-check` (oss + ee `tsc --noEmit`) — exit 0, no output.
+- `cd web && pnpm lint-fix` — 11/11 turbo tasks successful, 0 errors, no files reformatted.
+  The only warnings are the two pre-existing `react-hooks/incompatible-library` TanStack
+  Virtual warnings in `VirtualTileGrid.tsx` and `useDriveTreeViewport.ts` — neither file is
+  in this branch's diff.
+- antd-migration collision check: `git diff origin/release/v0.109.0...HEAD --
+  web/oss/src/components/Drives/` contains **no** line mentioning `CopyButton`.
+  `FolderView.tsx` is untouched entirely; the `CopyButton size="small"` lines in
+  `DriveFilePreview.tsx:121`, `DriveHeader.tsx:251` and `FolderView.tsx:181` are unchanged.
+- Working tree clean at `65d9821717` + the qa.md commit. `web/oss/test-results/junit.xml` is a
+  tracked vitest artifact that every run rewrites; it was restored rather than committed.
+
+Live QA script for a human: `docs/design/file-drawer-edit-mode/qa.md`.

--- a/docs/design/file-drawer-edit-mode/status.md
+++ b/docs/design/file-drawer-edit-mode/status.md
@@ -246,3 +246,80 @@ Deliberately left alone:
   A `setEditIssueAtom` would be the honest fix; logged here rather than done blind.
 - **`DriveEditBanner`'s two `Alert` branches.** Collapsing them into one `Alert` with three
   ternaries reads worse than the two explicit branches.
+
+---
+
+# Review triage — 2026-08-04 (orchestrated Codex fix pass, commit `ed64d2be0b`)
+
+Two independent implementation reviews were run against `af1d33c29a`, `2d7220ae5b`,
+`8301888ee8` and are preserved verbatim at
+`docs/design/file-drawer-edit-mode/reviews/impl-review-claude.md` and
+`.../impl-review-codex.md`. I triaged both against the source before briefing the fix run.
+**25 findings accepted, 12 rejected.** Everything accepted landed in one commit.
+
+## Accepted (deduped across the two reviews)
+
+P1 — correctness, each with a regression test:
+
+| # | Finding | Fix that landed |
+|---|---|---|
+| 1 | Editor is not byte-preserving (Codex B1) — `editorCodeUtils.ts:121,145` turns tabs into two spaces and `trimEnd()`s the document; `code/index.tsx:128` pretty-prints compact JSON on hydration | `DriveFileEditor` switched to `useNativeCodeNodes` (byte-preserving hydrate + `getTextContent()` serialize). New `DriveFileEditor.test.tsx` drives the real Lexical editor in jsdom over trailing newline / trailing spaces / literal tab / CRLF / non-ASCII / empty / compact JSON |
+| 2 | Overwrite permanently disarms conflict detection (Codex B2) — `onSave` early-returns on `draft === original`, leaving `skipConflictCheckOnce` armed | The bypass is no longer buffer state; `save(skipConflictCheck)` takes it as an argument |
+| 3 | Module-global buffer contaminates other drawers (Claude 1 / Codex B3) — a session switch unmounts the host without `onClose`, bricking the next drawer | Every consumer scoped through `ownedEditBufferAtomFamily(driveKey)`; a clean buffer is cleared on controller unmount, a dirty one survives but is invisible to other drives |
+| 4 | Unmount aborts the PUT and reports a failure for a write that may have landed (Claude 4) | AbortController removed entirely; the promise settles against the request-id discipline |
+| 5 | The save's abort signal hijacked the shared directory query (Claude 12) | `abortSignal: querySignal` — react-query owns cancellation |
+| 6 | A null `baseMtime` failed **open** (Claude 3) — two paths manufacture a null baseline, making every later save an unchecked overwrite | `conflictFromListing` tolerates a null baseline only when the listing entry also has no mtime; reload now re-reads the parent listing for a real mtime instead of reusing `theirMtime` |
+| 7 | "Reload from disk" silently no-ops if the user types during the fetch (Claude 2) | Explicit `reloading` buffer state; draft writes rejected and the editor read-only while it is set; `canAdoptReload` no longer depends on the draft |
+
+P2 — accepted: stale open snapshot via `isFetching` (Codex B4, cheap variant); known-oversized
+files no longer downloaded (S1); UTF-8 byte cap instead of `String.length` (S2); guard only on
+dirty so a clean buffer with a stale issue exits without a false dialog (S5); the
+saving-blocks-navigation deadlock — drive-swap deferred while saving, "Keep editing" re-enabled,
+blocked exits announced through the `aria-live` status (Claude 6); per-keystroke re-render of the
+whole drawer killed with `selectAtom` families, dead facets deleted (Claude 7 / Codex N3);
+shortcuts scoped to the explorer root (S4); a listing failure gets its own
+`listing-unavailable` availability and honest tooltip (Claude 8); reload errors get
+`editReloadFailedAtom`/`setEditIssueAtom` instead of faking a save (Claude 11 / Codex N2); the
+inert tree is dimmed (Claude 5); `teardownWarned` → `showTeardownNotice`, edit-bar row wraps,
+invented "filters resume after saving" copy dropped (Claude 10); Reload hidden for a `missing`
+conflict (S3); size-cap tooltip derived from `TEXT_CAP` (Claude 9); and the controller is finally
+mounted in tests — `useDriveEditController.test.tsx`, plus the two `saveDriveFile` gaps
+(null listing fails closed, `skipConflictCheck` skips the fetch) (Claude 13 / Codex S6).
+
+P3 — accepted: no double punctuation and product-copy-first error banner; `EDIT_KINDS` exposed as
+`ReadonlySet`; `mode: "markdown"` renamed to `supportsMarkdownPreview`; `invalidateMountListings`
+moved out of the React upload hook into `agenta-entities/session/state/mounts.ts` (Codex N4).
+
+## Rejected, and why
+
+1. **Per-drawer Jotai store/Provider** (Codex B3's prescribed fix) — the contamination is real,
+   but `driveKey` scoping fixes it without restructuring the drawer's composition root.
+2. **Splitting `useDriveEditController.ts` into three modules** (Codex N1) — churn with no
+   behaviour change, and it would have invalidated the controller tests added in the same pass.
+3. **The listing → content → listing retry loop** (Codex B4's prescribed fix) — the `isFetching`
+   gate closes the observed window; the residual race is logged in `open-questions.md`.
+4. **Removing the drilled `dirtyPath` prop for an atom in `DriveTreeList`/`TreeRow`** (Codex N6) —
+   passing one boolean into a virtualized row is deliberate; an atom subscription per row is worse.
+5. **Moving the `@agenta/entities/session` transport test into the package suite** (Codex N7) —
+   real, but out of scope for a correctness pass.
+6. **Using `size` from `MountFileWrittenResponse` instead of invalidating listings** (Claude's
+   `saved` note) — the reviewer already scored it acceptable.
+7. **`CODE_LANGS` being exported for a test** and 8. **`renderers.tsx` re-exporting `TEXT_CAP`**
+   (Claude's conventions nits) — not worth the churn.
+9. **The `autoFocus` caret-position claim** — a manual QA item, not a code finding.
+10-12. **Codex's four "questions the author must answer"** (Cancel disabled during save, no
+   "View diff", no "Save and continue", edit gated on the upload capability) — these are the
+   deviations already documented above, not new findings.
+
+## Verification (run independently of the fix agent)
+
+- `npx vitest run src/components/Drives` from `web/oss` — **6 files, 92 tests, all pass**
+  (was 4 files / 70 tests).
+- `tsc -p oss/tsconfig.json --noEmit` — exit 0.
+- `eslint src/components/Drives` — 0 errors, 2 pre-existing TanStack Virtual compiler warnings.
+- `prettier --check` on all touched files — clean.
+- Byte-fidelity test proven to bite: reverting only the two `useNativeCodeNodes` flags makes
+  3 of the 7 round-trip cases fail (compact JSON, trailing newline, CRLF).
+
+Still unverified and still owed: manual QA of the caret position under `autoFocus`, the theme
+pass, and the guard-route walkthrough in a live stack.

--- a/docs/design/file-drawer-edit-mode/status.md
+++ b/docs/design/file-drawer-edit-mode/status.md
@@ -160,6 +160,24 @@ turns out badly in QA.
 - **Do not push, do not open a PR, do not merge from this worktree.** The orchestrator does that.
 - Never touch `/home/mahmoud/code/agenta-2`. A release is running there.
 
+## Implementation checkpoint — 2026-08-04
+
+Build-order steps 1–10 and 12 are implemented. The Fern multipart write boundary, Jotai buffer
+state machine, conflict-safe save path, SharedEditor surface, drawer/header/tree wiring, guarded
+navigation, markdown preview, session warning, and focused unit tests are complete.
+
+Validation from `web/oss`:
+
+- `npx vitest run src/components/Drives` — 4 files passed, 70 tests passed
+- `npx tsc --noEmit` — passed with no errors
+- `pnpm lint-fix` from `web` — passed; the existing React Compiler warnings remain in
+  `VirtualTileGrid.tsx` and `useDriveTreeViewport.ts`
+- semantic-token audit — no new raw colors, inline styles, CSS-in-JS, or replacement editor
+
+Live backend verification and browser QA remain unrun because this worktree has no local stack or
+browser. The five-extension byte round-trip, both themes, caret placement, and every interactive
+guard route remain in the live QA checklist below.
+
 ## Live QA to run before calling it done
 
 From `CONTEXT.md`: edit and save `.txt`, `.csv`, `.md`, `.env`, and `.json`. For each, confirm the

--- a/docs/design/file-drawer-edit-mode/status.md
+++ b/docs/design/file-drawer-edit-mode/status.md
@@ -1,0 +1,84 @@
+# Status
+
+**Updated:** 2026-08-04
+**Worktree:** `/home/mahmoud/code/agenta-2-editmode`
+**Branch:** `feat/file-drawer-edit-mode`, based on `origin/release/v0.109.0`
+**PR base when the time comes:** `release/v0.109.0`. Never `main`.
+
+## Where the work is
+
+Planning is complete. No implementation code has been written.
+
+| Phase | State |
+|---|---|
+| Repo research | done, written up in `research.md` |
+| Design spec read and reconciled with the code | done |
+| Plan | done, in `plan.md` |
+| Implementation | not started |
+| Tests | not started |
+| Live QA | not started |
+
+The next session starts at `plan.md` section 9, step 1.
+
+## Decisions made and why
+
+| Decision | Reason |
+|---|---|
+| Save through `mounts.uploadMountFile`, not `mounts.writeMountFile` | The generated `writeMountFile` sends no request body and would write zero bytes. Both methods reach the same `MountsService.write_file`. `research.md` correction 1. |
+| Twelve spec states stored as one record plus a derived label, not a flat enum | Six of the twelve are orthogonal to the other six. A flat enum makes "dirty and in preview and in conflict" unrepresentable. |
+| Buffer atom keyed by mount id, holding one nullable buffer | Matches `driveSelectionAtomFamily`. The type makes two simultaneous buffers impossible. |
+| `SharedEditor` + our own `EditorProvider`, not `SimpleSharedEditor` | `SimpleSharedEditor` sniffs content and would flip a `.txt` file containing JSON into a JSON code editor. It also renders a competing header. |
+| Markdown buffers pin `SET_MARKDOWN_VIEW` to true; Preview is a separate pane | Editing markdown as rich text round-trips the file through the markdown serialiser and reflows formatting the user did not touch. |
+| Conflict diff uses `computeTextDiffLines`, with `DiffView` only for `json` | `DiffView` coerces everything to JSON or YAML and mangles markdown and CSV. `research.md` correction 2. |
+| `canUpload` is the writable-mount gate | `mountSchema` has no read-only flag. `canUpload` is the existing answer to the same question and already gates upload, drag-drop, and the staged inbox. |
+| Narrow cache invalidation, not `revalidateSessionMountsAtom` | That atom invalidates every mount in the project plus every cached body. A one-file save needs the file, its directory, and the mount listing. |
+| `TEXT_CAP` moves to `driveKinds.ts` | The edit gate needs the number and must not pull the Shiki and Markdown renderer graph in to read it. One definition, re-exported from `renderers.tsx`. |
+| No backend change | Deliberate. Everything above is solvable on the client. |
+
+## Open questions
+
+None are blocking. Each has a chosen answer; these are the ones worth revisiting if the answer
+turns out badly in QA.
+
+1. **Five-second self-write window.** After a save, conflict detection is suppressed for that
+   path for five seconds while the directory listing refetches and yields the real modification
+   time. A write by the agent inside that window is missed until the next save's pre-write check.
+   If QA shows the agent writing that fast in practice, shorten the window and rely on the
+   refetch's completion rather than a timer.
+2. **No modification time from the object store.** When `mtime` comes back null, the pre-write
+   check cannot fire and only the file-activity signal protects the write. Not observed in the
+   local stack; recorded so a report of a silent overwrite has somewhere to start.
+3. **Config-panel host has no session id.** `useDriveSessionId()` returns null there, so the
+   file-activity trigger never fires in that host. The pre-write check still runs. Threading a
+   session id through the config host is possible but out of scope.
+4. **UTF-8 replacement on read.** `read_file` decodes with `errors="replace"`
+   (`api/oss/src/core/mounts/service.py:1461-1474`), so a text file containing invalid UTF-8
+   loses those bytes on read and would lose them permanently on save. Not fixable on the client.
+   It is part of why only text kinds are editable.
+
+## Known gaps, deliberately out of scope
+
+- **`.env.local` and other multi-dot config files are not editable.** `resolveDriveFileKind`
+  returns `other` for them, which is the download card. Widening the resolver changes the
+  read-only viewer for every host that uses it, so it does not belong in this PR. Worth a
+  follow-up.
+- **No new file, rename, or delete.** Creating files stays the upload path's job.
+- **CSV edits as text, not as a table.** The spec puts `csv` among the editable text kinds and
+  there is no cell editor here.
+
+## Coordination
+
+- **PR #5643, the antd migration**, targets `main` and lands soon. It touches three lines under
+  `Drives/`, all `CopyButton size="small"` becoming `size="icon-sm"`, in `DriveFilePreview.tsx`,
+  `DriveHeader.tsx`, and `FolderView.tsx`. Do not touch those lines. Do not rebase onto or merge
+  that branch. The post-merge fixup here is two `import ... from "antd"` lines in two new files
+  (`plan.md` section 8).
+- **Do not push, do not open a PR, do not merge from this worktree.** The orchestrator does that.
+- Never touch `/home/mahmoud/code/agenta-2`. A release is running there.
+
+## Live QA to run before calling it done
+
+From `CONTEXT.md`, unchanged: edit and save `.txt`, `.csv`, `.md`, `.env`, and `.json`. For each,
+confirm the bytes round-trip without reformatting, the agent sees the change on its next tool
+call, and both light and dark themes render correctly. Then exercise the guard from all five exit
+routes and force a conflict by having the agent write to an open file.

--- a/docs/design/file-drawer-edit-mode/status.md
+++ b/docs/design/file-drawer-edit-mode/status.md
@@ -196,3 +196,53 @@ Then:
 - check both light and dark themes for every new state, not only the editor: the error banner,
   the conflict banner, the disabled Edit tooltip, the saving spinner, the Unsaved and Saved tags,
   and the guard modal
+
+## Simplification pass (2026-08-04)
+
+Behaviour-preserving cleanups over the two implementation commits. Unit tests (70) and
+`pnpm type-check` green before and after; `pnpm lint-fix` clean.
+
+Applied:
+
+- `parentOf` (`driveTreeView.ts`) replaces the new `parentDirectory` in `editMode/api.ts`
+  and the inline `lastIndexOf("/")` slice in the controller. One parent-path helper in the
+  module, not three.
+- `requestNavigationAtom` / `resolveNavigationAtom` return `NavigationIntent | null`
+  instead of `{run: intent | null}`. The wrapper existed at six call sites and bought
+  nothing; the `?.kind === "close"` checks it forced were tautological.
+- `saveDriveFile`'s injected `invalidateListings` dependency dropped — no test ever
+  overrode it. `queryDir` and `writeFile` (the two seams tests actually use) stay.
+- `DriveEditController.onRetry` removed; it was an alias for `onSave`. `DriveEditBanner`
+  takes `onRetry={edit.onSave}`.
+- `DriveExplorer` passes `edit={edit}` instead of re-listing nine fields, and `DriveHeader`
+  types the prop as `Pick<DriveEditController, …>` so the field list lives in one place.
+- The Edit button in `DriveHeader` was written twice (enabled / disabled-with-tooltip).
+  Now one `Button` with `disabled` plus an `EDIT_DISABLED_REASON` lookup — antd renders no
+  tooltip for the empty string, so the enabled case is unchanged.
+- `useDriveDrop`'s new "reset when disabled" effect duplicated the existing `onEnd` body.
+  Merged into the listener effect, which calls `onEnd()` on the `!enabled` path.
+- `useDriveUploads` no longer passes `onUpload: … ? uploadIntoFolder : () => {}` — every
+  `useDriveDrop` handler is now gated on `enabled`, so the noop was unreachable.
+- `focusEditor` uses one attribute selector instead of `querySelectorAll` + `find`.
+- `closeEditBufferAtom` deleted: no production caller. Tests set `driveEditBufferAtom` to
+  `null` directly (it is a plain writable atom).
+- Dropped the unused `includeGitignored` entry from `onEdit`'s dependency array.
+
+Deliberately left alone:
+
+- **`driveEditFacetsAtom`.** `mode`, `editorView`, and `guardOpen` have no production
+  reader today (components read `buffer.mode` / `buffer.editorView` directly). It is the
+  read model `plan.md` §2 specifies and `state.test.ts` asserts on, so trimming it would
+  contradict a settled plan for no behavioural gain. Worth revisiting if it stays unused.
+- **`DriveExplorer`'s second read of `editing` via `driveEditFacetsAtom`.** It exists to
+  break a cycle: `useDriveUploads` produces `canUpload`, which the controller consumes, so
+  the controller cannot be called before it.
+- **The drive-swap hold** (`heldDrive`/`holdDrive`/`requestedDriveSwap`/`pendingDriveSwap`).
+  More machinery than §2's table describes, but removing it changes what the user sees
+  when the host swaps drives under an open dirty buffer.
+- **`canAdoptReload()`'s nine-way check and the `startSave` + `saveFailed` pair used to
+  surface a reload error.** Both are convoluted (the second abuses the save atoms to set an
+  error issue), but the reload path has no unit test and the change is not risk-free.
+  A `setEditIssueAtom` would be the honest fix; logged here rather than done blind.
+- **`DriveEditBanner`'s two `Alert` branches.** Collapsing them into one `Alert` with three
+  ternaries reads worse than the two explicit branches.

--- a/docs/design/file-drawer-edit-mode/status.md
+++ b/docs/design/file-drawer-edit-mode/status.md
@@ -1,6 +1,6 @@
 # Status
 
-**Updated:** 2026-08-04
+**Updated:** 2026-08-04 (plan revised after the Codex review)
 **Worktree:** `/home/mahmoud/code/agenta-2-editmode`
 **Branch:** `feat/file-drawer-edit-mode`, based on `origin/release/v0.109.0`
 **PR base when the time comes:** `release/v0.109.0`. Never `main`.
@@ -18,39 +18,115 @@ Planning is complete. No implementation code has been written.
 | Tests | not started |
 | Live QA | not started |
 
-The next session starts at `plan.md` section 9, step 1.
+The plan was rewritten after the Codex review (see the decision record below). The next session
+starts at `plan.md` section 13, step 1.
 
 ## Decisions made and why
 
 | Decision | Reason |
 |---|---|
 | Save through `mounts.uploadMountFile`, not `mounts.writeMountFile` | The generated `writeMountFile` sends no request body and would write zero bytes. Both methods reach the same `MountsService.write_file`. `research.md` correction 1. |
-| Twelve spec states stored as one record plus a derived label, not a flat enum | Six of the twelve are orthogonal to the other six. A flat enum makes "dirty and in preview and in conflict" unrepresentable. |
-| Buffer atom keyed by mount id, holding one nullable buffer | Matches `driveSelectionAtomFamily`. The type makes two simultaneous buffers impossible. |
-| `SharedEditor` + our own `EditorProvider`, not `SimpleSharedEditor` | `SimpleSharedEditor` sniffs content and would flip a `.txt` file containing JSON into a JSON code editor. It also renders a competing header. |
-| Markdown buffers pin `SET_MARKDOWN_VIEW` to true; Preview is a separate pane | Editing markdown as rich text round-trips the file through the markdown serialiser and reflows formatting the user did not touch. |
-| Conflict diff uses `computeTextDiffLines`, with `DiffView` only for `json` | `DiffView` coerces everything to JSON or YAML and mangles markdown and CSV. `research.md` correction 2. |
-| `canUpload` is the writable-mount gate | `mountSchema` has no read-only flag. `canUpload` is the existing answer to the same question and already gates upload, drag-drop, and the staged inbox. |
-| Narrow cache invalidation, not `revalidateSessionMountsAtom` | That atom invalidates every mount in the project plus every cached body. A one-file save needs the file, its directory, and the mount listing. |
-| `TEXT_CAP` moves to `driveKinds.ts` | The edit gate needs the number and must not pull the Shiki and Markdown renderer graph in to read it. One definition, re-exported from `renderers.tsx`. |
+| Orthogonal facets, not the twelve spec names as a derived label | Six of the twelve are orthogonal to the other six, and `code` is a mode no label function can return. A first-match table loses information and its "one assertion per spec name" test is unwritable. |
+| One module-level `driveEditBufferAtom`, not an atom family | The spec's rule is one buffer at a time; a single nullable value enforces it by type, needs no key in the action atoms, and releases its two ~1.5 MB strings on close instead of pinning them per mount forever. |
+| Four distinct identity fields: `driveKey`, `targetMountId`, `targetPath`, `displayPath` | `agent-files/` folds a second mount into one presented tree (`useSessionDrive.ts:188-194`). Calling all four "mount id" and "path" guarantees a wrong query key or a write to the wrong mount. |
+| `SharedEditor` + our own `EditorProvider`, not `SimpleSharedEditor` | `SimpleSharedEditor` detects JSON/YAML/HTML from the content and would flip a `.txt` file containing JSON into a JSON code editor. It also renders a competing header. |
+| `codeOnly` for every editable kind, markdown included | Rich mode serializes the document and runs `stripBackslashEscapes` on every emission (`Editor.tsx:282-299`), and the first `SET_MARKDOWN_VIEW(true)` serializes the hydrated rich tree rather than injecting the file (`markdownPlugin.tsx:151-168`). Neither is byte-preserving. `codeOnly` also unmounts `MarkdownPlugin` entirely, so the whole markdown-view mechanism drops out. |
+| `disabled` passed to `SharedEditor`, not only to `EditorProvider` | `SharedEditor.state` is visual only; `EditorInner` defaults `disabled` to false and calls `setEditable(!disabled)` (`Editor.tsx:455-457`), re-enabling a provider-disabled editor. |
+| A successful save exits edit mode | The write response has no mtime, so a buffer left open has no trustworthy baseline: any mtime fetched afterwards may belong to an agent write that landed in between. Exiting means every baseline comes from a fresh read at Edit time. |
+| One conflict trigger: the pre-write listing check. No grace window, no activity trigger | A grace window silently overwrites agent writes inside it, and "the next save catches it" is false when the next save falls in the same window. Its stated purpose does not exist either — a frontend save appends no file activity. The activity trigger resolves paths only against the full-listing cache the lazy drawer usually does not have (`fileActivity.ts:86-99`, `useLazyDriveTree.tsx:117-138`). |
+| A missing directory entry is a conflict, not "no mtime, proceed" | The write is an unconditional `put_object`, so proceeding recreates a file the agent deleted. |
+| Every save completion carries its request id | A save started against file A can settle after the drawer closed and file B opened. An `AbortController` neither proves the server did not write nor stops a queued completion. |
+| `canUpload` is the writable-mount proxy, named `canEditMountFiles` | `mountSchema` has no read-only flag. It is a capability proxy, not proof the backend accepts the write, and the name should not claim otherwise. |
+| Reuse `useMountUpload`'s four-root invalidation | The header prefers `drive.recents` over the tree node's size, and recents come from `files-latest`/`files-root`. A directory-only invalidation leaves the visible size stale. |
+| The write lives in `@agenta/entities/session` beside `readMountFile` | `web/AGENTS.md` puts the Fern call, the schema, and the validation together. Schema-in-package plus call-in-app is the worst of both. |
+| The close guard is owned by `FilesDrawer`, not `DriveExplorer` | Antd receives the host `onClose` directly (`FilesDrawer.tsx:95-104`), so mask click and keyboard dismissal bypass anything wrapped further down. The guard modal also has to sit above the `key`-remount boundary. |
+| `TEXT_CAP` moves to `driveKinds.ts`; `CODE_LANGS` is exported | The edit gate needs the cap without pulling in the Shiki/Markdown graph, and the language mapper's test cannot iterate a module-private map. |
 | No backend change | Deliberate. Everything above is solvable on the client. |
+
+## Codex review: what was accepted and what was rejected
+
+Full review in `reviews/plan-review-codex.md`. Every claim below was re-verified against the code
+before the plan changed. The plan body carries the outcome, not the argument.
+
+### Accepted (the plan changed)
+
+| # | Finding | Change |
+|---|---|---|
+| 1.1 | `state="readOnly"` is visual; the editor stays editable during a save | `disabled` now goes on `SharedEditor` too |
+| 1.2 | Rich-mode markdown is not byte-preserving | `codeOnly` for every kind; the synchronizer, `SET_MARKDOWN_VIEW`, and `markdownViewAtom` are gone |
+| 1.3 | `initialValue`/`value` do not behave as the plan described | The buffer owns original and draft; the editor's props are outputs |
+| 1.4, 2.5, 2.9 | No save snapshot, no request identity | `bufferId` + `inflightRequestId`; mismatched completions are no-ops. The "typed during save" branch is unreachable because the editor is genuinely disabled |
+| 1.8 | `autoFocus` does not put the caret at the start | Stated as unverified, with the fallback plugin named |
+| 1.10 | The language test cannot import `CODE_LANGS` | It is exported |
+| 1.11 | `DiffView` is unsafe even for a mid-edit `.json` | Diff cut from this PR; when it lands it uses `computeTextDiffLines` for every kind |
+| 2.1 | No loaded/failed state for the original bytes | `driveEditAvailability` gained `loading` and `unreadable` |
+| 2.2 | The family key is not the write mount for `agent-files/` | Four distinct identity fields |
+| 2.3, 2.14 | Action atoms cannot select a family member; the family retains large buffers | A single atom |
+| 2.4 | `openedAt` referenced but never declared | Moot — the activity trigger is cut |
+| 2.6 | "Pure atoms" that run UI effects | Actions return an intent; the controller executes it |
+| 2.7 | Reload discards the buffer it then adopts into | Reload replaces the buffer in place and keeps it open |
+| 2.10 | `saved → read` unspecified, timer unowned | Save exits edit mode; the "Saved" tag timer is owned by the controller hook |
+| 2.11 | `AbortController` in the atom value | It lives in a hook ref, as `useMountUpload` already does |
+| 2.12, 2.13 | The derived label is lossy and untestable | Replaced with orthogonal facets |
+| 2.15 | The spec's session-teardown warning was missing | Section 9 |
+| 3.1, 4.7 | Mask click and antd Escape bypass the guard | `FilesDrawer` owns the guarded close |
+| 3.2 | `DriveTreeRow` cannot select a keyed atom | `DriveTreeList` takes `dirtyPath` and passes a boolean down |
+| 3.3 | The controller signature lacks what it needs | Resolved mount/path, content state, `includeGitignored`, and a shell close continuation |
+| 3.4 | Eleven more flat files | An `editMode/` directory with `model`/`state`/`api`/controller/`components` |
+| 3.7 | `DriveTreePane` has no inert seam | An `interactive` prop that sets `inert` on the scroll container and the resize handle |
+| 3.8, 3.9, O.1, O.4 | The import surface does not compile | The write moves into the session package; `mountDirQueryKey` is exported |
+| 3.11 | `canUpload` documented as writability | Renamed `canEditMountFiles` and described as a proxy |
+| 4.1, 4.2, 4.3, 4.5 | The grace window creates silent overwrites and false conflicts | Cut, together with the post-save baseline adoption it existed for |
+| 4.4 | The activity trigger usually cannot resolve a path | Cut |
+| 4.6 | A deleted file would be silently recreated | Missing entry is a conflict |
+| 4.8 | A changed `initialPath` bypasses a wrapped `select` | `FilesDrawer` holds it while dirty |
+| 4.9 | A drive swap remounts the editor | The buffer survives in the module atom; the guard renders above the remount boundary |
+| 4.10 | Drag spring-navigation bypasses the wrapped consumers | `enabled: canUpload && !editing` on the drop hook |
+| 4.12 | The pre-write query could hit the wrong listing variant | `includeGitignored` is in the key |
+| 4.17 | `content.length` is not a byte count | `size` is a required number in the schema |
+| 4.18 | A stale or unknown listing size bypasses the cap | Re-checked against the loaded string |
+| 4.19, O.5 | Invalidation too narrow for the header | Reuse the upload path's four roots |
+| O.6 | No accessibility requirements | Section 12 |
+| O.7 | ⌘E omitted | In the controller's key bindings |
+| O.10 | The plan's prose would leak into comments | Stated at the end of the plan |
+
+### Cut from this PR (accepted, deferred)
+
+Side-by-side conflict diff · agent-activity early conflict warning · Save-and-continue in the
+guard · the editor status footer (language is already in the bar, `UTF-8` is misleading after
+replacement decoding, and cursor position needs selection plumbing) · `{kind:"filter"}` in the
+intent union (unreachable while the toolbar is replaced).
+
+### Rejected
+
+| Finding | Why |
+|---|---|
+| Cut the markdown preview pane | It is a spec requirement and costs a segmented control plus the `Markdown` component we already render. The only defect cited was an unverified cursor-preservation claim in the prose, which is now removed. |
+| Cut the tree-row dirty dot | The spec asks for exactly two dirty affordances. The real objection — a keyed atom read from a virtualized row — is fixed by reading it once at the list. |
+| Cut the "Saved" confirmation entirely | The objection was an unowned timer, not the confirmation. It is now one timer owned by the controller hook and cleared on unmount. |
+| Split `banner` into separate `saveError` and `conflict` fields | The spec has one banner slot and says only one can ever show. Two fields make coexistence representable. Renamed to `issue` instead. |
+| Rename to `getDriveEditAvailability` | The value renames were taken; the `get` prefix does not match this module (`resolveDriveFileKind`, `driveCodeLanguage`). |
+| Add a `DriveEditBoundary` component layer | One controller hook plus the guarded close in `FilesDrawer` covers it. A wrapper component is indirection without a seam. |
+| Cancel stays live and aborts the write (spec rule) | Aborting the client request does not prove the server did not write, and an ambiguous outcome is worse than waiting. Cancel is disabled during the write and the request carries a timeout, so nobody is trapped. Deliberate deviation from the spec. |
+| Add component-level or visual theme tests | This repo has no such harness. Both themes stay a QA checklist item, now covering every new banner, tag, tooltip, and modal state rather than the happy path. |
+| Specify copy ownership and localization | The Drives area is English-only throughout and there is no i18n system to hook into. Not this PR's problem to invent. |
 
 ## Open questions
 
 None are blocking. Each has a chosen answer; these are the ones worth revisiting if the answer
 turns out badly in QA.
 
-1. **Five-second self-write window.** After a save, conflict detection is suppressed for that
-   path for five seconds while the directory listing refetches and yields the real modification
-   time. A write by the agent inside that window is missed until the next save's pre-write check.
-   If QA shows the agent writing that fast in practice, shorten the window and rely on the
-   refetch's completion rather than a timer.
-2. **No modification time from the object store.** When `mtime` comes back null, the pre-write
-   check cannot fire and only the file-activity signal protects the write. Not observed in the
-   local stack; recorded so a report of a silent overwrite has somewhere to start.
-3. **Config-panel host has no session id.** `useDriveSessionId()` returns null there, so the
-   file-activity trigger never fires in that host. The pre-write check still runs. Threading a
-   session id through the config host is possible but out of scope.
+1. **No modification time from the object store.** When `mtime` comes back null on either side,
+   the pre-write check cannot fire and nothing protects the write. It is the only conflict
+   trigger, so this is the one silent-overwrite path left. Not observed in the local stack;
+   recorded so a report has somewhere to start.
+2. **The conflict window is the write itself.** The pre-write check closes just before the PUT;
+   an agent write landing between the check and the PUT is lost. Closing that needs a
+   conditional write on the backend (an `If-Unmodified-Since`-style precondition), which is a
+   cross-stack change and out of scope here.
+3. **Caret position on open.** `autoFocus` mounts Lexical's `AutoFocusPlugin`, which does not
+   promise the caret lands at the start of the document as the spec asks. Check it in QA; the
+   fallback is a small select-start plugin via `editorProps.additionalCodePlugins`.
 4. **UTF-8 replacement on read.** `read_file` decodes with `errors="replace"`
    (`api/oss/src/core/mounts/service.py:1461-1474`), so a text file containing invalid UTF-8
    loses those bytes on read and would lose them permanently on save. Not fixable on the client.
@@ -65,6 +141,14 @@ turns out badly in QA.
 - **No new file, rename, or delete.** Creating files stays the upload path's job.
 - **CSV edits as text, not as a table.** The spec puts `csv` among the editable text kinds and
   there is no cell editor here.
+- **No rich-text markdown editing and no formatting controls.** Every editable kind uses
+  `codeOnly`, so the spec's "formatting controls stay visible but disabled in preview" has
+  nothing to disable. Byte fidelity beats a toolbar for a file editor.
+- **The design prototype's `capped` state is broken.** `STATES` lists it but `NOTES` has no entry,
+  so selecting it dereferences `undefined`, and the renderer treats everything except `read` and
+  `locked` as editing, putting `capped` into the editing layout. Our reading — Edit rendered but
+  disabled with a tooltip naming the cap — comes from the `locked` notes, which say it explicitly.
+  Worth fixing in the prototype before anyone treats all twelve rendered states as authoritative.
 
 ## Coordination
 
@@ -72,13 +156,25 @@ turns out badly in QA.
   `Drives/`, all `CopyButton size="small"` becoming `size="icon-sm"`, in `DriveFilePreview.tsx`,
   `DriveHeader.tsx`, and `FolderView.tsx`. Do not touch those lines. Do not rebase onto or merge
   that branch. The post-merge fixup here is two `import ... from "antd"` lines in two new files
-  (`plan.md` section 8).
+  (`plan.md` section 11).
 - **Do not push, do not open a PR, do not merge from this worktree.** The orchestrator does that.
 - Never touch `/home/mahmoud/code/agenta-2`. A release is running there.
 
 ## Live QA to run before calling it done
 
-From `CONTEXT.md`, unchanged: edit and save `.txt`, `.csv`, `.md`, `.env`, and `.json`. For each,
-confirm the bytes round-trip without reformatting, the agent sees the change on its next tool
-call, and both light and dark themes render correctly. Then exercise the guard from all five exit
-routes and force a conflict by having the agent write to an open file.
+From `CONTEXT.md`: edit and save `.txt`, `.csv`, `.md`, `.env`, and `.json`. For each, confirm the
+bytes round-trip without reformatting and the agent sees the change on its next tool call. A
+markdown file containing backslash escapes, a trailing newline, and a blank final line is the
+sharpest byte-fidelity case — check it explicitly.
+
+Then:
+
+- exercise the guard from every route in `plan.md` section 2: Cancel, Escape, the header close,
+  the drawer mask, a tree selection, a chat link changing `initialPath`, drag spring-navigation,
+  and browser unload
+- force a conflict by having the agent write to an open file, and a `missing` conflict by having
+  it delete one
+- check the caret lands at the start of the document on open
+- check both light and dark themes for every new state, not only the editor: the error banner,
+  the conflict banner, the disabled Edit tooltip, the saving spinner, the Unsaved and Saved tags,
+  and the guard modal

--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -35,6 +35,10 @@ import {DriveTreePane} from "./DriveTreePane"
 import {looksLikeFilePath} from "./driveTreeView"
 import {type DriveId, type DriveScope} from "./driveTypes"
 import {type DroppedFile} from "./dropEntries"
+import {DriveEditBanner} from "./editMode/components/DriveEditBanner"
+import {DriveEditBar} from "./editMode/components/DriveEditBar"
+import {driveEditFacetsAtom, type NavigationIntent} from "./editMode/state"
+import {useDriveEditController} from "./editMode/useDriveEditController"
 import {FolderView} from "./FolderView"
 import {useDriveDownloadAll} from "./useDriveDownloadAll"
 import {useDriveFilters} from "./useDriveFilters"
@@ -66,6 +70,7 @@ export function DriveExplorer({
     onToggleExpand,
     stagedFiles,
     onStagedChange,
+    registerEditNavigationRunner,
 }: {
     drive: SessionDriveData
     /** Render this flat list instead of the mount's lazy-loaded tree — the local-file mode used to
@@ -86,6 +91,7 @@ export function DriveExplorer({
      * and clicks "Upload here" — shown as ghost tiles in the grid. The host owns the list. */
     stagedFiles?: DroppedFile[]
     onStagedChange?: (files: DroppedFile[]) => void
+    registerEditNavigationRunner?: (runner: ((intent: NavigationIntent) => void) | null) => void
 }) {
     const rootLabel = driveRootLabel(drive.mount)
     const {
@@ -109,6 +115,7 @@ export function DriveExplorer({
     const download = useDriveItemDownload(drive)
     const copyText = useCopyText()
     const projectId = useAtomValue(projectIdAtom)
+    const editFacets = useAtomValue(driveEditFacetsAtom)
     // Chrome mode renders the single header + toolbar (the drawer hosts always pass onClose).
     const chrome = onClose != null
     // Details toggle, lifted so the ONE header owns it (file meta OR repo facts, per selection).
@@ -134,7 +141,14 @@ export function DriveExplorer({
         removeStaged,
         retryUpload,
         dismissUpload,
-    } = useDriveUploads({drive, explicitFiles, select, stagedFiles, onStagedChange})
+    } = useDriveUploads({
+        drive,
+        explicitFiles,
+        select,
+        enabled: !editFacets.editing,
+        stagedFiles,
+        onStagedChange,
+    })
 
     const {
         lazyTree,
@@ -196,6 +210,21 @@ export function DriveExplorer({
         selectedIsFolder && selectedPath
             ? (selectedNode?.itemCount ?? selectedNode?.children.length ?? null)
             : null
+
+    const edit = useDriveEditController({
+        driveKey: drive.mount?.id ?? "",
+        resolveMountPath: drive.resolveMount,
+        selectedPath,
+        selectedIsFolder,
+        selectedSize: selectedFileSize ?? null,
+        scope,
+        canEditMountFiles: canUpload,
+        includeGitignored: showGitignored,
+        select,
+        close: onClose ?? (() => undefined),
+        registerNavigationRunner: registerEditNavigationRunner,
+    })
+    const uploadsEnabled = canUpload && !edit.editing
 
     const {onMeasureContent, scrollXFor, attachTreeWheel} = useTreeGroupScroll({
         deferredSearch,
@@ -266,8 +295,8 @@ export function DriveExplorer({
                     // tile on open. With the tree shown, the tree owns focus, so don't.
                     autoFocus={!treeVisible}
                     anticipateShift={treeShift}
-                    onSelect={select}
-                    drop={canUpload ? drop : undefined}
+                    onSelect={edit.select}
+                    drop={uploadsEnabled ? drop : undefined}
                     // Uploads are injected into the tree under their folder; decorate the matching node.
                     pendingUploadByPath={pendingUploadByPath}
                     onRetryUpload={retryUpload}
@@ -288,15 +317,16 @@ export function DriveExplorer({
                     size={selected?.size ?? undefined}
                     hideHeader={chrome}
                     detailsOpen={detailsOpen}
-                    onSelect={select}
+                    onSelect={edit.select}
                 />
             )
         body = (
             <DriveTreePane
                 pane={pane}
+                interactive={!edit.editing}
                 treeScrollRef={treeScrollRef}
                 onTreeKeyDown={onTreeKeyDown}
-                treeDropProps={canUpload ? drop.containerDropProps(currentFolder) : undefined}
+                treeDropProps={uploadsEnabled ? drop.containerDropProps(currentFolder) : undefined}
                 rows={
                     <DriveTreeList
                         flatRows={flatRows}
@@ -307,17 +337,18 @@ export function DriveExplorer({
                         firstEverPaths={firstEverPaths}
                         shownExpanded={shownExpanded}
                         selectedPath={selectedPath}
+                        dirtyPath={edit.dirtyPath}
                         showOrigin={showOrigin}
                         isDirLoading={isDirLoading}
                         scrollXFor={scrollXFor}
                         onMeasureContent={onMeasureContent}
-                        canUpload={canUpload}
+                        canUpload={uploadsEnabled}
                         drop={drop}
                         pendingUploadByPath={pendingUploadByPath}
                         onRetryUpload={retryUpload}
                         onDismissUpload={dismissUpload}
                         setExpanded={setExpanded}
-                        select={select}
+                        select={edit.select}
                         copyPath={copyPath}
                         download={download}
                     />
@@ -346,7 +377,7 @@ export function DriveExplorer({
                         isRepo={headerRepo.isRepo}
                         detailsOpen={detailsOpen}
                         onToggleDetails={() => setDetailsOpen((v) => !v)}
-                        onNavigate={select}
+                        onNavigate={edit.select}
                         onClose={onClose}
                         copyText={copyText}
                         ids={driveIds ?? []}
@@ -368,6 +399,17 @@ export function DriveExplorer({
                         onUpload={canUpload ? () => uploadInputRef.current?.click() : undefined}
                         stagedCount={staged.length}
                         onUploadStaged={commitStaged}
+                        edit={{
+                            availability: edit.availability,
+                            editing: edit.editing,
+                            dirty: edit.dirty,
+                            saving: edit.saving,
+                            justSaved: edit.justSaved,
+                            statusText: edit.statusText,
+                            onEdit: edit.onEdit,
+                            onCancel: edit.onCancel,
+                            onSave: edit.onSave,
+                        }}
                     />
                     <input
                         ref={uploadInputRef}
@@ -390,21 +432,30 @@ export function DriveExplorer({
                     {/* Pending uploads render as tiles in the grid + a pinned group in the tree (both
                         drawer-global), so no separate header banner here — a banner that mounts/unmounts
                         shoved the toolbar + panes on every upload state change. */}
-                    <DriveToolbar
-                        search={search}
-                        setSearch={setSearch}
-                        searchActive={searchActive}
-                        showTree={showTree}
-                        treeVisible={treeVisible}
-                        toggleTree={toggleTree}
-                        showOrigin={showOrigin}
-                        originFilter={originFilter}
-                        setOriginFilter={setOriginFilter}
-                        showHidden={showHidden}
-                        setShowHidden={setShowHidden}
-                        inGitScope={inGitScope}
-                        showGitignored={showGitignored}
-                        setShowGitignored={setShowGitignored}
+                    {edit.editing ? (
+                        <DriveEditBar />
+                    ) : (
+                        <DriveToolbar
+                            search={search}
+                            setSearch={setSearch}
+                            searchActive={searchActive}
+                            showTree={showTree}
+                            treeVisible={treeVisible}
+                            toggleTree={toggleTree}
+                            showOrigin={showOrigin}
+                            originFilter={originFilter}
+                            setOriginFilter={setOriginFilter}
+                            showHidden={showHidden}
+                            setShowHidden={setShowHidden}
+                            inGitScope={inGitScope}
+                            showGitignored={showGitignored}
+                            setShowGitignored={setShowGitignored}
+                        />
+                    )}
+                    <DriveEditBanner
+                        onRetry={edit.onRetry}
+                        onReload={edit.onReload}
+                        onOverwrite={edit.onOverwrite}
                     />
                     <div className="flex min-h-0 flex-1 flex-col">{body}</div>
                 </div>

--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -15,7 +15,7 @@
  * keyboard nav ({@link useDriveTreeKeyboard}), selection reveal ({@link useDriveTreeReveal}) and
  * "Download all" ({@link useDriveDownloadAll}).
  */
-import {type ReactNode, useCallback, useState} from "react"
+import {type ReactNode, useCallback, useRef, useState} from "react"
 
 import {type MountFile} from "@agenta/entities/session"
 import {useAtomValue} from "jotai"
@@ -37,7 +37,7 @@ import {type DriveId, type DriveScope} from "./driveTypes"
 import {type DroppedFile} from "./dropEntries"
 import {DriveEditBanner} from "./editMode/components/DriveEditBanner"
 import {DriveEditBar} from "./editMode/components/DriveEditBar"
-import {driveEditFacetsAtom, type NavigationIntent} from "./editMode/state"
+import {driveEditingAtomFamily, type NavigationIntent} from "./editMode/state"
 import {useDriveEditController} from "./editMode/useDriveEditController"
 import {FolderView} from "./FolderView"
 import {useDriveDownloadAll} from "./useDriveDownloadAll"
@@ -115,7 +115,9 @@ export function DriveExplorer({
     const download = useDriveItemDownload(drive)
     const copyText = useCopyText()
     const projectId = useAtomValue(projectIdAtom)
-    const editFacets = useAtomValue(driveEditFacetsAtom)
+    const driveKey = drive.mount?.id ?? ""
+    const editing = useAtomValue(driveEditingAtomFamily(driveKey))
+    const rootRef = useRef<HTMLDivElement>(null)
     // Chrome mode renders the single header + toolbar (the drawer hosts always pass onClose).
     const chrome = onClose != null
     // Details toggle, lifted so the ONE header owns it (file meta OR repo facts, per selection).
@@ -145,7 +147,7 @@ export function DriveExplorer({
         drive,
         explicitFiles,
         select,
-        enabled: !editFacets.editing,
+        enabled: !editing,
         stagedFiles,
         onStagedChange,
     })
@@ -212,7 +214,7 @@ export function DriveExplorer({
             : null
 
     const edit = useDriveEditController({
-        driveKey: drive.mount?.id ?? "",
+        driveKey,
         resolveMountPath: drive.resolveMount,
         selectedPath,
         selectedIsFolder,
@@ -222,6 +224,7 @@ export function DriveExplorer({
         includeGitignored: showGitignored,
         select,
         close: onClose ?? (() => undefined),
+        rootRef,
         registerNavigationRunner: registerEditNavigationRunner,
     })
     const uploadsEnabled = canUpload && !edit.editing
@@ -309,6 +312,7 @@ export function DriveExplorer({
                     // Preview reads from the file's own mount (cwd or the nested agent-files mount),
                     // but the breadcrumb/name show the presented path (agent-files/ prefix).
                     mount={drive.resolveMount(selectedPath)?.mount ?? drive.mount}
+                    driveKey={driveKey}
                     path={drive.resolveMount(selectedPath)?.path ?? selectedPath}
                     displayPath={selectedPath}
                     showOrigin={showOrigin}
@@ -364,7 +368,7 @@ export function DriveExplorer({
         <>
             {lazyTree.subscribers}
             {onClose ? (
-                <div className="flex h-full min-h-0 w-full flex-col">
+                <div ref={rootRef} className="flex h-full min-h-0 w-full flex-col">
                     <DriveHeader
                         selectedPath={selectedPath}
                         isFolder={selectedIsFolder}
@@ -423,7 +427,7 @@ export function DriveExplorer({
                         drawer-global), so no separate header banner here — a banner that mounts/unmounts
                         shoved the toolbar + panes on every upload state change. */}
                     {edit.editing ? (
-                        <DriveEditBar />
+                        <DriveEditBar driveKey={driveKey} />
                     ) : (
                         <DriveToolbar
                             search={search}
@@ -443,6 +447,7 @@ export function DriveExplorer({
                         />
                     )}
                     <DriveEditBanner
+                        driveKey={driveKey}
                         onRetry={edit.onSave}
                         onReload={edit.onReload}
                         onOverwrite={edit.onOverwrite}

--- a/web/oss/src/components/Drives/DriveExplorer.tsx
+++ b/web/oss/src/components/Drives/DriveExplorer.tsx
@@ -399,17 +399,7 @@ export function DriveExplorer({
                         onUpload={canUpload ? () => uploadInputRef.current?.click() : undefined}
                         stagedCount={staged.length}
                         onUploadStaged={commitStaged}
-                        edit={{
-                            availability: edit.availability,
-                            editing: edit.editing,
-                            dirty: edit.dirty,
-                            saving: edit.saving,
-                            justSaved: edit.justSaved,
-                            statusText: edit.statusText,
-                            onEdit: edit.onEdit,
-                            onCancel: edit.onCancel,
-                            onSave: edit.onSave,
-                        }}
+                        edit={edit}
                     />
                     <input
                         ref={uploadInputRef}
@@ -453,7 +443,7 @@ export function DriveExplorer({
                         />
                     )}
                     <DriveEditBanner
-                        onRetry={edit.onRetry}
+                        onRetry={edit.onSave}
                         onReload={edit.onReload}
                         onOverwrite={edit.onOverwrite}
                     />

--- a/web/oss/src/components/Drives/DriveFilePreview.tsx
+++ b/web/oss/src/components/Drives/DriveFilePreview.tsx
@@ -4,11 +4,14 @@ import {type Mount} from "@agenta/entities/session"
 import {CopyButton} from "@agenta/ui/components/presentational"
 import {Info} from "@phosphor-icons/react"
 import {Button, Tooltip} from "antd"
+import {useAtomValue} from "jotai"
 import {AnimatePresence, motion} from "motion/react"
 
 import {DriveBreadcrumb} from "./DriveBreadcrumb"
 import {DriveFileContentViewer, DriveFileDownloadButton} from "./DriveFileContentViewer"
 import {META_REVEAL} from "./driveMotion"
+import {DriveFileEditor} from "./editMode/components/DriveFileEditor"
+import {driveEditBufferAtom} from "./editMode/state"
 import {DriveFileMetaList} from "./fileMeta"
 import {OriginTag} from "./OriginTag"
 import {fileOrigin} from "./useSessionDrive"
@@ -50,6 +53,13 @@ export const DriveFilePreview = ({
     const name = shown.split("/").pop() ?? shown
     const [metaExpanded, setMetaExpanded] = useState(false)
     const metaOpen = hideHeader ? Boolean(detailsOpen) : metaExpanded
+    const editBuffer = useAtomValue(driveEditBufferAtom)
+    const editingThisFile = Boolean(
+        editBuffer &&
+        editBuffer.targetMountId === mount?.id &&
+        editBuffer.targetPath === path &&
+        editBuffer.displayPath === shown,
+    )
 
     return (
         // h-full pins the preview to the content pane's height so the header stays put and only the
@@ -135,13 +145,17 @@ export const DriveFilePreview = ({
             )}
 
             <div className="flex min-h-0 flex-1 flex-col p-4 pt-3">
-                <DriveFileContentViewer
-                    mount={mount}
-                    path={path}
-                    size={size}
-                    displayPath={shown}
-                    onNavigate={onSelect}
-                />
+                {editingThisFile ? (
+                    <DriveFileEditor />
+                ) : (
+                    <DriveFileContentViewer
+                        mount={mount}
+                        path={path}
+                        size={size}
+                        displayPath={shown}
+                        onNavigate={onSelect}
+                    />
+                )}
             </div>
         </div>
     )

--- a/web/oss/src/components/Drives/DriveFilePreview.tsx
+++ b/web/oss/src/components/Drives/DriveFilePreview.tsx
@@ -11,7 +11,12 @@ import {DriveBreadcrumb} from "./DriveBreadcrumb"
 import {DriveFileContentViewer, DriveFileDownloadButton} from "./DriveFileContentViewer"
 import {META_REVEAL} from "./driveMotion"
 import {DriveFileEditor} from "./editMode/components/DriveFileEditor"
-import {driveEditBufferAtom} from "./editMode/state"
+import {
+    driveEditDisplayPathAtomFamily,
+    driveEditingAtomFamily,
+    driveEditTargetMountAtomFamily,
+    driveEditTargetPathAtomFamily,
+} from "./editMode/state"
 import {DriveFileMetaList} from "./fileMeta"
 import {OriginTag} from "./OriginTag"
 import {fileOrigin} from "./useSessionDrive"
@@ -21,6 +26,7 @@ import {fileOrigin} from "./useSessionDrive"
  * view, so the file info never scrolls away with the content. */
 export const DriveFilePreview = ({
     mount,
+    driveKey,
     path,
     displayPath,
     rootLabel,
@@ -32,6 +38,7 @@ export const DriveFilePreview = ({
     onSelect,
 }: {
     mount: Mount | null
+    driveKey: string
     /** Path relative to `mount` — used for reading (content/meta/download). */
     path: string
     /** Path as shown to the user (with the `agent-files/` prefix) — used for the breadcrumb + name.
@@ -53,12 +60,15 @@ export const DriveFilePreview = ({
     const name = shown.split("/").pop() ?? shown
     const [metaExpanded, setMetaExpanded] = useState(false)
     const metaOpen = hideHeader ? Boolean(detailsOpen) : metaExpanded
-    const editBuffer = useAtomValue(driveEditBufferAtom)
+    const editing = useAtomValue(driveEditingAtomFamily(driveKey))
+    const editTargetMount = useAtomValue(driveEditTargetMountAtomFamily(driveKey))
+    const editTargetPath = useAtomValue(driveEditTargetPathAtomFamily(driveKey))
+    const editDisplayPath = useAtomValue(driveEditDisplayPathAtomFamily(driveKey))
     const editingThisFile = Boolean(
-        editBuffer &&
-        editBuffer.targetMountId === mount?.id &&
-        editBuffer.targetPath === path &&
-        editBuffer.displayPath === shown,
+        editing &&
+        editTargetMount === mount?.id &&
+        editTargetPath === path &&
+        editDisplayPath === shown,
     )
 
     return (
@@ -146,7 +156,7 @@ export const DriveFilePreview = ({
 
             <div className="flex min-h-0 flex-1 flex-col p-4 pt-3">
                 {editingThisFile ? (
-                    <DriveFileEditor />
+                    <DriveFileEditor driveKey={driveKey} />
                 ) : (
                     <DriveFileContentViewer
                         mount={mount}

--- a/web/oss/src/components/Drives/DriveHeader.tsx
+++ b/web/oss/src/components/Drives/DriveHeader.tsx
@@ -20,7 +20,17 @@ import {DriveRetryButton} from "./DriveFileRow"
 import {humanSize} from "./driveTree"
 import {type DriveId} from "./driveTypes"
 import {type DriveEditAvailability} from "./editMode/model"
+import {type DriveEditController} from "./editMode/useDriveEditController"
 import {fileOrigin} from "./useSessionDrive"
+
+// Empty for "enabled" — antd renders no tooltip, so one Button covers both states.
+const EDIT_DISABLED_REASON: Record<DriveEditAvailability, string> = {
+    enabled: "",
+    loading: "File content is still loading",
+    unreadable: "This file couldn’t be read",
+    "too-large": "Files larger than 1.5 MB can’t be edited",
+    unavailable: "",
+}
 
 /**
  * DriveHeader — the drawer's ONE header. The breadcrumb IS the header (its last crumb the current
@@ -96,17 +106,18 @@ export const DriveHeader = ({
     partialErrored?: boolean
     onRetry?: () => void
     retrying?: boolean
-    edit?: {
-        availability: DriveEditAvailability
-        editing: boolean
-        dirty: boolean
-        saving: boolean
-        justSaved: boolean
-        statusText: string
-        onEdit: () => void
-        onCancel: () => void
-        onSave: () => void
-    }
+    edit?: Pick<
+        DriveEditController,
+        | "availability"
+        | "editing"
+        | "dirty"
+        | "saving"
+        | "justSaved"
+        | "statusText"
+        | "onEdit"
+        | "onCancel"
+        | "onSave"
+    >
 }) => {
     const atRoot = !selectedPath
     // A file always has details (size/modified); a folder only when it's a repo. Nothing selected
@@ -263,21 +274,14 @@ export const DriveHeader = ({
                         />
                     </Tooltip>
                 ) : null}
-                {edit?.availability === "enabled" ? (
-                    <Button size="small" icon={<PencilSimple size={14} />} onClick={edit.onEdit}>
-                        Edit
-                    </Button>
-                ) : edit && edit.availability !== "unavailable" ? (
-                    <Tooltip
-                        title={
-                            edit.availability === "too-large"
-                                ? "Files larger than 1.5 MB can’t be edited"
-                                : edit.availability === "loading"
-                                  ? "File content is still loading"
-                                  : "This file couldn’t be read"
-                        }
-                    >
-                        <Button size="small" icon={<PencilSimple size={14} />} disabled>
+                {edit && edit.availability !== "unavailable" ? (
+                    <Tooltip title={EDIT_DISABLED_REASON[edit.availability]}>
+                        <Button
+                            size="small"
+                            icon={<PencilSimple size={14} />}
+                            disabled={edit.availability !== "enabled"}
+                            onClick={edit.onEdit}
+                        >
                             Edit
                         </Button>
                     </Tooltip>

--- a/web/oss/src/components/Drives/DriveHeader.tsx
+++ b/web/oss/src/components/Drives/DriveHeader.tsx
@@ -7,6 +7,7 @@ import {
     DownloadSimple,
     GitBranch,
     Info,
+    PencilSimple,
     UploadSimple,
     WarningCircle,
     X,
@@ -18,6 +19,7 @@ import {DriveFileDownloadButton} from "./DriveFileContentViewer"
 import {DriveRetryButton} from "./DriveFileRow"
 import {humanSize} from "./driveTree"
 import {type DriveId} from "./driveTypes"
+import {type DriveEditAvailability} from "./editMode/model"
 import {fileOrigin} from "./useSessionDrive"
 
 /**
@@ -54,6 +56,7 @@ export const DriveHeader = ({
     onUpload,
     stagedCount = 0,
     onUploadStaged,
+    edit,
 }: {
     selectedPath: string | null
     isFolder: boolean
@@ -93,6 +96,17 @@ export const DriveHeader = ({
     partialErrored?: boolean
     onRetry?: () => void
     retrying?: boolean
+    edit?: {
+        availability: DriveEditAvailability
+        editing: boolean
+        dirty: boolean
+        saving: boolean
+        justSaved: boolean
+        statusText: string
+        onEdit: () => void
+        onCancel: () => void
+        onSave: () => void
+    }
 }) => {
     const atRoot = !selectedPath
     // A file always has details (size/modified); a folder only when it's a repo. Nothing selected
@@ -164,6 +178,15 @@ export const DriveHeader = ({
                         {fileOrigin(selectedPath) === "agent" ? "Agent" : "Session"}
                     </Tag>
                 ) : null}
+                {edit?.dirty ? (
+                    <Tag color="warning" className="m-0 shrink-0 text-[10px] font-normal">
+                        Unsaved
+                    </Tag>
+                ) : edit?.justSaved ? (
+                    <Tag color="success" className="m-0 shrink-0 text-[10px] font-normal">
+                        Saved
+                    </Tag>
+                ) : null}
             </div>
             {/* A mount failed but the drive still browses — a compact warning + retry that lives in
                 the header's existing slack (never a new row). Tooltip carries the full message so the
@@ -180,7 +203,7 @@ export const DriveHeader = ({
                     </span>
                 </Tooltip>
             ) : null}
-            <div className="flex shrink-0 items-center gap-1">
+            <div className={`${edit?.editing ? "hidden" : "flex"} shrink-0 items-center gap-1`}>
                 {/* ONE upload button, context-dependent: with files staged it commits them into this
                     folder (primary-tinted); otherwise it opens the file picker (neutral). */}
                 {stagedCount > 0 && onUploadStaged ? (
@@ -240,6 +263,25 @@ export const DriveHeader = ({
                         />
                     </Tooltip>
                 ) : null}
+                {edit?.availability === "enabled" ? (
+                    <Button size="small" icon={<PencilSimple size={14} />} onClick={edit.onEdit}>
+                        Edit
+                    </Button>
+                ) : edit && edit.availability !== "unavailable" ? (
+                    <Tooltip
+                        title={
+                            edit.availability === "too-large"
+                                ? "Files larger than 1.5 MB can’t be edited"
+                                : edit.availability === "loading"
+                                  ? "File content is still loading"
+                                  : "This file couldn’t be read"
+                        }
+                    >
+                        <Button size="small" icon={<PencilSimple size={14} />} disabled>
+                            Edit
+                        </Button>
+                    </Tooltip>
+                ) : null}
                 {!isFolder && selectedPath ? (
                     <DriveFileDownloadButton mount={downloadMount} path={downloadPath} />
                 ) : null}
@@ -262,6 +304,26 @@ export const DriveHeader = ({
                     />
                 </Dropdown>
             </div>
+            {edit?.editing ? (
+                <div className="flex shrink-0 items-center gap-1">
+                    <Button size="small" disabled={edit.saving} onClick={edit.onCancel}>
+                        Cancel
+                    </Button>
+                    <Button
+                        size="small"
+                        type="primary"
+                        disabled={!edit.dirty}
+                        loading={edit.saving}
+                        onClick={edit.onSave}
+                        aria-keyshortcuts="Control+S Meta+S"
+                    >
+                        {edit.saving ? "Saving" : "Save"}
+                    </Button>
+                </div>
+            ) : null}
+            <span className="sr-only" aria-live="polite">
+                {edit?.statusText ?? ""}
+            </span>
         </div>
     )
 }

--- a/web/oss/src/components/Drives/DriveHeader.tsx
+++ b/web/oss/src/components/Drives/DriveHeader.tsx
@@ -17,6 +17,7 @@ import {Button, Dropdown, type MenuProps, Tag, Tooltip} from "antd"
 import {DriveBreadcrumb} from "./DriveBreadcrumb"
 import {DriveFileDownloadButton} from "./DriveFileContentViewer"
 import {DriveRetryButton} from "./DriveFileRow"
+import {TEXT_CAP} from "./driveKinds"
 import {humanSize} from "./driveTree"
 import {type DriveId} from "./driveTypes"
 import {type DriveEditAvailability} from "./editMode/model"
@@ -28,7 +29,8 @@ const EDIT_DISABLED_REASON: Record<DriveEditAvailability, string> = {
     enabled: "",
     loading: "File content is still loading",
     unreadable: "This file couldn’t be read",
-    "too-large": "Files larger than 1.5 MB can’t be edited",
+    "listing-unavailable": "This file’s change status couldn’t be verified",
+    "too-large": `Files larger than ${humanSize(TEXT_CAP)} can’t be edited`,
     unavailable: "",
 }
 

--- a/web/oss/src/components/Drives/DriveTreeList.tsx
+++ b/web/oss/src/components/Drives/DriveTreeList.tsx
@@ -28,6 +28,7 @@ export function DriveTreeList({
     firstEverPaths,
     shownExpanded,
     selectedPath,
+    dirtyPath,
     showOrigin,
     isDirLoading,
     scrollXFor,
@@ -52,6 +53,7 @@ export function DriveTreeList({
     firstEverPaths: ReadonlySet<string>
     shownExpanded: Set<string>
     selectedPath: string | null
+    dirtyPath: string | null
     showOrigin: boolean
     isDirLoading: (path: string) => boolean
     scrollXFor: (parent: string) => number
@@ -132,6 +134,7 @@ export function DriveTreeList({
                                         depth={depth}
                                         isOpen={shownExpanded.has(node.path)}
                                         selected={node.path === selectedPath}
+                                        dirty={node.path === dirtyPath}
                                         loading={
                                             node.isFolder &&
                                             shownExpanded.has(node.path) &&

--- a/web/oss/src/components/Drives/DriveTreePane.tsx
+++ b/web/oss/src/components/Drives/DriveTreePane.tsx
@@ -66,7 +66,7 @@ export function DriveTreePane({
                         // Vertical scroll is native; horizontal is intercepted (treeScrollRef)
                         // and routed to the hovered row's FOLDER GROUP (transform), so siblings
                         // scroll together. `overscroll-contain` stops rubber-band chaining.
-                        className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain"
+                        className={`min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain transition-opacity ${interactive ? "" : "pointer-events-none opacity-50"}`}
                         onKeyDown={interactive ? onTreeKeyDown : undefined}
                         {...(interactive ? (treeDropProps ?? {}) : {})}
                     >

--- a/web/oss/src/components/Drives/DriveTreePane.tsx
+++ b/web/oss/src/components/Drives/DriveTreePane.tsx
@@ -15,6 +15,7 @@ export function DriveTreePane({
     treeScrollRef,
     onTreeKeyDown,
     treeDropProps,
+    interactive = true,
     rows,
     children,
 }: {
@@ -23,6 +24,7 @@ export function DriveTreePane({
     onTreeKeyDown: (e: KeyboardEvent<HTMLDivElement>) => void
     /** Drop-to-upload handlers for the tree's scroll container — absent = uploads disabled here. */
     treeDropProps?: ReturnType<DriveDrop["containerDropProps"]>
+    interactive?: boolean
     /** The tree's virtualized rows (see DriveTreeList) — a slot, so this module stays pure geometry. */
     rows: ReactNode
     /** The content pane: the folder grid or the file preview. */
@@ -60,12 +62,13 @@ export function DriveTreePane({
                 >
                     <div
                         ref={treeScrollRef}
+                        inert={interactive ? undefined : true}
                         // Vertical scroll is native; horizontal is intercepted (treeScrollRef)
                         // and routed to the hovered row's FOLDER GROUP (transform), so siblings
                         // scroll together. `overscroll-contain` stops rubber-band chaining.
                         className="min-h-0 flex-1 overflow-y-auto overflow-x-hidden overscroll-contain"
-                        onKeyDown={onTreeKeyDown}
-                        {...(treeDropProps ?? {})}
+                        onKeyDown={interactive ? onTreeKeyDown : undefined}
+                        {...(interactive ? (treeDropProps ?? {}) : {})}
                     >
                         {rows}
                     </div>
@@ -77,12 +80,13 @@ export function DriveTreePane({
             {treeVisible ? (
                 <div
                     role="separator"
+                    inert={interactive ? undefined : true}
                     aria-orientation="vertical"
                     aria-label="Resize file tree"
-                    onPointerDown={onTreeHandleDown}
-                    onPointerMove={onTreeHandleMove}
-                    onPointerUp={onTreeHandleUp}
-                    className="group relative z-10 -mx-1 w-2 shrink-0 cursor-col-resize touch-none"
+                    onPointerDown={interactive ? onTreeHandleDown : undefined}
+                    onPointerMove={interactive ? onTreeHandleMove : undefined}
+                    onPointerUp={interactive ? onTreeHandleUp : undefined}
+                    className={`group relative z-10 -mx-1 w-2 shrink-0 touch-none ${interactive ? "cursor-col-resize" : "pointer-events-none"}`}
                 >
                     <div
                         className={`absolute inset-y-0 left-1/2 w-px -translate-x-1/2 transition-colors ${treeDragging ? "bg-colorPrimary" : "bg-transparent group-hover:bg-colorPrimary"}`}

--- a/web/oss/src/components/Drives/DriveTreeRow.tsx
+++ b/web/oss/src/components/Drives/DriveTreeRow.tsx
@@ -17,6 +17,7 @@ export const TreeRow = ({
     depth,
     isOpen,
     selected,
+    dirty,
     showOrigin,
     parent,
     scrollX,
@@ -32,6 +33,7 @@ export const TreeRow = ({
     depth: number
     isOpen: boolean
     selected: boolean
+    dirty?: boolean
     /** This folder is expanded and its children are still being fetched — swap the caret for a spinner. */
     loading?: boolean
     /** Tag top-level nodes with their origin (agent-files vs session) — only when mixed. */
@@ -141,6 +143,12 @@ export const TreeRow = ({
                         <span className="shrink-0 text-[11px] text-colorTextQuaternary">
                             {humanSize(node.size)}
                         </span>
+                    ) : null}
+                    {dirty ? (
+                        <span
+                            aria-label="Unsaved changes"
+                            className="h-1.5 w-1.5 shrink-0 rounded-full bg-colorWarning"
+                        />
                     ) : null}
                     {/* In-flight upload status, trailing the name — the row is otherwise a normal file row. */}
                     {pending && !pending.error && pending.percent < 100 ? (

--- a/web/oss/src/components/Drives/FilesDrawer.tsx
+++ b/web/oss/src/components/Drives/FilesDrawer.tsx
@@ -9,7 +9,7 @@
  * The heavy body is `next/dynamic`-imported so the tree/renderer/pdfjs graph loads only when the
  * drawer opens (`destroyOnClose` unmounts it again).
  */
-import {useEffect, useRef, useState} from "react"
+import {useCallback, useEffect, useRef, useState} from "react"
 
 import {type MountFile} from "@agenta/entities/session"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
@@ -18,6 +18,9 @@ import dynamic from "next/dynamic"
 import {type DriveId, type DriveScope} from "./DriveExplorer"
 import {DriveExplorerSkeleton} from "./DriveExplorerSkeleton"
 import {type DroppedFile} from "./dropEntries"
+import {DriveEditGuardModal} from "./editMode/components/DriveEditGuardModal"
+import {type NavigationIntent} from "./editMode/state"
+import {useDriveEditGuard} from "./editMode/useDriveEditController"
 import {type SessionDriveData} from "./useSessionDrive"
 
 // Normal vs. expanded drawer width — the header's expand toggle flips between them, mirroring the
@@ -87,41 +90,68 @@ export function FilesDrawer({
     // Expanded (near-full) width, toggled from the drawer header. Reset on close so every open starts
     // at the normal width.
     const [expanded, setExpanded] = useState(false)
+    const [heldDrive, setHeldDrive] = useState(drive)
     useEffect(() => {
         if (!open) setExpanded(false)
     }, [open])
-    const driveGeneration = useDriveGeneration(drive.mount?.id)
+    const navigationRunner = useRef<((intent: NavigationIntent) => void) | null>(null)
+    const registerNavigationRunner = useCallback(
+        (runner: ((intent: NavigationIntent) => void) | null) => {
+            navigationRunner.current = runner
+        },
+        [],
+    )
+    const runNavigation = useCallback((intent: NavigationIntent) => {
+        navigationRunner.current?.(intent)
+    }, [])
+    const editGuard = useDriveEditGuard({
+        active: open,
+        initialPath,
+        driveKey: drive.mount?.id ?? "",
+        heldDriveKey: heldDrive.mount?.id ?? "",
+        onClose,
+        runNavigation,
+    })
+    useEffect(() => {
+        if (!editGuard.holdDrive) setHeldDrive(drive)
+    }, [drive, editGuard.holdDrive])
+    const displayedDrive = editGuard.holdDrive ? heldDrive : drive
+    const driveGeneration = useDriveGeneration(displayedDrive.mount?.id)
 
     return (
-        <EnhancedDrawer
-            rootClassName="ag-drawer-elevated"
-            open={open}
-            onClose={onClose}
-            placement="right"
-            // Two-pane (tree + preview) needs the room; expand for near-full width.
-            width={expanded ? EXPANDED_WIDTH : NORMAL_WIDTH}
-            destroyOnClose
-            closeOnLayoutClick={false}
-            // Headerless: DriveExplorer renders the one header (with its own close button).
-            closable={false}
-            title={null}
-            styles={{
-                body: {padding: 0, display: "flex", flexDirection: "column", minHeight: 0},
-            }}
-        >
-            <DriveExplorer
-                key={driveGeneration}
-                drive={drive}
-                explicitFiles={explicitFiles}
-                scope={scope}
-                initialPath={initialPath}
-                onClose={onClose}
-                driveIds={driveIds}
-                expanded={expanded}
-                onToggleExpand={() => setExpanded((v) => !v)}
-                stagedFiles={stagedFiles}
-                onStagedChange={onStagedChange}
-            />
-        </EnhancedDrawer>
+        <>
+            <EnhancedDrawer
+                rootClassName="ag-drawer-elevated"
+                open={open}
+                onClose={editGuard.onClose}
+                placement="right"
+                // Two-pane (tree + preview) needs the room; expand for near-full width.
+                width={expanded ? EXPANDED_WIDTH : NORMAL_WIDTH}
+                destroyOnClose
+                closeOnLayoutClick={false}
+                // Headerless: DriveExplorer renders the one header (with its own close button).
+                closable={false}
+                title={null}
+                styles={{
+                    body: {padding: 0, display: "flex", flexDirection: "column", minHeight: 0},
+                }}
+            >
+                <DriveExplorer
+                    key={driveGeneration}
+                    drive={displayedDrive}
+                    explicitFiles={explicitFiles}
+                    scope={scope}
+                    initialPath={editGuard.initialPath}
+                    onClose={editGuard.onClose}
+                    driveIds={driveIds}
+                    expanded={expanded}
+                    onToggleExpand={() => setExpanded((v) => !v)}
+                    stagedFiles={stagedFiles}
+                    onStagedChange={onStagedChange}
+                    registerEditNavigationRunner={registerNavigationRunner}
+                />
+            </EnhancedDrawer>
+            <DriveEditGuardModal {...editGuard.modal} />
+        </>
     )
 }

--- a/web/oss/src/components/Drives/driveFileSource.tsx
+++ b/web/oss/src/components/Drives/driveFileSource.tsx
@@ -64,7 +64,7 @@ export function useDriveObjectUrl(
 export function useDriveFileText(
     mount: Mount | null,
     path: string,
-): {data: string | undefined; isPending: boolean} {
+): {data: string | undefined; isPending: boolean; isFetching: boolean} {
     const local = useLocalFile(path)
     const mountQuery = useAtomValue(mountFileContentQueryFamily({mountId: mount?.id ?? "", path}))
     const [text, setText] = useState<string | undefined>(undefined)
@@ -79,8 +79,12 @@ export function useDriveFileText(
             cancelled = true
         }
     }, [local])
-    if (local) return {data: text, isPending: text === undefined}
-    return {data: mountQuery.data as string | undefined, isPending: mountQuery.isPending}
+    if (local) return {data: text, isPending: text === undefined, isFetching: text === undefined}
+    return {
+        data: mountQuery.data as string | undefined,
+        isPending: mountQuery.isPending,
+        isFetching: mountQuery.isFetching,
+    }
 }
 
 /** Download action: saves the local blob directly, or routes to the mount download. */

--- a/web/oss/src/components/Drives/driveKinds.ts
+++ b/web/oss/src/components/Drives/driveKinds.ts
@@ -19,9 +19,11 @@ export type DriveFileKind =
     | "video"
     | "other"
 
+export const TEXT_CAP = 1.5 * 1024 * 1024
+
 // Extension → Shiki language id for the code body (the lexical CodeBlock normalizes further;
 // unknown ids degrade to plaintext, never a broken viewer).
-const CODE_LANGS: Record<string, string> = {
+export const CODE_LANGS: Readonly<Record<string, string>> = {
     py: "python",
     ts: "typescript",
     tsx: "tsx",

--- a/web/oss/src/components/Drives/editMode/api.ts
+++ b/web/oss/src/components/Drives/editMode/api.ts
@@ -1,13 +1,13 @@
 import {
     mountDirQueryKey,
     mountFileContentQueryKey,
+    invalidateMountListings,
     queryMountDir,
     writeMountFile,
 } from "@agenta/entities/session"
 import type {QueryClient} from "@tanstack/react-query"
 
 import {parentOf} from "../driveTreeView"
-import {invalidateMountListings} from "../useMountUpload"
 
 import {conflictFromListing, type DriveEditConflict} from "./model"
 
@@ -20,7 +20,6 @@ export interface SaveDriveFileInput {
     baseMtime: number | null
     includeGitignored: boolean
     skipConflictCheck: boolean
-    signal?: AbortSignal
 }
 
 export type SaveDriveFileResult =
@@ -51,7 +50,6 @@ export async function saveDriveFile(
         baseMtime,
         includeGitignored,
         skipConflictCheck,
-        signal,
     } = input
 
     if (!skipConflictCheck) {
@@ -65,7 +63,7 @@ export async function saveDriveFile(
                     path: directory,
                     withCounts: true,
                     includeGitignored,
-                    abortSignal: signal ?? querySignal,
+                    abortSignal: querySignal,
                 }),
             staleTime: 0,
         })
@@ -81,7 +79,6 @@ export async function saveDriveFile(
         mountId: targetMountId,
         path: targetPath,
         content: draft,
-        signal,
     })
     if (!written.ok) return {kind: "error", message: written.message}
 

--- a/web/oss/src/components/Drives/editMode/api.ts
+++ b/web/oss/src/components/Drives/editMode/api.ts
@@ -1,0 +1,97 @@
+import {
+    mountDirQueryKey,
+    mountFileContentQueryKey,
+    queryMountDir,
+    writeMountFile,
+} from "@agenta/entities/session"
+import type {QueryClient} from "@tanstack/react-query"
+
+import {invalidateMountListings} from "../useMountUpload"
+
+import {conflictFromListing, type DriveEditConflict} from "./model"
+
+export interface SaveDriveFileInput {
+    queryClient: QueryClient
+    projectId: string
+    targetMountId: string
+    targetPath: string
+    draft: string
+    baseMtime: number | null
+    includeGitignored: boolean
+    skipConflictCheck: boolean
+    signal?: AbortSignal
+}
+
+export type SaveDriveFileResult =
+    | {kind: "saved"; size: number}
+    | ({kind: "conflict"} & DriveEditConflict)
+    | {kind: "error"; message: string}
+
+export interface SaveDriveFileDependencies {
+    queryDir: typeof queryMountDir
+    writeFile: typeof writeMountFile
+    invalidateListings: typeof invalidateMountListings
+}
+
+const DEFAULT_DEPENDENCIES: SaveDriveFileDependencies = {
+    queryDir: queryMountDir,
+    writeFile: writeMountFile,
+    invalidateListings: invalidateMountListings,
+}
+
+export const parentDirectory = (path: string): string => {
+    const separator = path.lastIndexOf("/")
+    return separator < 0 ? "" : path.slice(0, separator)
+}
+
+export async function saveDriveFile(
+    input: SaveDriveFileInput,
+    dependencies: SaveDriveFileDependencies = DEFAULT_DEPENDENCIES,
+): Promise<SaveDriveFileResult> {
+    const {
+        queryClient,
+        projectId,
+        targetMountId,
+        targetPath,
+        draft,
+        baseMtime,
+        includeGitignored,
+        skipConflictCheck,
+        signal,
+    } = input
+
+    if (!skipConflictCheck) {
+        const directory = parentDirectory(targetPath)
+        const listing = await queryClient.fetchQuery({
+            queryKey: mountDirQueryKey(projectId, targetMountId, directory, includeGitignored),
+            queryFn: ({signal: querySignal}) =>
+                dependencies.queryDir({
+                    projectId,
+                    mountId: targetMountId,
+                    path: directory,
+                    withCounts: true,
+                    includeGitignored,
+                    abortSignal: signal ?? querySignal,
+                }),
+            staleTime: 0,
+        })
+        if (!listing) {
+            return {kind: "error", message: "Couldn’t verify the file before saving"}
+        }
+        const conflict = conflictFromListing(listing, targetPath, baseMtime)
+        if (conflict) return {kind: "conflict", ...conflict}
+    }
+
+    const written = await dependencies.writeFile({
+        projectId,
+        mountId: targetMountId,
+        path: targetPath,
+        content: draft,
+        signal,
+    })
+    if (!written.ok) return {kind: "error", message: written.message}
+
+    queryClient.setQueryData(mountFileContentQueryKey(projectId, targetMountId, targetPath), draft)
+    dependencies.invalidateListings(queryClient, projectId)
+    return {kind: "saved", size: written.size}
+}

--- a/web/oss/src/components/Drives/editMode/api.ts
+++ b/web/oss/src/components/Drives/editMode/api.ts
@@ -6,6 +6,7 @@ import {
 } from "@agenta/entities/session"
 import type {QueryClient} from "@tanstack/react-query"
 
+import {parentOf} from "../driveTreeView"
 import {invalidateMountListings} from "../useMountUpload"
 
 import {conflictFromListing, type DriveEditConflict} from "./model"
@@ -30,18 +31,11 @@ export type SaveDriveFileResult =
 export interface SaveDriveFileDependencies {
     queryDir: typeof queryMountDir
     writeFile: typeof writeMountFile
-    invalidateListings: typeof invalidateMountListings
 }
 
 const DEFAULT_DEPENDENCIES: SaveDriveFileDependencies = {
     queryDir: queryMountDir,
     writeFile: writeMountFile,
-    invalidateListings: invalidateMountListings,
-}
-
-export const parentDirectory = (path: string): string => {
-    const separator = path.lastIndexOf("/")
-    return separator < 0 ? "" : path.slice(0, separator)
 }
 
 export async function saveDriveFile(
@@ -61,7 +55,7 @@ export async function saveDriveFile(
     } = input
 
     if (!skipConflictCheck) {
-        const directory = parentDirectory(targetPath)
+        const directory = parentOf(targetPath)
         const listing = await queryClient.fetchQuery({
             queryKey: mountDirQueryKey(projectId, targetMountId, directory, includeGitignored),
             queryFn: ({signal: querySignal}) =>
@@ -92,6 +86,6 @@ export async function saveDriveFile(
     if (!written.ok) return {kind: "error", message: written.message}
 
     queryClient.setQueryData(mountFileContentQueryKey(projectId, targetMountId, targetPath), draft)
-    dependencies.invalidateListings(queryClient, projectId)
+    invalidateMountListings(queryClient, projectId)
     return {kind: "saved", size: written.size}
 }

--- a/web/oss/src/components/Drives/editMode/components/DriveEditBanner.tsx
+++ b/web/oss/src/components/Drives/editMode/components/DriveEditBanner.tsx
@@ -1,0 +1,59 @@
+import {Alert, Button} from "antd"
+import {useAtomValue} from "jotai"
+
+import {driveEditBufferAtom} from "../state"
+
+export function DriveEditBanner({
+    onRetry,
+    onReload,
+    onOverwrite,
+}: {
+    onRetry: () => void
+    onReload: () => void
+    onOverwrite: () => void
+}) {
+    const buffer = useAtomValue(driveEditBufferAtom)
+    const issue = buffer?.issue
+
+    if (!buffer || !issue) return null
+
+    if (issue.kind === "error") {
+        return (
+            <Alert
+                showIcon
+                type="error"
+                message={`${issue.message}. Your changes are still here.`}
+                action={
+                    <Button size="small" onClick={onRetry}>
+                        Try again
+                    </Button>
+                }
+                className="shrink-0 rounded-none border-x-0 border-t-0"
+            />
+        )
+    }
+
+    const message =
+        issue.reason === "missing"
+            ? `${buffer.displayPath} was deleted while you were editing. Overwriting will recreate it.`
+            : `${buffer.displayPath} changed while you were editing. Overwriting will replace that version.`
+
+    return (
+        <Alert
+            showIcon
+            type="warning"
+            message={message}
+            action={
+                <div className="flex items-center gap-2">
+                    <Button size="small" onClick={onReload}>
+                        Reload from disk
+                    </Button>
+                    <Button size="small" type="primary" onClick={onOverwrite}>
+                        Overwrite
+                    </Button>
+                </div>
+            }
+            className="shrink-0 rounded-none border-x-0 border-t-0"
+        />
+    )
+}

--- a/web/oss/src/components/Drives/editMode/components/DriveEditBanner.tsx
+++ b/web/oss/src/components/Drives/editMode/components/DriveEditBanner.tsx
@@ -1,28 +1,35 @@
 import {Alert, Button} from "antd"
 import {useAtomValue} from "jotai"
 
-import {driveEditBufferAtom} from "../state"
+import {driveEditDisplayPathAtomFamily, driveEditIssueAtomFamily} from "../state"
+
+const punctuate = (message: string) => {
+    const trimmed = message.trim().replace(/\.{2,}$/, ".")
+    return /[.!?]$/.test(trimmed) ? trimmed : `${trimmed}.`
+}
 
 export function DriveEditBanner({
+    driveKey,
     onRetry,
     onReload,
     onOverwrite,
 }: {
+    driveKey: string
     onRetry: () => void
     onReload: () => void
     onOverwrite: () => void
 }) {
-    const buffer = useAtomValue(driveEditBufferAtom)
-    const issue = buffer?.issue
+    const issue = useAtomValue(driveEditIssueAtomFamily(driveKey))
+    const displayPath = useAtomValue(driveEditDisplayPathAtomFamily(driveKey))
 
-    if (!buffer || !issue) return null
+    if (!issue) return null
 
     if (issue.kind === "error") {
         return (
             <Alert
                 showIcon
                 type="error"
-                message={`${issue.message}. Your changes are still here.`}
+                message={`Couldn’t save this file. ${punctuate(issue.message)} Your changes are still here.`}
                 action={
                     <Button size="small" onClick={onRetry}>
                         Try again
@@ -35,8 +42,8 @@ export function DriveEditBanner({
 
     const message =
         issue.reason === "missing"
-            ? `${buffer.displayPath} was deleted while you were editing. Overwriting will recreate it.`
-            : `${buffer.displayPath} changed while you were editing. Overwriting will replace that version.`
+            ? `${displayPath} was deleted while you were editing. Overwriting will recreate it.`
+            : `${displayPath} changed while you were editing. Overwriting will replace that version.`
 
     return (
         <Alert
@@ -45,9 +52,11 @@ export function DriveEditBanner({
             message={message}
             action={
                 <div className="flex items-center gap-2">
-                    <Button size="small" onClick={onReload}>
-                        Reload from disk
-                    </Button>
+                    {issue.reason === "missing" ? null : (
+                        <Button size="small" onClick={onReload}>
+                            Reload from disk
+                        </Button>
+                    )}
                     <Button size="small" type="primary" onClick={onOverwrite}>
                         Overwrite
                     </Button>

--- a/web/oss/src/components/Drives/editMode/components/DriveEditBar.tsx
+++ b/web/oss/src/components/Drives/editMode/components/DriveEditBar.tsx
@@ -1,7 +1,14 @@
 import {Segmented, Tooltip} from "antd"
 import {useAtomValue, useSetAtom} from "jotai"
 
-import {driveEditBufferAtom, setEditorViewAtom} from "../state"
+import {
+    driveEditPreviewCapabilityAtomFamily,
+    driveEditingAtomFamily,
+    driveEditorLanguageAtomFamily,
+    driveEditorViewAtomFamily,
+    driveEditTeardownNoticeAtomFamily,
+    setEditorViewAtom,
+} from "../state"
 
 const LANGUAGE_LABELS = {
     json: "JSON",
@@ -12,41 +19,50 @@ const LANGUAGE_LABELS = {
     code: "Plain text",
 } as const
 
-export function DriveEditBar() {
-    const buffer = useAtomValue(driveEditBufferAtom)
+export function DriveEditBar({driveKey}: {driveKey: string}) {
+    const editing = useAtomValue(driveEditingAtomFamily(driveKey))
+    const supportsMarkdownPreview = useAtomValue(driveEditPreviewCapabilityAtomFamily(driveKey))
+    const editorView = useAtomValue(driveEditorViewAtomFamily(driveKey))
+    const language = useAtomValue(driveEditorLanguageAtomFamily(driveKey))
+    const showTeardownNotice = useAtomValue(driveEditTeardownNoticeAtomFamily(driveKey))
     const setEditorView = useSetAtom(setEditorViewAtom)
 
-    if (!buffer) return null
+    if (!editing) return null
 
     return (
-        <div className="flex min-h-11 shrink-0 items-center gap-3 border-0 border-b border-solid border-colorBorderSecondary bg-colorBgContainer px-3 py-2 text-xs text-colorText">
-            <span className="font-medium">Editing</span>
-            <span className="h-4 w-px bg-colorBorderSecondary" aria-hidden />
-            {buffer.mode === "markdown" ? (
+        <div className="flex min-h-11 shrink-0 flex-wrap items-center gap-x-3 gap-y-1 border-0 border-b border-solid border-colorBorderSecondary bg-colorBgContainer px-3 py-2 text-xs text-colorText">
+            <div className="flex min-w-0 items-center gap-3">
+                <span className="font-medium">Editing</span>
+                <span className="h-4 w-px bg-colorBorderSecondary" aria-hidden />
+            </div>
+            {supportsMarkdownPreview ? (
                 <Segmented
                     size="small"
-                    value={buffer.editorView}
+                    value={editorView}
                     options={[
                         {label: "Source", value: "source"},
                         {label: "Preview", value: "preview"},
                     ]}
-                    onChange={(value) => setEditorView(value as "source" | "preview")}
+                    onChange={(value) =>
+                        setEditorView({
+                            driveKey,
+                            editorView: value as "source" | "preview",
+                        })
+                    }
                 />
             ) : (
                 <Tooltip title="Syntax highlighting only">
                     <span className="rounded border border-solid border-colorBorderSecondary bg-colorFillQuaternary px-2 py-1 font-mono text-[11px] text-colorTextSecondary">
-                        {LANGUAGE_LABELS[buffer.language]}
+                        {LANGUAGE_LABELS[language]}
                     </span>
                 </Tooltip>
             )}
-            {buffer.teardownWarned ? (
-                <span className="text-colorWarning">
+            {showTeardownNotice ? (
+                <span className="min-w-0 flex-1 truncate text-colorWarning">
                     Session files may be removed when this session ends.
                 </span>
             ) : null}
-            <span className="ml-auto text-colorTextTertiary">
-                Esc to cancel · filters resume after saving
-            </span>
+            <span className="ml-auto shrink-0 text-colorTextTertiary">Esc to cancel</span>
         </div>
     )
 }

--- a/web/oss/src/components/Drives/editMode/components/DriveEditBar.tsx
+++ b/web/oss/src/components/Drives/editMode/components/DriveEditBar.tsx
@@ -1,0 +1,52 @@
+import {Segmented, Tooltip} from "antd"
+import {useAtomValue, useSetAtom} from "jotai"
+
+import {driveEditBufferAtom, setEditorViewAtom} from "../state"
+
+const LANGUAGE_LABELS = {
+    json: "JSON",
+    yaml: "YAML",
+    python: "Python",
+    javascript: "JavaScript",
+    typescript: "TypeScript",
+    code: "Plain text",
+} as const
+
+export function DriveEditBar() {
+    const buffer = useAtomValue(driveEditBufferAtom)
+    const setEditorView = useSetAtom(setEditorViewAtom)
+
+    if (!buffer) return null
+
+    return (
+        <div className="flex min-h-11 shrink-0 items-center gap-3 border-0 border-b border-solid border-colorBorderSecondary bg-colorBgContainer px-3 py-2 text-xs text-colorText">
+            <span className="font-medium">Editing</span>
+            <span className="h-4 w-px bg-colorBorderSecondary" aria-hidden />
+            {buffer.mode === "markdown" ? (
+                <Segmented
+                    size="small"
+                    value={buffer.editorView}
+                    options={[
+                        {label: "Source", value: "source"},
+                        {label: "Preview", value: "preview"},
+                    ]}
+                    onChange={(value) => setEditorView(value as "source" | "preview")}
+                />
+            ) : (
+                <Tooltip title="Syntax highlighting only">
+                    <span className="rounded border border-solid border-colorBorderSecondary bg-colorFillQuaternary px-2 py-1 font-mono text-[11px] text-colorTextSecondary">
+                        {LANGUAGE_LABELS[buffer.language]}
+                    </span>
+                </Tooltip>
+            )}
+            {buffer.teardownWarned ? (
+                <span className="text-colorWarning">
+                    Session files may be removed when this session ends.
+                </span>
+            ) : null}
+            <span className="ml-auto text-colorTextTertiary">
+                Esc to cancel · filters resume after saving
+            </span>
+        </div>
+    )
+}

--- a/web/oss/src/components/Drives/editMode/components/DriveEditGuardModal.tsx
+++ b/web/oss/src/components/Drives/editMode/components/DriveEditGuardModal.tsx
@@ -1,0 +1,38 @@
+import {EnhancedModal} from "@agenta/ui/components"
+
+export function DriveEditGuardModal({
+    open,
+    displayPath,
+    saving,
+    onKeep,
+    onDiscard,
+}: {
+    open: boolean
+    displayPath: string
+    saving: boolean
+    onKeep: () => void
+    onDiscard: () => void
+}) {
+    const name = displayPath.split("/").pop() || displayPath
+
+    return (
+        <EnhancedModal
+            open={open}
+            title="Discard unsaved changes?"
+            onCancel={onKeep}
+            onOk={onDiscard}
+            cancelText="Keep editing"
+            okText="Discard"
+            closable={false}
+            maskClosable={false}
+            cancelButtonProps={{disabled: saving}}
+            okButtonProps={{disabled: saving}}
+            width={440}
+        >
+            <p className="m-0 text-sm text-colorTextSecondary">
+                <span className="font-mono text-colorText">{name}</span> has changes that haven’t
+                been saved. Leaving now discards them.
+            </p>
+        </EnhancedModal>
+    )
+}

--- a/web/oss/src/components/Drives/editMode/components/DriveEditGuardModal.tsx
+++ b/web/oss/src/components/Drives/editMode/components/DriveEditGuardModal.tsx
@@ -25,7 +25,6 @@ export function DriveEditGuardModal({
             okText="Discard"
             closable={false}
             maskClosable={false}
-            cancelButtonProps={{disabled: saving}}
             okButtonProps={{disabled: saving}}
             width={440}
         >

--- a/web/oss/src/components/Drives/editMode/components/DriveFileEditor.test.tsx
+++ b/web/oss/src/components/Drives/editMode/components/DriveFileEditor.test.tsx
@@ -1,0 +1,70 @@
+import {act} from "react"
+
+import {createStore, Provider} from "jotai"
+import {createRoot, type Root} from "react-dom/client"
+import {afterAll, afterEach, beforeAll, describe, expect, it} from "vitest"
+
+import {driveEditBufferAtom, openEditBufferAtom} from "../state"
+
+import {DriveFileEditor} from "./DriveFileEditor"
+
+const reactActGlobal = globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}
+
+beforeAll(() => {
+    reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterAll(() => {
+    delete reactActGlobal.IS_REACT_ACT_ENVIRONMENT
+})
+
+describe("DriveFileEditor byte fidelity", () => {
+    let root: Root | null = null
+    let container: HTMLDivElement | null = null
+
+    afterEach(() => {
+        if (root) act(() => root?.unmount())
+        container?.remove()
+        root = null
+        container = null
+    })
+
+    it.each([
+        ["trailing newline", "first\nsecond\n"],
+        ["trailing spaces", "first\nsecond  "],
+        ["literal tab", "first\n\tsecond"],
+        ["CRLF", "first\r\nsecond\r\n"],
+        ["non-ASCII", "Grüße, 世界 🌍\n"],
+        ["empty string", ""],
+        ["compact JSON", '{"nested":{"value":1}}'],
+    ])("round-trips %s through the real editor", async (_case, initialValue) => {
+        const store = createStore()
+        store.set(openEditBufferAtom, {
+            bufferId: "buffer-a",
+            driveKey: "drive-a",
+            targetMountId: "mount-a",
+            targetPath: "data.json",
+            displayPath: "data.json",
+            scope: "app",
+            original: initialValue,
+            baseMtime: 10,
+            includeGitignored: false,
+            supportsMarkdownPreview: false,
+            language: "json",
+        })
+        container = document.createElement("div")
+        document.body.appendChild(container)
+        root = createRoot(container)
+
+        await act(async () => {
+            root?.render(
+                <Provider store={store}>
+                    <DriveFileEditor driveKey="drive-a" />
+                </Provider>,
+            )
+            await new Promise((resolve) => setTimeout(resolve, 0))
+        })
+
+        expect(store.get(driveEditBufferAtom)?.draft).toBe(initialValue)
+    })
+})

--- a/web/oss/src/components/Drives/editMode/components/DriveFileEditor.tsx
+++ b/web/oss/src/components/Drives/editMode/components/DriveFileEditor.tsx
@@ -1,0 +1,77 @@
+import {useCallback} from "react"
+
+import {EditorProvider} from "@agenta/ui/editor"
+import {SharedEditor} from "@agenta/ui/shared-editor"
+import {useAtomValue, useSetAtom} from "jotai"
+
+import Markdown from "@/oss/components/AgentChatSlice/assets/markdown"
+
+import {driveEditBufferAtom, markTeardownWarnedAtom, setEditDraftAtom} from "../state"
+
+export function DriveFileEditor() {
+    const buffer = useAtomValue(driveEditBufferAtom)
+    const setDraft = useSetAtom(setEditDraftAtom)
+    const markTeardownWarned = useSetAtom(markTeardownWarnedAtom)
+    const handleChange = useCallback(
+        (draft: string) => {
+            setDraft(draft)
+            if (
+                buffer?.scope === "session" &&
+                !buffer.teardownWarned &&
+                draft !== buffer.original
+            ) {
+                markTeardownWarned()
+            }
+        },
+        [buffer, markTeardownWarned, setDraft],
+    )
+
+    if (!buffer) return null
+
+    const saving = buffer.saveStatus === "saving"
+    const editorId = `drive-edit-${buffer.bufferId}`
+    const previewing = buffer.mode === "markdown" && buffer.editorView === "preview"
+
+    return (
+        <div
+            data-drive-edit-buffer={buffer.bufferId}
+            className="relative flex min-h-0 flex-1 overflow-hidden rounded-md bg-colorBgContainer"
+        >
+            <EditorProvider
+                codeOnly
+                language={buffer.language}
+                enableTokens={false}
+                showToolbar={false}
+                disabled={saving}
+                id={editorId}
+                className="!h-full !min-h-0 !rounded-none"
+            >
+                <SharedEditor
+                    id={editorId}
+                    editorType="borderless"
+                    state={saving ? "readOnly" : "filled"}
+                    disabled={saving}
+                    initialValue={buffer.original}
+                    value={buffer.draft}
+                    handleChange={handleChange}
+                    disableDebounce
+                    noProvider
+                    autoFocus
+                    editorProps={{
+                        codeOnly: true,
+                        language: buffer.language,
+                        noProvider: true,
+                        showToolbar: false,
+                        enableTokens: false,
+                    }}
+                    className={`!h-full !w-full !rounded-none !border-0 ${previewing ? "hidden" : ""}`}
+                />
+            </EditorProvider>
+            {previewing ? (
+                <div className="absolute inset-0 overflow-y-auto p-3">
+                    <Markdown content={buffer.draft} className="!text-xs" />
+                </div>
+            ) : null}
+        </div>
+    )
+}

--- a/web/oss/src/components/Drives/editMode/components/DriveFileEditor.tsx
+++ b/web/oss/src/components/Drives/editMode/components/DriveFileEditor.tsx
@@ -6,31 +6,31 @@ import {useAtomValue, useSetAtom} from "jotai"
 
 import Markdown from "@/oss/components/AgentChatSlice/assets/markdown"
 
-import {driveEditBufferAtom, markTeardownWarnedAtom, setEditDraftAtom} from "../state"
+import {ownedEditBufferAtomFamily, setEditDraftAtom, showTeardownNoticeAtom} from "../state"
 
-export function DriveFileEditor() {
-    const buffer = useAtomValue(driveEditBufferAtom)
+export function DriveFileEditor({driveKey}: {driveKey: string}) {
+    const buffer = useAtomValue(ownedEditBufferAtomFamily(driveKey))
     const setDraft = useSetAtom(setEditDraftAtom)
-    const markTeardownWarned = useSetAtom(markTeardownWarnedAtom)
+    const showTeardownNotice = useSetAtom(showTeardownNoticeAtom)
     const handleChange = useCallback(
         (draft: string) => {
-            setDraft(draft)
+            setDraft({driveKey, draft})
             if (
                 buffer?.scope === "session" &&
-                !buffer.teardownWarned &&
+                !buffer.showTeardownNotice &&
                 draft !== buffer.original
             ) {
-                markTeardownWarned()
+                showTeardownNotice(driveKey)
             }
         },
-        [buffer, markTeardownWarned, setDraft],
+        [buffer, driveKey, setDraft, showTeardownNotice],
     )
 
     if (!buffer) return null
 
-    const saving = buffer.saveStatus === "saving"
+    const disabled = buffer.saveStatus === "saving" || buffer.reloading
     const editorId = `drive-edit-${buffer.bufferId}`
-    const previewing = buffer.mode === "markdown" && buffer.editorView === "preview"
+    const previewing = buffer.supportsMarkdownPreview && buffer.editorView === "preview"
 
     return (
         <div
@@ -39,18 +39,19 @@ export function DriveFileEditor() {
         >
             <EditorProvider
                 codeOnly
+                useNativeCodeNodes
                 language={buffer.language}
                 enableTokens={false}
                 showToolbar={false}
-                disabled={saving}
+                disabled={disabled}
                 id={editorId}
                 className="!h-full !min-h-0 !rounded-none"
             >
                 <SharedEditor
                     id={editorId}
                     editorType="borderless"
-                    state={saving ? "readOnly" : "filled"}
-                    disabled={saving}
+                    state={disabled ? "readOnly" : "filled"}
+                    disabled={disabled}
                     initialValue={buffer.original}
                     value={buffer.draft}
                     handleChange={handleChange}
@@ -59,6 +60,7 @@ export function DriveFileEditor() {
                     autoFocus
                     editorProps={{
                         codeOnly: true,
+                        useNativeCodeNodes: true,
                         language: buffer.language,
                         noProvider: true,
                         showToolbar: false,

--- a/web/oss/src/components/Drives/editMode/controller.test.ts
+++ b/web/oss/src/components/Drives/editMode/controller.test.ts
@@ -12,8 +12,10 @@ import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from "vitest"
 import {saveDriveFile, type SaveDriveFileDependencies} from "./api"
 import {
     driveEditBufferAtom,
+    editSaveFailedAtom,
     editSaveSucceededAtom,
     openEditBufferAtom,
+    requestNavigationAtom,
     setEditDraftAtom,
     startEditSaveAtom,
     type NavigationIntent,
@@ -47,7 +49,8 @@ const baseBuffer = {
     scope: "session" as const,
     original: "original",
     baseMtime: 10,
-    mode: "markdown" as const,
+    includeGitignored: false,
+    supportsMarkdownPreview: true,
     language: "code" as const,
 }
 
@@ -55,7 +58,7 @@ const saveDependencies = ({
     listing = [{path: "notes/a.md", size: 8, mtime: 10}],
     size = 7,
 }: {
-    listing?: {path: string; size: number; mtime: number | null}[]
+    listing?: {path: string; size: number; mtime: number | null}[] | null
     size?: number
 } = {}) => {
     const queryDir = vi.fn().mockResolvedValue(listing)
@@ -69,6 +72,54 @@ afterEach(() => {
 })
 
 describe("saveDriveFile", () => {
+    it("fails closed when the directory listing cannot be loaded", async () => {
+        const queryClient = new QueryClient()
+        const {dependencies, writeFile} = saveDependencies({listing: null})
+
+        const result = await saveDriveFile(
+            {
+                queryClient,
+                projectId: "project",
+                targetMountId: "mount-a",
+                targetPath: "notes/a.md",
+                draft: "changed",
+                baseMtime: 10,
+                includeGitignored: false,
+                skipConflictCheck: false,
+            },
+            dependencies,
+        )
+
+        expect(result).toEqual({
+            kind: "error",
+            message: "Couldn’t verify the file before saving",
+        })
+        expect(writeFile).not.toHaveBeenCalled()
+    })
+
+    it("skips the directory fetch for an explicit overwrite", async () => {
+        const queryClient = new QueryClient()
+        const {dependencies, queryDir, writeFile} = saveDependencies()
+
+        const result = await saveDriveFile(
+            {
+                queryClient,
+                projectId: "project",
+                targetMountId: "mount-a",
+                targetPath: "notes/a.md",
+                draft: "changed",
+                baseMtime: 10,
+                includeGitignored: false,
+                skipConflictCheck: true,
+            },
+            dependencies,
+        )
+
+        expect(result.kind).toBe("saved")
+        expect(queryDir).not.toHaveBeenCalled()
+        expect(writeFile).toHaveBeenCalledOnce()
+    })
+
     it("treats a missing listing entry as a conflict", async () => {
         const queryClient = new QueryClient()
         const {dependencies, writeFile} = saveDependencies({listing: []})
@@ -112,6 +163,29 @@ describe("saveDriveFile", () => {
         expect(
             queryClient.getQueryState(mountDirQueryKey("project", "mount-a", "notes", true)),
         ).toBeDefined()
+    })
+
+    it("lets React Query own the pre-write fetch signal", async () => {
+        const queryClient = new QueryClient()
+        const {dependencies, queryDir} = saveDependencies()
+
+        await saveDriveFile(
+            {
+                queryClient,
+                projectId: "project",
+                targetMountId: "mount-a",
+                targetPath: "notes/a.md",
+                draft: "changed",
+                baseMtime: 10,
+                includeGitignored: false,
+                skipConflictCheck: false,
+            },
+            dependencies,
+        )
+
+        expect(queryDir).toHaveBeenCalledWith(
+            expect.objectContaining({abortSignal: expect.any(AbortSignal)}),
+        )
     })
 
     it("uses the resolved agent mount for the fetch, write, and content seed", async () => {
@@ -283,7 +357,7 @@ describe("useDriveEditGuard", () => {
         store.set(projectIdAtom, "project")
         store.set(queryClientAtom, new QueryClient())
         store.set(openEditBufferAtom, baseBuffer)
-        store.set(setEditDraftAtom, "changed")
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
         const onClose = vi.fn()
         const guard = mountGuard({initialPath: "notes/a.md", store, onClose})
 
@@ -300,7 +374,7 @@ describe("useDriveEditGuard", () => {
         store.set(projectIdAtom, "project")
         store.set(queryClientAtom, new QueryClient())
         store.set(openEditBufferAtom, baseBuffer)
-        store.set(setEditDraftAtom, "changed")
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
         const runNavigation = vi.fn()
         const guard = mountGuard({
             initialPath: "notes/a.md",
@@ -325,7 +399,7 @@ describe("useDriveEditGuard", () => {
         store.set(projectIdAtom, "project")
         store.set(queryClientAtom, new QueryClient())
         store.set(openEditBufferAtom, baseBuffer)
-        store.set(setEditDraftAtom, "changed")
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
         const guard = mountGuard({
             initialPath: "notes/a.md",
             store,
@@ -346,7 +420,7 @@ describe("useDriveEditGuard", () => {
         store.set(projectIdAtom, "project")
         store.set(queryClientAtom, new QueryClient())
         store.set(openEditBufferAtom, baseBuffer)
-        store.set(setEditDraftAtom, "changed")
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
         const runNavigation = vi.fn()
         const guard = mountGuard({
             initialPath: "notes/new-drive.md",
@@ -361,5 +435,51 @@ describe("useDriveEditGuard", () => {
 
         expect(store.get(driveEditBufferAtom)).toBeNull()
         expect(runNavigation).not.toHaveBeenCalled()
+    })
+
+    it("defers the drive-swap guard while a save is in flight", () => {
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient())
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
+        store.set(startEditSaveAtom, "save-a")
+        const guard = mountGuard({
+            initialPath: "notes/new-drive.md",
+            store,
+            onClose: vi.fn(),
+            driveKey: "drive-b",
+            heldDriveKey: "drive-a",
+        })
+
+        expect(guard.get().holdDrive).toBe(true)
+        expect(guard.get().modal.open).toBe(false)
+
+        act(() => store.set(editSaveFailedAtom, {requestId: "save-a", message: "write failed"}))
+        expect(guard.get().modal.open).toBe(true)
+    })
+
+    it("allows Keep editing to dismiss an existing guard during a save", () => {
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient())
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
+        store.set(requestNavigationAtom, {
+            driveKey: "drive-a",
+            intent: {kind: "close"},
+        })
+        store.set(startEditSaveAtom, "save-a")
+        const guard = mountGuard({
+            initialPath: "notes/a.md",
+            store,
+            onClose: vi.fn(),
+        })
+
+        expect(guard.get().modal.saving).toBe(true)
+        act(() => guard.get().modal.onKeep())
+
+        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toBeNull()
+        expect(guard.get().modal.open).toBe(false)
     })
 })

--- a/web/oss/src/components/Drives/editMode/controller.test.ts
+++ b/web/oss/src/components/Drives/editMode/controller.test.ts
@@ -9,11 +9,8 @@ import {queryClientAtom} from "jotai-tanstack-query"
 import {createRoot, type Root} from "react-dom/client"
 import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from "vitest"
 
-import {invalidateMountListings} from "../useMountUpload"
-
 import {saveDriveFile, type SaveDriveFileDependencies} from "./api"
 import {
-    closeEditBufferAtom,
     driveEditBufferAtom,
     editSaveSucceededAtom,
     openEditBufferAtom,
@@ -63,11 +60,7 @@ const saveDependencies = ({
 } = {}) => {
     const queryDir = vi.fn().mockResolvedValue(listing)
     const writeFile = vi.fn().mockResolvedValue({ok: true as const, size})
-    const dependencies: SaveDriveFileDependencies = {
-        queryDir,
-        writeFile,
-        invalidateListings: invalidateMountListings,
-    }
+    const dependencies: SaveDriveFileDependencies = {queryDir, writeFile}
     return {dependencies, queryDir, writeFile}
 }
 
@@ -213,7 +206,7 @@ describe("stale save completion", () => {
         const store = createStore()
         store.set(openEditBufferAtom, baseBuffer)
         store.set(startEditSaveAtom, "request-a")
-        store.set(closeEditBufferAtom)
+        store.set(driveEditBufferAtom, null)
         store.set(openEditBufferAtom, {
             ...baseBuffer,
             bufferId: "buffer-b",
@@ -242,7 +235,7 @@ describe("useDriveEditGuard", () => {
         initialPath,
         store,
         onClose,
-        runNavigation,
+        runNavigation = vi.fn(),
         driveKey = "drive-a",
         heldDriveKey = "drive-a",
     }: {

--- a/web/oss/src/components/Drives/editMode/controller.test.ts
+++ b/web/oss/src/components/Drives/editMode/controller.test.ts
@@ -1,0 +1,372 @@
+import {createElement, useLayoutEffect} from "react"
+import {act} from "react"
+
+import {mountDirQueryKey, mountFileContentQueryKey, writeMountFile} from "@agenta/entities/session"
+import {projectIdAtom} from "@agenta/shared/state"
+import {QueryClient} from "@tanstack/react-query"
+import {createStore, Provider} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+import {createRoot, type Root} from "react-dom/client"
+import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from "vitest"
+
+import {invalidateMountListings} from "../useMountUpload"
+
+import {saveDriveFile, type SaveDriveFileDependencies} from "./api"
+import {
+    closeEditBufferAtom,
+    driveEditBufferAtom,
+    editSaveSucceededAtom,
+    openEditBufferAtom,
+    setEditDraftAtom,
+    startEditSaveAtom,
+    type NavigationIntent,
+} from "./state"
+import {useDriveEditGuard} from "./useDriveEditController"
+
+const uploadMountFileMock = vi.hoisted(() => vi.fn())
+const reactActGlobal = globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}
+
+vi.mock("@agenta/sdk/resources", () => ({
+    getMountsClient: () => ({uploadMountFile: uploadMountFileMock}),
+    getLowPriorityMountsClient: () => ({}),
+    getSessionsClient: () => ({}),
+    getLowPrioritySessionsClient: () => ({}),
+}))
+
+beforeAll(() => {
+    reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterAll(() => {
+    delete reactActGlobal.IS_REACT_ACT_ENVIRONMENT
+})
+
+const baseBuffer = {
+    bufferId: "buffer-a",
+    driveKey: "drive-a",
+    targetMountId: "mount-a",
+    targetPath: "notes/a.md",
+    displayPath: "notes/a.md",
+    scope: "session" as const,
+    original: "original",
+    baseMtime: 10,
+    mode: "markdown" as const,
+    language: "code" as const,
+}
+
+const saveDependencies = ({
+    listing = [{path: "notes/a.md", size: 8, mtime: 10}],
+    size = 7,
+}: {
+    listing?: {path: string; size: number; mtime: number | null}[]
+    size?: number
+} = {}) => {
+    const queryDir = vi.fn().mockResolvedValue(listing)
+    const writeFile = vi.fn().mockResolvedValue({ok: true as const, size})
+    const dependencies: SaveDriveFileDependencies = {
+        queryDir,
+        writeFile,
+        invalidateListings: invalidateMountListings,
+    }
+    return {dependencies, queryDir, writeFile}
+}
+
+afterEach(() => {
+    uploadMountFileMock.mockReset()
+})
+
+describe("saveDriveFile", () => {
+    it("treats a missing listing entry as a conflict", async () => {
+        const queryClient = new QueryClient()
+        const {dependencies, writeFile} = saveDependencies({listing: []})
+
+        const result = await saveDriveFile(
+            {
+                queryClient,
+                projectId: "project",
+                targetMountId: "mount-a",
+                targetPath: "notes/a.md",
+                draft: "changed",
+                baseMtime: 10,
+                includeGitignored: false,
+                skipConflictCheck: false,
+            },
+            dependencies,
+        )
+
+        expect(result).toEqual({kind: "conflict", reason: "missing", theirMtime: null})
+        expect(writeFile).not.toHaveBeenCalled()
+    })
+
+    it("keys the pre-write fetch with includeGitignored", async () => {
+        const queryClient = new QueryClient()
+        const {dependencies} = saveDependencies()
+
+        await saveDriveFile(
+            {
+                queryClient,
+                projectId: "project",
+                targetMountId: "mount-a",
+                targetPath: "notes/a.md",
+                draft: "changed",
+                baseMtime: 10,
+                includeGitignored: true,
+                skipConflictCheck: false,
+            },
+            dependencies,
+        )
+
+        expect(
+            queryClient.getQueryState(mountDirQueryKey("project", "mount-a", "notes", true)),
+        ).toBeDefined()
+    })
+
+    it("uses the resolved agent mount for the fetch, write, and content seed", async () => {
+        const queryClient = new QueryClient()
+        const {dependencies, queryDir, writeFile} = saveDependencies({
+            listing: [{path: "x.md", size: 4, mtime: 5}],
+        })
+
+        const result = await saveDriveFile(
+            {
+                queryClient,
+                projectId: "project",
+                targetMountId: "agent-mount",
+                targetPath: "x.md",
+                draft: "exact draft\n",
+                baseMtime: 5,
+                includeGitignored: false,
+                skipConflictCheck: false,
+            },
+            dependencies,
+        )
+
+        expect(result.kind).toBe("saved")
+        expect(queryDir).toHaveBeenCalledWith(expect.objectContaining({mountId: "agent-mount"}))
+        expect(writeFile).toHaveBeenCalledWith(
+            expect.objectContaining({mountId: "agent-mount", path: "x.md"}),
+        )
+        expect(
+            queryClient.getQueryData(mountFileContentQueryKey("project", "agent-mount", "x.md")),
+        ).toBe("exact draft\n")
+    })
+
+    it("seeds the exact draft and invalidates all four listing roots", async () => {
+        const queryClient = new QueryClient()
+        const invalidate = vi.spyOn(queryClient, "invalidateQueries")
+        const {dependencies} = saveDependencies()
+
+        await saveDriveFile(
+            {
+                queryClient,
+                projectId: "project",
+                targetMountId: "mount-a",
+                targetPath: "notes/a.md",
+                draft: "raw\n\n",
+                baseMtime: 10,
+                includeGitignored: false,
+                skipConflictCheck: false,
+            },
+            dependencies,
+        )
+
+        expect(
+            queryClient.getQueryData(mountFileContentQueryKey("project", "mount-a", "notes/a.md")),
+        ).toBe("raw\n\n")
+        expect(invalidate.mock.calls.map(([filters]) => filters.queryKey)).toEqual([
+            ["mounts", "files", "project"],
+            ["mounts", "files-latest", "project"],
+            ["mounts", "files-root", "project"],
+            ["mounts", "files-dir", "project"],
+        ])
+    })
+})
+
+describe("writeMountFile", () => {
+    it("sends multipart content with the full path and disables retries", async () => {
+        uploadMountFileMock.mockResolvedValue({path: "nested/a.md", size: 6})
+
+        await expect(
+            writeMountFile({
+                projectId: "project",
+                mountId: "mount",
+                path: "nested/a.md",
+                content: "hello\n",
+            }),
+        ).resolves.toEqual({ok: true, size: 6})
+
+        const [request, options] = uploadMountFileMock.mock.calls[0]
+        expect(request).toMatchObject({mount_id: "mount", path: "nested/a.md"})
+        expect(request.file.filename).toBe("a.md")
+        expect(request.file.data).toBeInstanceOf(Blob)
+        expect(request.file.data).toMatchObject({size: 6, type: "text/plain;charset=utf-8"})
+        expect(options).toMatchObject({
+            queryParams: {project_id: "project"},
+            maxRetries: 0,
+            timeoutInSeconds: 30,
+        })
+    })
+})
+
+describe("stale save completion", () => {
+    it("does not mutate a replacement buffer", () => {
+        const store = createStore()
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(startEditSaveAtom, "request-a")
+        store.set(closeEditBufferAtom)
+        store.set(openEditBufferAtom, {
+            ...baseBuffer,
+            bufferId: "buffer-b",
+            targetPath: "notes/b.md",
+            displayPath: "notes/b.md",
+        })
+
+        store.set(editSaveSucceededAtom, "request-a")
+
+        expect(store.get(driveEditBufferAtom)?.bufferId).toBe("buffer-b")
+    })
+})
+
+describe("useDriveEditGuard", () => {
+    let root: Root | null = null
+    let container: HTMLDivElement | null = null
+
+    afterEach(() => {
+        if (root) act(() => root?.unmount())
+        container?.remove()
+        root = null
+        container = null
+    })
+
+    function mountGuard({
+        initialPath,
+        store,
+        onClose,
+        runNavigation,
+        driveKey = "drive-a",
+        heldDriveKey = "drive-a",
+    }: {
+        initialPath: string
+        store: ReturnType<typeof createStore>
+        onClose: () => void
+        runNavigation?: (intent: NavigationIntent) => void
+        driveKey?: string
+        heldDriveKey?: string
+    }) {
+        let current: ReturnType<typeof useDriveEditGuard> | null = null
+        const Harness = ({path, currentDriveKey}: {path: string; currentDriveKey: string}) => {
+            const value = useDriveEditGuard({
+                active: true,
+                initialPath: path,
+                driveKey: currentDriveKey,
+                heldDriveKey,
+                onClose,
+                runNavigation,
+            })
+            useLayoutEffect(() => {
+                current = value
+            }, [value])
+            return null
+        }
+        container = document.createElement("div")
+        document.body.appendChild(container)
+        root = createRoot(container)
+        const render = (path: string) =>
+            act(() => {
+                root?.render(
+                    createElement(
+                        Provider,
+                        {store},
+                        createElement(Harness, {path, currentDriveKey: driveKey}),
+                    ),
+                )
+            })
+        render(initialPath)
+        return {get: () => current as ReturnType<typeof useDriveEditGuard>, render}
+    }
+
+    it("routes a shell close through the dirty guard", () => {
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient())
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(setEditDraftAtom, "changed")
+        const onClose = vi.fn()
+        const guard = mountGuard({initialPath: "notes/a.md", store, onClose})
+
+        act(() => guard.get().onClose())
+
+        expect(onClose).not.toHaveBeenCalled()
+        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual({kind: "close"})
+        act(() => guard.get().modal.onDiscard())
+        expect(onClose).toHaveBeenCalledOnce()
+    })
+
+    it("holds a changed initialPath while a dirty buffer is guarded", () => {
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient())
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(setEditDraftAtom, "changed")
+        const runNavigation = vi.fn()
+        const guard = mountGuard({
+            initialPath: "notes/a.md",
+            store,
+            onClose: vi.fn(),
+            runNavigation,
+        })
+
+        guard.render("notes/b.md")
+
+        expect(guard.get().initialPath).toBe("notes/a.md")
+        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual({
+            kind: "select",
+            path: "notes/b.md",
+        })
+        act(() => guard.get().modal.onDiscard())
+        expect(runNavigation).toHaveBeenCalledWith({kind: "select", path: "notes/b.md"})
+    })
+
+    it("keeps the previous drive mounted after accepting a drive-swap guard", () => {
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient())
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(setEditDraftAtom, "changed")
+        const guard = mountGuard({
+            initialPath: "notes/a.md",
+            store,
+            onClose: vi.fn(),
+            driveKey: "drive-b",
+            heldDriveKey: "drive-a",
+        })
+
+        expect(guard.get().holdDrive).toBe(true)
+        expect(guard.get().modal.open).toBe(true)
+        act(() => guard.get().modal.onKeep())
+        expect(guard.get().holdDrive).toBe(true)
+        expect(guard.get().modal.open).toBe(false)
+    })
+
+    it("releases a discarded drive swap without selecting in the held drive", () => {
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient())
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(setEditDraftAtom, "changed")
+        const runNavigation = vi.fn()
+        const guard = mountGuard({
+            initialPath: "notes/new-drive.md",
+            store,
+            onClose: vi.fn(),
+            runNavigation,
+            driveKey: "drive-b",
+            heldDriveKey: "drive-a",
+        })
+
+        act(() => guard.get().modal.onDiscard())
+
+        expect(store.get(driveEditBufferAtom)).toBeNull()
+        expect(runNavigation).not.toHaveBeenCalled()
+    })
+})

--- a/web/oss/src/components/Drives/editMode/model.test.ts
+++ b/web/oss/src/components/Drives/editMode/model.test.ts
@@ -5,10 +5,11 @@ import {CODE_LANGS, resolveDriveFileKind, TEXT_CAP, type DriveFileKind} from "..
 import {
     conflictFromListing,
     driveEditAvailability,
-    driveEditBufferMode,
     driveEditorLanguage,
     EDIT_KINDS,
     isEditDirty,
+    supportsMarkdownPreview,
+    utf8ByteLength,
 } from "./model"
 
 describe("resolveDriveFileKind", () => {
@@ -44,21 +45,23 @@ describe("driveEditAvailability", () => {
     ]
     const listingSizes = [TEXT_CAP - 1, TEXT_CAP, TEXT_CAP + 1, null]
     const contentStates = [
-        {name: "pending", isPending: true, contentLength: null},
-        {name: "loaded", isPending: false, contentLength: TEXT_CAP},
-        {name: "unreadable", isPending: false, contentLength: null},
+        {name: "pending", isPending: true, isFetching: true, contentByteLength: null},
+        {name: "fetching", isPending: false, isFetching: true, contentByteLength: TEXT_CAP},
+        {name: "loaded", isPending: false, isFetching: false, contentByteLength: TEXT_CAP},
+        {name: "unreadable", isPending: false, isFetching: false, contentByteLength: null},
     ] as const
 
     it("covers every kind, listing size, content state, and edit capability", () => {
         for (const kind of kinds) {
             for (const listingSize of listingSizes) {
-                for (const {name, isPending, contentLength} of contentStates) {
+                for (const {name, isPending, isFetching, contentByteLength} of contentStates) {
                     for (const canEdit of [true, false]) {
                         const availability = driveEditAvailability({
                             kind,
                             listingSize,
-                            contentLength,
+                            contentByteLength,
                             isPending,
+                            isFetching,
                             canEdit,
                         })
                         const expected =
@@ -66,7 +69,7 @@ describe("driveEditAvailability", () => {
                                 ? "unavailable"
                                 : listingSize != null && listingSize > TEXT_CAP
                                   ? "too-large"
-                                  : name === "pending"
+                                  : name === "pending" || name === "fetching"
                                     ? "loading"
                                     : name === "unreadable"
                                       ? "unreadable"
@@ -85,8 +88,9 @@ describe("driveEditAvailability", () => {
             driveEditAvailability({
                 kind: "text",
                 listingSize: null,
-                contentLength: TEXT_CAP + 1,
+                contentByteLength: TEXT_CAP + 1,
                 isPending: false,
+                isFetching: false,
                 canEdit: true,
             }),
         ).toBe("too-large")
@@ -97,20 +101,27 @@ describe("driveEditAvailability", () => {
             driveEditAvailability({
                 kind: "text",
                 listingSize: TEXT_CAP,
-                contentLength: TEXT_CAP,
+                contentByteLength: TEXT_CAP,
                 isPending: false,
+                isFetching: false,
                 canEdit: true,
             }),
         ).toBe("enabled")
     })
 })
 
-describe("driveEditBufferMode", () => {
-    it("uses markdown mode only for markdown paths", () => {
-        expect(driveEditBufferMode("README.md")).toBe("markdown")
-        expect(driveEditBufferMode("notes.markdown")).toBe("markdown")
-        expect(driveEditBufferMode("data.json")).toBe("code")
-        expect(driveEditBufferMode("README")).toBe("code")
+describe("supportsMarkdownPreview", () => {
+    it("offers preview only for markdown paths", () => {
+        expect(supportsMarkdownPreview("README.md")).toBe(true)
+        expect(supportsMarkdownPreview("notes.markdown")).toBe(true)
+        expect(supportsMarkdownPreview("data.json")).toBe(false)
+        expect(supportsMarkdownPreview("README")).toBe(false)
+    })
+})
+
+describe("utf8ByteLength", () => {
+    it("counts UTF-8 bytes instead of UTF-16 code units", () => {
+        expect(utf8ByteLength("é".repeat(TEXT_CAP))).toBe(TEXT_CAP * 2)
     })
 })
 
@@ -166,8 +177,17 @@ describe("conflictFromListing", () => {
         expect(conflictFromListing([{path: "notes.txt", mtime: 10}], "notes.txt", 10)).toBeNull()
     })
 
-    it("accepts an unknown base mtime", () => {
-        expect(conflictFromListing([{path: "notes.txt", mtime: 11}], "notes.txt", null)).toBeNull()
+    it("fails closed when a null baseline meets a real listing mtime", () => {
+        expect(conflictFromListing([{path: "notes.txt", mtime: 11}], "notes.txt", null)).toEqual({
+            reason: "changed",
+            theirMtime: 11,
+        })
+    })
+
+    it("accepts a null baseline only when the listing also omits mtime", () => {
+        expect(
+            conflictFromListing([{path: "notes.txt", mtime: null}], "notes.txt", null),
+        ).toBeNull()
     })
 
     it("accepts an unknown listing mtime", () => {

--- a/web/oss/src/components/Drives/editMode/model.test.ts
+++ b/web/oss/src/components/Drives/editMode/model.test.ts
@@ -1,0 +1,176 @@
+import {describe, expect, it} from "vitest"
+
+import {CODE_LANGS, resolveDriveFileKind, TEXT_CAP, type DriveFileKind} from "../driveKinds"
+
+import {
+    conflictFromListing,
+    driveEditAvailability,
+    driveEditBufferMode,
+    driveEditorLanguage,
+    EDIT_KINDS,
+    isEditDirty,
+} from "./model"
+
+describe("resolveDriveFileKind", () => {
+    it.each([
+        ["notes.txt", "text"],
+        ["table.csv", "csv"],
+        ["README.md", "markdown"],
+        [".env", "text"],
+        ["data.json", "json"],
+        ["agent-files/.env", "text"],
+        [".env.local", "other"],
+        ["photo.png", "image"],
+        ["report.pdf", "pdf"],
+        ["README", "other"],
+    ] as const)("maps %s to %s", (path, kind) => {
+        expect(resolveDriveFileKind(path)).toBe(kind)
+    })
+})
+
+describe("driveEditAvailability", () => {
+    const kinds: DriveFileKind[] = [
+        "markdown",
+        "text",
+        "code",
+        "json",
+        "csv",
+        "html",
+        "image",
+        "pdf",
+        "audio",
+        "video",
+        "other",
+    ]
+    const listingSizes = [TEXT_CAP - 1, TEXT_CAP, TEXT_CAP + 1, null]
+    const contentStates = [
+        {name: "pending", isPending: true, contentLength: null},
+        {name: "loaded", isPending: false, contentLength: TEXT_CAP},
+        {name: "unreadable", isPending: false, contentLength: null},
+    ] as const
+
+    it("covers every kind, listing size, content state, and edit capability", () => {
+        for (const kind of kinds) {
+            for (const listingSize of listingSizes) {
+                for (const {name, isPending, contentLength} of contentStates) {
+                    for (const canEdit of [true, false]) {
+                        const availability = driveEditAvailability({
+                            kind,
+                            listingSize,
+                            contentLength,
+                            isPending,
+                            canEdit,
+                        })
+                        const expected =
+                            !canEdit || !EDIT_KINDS.has(kind)
+                                ? "unavailable"
+                                : listingSize != null && listingSize > TEXT_CAP
+                                  ? "too-large"
+                                  : name === "pending"
+                                    ? "loading"
+                                    : name === "unreadable"
+                                      ? "unreadable"
+                                      : "enabled"
+                        expect(availability).toBe(expected)
+                        if (availability === "too-large") expect(EDIT_KINDS.has(kind)).toBe(true)
+                        if (name === "unreadable") expect(availability).not.toBe("enabled")
+                    }
+                }
+            }
+        }
+    })
+
+    it("caps loaded content when the listing size is unknown", () => {
+        expect(
+            driveEditAvailability({
+                kind: "text",
+                listingSize: null,
+                contentLength: TEXT_CAP + 1,
+                isPending: false,
+                canEdit: true,
+            }),
+        ).toBe("too-large")
+    })
+
+    it("enables content exactly at the cap", () => {
+        expect(
+            driveEditAvailability({
+                kind: "text",
+                listingSize: TEXT_CAP,
+                contentLength: TEXT_CAP,
+                isPending: false,
+                canEdit: true,
+            }),
+        ).toBe("enabled")
+    })
+})
+
+describe("driveEditBufferMode", () => {
+    it("uses markdown mode only for markdown paths", () => {
+        expect(driveEditBufferMode("README.md")).toBe("markdown")
+        expect(driveEditBufferMode("notes.markdown")).toBe("markdown")
+        expect(driveEditBufferMode("data.json")).toBe("code")
+        expect(driveEditBufferMode("README")).toBe("code")
+    })
+})
+
+describe("driveEditorLanguage", () => {
+    const languages = new Set(["json", "yaml", "code", "python", "javascript", "typescript"])
+
+    it("maps every configured code extension into the editor language union", () => {
+        for (const extension of Object.keys(CODE_LANGS)) {
+            expect(languages.has(driveEditorLanguage(`file.${extension}`))).toBe(true)
+        }
+    })
+
+    it.each([
+        ["file.json", "json"],
+        ["file.yaml", "yaml"],
+        ["file.py", "python"],
+        ["file.sh", "code"],
+        ["file.md", "code"],
+    ] as const)("maps %s to %s", (path, language) => {
+        expect(driveEditorLanguage(path)).toBe(language)
+    })
+})
+
+describe("isEditDirty", () => {
+    it.each([
+        ["before", "after", true],
+        ["same", "same", false],
+        ["typed", "typed", false],
+        ["line", "line\n", true],
+        ["", "text", true],
+        ["", "", false],
+    ] as const)("compares the original and draft exactly", (original, draft, expected) => {
+        expect(isEditDirty(original, draft)).toBe(expected)
+    })
+})
+
+describe("conflictFromListing", () => {
+    it("reports a missing entry", () => {
+        expect(conflictFromListing([], "notes.txt", 10)).toEqual({
+            reason: "missing",
+            theirMtime: null,
+        })
+    })
+
+    it("reports a changed mtime", () => {
+        expect(conflictFromListing([{path: "notes.txt", mtime: 11}], "notes.txt", 10)).toEqual({
+            reason: "changed",
+            theirMtime: 11,
+        })
+    })
+
+    it("accepts an unchanged mtime", () => {
+        expect(conflictFromListing([{path: "notes.txt", mtime: 10}], "notes.txt", 10)).toBeNull()
+    })
+
+    it("accepts an unknown base mtime", () => {
+        expect(conflictFromListing([{path: "notes.txt", mtime: 11}], "notes.txt", null)).toBeNull()
+    })
+
+    it("accepts an unknown listing mtime", () => {
+        expect(conflictFromListing([{path: "notes.txt", mtime: null}], "notes.txt", 10)).toBeNull()
+    })
+})

--- a/web/oss/src/components/Drives/editMode/model.ts
+++ b/web/oss/src/components/Drives/editMode/model.ts
@@ -3,7 +3,7 @@ import type {CodeLanguage} from "@agenta/ui/editor"
 
 import {driveCodeLanguage, resolveDriveFileKind, TEXT_CAP, type DriveFileKind} from "../driveKinds"
 
-export const EDIT_KINDS = new Set<DriveFileKind>([
+export const EDIT_KINDS: ReadonlySet<DriveFileKind> = new Set([
     "markdown",
     "text",
     "code",
@@ -16,34 +16,41 @@ export type DriveEditAvailability =
     | "enabled"
     | "loading"
     | "unreadable"
+    | "listing-unavailable"
     | "too-large"
     | "unavailable"
 
 export interface DriveEditAvailabilityInput {
     kind: DriveFileKind
     listingSize: number | null
-    contentLength: number | null
+    contentByteLength: number | null
     isPending: boolean
+    isFetching: boolean
     canEdit: boolean
 }
 
 export function driveEditAvailability({
     kind,
     listingSize,
-    contentLength,
+    contentByteLength,
     isPending,
+    isFetching,
     canEdit,
 }: DriveEditAvailabilityInput): DriveEditAvailability {
     if (!canEdit || !EDIT_KINDS.has(kind)) return "unavailable"
     if (listingSize != null && listingSize > TEXT_CAP) return "too-large"
-    if (isPending) return "loading"
-    if (contentLength == null) return "unreadable"
-    if (contentLength > TEXT_CAP) return "too-large"
+    if (isPending || isFetching) return "loading"
+    if (contentByteLength == null) return "unreadable"
+    if (contentByteLength > TEXT_CAP) return "too-large"
     return "enabled"
 }
 
-export function driveEditBufferMode(path: string): "markdown" | "code" {
-    return resolveDriveFileKind(path) === "markdown" ? "markdown" : "code"
+export function supportsMarkdownPreview(path: string): boolean {
+    return resolveDriveFileKind(path) === "markdown"
+}
+
+export function utf8ByteLength(content: string): number {
+    return new TextEncoder().encode(content).length
 }
 
 export function driveEditorLanguage(path: string): CodeLanguage {
@@ -83,6 +90,9 @@ export function conflictFromListing(
     const entry = listing.find((file) => file.path === path)
     if (!entry) return {reason: "missing", theirMtime: null}
     const theirMtime = entry.mtime ?? null
-    if (baseMtime == null || theirMtime == null || baseMtime === theirMtime) return null
+    if (baseMtime == null) {
+        return theirMtime == null ? null : {reason: "changed", theirMtime}
+    }
+    if (theirMtime == null || baseMtime === theirMtime) return null
     return {reason: "changed", theirMtime}
 }

--- a/web/oss/src/components/Drives/editMode/model.ts
+++ b/web/oss/src/components/Drives/editMode/model.ts
@@ -1,0 +1,88 @@
+import type {MountFile} from "@agenta/entities/session"
+import type {CodeLanguage} from "@agenta/ui/editor"
+
+import {driveCodeLanguage, resolveDriveFileKind, TEXT_CAP, type DriveFileKind} from "../driveKinds"
+
+export const EDIT_KINDS = new Set<DriveFileKind>([
+    "markdown",
+    "text",
+    "code",
+    "json",
+    "csv",
+    "html",
+])
+
+export type DriveEditAvailability =
+    | "enabled"
+    | "loading"
+    | "unreadable"
+    | "too-large"
+    | "unavailable"
+
+export interface DriveEditAvailabilityInput {
+    kind: DriveFileKind
+    listingSize: number | null
+    contentLength: number | null
+    isPending: boolean
+    canEdit: boolean
+}
+
+export function driveEditAvailability({
+    kind,
+    listingSize,
+    contentLength,
+    isPending,
+    canEdit,
+}: DriveEditAvailabilityInput): DriveEditAvailability {
+    if (!canEdit || !EDIT_KINDS.has(kind)) return "unavailable"
+    if (listingSize != null && listingSize > TEXT_CAP) return "too-large"
+    if (isPending) return "loading"
+    if (contentLength == null) return "unreadable"
+    if (contentLength > TEXT_CAP) return "too-large"
+    return "enabled"
+}
+
+export function driveEditBufferMode(path: string): "markdown" | "code" {
+    return resolveDriveFileKind(path) === "markdown" ? "markdown" : "code"
+}
+
+export function driveEditorLanguage(path: string): CodeLanguage {
+    switch (driveCodeLanguage(path)) {
+        case "json":
+            return "json"
+        case "yaml":
+            return "yaml"
+        case "python":
+            return "python"
+        case "javascript":
+        case "jsx":
+        case "mjs":
+            return "javascript"
+        case "typescript":
+        case "tsx":
+            return "typescript"
+        default:
+            return "code"
+    }
+}
+
+export function isEditDirty(original: string, draft: string): boolean {
+    return draft !== original
+}
+
+export interface DriveEditConflict {
+    reason: "changed" | "missing"
+    theirMtime: number | null
+}
+
+export function conflictFromListing(
+    listing: readonly MountFile[],
+    path: string,
+    baseMtime: number | null,
+): DriveEditConflict | null {
+    const entry = listing.find((file) => file.path === path)
+    if (!entry) return {reason: "missing", theirMtime: null}
+    const theirMtime = entry.mtime ?? null
+    if (baseMtime == null || theirMtime == null || baseMtime === theirMtime) return null
+    return {reason: "changed", theirMtime}
+}

--- a/web/oss/src/components/Drives/editMode/state.test.ts
+++ b/web/oss/src/components/Drives/editMode/state.test.ts
@@ -3,18 +3,23 @@ import {describe, expect, it} from "vitest"
 
 import {
     driveEditBufferAtom,
-    driveEditFacetsAtom,
+    driveEditDirtyAtomFamily,
+    driveEditingAtomFamily,
+    driveEditIssueAtomFamily,
+    driveEditPendingNavigationAtomFamily,
+    editReloadFailedAtom,
     editSaveFailedAtom,
     editSaveSucceededAtom,
     markEditConflictAtom,
-    markTeardownWarnedAtom,
+    markNavigationBlockedWhileSavingAtom,
     openEditBufferAtom,
-    overwriteNextSaveAtom,
     replaceBufferFromRemoteAtom,
     requestNavigationAtom,
     resolveNavigationAtom,
     setEditDraftAtom,
     setEditorViewAtom,
+    showTeardownNoticeAtom,
+    startEditReloadAtom,
     startEditSaveAtom,
     type DriveEditBuffer,
     type NavigationIntent,
@@ -30,7 +35,8 @@ const baseInput: OpenDriveEditBufferInput = {
     scope: "app",
     original: "original\n",
     baseMtime: 100,
-    mode: "code",
+    includeGitignored: false,
+    supportsMarkdownPreview: false,
     language: "code",
 }
 
@@ -42,107 +48,115 @@ const open = (
     return store.get(driveEditBufferAtom)!
 }
 
-const makeDirty = (store: ReturnType<typeof createStore>) => {
-    store.set(setEditDraftAtom, "changed\n")
+const setDraft = (store: ReturnType<typeof createStore>, draft: string, driveKey = "drive-a") => {
+    store.set(setEditDraftAtom, {driveKey, draft})
 }
 
+const request = (
+    store: ReturnType<typeof createStore>,
+    intent: NavigationIntent,
+    driveKey = "drive-a",
+) => store.set(requestNavigationAtom, {driveKey, intent})
+
 describe("drive edit state", () => {
-    it("opens clean, becomes dirty after an edit, and becomes clean after restoring the original", () => {
+    it("scopes editing and dirty selectors to the owning drive", () => {
         const store = createStore()
         open(store)
 
-        expect(store.get(driveEditBufferAtom)?.draft).toBe("original\n")
-        expect(store.get(driveEditFacetsAtom)).toMatchObject({
-            editing: true,
-            dirty: false,
-            saving: false,
-            guardOpen: false,
-        })
-
-        store.set(setEditDraftAtom, "changed\n")
-        expect(store.get(driveEditFacetsAtom).dirty).toBe(true)
-
-        store.set(setEditDraftAtom, "original\n")
-        expect(store.get(driveEditFacetsAtom).dirty).toBe(false)
+        expect(store.get(driveEditingAtomFamily("drive-a"))).toBe(true)
+        expect(store.get(driveEditingAtomFamily("drive-b"))).toBe(false)
+        setDraft(store, "changed\n")
+        expect(store.get(driveEditDirtyAtomFamily("drive-a"))).toBe(true)
+        expect(store.get(driveEditDirtyAtomFamily("drive-b"))).toBe(false)
+        expect(store.get(driveEditIssueAtomFamily("drive-b"))).toBeNull()
     })
 
-    it("updates the editor view without changing another facet", () => {
+    it("opens clean, becomes dirty, and becomes clean after restoring the original", () => {
         const store = createStore()
-        open(store, {mode: "markdown"})
+        open(store)
 
-        store.set(setEditorViewAtom, "preview")
+        expect(store.get(driveEditDirtyAtomFamily("drive-a"))).toBe(false)
+        setDraft(store, "changed\n")
+        expect(store.get(driveEditDirtyAtomFamily("drive-a"))).toBe(true)
+        setDraft(store, "original\n")
+        expect(store.get(driveEditDirtyAtomFamily("drive-a"))).toBe(false)
+    })
 
-        expect(store.get(driveEditFacetsAtom)).toMatchObject({
-            editing: true,
-            dirty: false,
-            mode: "markdown",
+    it("updates the editor view without changing the buffer contents", () => {
+        const store = createStore()
+        open(store, {supportsMarkdownPreview: true})
+
+        store.set(setEditorViewAtom, {driveKey: "drive-a", editorView: "preview"})
+
+        expect(store.get(driveEditBufferAtom)).toMatchObject({
+            original: "original\n",
+            draft: "original\n",
             editorView: "preview",
         })
     })
 
-    it("runs clean navigation immediately and clears the buffer", () => {
+    it("runs clean navigation immediately even when an old issue exists", () => {
         const store = createStore()
-        open(store)
+        const buffer = open(store)
+        store.set(driveEditBufferAtom, {
+            ...buffer,
+            issue: {kind: "error", message: "old failure"},
+        })
         const intent: NavigationIntent = {kind: "select", path: "other.txt"}
 
-        expect(store.set(requestNavigationAtom, intent)).toEqual(intent)
+        expect(request(store, intent)).toEqual(intent)
         expect(store.get(driveEditBufferAtom)).toBeNull()
     })
 
     it("guards dirty navigation and records the pending intent", () => {
         const store = createStore()
         open(store)
-        makeDirty(store)
+        setDraft(store, "changed\n")
         const intent: NavigationIntent = {kind: "close"}
 
-        expect(store.set(requestNavigationAtom, intent)).toBeNull()
-        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual(intent)
-        expect(store.get(driveEditFacetsAtom).guardOpen).toBe(true)
+        expect(request(store, intent)).toBeNull()
+        expect(store.get(driveEditPendingNavigationAtomFamily("drive-a"))).toEqual(intent)
     })
 
-    it("guards navigation when an issue exists even if the draft is clean", () => {
+    it("lets a foreign drive navigate without mutating the owned buffer", () => {
         const store = createStore()
         open(store)
-        store.set(startEditSaveAtom, "request-a")
-        store.set(editSaveFailedAtom, {requestId: "request-a", message: "rejected"})
+        setDraft(store, "changed\n")
+        const before = store.get(driveEditBufferAtom)
+        const intent: NavigationIntent = {kind: "close"}
 
-        expect(store.set(requestNavigationAtom, {kind: "cancel"})).toBeNull()
-        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual({kind: "cancel"})
+        expect(request(store, intent, "drive-b")).toEqual(intent)
+        expect(store.get(driveEditBufferAtom)).toEqual(before)
     })
 
-    it("keeps the buffer and only clears pending navigation", () => {
+    it("keeps or discards guarded navigation", () => {
         const store = createStore()
         open(store)
-        makeDirty(store)
-        store.set(requestNavigationAtom, {kind: "close"})
-        const before = store.get(driveEditBufferAtom)!
+        setDraft(store, "changed\n")
+        request(store, {kind: "close"})
+        const before = store.get(driveEditBufferAtom)
 
-        expect(store.set(resolveNavigationAtom, "keep")).toBeNull()
+        expect(
+            store.set(resolveNavigationAtom, {driveKey: "drive-a", resolution: "keep"}),
+        ).toBeNull()
         expect(store.get(driveEditBufferAtom)).toEqual({...before, pendingNavigation: null})
-    })
 
-    it.each<NavigationIntent>([
-        {kind: "close"},
-        {kind: "cancel"},
-        {kind: "select", path: "other.txt"},
-    ])("discards the buffer before running $kind navigation", (intent) => {
-        const store = createStore()
-        open(store)
-        makeDirty(store)
-        store.set(requestNavigationAtom, intent)
-
-        expect(store.set(resolveNavigationAtom, "discard")).toEqual(intent)
+        request(store, {kind: "close"})
+        expect(
+            store.set(resolveNavigationAtom, {driveKey: "drive-a", resolution: "discard"}),
+        ).toEqual({kind: "close"})
         expect(store.get(driveEditBufferAtom)).toBeNull()
     })
 
-    it("keeps the buffer open when discarding into a reload", () => {
+    it("keeps the buffer when discard resolves to reload", () => {
         const store = createStore()
         open(store)
-        makeDirty(store)
-        const intent: NavigationIntent = {kind: "reload"}
-        store.set(requestNavigationAtom, intent)
+        setDraft(store, "changed\n")
+        request(store, {kind: "reload"})
 
-        expect(store.set(resolveNavigationAtom, "discard")).toEqual(intent)
+        expect(
+            store.set(resolveNavigationAtom, {driveKey: "drive-a", resolution: "discard"}),
+        ).toEqual({kind: "reload"})
         expect(store.get(driveEditBufferAtom)).toMatchObject({
             bufferId: "buffer-a",
             draft: "changed\n",
@@ -150,95 +164,73 @@ describe("drive edit state", () => {
         })
     })
 
-    it("ignores draft changes while saving", () => {
+    it("queues a clean reload without opening a discard path for other navigation", () => {
         const store = createStore()
         open(store)
-        makeDirty(store)
-        const before = store.get(driveEditBufferAtom)
-        store.set(startEditSaveAtom, "request-a")
 
-        store.set(setEditDraftAtom, "typed during save")
-
-        expect(store.get(driveEditBufferAtom)?.draft).toBe(before?.draft)
+        expect(request(store, {kind: "reload"})).toBeNull()
+        expect(store.get(driveEditBufferAtom)).toMatchObject({
+            bufferId: "buffer-a",
+            pendingNavigation: {kind: "reload"},
+        })
     })
 
-    it("ignores stale success, failure, and conflict completions", () => {
+    it("ignores draft changes while saving or reloading", () => {
         const store = createStore()
         open(store)
-        makeDirty(store)
+        setDraft(store, "changed\n")
+        store.set(startEditSaveAtom, "save-a")
+        setDraft(store, "typed during save")
+        expect(store.get(driveEditBufferAtom)?.draft).toBe("changed\n")
+
+        store.set(editSaveFailedAtom, {requestId: "save-a", message: "failed"})
+        store.set(startEditReloadAtom, "reload-a")
+        setDraft(store, "typed during reload")
+        expect(store.get(driveEditBufferAtom)?.draft).toBe("changed\n")
+    })
+
+    it("ignores stale save completions", () => {
+        const store = createStore()
+        open(store)
+        setDraft(store, "changed\n")
         store.set(startEditSaveAtom, "current-request")
         const before = store.get(driveEditBufferAtom)
 
         store.set(editSaveSucceededAtom, "stale-request")
-        expect(store.get(driveEditBufferAtom)).toEqual(before)
         store.set(editSaveFailedAtom, {requestId: "stale-request", message: "stale"})
-        expect(store.get(driveEditBufferAtom)).toEqual(before)
         store.set(markEditConflictAtom, {
             requestId: "stale-request",
             reason: "changed",
             theirMtime: 200,
         })
+
         expect(store.get(driveEditBufferAtom)).toEqual(before)
     })
 
-    it("ignores completions after the buffer was replaced", () => {
-        const store = createStore()
-        open(store)
-        makeDirty(store)
-        store.set(startEditSaveAtom, "request-a")
-        store.set(driveEditBufferAtom, null)
-        open(store, {
-            bufferId: "buffer-b",
-            targetPath: "other.txt",
-            displayPath: "other.txt",
-            original: "other",
-        })
-        const replacement = store.get(driveEditBufferAtom)
+    it("exits on success and preserves the exact draft on failure", () => {
+        const successfulStore = createStore()
+        open(successfulStore)
+        setDraft(successfulStore, "changed\n")
+        successfulStore.set(startEditSaveAtom, "save-a")
+        successfulStore.set(editSaveSucceededAtom, "save-a")
+        expect(successfulStore.get(driveEditBufferAtom)).toBeNull()
 
-        store.set(editSaveSucceededAtom, "request-a")
-        store.set(editSaveFailedAtom, {requestId: "request-a", message: "late"})
-        store.set(markEditConflictAtom, {
-            requestId: "request-a",
-            reason: "missing",
-            theirMtime: null,
-        })
-
-        expect(store.get(driveEditBufferAtom)).toEqual(replacement)
-    })
-
-    it("exits edit mode after the current save succeeds", () => {
-        const store = createStore()
-        open(store)
-        makeDirty(store)
-        store.set(startEditSaveAtom, "request-a")
-
-        store.set(editSaveSucceededAtom, "request-a")
-
-        expect(store.get(driveEditBufferAtom)).toBeNull()
-        expect(store.get(driveEditFacetsAtom).editing).toBe(false)
-    })
-
-    it("preserves the exact draft after the current save fails", () => {
-        const store = createStore()
-        open(store)
-        store.set(setEditDraftAtom, "changed\nwith trailing newline\n")
-        const draft = store.get(driveEditBufferAtom)?.draft
-        store.set(startEditSaveAtom, "request-a")
-
-        store.set(editSaveFailedAtom, {requestId: "request-a", message: "mount rejected"})
-
-        expect(store.get(driveEditBufferAtom)).toMatchObject({
-            draft,
+        const failedStore = createStore()
+        open(failedStore)
+        setDraft(failedStore, "changed\nwith trailing newline\n")
+        failedStore.set(startEditSaveAtom, "save-b")
+        failedStore.set(editSaveFailedAtom, {requestId: "save-b", message: "mount rejected"})
+        expect(failedStore.get(driveEditBufferAtom)).toMatchObject({
+            draft: "changed\nwith trailing newline\n",
             saveStatus: "idle",
             inflightRequestId: null,
             issue: {kind: "error", message: "mount rejected"},
         })
     })
 
-    it("uses one issue slot when conflict and error actions replace each other", () => {
+    it("keeps one issue slot when conflict and error actions replace each other", () => {
         const store = createStore()
         const buffer = open(store)
-
         store.set(driveEditBufferAtom, {
             ...buffer,
             saveStatus: "saving",
@@ -268,76 +260,67 @@ describe("drive edit state", () => {
         })
     })
 
-    it("arms one overwrite and clears the flag when the next save starts", () => {
-        const store = createStore()
-        const buffer = open(store)
-        store.set(driveEditBufferAtom, {
-            ...buffer,
-            issue: {kind: "conflict", reason: "changed", theirMtime: 200},
-        })
-
-        store.set(overwriteNextSaveAtom)
-        expect(store.get(driveEditBufferAtom)).toMatchObject({
-            issue: null,
-            skipConflictCheckOnce: true,
-        })
-
-        store.set(startEditSaveAtom, "overwrite-request")
-        expect(store.get(driveEditBufferAtom)).toMatchObject({
-            saveStatus: "saving",
-            inflightRequestId: "overwrite-request",
-            skipConflictCheckOnce: false,
-        })
-    })
-
-    it("replaces the baseline from remote and leaves a clean buffer open", () => {
+    it("adopts only the matching reload and preserves the refreshed baseline", () => {
         const store = createStore()
         open(store)
-        makeDirty(store)
-        store.set(startEditSaveAtom, "request-a")
-        store.set(editSaveFailedAtom, {requestId: "request-a", message: "rejected"})
+        setDraft(store, "changed\n")
+        store.set(startEditReloadAtom, "reload-a")
 
-        store.set(replaceBufferFromRemoteAtom, {content: "remote\n", mtime: 300})
+        store.set(replaceBufferFromRemoteAtom, {
+            requestId: "stale-reload",
+            content: "stale\n",
+            mtime: 200,
+        })
+        expect(store.get(driveEditBufferAtom)?.draft).toBe("changed\n")
 
+        store.set(replaceBufferFromRemoteAtom, {
+            requestId: "reload-a",
+            content: "remote\n",
+            mtime: 300,
+        })
         expect(store.get(driveEditBufferAtom)).toMatchObject({
             original: "remote\n",
             draft: "remote\n",
             baseMtime: 300,
+            reloading: false,
             issue: null,
         })
-        expect(store.get(driveEditFacetsAtom)).toMatchObject({editing: true, dirty: false})
+        expect(store.get(driveEditDirtyAtomFamily("drive-a"))).toBe(false)
     })
 
-    it("keeps exactly one buffer until guarded selection is discarded", () => {
+    it("records reload failure without manufacturing a save request", () => {
         const store = createStore()
         open(store)
-        makeDirty(store)
-        const intent: NavigationIntent = {kind: "select", path: "second.txt"}
-        store.set(requestNavigationAtom, intent)
+        store.set(startEditReloadAtom, "reload-a")
 
-        store.set(openEditBufferAtom, {
-            ...baseInput,
-            bufferId: "buffer-b",
-            targetPath: "second.txt",
-            displayPath: "second.txt",
-        })
+        store.set(editReloadFailedAtom, {requestId: "reload-a", message: "reload failed"})
+
         expect(store.get(driveEditBufferAtom)).toMatchObject({
-            bufferId: "buffer-a",
-            pendingNavigation: intent,
+            saveStatus: "idle",
+            inflightRequestId: null,
+            reloading: false,
+            inflightReloadRequestId: null,
+            issue: {kind: "error", message: "reload failed"},
         })
-
-        expect(store.set(resolveNavigationAtom, "discard")).toEqual(intent)
-        expect(store.get(driveEditBufferAtom)).toBeNull()
     })
 
-    it("marks the teardown warning and closes explicitly", () => {
+    it("records a blocked navigation attempt while saving", () => {
+        const store = createStore()
+        open(store)
+        setDraft(store, "changed")
+        store.set(startEditSaveAtom, "save-a")
+
+        store.set(markNavigationBlockedWhileSavingAtom, "drive-a")
+
+        expect(store.get(driveEditBufferAtom)?.navigationBlockedWhileSaving).toBe(true)
+    })
+
+    it("shows the teardown notice with an honest field name", () => {
         const store = createStore()
         open(store, {scope: "session"})
 
-        store.set(markTeardownWarnedAtom)
-        expect(store.get(driveEditBufferAtom)?.teardownWarned).toBe(true)
+        store.set(showTeardownNoticeAtom, "drive-a")
 
-        store.set(driveEditBufferAtom, null)
-        expect(store.get(driveEditBufferAtom)).toBeNull()
+        expect(store.get(driveEditBufferAtom)?.showTeardownNotice).toBe(true)
     })
 })

--- a/web/oss/src/components/Drives/editMode/state.test.ts
+++ b/web/oss/src/components/Drives/editMode/state.test.ts
@@ -2,7 +2,6 @@ import {createStore} from "jotai"
 import {describe, expect, it} from "vitest"
 
 import {
-    closeEditBufferAtom,
     driveEditBufferAtom,
     driveEditFacetsAtom,
     editSaveFailedAtom,
@@ -86,7 +85,7 @@ describe("drive edit state", () => {
         open(store)
         const intent: NavigationIntent = {kind: "select", path: "other.txt"}
 
-        expect(store.set(requestNavigationAtom, intent)).toEqual({run: intent})
+        expect(store.set(requestNavigationAtom, intent)).toEqual(intent)
         expect(store.get(driveEditBufferAtom)).toBeNull()
     })
 
@@ -96,7 +95,7 @@ describe("drive edit state", () => {
         makeDirty(store)
         const intent: NavigationIntent = {kind: "close"}
 
-        expect(store.set(requestNavigationAtom, intent)).toEqual({run: null})
+        expect(store.set(requestNavigationAtom, intent)).toBeNull()
         expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual(intent)
         expect(store.get(driveEditFacetsAtom).guardOpen).toBe(true)
     })
@@ -107,7 +106,7 @@ describe("drive edit state", () => {
         store.set(startEditSaveAtom, "request-a")
         store.set(editSaveFailedAtom, {requestId: "request-a", message: "rejected"})
 
-        expect(store.set(requestNavigationAtom, {kind: "cancel"})).toEqual({run: null})
+        expect(store.set(requestNavigationAtom, {kind: "cancel"})).toBeNull()
         expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual({kind: "cancel"})
     })
 
@@ -118,7 +117,7 @@ describe("drive edit state", () => {
         store.set(requestNavigationAtom, {kind: "close"})
         const before = store.get(driveEditBufferAtom)!
 
-        expect(store.set(resolveNavigationAtom, "keep")).toEqual({run: null})
+        expect(store.set(resolveNavigationAtom, "keep")).toBeNull()
         expect(store.get(driveEditBufferAtom)).toEqual({...before, pendingNavigation: null})
     })
 
@@ -132,7 +131,7 @@ describe("drive edit state", () => {
         makeDirty(store)
         store.set(requestNavigationAtom, intent)
 
-        expect(store.set(resolveNavigationAtom, "discard")).toEqual({run: intent})
+        expect(store.set(resolveNavigationAtom, "discard")).toEqual(intent)
         expect(store.get(driveEditBufferAtom)).toBeNull()
     })
 
@@ -143,7 +142,7 @@ describe("drive edit state", () => {
         const intent: NavigationIntent = {kind: "reload"}
         store.set(requestNavigationAtom, intent)
 
-        expect(store.set(resolveNavigationAtom, "discard")).toEqual({run: intent})
+        expect(store.set(resolveNavigationAtom, "discard")).toEqual(intent)
         expect(store.get(driveEditBufferAtom)).toMatchObject({
             bufferId: "buffer-a",
             draft: "changed\n",
@@ -187,7 +186,7 @@ describe("drive edit state", () => {
         open(store)
         makeDirty(store)
         store.set(startEditSaveAtom, "request-a")
-        store.set(closeEditBufferAtom)
+        store.set(driveEditBufferAtom, null)
         open(store, {
             bufferId: "buffer-b",
             targetPath: "other.txt",
@@ -327,7 +326,7 @@ describe("drive edit state", () => {
             pendingNavigation: intent,
         })
 
-        expect(store.set(resolveNavigationAtom, "discard")).toEqual({run: intent})
+        expect(store.set(resolveNavigationAtom, "discard")).toEqual(intent)
         expect(store.get(driveEditBufferAtom)).toBeNull()
     })
 
@@ -338,7 +337,7 @@ describe("drive edit state", () => {
         store.set(markTeardownWarnedAtom)
         expect(store.get(driveEditBufferAtom)?.teardownWarned).toBe(true)
 
-        store.set(closeEditBufferAtom)
+        store.set(driveEditBufferAtom, null)
         expect(store.get(driveEditBufferAtom)).toBeNull()
     })
 })

--- a/web/oss/src/components/Drives/editMode/state.test.ts
+++ b/web/oss/src/components/Drives/editMode/state.test.ts
@@ -1,0 +1,344 @@
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {
+    closeEditBufferAtom,
+    driveEditBufferAtom,
+    driveEditFacetsAtom,
+    editSaveFailedAtom,
+    editSaveSucceededAtom,
+    markEditConflictAtom,
+    markTeardownWarnedAtom,
+    openEditBufferAtom,
+    overwriteNextSaveAtom,
+    replaceBufferFromRemoteAtom,
+    requestNavigationAtom,
+    resolveNavigationAtom,
+    setEditDraftAtom,
+    setEditorViewAtom,
+    startEditSaveAtom,
+    type DriveEditBuffer,
+    type NavigationIntent,
+    type OpenDriveEditBufferInput,
+} from "./state"
+
+const baseInput: OpenDriveEditBufferInput = {
+    bufferId: "buffer-a",
+    driveKey: "drive-a",
+    targetMountId: "mount-a",
+    targetPath: "notes.txt",
+    displayPath: "agent-files/notes.txt",
+    scope: "app",
+    original: "original\n",
+    baseMtime: 100,
+    mode: "code",
+    language: "code",
+}
+
+const open = (
+    store: ReturnType<typeof createStore>,
+    overrides: Partial<OpenDriveEditBufferInput> = {},
+) => {
+    store.set(openEditBufferAtom, {...baseInput, ...overrides})
+    return store.get(driveEditBufferAtom)!
+}
+
+const makeDirty = (store: ReturnType<typeof createStore>) => {
+    store.set(setEditDraftAtom, "changed\n")
+}
+
+describe("drive edit state", () => {
+    it("opens clean, becomes dirty after an edit, and becomes clean after restoring the original", () => {
+        const store = createStore()
+        open(store)
+
+        expect(store.get(driveEditBufferAtom)?.draft).toBe("original\n")
+        expect(store.get(driveEditFacetsAtom)).toMatchObject({
+            editing: true,
+            dirty: false,
+            saving: false,
+            guardOpen: false,
+        })
+
+        store.set(setEditDraftAtom, "changed\n")
+        expect(store.get(driveEditFacetsAtom).dirty).toBe(true)
+
+        store.set(setEditDraftAtom, "original\n")
+        expect(store.get(driveEditFacetsAtom).dirty).toBe(false)
+    })
+
+    it("updates the editor view without changing another facet", () => {
+        const store = createStore()
+        open(store, {mode: "markdown"})
+
+        store.set(setEditorViewAtom, "preview")
+
+        expect(store.get(driveEditFacetsAtom)).toMatchObject({
+            editing: true,
+            dirty: false,
+            mode: "markdown",
+            editorView: "preview",
+        })
+    })
+
+    it("runs clean navigation immediately and clears the buffer", () => {
+        const store = createStore()
+        open(store)
+        const intent: NavigationIntent = {kind: "select", path: "other.txt"}
+
+        expect(store.set(requestNavigationAtom, intent)).toEqual({run: intent})
+        expect(store.get(driveEditBufferAtom)).toBeNull()
+    })
+
+    it("guards dirty navigation and records the pending intent", () => {
+        const store = createStore()
+        open(store)
+        makeDirty(store)
+        const intent: NavigationIntent = {kind: "close"}
+
+        expect(store.set(requestNavigationAtom, intent)).toEqual({run: null})
+        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual(intent)
+        expect(store.get(driveEditFacetsAtom).guardOpen).toBe(true)
+    })
+
+    it("guards navigation when an issue exists even if the draft is clean", () => {
+        const store = createStore()
+        open(store)
+        store.set(startEditSaveAtom, "request-a")
+        store.set(editSaveFailedAtom, {requestId: "request-a", message: "rejected"})
+
+        expect(store.set(requestNavigationAtom, {kind: "cancel"})).toEqual({run: null})
+        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual({kind: "cancel"})
+    })
+
+    it("keeps the buffer and only clears pending navigation", () => {
+        const store = createStore()
+        open(store)
+        makeDirty(store)
+        store.set(requestNavigationAtom, {kind: "close"})
+        const before = store.get(driveEditBufferAtom)!
+
+        expect(store.set(resolveNavigationAtom, "keep")).toEqual({run: null})
+        expect(store.get(driveEditBufferAtom)).toEqual({...before, pendingNavigation: null})
+    })
+
+    it.each<NavigationIntent>([
+        {kind: "close"},
+        {kind: "cancel"},
+        {kind: "select", path: "other.txt"},
+    ])("discards the buffer before running $kind navigation", (intent) => {
+        const store = createStore()
+        open(store)
+        makeDirty(store)
+        store.set(requestNavigationAtom, intent)
+
+        expect(store.set(resolveNavigationAtom, "discard")).toEqual({run: intent})
+        expect(store.get(driveEditBufferAtom)).toBeNull()
+    })
+
+    it("keeps the buffer open when discarding into a reload", () => {
+        const store = createStore()
+        open(store)
+        makeDirty(store)
+        const intent: NavigationIntent = {kind: "reload"}
+        store.set(requestNavigationAtom, intent)
+
+        expect(store.set(resolveNavigationAtom, "discard")).toEqual({run: intent})
+        expect(store.get(driveEditBufferAtom)).toMatchObject({
+            bufferId: "buffer-a",
+            draft: "changed\n",
+            pendingNavigation: null,
+        })
+    })
+
+    it("ignores draft changes while saving", () => {
+        const store = createStore()
+        open(store)
+        makeDirty(store)
+        const before = store.get(driveEditBufferAtom)
+        store.set(startEditSaveAtom, "request-a")
+
+        store.set(setEditDraftAtom, "typed during save")
+
+        expect(store.get(driveEditBufferAtom)?.draft).toBe(before?.draft)
+    })
+
+    it("ignores stale success, failure, and conflict completions", () => {
+        const store = createStore()
+        open(store)
+        makeDirty(store)
+        store.set(startEditSaveAtom, "current-request")
+        const before = store.get(driveEditBufferAtom)
+
+        store.set(editSaveSucceededAtom, "stale-request")
+        expect(store.get(driveEditBufferAtom)).toEqual(before)
+        store.set(editSaveFailedAtom, {requestId: "stale-request", message: "stale"})
+        expect(store.get(driveEditBufferAtom)).toEqual(before)
+        store.set(markEditConflictAtom, {
+            requestId: "stale-request",
+            reason: "changed",
+            theirMtime: 200,
+        })
+        expect(store.get(driveEditBufferAtom)).toEqual(before)
+    })
+
+    it("ignores completions after the buffer was replaced", () => {
+        const store = createStore()
+        open(store)
+        makeDirty(store)
+        store.set(startEditSaveAtom, "request-a")
+        store.set(closeEditBufferAtom)
+        open(store, {
+            bufferId: "buffer-b",
+            targetPath: "other.txt",
+            displayPath: "other.txt",
+            original: "other",
+        })
+        const replacement = store.get(driveEditBufferAtom)
+
+        store.set(editSaveSucceededAtom, "request-a")
+        store.set(editSaveFailedAtom, {requestId: "request-a", message: "late"})
+        store.set(markEditConflictAtom, {
+            requestId: "request-a",
+            reason: "missing",
+            theirMtime: null,
+        })
+
+        expect(store.get(driveEditBufferAtom)).toEqual(replacement)
+    })
+
+    it("exits edit mode after the current save succeeds", () => {
+        const store = createStore()
+        open(store)
+        makeDirty(store)
+        store.set(startEditSaveAtom, "request-a")
+
+        store.set(editSaveSucceededAtom, "request-a")
+
+        expect(store.get(driveEditBufferAtom)).toBeNull()
+        expect(store.get(driveEditFacetsAtom).editing).toBe(false)
+    })
+
+    it("preserves the exact draft after the current save fails", () => {
+        const store = createStore()
+        open(store)
+        store.set(setEditDraftAtom, "changed\nwith trailing newline\n")
+        const draft = store.get(driveEditBufferAtom)?.draft
+        store.set(startEditSaveAtom, "request-a")
+
+        store.set(editSaveFailedAtom, {requestId: "request-a", message: "mount rejected"})
+
+        expect(store.get(driveEditBufferAtom)).toMatchObject({
+            draft,
+            saveStatus: "idle",
+            inflightRequestId: null,
+            issue: {kind: "error", message: "mount rejected"},
+        })
+    })
+
+    it("uses one issue slot when conflict and error actions replace each other", () => {
+        const store = createStore()
+        const buffer = open(store)
+
+        store.set(driveEditBufferAtom, {
+            ...buffer,
+            saveStatus: "saving",
+            inflightRequestId: "conflict-request",
+            issue: {kind: "error", message: "old error"},
+        })
+        store.set(markEditConflictAtom, {
+            requestId: "conflict-request",
+            reason: "changed",
+            theirMtime: 200,
+        })
+        expect(store.get(driveEditBufferAtom)?.issue).toEqual({
+            kind: "conflict",
+            reason: "changed",
+            theirMtime: 200,
+        })
+
+        store.set(driveEditBufferAtom, {
+            ...(store.get(driveEditBufferAtom) as DriveEditBuffer),
+            saveStatus: "saving",
+            inflightRequestId: "error-request",
+        })
+        store.set(editSaveFailedAtom, {requestId: "error-request", message: "new error"})
+        expect(store.get(driveEditBufferAtom)?.issue).toEqual({
+            kind: "error",
+            message: "new error",
+        })
+    })
+
+    it("arms one overwrite and clears the flag when the next save starts", () => {
+        const store = createStore()
+        const buffer = open(store)
+        store.set(driveEditBufferAtom, {
+            ...buffer,
+            issue: {kind: "conflict", reason: "changed", theirMtime: 200},
+        })
+
+        store.set(overwriteNextSaveAtom)
+        expect(store.get(driveEditBufferAtom)).toMatchObject({
+            issue: null,
+            skipConflictCheckOnce: true,
+        })
+
+        store.set(startEditSaveAtom, "overwrite-request")
+        expect(store.get(driveEditBufferAtom)).toMatchObject({
+            saveStatus: "saving",
+            inflightRequestId: "overwrite-request",
+            skipConflictCheckOnce: false,
+        })
+    })
+
+    it("replaces the baseline from remote and leaves a clean buffer open", () => {
+        const store = createStore()
+        open(store)
+        makeDirty(store)
+        store.set(startEditSaveAtom, "request-a")
+        store.set(editSaveFailedAtom, {requestId: "request-a", message: "rejected"})
+
+        store.set(replaceBufferFromRemoteAtom, {content: "remote\n", mtime: 300})
+
+        expect(store.get(driveEditBufferAtom)).toMatchObject({
+            original: "remote\n",
+            draft: "remote\n",
+            baseMtime: 300,
+            issue: null,
+        })
+        expect(store.get(driveEditFacetsAtom)).toMatchObject({editing: true, dirty: false})
+    })
+
+    it("keeps exactly one buffer until guarded selection is discarded", () => {
+        const store = createStore()
+        open(store)
+        makeDirty(store)
+        const intent: NavigationIntent = {kind: "select", path: "second.txt"}
+        store.set(requestNavigationAtom, intent)
+
+        store.set(openEditBufferAtom, {
+            ...baseInput,
+            bufferId: "buffer-b",
+            targetPath: "second.txt",
+            displayPath: "second.txt",
+        })
+        expect(store.get(driveEditBufferAtom)).toMatchObject({
+            bufferId: "buffer-a",
+            pendingNavigation: intent,
+        })
+
+        expect(store.set(resolveNavigationAtom, "discard")).toEqual({run: intent})
+        expect(store.get(driveEditBufferAtom)).toBeNull()
+    })
+
+    it("marks the teardown warning and closes explicitly", () => {
+        const store = createStore()
+        open(store, {scope: "session"})
+
+        store.set(markTeardownWarnedAtom)
+        expect(store.get(driveEditBufferAtom)?.teardownWarned).toBe(true)
+
+        store.set(closeEditBufferAtom)
+        expect(store.get(driveEditBufferAtom)).toBeNull()
+    })
+})

--- a/web/oss/src/components/Drives/editMode/state.ts
+++ b/web/oss/src/components/Drives/editMode/state.ts
@@ -109,27 +109,28 @@ export const setEditorViewAtom = atom(
     },
 )
 
+/** Returns the intent to run now, or null when the guard took over. */
 export const requestNavigationAtom = atom(null, (get, set, intent: NavigationIntent) => {
     const buffer = get(driveEditBufferAtom)
-    if (!buffer) return {run: intent}
+    if (!buffer) return intent
 
     if (isEditDirty(buffer.original, buffer.draft) || buffer.issue) {
         set(driveEditBufferAtom, {...buffer, pendingNavigation: intent})
-        return {run: null}
+        return null
     }
 
     set(driveEditBufferAtom, null)
-    return {run: intent}
+    return intent
 })
 
 export const resolveNavigationAtom = atom(null, (get, set, resolution: "keep" | "discard") => {
     const buffer = get(driveEditBufferAtom)
     const intent = buffer?.pendingNavigation ?? null
-    if (!buffer || !intent) return {run: null}
+    if (!buffer || !intent) return null
 
     if (resolution === "keep") {
         set(driveEditBufferAtom, {...buffer, pendingNavigation: null})
-        return {run: null}
+        return null
     }
 
     if (intent.kind === "reload") {
@@ -137,7 +138,7 @@ export const resolveNavigationAtom = atom(null, (get, set, resolution: "keep" | 
     } else {
         set(driveEditBufferAtom, null)
     }
-    return {run: intent}
+    return intent
 })
 
 export const startEditSaveAtom = atom(null, (get, set, requestId: string) => {
@@ -233,8 +234,4 @@ export const markTeardownWarnedAtom = atom(null, (get, set) => {
     if (!buffer) return
 
     set(driveEditBufferAtom, {...buffer, teardownWarned: true})
-})
-
-export const closeEditBufferAtom = atom(null, (_get, set) => {
-    set(driveEditBufferAtom, null)
 })

--- a/web/oss/src/components/Drives/editMode/state.ts
+++ b/web/oss/src/components/Drives/editMode/state.ts
@@ -1,0 +1,240 @@
+import type {CodeLanguage} from "@agenta/ui/editor"
+import {atom} from "jotai"
+
+import type {DriveScope} from "../driveTypes"
+
+import {isEditDirty} from "./model"
+
+export type EditIssue =
+    | {kind: "error"; message: string}
+    | {kind: "conflict"; reason: "changed" | "missing"; theirMtime: number | null}
+
+export type NavigationIntent =
+    | {kind: "cancel"}
+    | {kind: "close"}
+    | {kind: "select"; path: string | null}
+    | {kind: "reload"}
+
+export interface DriveEditBuffer {
+    bufferId: string
+    driveKey: string
+    targetMountId: string
+    targetPath: string
+    displayPath: string
+    scope: DriveScope
+    original: string
+    draft: string
+    baseMtime: number | null
+    mode: "markdown" | "code"
+    language: CodeLanguage
+    editorView: "source" | "preview"
+    saveStatus: "idle" | "saving"
+    inflightRequestId: string | null
+    issue: EditIssue | null
+    pendingNavigation: NavigationIntent | null
+    skipConflictCheckOnce: boolean
+    teardownWarned: boolean
+}
+
+export type OpenDriveEditBufferInput = Pick<
+    DriveEditBuffer,
+    | "bufferId"
+    | "driveKey"
+    | "targetMountId"
+    | "targetPath"
+    | "displayPath"
+    | "scope"
+    | "original"
+    | "baseMtime"
+    | "mode"
+    | "language"
+>
+
+export interface DriveEditFacets {
+    editing: boolean
+    dirty: boolean
+    saving: boolean
+    mode: "markdown" | "code"
+    editorView: "source" | "preview"
+    issue: EditIssue | null
+    guardOpen: boolean
+}
+
+export const driveEditBufferAtom = atom<DriveEditBuffer | null>(null)
+
+export const driveEditFacetsAtom = atom<DriveEditFacets>((get) => {
+    const buffer = get(driveEditBufferAtom)
+
+    return {
+        editing: buffer !== null,
+        dirty: buffer ? isEditDirty(buffer.original, buffer.draft) : false,
+        saving: buffer?.saveStatus === "saving",
+        mode: buffer?.mode ?? "code",
+        editorView: buffer?.editorView ?? "source",
+        issue: buffer?.issue ?? null,
+        guardOpen: Boolean(buffer?.pendingNavigation),
+    }
+})
+
+export const openEditBufferAtom = atom(null, (get, set, input: OpenDriveEditBufferInput) => {
+    if (get(driveEditBufferAtom)) return
+
+    set(driveEditBufferAtom, {
+        ...input,
+        draft: input.original,
+        editorView: "source",
+        saveStatus: "idle",
+        inflightRequestId: null,
+        issue: null,
+        pendingNavigation: null,
+        skipConflictCheckOnce: false,
+        teardownWarned: false,
+    })
+})
+
+export const setEditDraftAtom = atom(null, (get, set, draft: string) => {
+    const buffer = get(driveEditBufferAtom)
+    if (!buffer || buffer.saveStatus === "saving") return
+
+    set(driveEditBufferAtom, {...buffer, draft})
+})
+
+export const setEditorViewAtom = atom(
+    null,
+    (get, set, editorView: DriveEditBuffer["editorView"]) => {
+        const buffer = get(driveEditBufferAtom)
+        if (!buffer) return
+
+        set(driveEditBufferAtom, {...buffer, editorView})
+    },
+)
+
+export const requestNavigationAtom = atom(null, (get, set, intent: NavigationIntent) => {
+    const buffer = get(driveEditBufferAtom)
+    if (!buffer) return {run: intent}
+
+    if (isEditDirty(buffer.original, buffer.draft) || buffer.issue) {
+        set(driveEditBufferAtom, {...buffer, pendingNavigation: intent})
+        return {run: null}
+    }
+
+    set(driveEditBufferAtom, null)
+    return {run: intent}
+})
+
+export const resolveNavigationAtom = atom(null, (get, set, resolution: "keep" | "discard") => {
+    const buffer = get(driveEditBufferAtom)
+    const intent = buffer?.pendingNavigation ?? null
+    if (!buffer || !intent) return {run: null}
+
+    if (resolution === "keep") {
+        set(driveEditBufferAtom, {...buffer, pendingNavigation: null})
+        return {run: null}
+    }
+
+    if (intent.kind === "reload") {
+        set(driveEditBufferAtom, {...buffer, pendingNavigation: null})
+    } else {
+        set(driveEditBufferAtom, null)
+    }
+    return {run: intent}
+})
+
+export const startEditSaveAtom = atom(null, (get, set, requestId: string) => {
+    const buffer = get(driveEditBufferAtom)
+    if (!buffer) return
+
+    set(driveEditBufferAtom, {
+        ...buffer,
+        saveStatus: "saving",
+        inflightRequestId: requestId,
+        issue: null,
+        skipConflictCheckOnce: false,
+    })
+})
+
+export const editSaveSucceededAtom = atom(null, (get, set, requestId: string) => {
+    const buffer = get(driveEditBufferAtom)
+    if (!buffer || buffer.inflightRequestId !== requestId) return
+
+    set(driveEditBufferAtom, null)
+})
+
+export const editSaveFailedAtom = atom(
+    null,
+    (get, set, input: {requestId: string; message: string}) => {
+        const buffer = get(driveEditBufferAtom)
+        if (!buffer || buffer.inflightRequestId !== input.requestId) return
+
+        set(driveEditBufferAtom, {
+            ...buffer,
+            saveStatus: "idle",
+            inflightRequestId: null,
+            issue: {kind: "error", message: input.message},
+        })
+    },
+)
+
+export const markEditConflictAtom = atom(
+    null,
+    (
+        get,
+        set,
+        input: {
+            requestId: string
+            reason: "changed" | "missing"
+            theirMtime: number | null
+        },
+    ) => {
+        const buffer = get(driveEditBufferAtom)
+        if (!buffer || buffer.inflightRequestId !== input.requestId) return
+
+        set(driveEditBufferAtom, {
+            ...buffer,
+            saveStatus: "idle",
+            inflightRequestId: null,
+            issue: {
+                kind: "conflict",
+                reason: input.reason,
+                theirMtime: input.theirMtime,
+            },
+        })
+    },
+)
+
+export const overwriteNextSaveAtom = atom(null, (get, set) => {
+    const buffer = get(driveEditBufferAtom)
+    if (!buffer) return
+
+    set(driveEditBufferAtom, {...buffer, issue: null, skipConflictCheckOnce: true})
+})
+
+export const replaceBufferFromRemoteAtom = atom(
+    null,
+    (get, set, input: {content: string; mtime: number | null}) => {
+        const buffer = get(driveEditBufferAtom)
+        if (!buffer) return
+
+        set(driveEditBufferAtom, {
+            ...buffer,
+            original: input.content,
+            draft: input.content,
+            baseMtime: input.mtime,
+            saveStatus: "idle",
+            inflightRequestId: null,
+            issue: null,
+            skipConflictCheckOnce: false,
+        })
+    },
+)
+
+export const markTeardownWarnedAtom = atom(null, (get, set) => {
+    const buffer = get(driveEditBufferAtom)
+    if (!buffer) return
+
+    set(driveEditBufferAtom, {...buffer, teardownWarned: true})
+})
+
+export const closeEditBufferAtom = atom(null, (_get, set) => {
+    set(driveEditBufferAtom, null)
+})

--- a/web/oss/src/components/Drives/editMode/state.ts
+++ b/web/oss/src/components/Drives/editMode/state.ts
@@ -1,5 +1,6 @@
 import type {CodeLanguage} from "@agenta/ui/editor"
 import {atom} from "jotai"
+import {atomFamily, selectAtom} from "jotai/utils"
 
 import type {DriveScope} from "../driveTypes"
 
@@ -25,15 +26,18 @@ export interface DriveEditBuffer {
     original: string
     draft: string
     baseMtime: number | null
-    mode: "markdown" | "code"
+    includeGitignored: boolean
+    supportsMarkdownPreview: boolean
     language: CodeLanguage
     editorView: "source" | "preview"
     saveStatus: "idle" | "saving"
     inflightRequestId: string | null
+    reloading: boolean
+    inflightReloadRequestId: string | null
     issue: EditIssue | null
     pendingNavigation: NavigationIntent | null
-    skipConflictCheckOnce: boolean
-    teardownWarned: boolean
+    navigationBlockedWhileSaving: boolean
+    showTeardownNotice: boolean
 }
 
 export type OpenDriveEditBufferInput = Pick<
@@ -46,35 +50,83 @@ export type OpenDriveEditBufferInput = Pick<
     | "scope"
     | "original"
     | "baseMtime"
-    | "mode"
+    | "includeGitignored"
+    | "supportsMarkdownPreview"
     | "language"
 >
 
-export interface DriveEditFacets {
-    editing: boolean
-    dirty: boolean
-    saving: boolean
-    mode: "markdown" | "code"
-    editorView: "source" | "preview"
-    issue: EditIssue | null
-    guardOpen: boolean
-}
-
 export const driveEditBufferAtom = atom<DriveEditBuffer | null>(null)
 
-export const driveEditFacetsAtom = atom<DriveEditFacets>((get) => {
-    const buffer = get(driveEditBufferAtom)
+export const ownedEditBufferAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(
+        driveEditBufferAtom,
+        (buffer) => (buffer?.driveKey === driveKey ? buffer : null),
+        Object.is,
+    ),
+)
 
-    return {
-        editing: buffer !== null,
-        dirty: buffer ? isEditDirty(buffer.original, buffer.draft) : false,
-        saving: buffer?.saveStatus === "saving",
-        mode: buffer?.mode ?? "code",
-        editorView: buffer?.editorView ?? "source",
-        issue: buffer?.issue ?? null,
-        guardOpen: Boolean(buffer?.pendingNavigation),
-    }
-})
+export const driveEditingAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) => buffer !== null),
+)
+export const driveEditBufferIdAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) => buffer?.bufferId ?? null),
+)
+export const driveEditDirtyAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) =>
+        buffer ? isEditDirty(buffer.original, buffer.draft) : false,
+    ),
+)
+export const driveEditSavingAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) => buffer?.saveStatus === "saving"),
+)
+export const driveEditIssueAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) => buffer?.issue ?? null, Object.is),
+)
+export const driveEditDirtyPathAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) =>
+        buffer && isEditDirty(buffer.original, buffer.draft) ? buffer.displayPath : null,
+    ),
+)
+export const driveEditPendingNavigationAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(
+        ownedEditBufferAtomFamily(driveKey),
+        (buffer) => buffer?.pendingNavigation ?? null,
+        Object.is,
+    ),
+)
+export const driveEditDisplayPathAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) => buffer?.displayPath ?? ""),
+)
+export const driveEditTargetMountAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) => buffer?.targetMountId ?? ""),
+)
+export const driveEditTargetPathAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) => buffer?.targetPath ?? ""),
+)
+export const driveEditNavigationBlockedAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(
+        ownedEditBufferAtomFamily(driveKey),
+        (buffer) => buffer?.navigationBlockedWhileSaving ?? false,
+    ),
+)
+export const driveEditPreviewCapabilityAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(
+        ownedEditBufferAtomFamily(driveKey),
+        (buffer) => buffer?.supportsMarkdownPreview ?? false,
+    ),
+)
+export const driveEditorViewAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) => buffer?.editorView ?? "source"),
+)
+export const driveEditorLanguageAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(ownedEditBufferAtomFamily(driveKey), (buffer) => buffer?.language ?? "code"),
+)
+export const driveEditTeardownNoticeAtomFamily = atomFamily((driveKey: string) =>
+    selectAtom(
+        ownedEditBufferAtomFamily(driveKey),
+        (buffer) => buffer?.showTeardownNotice ?? false,
+    ),
+)
 
 export const openEditBufferAtom = atom(null, (get, set, input: OpenDriveEditBufferInput) => {
     if (get(driveEditBufferAtom)) return
@@ -85,61 +137,75 @@ export const openEditBufferAtom = atom(null, (get, set, input: OpenDriveEditBuff
         editorView: "source",
         saveStatus: "idle",
         inflightRequestId: null,
+        reloading: false,
+        inflightReloadRequestId: null,
         issue: null,
         pendingNavigation: null,
-        skipConflictCheckOnce: false,
-        teardownWarned: false,
+        navigationBlockedWhileSaving: false,
+        showTeardownNotice: false,
     })
 })
 
-export const setEditDraftAtom = atom(null, (get, set, draft: string) => {
+export const setEditDraftAtom = atom(null, (get, set, input: {driveKey: string; draft: string}) => {
     const buffer = get(driveEditBufferAtom)
-    if (!buffer || buffer.saveStatus === "saving") return
+    if (
+        !buffer ||
+        buffer.driveKey !== input.driveKey ||
+        buffer.saveStatus === "saving" ||
+        buffer.reloading
+    ) {
+        return
+    }
 
-    set(driveEditBufferAtom, {...buffer, draft})
+    set(driveEditBufferAtom, {...buffer, draft: input.draft})
 })
 
 export const setEditorViewAtom = atom(
     null,
-    (get, set, editorView: DriveEditBuffer["editorView"]) => {
+    (get, set, input: {driveKey: string; editorView: DriveEditBuffer["editorView"]}) => {
         const buffer = get(driveEditBufferAtom)
-        if (!buffer) return
+        if (!buffer || buffer.driveKey !== input.driveKey) return
 
-        set(driveEditBufferAtom, {...buffer, editorView})
+        set(driveEditBufferAtom, {...buffer, editorView: input.editorView})
     },
 )
 
-/** Returns the intent to run now, or null when the guard took over. */
-export const requestNavigationAtom = atom(null, (get, set, intent: NavigationIntent) => {
-    const buffer = get(driveEditBufferAtom)
-    if (!buffer) return intent
+export const requestNavigationAtom = atom(
+    null,
+    (get, set, input: {driveKey: string; intent: NavigationIntent}) => {
+        const buffer = get(driveEditBufferAtom)
+        if (!buffer || buffer.driveKey !== input.driveKey) return input.intent
 
-    if (isEditDirty(buffer.original, buffer.draft) || buffer.issue) {
-        set(driveEditBufferAtom, {...buffer, pendingNavigation: intent})
-        return null
-    }
+        if (isEditDirty(buffer.original, buffer.draft) || input.intent.kind === "reload") {
+            set(driveEditBufferAtom, {...buffer, pendingNavigation: input.intent})
+            return null
+        }
 
-    set(driveEditBufferAtom, null)
-    return intent
-})
-
-export const resolveNavigationAtom = atom(null, (get, set, resolution: "keep" | "discard") => {
-    const buffer = get(driveEditBufferAtom)
-    const intent = buffer?.pendingNavigation ?? null
-    if (!buffer || !intent) return null
-
-    if (resolution === "keep") {
-        set(driveEditBufferAtom, {...buffer, pendingNavigation: null})
-        return null
-    }
-
-    if (intent.kind === "reload") {
-        set(driveEditBufferAtom, {...buffer, pendingNavigation: null})
-    } else {
         set(driveEditBufferAtom, null)
-    }
-    return intent
-})
+        return input.intent
+    },
+)
+
+export const resolveNavigationAtom = atom(
+    null,
+    (get, set, input: {driveKey: string; resolution: "keep" | "discard"}) => {
+        const buffer = get(driveEditBufferAtom)
+        const intent = buffer?.driveKey === input.driveKey ? buffer.pendingNavigation : null
+        if (!buffer || !intent) return null
+
+        if (input.resolution === "keep") {
+            set(driveEditBufferAtom, {...buffer, pendingNavigation: null})
+            return null
+        }
+
+        if (intent.kind === "reload") {
+            set(driveEditBufferAtom, {...buffer, pendingNavigation: null})
+        } else {
+            set(driveEditBufferAtom, null)
+        }
+        return intent
+    },
+)
 
 export const startEditSaveAtom = atom(null, (get, set, requestId: string) => {
     const buffer = get(driveEditBufferAtom)
@@ -150,7 +216,7 @@ export const startEditSaveAtom = atom(null, (get, set, requestId: string) => {
         saveStatus: "saving",
         inflightRequestId: requestId,
         issue: null,
-        skipConflictCheckOnce: false,
+        navigationBlockedWhileSaving: false,
     })
 })
 
@@ -172,6 +238,7 @@ export const editSaveFailedAtom = atom(
             saveStatus: "idle",
             inflightRequestId: null,
             issue: {kind: "error", message: input.message},
+            navigationBlockedWhileSaving: false,
         })
     },
 )
@@ -199,22 +266,49 @@ export const markEditConflictAtom = atom(
                 reason: input.reason,
                 theirMtime: input.theirMtime,
             },
+            navigationBlockedWhileSaving: false,
         })
     },
 )
 
-export const overwriteNextSaveAtom = atom(null, (get, set) => {
+export const setEditIssueAtom = atom(
+    null,
+    (get, set, input: {driveKey: string; issue: EditIssue | null}) => {
+        const buffer = get(driveEditBufferAtom)
+        if (!buffer || buffer.driveKey !== input.driveKey) return
+        set(driveEditBufferAtom, {...buffer, issue: input.issue})
+    },
+)
+
+export const startEditReloadAtom = atom(null, (get, set, requestId: string) => {
     const buffer = get(driveEditBufferAtom)
     if (!buffer) return
-
-    set(driveEditBufferAtom, {...buffer, issue: null, skipConflictCheckOnce: true})
+    set(driveEditBufferAtom, {
+        ...buffer,
+        reloading: true,
+        inflightReloadRequestId: requestId,
+    })
 })
+
+export const editReloadFailedAtom = atom(
+    null,
+    (get, set, input: {requestId: string; message: string}) => {
+        const buffer = get(driveEditBufferAtom)
+        if (!buffer || buffer.inflightReloadRequestId !== input.requestId) return
+        set(driveEditBufferAtom, {
+            ...buffer,
+            reloading: false,
+            inflightReloadRequestId: null,
+            issue: {kind: "error", message: input.message},
+        })
+    },
+)
 
 export const replaceBufferFromRemoteAtom = atom(
     null,
-    (get, set, input: {content: string; mtime: number | null}) => {
+    (get, set, input: {requestId: string; content: string; mtime: number | null}) => {
         const buffer = get(driveEditBufferAtom)
-        if (!buffer) return
+        if (!buffer || buffer.inflightReloadRequestId !== input.requestId) return
 
         set(driveEditBufferAtom, {
             ...buffer,
@@ -223,15 +317,30 @@ export const replaceBufferFromRemoteAtom = atom(
             baseMtime: input.mtime,
             saveStatus: "idle",
             inflightRequestId: null,
+            reloading: false,
+            inflightReloadRequestId: null,
             issue: null,
-            skipConflictCheckOnce: false,
+            navigationBlockedWhileSaving: false,
         })
     },
 )
 
-export const markTeardownWarnedAtom = atom(null, (get, set) => {
+export const markNavigationBlockedWhileSavingAtom = atom(null, (get, set, driveKey: string) => {
     const buffer = get(driveEditBufferAtom)
-    if (!buffer) return
+    if (
+        !buffer ||
+        buffer.driveKey !== driveKey ||
+        buffer.saveStatus !== "saving" ||
+        buffer.navigationBlockedWhileSaving
+    ) {
+        return
+    }
+    set(driveEditBufferAtom, {...buffer, navigationBlockedWhileSaving: true})
+})
 
-    set(driveEditBufferAtom, {...buffer, teardownWarned: true})
+export const showTeardownNoticeAtom = atom(null, (get, set, driveKey: string) => {
+    const buffer = get(driveEditBufferAtom)
+    if (!buffer || buffer.driveKey !== driveKey || buffer.showTeardownNotice) return
+
+    set(driveEditBufferAtom, {...buffer, showTeardownNotice: true})
 })

--- a/web/oss/src/components/Drives/editMode/useDriveEditController.test.tsx
+++ b/web/oss/src/components/Drives/editMode/useDriveEditController.test.tsx
@@ -1,0 +1,535 @@
+import {act, type RefObject, useLayoutEffect, useRef} from "react"
+
+import {projectIdAtom} from "@agenta/shared/state"
+import {QueryClient} from "@tanstack/react-query"
+import {createStore, Provider} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+import {createRoot, type Root} from "react-dom/client"
+import {afterAll, afterEach, beforeAll, describe, expect, it, vi} from "vitest"
+
+import {TEXT_CAP} from "../driveKinds"
+
+import {DriveEditBanner} from "./components/DriveEditBanner"
+import {DriveEditBar} from "./components/DriveEditBar"
+import {conflictFromListing} from "./model"
+import {
+    driveEditBufferAtom,
+    openEditBufferAtom,
+    requestNavigationAtom,
+    setEditDraftAtom,
+    type DriveEditBuffer,
+    type NavigationIntent,
+} from "./state"
+import {
+    type DriveEditController,
+    useDriveEditController,
+    useDriveEditGuard,
+} from "./useDriveEditController"
+
+const getMountFilesMock = vi.hoisted(() => vi.fn())
+const uploadMountFileMock = vi.hoisted(() => vi.fn())
+
+vi.mock("@agenta/sdk/resources", () => ({
+    getMountsClient: () => ({
+        getMountFiles: getMountFilesMock,
+        uploadMountFile: uploadMountFileMock,
+    }),
+    getLowPriorityMountsClient: () => ({getMountFiles: getMountFilesMock}),
+    getSessionsClient: () => ({}),
+    getLowPrioritySessionsClient: () => ({}),
+}))
+
+const reactActGlobal = globalThis as typeof globalThis & {IS_REACT_ACT_ENVIRONMENT?: boolean}
+const mount = {id: "mount-a", slug: "mount-a", name: "Mount A", session_id: "session-a"}
+
+const baseBuffer = {
+    bufferId: "buffer-a",
+    driveKey: "drive-a",
+    targetMountId: "mount-a",
+    targetPath: "notes.md",
+    displayPath: "notes.md",
+    scope: "session" as const,
+    original: "original",
+    baseMtime: 10,
+    includeGitignored: false,
+    supportsMarkdownPreview: true,
+    language: "code" as const,
+}
+
+const deferred = <T,>() => {
+    let resolve!: (value: T) => void
+    const promise = new Promise<T>((done) => {
+        resolve = done
+    })
+    return {promise, resolve}
+}
+
+beforeAll(() => {
+    reactActGlobal.IS_REACT_ACT_ENVIRONMENT = true
+})
+
+afterAll(() => {
+    delete reactActGlobal.IS_REACT_ACT_ENVIRONMENT
+})
+
+afterEach(() => {
+    getMountFilesMock.mockReset()
+    uploadMountFileMock.mockReset()
+    vi.useRealTimers()
+})
+
+const seedMountReads = ({content = "original", mtime = 10} = {}) => {
+    getMountFilesMock.mockImplementation((request: {read?: string}) =>
+        Promise.resolve(
+            request.read ? {content} : {files: [{path: "notes.md", size: content.length, mtime}]},
+        ),
+    )
+}
+
+async function flush() {
+    await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+    })
+}
+
+async function waitFor(check: () => boolean) {
+    for (let attempt = 0; attempt < 20; attempt += 1) {
+        if (check()) return
+        await flush()
+    }
+    throw new Error("Condition did not become true")
+}
+
+describe("useDriveEditController", () => {
+    let root: Root | null = null
+    let container: HTMLDivElement | null = null
+
+    afterEach(() => {
+        if (root) act(() => root?.unmount())
+        container?.remove()
+        root = null
+        container = null
+    })
+
+    function mountController({
+        store,
+        driveKey = "drive-a",
+        selectedPath = "notes.md",
+        selectedSize = 8,
+        select = vi.fn(),
+        close = vi.fn(),
+    }: {
+        store: ReturnType<typeof createStore>
+        driveKey?: string
+        selectedPath?: string
+        selectedSize?: number
+        select?: (path: string | null) => void
+        close?: () => void
+    }) {
+        let current: DriveEditController | null = null
+        let rootElement: HTMLDivElement | null = null
+        const Harness = () => {
+            const rootRef = useRef<HTMLDivElement>(null)
+            const controller = useDriveEditController({
+                driveKey,
+                resolveMountPath: (path) => ({mount, path}),
+                selectedPath,
+                selectedIsFolder: false,
+                selectedSize,
+                scope: "session",
+                canEditMountFiles: true,
+                includeGitignored: false,
+                select,
+                close,
+                rootRef: rootRef as RefObject<HTMLElement | null>,
+            })
+            useLayoutEffect(() => {
+                current = controller
+                rootElement = rootRef.current
+            }, [controller])
+            return (
+                <div ref={rootRef}>
+                    <button type="button">inside</button>
+                </div>
+            )
+        }
+        container = document.createElement("div")
+        document.body.appendChild(container)
+        root = createRoot(container)
+        act(() => {
+            root?.render(
+                <Provider store={store}>
+                    <Harness />
+                </Provider>,
+            )
+        })
+        return {
+            get: () => current as DriveEditController,
+            target: () => rootElement?.querySelector("button") as HTMLButtonElement,
+            container: () => rootElement as HTMLDivElement,
+        }
+    }
+
+    it("does not subscribe to file content when the listing size is over the cap", async () => {
+        seedMountReads()
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient({defaultOptions: {queries: {retry: false}}}))
+
+        const controller = mountController({store, selectedSize: TEXT_CAP + 1})
+        await waitFor(() => controller.get().availability === "too-large")
+
+        expect(getMountFilesMock).not.toHaveBeenCalled()
+    })
+
+    it("keeps foreign edit state and chrome invisible to another controller", async () => {
+        seedMountReads()
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient({defaultOptions: {queries: {retry: false}}}))
+        store.set(openEditBufferAtom, baseBuffer)
+        let controllerB: DriveEditController | null = null
+        const Probe = ({driveKey}: {driveKey: string}) => {
+            const rootRef = useRef<HTMLDivElement>(null)
+            const controller = useDriveEditController({
+                driveKey,
+                resolveMountPath: (path) => ({mount, path}),
+                selectedPath: "notes.md",
+                selectedIsFolder: false,
+                selectedSize: 8,
+                scope: "session",
+                canEditMountFiles: true,
+                includeGitignored: false,
+                select: vi.fn(),
+                close: vi.fn(),
+                rootRef,
+            })
+            useLayoutEffect(() => {
+                if (driveKey === "drive-b") controllerB = controller
+            }, [controller, driveKey])
+            return (
+                <div ref={rootRef} data-drive={driveKey}>
+                    <DriveEditBar driveKey={driveKey} />
+                    <DriveEditBanner
+                        driveKey={driveKey}
+                        onRetry={controller.onSave}
+                        onReload={controller.onReload}
+                        onOverwrite={controller.onOverwrite}
+                    />
+                </div>
+            )
+        }
+        container = document.createElement("div")
+        document.body.appendChild(container)
+        root = createRoot(container)
+        act(() =>
+            root?.render(
+                <Provider store={store}>
+                    <Probe driveKey="drive-a" />
+                    <Probe driveKey="drive-b" />
+                </Provider>,
+            ),
+        )
+        await waitFor(() => controllerB?.availability === "enabled")
+        const driveB = container.querySelector('[data-drive="drive-b"]')
+
+        expect(controllerB?.editing).toBe(false)
+        expect(driveB?.textContent).not.toContain("Editing")
+        expect(driveB?.textContent).not.toContain("changed while you were editing")
+    })
+
+    it("clears a clean owned buffer on unmount but preserves a dirty one", () => {
+        seedMountReads()
+        const cleanStore = createStore()
+        cleanStore.set(projectIdAtom, "project")
+        cleanStore.set(queryClientAtom, new QueryClient())
+        cleanStore.set(openEditBufferAtom, baseBuffer)
+        mountController({store: cleanStore})
+        act(() => root?.unmount())
+        root = null
+        expect(cleanStore.get(driveEditBufferAtom)).toBeNull()
+
+        const dirtyStore = createStore()
+        dirtyStore.set(projectIdAtom, "project")
+        dirtyStore.set(queryClientAtom, new QueryClient())
+        dirtyStore.set(openEditBufferAtom, baseBuffer)
+        dirtyStore.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
+        mountController({store: dirtyStore})
+        act(() => root?.unmount())
+        root = null
+        expect(dirtyStore.get(driveEditBufferAtom)?.draft).toBe("changed")
+    })
+
+    it("lets an in-flight real save settle after unmount", async () => {
+        seedMountReads()
+        const write = deferred<{path: string; size: number}>()
+        uploadMountFileMock.mockReturnValue(write.promise)
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient({defaultOptions: {queries: {retry: false}}}))
+        store.set(openEditBufferAtom, baseBuffer)
+        act(() => store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"}))
+        const controller = mountController({store})
+
+        act(() => controller.get().onSave())
+        await waitFor(() => uploadMountFileMock.mock.calls.length === 1)
+        act(() => root?.unmount())
+        root = null
+        write.resolve({path: "notes.md", size: 7})
+        await flush()
+
+        expect(store.get(driveEditBufferAtom)).toBeNull()
+    })
+
+    it("does not arm a later save after a no-op overwrite", async () => {
+        seedMountReads()
+        const write = deferred<{path: string; size: number}>()
+        uploadMountFileMock.mockReturnValue(write.promise)
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient({defaultOptions: {queries: {retry: false}}}))
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(driveEditBufferAtom, {
+            ...(store.get(driveEditBufferAtom) as DriveEditBuffer),
+            issue: {kind: "conflict", reason: "changed", theirMtime: 20},
+        })
+        const controller = mountController({store})
+
+        act(() => controller.get().onOverwrite())
+        expect(uploadMountFileMock).not.toHaveBeenCalled()
+        act(() => store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"}))
+        act(() => controller.get().onSave())
+        await waitFor(() => uploadMountFileMock.mock.calls.length === 1)
+
+        expect(getMountFilesMock).toHaveBeenCalledWith(
+            expect.objectContaining({depth: 1}),
+            expect.anything(),
+        )
+        await act(async () => {
+            write.resolve({path: "notes.md", size: 7})
+            await write.promise
+        })
+        await waitFor(() => store.get(driveEditBufferAtom) === null)
+    })
+
+    it("scopes shortcuts to the drawer root and respects a pending guard", async () => {
+        seedMountReads()
+        uploadMountFileMock.mockResolvedValue({path: "notes.md", size: 7})
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient({defaultOptions: {queries: {retry: false}}}))
+        const controller = mountController({store})
+        await waitFor(() => controller.get().availability === "enabled")
+        const outside = document.createElement("button")
+        document.body.appendChild(outside)
+
+        act(() =>
+            outside.dispatchEvent(
+                new KeyboardEvent("keydown", {key: "e", ctrlKey: true, bubbles: true}),
+            ),
+        )
+        expect(store.get(driveEditBufferAtom)).toBeNull()
+
+        act(() =>
+            controller
+                .target()
+                .dispatchEvent(
+                    new KeyboardEvent("keydown", {key: "e", ctrlKey: true, bubbles: true}),
+                ),
+        )
+        await waitFor(() => store.get(driveEditBufferAtom) !== null)
+        act(() => {
+            store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
+            store.set(requestNavigationAtom, {driveKey: "drive-a", intent: {kind: "close"}})
+        })
+
+        act(() => {
+            controller
+                .target()
+                .dispatchEvent(
+                    new KeyboardEvent("keydown", {key: "s", ctrlKey: true, bubbles: true}),
+                )
+            controller
+                .target()
+                .dispatchEvent(new KeyboardEvent("keydown", {key: "Escape", bubbles: true}))
+        })
+
+        expect(uploadMountFileMock).not.toHaveBeenCalled()
+        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual({kind: "close"})
+        outside.remove()
+    })
+
+    it("runs Cmd+S and Escape from inside the drawer", async () => {
+        seedMountReads()
+        const write = deferred<{path: string; size: number}>()
+        uploadMountFileMock.mockReturnValue(write.promise)
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient({defaultOptions: {queries: {retry: false}}}))
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
+        const controller = mountController({store})
+
+        act(() =>
+            controller
+                .target()
+                .dispatchEvent(
+                    new KeyboardEvent("keydown", {key: "s", metaKey: true, bubbles: true}),
+                ),
+        )
+        await waitFor(() => uploadMountFileMock.mock.calls.length === 1)
+        expect(store.get(driveEditBufferAtom)?.inflightRequestId).toEqual(expect.any(String))
+        act(() => controller.get().onCancel())
+        expect(controller.get().statusText).toBe("Saving — wait before leaving")
+        write.resolve({path: "notes.md", size: 7})
+        await flush()
+
+        act(() => {
+            store.set(openEditBufferAtom, {...baseBuffer, bufferId: "buffer-b"})
+            store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed again"})
+        })
+        await waitFor(() => controller.get().editing && controller.get().dirty)
+        act(() =>
+            controller
+                .target()
+                .dispatchEvent(new KeyboardEvent("keydown", {key: "Escape", bubbles: true})),
+        )
+
+        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual({kind: "cancel"})
+    })
+
+    it("guards selection except for the already-selected path", () => {
+        seedMountReads()
+        const select = vi.fn()
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient())
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
+        const controller = mountController({store, select})
+
+        act(() => controller.get().select("notes.md"))
+        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toBeNull()
+        expect(select).not.toHaveBeenCalled()
+
+        act(() => controller.get().select("other.md"))
+        expect(store.get(driveEditBufferAtom)?.pendingNavigation).toEqual({
+            kind: "select",
+            path: "other.md",
+        })
+        expect(select).not.toHaveBeenCalled()
+    })
+
+    it("registers and deregisters beforeunload only while dirty", () => {
+        seedMountReads()
+        const add = vi.spyOn(window, "addEventListener")
+        const remove = vi.spyOn(window, "removeEventListener")
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient())
+        store.set(openEditBufferAtom, baseBuffer)
+        mountController({store})
+
+        act(() => store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"}))
+        expect(add).toHaveBeenCalledWith("beforeunload", expect.any(Function))
+        act(() => store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "original"}))
+        expect(remove).toHaveBeenCalledWith("beforeunload", expect.any(Function))
+
+        add.mockRestore()
+        remove.mockRestore()
+    })
+
+    it("shows Saved for the selected path and clears it after two seconds", async () => {
+        seedMountReads()
+        uploadMountFileMock.mockResolvedValue({path: "notes.md", size: 7})
+        const timer = vi.spyOn(window, "setTimeout")
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient({defaultOptions: {queries: {retry: false}}}))
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
+        const controller = mountController({store})
+
+        act(() => controller.get().onSave())
+        await waitFor(() => controller.get().justSaved)
+        expect(controller.get().statusText).toBe("Saved")
+
+        const callback = timer.mock.calls.find(([, delay]) => delay === 2_000)?.[0]
+        expect(callback).toBeTypeOf("function")
+        act(() => (callback as () => void)())
+        expect(controller.get().justSaved).toBe(false)
+        timer.mockRestore()
+    })
+})
+
+describe("reload lifecycle", () => {
+    let root: Root | null = null
+    let container: HTMLDivElement | null = null
+
+    afterEach(() => {
+        if (root) act(() => root?.unmount())
+        container?.remove()
+        root = null
+        container = null
+    })
+
+    it("blocks draft writes, adopts remote bytes, and refreshes the baseline", async () => {
+        const contentRead = deferred<{content: string}>()
+        getMountFilesMock.mockImplementation((request: {read?: string}) =>
+            request.read
+                ? contentRead.promise
+                : Promise.resolve({files: [{path: "notes.md", size: 6, mtime: 20}]}),
+        )
+        const store = createStore()
+        store.set(projectIdAtom, "project")
+        store.set(queryClientAtom, new QueryClient({defaultOptions: {queries: {retry: false}}}))
+        store.set(openEditBufferAtom, baseBuffer)
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "changed"})
+        store.set(driveEditBufferAtom, {
+            ...(store.get(driveEditBufferAtom) as DriveEditBuffer),
+            issue: {kind: "conflict", reason: "changed", theirMtime: 15},
+        })
+        store.set(requestNavigationAtom, {driveKey: "drive-a", intent: {kind: "reload"}})
+        let guard: ReturnType<typeof useDriveEditGuard> | null = null
+        const Harness = () => {
+            const current = useDriveEditGuard({
+                active: true,
+                initialPath: "notes.md",
+                driveKey: "drive-a",
+                heldDriveKey: "drive-a",
+                onClose: vi.fn(),
+                runNavigation: (_intent: NavigationIntent) => undefined,
+            })
+            useLayoutEffect(() => {
+                guard = current
+            }, [current])
+            return null
+        }
+        container = document.createElement("div")
+        document.body.appendChild(container)
+        root = createRoot(container)
+        act(() =>
+            root?.render(
+                <Provider store={store}>
+                    <Harness />
+                </Provider>,
+            ),
+        )
+
+        act(() => guard?.modal.onDiscard())
+        expect(store.get(driveEditBufferAtom)?.reloading).toBe(true)
+        store.set(setEditDraftAtom, {driveKey: "drive-a", draft: "typed during reload"})
+        expect(store.get(driveEditBufferAtom)?.draft).toBe("changed")
+        contentRead.resolve({content: "remote"})
+        await waitFor(() => store.get(driveEditBufferAtom)?.reloading === false)
+
+        const buffer = store.get(driveEditBufferAtom)
+        expect(buffer).toMatchObject({original: "remote", draft: "remote", baseMtime: 20})
+        expect(
+            conflictFromListing([{path: "notes.md", mtime: 30}], "notes.md", buffer!.baseMtime),
+        ).toEqual({
+            reason: "changed",
+            theirMtime: 30,
+        })
+    })
+})

--- a/web/oss/src/components/Drives/editMode/useDriveEditController.ts
+++ b/web/oss/src/components/Drives/editMode/useDriveEditController.ts
@@ -1,0 +1,539 @@
+import {useCallback, useEffect, useRef, useState} from "react"
+
+import {
+    mountDirQueryFamily,
+    mountFileContentQueryKey,
+    readMountFile,
+} from "@agenta/entities/session"
+import {useAtomValue, useSetAtom, useStore} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+
+import {projectIdAtom} from "@/oss/state/project"
+
+import {useDriveFileText} from "../driveFileSource"
+import {resolveDriveFileKind} from "../driveKinds"
+import type {DriveScope} from "../driveTypes"
+import type {ResolvedMountPath} from "../useSessionDrive"
+
+import {saveDriveFile} from "./api"
+import {
+    driveEditAvailability,
+    driveEditBufferMode,
+    driveEditorLanguage,
+    EDIT_KINDS,
+    type DriveEditAvailability,
+} from "./model"
+import {
+    driveEditBufferAtom,
+    driveEditFacetsAtom,
+    editSaveFailedAtom,
+    editSaveSucceededAtom,
+    markEditConflictAtom,
+    openEditBufferAtom,
+    overwriteNextSaveAtom,
+    replaceBufferFromRemoteAtom,
+    requestNavigationAtom,
+    resolveNavigationAtom,
+    startEditSaveAtom,
+    type NavigationIntent,
+} from "./state"
+
+const newId = (): string =>
+    typeof crypto !== "undefined" && "randomUUID" in crypto
+        ? crypto.randomUUID()
+        : `${Date.now()}-${Math.random().toString(36).slice(2)}`
+
+const focusEditor = (bufferId: string) => {
+    requestAnimationFrame(() => {
+        const container = Array.from(
+            document.querySelectorAll<HTMLElement>("[data-drive-edit-buffer]"),
+        ).find((element) => element.dataset.driveEditBuffer === bufferId)
+        container
+            ?.querySelector<HTMLElement>(".agenta-shared-editor [contenteditable='true']")
+            ?.focus()
+    })
+}
+
+export interface DriveEditController {
+    availability: DriveEditAvailability
+    editing: boolean
+    dirty: boolean
+    saving: boolean
+    justSaved: boolean
+    statusText: string
+    dirtyPath: string | null
+    onEdit: () => void
+    onSave: () => void
+    onCancel: () => void
+    onRetry: () => void
+    onReload: () => void
+    onOverwrite: () => void
+    select: (path: string | null) => void
+}
+
+export function useDriveEditController({
+    driveKey,
+    resolveMountPath,
+    selectedPath,
+    selectedIsFolder,
+    selectedSize,
+    scope,
+    canEditMountFiles,
+    includeGitignored,
+    select,
+    close,
+    registerNavigationRunner,
+}: {
+    driveKey: string
+    resolveMountPath: (displayPath: string) => ResolvedMountPath | null
+    selectedPath: string | null
+    selectedIsFolder: boolean
+    selectedSize: number | null
+    scope: DriveScope
+    canEditMountFiles: boolean
+    includeGitignored: boolean
+    select: (path: string | null) => void
+    close: () => void
+    registerNavigationRunner?: (runner: ((intent: NavigationIntent) => void) | null) => void
+}): DriveEditController {
+    const store = useStore()
+    const queryClient = useAtomValue(queryClientAtom)
+    const projectId = useAtomValue(projectIdAtom)
+    const buffer = useAtomValue(driveEditBufferAtom)
+    const facets = useAtomValue(driveEditFacetsAtom)
+    const openBuffer = useSetAtom(openEditBufferAtom)
+    const requestNavigation = useSetAtom(requestNavigationAtom)
+    const startSave = useSetAtom(startEditSaveAtom)
+    const saveSucceeded = useSetAtom(editSaveSucceededAtom)
+    const saveFailed = useSetAtom(editSaveFailedAtom)
+    const markConflict = useSetAtom(markEditConflictAtom)
+    const overwriteNextSave = useSetAtom(overwriteNextSaveAtom)
+    const [justSavedPath, setJustSavedPath] = useState<string | null>(null)
+    const saveController = useRef<{
+        controller: AbortController
+        requestId: string
+    } | null>(null)
+    const savedTimer = useRef<number | null>(null)
+
+    const kind = resolveDriveFileKind(selectedPath ?? "")
+    const editableKind = EDIT_KINDS.has(kind) && !selectedIsFolder
+    const resolved =
+        selectedPath && editableKind
+            ? resolveMountPath(selectedPath)
+            : (null as ResolvedMountPath | null)
+    const content = useDriveFileText(resolved?.mount ?? null, resolved?.path ?? "")
+    const directory = resolved?.path.includes("/")
+        ? resolved.path.slice(0, resolved.path.lastIndexOf("/"))
+        : ""
+    const listingQuery = useAtomValue(
+        mountDirQueryFamily({
+            mountId: resolved?.mount.id ?? "",
+            path: directory,
+            includeGitignored,
+        }),
+    )
+    const contentAvailability = driveEditAvailability({
+        kind,
+        listingSize: selectedSize,
+        contentLength: typeof content.data === "string" ? content.data.length : null,
+        isPending: content.isPending,
+        canEdit: canEditMountFiles && Boolean(projectId && resolved && selectedPath),
+    })
+    const availability =
+        contentAvailability !== "enabled"
+            ? contentAvailability
+            : listingQuery.isPending
+              ? "loading"
+              : Array.isArray(listingQuery.data)
+                ? "enabled"
+                : "unreadable"
+
+    const runIntent = useCallback(
+        (intent: NavigationIntent) => {
+            if (intent.kind === "select") select(intent.path)
+            if (intent.kind === "close") close()
+        },
+        [close, select],
+    )
+
+    const guardedSelect = useCallback(
+        (path: string | null) => {
+            if (path === selectedPath) return
+            const result = requestNavigation({kind: "select", path})
+            if (result.run) runIntent(result.run)
+        },
+        [requestNavigation, runIntent, selectedPath],
+    )
+
+    useEffect(() => {
+        registerNavigationRunner?.(runIntent)
+        return () => registerNavigationRunner?.(null)
+    }, [registerNavigationRunner, runIntent])
+
+    const onEdit = useCallback(() => {
+        if (
+            availability !== "enabled" ||
+            !projectId ||
+            !selectedPath ||
+            !resolved ||
+            typeof content.data !== "string" ||
+            !Array.isArray(listingQuery.data)
+        ) {
+            return
+        }
+        const baseMtime =
+            listingQuery.data.find((file) => file.path === resolved.path)?.mtime ?? null
+        setJustSavedPath(null)
+        openBuffer({
+            bufferId: newId(),
+            driveKey,
+            targetMountId: resolved.mount.id,
+            targetPath: resolved.path,
+            displayPath: selectedPath,
+            scope,
+            original: content.data,
+            baseMtime,
+            mode: driveEditBufferMode(selectedPath),
+            language: driveEditorLanguage(selectedPath),
+        })
+    }, [
+        availability,
+        content.data,
+        driveKey,
+        includeGitignored,
+        listingQuery.data,
+        openBuffer,
+        projectId,
+        resolved,
+        scope,
+        selectedPath,
+    ])
+
+    const onSave = useCallback(() => {
+        const current = store.get(driveEditBufferAtom)
+        if (
+            !current ||
+            !projectId ||
+            current.saveStatus === "saving" ||
+            current.draft === current.original
+        ) {
+            return
+        }
+        const requestId = newId()
+        const controller = new AbortController()
+        saveController.current?.controller.abort()
+        saveController.current = {controller, requestId}
+        const skipConflictCheck = current.skipConflictCheckOnce
+        startSave(requestId)
+        void saveDriveFile({
+            queryClient,
+            projectId,
+            targetMountId: current.targetMountId,
+            targetPath: current.targetPath,
+            draft: current.draft,
+            baseMtime: current.baseMtime,
+            includeGitignored,
+            skipConflictCheck,
+            signal: controller.signal,
+        })
+            .then((result) => {
+                if (result.kind === "conflict") {
+                    markConflict({requestId, reason: result.reason, theirMtime: result.theirMtime})
+                    return
+                }
+                if (result.kind === "error") {
+                    saveFailed({requestId, message: result.message})
+                    return
+                }
+                if (store.get(driveEditBufferAtom)?.inflightRequestId !== requestId) return
+                saveSucceeded(requestId)
+                setJustSavedPath(current.displayPath)
+                if (savedTimer.current != null) window.clearTimeout(savedTimer.current)
+                savedTimer.current = window.setTimeout(() => setJustSavedPath(null), 2_000)
+            })
+            .catch((error: unknown) => {
+                if (controller.signal.aborted) return
+                saveFailed({
+                    requestId,
+                    message: error instanceof Error ? error.message : "Couldn’t save this file",
+                })
+            })
+    }, [
+        includeGitignored,
+        markConflict,
+        projectId,
+        queryClient,
+        saveFailed,
+        saveSucceeded,
+        startSave,
+        store,
+    ])
+
+    const onCancel = useCallback(() => {
+        if (store.get(driveEditBufferAtom)?.saveStatus === "saving") return
+        const result = requestNavigation({kind: "cancel"})
+        if (result.run) runIntent(result.run)
+    }, [requestNavigation, runIntent, store])
+    const onReload = useCallback(() => {
+        const result = requestNavigation({kind: "reload"})
+        if (result.run) runIntent(result.run)
+    }, [requestNavigation, runIntent])
+    const onOverwrite = useCallback(() => {
+        overwriteNextSave()
+        onSave()
+    }, [onSave, overwriteNextSave])
+
+    useEffect(() => {
+        const onKeyDown = (event: KeyboardEvent) => {
+            if (store.get(driveEditBufferAtom)?.pendingNavigation) return
+            const command = event.metaKey || event.ctrlKey
+            if (command && event.key.toLowerCase() === "e" && availability === "enabled") {
+                event.preventDefault()
+                onEdit()
+                return
+            }
+            if (command && event.key.toLowerCase() === "s" && facets.editing) {
+                event.preventDefault()
+                onSave()
+                return
+            }
+            if (event.key === "Escape" && facets.editing) {
+                event.preventDefault()
+                event.stopPropagation()
+                onCancel()
+            }
+        }
+        window.addEventListener("keydown", onKeyDown, true)
+        return () => window.removeEventListener("keydown", onKeyDown, true)
+    }, [availability, facets.editing, onCancel, onEdit, onSave, store])
+
+    useEffect(() => {
+        if (!facets.dirty) return
+        const onBeforeUnload = (event: BeforeUnloadEvent) => event.preventDefault()
+        window.addEventListener("beforeunload", onBeforeUnload)
+        return () => window.removeEventListener("beforeunload", onBeforeUnload)
+    }, [facets.dirty])
+
+    useEffect(
+        () => () => {
+            const inflight = saveController.current
+            inflight?.controller.abort()
+            if (inflight) {
+                store.set(editSaveFailedAtom, {
+                    requestId: inflight.requestId,
+                    message: "Save was interrupted",
+                })
+            }
+            if (savedTimer.current != null) window.clearTimeout(savedTimer.current)
+        },
+        [store],
+    )
+
+    const justSaved = justSavedPath === selectedPath
+    const statusText = facets.saving
+        ? "Saving"
+        : justSaved
+          ? "Saved"
+          : facets.issue?.kind === "error"
+            ? facets.issue.message
+            : facets.issue?.kind === "conflict"
+              ? "This file changed while you were editing"
+              : ""
+
+    return {
+        availability,
+        editing: facets.editing,
+        dirty: facets.dirty,
+        saving: facets.saving,
+        justSaved,
+        statusText,
+        dirtyPath: facets.dirty ? (buffer?.displayPath ?? null) : null,
+        onEdit,
+        onSave,
+        onCancel,
+        onRetry: onSave,
+        onReload,
+        onOverwrite,
+        select: guardedSelect,
+    }
+}
+
+export function useDriveEditGuard({
+    active,
+    initialPath,
+    driveKey,
+    heldDriveKey,
+    onClose,
+    runNavigation,
+}: {
+    active: boolean
+    initialPath?: string | null
+    driveKey?: string
+    heldDriveKey?: string
+    onClose: () => void
+    runNavigation?: (intent: NavigationIntent) => void
+}) {
+    const store = useStore()
+    const projectId = useAtomValue(projectIdAtom)
+    const queryClient = useAtomValue(queryClientAtom)
+    const buffer = useAtomValue(driveEditBufferAtom)
+    const requestNavigation = useSetAtom(requestNavigationAtom)
+    const resolveNavigation = useSetAtom(resolveNavigationAtom)
+    const replaceFromRemote = useSetAtom(replaceBufferFromRemoteAtom)
+    const startSave = useSetAtom(startEditSaveAtom)
+    const saveFailed = useSetAtom(editSaveFailedAtom)
+    const [heldInitialPath, setHeldInitialPath] = useState(initialPath)
+    const previousInitialPath = useRef(initialPath)
+    const requestedDriveSwap = useRef<string | null>(null)
+    const pendingDriveSwap = useRef(false)
+    const reloadRequest = useRef<string | null>(null)
+    const holdDrive = Boolean(
+        active && buffer && driveKey !== undefined && driveKey !== heldDriveKey,
+    )
+
+    useEffect(() => {
+        if (!active) {
+            if (!store.get(driveEditBufferAtom)) {
+                previousInitialPath.current = initialPath
+                setHeldInitialPath(initialPath)
+            }
+            return
+        }
+        if (previousInitialPath.current === initialPath) return
+        previousInitialPath.current = initialPath
+        const current = store.get(driveEditBufferAtom)
+        if (!current) {
+            setHeldInitialPath(initialPath)
+            return
+        }
+        const result = requestNavigation({kind: "select", path: initialPath ?? null})
+        if (result.run?.kind === "select") {
+            setHeldInitialPath(result.run.path)
+            runNavigation?.(result.run)
+        }
+    }, [active, initialPath, requestNavigation, runNavigation, store])
+
+    useEffect(() => {
+        if (!holdDrive || !buffer) {
+            if (!buffer) requestedDriveSwap.current = null
+            if (!holdDrive) pendingDriveSwap.current = false
+            return
+        }
+        const token = `${buffer.bufferId}:${driveKey}`
+        if (requestedDriveSwap.current === token) return
+        requestedDriveSwap.current = token
+        pendingDriveSwap.current = true
+        requestNavigation({kind: "select", path: initialPath ?? null})
+    }, [buffer, driveKey, holdDrive, initialPath, requestNavigation])
+
+    useEffect(() => {
+        if (!buffer) setHeldInitialPath(initialPath)
+    }, [buffer, initialPath])
+
+    const guardedClose = useCallback(() => {
+        if (!active) return
+        if (store.get(driveEditBufferAtom)?.saveStatus === "saving") return
+        const result = requestNavigation({kind: "close"})
+        if (result.run?.kind === "close") onClose()
+    }, [active, onClose, requestNavigation, store])
+
+    const keepEditing = useCallback(() => {
+        const bufferId = store.get(driveEditBufferAtom)?.bufferId
+        resolveNavigation("keep")
+        if (bufferId) focusEditor(bufferId)
+    }, [resolveNavigation, store])
+
+    const discard = useCallback(() => {
+        const current = store.get(driveEditBufferAtom)
+        const discardedDraft = current?.draft
+        const result = resolveNavigation("discard")
+        const intent = result.run
+        if (!intent) return
+        if (intent.kind === "close") {
+            onClose()
+            return
+        }
+        if (intent.kind === "select") {
+            setHeldInitialPath(intent.path)
+            if (!pendingDriveSwap.current) runNavigation?.(intent)
+            pendingDriveSwap.current = false
+            return
+        }
+        if (intent.kind !== "reload" || !current || !projectId) return
+
+        const requestId = newId()
+        reloadRequest.current = requestId
+        const canAdoptReload = () => {
+            const live = store.get(driveEditBufferAtom)
+            return Boolean(
+                reloadRequest.current === requestId &&
+                live?.bufferId === current.bufferId &&
+                live.draft === discardedDraft &&
+                live.saveStatus === "idle" &&
+                live.inflightRequestId === null &&
+                live.issue?.kind === "conflict" &&
+                current.issue?.kind === "conflict" &&
+                live.issue.reason === current.issue.reason &&
+                live.issue.theirMtime === current.issue.theirMtime,
+            )
+        }
+        void queryClient
+            .fetchQuery({
+                queryKey: mountFileContentQueryKey(
+                    projectId,
+                    current.targetMountId,
+                    current.targetPath,
+                ),
+                queryFn: ({signal}) =>
+                    readMountFile({
+                        projectId,
+                        mountId: current.targetMountId,
+                        path: current.targetPath,
+                        abortSignal: signal,
+                    }),
+                staleTime: 0,
+            })
+            .then((content) => {
+                // Drop a reload completion after the user has moved to another buffer.
+                if (!canAdoptReload()) return
+                reloadRequest.current = null
+                if (typeof content !== "string") {
+                    startSave(requestId)
+                    saveFailed({requestId, message: "Couldn’t reload this file"})
+                    return
+                }
+                const mtime = current.issue?.kind === "conflict" ? current.issue.theirMtime : null
+                replaceFromRemote({content, mtime})
+                focusEditor(current.bufferId)
+            })
+            .catch(() => {
+                if (!canAdoptReload()) return
+                reloadRequest.current = null
+                startSave(requestId)
+                saveFailed({requestId, message: "Couldn’t reload this file"})
+            })
+    }, [
+        onClose,
+        projectId,
+        queryClient,
+        replaceFromRemote,
+        resolveNavigation,
+        runNavigation,
+        saveFailed,
+        startSave,
+        store,
+    ])
+
+    return {
+        initialPath: heldInitialPath,
+        holdDrive,
+        onClose: guardedClose,
+        modal: {
+            open: active && Boolean(buffer?.pendingNavigation),
+            saving: buffer?.saveStatus === "saving",
+            displayPath: buffer?.displayPath ?? "",
+            onKeep: keepEditing,
+            onDiscard: discard,
+        },
+    }
+}

--- a/web/oss/src/components/Drives/editMode/useDriveEditController.ts
+++ b/web/oss/src/components/Drives/editMode/useDriveEditController.ts
@@ -1,8 +1,10 @@
-import {useCallback, useEffect, useRef, useState} from "react"
+import {type RefObject, useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import {
     mountDirQueryFamily,
+    mountDirQueryKey,
     mountFileContentQueryKey,
+    queryMountDir,
     readMountFile,
 } from "@agenta/entities/session"
 import {useAtomValue, useSetAtom, useStore} from "jotai"
@@ -11,7 +13,7 @@ import {queryClientAtom} from "jotai-tanstack-query"
 import {projectIdAtom} from "@/oss/state/project"
 
 import {useDriveFileText} from "../driveFileSource"
-import {resolveDriveFileKind} from "../driveKinds"
+import {resolveDriveFileKind, TEXT_CAP} from "../driveKinds"
 import {parentOf} from "../driveTreeView"
 import type {DriveScope} from "../driveTypes"
 import type {ResolvedMountPath} from "../useSessionDrive"
@@ -19,22 +21,34 @@ import type {ResolvedMountPath} from "../useSessionDrive"
 import {saveDriveFile} from "./api"
 import {
     driveEditAvailability,
-    driveEditBufferMode,
     driveEditorLanguage,
     EDIT_KINDS,
+    supportsMarkdownPreview,
+    utf8ByteLength,
     type DriveEditAvailability,
 } from "./model"
 import {
     driveEditBufferAtom,
-    driveEditFacetsAtom,
+    driveEditBufferIdAtomFamily,
+    driveEditDirtyAtomFamily,
+    driveEditDirtyPathAtomFamily,
+    driveEditDisplayPathAtomFamily,
+    driveEditingAtomFamily,
+    driveEditIssueAtomFamily,
+    driveEditNavigationBlockedAtomFamily,
+    driveEditPendingNavigationAtomFamily,
+    driveEditSavingAtomFamily,
+    editReloadFailedAtom,
     editSaveFailedAtom,
     editSaveSucceededAtom,
     markEditConflictAtom,
+    markNavigationBlockedWhileSavingAtom,
     openEditBufferAtom,
-    overwriteNextSaveAtom,
     replaceBufferFromRemoteAtom,
     requestNavigationAtom,
     resolveNavigationAtom,
+    setEditIssueAtom,
+    startEditReloadAtom,
     startEditSaveAtom,
     type NavigationIntent,
 } from "./state"
@@ -81,6 +95,7 @@ export function useDriveEditController({
     includeGitignored,
     select,
     close,
+    rootRef,
     registerNavigationRunner,
 }: {
     driveKey: string
@@ -93,56 +108,66 @@ export function useDriveEditController({
     includeGitignored: boolean
     select: (path: string | null) => void
     close: () => void
+    rootRef: RefObject<HTMLElement | null>
     registerNavigationRunner?: (runner: ((intent: NavigationIntent) => void) | null) => void
 }): DriveEditController {
     const store = useStore()
     const queryClient = useAtomValue(queryClientAtom)
     const projectId = useAtomValue(projectIdAtom)
-    const buffer = useAtomValue(driveEditBufferAtom)
-    const facets = useAtomValue(driveEditFacetsAtom)
+    const editing = useAtomValue(driveEditingAtomFamily(driveKey))
+    const dirty = useAtomValue(driveEditDirtyAtomFamily(driveKey))
+    const saving = useAtomValue(driveEditSavingAtomFamily(driveKey))
+    const issue = useAtomValue(driveEditIssueAtomFamily(driveKey))
+    const dirtyPath = useAtomValue(driveEditDirtyPathAtomFamily(driveKey))
+    const navigationBlocked = useAtomValue(driveEditNavigationBlockedAtomFamily(driveKey))
     const openBuffer = useSetAtom(openEditBufferAtom)
     const requestNavigation = useSetAtom(requestNavigationAtom)
     const startSave = useSetAtom(startEditSaveAtom)
     const saveSucceeded = useSetAtom(editSaveSucceededAtom)
     const saveFailed = useSetAtom(editSaveFailedAtom)
     const markConflict = useSetAtom(markEditConflictAtom)
-    const overwriteNextSave = useSetAtom(overwriteNextSaveAtom)
+    const setIssue = useSetAtom(setEditIssueAtom)
+    const markNavigationBlocked = useSetAtom(markNavigationBlockedWhileSavingAtom)
     const [justSavedPath, setJustSavedPath] = useState<string | null>(null)
-    const saveController = useRef<{
-        controller: AbortController
-        requestId: string
-    } | null>(null)
     const savedTimer = useRef<number | null>(null)
+    const mounted = useRef(true)
 
     const kind = resolveDriveFileKind(selectedPath ?? "")
     const editableKind = EDIT_KINDS.has(kind) && !selectedIsFolder
-    const resolved =
+    const selectedResolved =
         selectedPath && editableKind
             ? resolveMountPath(selectedPath)
             : (null as ResolvedMountPath | null)
-    const content = useDriveFileText(resolved?.mount ?? null, resolved?.path ?? "")
+    const knownTooLarge = selectedSize != null && selectedSize > TEXT_CAP
+    const contentResolved = knownTooLarge ? null : selectedResolved
+    const content = useDriveFileText(contentResolved?.mount ?? null, contentResolved?.path ?? "")
     const listingQuery = useAtomValue(
         mountDirQueryFamily({
-            mountId: resolved?.mount.id ?? "",
-            path: parentOf(resolved?.path ?? ""),
+            mountId: contentResolved?.mount.id ?? "",
+            path: parentOf(contentResolved?.path ?? ""),
             includeGitignored,
         }),
+    )
+    const contentByteLength = useMemo(
+        () => (typeof content.data === "string" ? utf8ByteLength(content.data) : null),
+        [content.data],
     )
     const contentAvailability = driveEditAvailability({
         kind,
         listingSize: selectedSize,
-        contentLength: typeof content.data === "string" ? content.data.length : null,
+        contentByteLength,
         isPending: content.isPending,
-        canEdit: canEditMountFiles && Boolean(projectId && resolved && selectedPath),
+        isFetching: content.isFetching,
+        canEdit: canEditMountFiles && Boolean(projectId && selectedResolved && selectedPath),
     })
     const availability =
         contentAvailability !== "enabled"
             ? contentAvailability
-            : listingQuery.isPending
+            : listingQuery.isPending || listingQuery.isFetching
               ? "loading"
               : Array.isArray(listingQuery.data)
                 ? "enabled"
-                : "unreadable"
+                : "listing-unavailable"
 
     const runIntent = useCallback(
         (intent: NavigationIntent) => {
@@ -155,10 +180,10 @@ export function useDriveEditController({
     const guardedSelect = useCallback(
         (path: string | null) => {
             if (path === selectedPath) return
-            const intent = requestNavigation({kind: "select", path})
+            const intent = requestNavigation({driveKey, intent: {kind: "select", path}})
             if (intent) runIntent(intent)
         },
-        [requestNavigation, runIntent, selectedPath],
+        [driveKey, requestNavigation, runIntent, selectedPath],
     )
 
     useEffect(() => {
@@ -171,128 +196,140 @@ export function useDriveEditController({
             availability !== "enabled" ||
             !projectId ||
             !selectedPath ||
-            !resolved ||
+            !selectedResolved ||
             typeof content.data !== "string" ||
             !Array.isArray(listingQuery.data)
         ) {
             return
         }
         const baseMtime =
-            listingQuery.data.find((file) => file.path === resolved.path)?.mtime ?? null
+            listingQuery.data.find((file) => file.path === selectedResolved.path)?.mtime ?? null
         setJustSavedPath(null)
         openBuffer({
             bufferId: newId(),
             driveKey,
-            targetMountId: resolved.mount.id,
-            targetPath: resolved.path,
+            targetMountId: selectedResolved.mount.id,
+            targetPath: selectedResolved.path,
             displayPath: selectedPath,
             scope,
             original: content.data,
             baseMtime,
-            mode: driveEditBufferMode(selectedPath),
+            includeGitignored,
+            supportsMarkdownPreview: supportsMarkdownPreview(selectedPath),
             language: driveEditorLanguage(selectedPath),
         })
     }, [
         availability,
         content.data,
         driveKey,
+        includeGitignored,
         listingQuery.data,
         openBuffer,
         projectId,
-        resolved,
         scope,
         selectedPath,
+        selectedResolved,
     ])
 
-    const onSave = useCallback(() => {
+    const save = useCallback(
+        (skipConflictCheck: boolean) => {
+            const current = store.get(driveEditBufferAtom)
+            if (
+                !current ||
+                current.driveKey !== driveKey ||
+                !projectId ||
+                current.saveStatus === "saving" ||
+                current.reloading ||
+                current.draft === current.original
+            ) {
+                return
+            }
+            const requestId = newId()
+            startSave(requestId)
+            void saveDriveFile({
+                queryClient,
+                projectId,
+                targetMountId: current.targetMountId,
+                targetPath: current.targetPath,
+                draft: current.draft,
+                baseMtime: current.baseMtime,
+                includeGitignored: current.includeGitignored,
+                skipConflictCheck,
+            })
+                .then((result) => {
+                    if (result.kind === "conflict") {
+                        markConflict({
+                            requestId,
+                            reason: result.reason,
+                            theirMtime: result.theirMtime,
+                        })
+                        return
+                    }
+                    if (result.kind === "error") {
+                        saveFailed({requestId, message: result.message})
+                        return
+                    }
+                    if (store.get(driveEditBufferAtom)?.inflightRequestId !== requestId) return
+                    saveSucceeded(requestId)
+                    if (!mounted.current) return
+                    setJustSavedPath(current.displayPath)
+                    if (savedTimer.current != null) window.clearTimeout(savedTimer.current)
+                    savedTimer.current = window.setTimeout(() => setJustSavedPath(null), 2_000)
+                })
+                .catch((error: unknown) => {
+                    saveFailed({
+                        requestId,
+                        message: error instanceof Error ? error.message : "Couldn’t save this file",
+                    })
+                })
+        },
+        [
+            driveKey,
+            markConflict,
+            projectId,
+            queryClient,
+            saveFailed,
+            saveSucceeded,
+            startSave,
+            store,
+        ],
+    )
+
+    const onSave = useCallback(() => save(false), [save])
+    const onCancel = useCallback(() => {
         const current = store.get(driveEditBufferAtom)
-        if (
-            !current ||
-            !projectId ||
-            current.saveStatus === "saving" ||
-            current.draft === current.original
-        ) {
+        if (current?.driveKey === driveKey && current.saveStatus === "saving") {
+            markNavigationBlocked(driveKey)
             return
         }
-        const requestId = newId()
-        const controller = new AbortController()
-        saveController.current?.controller.abort()
-        saveController.current = {controller, requestId}
-        const skipConflictCheck = current.skipConflictCheckOnce
-        startSave(requestId)
-        void saveDriveFile({
-            queryClient,
-            projectId,
-            targetMountId: current.targetMountId,
-            targetPath: current.targetPath,
-            draft: current.draft,
-            baseMtime: current.baseMtime,
-            includeGitignored,
-            skipConflictCheck,
-            signal: controller.signal,
-        })
-            .then((result) => {
-                if (result.kind === "conflict") {
-                    markConflict({requestId, reason: result.reason, theirMtime: result.theirMtime})
-                    return
-                }
-                if (result.kind === "error") {
-                    saveFailed({requestId, message: result.message})
-                    return
-                }
-                if (store.get(driveEditBufferAtom)?.inflightRequestId !== requestId) return
-                saveSucceeded(requestId)
-                setJustSavedPath(current.displayPath)
-                if (savedTimer.current != null) window.clearTimeout(savedTimer.current)
-                savedTimer.current = window.setTimeout(() => setJustSavedPath(null), 2_000)
-            })
-            .catch((error: unknown) => {
-                if (controller.signal.aborted) return
-                saveFailed({
-                    requestId,
-                    message: error instanceof Error ? error.message : "Couldn’t save this file",
-                })
-            })
-    }, [
-        includeGitignored,
-        markConflict,
-        projectId,
-        queryClient,
-        saveFailed,
-        saveSucceeded,
-        startSave,
-        store,
-    ])
-
-    const onCancel = useCallback(() => {
-        if (store.get(driveEditBufferAtom)?.saveStatus === "saving") return
-        const intent = requestNavigation({kind: "cancel"})
+        const intent = requestNavigation({driveKey, intent: {kind: "cancel"}})
         if (intent) runIntent(intent)
-    }, [requestNavigation, runIntent, store])
+    }, [driveKey, markNavigationBlocked, requestNavigation, runIntent, store])
     const onReload = useCallback(() => {
-        const intent = requestNavigation({kind: "reload"})
+        const intent = requestNavigation({driveKey, intent: {kind: "reload"}})
         if (intent) runIntent(intent)
-    }, [requestNavigation, runIntent])
+    }, [driveKey, requestNavigation, runIntent])
     const onOverwrite = useCallback(() => {
-        overwriteNextSave()
-        onSave()
-    }, [onSave, overwriteNextSave])
+        setIssue({driveKey, issue: null})
+        save(true)
+    }, [driveKey, save, setIssue])
 
     useEffect(() => {
         const onKeyDown = (event: KeyboardEvent) => {
-            if (store.get(driveEditBufferAtom)?.pendingNavigation) return
+            if (!rootRef.current?.contains(event.target as Node)) return
+            if (store.get(driveEditPendingNavigationAtomFamily(driveKey))) return
             const command = event.metaKey || event.ctrlKey
             if (command && event.key.toLowerCase() === "e" && availability === "enabled") {
                 event.preventDefault()
                 onEdit()
                 return
             }
-            if (command && event.key.toLowerCase() === "s" && facets.editing) {
+            if (command && event.key.toLowerCase() === "s" && editing) {
                 event.preventDefault()
                 onSave()
                 return
             }
-            if (event.key === "Escape" && facets.editing) {
+            if (event.key === "Escape" && editing) {
                 event.preventDefault()
                 event.stopPropagation()
                 onCancel()
@@ -300,49 +337,54 @@ export function useDriveEditController({
         }
         window.addEventListener("keydown", onKeyDown, true)
         return () => window.removeEventListener("keydown", onKeyDown, true)
-    }, [availability, facets.editing, onCancel, onEdit, onSave, store])
+    }, [availability, driveKey, editing, onCancel, onEdit, onSave, rootRef, store])
 
     useEffect(() => {
-        if (!facets.dirty) return
+        if (!dirty) return
         const onBeforeUnload = (event: BeforeUnloadEvent) => event.preventDefault()
         window.addEventListener("beforeunload", onBeforeUnload)
         return () => window.removeEventListener("beforeunload", onBeforeUnload)
-    }, [facets.dirty])
+    }, [dirty])
 
-    useEffect(
-        () => () => {
-            const inflight = saveController.current
-            inflight?.controller.abort()
-            if (inflight) {
-                store.set(editSaveFailedAtom, {
-                    requestId: inflight.requestId,
-                    message: "Save was interrupted",
-                })
+    useEffect(() => {
+        mounted.current = true
+        return () => {
+            mounted.current = false
+            const current = store.get(driveEditBufferAtom)
+            if (
+                current?.driveKey === driveKey &&
+                !isDirtyBuffer(current) &&
+                !current.issue &&
+                current.saveStatus !== "saving" &&
+                !current.reloading
+            ) {
+                store.set(driveEditBufferAtom, null)
             }
             if (savedTimer.current != null) window.clearTimeout(savedTimer.current)
-        },
-        [store],
-    )
+        }
+    }, [driveKey, store])
 
     const justSaved = justSavedPath === selectedPath
-    const statusText = facets.saving
-        ? "Saving"
+    const statusText = saving
+        ? navigationBlocked
+            ? "Saving — wait before leaving"
+            : "Saving"
         : justSaved
           ? "Saved"
-          : facets.issue?.kind === "error"
-            ? facets.issue.message
-            : facets.issue?.kind === "conflict"
+          : issue?.kind === "error"
+            ? issue.message
+            : issue?.kind === "conflict"
               ? "This file changed while you were editing"
               : ""
 
     return {
         availability,
-        editing: facets.editing,
-        dirty: facets.dirty,
-        saving: facets.saving,
+        editing,
+        dirty,
+        saving,
         justSaved,
         statusText,
-        dirtyPath: facets.dirty ? (buffer?.displayPath ?? null) : null,
+        dirtyPath,
         onEdit,
         onSave,
         onCancel,
@@ -351,6 +393,9 @@ export function useDriveEditController({
         select: guardedSelect,
     }
 }
+
+const isDirtyBuffer = (buffer: {original: string; draft: string}) =>
+    buffer.original !== buffer.draft
 
 export function useDriveEditGuard({
     active,
@@ -367,25 +412,31 @@ export function useDriveEditGuard({
     onClose: () => void
     runNavigation: (intent: NavigationIntent) => void
 }) {
+    const ownerDriveKey = heldDriveKey
     const store = useStore()
     const projectId = useAtomValue(projectIdAtom)
     const queryClient = useAtomValue(queryClientAtom)
-    const buffer = useAtomValue(driveEditBufferAtom)
+    const editing = useAtomValue(driveEditingAtomFamily(ownerDriveKey))
+    const dirty = useAtomValue(driveEditDirtyAtomFamily(ownerDriveKey))
+    const bufferId = useAtomValue(driveEditBufferIdAtomFamily(ownerDriveKey))
+    const saving = useAtomValue(driveEditSavingAtomFamily(ownerDriveKey))
+    const pendingNavigation = useAtomValue(driveEditPendingNavigationAtomFamily(ownerDriveKey))
+    const displayPath = useAtomValue(driveEditDisplayPathAtomFamily(ownerDriveKey))
     const requestNavigation = useSetAtom(requestNavigationAtom)
     const resolveNavigation = useSetAtom(resolveNavigationAtom)
     const replaceFromRemote = useSetAtom(replaceBufferFromRemoteAtom)
-    const startSave = useSetAtom(startEditSaveAtom)
-    const saveFailed = useSetAtom(editSaveFailedAtom)
+    const startReload = useSetAtom(startEditReloadAtom)
+    const reloadFailed = useSetAtom(editReloadFailedAtom)
+    const markNavigationBlocked = useSetAtom(markNavigationBlockedWhileSavingAtom)
     const [heldInitialPath, setHeldInitialPath] = useState(initialPath)
     const previousInitialPath = useRef(initialPath)
     const requestedDriveSwap = useRef<string | null>(null)
     const pendingDriveSwap = useRef(false)
-    const reloadRequest = useRef<string | null>(null)
-    const holdDrive = Boolean(active && buffer && driveKey !== heldDriveKey)
+    const holdDrive = Boolean(active && editing && driveKey !== heldDriveKey)
 
     useEffect(() => {
         if (!active) {
-            if (!store.get(driveEditBufferAtom)) {
+            if (!store.get(driveEditBufferAtom) || !editing) {
                 previousInitialPath.current = initialPath
                 setHeldInitialPath(initialPath)
             }
@@ -394,50 +445,62 @@ export function useDriveEditGuard({
         if (previousInitialPath.current === initialPath) return
         previousInitialPath.current = initialPath
         const current = store.get(driveEditBufferAtom)
-        if (!current) {
+        if (!current || current.driveKey !== ownerDriveKey) {
             setHeldInitialPath(initialPath)
             return
         }
-        const intent = requestNavigation({kind: "select", path: initialPath ?? null})
+        const intent = requestNavigation({
+            driveKey: ownerDriveKey,
+            intent: {kind: "select", path: initialPath ?? null},
+        })
         if (intent?.kind === "select") {
             setHeldInitialPath(intent.path)
             runNavigation(intent)
         }
-    }, [active, initialPath, requestNavigation, runNavigation, store])
+    }, [active, editing, initialPath, ownerDriveKey, requestNavigation, runNavigation, store])
 
     useEffect(() => {
-        if (!holdDrive || !buffer) {
-            if (!buffer) requestedDriveSwap.current = null
+        if (!holdDrive || !bufferId) {
+            if (!bufferId) requestedDriveSwap.current = null
             if (!holdDrive) pendingDriveSwap.current = false
             return
         }
-        const token = `${buffer.bufferId}:${driveKey}`
+        if (saving) return
+        const token = `${bufferId}:${driveKey}`
         if (requestedDriveSwap.current === token) return
         requestedDriveSwap.current = token
         pendingDriveSwap.current = true
-        requestNavigation({kind: "select", path: initialPath ?? null})
-    }, [buffer, driveKey, holdDrive, initialPath, requestNavigation])
+        requestNavigation({
+            driveKey: ownerDriveKey,
+            intent: {kind: "select", path: initialPath ?? null},
+        })
+    }, [bufferId, driveKey, holdDrive, initialPath, ownerDriveKey, requestNavigation, saving])
 
     useEffect(() => {
-        if (!buffer) setHeldInitialPath(initialPath)
-    }, [buffer, initialPath])
+        if (!editing) setHeldInitialPath(initialPath)
+    }, [editing, initialPath])
 
     const guardedClose = useCallback(() => {
         if (!active) return
-        if (store.get(driveEditBufferAtom)?.saveStatus === "saving") return
-        if (requestNavigation({kind: "close"})) onClose()
-    }, [active, onClose, requestNavigation, store])
+        const current = store.get(driveEditBufferAtom)
+        if (current?.driveKey === ownerDriveKey && current.saveStatus === "saving") {
+            markNavigationBlocked(ownerDriveKey)
+            return
+        }
+        if (requestNavigation({driveKey: ownerDriveKey, intent: {kind: "close"}})) onClose()
+    }, [active, markNavigationBlocked, onClose, ownerDriveKey, requestNavigation, store])
 
     const keepEditing = useCallback(() => {
-        const bufferId = store.get(driveEditBufferAtom)?.bufferId
-        resolveNavigation("keep")
-        if (bufferId) focusEditor(bufferId)
-    }, [resolveNavigation, store])
+        const current = store.get(driveEditBufferAtom)
+        const ownedBufferId = current?.driveKey === ownerDriveKey ? current.bufferId : null
+        resolveNavigation({driveKey: ownerDriveKey, resolution: "keep"})
+        if (ownedBufferId) focusEditor(ownedBufferId)
+    }, [ownerDriveKey, resolveNavigation, store])
 
     const discard = useCallback(() => {
         const current = store.get(driveEditBufferAtom)
-        const discardedDraft = current?.draft
-        const intent = resolveNavigation("discard")
+        if (!current || current.driveKey !== ownerDriveKey) return
+        const intent = resolveNavigation({driveKey: ownerDriveKey, resolution: "discard"})
         if (!intent) return
         if (intent.kind === "close") {
             onClose()
@@ -449,26 +512,21 @@ export function useDriveEditGuard({
             pendingDriveSwap.current = false
             return
         }
-        if (intent.kind !== "reload" || !current || !projectId) return
+        if (intent.kind !== "reload" || !projectId) return
 
         const requestId = newId()
-        reloadRequest.current = requestId
+        startReload(requestId)
         const canAdoptReload = () => {
             const live = store.get(driveEditBufferAtom)
             return Boolean(
-                reloadRequest.current === requestId &&
-                live?.bufferId === current.bufferId &&
-                live.draft === discardedDraft &&
-                live.saveStatus === "idle" &&
-                live.inflightRequestId === null &&
-                live.issue?.kind === "conflict" &&
-                current.issue?.kind === "conflict" &&
-                live.issue.reason === current.issue.reason &&
-                live.issue.theirMtime === current.issue.theirMtime,
+                live?.driveKey === ownerDriveKey &&
+                live.bufferId === current.bufferId &&
+                live.reloading &&
+                live.inflightReloadRequestId === requestId,
             )
         }
-        void queryClient
-            .fetchQuery({
+        void (async () => {
+            const content = await queryClient.fetchQuery({
                 queryKey: mountFileContentQueryKey(
                     projectId,
                     current.targetMountId,
@@ -483,45 +541,63 @@ export function useDriveEditGuard({
                     }),
                 staleTime: 0,
             })
-            .then((content) => {
-                // Drop a reload completion after the user has moved to another buffer.
-                if (!canAdoptReload()) return
-                reloadRequest.current = null
-                if (typeof content !== "string") {
-                    startSave(requestId)
-                    saveFailed({requestId, message: "Couldn’t reload this file"})
-                    return
-                }
-                const mtime = current.issue?.kind === "conflict" ? current.issue.theirMtime : null
-                replaceFromRemote({content, mtime})
-                focusEditor(current.bufferId)
+            if (!canAdoptReload()) return
+            if (typeof content !== "string") throw new Error("Couldn’t reload this file")
+            const directory = parentOf(current.targetPath)
+            const listing = await queryClient.fetchQuery({
+                queryKey: mountDirQueryKey(
+                    projectId,
+                    current.targetMountId,
+                    directory,
+                    current.includeGitignored,
+                ),
+                queryFn: ({signal}) =>
+                    queryMountDir({
+                        projectId,
+                        mountId: current.targetMountId,
+                        path: directory,
+                        withCounts: true,
+                        includeGitignored: current.includeGitignored,
+                        abortSignal: signal,
+                    }),
+                staleTime: 0,
             })
-            .catch(() => {
-                if (!canAdoptReload()) return
-                reloadRequest.current = null
-                startSave(requestId)
-                saveFailed({requestId, message: "Couldn’t reload this file"})
-            })
+            if (!canAdoptReload()) return
+            const mtime = listing?.find((file) => file.path === current.targetPath)?.mtime ?? null
+            replaceFromRemote({requestId, content, mtime})
+            focusEditor(current.bufferId)
+        })().catch(() => {
+            if (!canAdoptReload()) return
+            reloadFailed({requestId, message: "Couldn’t reload this file"})
+        })
     }, [
         onClose,
+        ownerDriveKey,
         projectId,
         queryClient,
+        reloadFailed,
         replaceFromRemote,
         resolveNavigation,
         runNavigation,
-        saveFailed,
-        startSave,
+        startReload,
         store,
     ])
+
+    useEffect(() => {
+        if (active && !dirty && pendingNavigation?.kind === "reload") discard()
+    }, [active, dirty, discard, pendingNavigation])
 
     return {
         initialPath: heldInitialPath,
         holdDrive,
         onClose: guardedClose,
         modal: {
-            open: active && Boolean(buffer?.pendingNavigation),
-            saving: buffer?.saveStatus === "saving",
-            displayPath: buffer?.displayPath ?? "",
+            open:
+                active &&
+                pendingNavigation !== null &&
+                (dirty || pendingNavigation.kind !== "reload"),
+            saving,
+            displayPath,
             onKeep: keepEditing,
             onDiscard: discard,
         },

--- a/web/oss/src/components/Drives/editMode/useDriveEditController.ts
+++ b/web/oss/src/components/Drives/editMode/useDriveEditController.ts
@@ -12,6 +12,7 @@ import {projectIdAtom} from "@/oss/state/project"
 
 import {useDriveFileText} from "../driveFileSource"
 import {resolveDriveFileKind} from "../driveKinds"
+import {parentOf} from "../driveTreeView"
 import type {DriveScope} from "../driveTypes"
 import type {ResolvedMountPath} from "../useSessionDrive"
 
@@ -45,11 +46,10 @@ const newId = (): string =>
 
 const focusEditor = (bufferId: string) => {
     requestAnimationFrame(() => {
-        const container = Array.from(
-            document.querySelectorAll<HTMLElement>("[data-drive-edit-buffer]"),
-        ).find((element) => element.dataset.driveEditBuffer === bufferId)
-        container
-            ?.querySelector<HTMLElement>(".agenta-shared-editor [contenteditable='true']")
+        document
+            .querySelector<HTMLElement>(
+                `[data-drive-edit-buffer="${bufferId}"] .agenta-shared-editor [contenteditable='true']`,
+            )
             ?.focus()
     })
 }
@@ -65,7 +65,6 @@ export interface DriveEditController {
     onEdit: () => void
     onSave: () => void
     onCancel: () => void
-    onRetry: () => void
     onReload: () => void
     onOverwrite: () => void
     select: (path: string | null) => void
@@ -122,13 +121,10 @@ export function useDriveEditController({
             ? resolveMountPath(selectedPath)
             : (null as ResolvedMountPath | null)
     const content = useDriveFileText(resolved?.mount ?? null, resolved?.path ?? "")
-    const directory = resolved?.path.includes("/")
-        ? resolved.path.slice(0, resolved.path.lastIndexOf("/"))
-        : ""
     const listingQuery = useAtomValue(
         mountDirQueryFamily({
             mountId: resolved?.mount.id ?? "",
-            path: directory,
+            path: parentOf(resolved?.path ?? ""),
             includeGitignored,
         }),
     )
@@ -159,8 +155,8 @@ export function useDriveEditController({
     const guardedSelect = useCallback(
         (path: string | null) => {
             if (path === selectedPath) return
-            const result = requestNavigation({kind: "select", path})
-            if (result.run) runIntent(result.run)
+            const intent = requestNavigation({kind: "select", path})
+            if (intent) runIntent(intent)
         },
         [requestNavigation, runIntent, selectedPath],
     )
@@ -200,7 +196,6 @@ export function useDriveEditController({
         availability,
         content.data,
         driveKey,
-        includeGitignored,
         listingQuery.data,
         openBuffer,
         projectId,
@@ -271,12 +266,12 @@ export function useDriveEditController({
 
     const onCancel = useCallback(() => {
         if (store.get(driveEditBufferAtom)?.saveStatus === "saving") return
-        const result = requestNavigation({kind: "cancel"})
-        if (result.run) runIntent(result.run)
+        const intent = requestNavigation({kind: "cancel"})
+        if (intent) runIntent(intent)
     }, [requestNavigation, runIntent, store])
     const onReload = useCallback(() => {
-        const result = requestNavigation({kind: "reload"})
-        if (result.run) runIntent(result.run)
+        const intent = requestNavigation({kind: "reload"})
+        if (intent) runIntent(intent)
     }, [requestNavigation, runIntent])
     const onOverwrite = useCallback(() => {
         overwriteNextSave()
@@ -351,7 +346,6 @@ export function useDriveEditController({
         onEdit,
         onSave,
         onCancel,
-        onRetry: onSave,
         onReload,
         onOverwrite,
         select: guardedSelect,
@@ -368,10 +362,10 @@ export function useDriveEditGuard({
 }: {
     active: boolean
     initialPath?: string | null
-    driveKey?: string
-    heldDriveKey?: string
+    driveKey: string
+    heldDriveKey: string
     onClose: () => void
-    runNavigation?: (intent: NavigationIntent) => void
+    runNavigation: (intent: NavigationIntent) => void
 }) {
     const store = useStore()
     const projectId = useAtomValue(projectIdAtom)
@@ -387,9 +381,7 @@ export function useDriveEditGuard({
     const requestedDriveSwap = useRef<string | null>(null)
     const pendingDriveSwap = useRef(false)
     const reloadRequest = useRef<string | null>(null)
-    const holdDrive = Boolean(
-        active && buffer && driveKey !== undefined && driveKey !== heldDriveKey,
-    )
+    const holdDrive = Boolean(active && buffer && driveKey !== heldDriveKey)
 
     useEffect(() => {
         if (!active) {
@@ -406,10 +398,10 @@ export function useDriveEditGuard({
             setHeldInitialPath(initialPath)
             return
         }
-        const result = requestNavigation({kind: "select", path: initialPath ?? null})
-        if (result.run?.kind === "select") {
-            setHeldInitialPath(result.run.path)
-            runNavigation?.(result.run)
+        const intent = requestNavigation({kind: "select", path: initialPath ?? null})
+        if (intent?.kind === "select") {
+            setHeldInitialPath(intent.path)
+            runNavigation(intent)
         }
     }, [active, initialPath, requestNavigation, runNavigation, store])
 
@@ -433,8 +425,7 @@ export function useDriveEditGuard({
     const guardedClose = useCallback(() => {
         if (!active) return
         if (store.get(driveEditBufferAtom)?.saveStatus === "saving") return
-        const result = requestNavigation({kind: "close"})
-        if (result.run?.kind === "close") onClose()
+        if (requestNavigation({kind: "close"})) onClose()
     }, [active, onClose, requestNavigation, store])
 
     const keepEditing = useCallback(() => {
@@ -446,8 +437,7 @@ export function useDriveEditGuard({
     const discard = useCallback(() => {
         const current = store.get(driveEditBufferAtom)
         const discardedDraft = current?.draft
-        const result = resolveNavigation("discard")
-        const intent = result.run
+        const intent = resolveNavigation("discard")
         if (!intent) return
         if (intent.kind === "close") {
             onClose()
@@ -455,7 +445,7 @@ export function useDriveEditGuard({
         }
         if (intent.kind === "select") {
             setHeldInitialPath(intent.path)
-            if (!pendingDriveSwap.current) runNavigation?.(intent)
+            if (!pendingDriveSwap.current) runNavigation(intent)
             pendingDriveSwap.current = false
             return
         }

--- a/web/oss/src/components/Drives/renderers.tsx
+++ b/web/oss/src/components/Drives/renderers.tsx
@@ -26,9 +26,11 @@ import {
     useDriveMediaSrc,
     useDriveObjectUrl,
 } from "./driveFileSource"
-import {driveCodeLanguage, resolveDriveFileKind, type DriveFileKind} from "./driveKinds"
+import {driveCodeLanguage, resolveDriveFileKind, TEXT_CAP, type DriveFileKind} from "./driveKinds"
 import {fetchMountFileBlob} from "./driveMedia"
 import {humanSize} from "./driveTree"
+
+export {TEXT_CAP} from "./driveKinds"
 
 // Lexical + lazy-Shiki code block (theme-paired highlighting). Loaded only when a code body
 // actually opens — @lexical/code-shiki is an ~8.7 MB chunk that must stay out of first load.
@@ -38,7 +40,6 @@ const LazyCodeBlock = dynamic(() => import("@/oss/components/DynamicCodeBlock/Co
 })
 
 // Inline-render caps (bytes). Over-cap is a graceful card, never a frozen tab.
-const TEXT_CAP = 1.5 * 1024 * 1024
 const MEDIA_CAP = 25 * 1024 * 1024
 
 /** Quote-aware-enough CSV parse for previews (RFC 4180 essentials: quotes, escaped quotes,

--- a/web/oss/src/components/Drives/useDriveDrop.ts
+++ b/web/oss/src/components/Drives/useDriveDrop.ts
@@ -61,7 +61,6 @@ export function useDriveDrop({
     // dragenter/leave flicker from moving across child elements).
     const depth = useRef(0)
     useEffect(() => {
-        if (!enabled) return
         const has = (e: DragEvent) => Array.from(e.dataTransfer?.types ?? []).includes("Files")
         const onEnter = (e: DragEvent) => {
             if (has(e)) {
@@ -79,6 +78,11 @@ export function useDriveDrop({
             setHoverPath(null)
             clearSpring()
         }
+        // Disabling mid-drag must also clear whatever the drag left behind.
+        if (!enabled) {
+            onEnd()
+            return
+        }
         window.addEventListener("dragenter", onEnter)
         window.addEventListener("dragleave", onLeave)
         window.addEventListener("drop", onEnd)
@@ -90,14 +94,6 @@ export function useDriveDrop({
             window.removeEventListener("dragend", onEnd)
         }
     }, [enabled, clearSpring])
-
-    useEffect(() => {
-        if (enabled) return
-        depth.current = 0
-        clearSpring()
-        setDragging(false)
-        setHoverPath(null)
-    }, [clearSpring, enabled])
 
     const startSpring = useCallback(
         (path: string) => {

--- a/web/oss/src/components/Drives/useDriveDrop.ts
+++ b/web/oss/src/components/Drives/useDriveDrop.ts
@@ -91,6 +91,14 @@ export function useDriveDrop({
         }
     }, [enabled, clearSpring])
 
+    useEffect(() => {
+        if (enabled) return
+        depth.current = 0
+        clearSpring()
+        setDragging(false)
+        setHoverPath(null)
+    }, [clearSpring, enabled])
+
     const startSpring = useCallback(
         (path: string) => {
             if (springPath.current === path) return // already counting down on this folder
@@ -110,19 +118,19 @@ export function useDriveDrop({
             // Folder targets stop propagation, so the container's onDragEnter only fires over empty
             // space — which is how the hover clears when you move off a folder.
             onDragEnter: (e: React.DragEvent) => {
-                if (!isFileDrag(e)) return
+                if (!enabled || !isFileDrag(e)) return
                 e.preventDefault()
                 e.stopPropagation()
                 setHoverPath(path)
                 startSpring(path)
             },
             onDragOver: (e: React.DragEvent) => {
-                if (!isFileDrag(e)) return
+                if (!enabled || !isFileDrag(e)) return
                 e.preventDefault()
                 e.stopPropagation()
             },
             onDrop: (e: React.DragEvent) => {
-                if (!isFileDrag(e)) return
+                if (!enabled || !isFileDrag(e)) return
                 e.preventDefault()
                 e.stopPropagation()
                 void readDroppedFiles(e.dataTransfer).then((files) => {
@@ -132,21 +140,21 @@ export function useDriveDrop({
                 clearSpring()
             },
         }),
-        [onUpload, startSpring, clearSpring],
+        [enabled, onUpload, startSpring, clearSpring],
     )
 
     const containerDropProps = useCallback(
         (currentFolder: string) => ({
             onDragEnter: (e: React.DragEvent) => {
-                if (!isFileDrag(e)) return
+                if (!enabled || !isFileDrag(e)) return
                 setHoverPath(null)
                 clearSpring()
             },
             onDragOver: (e: React.DragEvent) => {
-                if (isFileDrag(e)) e.preventDefault()
+                if (enabled && isFileDrag(e)) e.preventDefault()
             },
             onDrop: (e: React.DragEvent) => {
-                if (!isFileDrag(e)) return
+                if (!enabled || !isFileDrag(e)) return
                 e.preventDefault()
                 void readDroppedFiles(e.dataTransfer).then((files) => {
                     if (files.length) onUpload(files, currentFolder)
@@ -155,7 +163,7 @@ export function useDriveDrop({
                 clearSpring()
             },
         }),
-        [onUpload, clearSpring],
+        [enabled, onUpload, clearSpring],
     )
 
     return {dragging, hoverPath, folderDropProps, containerDropProps}

--- a/web/oss/src/components/Drives/useDriveUploads.ts
+++ b/web/oss/src/components/Drives/useDriveUploads.ts
@@ -88,9 +88,10 @@ export function useDriveUploads({
     )
     // Drag-and-drop uploads: highlight + spring-load into folders, drop to upload. Disabled in the
     // local-file preview (no mount to write to).
+    // useDriveDrop gates every handler on `enabled`, so onUpload is unreachable when it is off.
     const drop = useDriveDrop({
         enabled: canUpload && enabled,
-        onUpload: canUpload && enabled ? uploadIntoFolder : () => {},
+        onUpload: uploadIntoFolder,
         onNavigate: select,
     })
 

--- a/web/oss/src/components/Drives/useDriveUploads.ts
+++ b/web/oss/src/components/Drives/useDriveUploads.ts
@@ -31,6 +31,7 @@ export function useDriveUploads({
     drive,
     explicitFiles,
     select,
+    enabled = true,
     stagedFiles,
     onStagedChange,
 }: {
@@ -39,6 +40,7 @@ export function useDriveUploads({
     explicitFiles?: MountFile[]
     /** The explorer's selection callback — a drop springs-loads into the hovered folder. */
     select: (path: string | null) => void
+    enabled?: boolean
     stagedFiles?: DroppedFile[]
     onStagedChange?: (files: DroppedFile[]) => void
 }) {
@@ -87,8 +89,8 @@ export function useDriveUploads({
     // Drag-and-drop uploads: highlight + spring-load into folders, drop to upload. Disabled in the
     // local-file preview (no mount to write to).
     const drop = useDriveDrop({
-        enabled: canUpload,
-        onUpload: canUpload ? uploadIntoFolder : () => {},
+        enabled: canUpload && enabled,
+        onUpload: canUpload && enabled ? uploadIntoFolder : () => {},
         onNavigate: select,
     })
 

--- a/web/oss/src/components/Drives/useMountUpload.ts
+++ b/web/oss/src/components/Drives/useMountUpload.ts
@@ -1,7 +1,6 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
-import {type Mount} from "@agenta/entities/session"
-import {type QueryClient} from "@tanstack/react-query"
+import {invalidateMountListings, type Mount} from "@agenta/entities/session"
 import {useAtomValue} from "jotai"
 import {queryClientAtom} from "jotai-tanstack-query"
 
@@ -64,16 +63,6 @@ export interface MountUpload {
     upload: (files: DroppedFile[], target: MountUploadTarget) => void
     retry: (id: string) => void
     dismiss: (id: string) => void
-}
-
-export function invalidateMountListings(
-    queryClient: QueryClient,
-    projectId: string | null | undefined,
-): void {
-    if (!projectId) return
-    for (const root of ["files", "files-latest", "files-root", "files-dir"]) {
-        void queryClient.invalidateQueries({queryKey: ["mounts", root, projectId]})
-    }
 }
 
 export function useMountUpload(): MountUpload {

--- a/web/oss/src/components/Drives/useMountUpload.ts
+++ b/web/oss/src/components/Drives/useMountUpload.ts
@@ -1,6 +1,7 @@
 import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import {type Mount} from "@agenta/entities/session"
+import {type QueryClient} from "@tanstack/react-query"
 import {useAtomValue} from "jotai"
 import {queryClientAtom} from "jotai-tanstack-query"
 
@@ -65,6 +66,16 @@ export interface MountUpload {
     dismiss: (id: string) => void
 }
 
+export function invalidateMountListings(
+    queryClient: QueryClient,
+    projectId: string | null | undefined,
+): void {
+    if (!projectId) return
+    for (const root of ["files", "files-latest", "files-root", "files-dir"]) {
+        void queryClient.invalidateQueries({queryKey: ["mounts", root, projectId]})
+    }
+}
+
 export function useMountUpload(): MountUpload {
     const projectId = useAtomValue(projectIdAtom)
     const queryClient = useAtomValue(queryClientAtom)
@@ -82,12 +93,10 @@ export function useMountUpload(): MountUpload {
         setItems((prev) => prev.map((it) => (it.id === id ? {...it, ...next} : it)))
     }, [])
 
-    const refreshListing = useCallback(() => {
-        // Prefix-match every mount file-query root for the project (dir listing, root, latest, summary).
-        for (const root of ["files", "files-latest", "files-root", "files-dir"]) {
-            void queryClient.invalidateQueries({queryKey: ["mounts", root, projectId]})
-        }
-    }, [queryClient, projectId])
+    const refreshListing = useCallback(
+        () => invalidateMountListings(queryClient, projectId),
+        [queryClient, projectId],
+    )
 
     const run = useCallback(
         (id: string) => {

--- a/web/packages/agenta-entities/src/session/api/api.ts
+++ b/web/packages/agenta-entities/src/session/api/api.ts
@@ -12,6 +12,7 @@ import {safeParseWithLogging} from "../../shared/utils/zodSchema"
 import {
     mountFileContentResponseSchema,
     mountFileListResponseSchema,
+    mountFileWrittenResponseSchema,
     sessionInteractionResponseSchema,
     sessionInteractionsResponseSchema,
     sessionRecordsQueryResponseSchema,
@@ -36,6 +37,7 @@ import {
     getLowPrioritySessionsClient,
     getMountsClient,
     getSessionsClient,
+    isAbortError,
     projectScopedRequest,
 } from "./client"
 
@@ -687,4 +689,53 @@ export async function readMountFile({
 
     const validated = safeParseWithLogging(mountFileContentResponseSchema, data, "[readMountFile]")
     return validated?.content ?? null
+}
+
+export async function writeMountFile({
+    projectId,
+    mountId,
+    path,
+    content,
+    signal,
+}: {
+    projectId: string
+    mountId: string
+    path: string
+    content: string
+    signal?: AbortSignal
+}): Promise<{ok: true; size: number} | {ok: false; message: string}> {
+    if (!projectId || !mountId || !path) {
+        return {ok: false, message: "Missing project, mount, or file path"}
+    }
+
+    try {
+        // Multipart is required because the generated raw-body method drops file content.
+        const data = await getMountsClient().uploadMountFile(
+            {
+                mount_id: mountId,
+                path,
+                file: {
+                    data: new Blob([content], {type: "text/plain;charset=utf-8"}),
+                    filename: path.split("/").pop() || "file",
+                },
+            },
+            {
+                ...projectScopedRequest(projectId, undefined, signal, 0),
+                timeoutInSeconds: 30,
+            },
+        )
+        const validated = safeParseWithLogging(
+            mountFileWrittenResponseSchema,
+            data,
+            "[writeMountFile]",
+        )
+        if (!validated) return {ok: false, message: "The mount returned an invalid response"}
+        return {ok: true, size: validated.size}
+    } catch (error) {
+        if (isAbortError(error)) throw error
+        return {
+            ok: false,
+            message: error instanceof Error ? error.message : String(error),
+        }
+    }
 }

--- a/web/packages/agenta-entities/src/session/core/schema.ts
+++ b/web/packages/agenta-entities/src/session/core/schema.ts
@@ -168,6 +168,11 @@ export const mountFileContentResponseSchema = z.object({
     content: z.string().nullish(),
 })
 
+export const mountFileWrittenResponseSchema = z.object({
+    path: z.string(),
+    size: z.number(),
+})
+
 /** A mount row (a drive): the durable prefix bound to a session (or, later, an agent). */
 export const mountSchema = z.object({
     id: z.string(),

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -21,8 +21,10 @@ export {
     unarchiveSession as unarchiveSessionRemote,
     querySessionMounts,
     queryMountFiles,
+    queryMountDir,
     queryLatestMountFiles,
     readMountFile,
+    writeMountFile,
     type MountFilesPage,
     type LatestMountFilesParams,
     type QueryRecordsParams,
@@ -55,6 +57,7 @@ export {
     type StreamStatusCode,
     type CommandMode,
     mountFileSchema,
+    mountFileWrittenResponseSchema,
     mountSchema,
     type MountFile,
     type Mount,
@@ -89,6 +92,7 @@ export {
     sessionMountsQueryKey,
     mountFilesQueryKey,
     latestMountFilesQueryKey,
+    mountDirQueryKey,
     mountFileContentQueryKey,
 } from "./state/mounts"
 export {

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -94,6 +94,7 @@ export {
     latestMountFilesQueryKey,
     mountDirQueryKey,
     mountFileContentQueryKey,
+    invalidateMountListings,
 } from "./state/mounts"
 export {
     detectFileActivity,

--- a/web/packages/agenta-entities/src/session/state/mounts.ts
+++ b/web/packages/agenta-entities/src/session/state/mounts.ts
@@ -10,6 +10,7 @@
  * never render-critical.
  */
 import {projectIdAtom} from "@agenta/shared/state"
+import type {QueryClient} from "@tanstack/react-query"
 import {atom} from "jotai"
 import {atomFamily} from "jotai/utils"
 import {atomWithQuery, queryClientAtom} from "jotai-tanstack-query"
@@ -45,6 +46,16 @@ export const mountDirQueryKey = (
     path: string,
     includeGitignored = false,
 ) => ["mounts", "files-dir", projectId, mountId, path, includeGitignored] as const
+
+export function invalidateMountListings(
+    queryClient: QueryClient,
+    projectId: string | null | undefined,
+): void {
+    if (!projectId) return
+    for (const root of ["files", "files-latest", "files-root", "files-dir"]) {
+        void queryClient.invalidateQueries({queryKey: ["mounts", root, projectId]})
+    }
+}
 
 /** The mounts (drives) bound to one session. */
 export const sessionMountsQueryFamily = atomFamily((sessionId: string) =>


### PR DESCRIPTION
Tracked in #6123. Assigned to @ashrafchowdury, who should sync with Mahmoud before starting.

> **Parked.** Do not review or merge yet. One design decision is still open (see
> "Why this is parked"), the branch is based on `release/v0.109.0` and needs a rebase, and
> nothing here has been exercised in a browser.

## Context

Files an agent writes are read-only in the Files drawer. To fix a typo in a document the
agent produced, you have to ask the agent to rewrite the file for you.

The backend already supported this. `PUT /mounts/{mount_id}/files` has existed for a while,
it is guarded by the `EDIT_MOUNTS` permission, and it is already exposed in the generated
Fern client as `mounts.writeMountFile`. The sandbox mounts the same object-store prefix over
FUSE, so bytes saved from the browser land in the agent's working directory with no sync
step. Only the user interface was missing.

## What this adds

An Edit button in the Files drawer header for text files. Entering edit mode replaces the
toolbar (search, origin filter, visibility toggles) with an edit bar, and swaps the header's
action cluster for Cancel and Save. The tree stays visible but goes inert, so scroll position
and expanded folders survive the round trip.

The new code lives in `web/oss/src/components/Drives/editMode/`: a model, Jotai state, the
save call, a controller hook, and four components for the edit bar, the editor, the banner
and the discard guard. Changes to existing Drives files are small.

Which files can be edited is decided by the existing `resolveDriveFileKind`, not a second
extension list. Six kinds are editable: markdown, text, code, json, csv and html. Anything
else, including images and PDFs, does not render an Edit button at all. A text file above the
viewer's existing 1.5 MB cap does render the button, disabled, with a tooltip naming the cap.
That difference is deliberate: a category cannot be edited, a limit can be explained.

Saving goes through the Fern client and invalidates the file content and directory queries.
Before every write, the controller re-checks the file's `mtime` against the value it read at
open time. If the agent wrote underneath you, a banner offers to view a diff, reload from
disk, or overwrite and say so.

## Why this is parked

Markdown is edited as source text with a Source and Preview toggle, where Preview is a
read-only rendering. It is not edited as rendered rich text.

That matches the design, but it is not what we want. The reason it landed this way is a real
constraint rather than an oversight. In rich text mode `Editor.tsx` runs every change through
`stripBackslashEscapes`, which deletes every backslash that precedes another character. An
agent file with a fenced code block containing a regex or a shell command would be silently
corrupted. Separately, the first switch into markdown view serializes the tree it hydrated
instead of injecting the original file text, so the document can be reformatted before you
type anything.

So the open decision is whether to keep byte-exact source editing, move markdown to rich
editing and accept that saving normalizes formatting, or offer both with source as the
default. Settle that before anyone continues, because it changes the editor component wiring
and what the tests assert.

## Verified

- 92 unit tests pass across five files, covering the state model, the buffer state machine,
  the controller, and the editor's byte fidelity.
- `tsc --noEmit` is clean for both `oss` and `ee`. `pnpm lint-fix` is clean.
- The byte round trip was checked against a live backend, not just in unit tests. Eight files
  were written and read back through the real endpoint: `.txt`, `.csv`, `.md`, `.env` and
  `.json`, plus a file with no trailing newline, one with Windows line endings, and one with
  emoji and tabs. All eight came back byte identical.

Byte fidelity got that much attention because the first implementation failed it. The editor
was converting tabs into two spaces, trimming the end of the document, and pretty-printing
compact JSON. A review caught it, and the regression test that now guards it fails when the
fix is reverted.

## Not verified

Nothing here has run in a browser. The five file types have never been round-tripped through
the actual user interface, and the discard guard, the conflict banner, the save-failure
banner and the light and dark theme pass are all untested outside of unit tests.

## Before this can move

1. Decide the markdown editing question above.
2. Rebase onto the current release branch. This is based on `release/v0.109.0`.
3. Migrate the antd usages. This was written before
   [#5643](https://github.com/Agenta-AI/agenta/pull/5643) merged, so it still imports `Button`,
   `Alert`, `Segmented` and `Tooltip` from `antd`. The work is seven `size="small"` props and
   two import lines, confined to `DriveEditBar.tsx` and `DriveEditBanner.tsx`.
4. Run the live QA script committed at `docs/design/file-drawer-edit-mode/qa.md`.

## Planning workspace

`docs/design/file-drawer-edit-mode/` holds the design, the plan, the research, the review
triage and the QA script. Read `README.md` first for the reading order. `open-questions.md`
records where the implementation knowingly diverged from the plan.
