### PR TITLE
fix(hosting): Let the dev web container write into the mounted public dirs

### DIFF
--- a/hosting/docker-compose/run.sh
+++ b/hosting/docker-compose/run.sh
@@ -434,6 +434,27 @@ if [[ "$WEB_MODE" == "docker" ]]; then
     COMPOSE_CMD+=" --profile with-web"
 fi
 
+# The dev web container runs as uid 10001 and writes generated files into the public/ directories
+# that compose bind-mounts from this checkout: entrypoint.sh writes __env.js, and the OSS and EE
+# dev scripts write the pdfjs worker. A fresh clone leaves those directories mode 755 owned by the
+# host user, so uid 10001 cannot write and the container crash-loops in the entrypoint before
+# Next.js ever starts. Widen them here instead of making every contributor rediscover that. They
+# hold public static assets only, and the gh images bind-mount no source, so this is dev-only.
+if [[ "$IMAGE_MODE" == "dev" && "$WEB_MODE" == "docker" ]]; then
+    for _public_dir in ./web/oss/public ./web/ee/public ./web/mobile/public; do
+        [[ -d "$_public_dir" ]] || continue
+        chmod o+rwx "$_public_dir" 2>/dev/null ||
+            echo "Warning: could not make $_public_dir writable by the web container (uid 10001)." >&2
+        # An __env.js or worker left behind by a host-side `pnpm dev` is owned by the host user,
+        # and the container overwrites the file in place, so widen those two as well.
+        for _generated in "$_public_dir/__env.js" "$_public_dir/pdf.worker.min.mjs"; do
+            if [[ -f "$_generated" ]]; then
+                chmod o+rw "$_generated" 2>/dev/null || true
+            fi
+        done
+    done
+fi
+
 if $WITH_NGINX; then
     COMPOSE_CMD+=" --profile with-nginx"
 else


### PR DESCRIPTION
## Summary

On Linux, a fresh clone cannot start the dev web container at all. The dev web image runs as uid 10001, and compose bind-mounts `web/<edition>/public` over the container's public directory. `entrypoint.sh` writes `__env.js` there, and the dev scripts write the pdfjs worker, so both writes land on the host. A fresh clone leaves those directories mode 755 owned by the cloning user, so uid 10001 cannot write:

```
./entrypoint.sh: 184: cannot create /app/oss/public/__env.js: Permission denied
```

The entrypoint runs `set -e`, so the container exits and restarts forever, before Next.js is ever reached. macOS hides this, because Docker Desktop bind mounts ignore host ownership. Nothing in `run.sh` or the contributing docs fixes the permissions today, so every Linux contributor has to work it out.

## What changed

`run.sh` widens the three bind-mounted public directories, and any generated file already inside them, before starting a dev stack. The block only runs for `--dev` with the web container enabled. The `gh` images bind-mount no source, so they are unaffected. These directories hold public static assets only.

## Testing

### Verified locally

- Reproduced the failure first. Mounting a 755 host directory into `agenta-oss-dev-web:latest` gives exactly the `Permission denied` line above and the container exits.
- Set `web/oss/public`, `web/ee/public`, and `web/mobile/public` back to 755 with a host-owned `__env.js`, then ran `run.sh --oss --dev --down`. All three directories became `drwxr-xrwx` and the stale `__env.js` became `-rw-r--rw-`.
- Started the same container against the widened directory afterwards. The entrypoint completes and writes `__env.js` as uid 10001.
- Ran `run.sh --oss --gh --down` with the directories reset to 755. They stayed at 755, so `gh` runs are untouched.
- `bash -n hosting/docker-compose/run.sh` passes.

### Added or updated tests

N/A. Deployment script only.

## Demo

Not a UI change. The effect is that `bash hosting/docker-compose/run.sh --oss --dev --build` now brings the web container up on a fresh Linux clone instead of crash-looping in the entrypoint.
