### PR TITLE
fix(web): Copy the pdfjs worker into the EE app's public dir

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -64,6 +64,7 @@ services:
             - ../../../web/ee/public:/app/ee/public
             - ../../../web/oss/src:/app/oss/src
             - ../../../web/oss/public:/app/oss/public
+            - ../../../web/oss/scripts:/app/oss/scripts
             - ../../../web/packages:/app/packages
             - nextjs-ee-cache:/app/ee/.next/cache
             - nextjs-oss-cache:/app/oss/.next/cache

--- a/web/ee/.gitignore
+++ b/web/ee/.gitignore
@@ -35,3 +35,6 @@ yarn-error.log*
 next-env.d.ts
 
 
+
+# pdfjs worker copied into public/ at dev+build time (see ../oss/scripts/copy-pdf-worker.mjs)
+public/pdf.worker.min.mjs

--- a/web/ee/docker/Dockerfile.dev
+++ b/web/ee/docker/Dockerfile.dev
@@ -98,6 +98,7 @@ COPY --chown=agenta:agenta ee/src ./ee/src
 COPY --chown=agenta:agenta ee/public ./ee/public
 COPY --chown=agenta:agenta oss/src ./oss/src
 COPY --chown=agenta:agenta oss/public ./oss/public
+COPY --chown=agenta:agenta oss/scripts ./oss/scripts
 COPY --chown=agenta:agenta tsconfig.json .
 COPY --chown=agenta:agenta ee/tsconfig.json ./ee
 COPY --chown=agenta:agenta oss/tsconfig.json ./oss

--- a/web/ee/package.json
+++ b/web/ee/package.json
@@ -6,10 +6,10 @@
         "node": "24.x"
     },
     "scripts": {
-        "dev": "next dev --turbopack",
-        "dev:local": "ENV_FILE=.local.env next dev",
-        "dev:turbo": "ENV_FILE=.local.env next dev --turbo",
-        "build": "next build && cp -r public/. ./.next/standalone/ee/public && cp -r .next/static/. ./.next/standalone/ee/.next/static",
+        "dev": "node ../oss/scripts/copy-pdf-worker.mjs public && next dev --turbopack",
+        "dev:local": "node ../oss/scripts/copy-pdf-worker.mjs public && ENV_FILE=.local.env next dev",
+        "dev:turbo": "node ../oss/scripts/copy-pdf-worker.mjs public && ENV_FILE=.local.env next dev --turbo",
+        "build": "node ../oss/scripts/copy-pdf-worker.mjs public && next build && cp -r public/. ./.next/standalone/ee/public && cp -r .next/static/. ./.next/standalone/ee/.next/static",
         "start": "next start",
         "lint": "next lint",
         "lint-fix": "next lint --fix",

--- a/web/oss/scripts/copy-pdf-worker.mjs
+++ b/web/oss/scripts/copy-pdf-worker.mjs
@@ -7,17 +7,24 @@
  * Dev uses turbopack, which tolerated it — so the break only ever showed in CI. Serving it from
  * public/ keeps it local (no CDN) for self-hosted deployments and works under both bundlers.
  *
- * Runs in the `dev` and `build` scripts. The copied file is gitignored (a node_modules artifact).
+ * Runs in the `dev` and `build` scripts of both apps. OSS calls it with no argument and gets
+ * its own public/; EE passes a destination ("public", relative to web/ee) because it serves
+ * its own public dir. The copied file is gitignored (a node_modules artifact).
  */
 import {copyFileSync, mkdirSync} from "node:fs"
 import {createRequire} from "node:module"
-import {dirname, join} from "node:path"
+import {dirname, join, relative, resolve} from "node:path"
 import {fileURLToPath} from "node:url"
 
 const require = createRequire(import.meta.url)
 const source = require.resolve("pdfjs-dist/build/pdf.worker.min.mjs")
-const publicDir = join(dirname(fileURLToPath(import.meta.url)), "..", "public")
+const publicDir = process.argv[2]
+    ? resolve(process.cwd(), process.argv[2])
+    : join(dirname(fileURLToPath(import.meta.url)), "..", "public")
+const destination = join(publicDir, "pdf.worker.min.mjs")
 
 mkdirSync(publicDir, {recursive: true})
-copyFileSync(source, join(publicDir, "pdf.worker.min.mjs"))
-console.log("[copy-pdf-worker] pdfjs worker → public/pdf.worker.min.mjs")
+copyFileSync(source, destination)
+console.log(
+    `[copy-pdf-worker] pdfjs worker → ${relative(process.cwd(), destination) || destination}`,
+)


### PR DESCRIPTION
## Summary

`/pdf.worker.min.mjs` returns 404 on every EE deployment. `web/oss/scripts/copy-pdf-worker.mjs` copies the pdfjs worker into `public/`, but only the OSS package called it, and it always wrote into `web/oss/public`. The EE app serves its own `web/ee/public`, so the file never lands where EE can serve it. PDF attachments in the agent chat file pane silently fall back to a generic file icon, because `renderPdfFirstPage` catches the worker failure and returns null.

Confirmed on a deployed EE instance before this change: `/__env.js` returns 200 and `/pdf.worker.min.mjs` returns 404.

## What changed

- The script now takes an optional destination directory. With no argument it behaves exactly as before, so the OSS scripts are untouched.
- EE's `dev`, `dev:local`, `dev:turbo`, and `build` scripts call it with `public`, matching what OSS already does.
- `web/ee/.gitignore` ignores the copied worker, the same way `web/oss/.gitignore` does.
- The EE dev image and the EE dev compose file get `oss/scripts`, the same two lines #6114 added on the OSS side.
- `web/ee/docker/Dockerfile.gh` needs no change. It already copies the whole `oss/` and `ee/` trees, and the EE build script now produces the file.

## Testing

### Verified locally

- Ran the script from `web/ee` with the new argument and from `web/oss` with no argument. Both write the 1,375,838 byte worker into the correct `public/`, and git ignores both copies.
- Built `web/ee/docker/Dockerfile.dev` and started the container with the real dev command:

```
@agenta/ee:dev: $ node ../oss/scripts/copy-pdf-worker.mjs public && next dev --turbopack
@agenta/ee:dev: [copy-pdf-worker] pdfjs worker → public/pdf.worker.min.mjs
@agenta/ee:dev:  ✓ Ready in 1093ms
```

  `/app/ee/public` then holds `pdf.worker.min.mjs` next to the generated `__env.js`.

- `docker compose --profile with-web -f hosting/docker-compose/ee/docker-compose.dev.yml config` renders the new `web/oss/scripts` mount.
- `turbo run build --filter=@agenta/ee --dry=json` resolves the EE build to the new command and leaves the OSS build command unchanged.
- pre-commit ran prettier and `turbo run lint` across `web`. Both passed.

### Not run

The full EE production Next build. The step this PR adds is the same command proven above, run from the same relative layout the gh builder uses (`/app/ee` with `/app/oss` beside it).

### Added or updated tests

N/A. Build and packaging configuration only.

## Demo

Not a UI change in itself. The user visible effect is that a PDF attachment in the agent chat file pane shows its first page instead of a generic file icon on EE deployments.
