### PR TITLE
[6035] fix(frontend): Give the post-signup survey card its own surface

### DIFF
--- a/web/ee/src/components/PostSignupForm/PostSignupForm.tsx
+++ b/web/ee/src/components/PostSignupForm/PostSignupForm.tsx
@@ -22,9 +22,14 @@ import {
 import PostSignupHeader from "./PostSignupHeader"
 import PostSignupSubmitting from "./PostSignupSubmitting"
 
-const mainContainerClass = "w-[400px] mx-auto h-[82vh] flex flex-col justify-between"
+const mainContainerClass = "w-[400px] mx-auto flex flex-col gap-4 pb-12"
+// The card paints its own surface from the same antd token layer that colors its
+// text, so background and foreground can never resolve to different themes. With
+// no background of its own it took the page color, which left no visible card
+// edge and made the text unreadable whenever the page surface and the antd
+// tokens disagreed.
 const containerClass =
-    "p-6 grid gap-8 rounded-lg shadow-[0px_9px_28px_8px_#0000000D,0px_3px_6px_-4px_#0000001F,0px_6px_16px_0px_#00000014] border border-colorBorder"
+    "p-6 grid gap-8 rounded-lg bg-[var(--ant-color-bg-elevated)] border border-solid border-[var(--ant-color-border-secondary)] shadow-[var(--ant-box-shadow)]"
 const formItemClass = "gap-2 [&>.ant-form-item-row>.ant-form-item-label]:font-medium"
 
 // Fisher-Yates shuffle algorithm
@@ -495,7 +500,7 @@ const PostSignupForm = ({survey, user, orgs, posthog}: PostSignupFormProps) => {
                     size="large"
                     type="primary"
                     onClick={isLastStep ? form.submit : handleNextStep}
-                    className="w-full min-h-[32px] mt-2"
+                    className="w-full min-h-[32px]"
                     iconPlacement="end"
                     icon={<ArrowRight className="mt-[3px]" />}
                     disabled={!isCurrentStepValid}


### PR DESCRIPTION
Closes #6035.

## The problem

The signup survey card on `/post-signup` had no background of its own. It drew a
border and a shadow, but its surface color was whatever the page behind it was, so
it never read as a card. In dark mode the page and the "card" were both `#141414`.

That also made the card fragile. Its background came from the page shell, which
the app paints with react-jss from React state, while its text came from antd's
CSS variable layer. Two independent sources for one surface. The reporter's
screenshot shows what happens when they disagree: a dark page shell with
light-theme text on top of it, unreadable.

A second problem on the same page: the form was pinned to `h-[82vh]` with
`justify-between`, which pushed the Continue and Submit buttons past the bottom of
the viewport on a 900px-tall screen. The reporter's 879px-tall screenshot is cut
off the same way.

## The fix

The card now paints its background, border, and shadow from the same antd token
layer that colors its text (`--ant-color-bg-elevated`, `--ant-color-border-secondary`,
`--ant-box-shadow`). Background and foreground come from one source, so they cannot
resolve to different themes, and the card sits on `colorBgElevated` above the page's
`colorBgContainer`. That is a real surface in dark mode, and the light mode look is
unchanged.

The fixed `82vh` height is gone. The form flows naturally with a gap between the card
and the button, so the button is always reachable and the page scrolls when the card
is tall.

## Before and after, dark mode

Before: the card is the same color as the page, so only a faint border marks its
edge, and the Continue button is clipped at the bottom of the viewport.

After: the card sits on its own lighter surface, clearly separated from the page,
and the Continue button is fully visible below it.

## Verification

Driven in a browser against an EE dev stack, at 1440x900, in both color schemes and
across both survey steps:

- Dark mode, step 1 and step 2: card is visibly distinct from the page, all labels and
  options readable, Continue/Submit visible and clickable.
- Light mode: unchanged from before apart from the button no longer being clipped.
- Selecting options and advancing from step 1 to step 2 still works.

## Note on the unreadable text

I could not reproduce the light-text-on-dark-shell state from the issue screenshot on
either a dev build or a production build, in dark mode, on a first load or after a
client-side navigation. antd v6 replaces its CSS variable block cleanly on a theme
switch here, so I have no repro for the trigger.

What this change does do is remove the condition that turns that state into an
unreadable page: because the card's surface and its text now come from the same token
layer, a card that renders light-theme text renders a light-theme background under it.
