### PR TITLE
[6084] fix(runner): balance the run deadline with the mount lease (11h deadline, 12h lease)

### DIFF
--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -1213,11 +1213,16 @@ class MountsConfig(BaseModel):
     """Mounts-domain config. Store credentials live in StoreConfig."""
 
     # Lifetime of signed mount credentials, in seconds. The store backends clamp it to their
-    # own STS bounds.
+    # own STS bounds. The default is 43200 (12h) because that is SeaweedFS's maxSessionLength
+    # ceiling (AWS GetFederationToken accepts up to 129600), and because it must stay ABOVE the
+    # runner's default total run deadline (11h, DEFAULT_TOTAL_DEADLINE_MS in run-limits.ts) plus
+    # its 60s lease skew: the runner only reuses a warm sandbox when the lease covers
+    # `now + deadline + skew`, so a TTL at or below the deadline forces every mount-backed
+    # session to rebuild cold.
     credentials_ttl_seconds: int = Field(
         default_factory=lambda: (
             _parse_optional_positive_int_env("AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS")
-            or 3600
+            or 43200
         )
     )
 

--- a/api/oss/tests/pytest/unit/test_mounts_injection.py
+++ b/api/oss/tests/pytest/unit/test_mounts_injection.py
@@ -221,7 +221,7 @@ class TestSignMountCredentials:
         assert creds.access_key != _MASTER_KEY
         assert creds.secret_key != _MASTER_SECRET
 
-    async def test_short_ttl_by_default(self):
+    async def test_bounded_ttl_by_default(self):
         service, _, storage = _make_service()
         pid, uid = uuid4(), uuid4()
         mount = await service.get_or_create_session_cwd(
@@ -230,8 +230,9 @@ class TestSignMountCredentials:
 
         await service.sign_mount_credentials(project_id=pid, mount_id=mount.id)
 
-        # Minutes, not hours.
-        assert 0 < storage.signed_with["duration_seconds"] <= 3600
+        # Bounded at the 12h default (SeaweedFS's maxSessionLength ceiling; the runner's
+        # 11h run deadline must fit under it — see MountsConfig.credentials_ttl_seconds).
+        assert 0 < storage.signed_with["duration_seconds"] <= 43200
 
     async def test_unavailable_without_storage(self):
         dao = _UpsertDAO()
@@ -566,10 +567,10 @@ class TestMountsCredentialsTtlConfig:
     @pytest.mark.parametrize(
         "value, expected",
         [
-            (None, 3600),
+            (None, 43200),
             ("120", 120),
             # An unset compose passthrough delivers an empty string, not an absent variable.
-            ("", 3600),
+            ("", 43200),
         ],
     )
     def test_credentials_ttl_reads_the_env_at_instantiation(

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -109,8 +109,8 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # AGENTA_RUNNER_SESSION_KEEPALIVE=
 
 # --- Run limits (per run; a run paused on a human approval is exempt from all four) ---
-# 24 hours. Override this to enforce a different per-run wall-clock limit.
-# AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=86400000
+# 11 hours (must stay below the 12h mount-lease TTL minus 60s skew, or warm reuse dies).
+# AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=39600000
 # 30 min without a progress event. Must stay below the total.
 # AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=1800000
 # 2 min to the first response.

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -113,8 +113,8 @@ AGENTA_RUNNER_TOKEN=replace-me
 # AGENTA_RUNNER_SESSION_KEEPALIVE=
 
 # --- Run limits (per run; a run paused on a human approval is exempt from all four) ---
-# 24 hours. Override this to enforce a different per-run wall-clock limit.
-# AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=86400000
+# 11 hours (must stay below the 12h mount-lease TTL minus 60s skew, or warm reuse dies).
+# AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=39600000
 # 30 min without a progress event. Must stay below the total.
 # AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=1800000
 # 2 min to the first response.

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -109,8 +109,8 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # AGENTA_RUNNER_SESSION_KEEPALIVE=
 
 # --- Run limits (per run; a run paused on a human approval is exempt from all four) ---
-# 24 hours. Override this to enforce a different per-run wall-clock limit.
-# AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=86400000
+# 11 hours (must stay below the 12h mount-lease TTL minus 60s skew, or warm reuse dies).
+# AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=39600000
 # 30 min without a progress event. Must stay below the total.
 # AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=1800000
 # 2 min to the first response.

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -113,8 +113,8 @@ AGENTA_RUNNER_TOKEN=replace-me
 # AGENTA_RUNNER_SESSION_KEEPALIVE=
 
 # --- Run limits (per run; a run paused on a human approval is exempt from all four) ---
-# 24 hours. Override this to enforce a different per-run wall-clock limit.
-# AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=86400000
+# 11 hours (must stay below the 12h mount-lease TTL minus 60s skew, or warm reuse dies).
+# AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS=39600000
 # 30 min without a progress event. Must stay below the total.
 # AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS=1800000
 # 2 min to the first response.

--- a/services/runner/src/engines/sandbox_agent/run-limits.ts
+++ b/services/runner/src/engines/sandbox_agent/run-limits.ts
@@ -29,7 +29,14 @@ export const IDLE_TIMEOUT_ENV = "AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS";
 export const TTFB_TIMEOUT_ENV = "AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS";
 export const TOOL_CALL_TIMEOUT_ENV = "AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS";
 
-export const DEFAULT_TOTAL_DEADLINE_MS = 24 * 60 * 60_000; // 24 hours
+// 11 hours. This default must stay BELOW the mount-lease TTL (43200s, see
+// AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS in the API's env.py) minus the 60s
+// MOUNT_LEASE_SKEW_MS: the session coordinator only reuses a warm sandbox when its
+// mount lease covers `now + this deadline + skew` (session-coordinator.ts's
+// `requiredValidThroughMs` horizon), so a default at or above the lease TTL makes
+// every mount-backed warm session rebuild cold. The ~1h gap under the 12h lease is
+// the warm parking window.
+export const DEFAULT_TOTAL_DEADLINE_MS = 11 * 60 * 60_000; // 11 hours
 export const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60_000; // 30 min
 export const DEFAULT_TTFB_TIMEOUT_MS = 2 * 60_000; // 2 min
 export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 30 * 60_000; // 30 min

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -33,9 +33,11 @@ import {
   computeCredentialEpoch,
   configFingerprint,
   mountExpiryMs,
+  MOUNT_LEASE_SKEW_MS,
   type InstalledMountExpiries,
   type KeepaliveConfig,
 } from "../../src/engines/sandbox_agent/session-identity.ts";
+import { resolveRunLimits } from "../../src/engines/sandbox_agent/run-limits.ts";
 import {
   appliedStateForRequest,
   AppliedState,
@@ -1239,9 +1241,13 @@ describe("runWithKeepalive: approval credential lifecycle", () => {
   });
 
   it("the repark after a resume keeps the parked secrets hash AND the installed mount lease", async () => {
-    // Six hours out, so neither the expiry bound nor the expiring-lease bound fires here.
+    // The lease must outlive the reuse horizon (`now + total deadline + skew`, the
+    // session coordinator's `requiredValidThroughMs`) or the resume rebuilds cold and
+    // this test fails for the wrong reason. Derive it from the real default so a future
+    // change to DEFAULT_TOTAL_DEADLINE_MS cannot silently invalidate the setup; the
+    // hour of margin keeps the expiring-lease bound from firing either.
     const installedExpiresAt = new Date(
-      Date.now() + 6 * 3_600_000,
+      Date.now() + resolveRunLimits().totalMs + MOUNT_LEASE_SKEW_MS + 3_600_000,
     ).toISOString();
     const { engine, calls } = makeApprovalEngine(
       [


### PR DESCRIPTION
## Context

Since #6091 raised the default total run deadline from 45 minutes to 24 hours, every mount-backed session rebuilds its sandbox cold instead of resuming warm, and one runner unit test fails deterministically (`session-keepalive-approval.test.ts`, the repark-after-resume case).

The two numbers are coupled. The session coordinator only reuses a warm sandbox when its installed mount lease covers `now + total run deadline + 60s skew` (`session-coordinator.ts`, `requiredValidThroughMs`). The API signs mount leases for 3600s by default, and no backend can sign one past 12 hours anyway (SeaweedFS caps at its 43200s `maxSessionLength`; AWS GetFederationToken at 129600s). With a 24-hour deadline no lease can ever satisfy the check, so warm reuse was dead for every mount-backed session.

## Changes

Two defaults move so the reuse check can pass again:

- Runner default total run deadline: 24h to **11h** (`DEFAULT_TOTAL_DEADLINE_MS` in `run-limits.ts`).
- API default mount lease TTL: 3600s to **43200s** (`MountsConfig.credentials_ttl_seconds` in `env.py`), the SeaweedFS ceiling; AWS accepts it too.

11h + 60s skew sits under the 12h lease, and the roughly one hour of headroom is the warm parking window. Both constants now carry a comment stating the constraint (deadline below lease TTL minus skew, and why 43200 is the ceiling) so the next person who changes one knows about the other. The four env example files show the new default. The env overrides `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS` and `AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS` keep working unchanged.

The failing test parked a hardcoded 6-hour lease, which silently stopped clearing the reuse horizon when the default grew. It now derives the lease from `resolveRunLimits().totalMs + MOUNT_LEASE_SKEW_MS` plus an hour of margin, with a comment explaining the horizon, so a future default change cannot invalidate it again. The API-side TTL config tests move from 3600 to 43200 accordingly.

**Security trade-off, accepted by Mahmoud:** a leaked mount lease is prefix-scoped to one session's storage, but it is now usable for 12 hours instead of 1. The real fix for long runs is refreshing credentials in place on the warm sandbox instead of stretching the lease; that follow-up is out of scope here (tracked in `docs/design/fix-sts-mount-expiry/decisions.md`).

## Tests

- `services/runner`: `pnpm test` passes (131 files, 2225 passed, 7 expected-fail), including the previously failing `session-keepalive-approval.test.ts`. `pnpm run typecheck` clean.
- `api`: `pytest oss/tests/pytest/unit/test_mounts_injection.py` passes (27 tests). `ruff@0.15.12 format --check` and `check` clean on the changed files.
