### PR TITLE
fix(ci): regenerate consumer uv locks after the pytest 9 bump

### DIFF
--- a/api/uv.lock
+++ b/api/uv.lock
@@ -86,7 +86,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8,<9" }]
+dev = [{ name = "pytest", specifier = ">=9.0.3,<10" }]
 
 [[package]]
 name = "aiofile"

--- a/sdks/python/uv.lock
+++ b/sdks/python/uv.lock
@@ -99,7 +99,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8,<9" }]
+dev = [{ name = "pytest", specifier = ">=9.0.3,<10" }]
 
 [[package]]
 name = "aiofiles"

--- a/services/uv.lock
+++ b/services/uv.lock
@@ -86,7 +86,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [{ name = "pytest", specifier = ">=8,<9" }]
+dev = [{ name = "pytest", specifier = ">=9.0.3,<10" }]
 
 [[package]]
 name = "aiofiles"


### PR DESCRIPTION
## Context
The api, sdk, and services unit-test jobs and the agenta-api / agenta-services image builds all fail on release/v0.112.3 because `uv sync --locked` rejects the lockfiles. Dependabot PR #5979 bumped the dev-group pytest bound in `clients/python/pyproject.toml` from `>=8,<9` to `>=9.0.3,<10` but regenerated only `clients/python/uv.lock`. The three consumers that install agenta-client as an editable dependency embed its `requires-dev` metadata in their own lockfiles, and those still recorded the old bound, so every `uv sync --locked` sees a lock that no longer matches the source tree. In the docker builds the install step swallows the error and ships an empty venv, which the verify step then catches.

## Changes
Ran `uv lock` (uv 0.11.14, the version CI pins) in `api/`, `sdks/python/`, and `services/`. Each lockfile changes exactly one line, in agenta-client's `[package.metadata.requires-dev]` block:

Before:
```
dev = [{ name = "pytest", specifier = ">=8,<9" }]
```

After:
```
dev = [{ name = "pytest", specifier = ">=9.0.3,<10" }]
```

No resolved package versions change; pytest lives in the dev group, which these consumers do not install.

This clears six jobs: the api, sdk, and services unit tests, plus the agenta-api and agenta-services image builds on both amd64 and arm64. A plain re-run could not fix the image builds: the poisoned install layer sat in the shared build cache, and only a lockfile change shifts the layer digests past it.

## Tests
- `uv lock --check` (uv 0.11.14) passes in all three directories after regeneration.
- `git diff --stat` confirms 3 files, 1 line each; nothing else moved.
