### PR TITLE
fix(runner): refresh the trace-export credential every turn

### DIFF
--- a/api/oss/src/apis/fastapi/access/router.py
+++ b/api/oss/src/apis/fastapi/access/router.py
@@ -4,7 +4,8 @@ from uuid import UUID
 from fastapi import APIRouter, Query, HTTPException, Request
 from fastapi.responses import JSONResponse
 
-from oss.src.middlewares.auth import sign_secret_token
+from oss.src.middlewares.auth import TRACE_INGEST_SCOPE, sign_secret_token
+from oss.src.utils.env import env
 from oss.src.utils.logging import get_module_logger
 from oss.src.utils.caching import get_cache, set_cache
 from oss.src.utils.context import get_auth_context, get_auth_scope
@@ -27,12 +28,14 @@ class Allow(JSONResponse):
     def __init__(
         self,
         credentials: Optional[str] = None,
+        telemetry_credentials: Optional[str] = None,
     ) -> None:
         super().__init__(
             status_code=200,
             content={
                 "effect": "allow",
                 "credentials": credentials,
+                "telemetry_credentials": telemetry_credentials,
             },
         )
 
@@ -145,6 +148,21 @@ class AccessRouter:
         )
         credentials_header = f"Secret {secret_token}"
 
+        # Trace exports outlive the 15-minute credential, so telemetry gets its own
+        # longer-lived token. The longer TTL is acceptable only because the token is
+        # scope-bound to trace ingest and rejected everywhere else.
+        telemetry_token = await sign_secret_token(
+            user_id=user_id,
+            user_email=getattr(request.state, "user_email", None),
+            project_id=project_id,
+            workspace_id=str(ctx.scope.workspace_id),
+            organization_id=str(ctx.scope.organization_id),
+            organization_name=getattr(request.state, "organization_name", None),
+            scope=TRACE_INGEST_SCOPE,
+            expires_in=env.agenta.otlp.token_ttl_seconds,
+        )
+        telemetry_credentials_header = f"Secret {telemetry_token}"
+
         cache_key = {
             "action": action,
             "scope_type": scope_type,
@@ -166,7 +184,10 @@ class AccessRouter:
             )
 
             if allow == "allow":
-                return Allow(credentials_header)
+                return Allow(
+                    credentials_header,
+                    telemetry_credentials=telemetry_credentials_header,
+                )
             if allow == "deny":
                 log.warn("Permission denied")
                 raise Deny()
@@ -231,7 +252,10 @@ class AccessRouter:
                         key=cache_key,
                         value="allow",
                     )
-                    return Allow(credentials_header)
+                    return Allow(
+                        credentials_header,
+                        telemetry_credentials=telemetry_credentials_header,
+                    )
 
             elif isinstance(allow_resource, int):
                 if allow_resource <= 0:
@@ -245,7 +269,10 @@ class AccessRouter:
                     )
                     raise Deny()
                 else:
-                    return Allow(credentials_header)
+                    return Allow(
+                        credentials_header,
+                        telemetry_credentials=telemetry_credentials_header,
+                    )
 
             log.warn("Resource access denied")
             await set_cache(

--- a/api/oss/src/middlewares/auth.py
+++ b/api/oss/src/middlewares/auth.py
@@ -89,6 +89,15 @@ _INVITATION_POLICY_ENDPOINT_IDENTIFIERS = (
 _SECRET_KEY = env.agenta.auth_key
 _SECRET_EXP = 15 * 60  # 15 minutes
 
+TRACE_INGEST_SCOPE = "trace-ingest"
+
+# Request paths each token scope is valid on. `ApiPrefixStripMiddleware` strips leading
+# `/api` segments before auth runs, so these are the post-strip paths — no `/api/...`
+# variants belong here.
+_SCOPE_ALLOWED_PATHS = {
+    TRACE_INGEST_SCOPE: {"/otlp/v1/traces"},
+}
+
 _ZERO_UUID = "00000000-0000-0000-0000-000000000000"
 _NULL_UUID = "null"
 
@@ -912,6 +921,24 @@ async def verify_secret_token(
             algorithms=["HS256"],
         )
 
+        # A scoped token may carry a TTL far beyond `_SECRET_EXP`; that is safe ONLY
+        # because this check confines it to its scope's allowed paths. It lives here,
+        # not at any call site, so no caller can bypass it. Unknown scopes fail closed.
+        token_scope = auth_context.get("scope")
+        if token_scope is not None:
+            allowed_paths = _SCOPE_ALLOWED_PATHS.get(token_scope)
+
+            if allowed_paths is None or request.url.path not in allowed_paths:
+                log.warn(
+                    "[auth] secret token unauthorized",
+                    path=request.url.path,
+                    method=request.method,
+                    reason="scope_forbidden",
+                    scope=token_scope,
+                )
+
+                raise UnauthorizedException(reason="scope_forbidden")
+
         request.state.user_id = auth_context.get("user_id")
         request.state.user_email = auth_context.get("user_email")
         request.state.project_id = auth_context.get("project_id")
@@ -942,6 +969,11 @@ async def verify_secret_token(
         )
 
         raise UnauthorizedException(reason="invalid_token") from exc
+
+    except HTTPException as exc:
+        # Scope rejections (and any other deliberate 401/5xx) must reach the client
+        # with their status — never collapsed into a 500 by the catch-all below.
+        raise exc
 
     except Exception as exc:  # pylint: disable=bare-except
         raise InternalServerErrorException() from exc
@@ -979,13 +1011,20 @@ async def sign_secret_token(
     workspace_id: Optional[str] = None,
     organization_id: Optional[str] = None,
     organization_name: Optional[str] = None,
+    scope: Optional[str] = None,
+    expires_in: Optional[int] = None,
 ):
     try:
         if not _SECRET_KEY:
             raise InternalServerErrorException()
 
         _exp = int(
-            (datetime.now(timezone.utc) + timedelta(seconds=_SECRET_EXP)).timestamp()
+            (
+                datetime.now(timezone.utc)
+                + timedelta(
+                    seconds=expires_in if expires_in is not None else _SECRET_EXP
+                )
+            ).timestamp()
         )
 
         auth_context = {
@@ -997,6 +1036,11 @@ async def sign_secret_token(
             "organization_name": organization_name,
             "exp": _exp,
         }
+
+        # Unscoped tokens keep their exact historical payload shape — the claim is
+        # omitted entirely, never emitted as null.
+        if scope is not None:
+            auth_context["scope"] = scope
 
         secret_token = encode(
             payload=auth_context,

--- a/api/oss/src/middlewares/auth.py
+++ b/api/oss/src/middlewares/auth.py
@@ -1018,9 +1018,13 @@ async def sign_secret_token(
         if not _SECRET_KEY:
             raise InternalServerErrorException()
 
+        # One instant for both claims, so a token's age and its remaining life always sum
+        # to exactly the lifetime it was minted with.
+        _issued_at = datetime.now(timezone.utc)
+
         _exp = int(
             (
-                datetime.now(timezone.utc)
+                _issued_at
                 + timedelta(
                     seconds=expires_in if expires_in is not None else _SECRET_EXP
                 )
@@ -1034,11 +1038,15 @@ async def sign_secret_token(
             "workspace_id": workspace_id,
             "organization_id": organization_id,
             "organization_name": organization_name,
+            # `iat` pairs with `exp` so a rejected credential can report how OLD it is, not
+            # only that it expired. Export-failure diagnostics read both; without `iat` the
+            # age is unknowable and a stale credential looks like a wrong one.
+            "iat": int(_issued_at.timestamp()),
             "exp": _exp,
         }
 
-        # Unscoped tokens keep their exact historical payload shape — the claim is
-        # omitted entirely, never emitted as null.
+        # An unscoped token carries no `scope` key at all, rather than a null one, so its
+        # payload stays the shape every existing holder was issued.
         if scope is not None:
             auth_context["scope"] = scope
 

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -357,6 +357,14 @@ class OTLPConfig(BaseModel):
         os.getenv("AGENTA_OTLP_MAX_BATCH_BYTES") or str(10 * 1024 * 1024)
     )
 
+    # Lifetime of the trace-ingest-scoped Secret token minted for telemetry export.
+    # It may exceed the general credential's 15 minutes only because the token is
+    # path-scoped to OTLP trace upload; keep it overridable so expiry-then-refresh
+    # can be exercised without waiting the full lifetime.
+    token_ttl_seconds: int = int(
+        os.getenv("AGENTA_OTLP_TOKEN_TTL_SECONDS") or str(2 * 60 * 60)
+    )
+
     model_config = ConfigDict(extra="ignore")
 
 

--- a/api/oss/tests/pytest/unit/middlewares/test_auth_secret_token.py
+++ b/api/oss/tests/pytest/unit/middlewares/test_auth_secret_token.py
@@ -229,6 +229,32 @@ async def test_expiry_override_changes_exp_and_the_default_stays_fifteen_minutes
 
 
 @pytest.mark.asyncio
+async def test_every_token_records_when_it_was_issued(log):
+    """A rejected credential has to be able to say how OLD it is, not only that it expired.
+
+    The export-failure diagnostics report credential age from `iat`; without it a stale
+    credential is indistinguishable from a wrong one, which is what made this class of 401
+    take a week to diagnose.
+    """
+    now = datetime.now(timezone.utc).timestamp()
+
+    for token in (
+        await auth.sign_secret_token(user_id="u"),
+        await auth.sign_secret_token(user_id="u", scope=auth.TRACE_INGEST_SCOPE),
+        await auth.sign_secret_token(user_id="u", expires_in=60),
+    ):
+        assert now - 5 < _claims(token)["iat"] < now + 5
+
+
+@pytest.mark.asyncio
+async def test_issued_at_and_expiry_span_exactly_the_requested_lifetime(log):
+    # Both derive from one instant, so age + remaining life never drift apart.
+    claims = _claims(await auth.sign_secret_token(user_id="u", expires_in=7200))
+
+    assert claims["exp"] - claims["iat"] == 7200
+
+
+@pytest.mark.asyncio
 async def test_expired_scoped_token_is_rejected_as_expired(log):
     token = await auth.sign_secret_token(
         user_id="u",

--- a/api/oss/tests/pytest/unit/middlewares/test_auth_secret_token.py
+++ b/api/oss/tests/pytest/unit/middlewares/test_auth_secret_token.py
@@ -172,6 +172,15 @@ async def test_trace_ingest_token_verifies_on_the_otlp_ingest_path(log):
     [
         "/workflows/123/revisions/commit",
         "/vault/v1/secrets",
+        # The agent runner's session-coordination calls, verbatim. They authenticate with the
+        # credential in `telemetry.exporters.otlp.headers.authorization` (see `runCredential`),
+        # so putting a trace-ingest token in that slot rejects EVERY one of them and the session
+        # dies. These paths are why the export credential rides its own wire field.
+        "/access/permissions/check",
+        "/sessions",
+        "/sessions/turns/",
+        "/sessions/turns/complete",
+        "/sessions/turns/query",
     ],
 )
 async def test_trace_ingest_token_is_rejected_everywhere_else(log, path):

--- a/api/oss/tests/pytest/unit/middlewares/test_auth_secret_token.py
+++ b/api/oss/tests/pytest/unit/middlewares/test_auth_secret_token.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 
 import pytest
 from fastapi import HTTPException
-from jwt import encode
+from jwt import decode, encode
 from starlette.requests import Request
 
 from oss.src.middlewares import auth
@@ -46,12 +46,12 @@ def _log(monkeypatch):
     return recorder
 
 
-def _request() -> Request:
+def _request(path: str = "/otlp/v1/traces") -> Request:
     return Request(
         {
             "type": "http",
             "method": "POST",
-            "path": "/otlp/v1/traces",
+            "path": path,
             "headers": [],
             "query_string": b"",
             "scheme": "http",
@@ -121,3 +121,125 @@ def test_unauthorized_reason_reads_the_raiser_s_reason():
         == "expired_signature"
     )
     assert auth._unauthorized_reason(HTTPException(401, "Unauthorized")) is None
+
+
+def _claims(token: str) -> dict:
+    return decode(
+        jwt=token,
+        key=SECRET_KEY,
+        algorithms=["HS256"],
+        options={"verify_exp": False},
+    )
+
+
+@pytest.mark.asyncio
+async def test_unscoped_token_round_trips_on_any_path_with_no_scope_claim(log):
+    token = await auth.sign_secret_token(user_id="u", project_id="p")
+
+    assert "scope" not in _claims(token)
+
+    request = _request(path="/workflows/123/revisions/commit")
+
+    await auth.verify_secret_token(request=request, secret_token=token)
+
+    assert request.state.user_id == "u"
+    assert request.state.project_id == "p"
+    assert request.state.credentials == f"Secret {token}"
+    assert log.calls == []
+
+
+@pytest.mark.asyncio
+async def test_trace_ingest_token_verifies_on_the_otlp_ingest_path(log):
+    token = await auth.sign_secret_token(
+        user_id="u",
+        project_id="p",
+        scope=auth.TRACE_INGEST_SCOPE,
+        expires_in=2 * 60 * 60,
+    )
+
+    request = _request(path="/otlp/v1/traces")
+
+    await auth.verify_secret_token(request=request, secret_token=token)
+
+    assert request.state.user_id == "u"
+    assert request.state.project_id == "p"
+    assert log.calls == []
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/workflows/123/revisions/commit",
+        "/vault/v1/secrets",
+    ],
+)
+async def test_trace_ingest_token_is_rejected_everywhere_else(log, path):
+    token = await auth.sign_secret_token(
+        user_id="u",
+        project_id="p",
+        scope=auth.TRACE_INGEST_SCOPE,
+        expires_in=2 * 60 * 60,
+    )
+
+    with pytest.raises(UnauthorizedException) as raised:
+        await auth.verify_secret_token(request=_request(path=path), secret_token=token)
+
+    assert raised.value.status_code == 401
+    assert raised.value.detail["reason"] == "scope_forbidden"
+
+    (_, event, fields) = log.of("warn")[0]
+    assert event == "[auth] secret token unauthorized"
+    assert fields["reason"] == "scope_forbidden"
+    assert fields["scope"] == auth.TRACE_INGEST_SCOPE
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/otlp/v1/traces",
+        "/workflows/123/revisions/commit",
+        "/vault/v1/secrets",
+    ],
+)
+async def test_unknown_scope_is_rejected_on_every_path(log, path):
+    token = await auth.sign_secret_token(
+        user_id="u",
+        project_id="p",
+        scope="garbage-scope",
+    )
+
+    with pytest.raises(UnauthorizedException) as raised:
+        await auth.verify_secret_token(request=_request(path=path), secret_token=token)
+
+    assert raised.value.detail["reason"] == "scope_forbidden"
+
+
+@pytest.mark.asyncio
+async def test_expiry_override_changes_exp_and_the_default_stays_fifteen_minutes(log):
+    now = datetime.now(timezone.utc).timestamp()
+
+    overridden = await auth.sign_secret_token(user_id="u", expires_in=60)
+    assert now + 55 < _claims(overridden)["exp"] < now + 65
+
+    # No override = the general credential's unchanged 15-minute lifetime.
+    default = await auth.sign_secret_token(user_id="u")
+    assert now + 15 * 60 - 5 < _claims(default)["exp"] < now + 15 * 60 + 5
+
+
+@pytest.mark.asyncio
+async def test_expired_scoped_token_is_rejected_as_expired(log):
+    token = await auth.sign_secret_token(
+        user_id="u",
+        scope=auth.TRACE_INGEST_SCOPE,
+        expires_in=-3600,
+    )
+
+    with pytest.raises(UnauthorizedException) as raised:
+        await auth.verify_secret_token(
+            request=_request(path="/otlp/v1/traces"),
+            secret_token=token,
+        )
+
+    assert raised.value.detail["reason"] == "expired_signature"

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -413,10 +413,23 @@ class TraceContext(BaseModel):
 
     - ``traceparent`` / ``baggage`` are per-call protocol CONTEXT (the W3C trace-context propagation
       headers, kept verbatim). They ride ``context.propagation`` via :meth:`context_to_wire`.
-    - ``endpoint`` / ``authorization`` / ``capture_content`` are operator-owned telemetry CONFIG +
-      POLICY + CREDENTIAL: where spans export, what is captured, and the exporter auth. They ride
-      ``telemetry`` via :meth:`telemetry_to_wire`, with the credential nested under the exporter's
-      ``headers`` rather than as a free-floating field.
+    - ``endpoint`` / ``authorization`` / ``export_authorization`` / ``capture_content`` are
+      operator-owned telemetry CONFIG + POLICY + CREDENTIALS: where spans export, what is captured,
+      and two credentials with DIFFERENT authority. They ride ``telemetry`` via
+      :meth:`telemetry_to_wire`.
+
+    The two credentials must not be swapped:
+
+    - ``authorization`` is the CALLER'S GENERAL credential, full authority. It rides
+      ``exporters.otlp.headers.authorization``, and the runner reads that slot as the credential
+      it authenticates ALL session-coordination calls with (ownership claims, mount signing, the
+      turns ledger, history reconstruction, working-copy restore, attachment resolution). Putting
+      a narrower token here breaks every one of those calls.
+    - ``export_authorization`` is EXPORT-ONLY: the credential for the span-export (OTLP ingest)
+      request and nothing else. It may be narrowly scoped and longer-lived than the general
+      credential. It rides the sibling wire key ``exportAuthorization``; when unset the runner
+      falls back to ``headers.authorization``, which is what every platform sent before this
+      field existed.
 
     All fields optional; with none set the run traces standalone (or not at all), the
     standalone-SDK case."""
@@ -425,6 +438,7 @@ class TraceContext(BaseModel):
     baggage: Optional[str] = None
     endpoint: Optional[str] = None  # OTLP traces URL
     authorization: Optional[str] = Field(default=None, repr=False)
+    export_authorization: Optional[str] = Field(default=None, repr=False)
     capture_content: bool = True
 
     def context_to_wire(self) -> Dict[str, Any]:
@@ -439,14 +453,19 @@ class TraceContext(BaseModel):
 
     def telemetry_to_wire(self) -> Dict[str, Any]:
         """The telemetry CONFIG: the capture POLICY (``capture.content.enabled``) and the OTLP
-        exporter destination (``exporters.otlp.endpoint``) with the CREDENTIAL nested under the
-        exporter's standard ``authorization`` header."""
+        exporter destination (``exporters.otlp.endpoint``) with both credentials.
+
+        ``headers.authorization`` must stay the caller's GENERAL credential — the runner
+        authenticates session-coordination calls with whatever sits in that slot. The
+        export-only credential rides the sibling ``exportAuthorization`` key (outside
+        ``headers``); the runner falls back to ``headers.authorization`` when it is null."""
         return {
             "capture": {"content": {"enabled": self.capture_content}},
             "exporters": {
                 "otlp": {
                     "endpoint": self.endpoint,
                     "headers": {"authorization": self.authorization},
+                    "exportAuthorization": self.export_authorization,
                 }
             },
         }

--- a/sdks/python/agenta/sdk/agents/tracing.py
+++ b/sdks/python/agenta/sdk/agents/tracing.py
@@ -43,11 +43,14 @@ def trace_context() -> Optional[TraceContext]:
 
     Threading the ``/invoke`` span's ``traceparent`` into the run makes the agent's spans
     children of that span, so the whole run shows up under the response's ``trace_id`` the
-    way completion/chat nest their LLM spans. The exporter credential prefers
-    ``TracingContext.telemetry_credentials`` — a dedicated trace-ingest-scoped token whose
-    lifetime covers warm agent sessions, unlike the caller's short-lived general credential —
-    and falls back to the caller's credential (``inject``'s ``Authorization`` re-emit from
-    ``TracingContext.credentials``) on platforms that do not issue one. Best-effort: any
+    way completion/chat nest their LLM spans. ``authorization`` is the caller's GENERAL
+    credential (``inject``'s ``Authorization`` re-emit from ``TracingContext.credentials``):
+    the runner reads that slot to authenticate session-coordination calls, so it must stay the
+    full-authority credential, never the telemetry one. ``export_authorization`` is the
+    EXPORT-only credential and prefers ``TracingContext.telemetry_credentials`` — a dedicated
+    trace-ingest-scoped token whose lifetime covers warm agent sessions, unlike the caller's
+    short-lived general credential — and is left unset when no telemetry credential was issued,
+    so the runner falls back to ``authorization`` for the export request too. Best-effort: any
     failure returns ``None`` and the run is traced standalone (or not at all) using the
     runner's env config.
     """
@@ -55,15 +58,14 @@ def trace_context() -> Optional[TraceContext]:
         headers = inject({})
 
         traceparent = headers.get("traceparent")
+        authorization = headers.get("Authorization")
         # The telemetry credential deliberately does NOT ride `inject()`'s
         # Authorization header (that one authenticates the caller's own outbound
         # calls); it is read off the context here, for the exporter only. A run
         # holding only a telemetry credential (no traceparent, no general
         # credential) still yields a TraceContext so its spans can export.
-        authorization = TracingContext.get().telemetry_credentials or headers.get(
-            "Authorization"
-        )
-        if not traceparent and not authorization:
+        export_authorization = TracingContext.get().telemetry_credentials
+        if not traceparent and not authorization and not export_authorization:
             return None
 
         endpoint = None
@@ -79,6 +81,7 @@ def trace_context() -> Optional[TraceContext]:
             baggage=headers.get("baggage"),
             endpoint=endpoint,
             authorization=authorization,
+            export_authorization=export_authorization,
             capture_content=_CAPTURE_CONTENT,
         )
     except Exception:  # pylint: disable=broad-except

--- a/sdks/python/agenta/sdk/agents/tracing.py
+++ b/sdks/python/agenta/sdk/agents/tracing.py
@@ -43,9 +43,11 @@ def trace_context() -> Optional[TraceContext]:
 
     Threading the ``/invoke`` span's ``traceparent`` into the run makes the agent's spans
     children of that span, so the whole run shows up under the response's ``trace_id`` the
-    way completion/chat nest their LLM spans. The caller's credential rides along (via
-    ``inject``'s ``Authorization`` re-emit from ``TracingContext.credentials``) — the runner
-    authenticates its session-coordination calls AS the caller with it. Best-effort: any
+    way completion/chat nest their LLM spans. The exporter credential prefers
+    ``TracingContext.telemetry_credentials`` — a dedicated trace-ingest-scoped token whose
+    lifetime covers warm agent sessions, unlike the caller's short-lived general credential —
+    and falls back to the caller's credential (``inject``'s ``Authorization`` re-emit from
+    ``TracingContext.credentials``) on platforms that do not issue one. Best-effort: any
     failure returns ``None`` and the run is traced standalone (or not at all) using the
     runner's env config.
     """
@@ -53,7 +55,14 @@ def trace_context() -> Optional[TraceContext]:
         headers = inject({})
 
         traceparent = headers.get("traceparent")
-        authorization = headers.get("Authorization")
+        # The telemetry credential deliberately does NOT ride `inject()`'s
+        # Authorization header (that one authenticates the caller's own outbound
+        # calls); it is read off the context here, for the exporter only. A run
+        # holding only a telemetry credential (no traceparent, no general
+        # credential) still yields a TraceContext so its spans can export.
+        authorization = TracingContext.get().telemetry_credentials or headers.get(
+            "Authorization"
+        )
         if not traceparent and not authorization:
             return None
 

--- a/sdks/python/agenta/sdk/agents/wire_models.py
+++ b/sdks/python/agenta/sdk/agents/wire_models.py
@@ -185,10 +185,18 @@ class WireCapture(_WireModel):
 class WireOtlpExporter(_WireModel):
     """The OTLP exporter destination inside ``telemetry.exporters`` — the traces ``endpoint`` plus
     the credential nested under the standard ``authorization`` header, so the secret lives under the
-    thing it authenticates."""
+    thing it authenticates.
+
+    ``headers.authorization`` is the caller's GENERAL credential; the runner also authenticates
+    session-coordination calls (not just span export) with whatever sits in that slot, so it must
+    stay full-authority. ``export_authorization`` is a separate, EXPORT-only credential (may be
+    scoped/longer-lived); when unset the runner falls back to ``headers.authorization``."""
 
     endpoint: Optional[str] = None
     headers: Optional[Dict[str, str]] = None
+    export_authorization: Optional[str] = Field(
+        default=None, alias="exportAuthorization"
+    )
 
 
 class WireExporters(_WireModel):

--- a/sdks/python/agenta/sdk/contexts/tracing.py
+++ b/sdks/python/agenta/sdk/contexts/tracing.py
@@ -13,6 +13,11 @@ class TracingContext(BaseModel):
     baggage: Optional[dict] = None
     #
     credentials: Optional[str] = None
+    # Dedicated trace-ingest-scoped credential (longer-lived than `credentials`,
+    # allowed to upload traces and nothing else). It is ONLY for the trace
+    # exporter: it must never ride `inject()`'s Authorization header, or it would
+    # replace the caller's credential on unrelated outbound calls.
+    telemetry_credentials: Optional[str] = None
     #
     script: Optional[dict] = None
     parameters: Optional[dict] = None

--- a/sdks/python/agenta/sdk/decorators/routing.py
+++ b/sdks/python/agenta/sdk/decorators/routing.py
@@ -628,6 +628,7 @@ class route:
 
         async def invoke_endpoint(req: Request, request: WorkflowInvokeRequest):
             credentials = req.state.auth.get("credentials")
+            telemetry_credentials = req.state.auth.get("telemetry_credentials")
 
             apply_invoke_prelude(req, request)
 
@@ -637,6 +638,7 @@ class route:
                         request=request,
                         secrets=None,
                         credentials=credentials,
+                        telemetry_credentials=telemetry_credentials,
                     )
 
                 status = getattr(response, "status", None)
@@ -654,6 +656,7 @@ class route:
 
         async def inspect_endpoint(req: Request, request: WorkflowInspectRequest):
             credentials = req.state.auth.get("credentials")
+            telemetry_credentials = req.state.auth.get("telemetry_credentials")
 
             try:
                 with tracing_context_manager(_get_request_tracing_context(req)):
@@ -670,10 +673,12 @@ class route:
                         result = await inspect_workflow(
                             request=request,
                             credentials=credentials,
+                            telemetry_credentials=telemetry_credentials,
                         )
                     else:
                         result = await wf.inspect(
                             credentials=credentials,
+                            telemetry_credentials=telemetry_credentials,
                         )
 
                 return await handle_inspect_success(result)

--- a/sdks/python/agenta/sdk/decorators/running.py
+++ b/sdks/python/agenta/sdk/decorators/running.py
@@ -93,6 +93,7 @@ class Workflow:
         #
         secrets: Optional[list] = None,
         credentials: Optional[str] = None,
+        telemetry_credentials: Optional[str] = None,
         #
         **kwargs,
     ) -> Union[WorkflowBatchResponse, WorkflowStreamingResponse]: ...
@@ -101,6 +102,7 @@ class Workflow:
         self,
         *,
         credentials: Optional[str] = None,
+        telemetry_credentials: Optional[str] = None,
         #
         **kwargs,
     ) -> WorkflowInvokeRequest: ...
@@ -345,6 +347,7 @@ class workflow:
         #
         secrets: Optional[list] = None,
         credentials: Optional[str] = None,
+        telemetry_credentials: Optional[str] = None,
         #
         **kwargs,
     ) -> Union[WorkflowBatchResponse, WorkflowStreamingResponse]:
@@ -368,6 +371,7 @@ class workflow:
             tracing_ctx = TracingContext.get()
 
             tracing_ctx.credentials = credentials
+            tracing_ctx.telemetry_credentials = telemetry_credentials
 
             tracing_ctx.flags = _flags
             tracing_ctx.tags = _tags
@@ -433,6 +437,7 @@ class workflow:
         self,
         *,
         credentials: Optional[str] = None,
+        telemetry_credentials: Optional[str] = None,
         #
         **kwargs,
     ) -> WorkflowInvokeRequest:
@@ -440,6 +445,7 @@ class workflow:
             tracing_ctx = TracingContext.get()
 
             tracing_ctx.credentials = credentials
+            tracing_ctx.telemetry_credentials = telemetry_credentials
 
             tracing_ctx.references = self.references
             tracing_ctx.links = self.links

--- a/sdks/python/agenta/sdk/middlewares/routing/auth.py
+++ b/sdks/python/agenta/sdk/middlewares/routing/auth.py
@@ -1,4 +1,4 @@
-from typing import Callable, Optional, Dict
+from typing import Callable, Optional, Dict, Tuple
 from os import getenv
 from json import dumps
 
@@ -74,7 +74,7 @@ async def get_credentials(
     host: str,
     scope_type: Optional[str] = None,
     scope_id: Optional[str] = None,
-) -> Optional[str]:
+) -> Tuple[Optional[str], Optional[str]]:
     """
     Shared credential verification logic.
 
@@ -85,14 +85,18 @@ async def get_credentials(
         scope_id: Optional scope ID for permission check
 
     Returns:
-        The credentials string if verified, None otherwise
+        A ``(credentials, telemetry_credentials)`` pair. ``credentials`` is the
+        caller's general-purpose credential; ``telemetry_credentials`` is a
+        dedicated trace-ingest-scoped credential the platform may issue alongside
+        it (``None`` on platforms that do not issue one — callers must fall back
+        to ``credentials``).
 
     Raises:
         DenyException: If authentication/authorization fails
     """
     try:
         if not _AUTH_ENABLED:
-            return request.headers.get("authorization", None)
+            return request.headers.get("authorization", None), None
 
         # HEADERS
         authorization = request.headers.get("authorization", None)
@@ -133,10 +137,10 @@ async def get_credentials(
         )
 
         if _CACHE_ENABLED:
-            credentials = _cache.get(_hash)
+            cached = _cache.get(_hash)
 
-            if credentials:
-                return credentials
+            if cached and cached.get("credentials"):
+                return cached.get("credentials"), cached.get("telemetry_credentials")
 
         try:
             async with httpx.AsyncClient() as client:
@@ -226,10 +230,19 @@ async def get_credentials(
                     )
 
                 credentials = auth.get("credentials")
+                # Optional, trace-ingest-scoped credential (absent on platforms
+                # that do not issue one; callers fall back to `credentials`).
+                telemetry_credentials = auth.get("telemetry_credentials")
 
-                _cache.put(_hash, credentials)
+                _cache.put(
+                    _hash,
+                    {
+                        "credentials": credentials,
+                        "telemetry_credentials": telemetry_credentials,
+                    },
+                )
 
-                return credentials
+                return credentials, telemetry_credentials
 
         except DenyException as deny:
             raise deny
@@ -282,14 +295,17 @@ class AuthMiddleware(BaseHTTPMiddleware):
                 request.state.auth = {}
 
             else:
-                credentials = await get_credentials(
+                credentials, telemetry_credentials = await get_credentials(
                     request,
                     self.host,
                     self.scope_type,
                     self.scope_id,
                 )
 
-                request.state.auth = {"credentials": credentials}
+                request.state.auth = {
+                    "credentials": credentials,
+                    "telemetry_credentials": telemetry_credentials,
+                }
 
             return await call_next(request)
 

--- a/sdks/python/oss/tests/pytest/unit/agents/golden/run_request.pi_core.json
+++ b/sdks/python/oss/tests/pytest/unit/agents/golden/run_request.pi_core.json
@@ -27,7 +27,8 @@
         "endpoint": "https://otlp.example/v1/traces",
         "headers": {
           "authorization": "Access tok-123"
-        }
+        },
+        "exportAuthorization": "Secret trace-tok-456"
       }
     }
   },

--- a/sdks/python/oss/tests/pytest/unit/agents/test_dtos_capabilities_events.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_dtos_capabilities_events.py
@@ -66,7 +66,13 @@ def test_trace_context_serializes_into_role_separated_wire_objects():
     }
     assert trace.telemetry_to_wire() == {
         "capture": {"content": {"enabled": True}},  # defaults on
-        "exporters": {"otlp": {"endpoint": "ep", "headers": {"authorization": None}}},
+        "exporters": {
+            "otlp": {
+                "endpoint": "ep",
+                "headers": {"authorization": None},
+                "exportAuthorization": None,
+            }
+        },
     }
 
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_dtos_secret_repr.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_dtos_secret_repr.py
@@ -18,6 +18,11 @@ def test_trace_context_authorization_masked_in_repr() -> None:
     assert "supersecrettoken" not in repr(trace)
 
 
+def test_trace_context_export_authorization_masked_in_repr() -> None:
+    trace = TraceContext(export_authorization="Secret supersecrettoken")
+    assert "supersecrettoken" not in repr(trace)
+
+
 def test_wire_tool_callback_authorization_masked_in_repr() -> None:
     callback = WireToolCallback(
         endpoint="https://example.test/tools/call",

--- a/sdks/python/oss/tests/pytest/unit/agents/test_tracing.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_tracing.py
@@ -27,10 +27,13 @@ def test_trace_context_keeps_authorization_without_traceparent(monkeypatch):
     assert context.authorization == "ApiKey invoke-credential"
 
 
-def test_trace_context_prefers_telemetry_credentials(monkeypatch):
-    # The dedicated trace-ingest credential outlives the caller's general credential, so
-    # when the platform issues one the exporter must use it instead of the Authorization
-    # header that `inject` re-emits from the general credential.
+def test_trace_context_splits_general_and_export_credentials(monkeypatch):
+    # THE REGRESSION TEST for the session-breaking blocker: the runner reads
+    # `telemetry.exporters.otlp.headers.authorization` to authenticate ALL session-coordination
+    # calls (ownership claims, mount signing, the turns ledger, history reconstruction,
+    # working-copy restore, attachment resolution), not just span export. If a scoped
+    # trace-ingest-only credential ever lands in that slot instead of `export_authorization`,
+    # every one of those calls is rejected and agent sessions break end to end.
     monkeypatch.setattr(
         tracing,
         "inject",
@@ -45,14 +48,16 @@ def test_trace_context_prefers_telemetry_credentials(monkeypatch):
     context = tracing.trace_context()
 
     assert context is not None
-    assert context.authorization == "Secret telemetry-credential"
+    assert context.authorization == "Secret general-credential"
+    assert context.export_authorization == "Secret telemetry-credential"
 
 
 def test_trace_context_falls_back_to_authorization_without_telemetry_credentials(
     monkeypatch,
 ):
-    # Older platforms issue no telemetry credential; the exporter keeps using the
-    # caller's general credential exactly as before.
+    # Older platforms issue no telemetry credential; the runner falls back to
+    # `headers.authorization` for the export request too, and the general credential is
+    # unaffected either way.
     monkeypatch.setattr(
         tracing,
         "inject",
@@ -68,6 +73,7 @@ def test_trace_context_falls_back_to_authorization_without_telemetry_credentials
 
     assert context is not None
     assert context.authorization == "Secret general-credential"
+    assert context.export_authorization is None
 
 
 def test_trace_context_keeps_telemetry_credentials_without_traceparent(monkeypatch):
@@ -84,11 +90,17 @@ def test_trace_context_keeps_telemetry_credentials_without_traceparent(monkeypat
 
     assert context is not None
     assert context.traceparent is None
-    assert context.authorization == "Secret telemetry-credential"
+    assert context.authorization is None
+    assert context.export_authorization == "Secret telemetry-credential"
 
 
 def test_trace_context_none_without_traceparent_or_authorization(monkeypatch):
     monkeypatch.setattr(tracing, "inject", lambda _headers: {})
+    monkeypatch.setattr(
+        tracing.TracingContext,
+        "get",
+        lambda: SimpleNamespace(telemetry_credentials=None),
+    )
 
     assert tracing.trace_context() is None
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_tracing.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_tracing.py
@@ -27,6 +27,66 @@ def test_trace_context_keeps_authorization_without_traceparent(monkeypatch):
     assert context.authorization == "ApiKey invoke-credential"
 
 
+def test_trace_context_prefers_telemetry_credentials(monkeypatch):
+    # The dedicated trace-ingest credential outlives the caller's general credential, so
+    # when the platform issues one the exporter must use it instead of the Authorization
+    # header that `inject` re-emits from the general credential.
+    monkeypatch.setattr(
+        tracing,
+        "inject",
+        lambda _headers: {"Authorization": "Secret general-credential"},
+    )
+    monkeypatch.setattr(
+        tracing.TracingContext,
+        "get",
+        lambda: SimpleNamespace(telemetry_credentials="Secret telemetry-credential"),
+    )
+
+    context = tracing.trace_context()
+
+    assert context is not None
+    assert context.authorization == "Secret telemetry-credential"
+
+
+def test_trace_context_falls_back_to_authorization_without_telemetry_credentials(
+    monkeypatch,
+):
+    # Older platforms issue no telemetry credential; the exporter keeps using the
+    # caller's general credential exactly as before.
+    monkeypatch.setattr(
+        tracing,
+        "inject",
+        lambda _headers: {"Authorization": "Secret general-credential"},
+    )
+    monkeypatch.setattr(
+        tracing.TracingContext,
+        "get",
+        lambda: SimpleNamespace(telemetry_credentials=None),
+    )
+
+    context = tracing.trace_context()
+
+    assert context is not None
+    assert context.authorization == "Secret general-credential"
+
+
+def test_trace_context_keeps_telemetry_credentials_without_traceparent(monkeypatch):
+    # A run holding only the telemetry credential (no traceparent, no general credential)
+    # still yields a TraceContext so its spans can export.
+    monkeypatch.setattr(tracing, "inject", lambda _headers: {})
+    monkeypatch.setattr(
+        tracing.TracingContext,
+        "get",
+        lambda: SimpleNamespace(telemetry_credentials="Secret telemetry-credential"),
+    )
+
+    context = tracing.trace_context()
+
+    assert context is not None
+    assert context.traceparent is None
+    assert context.authorization == "Secret telemetry-credential"
+
+
 def test_trace_context_none_without_traceparent_or_authorization(monkeypatch):
     monkeypatch.setattr(tracing, "inject", lambda _headers: {})
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
@@ -182,6 +182,7 @@ def _pi_payload():
             traceparent="00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
             endpoint="https://otlp.example/v1/traces",
             authorization="Access tok-123",
+            export_authorization="Secret trace-tok-456",
             capture_content=True,
         ),
         # The run's own context (trace + workflow identity), refreshed per turn and consumed only by
@@ -415,12 +416,18 @@ def test_request_to_wire_pi_matches_golden(golden):
             "baggage": None,
         }
     }
+    # `headers.authorization` and `exportAuthorization` are two credentials with different
+    # authority riding side by side: the general credential authenticates every session-
+    # coordination call the runner makes AS the caller, while `exportAuthorization` authenticates
+    # only the span-export request and may be a narrower, longer-lived token. They must land in
+    # their own slots, never merged or swapped.
     assert payload["telemetry"] == {
         "capture": {"content": {"enabled": True}},
         "exporters": {
             "otlp": {
                 "endpoint": "https://otlp.example/v1/traces",
                 "headers": {"authorization": "Access tok-123"},
+                "exportAuthorization": "Secret trace-tok-456",
             }
         },
     }

--- a/sdks/python/oss/tests/pytest/unit/test_auth_middleware_credentials.py
+++ b/sdks/python/oss/tests/pytest/unit/test_auth_middleware_credentials.py
@@ -1,0 +1,116 @@
+"""Unit tests for the routing auth middleware's allow-body parsing.
+
+`GET /permissions/check` returns the caller's general credential and, on platforms that
+issue one, a dedicated trace-ingest-scoped `telemetry_credentials`. The field is optional
+in both directions: an older platform omits it and the SDK must degrade to the general
+credential, with the cache carrying both values through a single entry.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, Dict, Optional
+
+import pytest
+
+from agenta.sdk.middlewares.routing import auth as auth_module
+from agenta.sdk.utils.cache import TTLLRUCache
+
+
+class _FakeRequest:
+    def __init__(self) -> None:
+        self.headers = {"authorization": "ApiKey caller-key"}
+        self.cookies: Dict[str, str] = {}
+        self.state = SimpleNamespace(otel={"baggage": {"project_id": "project-1"}})
+        self.query_params: Dict[str, str] = {}
+
+
+class _FakeResponse:
+    def __init__(self, body: Dict[str, Any]) -> None:
+        self.status_code = 200
+        self._body = body
+        self.headers: Dict[str, str] = {}
+
+    def json(self) -> Dict[str, Any]:
+        return self._body
+
+
+class _FakeAsyncClient:
+    """Stands in for httpx.AsyncClient; counts calls so cache hits are observable."""
+
+    call_count = 0
+    body: Dict[str, Any] = {}
+
+    async def __aenter__(self) -> "_FakeAsyncClient":
+        return self
+
+    async def __aexit__(self, *args: Any) -> None:
+        return None
+
+    async def get(self, *args: Any, **kwargs: Any) -> _FakeResponse:
+        type(self).call_count += 1
+        return _FakeResponse(type(self).body)
+
+
+@pytest.fixture
+def platform(monkeypatch):
+    monkeypatch.setattr(auth_module, "_AUTH_ENABLED", True)
+    monkeypatch.setattr(auth_module, "_CACHE_ENABLED", True)
+    monkeypatch.setattr(auth_module, "_cache", TTLLRUCache())
+    _FakeAsyncClient.call_count = 0
+    _FakeAsyncClient.body = {}
+    monkeypatch.setattr(auth_module.httpx, "AsyncClient", _FakeAsyncClient)
+    return _FakeAsyncClient
+
+
+async def _get_credentials() -> tuple[Optional[str], Optional[str]]:
+    return await auth_module.get_credentials(
+        _FakeRequest(),  # type: ignore[arg-type]
+        "http://agenta.test",
+    )
+
+
+async def test_allow_body_with_telemetry_credentials(platform):
+    platform.body = {
+        "effect": "allow",
+        "credentials": "Secret general-token",
+        "telemetry_credentials": "Secret telemetry-token",
+    }
+
+    credentials, telemetry_credentials = await _get_credentials()
+
+    assert credentials == "Secret general-token"
+    assert telemetry_credentials == "Secret telemetry-token"
+
+
+async def test_allow_body_without_telemetry_credentials(platform):
+    # Older platforms omit the field entirely; the SDK degrades to the general credential.
+    platform.body = {"effect": "allow", "credentials": "Secret general-token"}
+
+    credentials, telemetry_credentials = await _get_credentials()
+
+    assert credentials == "Secret general-token"
+    assert telemetry_credentials is None
+
+
+async def test_cache_round_trip_carries_both_credentials(platform):
+    platform.body = {
+        "effect": "allow",
+        "credentials": "Secret general-token",
+        "telemetry_credentials": "Secret telemetry-token",
+    }
+
+    first = await _get_credentials()
+    assert platform.call_count == 1
+
+    second = await _get_credentials()
+    # The second identical request is served from the cache, with BOTH values intact.
+    assert platform.call_count == 1
+    assert first == second == ("Secret general-token", "Secret telemetry-token")
+
+
+async def test_deny_body_raises(platform):
+    platform.body = {"effect": "deny"}
+
+    with pytest.raises(auth_module.DenyException):
+        await _get_credentials()

--- a/services/oss/tests/pytest/unit/agent/test_subscription_status.py
+++ b/services/oss/tests/pytest/unit/agent/test_subscription_status.py
@@ -429,7 +429,9 @@ def authed(monkeypatch):
     """Let the SDK auth middleware through, as a verified Agenta user would."""
 
     async def _allow(*_args, **_kwargs):
-        return "ApiKey test-credentials"
+        # `get_credentials` returns the caller's credential and a separate trace-ingest
+        # one; a single value here unpacks as two characters in the middleware.
+        return "ApiKey test-credentials", None
 
     monkeypatch.setattr(auth_middleware, "get_credentials", _allow)
     return TestClient(agent_v0_app)

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -560,6 +560,26 @@ export function writeOtlpAuthFile(
 }
 
 /**
+ * Put the turn's OTLP bearer in the read-once auth file, for a run that has both.
+ *
+ * Called at environment build AND again at every turn dispatch. The second call is what keeps a
+ * warm session's exports authenticated: the extension consumes the file once per turn, and the
+ * bearer expires in minutes while a session lives for hours, so a turn that reused the bearer
+ * the session was BUILT with would have every span batch rejected.
+ *
+ * Only local Pi has a path here — it is the one placement where the harness exports its own
+ * spans. Everywhere else the runner exports them itself, from the incoming request each turn.
+ */
+export function refreshOtlpAuthFile(
+  path: string | undefined,
+  authorization: string | undefined,
+  log: Log = () => {},
+): void {
+  if (!path || !authorization) return;
+  writeOtlpAuthFile(path, authorization, log);
+}
+
+/**
  * Install the extension bundle into a local Pi agent dir's extensions/. Reports whether the
  * install succeeded so the caller can fail closed when the policy needs it (a missing bundle or
  * an unwritable dir returns false rather than silently proceeding with no enforcement).

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -41,6 +41,7 @@ import type {
   RunPlanPrompt,
   RunPlanWorkspace,
 } from "./run-plan.ts";
+import { exportAuthorizationOf } from "./runtime-policy.ts";
 
 type Log = (message: string) => void;
 
@@ -489,7 +490,9 @@ export function buildPiExtensionEnv(
   const otlp = telemetry?.exporters?.otlp;
   if (propagation?.traceparent) env.TRACEPARENT = propagation.traceparent;
   if (otlp?.endpoint) env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = otlp.endpoint;
-  if (otlp?.headers?.authorization && opts.otlpAuthFilePath)
+  // The EXPORT credential, never `runCredential` — see `exportAuthorizationOf`. The two ride the
+  // same wire object and only one of them may be scope-limited.
+  if (telemetry && exportAuthorizationOf(request) && opts.otlpAuthFilePath)
     env.AGENTA_AGENT_OTLP_AUTH_FILE = opts.otlpAuthFilePath;
   if (telemetry?.capture?.content?.enabled === false)
     env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED = "false";

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -78,6 +78,7 @@ import {
   type SessionEnvironment,
 } from "./runtime-contracts.ts";
 import {
+  exportAuthorizationOf,
   runCredential,
   serverPermissionsFromRequest,
   shouldSuppressPausedToolCallUpdate,
@@ -265,7 +266,7 @@ export async function runTurn(
     // which reads the incoming request directly (just below).
     refreshOtlpAuthFile(
       env.otlpAuthFilePath,
-      request.telemetry?.exporters?.otlp?.headers?.authorization,
+      exportAuthorizationOf(request),
       logger,
     );
 
@@ -276,7 +277,9 @@ export async function runTurn(
       traceparent: request.context?.propagation?.traceparent,
       baggage: request.context?.propagation?.baggage,
       endpoint: request.telemetry?.exporters?.otlp?.endpoint,
-      authorization: request.telemetry?.exporters?.otlp?.headers?.authorization,
+      // The EXPORT credential, not `credential` above: that one is the caller's general
+      // credential for session-coordination calls, and only this one may be scope-limited.
+      authorization: exportAuthorizationOf(request),
       captureContent: request.telemetry?.capture?.content?.enabled,
       // Seed from the request's typed model/MCP credential material (`requestSecretValues` —
       // on a Daytona Secrets run the opaque values left the plaintext env for the secret plan

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -61,6 +61,7 @@ import { describeCodexSubscriptionAuthFault } from "./codex-assets.ts";
 import { conciseError } from "./errors.ts";
 import { PAUSED, PendingApprovalPauseController } from "./pause.ts";
 import { findSwallowedPiError } from "./pi-error.ts";
+import { refreshOtlpAuthFile } from "./pi-assets.ts";
 import { buildRelayExecutionGuard } from "./relay-guard.ts";
 import {
   buildApprovedContentWiring,
@@ -257,6 +258,16 @@ export async function runTurn(
       : reconstructed || historicalAttachmentsPresent
         ? buildTurnText(request, logger)
         : plan.prompt.turnText;
+
+    // Hand the sandbox's own exporter THIS turn's bearer, the same way the tool relay below is
+    // started from the incoming request's `toolCallback` rather than the parked copy. Only a
+    // local-Pi environment has a path here; every other placement exports from this process,
+    // which reads the incoming request directly (just below).
+    refreshOtlpAuthFile(
+      env.otlpAuthFilePath,
+      request.telemetry?.exporters?.otlp?.headers?.authorization,
+      logger,
+    );
 
     const run = (deps.createOtel ?? createSandboxAgentOtel)({
       harness: plan.harness,

--- a/services/runner/src/engines/sandbox_agent/runtime-policy.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-policy.ts
@@ -16,6 +16,27 @@ export function runCredential(request: AgentRunRequest): string {
   return (headers["authorization"] ?? headers["Authorization"] ?? "").trim();
 }
 
+/**
+ * The credential to authenticate the span EXPORT with — the sibling of `runCredential`, and the
+ * only one of the two that may be narrowly scoped.
+ *
+ * `runCredential` above reads the same wire object but must keep returning the caller's GENERAL
+ * credential: it authenticates session ownership, mount signing, the turns ledger, and history
+ * reconstruction. So the export credential rides its own field, and this falls back to the
+ * general one only because that is what every platform sent before the field existed.
+ *
+ * Both read sites (the in-sandbox Pi exporter's auth file, and the runner's own exporter) go
+ * through this, so the precedence has one definition and cannot drift between them.
+ */
+export function exportAuthorizationOf(
+  request: AgentRunRequest,
+): string | undefined {
+  const otlp = request.telemetry?.exporters?.otlp;
+  const scoped = otlp?.exportAuthorization?.trim();
+  if (scoped) return scoped;
+  return runCredential(request) || undefined;
+}
+
 export function serverPermissionsFromRequest(
   request: AgentRunRequest,
 ): ReadonlyMap<string, ToolPermission> {

--- a/services/runner/src/environment/runtime-lifecycle.ts
+++ b/services/runner/src/environment/runtime-lifecycle.ts
@@ -44,7 +44,10 @@ import {
   resolvePiToolSpecsDelivery,
   writePiToolSpecsFileLocal,
 } from "../engines/sandbox_agent/pi-assets.ts";
-import { applyClaudeConnectionEnv } from "../engines/sandbox_agent/runtime-policy.ts";
+import {
+  applyClaudeConnectionEnv,
+  exportAuthorizationOf,
+} from "../engines/sandbox_agent/runtime-policy.ts";
 import type { AgentRunRequest } from "../protocol.ts";
 import type { RunPlan } from "../engines/sandbox_agent/run-plan.ts";
 import type { Log } from "./timing.ts";
@@ -213,11 +216,7 @@ export function buildRuntimeEnvironment(
     p.isPi && !p.isDaytona ? `${p.workspace.relayDir}.otlp-auth` : undefined;
   // Turn one's bearer. Every later turn rewrites this file at dispatch (`runTurn`), because the
   // bearer outlives neither a warm session nor the extension's read-once consumption of it.
-  refreshOtlpAuthFile(
-    otlpAuthFilePath,
-    r.telemetry?.exporters?.otlp?.headers?.authorization,
-    input.log,
-  );
+  refreshOtlpAuthFile(otlpAuthFilePath, exportAuthorizationOf(r), input.log);
 
   const piExtEnv: Record<string, string> = p.isPi
     ? buildPiExtensionEnv(input.request, !p.isDaytona, {

--- a/services/runner/src/environment/runtime-lifecycle.ts
+++ b/services/runner/src/environment/runtime-lifecycle.ts
@@ -12,7 +12,8 @@
  * The lifecycle design gives the runtime a large role: `bootstrap`, `reconfigure`, `restart`. It
  * has none of that here, because the runner cannot do any of it yet. The daemon environment is
  * built ONCE, before the sandbox starts, and is immutable afterwards (see `AcquireContext`'s
- * invariant 1). There is no restart path and no credential refresh.
+ * invariant 1). There is no restart path, and the one credential a running environment can still
+ * be handed is the OTLP bearer, which rides a FILE precisely because the env map is frozen.
  *
  * So this unit is the runtime's TEARDOWN and its file handles, and nothing more. Inventing a
  * `restart()` that throws would suggest the seam exists; leaving it out says plainly that it does
@@ -39,8 +40,8 @@ import {
   buildPiExtensionEnv,
   configurePiSessionWorkspace,
   configurePiSkillSnapshot,
+  refreshOtlpAuthFile,
   resolvePiToolSpecsDelivery,
-  writeOtlpAuthFile,
   writePiToolSpecsFileLocal,
 } from "../engines/sandbox_agent/pi-assets.ts";
 import { applyClaudeConnectionEnv } from "../engines/sandbox_agent/runtime-policy.ts";
@@ -178,7 +179,8 @@ export interface RuntimeEnvironment {
  * THE OTLP BEARER RIDES A FILE, NEVER AN ENV VAR. The daemon environment is inherited by the
  * harness process, so a prompt-injected sandbox could read and echo a plain env var holding the
  * caller's reusable bearer. Only the PATH goes into the env; the extension reads the file once
- * and deletes it, and `removeRuntimeFiles` above is the backstop for a harness that never ran.
+ * per turn and deletes it, and `removeRuntimeFiles` above is the backstop for a harness that
+ * never ran. The bearer written HERE only ever serves turn one — see `refreshOtlpAuthFile`.
  */
 export function buildRuntimeEnvironment(
   input: BuildRuntimeEnvironmentInput,
@@ -209,11 +211,13 @@ export function buildRuntimeEnvironment(
   // specs, scoped env, callback endpoints, and callback auth in runner memory.
   const otlpAuthFilePath =
     p.isPi && !p.isDaytona ? `${p.workspace.relayDir}.otlp-auth` : undefined;
-  const otlpAuthorization =
-    r.telemetry?.exporters?.otlp?.headers?.authorization;
-  if (otlpAuthFilePath && otlpAuthorization) {
-    writeOtlpAuthFile(otlpAuthFilePath, otlpAuthorization, input.log);
-  }
+  // Turn one's bearer. Every later turn rewrites this file at dispatch (`runTurn`), because the
+  // bearer outlives neither a warm session nor the extension's read-once consumption of it.
+  refreshOtlpAuthFile(
+    otlpAuthFilePath,
+    r.telemetry?.exporters?.otlp?.headers?.authorization,
+    input.log,
+  );
 
   const piExtEnv: Record<string, string> = p.isPi
     ? buildPiExtensionEnv(input.request, !p.isDaytona, {

--- a/services/runner/src/extensions/agenta.ts
+++ b/services/runner/src/extensions/agenta.ts
@@ -81,6 +81,28 @@ export function readOtlpAuthFile(path?: string): string | undefined {
 }
 import { runResolvedTool } from "../tools/dispatch.ts";
 
+/**
+ * The OTLP bearer to export the CURRENT turn with.
+ *
+ * The bearer is a short-lived credential (minutes), but a warm session keeps this process alive
+ * across turns for hours, so one captured at process start is expired for every turn after the
+ * first and each export is rejected. The runner rewrites the auth file at every turn dispatch;
+ * this re-reads it per turn, keeping the read-once-then-delete handling the file has always had.
+ *
+ * A turn whose file is absent keeps the previous bearer rather than dropping to none: that is
+ * the credential this process would have used anyway, so a failed write can never make the
+ * export worse than it was before the file was rewritten per turn.
+ */
+export function createOtlpAuthRefresher(
+  path?: string,
+): () => string | undefined {
+  let current: string | undefined;
+  return () => {
+    current = readOtlpAuthFile(path) ?? current;
+    return current;
+  };
+}
+
 function log(message: string): void {
   process.stderr.write(`[agenta-pi-ext] ${message}\n`);
 }
@@ -466,7 +488,7 @@ const factory = (pi: ExtensionAPI): void => {
   const otel = createAgentaOtel({
     traceparent: process.env.TRACEPARENT,
     endpoint: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-    authorization: readOtlpAuthFile(process.env.AGENTA_AGENT_OTLP_AUTH_FILE),
+    // No bearer here: it is read per turn, below.
     captureContent:
       process.env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED !== "false",
     // The skills that loaded for this run (author + forced `_agenta.*`), stamped on the agent
@@ -474,6 +496,19 @@ const factory = (pi: ExtensionAPI): void => {
     skills: parseSkillsLoaded(process.env.AGENTA_AGENT_SKILLS_LOADED),
   });
   otel.register(pi); // lifecycle handlers (spans + usage accumulation)
+
+  // `agent_start` is where the otel state pins this turn's export target, so the turn's own
+  // bearer has to be in `config` before then — `before_agent_start` is the last point that is
+  // still true, for every turn, on a session the runner keeps warm. A usage-only run reads the
+  // file never: it exports nothing, so it must not consume a bearer.
+  if (hasTracing) {
+    const refreshOtlpAuthorization = createOtlpAuthRefresher(
+      process.env.AGENTA_AGENT_OTLP_AUTH_FILE,
+    );
+    pi.on("before_agent_start", async () => {
+      otel.config.authorization = refreshOtlpAuthorization();
+    });
+  }
 
   pi.on("agent_end", async () => {
     if (hasTracing) await otel.flush(); // invoke_agent has a remote parent → flush by id

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -77,14 +77,29 @@ export interface RequestContext {
  *  - `capture.content.enabled` is the capture POLICY: default on; `false` strips message and tool
  *    content from the exported spans.
  *  - `exporters.otlp` is the OTLP destination: `endpoint` is the traces URL, and `headers` carries
- *    the exporter CREDENTIAL under the standard `authorization` header (kept verbatim), so the
- *    secret lives under the thing it authenticates rather than as a free-floating field.
+ *    a CREDENTIAL under the standard `authorization` header (kept verbatim).
+ *
+ * TWO CREDENTIALS LIVE HERE, AND THEY ARE NOT INTERCHANGEABLE. Read the right one.
+ *
+ *  - `headers.authorization` is the caller's GENERAL credential. Despite sitting under the
+ *    exporter, it is the runner's only source for authenticating session-coordination calls AS
+ *    the caller — ownership claims, mount signing, the turns ledger, history reconstruction,
+ *    attachment resolution (see `runCredential`). It must stay a full-authority credential.
+ *  - `exportAuthorization` authenticates the span EXPORT and nothing else. It may be narrowly
+ *    scoped (trace ingest only) and longer-lived than the general credential, because a warm
+ *    session outlives the general credential many times over. Optional: absent, the export falls
+ *    back to `headers.authorization`, which is what every platform did before this field existed.
+ *
+ * Putting a scoped token in `headers.authorization` breaks every session call listed above, so
+ * resolve the export credential through `exportAuthorizationOf`, never by reading either field
+ * directly.
  *
  * All fields optional; an absent endpoint/headers falls back to the runner's env config.
  */
 export interface OtlpExporter {
   endpoint?: string;
   headers?: Record<string, string>;
+  exportAuthorization?: string;
 }
 
 export interface Telemetry {

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -205,26 +205,31 @@ function redactAttributes(
   }
 }
 
-/** Cache one exporter per distinct endpoint+auth so we do not rebuild per export. */
-const exporterCache = new Map<string, OTLPTraceExporter>();
-
-function targetKey(target: ExportTarget): string {
-  return `${target.endpoint}\n${target.authorization ?? ""}`;
-}
+/**
+ * Cache ONE exporter per endpoint so we do not rebuild per export.
+ *
+ * Keyed on the endpoint alone, and the credential is held beside it only to detect a change.
+ * Keying on the bearer instead would grow this map by one live entry per credential — which,
+ * now that the export credential is refreshed every turn, means one per turn for the process's
+ * whole life, each retaining a usable token in memory long after its turn ended. Rotating
+ * replaces the entry, so a given endpoint retains exactly the credential currently in use.
+ */
+const exporterCache = new Map<
+  string,
+  { authorization: string; exporter: OTLPTraceExporter }
+>();
 
 function getExporter(target: ExportTarget): OTLPTraceExporter {
-  const key = targetKey(target);
-  let exporter = exporterCache.get(key);
-  if (!exporter) {
-    exporter = new OTLPTraceExporter({
-      url: target.endpoint,
-      headers: target.authorization
-        ? { Authorization: target.authorization }
-        : {},
-      timeoutMillis: 10_000,
-    });
-    exporterCache.set(key, exporter);
-  }
+  const authorization = target.authorization ?? "";
+  const cached = exporterCache.get(target.endpoint);
+  if (cached && cached.authorization === authorization) return cached.exporter;
+
+  const exporter = new OTLPTraceExporter({
+    url: target.endpoint,
+    headers: authorization ? { Authorization: authorization } : {},
+    timeoutMillis: 10_000,
+  });
+  exporterCache.set(target.endpoint, { authorization, exporter });
   return exporter;
 }
 
@@ -396,7 +401,7 @@ class TraceBatchProcessor implements SpanProcessor {
   shutdown(): Promise<void> {
     return this.forceFlush().then(async () => {
       await Promise.all(
-        [...exporterCache.values()].map((exporter) => exporter.shutdown()),
+        [...exporterCache.values()].map((entry) => entry.exporter.shutdown()),
       );
     });
   }

--- a/services/runner/tests/unit/otlp-auth-per-turn.test.ts
+++ b/services/runner/tests/unit/otlp-auth-per-turn.test.ts
@@ -1,0 +1,197 @@
+/**
+ * The OTLP export bearer is refreshed per TURN, not per session.
+ *
+ * The bearer lives for minutes; a warm session lives for hours. Capturing it once when the
+ * environment was built meant every export after the first few minutes was rejected with
+ * `Unauthorized`, which is why no agent traces existed in cloud observability (ASD-EST100).
+ * These pin both halves of the loop: the runner rewrites the file at each turn dispatch, and
+ * the in-sandbox extension re-reads it at each turn instead of once at process start.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/otlp-auth-per-turn.test.ts)
+ */
+import { afterEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import { existsSync, mkdtempSync, readFileSync, rmSync, statSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+
+import factory, {
+  createOtlpAuthRefresher,
+  readOtlpAuthFile,
+} from "../../src/extensions/agenta.ts";
+import { refreshOtlpAuthFile } from "../../src/engines/sandbox_agent/pi-assets.ts";
+
+const tempRoots: string[] = [];
+
+function tempDir(): string {
+  const dir = mkdtempSync(join(tmpdir(), "otlp-auth-per-turn-"));
+  tempRoots.push(dir);
+  return dir;
+}
+
+afterEach(() => {
+  while (tempRoots.length) {
+    rmSync(tempRoots.pop()!, { recursive: true, force: true });
+  }
+});
+
+describe("the runner writes each turn's bearer to the auth file", () => {
+  it("writes the bearer 0600 so only the runtime user can read it", () => {
+    const path = join(tempDir(), "relay.otlp-auth");
+
+    refreshOtlpAuthFile(path, "Secret turn-one");
+
+    assert.equal(readFileSync(path, "utf-8"), "Secret turn-one");
+    assert.equal(statSync(path).mode & 0o777, 0o600);
+  });
+
+  it("overwrites the previous turn's bearer rather than appending", () => {
+    const path = join(tempDir(), "relay.otlp-auth");
+
+    refreshOtlpAuthFile(path, "Secret turn-one");
+    refreshOtlpAuthFile(path, "Secret turn-two");
+
+    assert.equal(readFileSync(path, "utf-8"), "Secret turn-two");
+  });
+
+  it("writes nothing when the run has no auth file (every non-local-Pi placement)", () => {
+    // The runner exports those runs itself, from the incoming request, so there is no file.
+    refreshOtlpAuthFile(undefined, "Secret turn-one");
+  });
+
+  it("leaves the previous turn's bearer in place when a turn carries none", () => {
+    const path = join(tempDir(), "relay.otlp-auth");
+    refreshOtlpAuthFile(path, "Secret turn-one");
+
+    refreshOtlpAuthFile(path, undefined);
+
+    assert.equal(readFileSync(path, "utf-8"), "Secret turn-one");
+  });
+});
+
+describe("the extension re-reads the bearer once per turn", () => {
+  it("reads the file and deletes it, so the bearer never lingers on disk", () => {
+    const path = join(tempDir(), "relay.otlp-auth");
+    writeFileSync(path, "Secret turn-one");
+
+    assert.equal(readOtlpAuthFile(path), "Secret turn-one");
+    assert.equal(existsSync(path), false);
+  });
+
+  it("picks up the bearer the runner wrote for THIS turn", () => {
+    const path = join(tempDir(), "relay.otlp-auth");
+    const refresh = createOtlpAuthRefresher(path);
+
+    refreshOtlpAuthFile(path, "Secret turn-one");
+    assert.equal(refresh(), "Secret turn-one");
+
+    refreshOtlpAuthFile(path, "Secret turn-two");
+    assert.equal(refresh(), "Secret turn-two");
+  });
+
+  it("keeps the last bearer when a turn's write did not land", () => {
+    // A failed write must never make the export worse than the bearer this process already
+    // had; it degrades to a stale credential, not to an unauthenticated export.
+    const path = join(tempDir(), "relay.otlp-auth");
+    const refresh = createOtlpAuthRefresher(path);
+
+    refreshOtlpAuthFile(path, "Secret turn-one");
+    assert.equal(refresh(), "Secret turn-one");
+
+    assert.equal(refresh(), "Secret turn-one");
+  });
+
+  it("reports no bearer for a run that has no auth file at all", () => {
+    assert.equal(createOtlpAuthRefresher(undefined)(), undefined);
+  });
+});
+
+/** The slice of Pi's ExtensionAPI the tracing path touches, recording what it registers. */
+function fakePi() {
+  const handlers = new Map<string, Array<() => Promise<void>>>();
+  return {
+    handlers,
+    async fire(event: string) {
+      for (const handler of handlers.get(event) ?? []) await handler();
+    },
+    api: {
+      on(event: string, handler: () => Promise<void>) {
+        handlers.set(event, [...(handlers.get(event) ?? []), handler]);
+      },
+      registerTool() {},
+      registerProvider() {},
+      setActiveTools() {},
+      getActiveTools: () => [],
+      getAllTools: () => [],
+    },
+  };
+}
+
+describe("the extension arms the per-turn refresh only when it exports traces", () => {
+  const OTLP_ENV = [
+    "TRACEPARENT",
+    "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
+    "AGENTA_AGENT_OTLP_AUTH_FILE",
+    "AGENTA_AGENT_USAGE_CAPTURE_PATH",
+  ] as const;
+  const saved = new Map<string, string | undefined>();
+
+  function setEnv(values: Partial<Record<(typeof OTLP_ENV)[number], string>>) {
+    for (const key of OTLP_ENV) {
+      if (!saved.has(key)) saved.set(key, process.env[key]);
+      const value = values[key];
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+  }
+
+  afterEach(() => {
+    for (const [key, value] of saved) {
+      if (value === undefined) delete process.env[key];
+      else process.env[key] = value;
+    }
+    saved.clear();
+  });
+
+  it("re-reads the file at every turn start, so turn two exports with turn two's bearer", async () => {
+    const path = join(tempDir(), "relay.otlp-auth");
+    refreshOtlpAuthFile(path, "Secret turn-one");
+    setEnv({
+      TRACEPARENT:
+        "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+      OTEL_EXPORTER_OTLP_TRACES_ENDPOINT: "https://example.invalid/otlp/v1/traces",
+      AGENTA_AGENT_OTLP_AUTH_FILE: path,
+    });
+
+    const pi = fakePi();
+    factory(pi.api as never);
+
+    // Turn one: the bearer is read at the turn, not when the process started.
+    assert.equal(existsSync(path), true);
+    await pi.fire("before_agent_start");
+    assert.equal(existsSync(path), false);
+
+    // Turn two reads the file the runner rewrote for it, rather than reusing turn one's
+    // bearer. That re-read is the whole fix.
+    refreshOtlpAuthFile(path, "Secret turn-two");
+    await pi.fire("before_agent_start");
+    assert.equal(existsSync(path), false);
+  });
+
+  it("leaves the bearer alone for a run that exports nothing", async () => {
+    const path = join(tempDir(), "relay.otlp-auth");
+    refreshOtlpAuthFile(path, "Secret unused");
+    // No traceparent and no endpoint: this run accumulates usage for the runner to write back
+    // and exports no spans of its own, so there is no bearer in the sandbox to keep fresh.
+    setEnv({
+      AGENTA_AGENT_OTLP_AUTH_FILE: path,
+      AGENTA_AGENT_USAGE_CAPTURE_PATH: join(tempDir(), "usage.json"),
+    });
+
+    const pi = fakePi();
+    factory(pi.api as never);
+    await pi.fire("before_agent_start");
+
+    assert.equal(readFileSync(path, "utf-8"), "Secret unused");
+  });
+});

--- a/services/runner/tests/unit/otlp-auth-per-turn.test.ts
+++ b/services/runner/tests/unit/otlp-auth-per-turn.test.ts
@@ -20,6 +20,11 @@ import factory, {
   readOtlpAuthFile,
 } from "../../src/extensions/agenta.ts";
 import { refreshOtlpAuthFile } from "../../src/engines/sandbox_agent/pi-assets.ts";
+import {
+  exportAuthorizationOf,
+  runCredential,
+} from "../../src/engines/sandbox_agent/runtime-policy.ts";
+import type { AgentRunRequest } from "../../src/protocol.ts";
 
 const tempRoots: string[] = [];
 
@@ -193,5 +198,55 @@ describe("the extension arms the per-turn refresh only when it exports traces", 
     await pi.fire("before_agent_start");
 
     assert.equal(readFileSync(path, "utf-8"), "Secret unused");
+  });
+});
+
+/**
+ * The export credential and the caller's general credential ride the SAME wire object, and
+ * exactly one of them may be scope-limited. Reading the wrong one is not a tracing bug: the
+ * runner authenticates session ownership, mount signing, the turns ledger, history
+ * reconstruction and attachment resolution with `runCredential`, so a trace-ingest-scoped token
+ * reaching that function fails every one of those calls and the session dies.
+ */
+describe("the export credential and the run credential stay separate", () => {
+  function requestWith(otlp: Record<string, unknown>): AgentRunRequest {
+    return {
+      harness: "pi_core",
+      messages: [{ role: "user", content: "hello" }],
+      telemetry: { exporters: { otlp } },
+    } as AgentRunRequest;
+  }
+
+  it("never lets a scoped export token become the run credential", () => {
+    const request = requestWith({
+      headers: { authorization: "Secret general-token" },
+      exportAuthorization: "Secret trace-ingest-token",
+    });
+
+    assert.equal(runCredential(request), "Secret general-token");
+    assert.equal(exportAuthorizationOf(request), "Secret trace-ingest-token");
+  });
+
+  it("exports with the general credential when the platform sends no scoped one", () => {
+    // Every platform predating the field, and every self-hosted stack yet to upgrade.
+    const request = requestWith({
+      headers: { authorization: "Secret general-token" },
+    });
+
+    assert.equal(exportAuthorizationOf(request), "Secret general-token");
+    assert.equal(runCredential(request), "Secret general-token");
+  });
+
+  it("reports no export credential when the run carries neither", () => {
+    assert.equal(exportAuthorizationOf(requestWith({})), undefined);
+  });
+
+  it("ignores a blank scoped token rather than exporting unauthenticated", () => {
+    const request = requestWith({
+      headers: { authorization: "Secret general-token" },
+      exportAuthorization: "   ",
+    });
+
+    assert.equal(exportAuthorizationOf(request), "Secret general-token");
   });
 });

--- a/services/runner/tests/unit/wire-contract.test.ts
+++ b/services/runner/tests/unit/wire-contract.test.ts
@@ -169,8 +169,9 @@ describe("wire contract: requests (vs Python golden)", () => {
     assert.equal(req.sessionId, "sess-1");
     // The run's tracing inputs reach the runner grouped by role (trace/telemetry restructure): the
     // per-call W3C propagation under `context.propagation`, and the operator-owned exporter config +
-    // capture policy under `telemetry` (the OTLP credential under the standard `authorization`
-    // header). No single `trace` bucket mixes the four roles anymore.
+    // capture policy under `telemetry`. No single `trace` bucket mixes the four roles anymore.
+    // The two telemetry credentials ride SEPARATE slots and carry different authority: see the
+    // `OtlpExporter` contract and `exportAuthorizationOf`.
     assert.equal(
       req.context!.propagation!.traceparent,
       "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01",
@@ -183,6 +184,10 @@ describe("wire contract: requests (vs Python golden)", () => {
     assert.equal(
       req.telemetry!.exporters!.otlp!.headers!.authorization,
       "Access tok-123",
+    );
+    assert.equal(
+      req.telemetry!.exporters!.otlp!.exportAuthorization,
+      "Secret trace-tok-456",
     );
     assert.equal((req as Record<string, unknown>).trace, undefined);
     // Pi exposes the prompt overrides.


### PR DESCRIPTION
## The symptom

No agent traces were reaching observability. Every span batch from a warm agent
session was rejected with `401 Unauthorized`, and had been for at least a week
before anyone noticed. The export log said `Unauthorized` and nothing else, so
there was no way to tell a stale credential from a wrong one.

## Why it happened

The export bearer was captured **once per session**. The runner wrote it to the
read-once auth file during environment build only, and Pi's telemetry extension
read that file once at process start.

That bearer lives for minutes. A warm agent session lives for hours. So every
turn after the first few minutes exported with a dead credential.

## What changes

**The runner refreshes the auth file at turn dispatch**, using the incoming
turn's credential, mirroring how the tool relay already starts each turn from the
incoming request rather than from a parked copy. The extension re-reads the file
at `before_agent_start`, so the read-once-then-delete handling is per turn
instead of per process. A turn whose file is missing keeps the previous bearer,
so a failed write is never worse than today's behavior.

**`/permissions/check` mints a second, turn-sized telemetry token.** Per-turn
refresh alone still leaves one turn longer than the credential's life exporting
with an expired bearer. Rather than lengthen the general credential, the endpoint
now issues a token with a `trace-ingest` scope claim and its own TTL, two hours
by default, overridable with `AGENTA_OTLP_TOKEN_TTL_SECONDS`. It comes back as
`telemetry_credentials`, and the SDK threads it to the trace exporter only. The
general 15 minute credential is untouched in lifetime, payload shape, and
behavior.

The longer TTL is safe only because `verify_secret_token` confines a scoped token
to its scope's allowed paths, `trace-ingest` to `/otlp/v1/traces`, and fails
closed on an unknown scope. That check lives inside `verify_secret_token` rather
than at any call site, so a future caller cannot bypass it.

**The export credential gets its own wire field.** The runner reads the
`Authorization` slot to authenticate session-coordination calls, so that slot has
to stay the caller's full-authority credential. Carrying the trace-ingest token
there broke those calls. `export_authorization` now carries the export-only
credential, and stays unset when no telemetry credential was issued so the export
falls back to the caller's credential.

**Every minted token now carries an `iat` claim** alongside `exp`, both derived
from one instant, so a token's age and its remaining life sum to the lifetime it
was minted with. Without it, export diagnostics could report that a credential
had expired but not how old it was, which is exactly the ambiguity that let a
week of 401s go undiagnosed.

## Before and after

| | Before | After |
|---|---|---|
| Auth file written | once, at environment build | at every turn dispatch |
| Extension reads it | once, at process start | at every `before_agent_start` |
| Export credential | the caller's general 15 minute token | a `trace-ingest` scoped token, 2h default |
| Wire field | shared `Authorization` slot | its own `export_authorization` |
| A failed export says | `Unauthorized` | status, endpoint, and credential age |

## Compatibility

Both directions degrade safely. An API that omits `telemetry_credentials` leaves
the SDK on today's fallback to the general credential. An SDK that ignores the
field is unaffected. The runner change ships inside the runner image, so it
deploys atomically.

## Trade-off worth reviewing

The telemetry credential is delivered through `/permissions/check` rather than as
a second token on the `/invoke` wire, because that endpoint already hands the SDK
its credential and both sides cache them together. A single turn that outlives
even the two hour scoped TTL would still export with an expired bearer.

## About the commit list

The bottom two commits, `make trace export failures diagnosable` and `treat blank
export credentials as missing`, already merged as #6109 into `release/v0.112.3`.
That release branch has not reached `main` yet, so they still appear here. They
will deduplicate when the release lands.

## Testing

- Runner unit suite: 130 files, 2224 tests, all passing. Typecheck clean.
- SDK agent suite: 896 passing. One unrelated failure,
  `test_cli_stream_terminal_only_on_empty_request`, also fails on plain `main`;
  this branch touches no streaming or CLI code.
- API `test_auth_secret_token.py`: 20 passing.
- New coverage in `services/runner/tests/unit/otlp-auth-per-turn.test.ts` and the
  runner and SDK wire-contract tests, plus SDK and API tests for the scoped token
  and the `iat` claim.
