### PR TITLE
[fix] Surface errored harness turns on Daytona sandboxes

### DIFF
--- a/services/runner/src/engines/sandbox_agent/pi-error.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-error.ts
@@ -15,13 +15,33 @@
  * the sandbox's daemon file API (the same API `usage.ts` and `pi-assets.ts` read through),
  * which must happen while the sandbox is still alive — the transcript dies with it.
  *
- * It is deliberately best-effort and side-effect free: any filesystem/parse problem returns
- * `undefined` so a genuinely empty (but successful) turn is never turned into a false error.
+ * It is deliberately best-effort and side-effect free, and errs toward NO recovery: any
+ * filesystem/parse problem returns `undefined` so a genuinely empty (but successful) turn is
+ * never turned into a false error, and only the NEWEST transcript this run owns may supply
+ * the error — an older sibling must never resurrect a failure the current turn did not have.
+ * The remote probe is additionally bounded (one overall deadline, bounded head/tail parsing)
+ * because it runs between the prompt settling and teardown: it must never hold the turn open.
  */
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
 
 import { piSessionWorkspaceDir } from "./pi-assets.ts";
+
+/** Overall deadline for the whole remote probe (listing plus reads). */
+const REMOTE_PROBE_TIMEOUT_MS = 15_000;
+
+/** Deadline for the remote `ls` child on its own (the daemon accepts a per-process timeout). */
+const REMOTE_LS_TIMEOUT_MS = 10_000;
+
+/** Bytes of a transcript's head that must contain the `session` record (it is line one). */
+const SESSION_RECORD_HEAD_BYTES = 4 * 1024;
+
+/**
+ * Bytes of a transcript's tail scanned for the failed assistant record. The error is by
+ * definition at the end (it is what ended the turn), so a bounded window is enough, and it
+ * keeps a huge long-lived transcript from being decoded and split wholesale.
+ */
+const ERROR_SCAN_TAIL_BYTES = 64 * 1024;
 
 /** A Pi transcript `session` record (first line of the .jsonl). */
 interface PiSessionRecord {
@@ -41,29 +61,33 @@ interface PiMessageRecord {
   };
 }
 
-/** The most recent assistant error in one transcript's content, or undefined if none. */
+/**
+ * The trailing assistant error in one transcript's content, or undefined if none.
+ *
+ * Scans BACKWARD from the end: the record that decides is the last assistant message, and
+ * anything unparseable behind it (a partially written final record, trailing corruption)
+ * disqualifies recovery entirely rather than letting the scan step over it to an older
+ * error. A window cut mid-record at the START of the content is harmless: the backward scan
+ * only reaches it when nothing behind it decided, and then "no recovery" is the right call.
+ */
 function lastAssistantError(raw: string): string | undefined {
-  let found: string | undefined;
-  for (const line of raw.split("\n")) {
-    const trimmed = line.trim();
+  const lines = raw.split("\n");
+  for (let i = lines.length - 1; i >= 0; i--) {
+    const trimmed = lines[i]?.trim();
     if (!trimmed) continue;
     let record: PiMessageRecord;
     try {
       record = JSON.parse(trimmed) as PiMessageRecord;
     } catch {
-      continue;
+      return undefined;
     }
     const msg = record.message;
     if (record.type !== "message" || msg?.role !== "assistant") continue;
-    // Keep scanning so a later successful turn clears an earlier error; only an error that
-    // is the LAST assistant turn (and is what produced the empty output) is surfaced.
-    if (msg.stopReason === "error" && msg.errorMessage) {
-      found = msg.errorMessage.trim() || undefined;
-    } else {
-      found = undefined;
-    }
+    return msg.stopReason === "error" && msg.errorMessage
+      ? msg.errorMessage.trim() || undefined
+      : undefined;
   }
-  return found;
+  return undefined;
 }
 
 /** The `session` record of a transcript's content, or undefined if not a session. */
@@ -99,21 +123,25 @@ function readLocalFile(path: string): string | undefined {
  *
  * Without `remote`, the transcript is read from this process's filesystem (a local run) and
  * the answer is synchronous. With `remote`, it is read out of the given sandbox (a Daytona
- * run) through the daemon file API, and the answer is a promise.
+ * run) through the daemon file API, and the answer is a promise that resolves within
+ * `remote.timeoutMs` (default 15s) — on deadline it resolves undefined, never rejects.
  */
 export function findSwallowedPiError(
   sessionWorkspaceCwd: string,
 ): string | undefined;
 export function findSwallowedPiError(
   sessionWorkspaceCwd: string,
-  remote: { sandbox: any },
+  remote: { sandbox: any; timeoutMs?: number },
 ): Promise<string | undefined>;
 export function findSwallowedPiError(
   sessionWorkspaceCwd: string,
-  remote?: { sandbox: any },
+  remote?: { sandbox: any; timeoutMs?: number },
 ): string | undefined | Promise<string | undefined> {
   if (remote)
-    return findRemoteSwallowedPiError(remote.sandbox, sessionWorkspaceCwd);
+    return withDeadline(
+      findRemoteSwallowedPiError(remote.sandbox, sessionWorkspaceCwd),
+      remote.timeoutMs ?? REMOTE_PROBE_TIMEOUT_MS,
+    );
   return findLocalSwallowedPiError(sessionWorkspaceCwd);
 }
 
@@ -151,6 +179,40 @@ function findLocalSwallowedPiError(
   return newestRaw ? lastAssistantError(newestRaw) : undefined;
 }
 
+/** Resolve undefined when `promise` has not settled within `timeoutMs`; never rejects. */
+function withDeadline(
+  promise: Promise<string | undefined>,
+  timeoutMs: number,
+): Promise<string | undefined> {
+  let timer: NodeJS.Timeout | undefined;
+  const deadline = new Promise<undefined>((resolve) => {
+    timer = setTimeout(() => resolve(undefined), timeoutMs);
+    timer.unref?.();
+  });
+  return Promise.race([promise.catch(() => undefined), deadline]).finally(() =>
+    clearTimeout(timer),
+  );
+}
+
+/** Decode a bounded byte window of a daemon file read (which may arrive as string or bytes). */
+function decodeWindow(
+  data: unknown,
+  window: "head" | "tail",
+  bytes: number,
+): string {
+  if (typeof data === "string")
+    return window === "head" ? data.slice(0, bytes) : data.slice(-bytes);
+  const view =
+    data instanceof Uint8Array ? data : new Uint8Array(data as ArrayBuffer);
+  const slice =
+    window === "head"
+      ? view.subarray(0, bytes)
+      : view.subarray(Math.max(0, view.length - bytes));
+  // A multibyte character cut at the window edge decodes lossily; the damage lands in the
+  // window's partial boundary line, which the parsers already treat as noise.
+  return new TextDecoder().decode(slice);
+}
+
 async function findRemoteSwallowedPiError(
   sandbox: any,
   sessionWorkspaceCwd: string,
@@ -163,8 +225,9 @@ async function findRemoteSwallowedPiError(
     const ls = await sandbox.runProcess({
       command: "ls",
       args: ["-1t", transcriptDir],
-      timeoutMs: 10_000,
+      timeoutMs: REMOTE_LS_TIMEOUT_MS,
     });
+    if (ls?.exitCode !== 0) return undefined;
     names = String(ls?.stdout ?? "")
       .split("\n")
       .map((s) => s.trim())
@@ -175,19 +238,26 @@ async function findRemoteSwallowedPiError(
 
   for (const name of names) {
     if (!name.endsWith(".jsonl")) continue;
-    let raw: string;
+    let data: unknown;
     try {
-      const bytes = await sandbox.readFsFile({
-        path: `${transcriptDir}/${name}`,
-      });
-      raw = typeof bytes === "string" ? bytes : new TextDecoder().decode(bytes);
+      data = await sandbox.readFsFile({ path: `${transcriptDir}/${name}` });
     } catch {
-      continue;
+      // The newest candidate could not be read, so which transcript is "the newest this
+      // run owns" cannot be established. Stop rather than fall through to an older file:
+      // a stale sibling must never supply this turn's error.
+      return undefined;
     }
-    if (sessionRecordOf(raw)?.cwd !== sessionWorkspaceCwd) continue;
-    // The newest transcript this run owns decides, exactly like the local mtime pick: a
-    // stale sibling behind it must not resurrect an older error.
-    return lastAssistantError(raw);
+    const session = sessionRecordOf(
+      decodeWindow(data, "head", SESSION_RECORD_HEAD_BYTES),
+    );
+    // An unreadable/partial header is disqualifying for the same reason as a failed read.
+    if (!session) return undefined;
+    // A transcript stamped with another workspace's cwd is foreign (stale or copied), not
+    // a candidate at all — skipping it to the next-newest is not a stale fallback.
+    if (session.cwd !== sessionWorkspaceCwd) continue;
+    return lastAssistantError(
+      decodeWindow(data, "tail", ERROR_SCAN_TAIL_BYTES),
+    );
   }
   return undefined;
 }

--- a/services/runner/src/engines/sandbox_agent/pi-error.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-error.ts
@@ -1,5 +1,5 @@
 /**
- * Recover a model-call error that Pi swallows on the local sandbox-agent path.
+ * Recover a model-call error that Pi swallows on the sandbox-agent path.
  *
  * When Pi's provider call fails (out-of-quota, bad key, rate limit, unknown model, ...),
  * Pi records the failed turn in its session transcript as an assistant message with
@@ -8,15 +8,15 @@
  * then returns an `ok: true` run with empty output, and the user sees a silent "No response"
  * instead of the real failure.
  *
- * This reader closes that gap on the LOCAL path (Pi runs on the runner host, so its session
- * dir is on this filesystem). After a Pi turn that produced no output, the engine asks this
+ * This reader closes that gap. After a Pi turn that produced no output, the engine asks this
  * helper for the transcript's last assistant `errorMessage`; when present, the run is failed
- * loud with that message instead of returning an empty turn.
+ * loud with that message instead of returning an empty turn. On a local run the transcript is
+ * on this filesystem; on a Daytona run it lives inside the remote sandbox and is read through
+ * the sandbox's daemon file API (the same API `usage.ts` and `pi-assets.ts` read through),
+ * which must happen while the sandbox is still alive — the transcript dies with it.
  *
  * It is deliberately best-effort and side-effect free: any filesystem/parse problem returns
  * `undefined` so a genuinely empty (but successful) turn is never turned into a false error.
- * Daytona is out of scope (the transcript lives in the remote sandbox); the empty-turn there
- * stays as-is until the harness surfaces the error over ACP.
  */
 import { readFileSync, readdirSync, statSync } from "node:fs";
 import { join } from "node:path";
@@ -41,14 +41,8 @@ interface PiMessageRecord {
   };
 }
 
-/** The most recent assistant error in one transcript, or undefined if none / unreadable. */
-function lastAssistantError(jsonlPath: string): string | undefined {
-  let raw: string;
-  try {
-    raw = readFileSync(jsonlPath, "utf8");
-  } catch {
-    return undefined;
-  }
+/** The most recent assistant error in one transcript's content, or undefined if none. */
+function lastAssistantError(raw: string): string | undefined {
   let found: string | undefined;
   for (const line of raw.split("\n")) {
     const trimmed = line.trim();
@@ -72,19 +66,21 @@ function lastAssistantError(jsonlPath: string): string | undefined {
   return found;
 }
 
-/** The `session` record of a transcript file, or undefined if unreadable / not a session. */
-function readSessionRecord(jsonlPath: string): PiSessionRecord | undefined {
-  let raw: string;
-  try {
-    raw = readFileSync(jsonlPath, "utf8");
-  } catch {
-    return undefined;
-  }
+/** The `session` record of a transcript's content, or undefined if not a session. */
+function sessionRecordOf(raw: string): PiSessionRecord | undefined {
   const firstLine = raw.split("\n", 1)[0]?.trim();
   if (!firstLine) return undefined;
   try {
     const record = JSON.parse(firstLine) as PiSessionRecord;
     return record.type === "session" ? record : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function readLocalFile(path: string): string | undefined {
+  try {
+    return readFileSync(path, "utf8");
   } catch {
     return undefined;
   }
@@ -100,8 +96,28 @@ function readSessionRecord(jsonlPath: string): PiSessionRecord | undefined {
  * transcripts flat into it, one `.jsonl` per session. Pi also stamps the cwd on every
  * transcript's `session` record; matching on it guards against stale or copied transcripts.
  * Among matches (a resumed session can have several), the newest file wins.
+ *
+ * Without `remote`, the transcript is read from this process's filesystem (a local run) and
+ * the answer is synchronous. With `remote`, it is read out of the given sandbox (a Daytona
+ * run) through the daemon file API, and the answer is a promise.
  */
 export function findSwallowedPiError(
+  sessionWorkspaceCwd: string,
+): string | undefined;
+export function findSwallowedPiError(
+  sessionWorkspaceCwd: string,
+  remote: { sandbox: any },
+): Promise<string | undefined>;
+export function findSwallowedPiError(
+  sessionWorkspaceCwd: string,
+  remote?: { sandbox: any },
+): string | undefined | Promise<string | undefined> {
+  if (remote)
+    return findRemoteSwallowedPiError(remote.sandbox, sessionWorkspaceCwd);
+  return findLocalSwallowedPiError(sessionWorkspaceCwd);
+}
+
+function findLocalSwallowedPiError(
   sessionWorkspaceCwd: string,
 ): string | undefined {
   const transcriptDir = piSessionWorkspaceDir(sessionWorkspaceCwd);
@@ -112,13 +128,14 @@ export function findSwallowedPiError(
     return undefined;
   }
 
-  let newestPath: string | undefined;
+  let newestRaw: string | undefined;
   let newestMtime = -1;
   for (const file of files) {
     if (!file.endsWith(".jsonl")) continue;
     const filePath = join(transcriptDir, file);
-    const session = readSessionRecord(filePath);
-    if (session?.cwd !== sessionWorkspaceCwd) continue;
+    const raw = readLocalFile(filePath);
+    if (raw === undefined) continue;
+    if (sessionRecordOf(raw)?.cwd !== sessionWorkspaceCwd) continue;
     let mtime: number;
     try {
       mtime = statSync(filePath).mtimeMs;
@@ -127,9 +144,50 @@ export function findSwallowedPiError(
     }
     if (mtime > newestMtime) {
       newestMtime = mtime;
-      newestPath = filePath;
+      newestRaw = raw;
     }
   }
 
-  return newestPath ? lastAssistantError(newestPath) : undefined;
+  return newestRaw ? lastAssistantError(newestRaw) : undefined;
+}
+
+async function findRemoteSwallowedPiError(
+  sandbox: any,
+  sessionWorkspaceCwd: string,
+): Promise<string | undefined> {
+  const transcriptDir = piSessionWorkspaceDir(sessionWorkspaceCwd);
+  let names: string[];
+  try {
+    // `-t` sorts newest-first, standing in for the local reader's mtime comparison (the
+    // remote listing carries no timestamps to compare).
+    const ls = await sandbox.runProcess({
+      command: "ls",
+      args: ["-1t", transcriptDir],
+      timeoutMs: 10_000,
+    });
+    names = String(ls?.stdout ?? "")
+      .split("\n")
+      .map((s) => s.trim())
+      .filter(Boolean);
+  } catch {
+    return undefined;
+  }
+
+  for (const name of names) {
+    if (!name.endsWith(".jsonl")) continue;
+    let raw: string;
+    try {
+      const bytes = await sandbox.readFsFile({
+        path: `${transcriptDir}/${name}`,
+      });
+      raw = typeof bytes === "string" ? bytes : new TextDecoder().decode(bytes);
+    } catch {
+      continue;
+    }
+    if (sessionRecordOf(raw)?.cwd !== sessionWorkspaceCwd) continue;
+    // The newest transcript this run owns decides, exactly like the local mtime pick: a
+    // stale sibling behind it must not resurrect an older error.
+    return lastAssistantError(raw);
+  }
+  return undefined;
 }

--- a/services/runner/src/engines/sandbox_agent/pi-error.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-error.ts
@@ -8,9 +8,10 @@
  * then returns an `ok: true` run with empty output, and the user sees a silent "No response"
  * instead of the real failure.
  *
- * This reader closes that gap. After a Pi turn that produced no output, the engine asks this
- * helper for the transcript's last assistant `errorMessage`; when present, the run is failed
- * loud with that message instead of returning an empty turn. On a local run the transcript is
+ * This reader closes that gap. Before prompting, the engine captures the current transcript's
+ * file and offset. After a Pi turn that produced no output, it asks this helper for an assistant
+ * `errorMessage` appended after that cursor; when present, the run is failed loud with that
+ * message instead of returning an empty turn. On a local run the transcript is
  * on this filesystem; on a Daytona run it lives inside the remote sandbox and is read through
  * the sandbox's daemon file API (the same API `usage.ts` and `pi-assets.ts` read through),
  * which must happen while the sandbox is still alive — the transcript dies with it.
@@ -61,6 +62,23 @@ interface PiMessageRecord {
   };
 }
 
+/** The current Pi session's transcript and length immediately before one turn starts. */
+export interface PiTranscriptCursor {
+  sessionId: string;
+  fileName?: string;
+  offset: number;
+}
+
+function transcriptFileForSession(
+  names: string[],
+  sessionId: string,
+): string | undefined {
+  const suffix = `_${sessionId}.jsonl`;
+  return names.find(
+    (name) => name === `${sessionId}.jsonl` || name.endsWith(suffix),
+  );
+}
+
 /**
  * The trailing assistant error in one transcript's content, or undefined if none.
  *
@@ -102,24 +120,80 @@ function sessionRecordOf(raw: string): PiSessionRecord | undefined {
   }
 }
 
-function readLocalFile(path: string): string | undefined {
+function readLocalFile(path: string): Uint8Array | undefined {
   try {
-    return readFileSync(path, "utf8");
+    return readFileSync(path);
   } catch {
     return undefined;
   }
 }
 
+function listLocalTranscripts(
+  sessionWorkspaceCwd: string,
+): string[] | undefined {
+  const transcriptDir = piSessionWorkspaceDir(sessionWorkspaceCwd);
+  try {
+    return readdirSync(transcriptDir).filter((name) => name.endsWith(".jsonl"));
+  } catch (err) {
+    return (err as NodeJS.ErrnoException).code === "ENOENT" ? [] : undefined;
+  }
+}
+
 /**
- * Find the Pi transcript for a run (identified by its unique `sessionWorkspaceCwd`) and
+ * Capture the transcript boundary before a Pi turn starts. An undefined cursor means the
+ * boundary could not be established, so the caller must skip recovery for that turn.
+ */
+export function capturePiTranscriptCursor(
+  sessionWorkspaceCwd: string,
+  sessionId: string,
+): PiTranscriptCursor | undefined;
+export function capturePiTranscriptCursor(
+  sessionWorkspaceCwd: string,
+  sessionId: string,
+  remote: { sandbox: any; timeoutMs?: number },
+): Promise<PiTranscriptCursor | undefined>;
+export function capturePiTranscriptCursor(
+  sessionWorkspaceCwd: string,
+  sessionId: string,
+  remote?: { sandbox: any; timeoutMs?: number },
+): PiTranscriptCursor | undefined | Promise<PiTranscriptCursor | undefined> {
+  if (remote)
+    return withDeadline(
+      captureRemotePiTranscriptCursor(
+        remote.sandbox,
+        sessionWorkspaceCwd,
+        sessionId,
+      ),
+      remote.timeoutMs ?? REMOTE_PROBE_TIMEOUT_MS,
+    );
+  const names = listLocalTranscripts(sessionWorkspaceCwd);
+  if (!names) return undefined;
+  const fileName = transcriptFileForSession(names, sessionId);
+  if (!fileName) return { sessionId, offset: 0 };
+  try {
+    return {
+      sessionId,
+      fileName,
+      offset: statSync(
+        join(piSessionWorkspaceDir(sessionWorkspaceCwd), fileName),
+      ).size,
+    };
+  } catch {
+    // The file existed in the listing but vanished or became unreadable before stat. That is an
+    // unknown boundary, not an empty transcript; skip recovery rather than scan an older error.
+    return undefined;
+  }
+}
+
+/**
+ * Find the Pi transcript for a run (identified by its Pi session id and workspace cwd) and
  * return the last assistant turn's `errorMessage`, or undefined when there is none.
  *
  * The transcript location is derived from the same shared helper (`piSessionWorkspaceDir`)
  * that `configurePiSessionWorkspace` uses to point Pi at it, so the two can never disagree.
  * Because that directory is passed to Pi explicitly (PI_CODING_AGENT_SESSION_DIR), Pi writes
- * transcripts flat into it, one `.jsonl` per session. Pi also stamps the cwd on every
- * transcript's `session` record; matching on it guards against stale or copied transcripts.
- * Among matches (a resumed session can have several), the newest file wins.
+ * transcripts flat into it, one `.jsonl` per session, with the session id in the filename and
+ * header. Matching both that id and the stamped cwd guards against stale or copied transcripts.
  *
  * Without `remote`, the transcript is read from this process's filesystem (a local run) and
  * the answer is synchronous. With `remote`, it is read out of the given sandbox (a Daytona
@@ -128,62 +202,55 @@ function readLocalFile(path: string): string | undefined {
  */
 export function findSwallowedPiError(
   sessionWorkspaceCwd: string,
+  cursor: PiTranscriptCursor,
 ): string | undefined;
 export function findSwallowedPiError(
   sessionWorkspaceCwd: string,
+  cursor: PiTranscriptCursor,
   remote: { sandbox: any; timeoutMs?: number },
 ): Promise<string | undefined>;
 export function findSwallowedPiError(
   sessionWorkspaceCwd: string,
+  cursor: PiTranscriptCursor,
   remote?: { sandbox: any; timeoutMs?: number },
 ): string | undefined | Promise<string | undefined> {
   if (remote)
     return withDeadline(
-      findRemoteSwallowedPiError(remote.sandbox, sessionWorkspaceCwd),
+      findRemoteSwallowedPiError(remote.sandbox, sessionWorkspaceCwd, cursor),
       remote.timeoutMs ?? REMOTE_PROBE_TIMEOUT_MS,
     );
-  return findLocalSwallowedPiError(sessionWorkspaceCwd);
+  return findLocalSwallowedPiError(sessionWorkspaceCwd, cursor);
 }
 
 function findLocalSwallowedPiError(
   sessionWorkspaceCwd: string,
+  cursor: PiTranscriptCursor,
 ): string | undefined {
-  const transcriptDir = piSessionWorkspaceDir(sessionWorkspaceCwd);
-  let files: string[];
-  try {
-    files = readdirSync(transcriptDir);
-  } catch {
+  const names = listLocalTranscripts(sessionWorkspaceCwd);
+  if (!names) return undefined;
+  const fileName =
+    cursor.fileName ?? transcriptFileForSession(names, cursor.sessionId);
+  if (!fileName || !names.includes(fileName)) return undefined;
+  const data = readLocalFile(
+    join(piSessionWorkspaceDir(sessionWorkspaceCwd), fileName),
+  );
+  if (data === undefined) return undefined;
+  const session = sessionRecordOf(
+    decodeWindow(data, "head", SESSION_RECORD_HEAD_BYTES),
+  );
+  if (session?.id !== cursor.sessionId || session.cwd !== sessionWorkspaceCwd)
     return undefined;
-  }
-
-  let newestRaw: string | undefined;
-  let newestMtime = -1;
-  for (const file of files) {
-    if (!file.endsWith(".jsonl")) continue;
-    const filePath = join(transcriptDir, file);
-    const raw = readLocalFile(filePath);
-    if (raw === undefined) continue;
-    if (sessionRecordOf(raw)?.cwd !== sessionWorkspaceCwd) continue;
-    let mtime: number;
-    try {
-      mtime = statSync(filePath).mtimeMs;
-    } catch {
-      continue;
-    }
-    if (mtime > newestMtime) {
-      newestMtime = mtime;
-      newestRaw = raw;
-    }
-  }
-
-  return newestRaw ? lastAssistantError(newestRaw) : undefined;
+  if (data.length <= cursor.offset) return undefined;
+  return lastAssistantError(
+    decodeWindow(data.subarray(cursor.offset), "tail", ERROR_SCAN_TAIL_BYTES),
+  );
 }
 
 /** Resolve undefined when `promise` has not settled within `timeoutMs`; never rejects. */
-function withDeadline(
-  promise: Promise<string | undefined>,
+function withDeadline<T>(
+  promise: Promise<T | undefined>,
   timeoutMs: number,
-): Promise<string | undefined> {
+): Promise<T | undefined> {
   let timer: NodeJS.Timeout | undefined;
   const deadline = new Promise<undefined>((resolve) => {
     timer = setTimeout(() => resolve(undefined), timeoutMs);
@@ -192,6 +259,13 @@ function withDeadline(
   return Promise.race([promise.catch(() => undefined), deadline]).finally(() =>
     clearTimeout(timer),
   );
+}
+
+function asBytes(data: unknown): Uint8Array {
+  if (typeof data === "string") return new TextEncoder().encode(data);
+  return data instanceof Uint8Array
+    ? data
+    : new Uint8Array(data as ArrayBuffer);
 }
 
 /** Decode a bounded byte window of a daemon file read (which may arrive as string or bytes). */
@@ -213,51 +287,84 @@ function decodeWindow(
   return new TextDecoder().decode(slice);
 }
 
-async function findRemoteSwallowedPiError(
+async function listRemoteTranscripts(
   sandbox: any,
   sessionWorkspaceCwd: string,
-): Promise<string | undefined> {
+): Promise<string[] | undefined> {
   const transcriptDir = piSessionWorkspaceDir(sessionWorkspaceCwd);
-  let names: string[];
   try {
-    // `-t` sorts newest-first, standing in for the local reader's mtime comparison (the
-    // remote listing carries no timestamps to compare).
     const ls = await sandbox.runProcess({
       command: "ls",
-      args: ["-1t", transcriptDir],
+      args: ["-1", transcriptDir],
       timeoutMs: REMOTE_LS_TIMEOUT_MS,
     });
     if (ls?.exitCode !== 0) return undefined;
-    names = String(ls?.stdout ?? "")
+    return String(ls?.stdout ?? "")
       .split("\n")
       .map((s) => s.trim())
-      .filter(Boolean);
+      .filter((name) => name.endsWith(".jsonl"));
   } catch {
     return undefined;
   }
+}
 
-  for (const name of names) {
-    if (!name.endsWith(".jsonl")) continue;
-    let data: unknown;
-    try {
-      data = await sandbox.readFsFile({ path: `${transcriptDir}/${name}` });
-    } catch {
-      // The newest candidate could not be read, so which transcript is "the newest this
-      // run owns" cannot be established. Stop rather than fall through to an older file:
-      // a stale sibling must never supply this turn's error.
-      return undefined;
-    }
-    const session = sessionRecordOf(
-      decodeWindow(data, "head", SESSION_RECORD_HEAD_BYTES),
-    );
-    // An unreadable/partial header is disqualifying for the same reason as a failed read.
-    if (!session) return undefined;
-    // A transcript stamped with another workspace's cwd is foreign (stale or copied), not
-    // a candidate at all — skipping it to the next-newest is not a stale fallback.
-    if (session.cwd !== sessionWorkspaceCwd) continue;
-    return lastAssistantError(
-      decodeWindow(data, "tail", ERROR_SCAN_TAIL_BYTES),
-    );
+async function captureRemotePiTranscriptCursor(
+  sandbox: any,
+  sessionWorkspaceCwd: string,
+  sessionId: string,
+): Promise<PiTranscriptCursor | undefined> {
+  const names = await listRemoteTranscripts(sandbox, sessionWorkspaceCwd);
+  if (!names) return undefined;
+  const fileName = transcriptFileForSession(names, sessionId);
+  if (!fileName) return { sessionId, offset: 0 };
+  try {
+    const stat = await sandbox.runProcess({
+      command: "stat",
+      args: [
+        "-c",
+        "%s",
+        "--",
+        `${piSessionWorkspaceDir(sessionWorkspaceCwd)}/${fileName}`,
+      ],
+      timeoutMs: REMOTE_LS_TIMEOUT_MS,
+    });
+    const rawOffset = String(stat?.stdout ?? "").trim();
+    if (!/^\d+$/.test(rawOffset)) return undefined;
+    const offset = Number(rawOffset);
+    if (stat?.exitCode !== 0 || !Number.isSafeInteger(offset)) return undefined;
+    return { sessionId, fileName, offset };
+  } catch {
+    return undefined;
   }
-  return undefined;
+}
+
+async function findRemoteSwallowedPiError(
+  sandbox: any,
+  sessionWorkspaceCwd: string,
+  cursor: PiTranscriptCursor,
+): Promise<string | undefined> {
+  const names = await listRemoteTranscripts(sandbox, sessionWorkspaceCwd);
+  if (!names) return undefined;
+  const fileName =
+    cursor.fileName ?? transcriptFileForSession(names, cursor.sessionId);
+  if (!fileName || !names.includes(fileName)) return undefined;
+  let data: Uint8Array;
+  try {
+    data = asBytes(
+      await sandbox.readFsFile({
+        path: `${piSessionWorkspaceDir(sessionWorkspaceCwd)}/${fileName}`,
+      }),
+    );
+  } catch {
+    return undefined;
+  }
+  const session = sessionRecordOf(
+    decodeWindow(data, "head", SESSION_RECORD_HEAD_BYTES),
+  );
+  if (session?.id !== cursor.sessionId || session.cwd !== sessionWorkspaceCwd)
+    return undefined;
+  if (data.length <= cursor.offset) return undefined;
+  return lastAssistantError(
+    decodeWindow(data.subarray(cursor.offset), "tail", ERROR_SCAN_TAIL_BYTES),
+  );
 }

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -1143,13 +1143,16 @@ export async function runTurn(
 
     const swallowedPiError =
       plan.isPi &&
-      !plan.isDaytona &&
       !run.output().trim() &&
       !run.events().some((e) => e.type === "tool_call")
         ? // The helper derives the transcript location from
           // `piSessionWorkspaceDir(plan.workspace.cwd)`, the same shared helper
-          // `configurePiSessionWorkspace` used to point Pi at it.
-          findSwallowedPiError(plan.workspace.cwd)
+          // `configurePiSessionWorkspace` used to point Pi at it. On Daytona the
+          // transcript lives inside the remote sandbox, so it is read through the
+          // sandbox's file API here, before teardown takes the only copy with it.
+          await (plan.isDaytona
+            ? findSwallowedPiError(plan.workspace.cwd, { sandbox: env.sandbox })
+            : findSwallowedPiError(plan.workspace.cwd))
         : undefined;
     let swallowedError: string | undefined;
     if (swallowedPiError) {

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -60,7 +60,7 @@ import {
 import { describeCodexSubscriptionAuthFault } from "./codex-assets.ts";
 import { conciseError } from "./errors.ts";
 import { PAUSED, PendingApprovalPauseController } from "./pause.ts";
-import { findSwallowedPiError } from "./pi-error.ts";
+import { capturePiTranscriptCursor, findSwallowedPiError } from "./pi-error.ts";
 import { buildRelayExecutionGuard } from "./relay-guard.ts";
 import {
   buildApprovedContentWiring,
@@ -927,6 +927,18 @@ export async function runTurn(
       await turn.toolRelay?.ready?.catch?.(() => {});
     }
 
+    // Capture the append-only transcript boundary before this turn can write into it. Recovery
+    // must never attribute an error already present here to the prompt below.
+    const piSessionId = env.session?.agentSessionId;
+    const piTranscriptCursor =
+      plan.isPi && piSessionId
+        ? await (plan.isDaytona
+            ? capturePiTranscriptCursor(plan.workspace.cwd, piSessionId, {
+                sandbox: env.sandbox,
+              })
+            : capturePiTranscriptCursor(plan.workspace.cwd, piSessionId))
+        : undefined;
+
     // The prompt promise this turn races against the pause signal. A normal/continuation turn
     // sends a fresh prompt; a live approval resume answers the parked gate on the SAME session and
     // continues the ORIGINAL, still-pending prompt promise (the tool then runs with its original
@@ -1016,9 +1028,7 @@ export async function runTurn(
         pause.pause();
       }
     } else {
-      promptPromise = Promise.resolve(
-        env.session.prompt(promptBlocks),
-      );
+      promptPromise = Promise.resolve(env.session.prompt(promptBlocks));
       promptPromise.catch(() => {});
     }
     // A user Stop aborts `signal`, which severs the harness fetch (rejecting the prompt). We want a
@@ -1143,6 +1153,8 @@ export async function runTurn(
 
     const swallowedPiError =
       plan.isPi &&
+      stopReason === "end_turn" &&
+      piTranscriptCursor &&
       !run.output().trim() &&
       !run.events().some((e) => e.type === "tool_call")
         ? // The helper derives the transcript location from
@@ -1151,8 +1163,10 @@ export async function runTurn(
           // transcript lives inside the remote sandbox, so it is read through the
           // sandbox's file API here, before teardown takes the only copy with it.
           await (plan.isDaytona
-            ? findSwallowedPiError(plan.workspace.cwd, { sandbox: env.sandbox })
-            : findSwallowedPiError(plan.workspace.cwd))
+            ? findSwallowedPiError(plan.workspace.cwd, piTranscriptCursor, {
+                sandbox: env.sandbox,
+              })
+            : findSwallowedPiError(plan.workspace.cwd, piTranscriptCursor))
         : undefined;
     let swallowedError: string | undefined;
     if (swallowedPiError) {

--- a/services/runner/tests/unit/daytona-transcript-recovery.test.ts
+++ b/services/runner/tests/unit/daytona-transcript-recovery.test.ts
@@ -21,10 +21,16 @@ import { mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { findSwallowedPiError } from "../../src/engines/sandbox_agent/pi-error.ts";
+import {
+  capturePiTranscriptCursor,
+  findSwallowedPiError,
+  type PiTranscriptCursor,
+} from "../../src/engines/sandbox_agent/pi-error.ts";
 import { piSessionWorkspaceDir } from "../../src/engines/sandbox_agent/pi-assets.ts";
 import {
   enableDaytonaProvider,
+  AGENT_SESSION_ID,
+  piTranscriptFileName,
   piTranscript,
   piTranscriptWithError,
   runSilentTurn,
@@ -63,9 +69,11 @@ describe("a Pi transcript inside a remote sandbox", () => {
     // silence in the expectations below.
     const cwd = mkdtempSync(join(tmpdir(), "agenta-daytona-transcript-"));
     dirs.push(cwd);
+    const cursor = capturePiTranscriptCursor(cwd, AGENT_SESSION_ID);
+    assert.ok(cursor);
     seedFailedTranscript(cwd, RATE_LIMIT_ERROR);
 
-    assert.equal(findSwallowedPiError(cwd), RATE_LIMIT_ERROR);
+    assert.equal(findSwallowedPiError(cwd, cursor), RATE_LIMIT_ERROR);
   });
 
   it("does not disturb a Daytona turn that produced an answer", async () => {
@@ -116,6 +124,107 @@ describe("a Pi transcript inside a remote sandbox", () => {
     );
   });
 
+  it("does not resurrect a previous turn's error when the transcript is unchanged", async () => {
+    const { result, events } = await runSilentTurn(
+      { harness: "pi_core", sandbox: "daytona" },
+      {
+        cwd: REMOTE_CWD,
+        initialSandboxTranscript: piTranscriptWithError(
+          REMOTE_CWD,
+          RATE_LIMIT_ERROR,
+        ),
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.stopReason, "end_turn");
+    assert.ok(
+      !events.some((event) => event.type === "error"),
+      "an unchanged transcript cannot supply this turn's error",
+    );
+  });
+
+  it("recovers only the error appended to an existing transcript by this turn", async () => {
+    const previousError = piTranscriptWithError(
+      REMOTE_CWD,
+      "previous turn failed",
+    );
+    const currentError = "Current turn model call failed.";
+    const currentRecords =
+      [
+        {
+          type: "message",
+          message: { role: "user", content: [{ type: "text", text: "again" }] },
+        },
+        {
+          type: "message",
+          message: {
+            role: "assistant",
+            content: [],
+            stopReason: "error",
+            errorMessage: currentError,
+          },
+        },
+      ]
+        .map((record) => JSON.stringify(record))
+        .join("\n") + "\n";
+
+    const { result } = await runSilentTurn(
+      { harness: "pi_core", sandbox: "daytona" },
+      {
+        cwd: REMOTE_CWD,
+        initialSandboxTranscript: previousError,
+        sandboxTranscript: previousError + currentRecords,
+      },
+    );
+
+    assert.equal(result.ok, false);
+    assert.ok(
+      result.error?.includes("Current turn"),
+      `expected only the appended error, got: ${result.error}`,
+    );
+    assert.ok(!result.error?.includes("previous turn"));
+  });
+
+  it("does not resurrect a previous turn's error when the turn is cancelled", async () => {
+    const { result, events } = await runSilentTurn(
+      { harness: "pi_core", sandbox: "daytona" },
+      {
+        cwd: REMOTE_CWD,
+        cancel: true,
+        initialSandboxTranscript: piTranscriptWithError(
+          REMOTE_CWD,
+          RATE_LIMIT_ERROR,
+        ),
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.stopReason, "cancelled");
+    assert.ok(
+      !events.some((event) => event.type === "error"),
+      "a cancelled turn cannot inherit a previous turn's error",
+    );
+  });
+
+  it("does not resurrect a previous turn's error when the turn is paused", async () => {
+    const { result, events } = await runSilentTurn(
+      { harness: "pi_core", sandbox: "daytona" },
+      {
+        cwd: REMOTE_CWD,
+        park: true,
+        initialSandboxTranscript: piTranscriptWithError(
+          REMOTE_CWD,
+          RATE_LIMIT_ERROR,
+        ),
+      },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(result.stopReason, "paused");
+    assert.ok(!events.some((event) => event.type === "error"));
+  });
+
   it("reads the transcript out of the sandbox before teardown", async () => {
     const { readFsFilePaths } = await runSilentTurn(
       { harness: "pi_core", sandbox: "daytona" },
@@ -141,6 +250,8 @@ interface FakeRemoteFile {
   unreadable?: boolean;
   /** Never settle the read, like a stalled daemon response. */
   hang?: boolean;
+  /** Override the metadata returned by `stat`, including malformed output. */
+  statOutput?: string;
 }
 
 /**
@@ -154,6 +265,20 @@ function fakeRemoteSandbox(files: Array<[name: string, file: FakeRemoteFile]>) {
   const sandbox = {
     async runProcess(input?: RecordedRunProcessCall) {
       runProcessCalls.push({ ...input });
+      if (input?.command === "stat") {
+        const path = input.args?.at(-1);
+        const transcriptDir = piSessionWorkspaceDir(REMOTE_CWD);
+        const file = files.find(
+          ([name]) => path === join(transcriptDir, name),
+        )?.[1];
+        if (!file || file.unreadable) return { exitCode: 1, stdout: "" };
+        return {
+          exitCode: 0,
+          stdout:
+            file.statOutput ??
+            `${new TextEncoder().encode(file.content ?? "").length}\n`,
+        };
+      }
       return {
         exitCode: 0,
         stdout: files.map(([name]) => name).join("\n") + "\n",
@@ -211,16 +336,23 @@ function errorTranscript(
 }
 
 describe("the remote reader, driven directly", () => {
+  const newTurnCursor = (sessionId: string): PiTranscriptCursor => ({
+    sessionId,
+    offset: 0,
+  });
+
   it("asks the daemon for a bounded ls of the run's transcript directory", async () => {
     const { sandbox, runProcessCalls } = fakeRemoteSandbox([
       [
-        "sess-a.jsonl",
+        piTranscriptFileName("sess-a"),
         { content: errorTranscript(REMOTE_CWD, "sess-a", RATE_LIMIT_ERROR) },
       ],
     ]);
 
     assert.equal(
-      await findSwallowedPiError(REMOTE_CWD, { sandbox }),
+      await findSwallowedPiError(REMOTE_CWD, newTurnCursor("sess-a"), {
+        sandbox,
+      }),
       RATE_LIMIT_ERROR,
     );
 
@@ -233,22 +365,59 @@ describe("the remote reader, driven directly", () => {
     );
   });
 
+  it("captures the existing boundary with metadata and no transcript download", async () => {
+    const content = errorTranscript(REMOTE_CWD, "sess-a", RATE_LIMIT_ERROR);
+    const { sandbox, runProcessCalls, readPaths } = fakeRemoteSandbox([
+      [piTranscriptFileName("sess-a"), { content }],
+    ]);
+
+    assert.deepEqual(
+      await capturePiTranscriptCursor(REMOTE_CWD, "sess-a", { sandbox }),
+      {
+        sessionId: "sess-a",
+        fileName: piTranscriptFileName("sess-a"),
+        offset: new TextEncoder().encode(content).length,
+      },
+    );
+    assert.ok(runProcessCalls.some((call) => call.command === "stat"));
+    assert.deepEqual(readPaths, []);
+  });
+
+  it("rejects an empty stat result instead of treating the transcript as new", async () => {
+    const { sandbox } = fakeRemoteSandbox([
+      [
+        piTranscriptFileName("sess-a"),
+        {
+          content: errorTranscript(REMOTE_CWD, "sess-a", RATE_LIMIT_ERROR),
+          statOutput: "",
+        },
+      ],
+    ]);
+
+    assert.equal(
+      await capturePiTranscriptCursor(REMOTE_CWD, "sess-a", { sandbox }),
+      undefined,
+    );
+  });
+
   it("lets the newest owning transcript decide even when an older one holds an error", async () => {
     // The current session ended cleanly; only a PREVIOUS session of the same workspace failed.
     // Surfacing that older error would invent a failure this turn did not have.
     const { sandbox } = fakeRemoteSandbox([
       [
-        "sess-new.jsonl",
+        piTranscriptFileName("sess-new"),
         { content: successTranscript(REMOTE_CWD, "sess-new") },
       ],
       [
-        "sess-old.jsonl",
+        piTranscriptFileName("sess-old"),
         { content: errorTranscript(REMOTE_CWD, "sess-old", RATE_LIMIT_ERROR) },
       ],
     ]);
 
     assert.equal(
-      await findSwallowedPiError(REMOTE_CWD, { sandbox }),
+      await findSwallowedPiError(REMOTE_CWD, newTurnCursor("sess-new"), {
+        sandbox,
+      }),
       undefined,
     );
   });
@@ -258,7 +427,7 @@ describe("the remote reader, driven directly", () => {
     // stepping past it to this run's own newest transcript is not a stale fallback.
     const { sandbox } = fakeRemoteSandbox([
       [
-        "sess-foreign.jsonl",
+        piTranscriptFileName("sess-foreign"),
         {
           content: errorTranscript(
             REMOTE_CWD,
@@ -269,13 +438,15 @@ describe("the remote reader, driven directly", () => {
         },
       ],
       [
-        "sess-mine.jsonl",
+        piTranscriptFileName("sess-mine"),
         { content: errorTranscript(REMOTE_CWD, "sess-mine", RATE_LIMIT_ERROR) },
       ],
     ]);
 
     assert.equal(
-      await findSwallowedPiError(REMOTE_CWD, { sandbox }),
+      await findSwallowedPiError(REMOTE_CWD, newTurnCursor("sess-mine"), {
+        sandbox,
+      }),
       RATE_LIMIT_ERROR,
     );
   });
@@ -284,15 +455,17 @@ describe("the remote reader, driven directly", () => {
     // With the newest candidate unreadable, which transcript is "the newest this run owns"
     // cannot be established — an older sibling must not supply this turn's error.
     const { sandbox } = fakeRemoteSandbox([
-      ["sess-new.jsonl", { unreadable: true }],
+      [piTranscriptFileName("sess-new"), { unreadable: true }],
       [
-        "sess-old.jsonl",
+        piTranscriptFileName("sess-old"),
         { content: errorTranscript(REMOTE_CWD, "sess-old", RATE_LIMIT_ERROR) },
       ],
     ]);
 
     assert.equal(
-      await findSwallowedPiError(REMOTE_CWD, { sandbox }),
+      await findSwallowedPiError(REMOTE_CWD, newTurnCursor("sess-new"), {
+        sandbox,
+      }),
       undefined,
     );
   });
@@ -304,23 +477,28 @@ describe("the remote reader, driven directly", () => {
       errorTranscript(REMOTE_CWD, "sess-partial", RATE_LIMIT_ERROR) +
       '{"type":"message","message":{"role":"assistant"';
     const { sandbox } = fakeRemoteSandbox([
-      ["sess-partial.jsonl", { content: partial }],
+      [piTranscriptFileName("sess-partial"), { content: partial }],
     ]);
 
     assert.equal(
-      await findSwallowedPiError(REMOTE_CWD, { sandbox }),
+      await findSwallowedPiError(REMOTE_CWD, newTurnCursor("sess-partial"), {
+        sandbox,
+      }),
       undefined,
     );
   });
 
   it("resolves within its deadline when a read hangs", async () => {
     const { sandbox } = fakeRemoteSandbox([
-      ["sess-hang.jsonl", { hang: true }],
+      [piTranscriptFileName("sess-hang"), { hang: true }],
     ]);
 
     const startedAt = Date.now();
     assert.equal(
-      await findSwallowedPiError(REMOTE_CWD, { sandbox, timeoutMs: 50 }),
+      await findSwallowedPiError(REMOTE_CWD, newTurnCursor("sess-hang"), {
+        sandbox,
+        timeoutMs: 50,
+      }),
       undefined,
     );
     // Generous ceiling for a slow CI box; the point is that a stalled daemon response cannot

--- a/services/runner/tests/unit/daytona-transcript-recovery.test.ts
+++ b/services/runner/tests/unit/daytona-transcript-recovery.test.ts
@@ -8,10 +8,10 @@
  * only copy of the message with it. These tests stand a Pi transcript up inside a fake remote
  * sandbox and pin that the error reaches the caller.
  *
- * Fixture note: the fake supports both ways a reader might find the transcript — `readFsFile`
- * serves it for any `.jsonl` path, and `runProcess` answers an `ls` on stdout the way
- * `sandboxRelayHost.list` reads it (`src/tools/relay.ts`). So the expectations below stay
- * implementation-neutral: they pin that the transcript is read, not how it is located.
+ * Fixture note: the fake honors the daemon contract — `runProcess` answers an `ls` on stdout
+ * the way `sandboxRelayHost.list` reads it (`src/tools/relay.ts`) and only for the transcript
+ * directory, and `readFsFile` serves the transcript only at its exact path — so these tests
+ * pin both that the transcript is read and that it is located where Pi writes it.
  *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/daytona-transcript-recovery.test.ts)
  */
@@ -22,12 +22,15 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import { findSwallowedPiError } from "../../src/engines/sandbox_agent/pi-error.ts";
+import { piSessionWorkspaceDir } from "../../src/engines/sandbox_agent/pi-assets.ts";
 import {
   enableDaytonaProvider,
+  piTranscript,
   piTranscriptWithError,
   runSilentTurn,
   seedFailedTranscript,
   textChunk,
+  type RecordedRunProcessCall,
 } from "../utils/silent-turn.ts";
 
 const RATE_LIMIT_ERROR =
@@ -82,7 +85,7 @@ describe("a Pi transcript inside a remote sandbox", () => {
   });
 
   it("surfaces the provider failure on an empty turn", async () => {
-    const { result } = await runSilentTurn(
+    const { result, events } = await runSilentTurn(
       { harness: "pi_core", sandbox: "daytona" },
       {
         cwd: REMOTE_CWD,
@@ -97,6 +100,14 @@ describe("a Pi transcript inside a remote sandbox", () => {
     assert.ok(
       result.error?.toLowerCase().includes("rate limit"),
       `expected the transcript's failure, got: ${result.error}`,
+    );
+    // The playground renders the event stream, not the result envelope: the error has to be IN
+    // the stream, and ahead of the terminal `done`, or the turn still renders as a silent blank.
+    const order = events.map((e) => e.type);
+    assert.ok(order.includes("error"), `no error event in stream: ${order}`);
+    assert.ok(
+      order.indexOf("error") < order.lastIndexOf("done"),
+      `the error event must precede the terminal done: ${order}`,
     );
   });
 
@@ -114,6 +125,201 @@ describe("a Pi transcript inside a remote sandbox", () => {
     assert.ok(
       readFsFilePaths.some((path) => path.endsWith(".jsonl")),
       `no transcript read from the sandbox, only: ${readFsFilePaths.join(", ")}`,
+    );
+  });
+});
+
+/** What one file in the fake remote transcript directory does when read. */
+interface FakeRemoteFile {
+  content?: string;
+  /** Reject the read, like a vanished or permission-broken file. */
+  unreadable?: boolean;
+  /** Never settle the read, like a stalled daemon response. */
+  hang?: boolean;
+}
+
+/**
+ * A minimal remote sandbox for driving `findSwallowedPiError`'s remote mode directly:
+ * `ls` lists `files` in the given order (newest first, the way `-t` answers), reads serve,
+ * reject, or hang per file. Calls are recorded so tests can pin the daemon contract.
+ */
+function fakeRemoteSandbox(files: Array<[name: string, file: FakeRemoteFile]>) {
+  const runProcessCalls: RecordedRunProcessCall[] = [];
+  const readPaths: string[] = [];
+  const sandbox = {
+    async runProcess(input?: RecordedRunProcessCall) {
+      runProcessCalls.push({ ...input });
+      return {
+        exitCode: 0,
+        stdout: files.map(([name]) => name).join("\n") + "\n",
+      };
+    },
+    async readFsFile({ path }: { path: string }) {
+      readPaths.push(path);
+      const file = files.find(([name]) => path.endsWith(`/${name}`))?.[1];
+      if (!file || file.unreadable) throw new Error(`ENOENT: ${path}`);
+      if (file.hang) return new Promise<never>(() => {});
+      return new TextEncoder().encode(file.content ?? "");
+    },
+  };
+  return { sandbox, runProcessCalls, readPaths };
+}
+
+function successTranscript(cwd: string, name: string): string {
+  return piTranscript(cwd, name, [
+    {
+      type: "message",
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        stopReason: "end_turn",
+      },
+    },
+  ]);
+}
+
+function errorTranscript(
+  cwd: string,
+  name: string,
+  message: string,
+  recordCwd: string = cwd,
+): string {
+  return piTranscript(
+    cwd,
+    name,
+    [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: message,
+        },
+      },
+    ],
+    recordCwd,
+  );
+}
+
+describe("the remote reader, driven directly", () => {
+  it("asks the daemon for a bounded ls of the run's transcript directory", async () => {
+    const { sandbox, runProcessCalls } = fakeRemoteSandbox([
+      [
+        "sess-a.jsonl",
+        { content: errorTranscript(REMOTE_CWD, "sess-a", RATE_LIMIT_ERROR) },
+      ],
+    ]);
+
+    assert.equal(
+      await findSwallowedPiError(REMOTE_CWD, { sandbox }),
+      RATE_LIMIT_ERROR,
+    );
+
+    const ls = runProcessCalls.find((call) => call.command === "ls");
+    assert.ok(ls, "no ls reached the daemon");
+    assert.equal(ls.args?.at(-1), piSessionWorkspaceDir(REMOTE_CWD));
+    assert.ok(
+      typeof ls.timeoutMs === "number" && ls.timeoutMs > 0,
+      `the ls child must carry its own deadline, got: ${ls.timeoutMs}`,
+    );
+  });
+
+  it("lets the newest owning transcript decide even when an older one holds an error", async () => {
+    // The current session ended cleanly; only a PREVIOUS session of the same workspace failed.
+    // Surfacing that older error would invent a failure this turn did not have.
+    const { sandbox } = fakeRemoteSandbox([
+      [
+        "sess-new.jsonl",
+        { content: successTranscript(REMOTE_CWD, "sess-new") },
+      ],
+      [
+        "sess-old.jsonl",
+        { content: errorTranscript(REMOTE_CWD, "sess-old", RATE_LIMIT_ERROR) },
+      ],
+    ]);
+
+    assert.equal(
+      await findSwallowedPiError(REMOTE_CWD, { sandbox }),
+      undefined,
+    );
+  });
+
+  it("skips a foreign transcript to the newest one this run owns", async () => {
+    // A transcript stamped with another workspace's cwd is stale or copied, never a candidate;
+    // stepping past it to this run's own newest transcript is not a stale fallback.
+    const { sandbox } = fakeRemoteSandbox([
+      [
+        "sess-foreign.jsonl",
+        {
+          content: errorTranscript(
+            REMOTE_CWD,
+            "sess-foreign",
+            "foreign boom",
+            "/tmp/other-cwd",
+          ),
+        },
+      ],
+      [
+        "sess-mine.jsonl",
+        { content: errorTranscript(REMOTE_CWD, "sess-mine", RATE_LIMIT_ERROR) },
+      ],
+    ]);
+
+    assert.equal(
+      await findSwallowedPiError(REMOTE_CWD, { sandbox }),
+      RATE_LIMIT_ERROR,
+    );
+  });
+
+  it("recovers nothing when the newest transcript cannot be read", async () => {
+    // With the newest candidate unreadable, which transcript is "the newest this run owns"
+    // cannot be established — an older sibling must not supply this turn's error.
+    const { sandbox } = fakeRemoteSandbox([
+      ["sess-new.jsonl", { unreadable: true }],
+      [
+        "sess-old.jsonl",
+        { content: errorTranscript(REMOTE_CWD, "sess-old", RATE_LIMIT_ERROR) },
+      ],
+    ]);
+
+    assert.equal(
+      await findSwallowedPiError(REMOTE_CWD, { sandbox }),
+      undefined,
+    );
+  });
+
+  it("recovers nothing when the transcript's final record is partially written", async () => {
+    // A truncated trailing record means the transcript's end is not trustworthy; the reader
+    // must not step over it to the older error record above.
+    const partial =
+      errorTranscript(REMOTE_CWD, "sess-partial", RATE_LIMIT_ERROR) +
+      '{"type":"message","message":{"role":"assistant"';
+    const { sandbox } = fakeRemoteSandbox([
+      ["sess-partial.jsonl", { content: partial }],
+    ]);
+
+    assert.equal(
+      await findSwallowedPiError(REMOTE_CWD, { sandbox }),
+      undefined,
+    );
+  });
+
+  it("resolves within its deadline when a read hangs", async () => {
+    const { sandbox } = fakeRemoteSandbox([
+      ["sess-hang.jsonl", { hang: true }],
+    ]);
+
+    const startedAt = Date.now();
+    assert.equal(
+      await findSwallowedPiError(REMOTE_CWD, { sandbox, timeoutMs: 50 }),
+      undefined,
+    );
+    // Generous ceiling for a slow CI box; the point is that a stalled daemon response cannot
+    // hold the turn (and with it, sandbox teardown) open past the probe's deadline.
+    assert.ok(
+      Date.now() - startedAt < 5_000,
+      "the probe must resolve by its deadline, not wait on the read",
     );
   });
 });

--- a/services/runner/tests/unit/daytona-transcript-recovery.test.ts
+++ b/services/runner/tests/unit/daytona-transcript-recovery.test.ts
@@ -104,7 +104,12 @@ describe("a Pi transcript inside a remote sandbox", () => {
     // The playground renders the event stream, not the result envelope: the error has to be IN
     // the stream, and ahead of the terminal `done`, or the turn still renders as a silent blank.
     const order = events.map((e) => e.type);
-    assert.ok(order.includes("error"), `no error event in stream: ${order}`);
+    const errorEvent = events.find((event) => event.type === "error");
+    assert.ok(errorEvent, `no error event in stream: ${order}`);
+    assert.ok(
+      errorEvent.message.toLowerCase().includes("rate limit"),
+      `expected recovered rate-limit error in stream, got: ${errorEvent.message}`,
+    );
     assert.ok(
       order.indexOf("error") < order.lastIndexOf("done"),
       `the error event must precede the terminal done: ${order}`,
@@ -156,7 +161,10 @@ function fakeRemoteSandbox(files: Array<[name: string, file: FakeRemoteFile]>) {
     },
     async readFsFile({ path }: { path: string }) {
       readPaths.push(path);
-      const file = files.find(([name]) => path.endsWith(`/${name}`))?.[1];
+      const transcriptDir = piSessionWorkspaceDir(REMOTE_CWD);
+      const file = files.find(
+        ([name]) => path === join(transcriptDir, name),
+      )?.[1];
       if (!file || file.unreadable) throw new Error(`ENOENT: ${path}`);
       if (file.hang) return new Promise<never>(() => {});
       return new TextEncoder().encode(file.content ?? "");

--- a/services/runner/tests/unit/daytona-transcript-recovery.test.ts
+++ b/services/runner/tests/unit/daytona-transcript-recovery.test.ts
@@ -1,16 +1,12 @@
 /**
  * Recovering a swallowed provider error from a REMOTE (Daytona) sandbox.
  *
- * `findSwallowedPiError` reads Pi's transcript to turn an empty turn into a real failure, but it
- * reads the runner's own filesystem, so it is switched off on Daytona (`pi-error.ts` says so in
- * its header, `run-turn.ts` gates it behind `!plan.isDaytona`). Cloud runs on Daytona. That makes
- * production the one place where the safety net does not exist — every swallowed provider error
- * there becomes a blank bubble, and the only copy of the message dies with the sandbox.
- *
- * The sandbox already exposes a daemon file API that other code reads through (`usage.ts` pulls
- * the usage file, `pi-assets.ts` pulls the skill-snapshot marker), so the transcript is reachable
- * before teardown. These tests stand a Pi transcript up inside a fake remote sandbox and pin that
- * the error reaches the caller.
+ * `findSwallowedPiError` reads Pi's transcript to turn an empty turn into a real failure. On a
+ * local run it reads the runner's own filesystem; on Daytona — which is where cloud runs — the
+ * transcript lives inside the remote sandbox, so the reader goes through the sandbox's daemon
+ * file API (the same API `usage.ts` and `pi-assets.ts` read through), before teardown takes the
+ * only copy of the message with it. These tests stand a Pi transcript up inside a fake remote
+ * sandbox and pin that the error reaches the caller.
  *
  * Fixture note: the fake supports both ways a reader might find the transcript — `readFsFile`
  * serves it for any `.jsonl` path, and `runProcess` answers an `ls` on stdout the way
@@ -85,45 +81,39 @@ describe("a Pi transcript inside a remote sandbox", () => {
     assert.equal(result.output, "The answer is 4.");
   });
 
-  it.fails(
-    "surfaces the provider failure on an empty turn [awaiting fix: Daytona swallowed-error reader]",
-    async () => {
-      const { result } = await runSilentTurn(
-        { harness: "pi_core", sandbox: "daytona" },
-        {
-          cwd: REMOTE_CWD,
-          sandboxTranscript: piTranscriptWithError(REMOTE_CWD, RATE_LIMIT_ERROR),
-        },
-      );
+  it("surfaces the provider failure on an empty turn", async () => {
+    const { result } = await runSilentTurn(
+      { harness: "pi_core", sandbox: "daytona" },
+      {
+        cwd: REMOTE_CWD,
+        sandboxTranscript: piTranscriptWithError(REMOTE_CWD, RATE_LIMIT_ERROR),
+      },
+    );
 
-      assert.equal(result.ok, false);
-      // Asserting on the substance of THIS failure, not on wording: only a recovery that actually
-      // read the remote transcript can produce it. A generic "the agent produced no output"
-      // cannot satisfy this, which is the point.
-      assert.ok(
-        result.error?.toLowerCase().includes("rate limit"),
-        `expected the transcript's failure, got: ${result.error}`,
-      );
-    },
-  );
+    assert.equal(result.ok, false);
+    // Asserting on the substance of THIS failure, not on wording: only a recovery that actually
+    // read the remote transcript can produce it. A generic "the agent produced no output"
+    // cannot satisfy this, which is the point.
+    assert.ok(
+      result.error?.toLowerCase().includes("rate limit"),
+      `expected the transcript's failure, got: ${result.error}`,
+    );
+  });
 
-  it.fails(
-    "reads the transcript out of the sandbox before teardown [awaiting fix: Daytona swallowed-error reader]",
-    async () => {
-      const { readFsFilePaths } = await runSilentTurn(
-        { harness: "pi_core", sandbox: "daytona" },
-        {
-          cwd: REMOTE_CWD,
-          sandboxTranscript: piTranscriptWithError(REMOTE_CWD, RATE_LIMIT_ERROR),
-        },
-      );
+  it("reads the transcript out of the sandbox before teardown", async () => {
+    const { readFsFilePaths } = await runSilentTurn(
+      { harness: "pi_core", sandbox: "daytona" },
+      {
+        cwd: REMOTE_CWD,
+        sandboxTranscript: piTranscriptWithError(REMOTE_CWD, RATE_LIMIT_ERROR),
+      },
+    );
 
-      // The recovery has to happen while the sandbox is still alive. Pinning the read (rather
-      // than only the message) is what stops the check being satisfied by a hard-coded string.
-      assert.ok(
-        readFsFilePaths.some((path) => path.endsWith(".jsonl")),
-        `no transcript read from the sandbox, only: ${readFsFilePaths.join(", ")}`,
-      );
-    },
-  );
+    // The recovery has to happen while the sandbox is still alive. Pinning the read (rather
+    // than only the message) is what stops the check being satisfied by a hard-coded string.
+    assert.ok(
+      readFsFilePaths.some((path) => path.endsWith(".jsonl")),
+      `no transcript read from the sandbox, only: ${readFsFilePaths.join(", ")}`,
+    );
+  });
 });

--- a/services/runner/tests/unit/sandbox-agent-pi-error.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-error.test.ts
@@ -16,14 +16,21 @@
  */
 import { afterEach, describe, it } from "vitest";
 import assert from "node:assert/strict";
-import { mkdtempSync, rmSync } from "node:fs";
+import { appendFileSync, mkdtempSync, rmSync } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 
-import { findSwallowedPiError } from "../../src/engines/sandbox_agent/pi-error.ts";
+import {
+  capturePiTranscriptCursor,
+  findSwallowedPiError,
+} from "../../src/engines/sandbox_agent/pi-error.ts";
+import { piSessionWorkspaceDir } from "../../src/engines/sandbox_agent/pi-assets.ts";
 // The transcript encoder is shared with the silent-turn suites, so the format lives in one
 // place: two hand-rolled copies could drift together and both stop matching what Pi writes.
-import { writePiTranscript as writeTranscript } from "../utils/silent-turn.ts";
+import {
+  piTranscriptFileName,
+  writePiTranscript as writeTranscript,
+} from "../utils/silent-turn.ts";
 
 const dirs: string[] = [];
 
@@ -41,6 +48,8 @@ afterEach(() => {
 describe("findSwallowedPiError", () => {
   it("returns the last assistant errorMessage from the session-workspace transcript", () => {
     const cwd = tempDir();
+    const cursor = capturePiTranscriptCursor(cwd, "sess-quota");
+    assert.ok(cursor);
     writeTranscript(cwd, "sess-quota", [
       {
         type: "message",
@@ -58,7 +67,7 @@ describe("findSwallowedPiError", () => {
       },
     ]);
 
-    const error = findSwallowedPiError(cwd);
+    const error = findSwallowedPiError(cwd, cursor);
     assert.equal(
       error,
       "You exceeded your current quota, please check your plan.",
@@ -67,6 +76,8 @@ describe("findSwallowedPiError", () => {
 
   it("returns undefined for a successful turn", () => {
     const cwd = tempDir();
+    const cursor = capturePiTranscriptCursor(cwd, "sess-ok");
+    assert.ok(cursor);
     writeTranscript(cwd, "sess-ok", [
       {
         type: "message",
@@ -78,11 +89,13 @@ describe("findSwallowedPiError", () => {
       },
     ]);
 
-    assert.equal(findSwallowedPiError(cwd), undefined);
+    assert.equal(findSwallowedPiError(cwd, cursor), undefined);
   });
 
   it("does not surface an error cleared by a later successful turn", () => {
     const cwd = tempDir();
+    const cursor = capturePiTranscriptCursor(cwd, "sess-recovered");
+    assert.ok(cursor);
     writeTranscript(cwd, "sess-recovered", [
       {
         type: "message",
@@ -103,11 +116,44 @@ describe("findSwallowedPiError", () => {
       },
     ]);
 
-    assert.equal(findSwallowedPiError(cwd), undefined);
+    assert.equal(findSwallowedPiError(cwd, cursor), undefined);
+  });
+
+  it("reads only the records appended after an existing transcript cursor", () => {
+    const cwd = tempDir();
+    writeTranscript(cwd, "sess-continued", [
+      {
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: "古いエラー",
+        },
+      },
+    ]);
+    const cursor = capturePiTranscriptCursor(cwd, "sess-continued");
+    assert.ok(cursor);
+    appendFileSync(
+      join(piSessionWorkspaceDir(cwd), piTranscriptFileName("sess-continued")),
+      `${JSON.stringify({
+        type: "message",
+        message: {
+          role: "assistant",
+          content: [],
+          stopReason: "error",
+          errorMessage: "current error",
+        },
+      })}\n`,
+    );
+
+    assert.equal(findSwallowedPiError(cwd, cursor), "current error");
   });
 
   it("ignores transcripts whose session record was stamped with a different cwd", () => {
     const cwd = tempDir();
+    const cursor = capturePiTranscriptCursor(cwd, "sess-stale");
+    assert.ok(cursor);
     writeTranscript(
       cwd,
       "sess-stale",
@@ -125,10 +171,13 @@ describe("findSwallowedPiError", () => {
       "/tmp/some-other-cwd",
     );
 
-    assert.equal(findSwallowedPiError(cwd), undefined);
+    assert.equal(findSwallowedPiError(cwd, cursor), undefined);
   });
 
   it("returns undefined when the transcript dir is absent", () => {
-    assert.equal(findSwallowedPiError(tempDir()), undefined);
+    const cwd = tempDir();
+    const cursor = capturePiTranscriptCursor(cwd, "sess-missing");
+    assert.ok(cursor);
+    assert.equal(findSwallowedPiError(cwd, cursor), undefined);
   });
 });

--- a/services/runner/tests/unit/silent-turn-contract.test.ts
+++ b/services/runner/tests/unit/silent-turn-contract.test.ts
@@ -31,8 +31,8 @@ import {
   AGENT_SESSION_ID,
   SESSION_ID,
   enableDaytonaProvider,
+  piTranscriptWithError,
   runSilentTurn,
-  seedFailedTranscript,
   textChunk,
   toolCallChunk,
 } from "../utils/silent-turn.ts";
@@ -47,11 +47,10 @@ const BANNER = [
 
 const dirs: string[] = [];
 
-/** A run cwd holding a Pi transcript whose last turn failed, where the reader looks for it. */
-function cwdWithFailedTranscript(): string {
+/** A private local run cwd, cleaned up after each test. */
+function localRunCwd(): string {
   const cwd = mkdtempSync(join(tmpdir(), "agenta-silent-turn-"));
   dirs.push(cwd);
-  seedFailedTranscript(cwd, QUOTA_ERROR);
   return cwd;
 }
 
@@ -68,11 +67,11 @@ afterEach(() => {
 
 describe("a turn whose model call failed", () => {
   it("fails loud with the provider's own message (local Pi)", async () => {
-    const cwd = cwdWithFailedTranscript();
+    const cwd = localRunCwd();
 
     const { result, events, store } = await runSilentTurn(
       { harness: "pi_core" },
-      { cwd },
+      { cwd, localTranscript: piTranscriptWithError(cwd, QUOTA_ERROR) },
     );
 
     assert.equal(result.ok, false);

--- a/services/runner/tests/unit/silent-turn-contract.test.ts
+++ b/services/runner/tests/unit/silent-turn-contract.test.ts
@@ -18,12 +18,6 @@
  * so the fail-loud fix cannot be satisfied by failing everything, and the empty-turn check cannot
  * be satisfied by suppressing it.
  *
- * Tests marked `it.fails` pin behavior that is NOT implemented yet; they pass today BECAUSE the
- * assertion fails, and turn red the moment the named fix lands, which is the signal to drop the
- * `.fails`. The fix names are in the test titles. Note that `it.fails` is satisfied by ANY
- * failure, including a fixture that dies before running a turn — so each one is backed by a guard
- * test above it that proves its setup reaches a real turn.
- *
  * Run: pnpm test (or: pnpm exec vitest run tests/unit/silent-turn-contract.test.ts)
  */
 import { afterEach, beforeEach, describe, it } from "vitest";
@@ -154,11 +148,11 @@ describe("turns that must keep working (guards against an over-eager fail-loud)"
   });
 });
 
-describe("empty turns that still pass silently", () => {
-  it("reaches a real turn on Daytona and closes it (guards the expectations below)", async () => {
-    // Without this, a fixture that dies during sandbox setup would satisfy every `it.fails`
-    // below forever — which is exactly how this fixture first "passed". Both assertions hold
-    // before and after the fail-loud fix, so this stays a fixture check and not a second alarm.
+describe("paths where an empty turn is still silent", () => {
+  it("reaches a real turn on Daytona and closes it", async () => {
+    // An empty Daytona turn still ends as a clean, silent `done`. This pins that the fixture
+    // completes a real turn rather than dying during sandbox setup, which is what every other
+    // Daytona assertion in this suite rests on.
     const { result, events } = await runSilentTurn({
       harness: "pi_core",
       sandbox: "daytona",
@@ -168,7 +162,7 @@ describe("empty turns that still pass silently", () => {
     assert.equal(result.output ?? "", "");
   });
 
-  it("reaches a real turn on a non-Pi harness (guards the expectation below)", async () => {
+  it("answers on a non-Pi harness", async () => {
     const { result } = await runSilentTurn(
       { harness: "claude" },
       { promptEvents: [textChunk("The answer is 4.\n")] },
@@ -178,10 +172,9 @@ describe("empty turns that still pass silently", () => {
     assert.equal(result.output, "The answer is 4.");
   });
 
-  it("puts a tool call in the stream (guards the expectation below)", async () => {
-    // The tool-call expectation below is `it.fails`, so its own in-body check that the tool call
-    // arrived would be satisfied by a fixture that stopped emitting one — the test would sit at
-    // "expected fail" forever, including after the fix lands. This guard is the external one.
+  it("puts a tool call in the stream", async () => {
+    // The swallowed-error probe is skipped whenever a turn emitted a tool call, so several
+    // behaviors here hinge on the fixture really putting one in the stream.
     const { events } = await runSilentTurn(
       { harness: "pi_core" },
       { promptEvents: [toolCallChunk("tool-1")] },
@@ -193,10 +186,10 @@ describe("empty turns that still pass silently", () => {
     );
   });
 
-  it("strips a banner-only turn down to nothing (guards the expectation below)", async () => {
-    // The premise of the banner case: after stripping, a turn that streamed only the banner is
-    // indistinguishable from a turn that streamed nothing. Asserting it here rather than inside
-    // the `it.fails` means a change to the banner format shows up as a real failure.
+  it("strips a banner-only turn down to nothing", async () => {
+    // pi-acp emits its startup banner as the first message chunk. After stripping, a turn that
+    // streamed only the banner is indistinguishable from a turn that streamed nothing — which is
+    // why such a turn still arrives at empty output and a blank bubble.
     const { result } = await runSilentTurn(
       { harness: "pi_core" },
       { promptEvents: BANNER.map(textChunk) },
@@ -204,78 +197,4 @@ describe("empty turns that still pass silently", () => {
 
     assert.equal(result.output, "");
   });
-
-  it.fails(
-    "must fail loud on Daytona when the transcript holds no error [awaiting fix: fail-loud empty turn]",
-    async () => {
-      // The transcript reader runs on Daytona too now, but it can only recover an error Pi
-      // actually wrote: a harness that dies without one still ends as a silent success.
-      const { result } = await runSilentTurn({
-        harness: "pi_core",
-        sandbox: "daytona",
-      });
-
-      assert.equal(result.ok, false);
-    },
-  );
-
-  it.fails(
-    "must fail loud for a non-Pi harness, whose transcript is never read [awaiting fix: fail-loud empty turn]",
-    async () => {
-      // The swallowed-error probe is Pi-only, so an empty Claude/Codex turn is silent everywhere.
-      const { result } = await runSilentTurn({ harness: "claude" });
-
-      assert.equal(result.ok, false);
-    },
-  );
-
-  it.fails(
-    "must not record continuity for an empty turn [awaiting fix: fail-loud empty turn]",
-    async () => {
-      // Recording an empty turn as the session's last good turn is what let one silent failure
-      // poison every later turn: the next turn restores that state cleanly and fails the same way.
-      const { store } = await runSilentTurn({
-        harness: "pi_core",
-        sandbox: "daytona",
-      });
-
-      assert.equal(store.get(SESSION_ID, "pi_core"), undefined);
-    },
-  );
-
-  it.fails(
-    "must fail loud when the whole answer was the startup banner [awaiting fix: fail-loud empty turn]",
-    async () => {
-      // pi-acp emits its startup banner as the first message chunk. The stripper removes it, so a
-      // turn that streamed ONLY the banner arrives at the same place as a turn that streamed
-      // nothing: empty output, `ok: true`, blank bubble.
-      const { result } = await runSilentTurn(
-        { harness: "pi_core" },
-        { promptEvents: BANNER.map(textChunk) },
-      );
-
-      assert.equal(result.ok, false);
-    },
-  );
-
-  it.fails(
-    "must surface the error when the turn called a tool and then died [awaiting fix: fail-loud empty turn]",
-    async () => {
-      // The probe is skipped whenever the turn emitted a tool call, so a turn that ran a tool and
-      // then hit the provider failure stays silent even on the local path that can read the
-      // transcript. This is the shape of issue #6102 (a turn ends after a tool call, no answer,
-      // no stated reason).
-      const cwd = cwdWithFailedTranscript();
-
-      const { result, events } = await runSilentTurn(
-        { harness: "pi_core" },
-        { cwd, promptEvents: [toolCallChunk("tool-1")] },
-      );
-
-      // The tool call really reached the stream, so this is about the empty turn after it.
-      assert.ok(types(events).includes("tool_call"));
-      assert.equal(result.ok, false);
-      assert.ok(result.error?.includes("credit"));
-    },
-  );
 });

--- a/services/runner/tests/unit/silent-turn-contract.test.ts
+++ b/services/runner/tests/unit/silent-turn-contract.test.ts
@@ -206,9 +206,10 @@ describe("empty turns that still pass silently", () => {
   });
 
   it.fails(
-    "must fail loud on Daytona, where the transcript reader is switched off [awaiting fix: fail-loud empty turn]",
+    "must fail loud on Daytona when the transcript holds no error [awaiting fix: fail-loud empty turn]",
     async () => {
-      // Cloud runs on Daytona, so this is the one placement where the safety net does not exist.
+      // The transcript reader runs on Daytona too now, but it can only recover an error Pi
+      // actually wrote: a harness that dies without one still ends as a silent success.
       const { result } = await runSilentTurn({
         harness: "pi_core",
         sandbox: "daytona",

--- a/services/runner/tests/utils/silent-turn.ts
+++ b/services/runner/tests/utils/silent-turn.ts
@@ -81,8 +81,8 @@ export function toolCallChunk(
 
 /**
  * Enable the Daytona provider for a test, and drop the memoized config so the run plan reads the
- * enabled set. Daytona placement is under test (it is the cloud path, and the one where the
- * swallowed-error reader is switched off), so both suites need this in `beforeEach`.
+ * enabled set. Daytona placement is under test (it is the cloud path, where the swallowed-error
+ * reader goes through the sandbox's file API), so both suites need this in `beforeEach`.
  */
 export function enableDaytonaProvider(): void {
   process.env.AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS = "local,daytona";
@@ -105,11 +105,21 @@ export interface SilentTurnOptions {
    */
   cwd?: string;
   /**
-   * A Pi transcript the sandbox serves for ANY `.jsonl` path. The in-sandbox transcript
-   * directory is the reader's to choose, so a test pins that a transcript is read at all rather
-   * than hard-coding a path the fix has not picked yet.
+   * A Pi transcript the sandbox serves at the reader's contractual location: the file
+   * `TRANSCRIPT_FILENAME` inside `piSessionWorkspaceDir(cwd)`. The fake honors the daemon
+   * contract rather than answering promiscuously — `ls` lists only that directory (any other
+   * directory fails the way a real `ls` does) and `readFsFile` serves only that exact path —
+   * so a reader that lists the wrong directory or joins the path wrong fails here instead of
+   * passing against a fake that serves everything.
    */
   sandboxTranscript?: string;
+}
+
+/** One `runProcess` invocation the fake sandbox received, for pinning the daemon contract. */
+export interface RecordedRunProcessCall {
+  command?: string;
+  args?: string[];
+  timeoutMs?: number;
 }
 
 export interface SilentTurnRun {
@@ -118,6 +128,8 @@ export interface SilentTurnRun {
   events: AgentEvent[];
   /** Every path read through the sandbox's daemon file API, in order. */
   readFsFilePaths: string[];
+  /** Every process the sandbox was asked to run, in order (command, args, timeoutMs). */
+  runProcessCalls: RecordedRunProcessCall[];
   store: SessionContinuityStore;
 }
 
@@ -132,6 +144,7 @@ export async function runSilentTurn(
   options: SilentTurnOptions = {},
 ): Promise<SilentTurnRun> {
   const readFsFilePaths: string[] = [];
+  const runProcessCalls: RecordedRunProcessCall[] = [];
   const store = new SessionContinuityStore();
   const events: AgentEvent[] = [];
   // A run without an explicit cwd still gets a private one. A fixed shared /tmp path would let a
@@ -177,21 +190,34 @@ export async function runSilentTurn(
     },
   };
 
+  // Where the seeded transcript lives inside the fake sandbox: the same location the reader
+  // derives from the run's cwd, so path agreement is part of what these runs pin.
+  const remoteTranscriptDir = piSessionWorkspaceDir(cwd);
+  const remoteTranscriptPath = join(remoteTranscriptDir, TRANSCRIPT_FILENAME);
+
   const sandbox = {
     async mkdirFs() {},
-    // Two jobs, both matching the real contract:
-    //  - `exitCode: 0` makes the Daytona bootstrap's `test -x <pinned pi>` succeed, i.e. the
-    //    image already has Pi baked in — otherwise the run dies during setup and never reaches
-    //    a turn.
+    // Matches the real daemon contract, not a promiscuous fake:
+    //  - Non-`ls` commands answer `exitCode: 0` so the Daytona bootstrap's `test -x <pinned pi>`
+    //    succeeds (the image already has Pi baked in) — otherwise the run dies during setup and
+    //    never reaches a turn.
     //  - `ls` answers on STDOUT, the way `sandboxRelayHost.list` reads it in `src/tools/relay.ts`
-    //    (`String(ls?.stdout ?? "").split("\n")`). A reader that finds the transcript by LISTING
-    //    the directory has to see the file; returning a bare exit code would hand it an empty
-    //    listing, and the Daytona expectations would stay green through the fix that closes them.
-    async runProcess(input?: { command?: string }) {
-      const listing =
-        input?.command === "ls" && options.sandboxTranscript
-          ? `${TRANSCRIPT_FILENAME}\n`
-          : "";
+    //    (`String(ls?.stdout ?? "").split("\n")`), and honors its `args`: only the transcript
+    //    directory exists, any other directory fails the way a real `ls` fails. Every call is
+    //    recorded (command, args, timeoutMs) so tests can pin what the daemon was asked.
+    async runProcess(input?: RecordedRunProcessCall) {
+      runProcessCalls.push({ ...input });
+      if (input?.command !== "ls") return { exitCode: 0, stdout: "" };
+      const dir = input.args?.at(-1);
+      if (dir !== remoteTranscriptDir)
+        return {
+          exitCode: 2,
+          stdout: "",
+          stderr: `ls: cannot access '${dir}'`,
+        };
+      const listing = options.sandboxTranscript
+        ? `${TRANSCRIPT_FILENAME}\n`
+        : "";
       return { exitCode: 0, stdout: listing };
     },
     async writeFsFile() {},
@@ -204,11 +230,11 @@ export async function runSilentTurn(
     },
     async destroySandbox() {},
     async dispose() {},
+    // Serves ONLY the seeded transcript at its exact path, like a real filesystem would.
     async readFsFile({ path }: { path: string }) {
       readFsFilePaths.push(path);
-      const content = path.endsWith(".jsonl")
-        ? options.sandboxTranscript
-        : undefined;
+      const content =
+        path === remoteTranscriptPath ? options.sandboxTranscript : undefined;
       if (content === undefined) throw new Error(`ENOENT: ${path}`);
       return new TextEncoder().encode(content);
     },
@@ -266,7 +292,7 @@ export async function runSilentTurn(
       deps,
     );
 
-    return { result, events, readFsFilePaths, store };
+    return { result, events, readFsFilePaths, runProcessCalls, store };
   } finally {
     if (ownedCwd) rmSync(ownedCwd, { recursive: true, force: true });
   }

--- a/services/runner/tests/utils/silent-turn.ts
+++ b/services/runner/tests/utils/silent-turn.ts
@@ -97,6 +97,8 @@ export interface SilentTurnOptions {
   promptError?: Error;
   /** Raise a permission gate mid-prompt, then hang — the shape a parked turn has. */
   park?: boolean;
+  /** Abort a still-pending prompt, the shape a user-cancelled turn has. */
+  cancel?: boolean;
   /**
    * The run's working directory. On a local run a Pi transcript is read from under it; on a
    * Daytona run it is the workspace path INSIDE the sandbox, which is the cwd Pi stamps on the
@@ -105,7 +107,8 @@ export interface SilentTurnOptions {
    */
   cwd?: string;
   /**
-   * A Pi transcript the sandbox serves at the reader's contractual location: the file
+   * A Pi transcript the sandbox writes while the prompt runs, then serves at the reader's
+   * contractual location: the file
    * `TRANSCRIPT_FILENAME` inside `piSessionWorkspaceDir(cwd)`. The fake honors the daemon
    * contract rather than answering promiscuously — `ls` lists only that directory (any other
    * directory fails the way a real `ls` does) and `readFsFile` serves only that exact path —
@@ -113,6 +116,10 @@ export interface SilentTurnOptions {
    * passing against a fake that serves everything.
    */
   sandboxTranscript?: string;
+  /** A stale Pi transcript that already exists before this turn starts. */
+  initialSandboxTranscript?: string;
+  /** A Pi transcript written to the local workspace while the prompt runs. */
+  localTranscript?: string;
 }
 
 /** One `runProcess` invocation the fake sandbox received, for pinning the daemon contract. */
@@ -162,6 +169,13 @@ export async function runSilentTurn(
   // what the sandbox-agent package does on `destroySession` (the same model `fakeHarness` in
   // `tests/unit/sandbox-agent-orchestration.test.ts` carries — keep the two in step).
   let resolveHungPrompt: ((value: unknown) => void) | undefined;
+  const abortController = new AbortController();
+
+  // Where the seeded transcript lives inside the fake sandbox: the same location the reader
+  // derives from the run's cwd, so path agreement is part of what these runs pin.
+  const remoteTranscriptDir = piSessionWorkspaceDir(cwd);
+  const remoteTranscriptPath = join(remoteTranscriptDir, TRANSCRIPT_FILENAME);
+  let remoteTranscript = options.initialSandboxTranscript;
 
   const session = {
     id: "session-1",
@@ -174,8 +188,20 @@ export async function runSilentTurn(
     },
     async respondPermission() {},
     async prompt() {
+      if (options.sandboxTranscript !== undefined)
+        remoteTranscript = options.sandboxTranscript;
+      if (options.localTranscript !== undefined) {
+        mkdirSync(remoteTranscriptDir, { recursive: true });
+        writeFileSync(remoteTranscriptPath, options.localTranscript);
+      }
       for (const event of options.promptEvents ?? []) eventHandler?.(event);
       if (options.promptError) throw options.promptError;
+      if (options.cancel) {
+        queueMicrotask(() => abortController.abort());
+        return new Promise((resolve) => {
+          resolveHungPrompt = resolve;
+        });
+      }
       if (options.park) {
         permissionHandler?.({
           id: "perm-1",
@@ -190,11 +216,6 @@ export async function runSilentTurn(
     },
   };
 
-  // Where the seeded transcript lives inside the fake sandbox: the same location the reader
-  // derives from the run's cwd, so path agreement is part of what these runs pin.
-  const remoteTranscriptDir = piSessionWorkspaceDir(cwd);
-  const remoteTranscriptPath = join(remoteTranscriptDir, TRANSCRIPT_FILENAME);
-
   const sandbox = {
     async mkdirFs() {},
     // Matches the real daemon contract, not a promiscuous fake:
@@ -207,6 +228,15 @@ export async function runSilentTurn(
     //    recorded (command, args, timeoutMs) so tests can pin what the daemon was asked.
     async runProcess(input?: RecordedRunProcessCall) {
       runProcessCalls.push({ ...input });
+      if (input?.command === "stat") {
+        const path = input.args?.at(-1);
+        if (path !== remoteTranscriptPath || remoteTranscript === undefined)
+          return { exitCode: 1, stdout: "" };
+        return {
+          exitCode: 0,
+          stdout: `${new TextEncoder().encode(remoteTranscript).length}\n`,
+        };
+      }
       if (input?.command !== "ls") return { exitCode: 0, stdout: "" };
       const dir = input.args?.at(-1);
       if (dir !== remoteTranscriptDir)
@@ -215,9 +245,7 @@ export async function runSilentTurn(
           stdout: "",
           stderr: `ls: cannot access '${dir}'`,
         };
-      const listing = options.sandboxTranscript
-        ? `${TRANSCRIPT_FILENAME}\n`
-        : "";
+      const listing = remoteTranscript ? `${TRANSCRIPT_FILENAME}\n` : "";
       return { exitCode: 0, stdout: listing };
     },
     async writeFsFile() {},
@@ -234,7 +262,7 @@ export async function runSilentTurn(
     async readFsFile({ path }: { path: string }) {
       readFsFilePaths.push(path);
       const content =
-        path === remoteTranscriptPath ? options.sandboxTranscript : undefined;
+        path === remoteTranscriptPath ? remoteTranscript : undefined;
       if (content === undefined) throw new Error(`ENOENT: ${path}`);
       return new TextEncoder().encode(content);
     },
@@ -288,7 +316,7 @@ export async function runSilentTurn(
         ...request,
       } as AgentRunRequest,
       (event) => events.push(event),
-      undefined,
+      options.cancel ? abortController.signal : undefined,
       deps,
     );
 
@@ -332,14 +360,19 @@ export function writePiTranscript(
   const dir = piSessionWorkspaceDir(cwd);
   mkdirSync(dir, { recursive: true });
   writeFileSync(
-    join(dir, `${name}.jsonl`),
+    join(dir, piTranscriptFileName(name)),
     piTranscript(cwd, name, messages, recordCwd),
   );
 }
 
+/** Pi's persisted filename shape: timestamp followed by the session id. */
+export function piTranscriptFileName(sessionId: string): string {
+  return `2026-08-23T00-00-00-000Z_${sessionId}.jsonl`;
+}
+
 /** The one transcript these suites stand up; also what the fake sandbox's `ls` reports. */
-const TRANSCRIPT_NAME = "sess-failed";
-export const TRANSCRIPT_FILENAME = `${TRANSCRIPT_NAME}.jsonl`;
+const TRANSCRIPT_NAME = AGENT_SESSION_ID;
+export const TRANSCRIPT_FILENAME = piTranscriptFileName(TRANSCRIPT_NAME);
 
 /** The messages of a session whose last assistant turn failed with `message`. */
 function failedTurnMessages(message: string): Array<Record<string, unknown>> {


### PR DESCRIPTION
## Context
When a Pi run on a cloud (Daytona) sandbox hits a provider failure mid-turn (rate limit, exhausted quota, bad key, unknown model), the user sees "The agent produced no output." instead of the real error. Pi records the failed turn in its transcript, but its pi-acp bridge reports a clean `end_turn` with no content. The runner already has a recovery for this: after an empty Pi turn, `findSwallowedPiError` reads the transcript and fails the run loud with the transcript's error. That reader used the runner's own filesystem, so `run-turn.ts` switched it off behind `!plan.isDaytona`. Cloud runs on Daytona, so production was the one place without the safety net, and the only copy of the error message died with the sandbox.

## Changes
`findSwallowedPiError` now also works against a remote sandbox. Handed the sandbox, it lists the Pi session directory inside the sandbox (`ls -1t`, newest first, standing in for the local reader's mtime pick) and reads the transcript through the sandbox's daemon file API, the same API `usage.ts` and `pi-assets.ts` already read through. The ownership rule is unchanged: only a transcript whose `session` record is stamped with this run's workspace cwd counts, and the newest owning transcript decides.

`run-turn.ts` drops the `!plan.isDaytona` gate and branches instead: a local run keeps the synchronous filesystem read; a Daytona run awaits the remote read, which happens mid-turn while the sandbox is still alive.

Before, on Daytona: `ok: true`, empty output, the chat renders "The agent produced no output."
After: `ok: false` with the transcript's failure, for example "Rate limit reached for gpt-5 in organization org-abc on tokens per min.", recorded on the trace and emitted as an error event ahead of the terminal `done`, exactly like the local path.

## Review response (Codex xhigh + CodeRabbit, second commit)
- Bounded probe (P1): the whole remote recovery now runs under one 15 second deadline (`Promise.race`, resolves undefined on timeout, never rejects), on top of the 10 second `timeoutMs` the `ls` child already had. Parsing is bounded too: the `session` record is parsed from the first 4 KiB and the error scan from the last 64 KiB of the fetched bytes, so a huge long-lived transcript is not decoded and split wholesale. A stalled daemon response can no longer hold the turn or sandbox teardown open.
- No stale fallback (P2): if the newest candidate transcript cannot be read, or its header is missing or partial, recovery stops with undefined instead of falling through to an older file. The error scan now walks backward from the end of the transcript: the last assistant record decides, and an unparseable trailing line (a partially written final record) disqualifies recovery instead of being stepped over to an older error. Skipping a transcript stamped with a foreign cwd is still allowed; that is ownership filtering, not a stale fallback.
- Test gaps: the Daytona failure test now asserts the `error` event precedes the terminal `done` (mirroring the local assertion). New direct remote-reader cases cover newest-versus-older sessions, foreign cwd stamps, an unreadable newest file, a partially written final record, a hanging read resolving within the deadline, and the `ls` contract (right directory, own `timeoutMs`). The shared fixture now honors the daemon contract instead of answering promiscuously: `ls` respects its `args` (only the transcript directory exists, other directories fail with a nonzero exit) and is recorded with `timeoutMs`; `readFsFile` serves only the transcript's exact path.
- Nit: renamed the expected-failure case that claimed the Daytona reader is "switched off". That case has since been dropped entirely, along with the other four placeholders (see "Dropped placeholder tests").

## Tests
- The test scaffolding comes from #6113 (merged into `release/v0.112.3`): `tests/utils/silent-turn.ts`, `tests/unit/silent-turn-contract.test.ts`, `tests/unit/daytona-transcript-recovery.test.ts`, and the fixture refactor of `tests/unit/sandbox-agent-pi-error.test.ts` are copied into this branch. The two Daytona tests marked `it.fails("... [awaiting fix: Daytona swallowed-error reader]")` are flipped to plain `it` and pass.
- Full runner suite: 132 files, 2242 passed, zero expected-fail. `pnpm run typecheck` clean.
- Not yet verified against a live Daytona sandbox; the fake sandbox in the fixture serves the same `readFsFile`/`runProcess` contract the real Daytona paths use.

## Dropped placeholder tests (third commit)
`silent-turn-contract.test.ts` carried five `it.fails` cases pinning the broader "fail loud on an empty turn" behavior, which is not built. `it.fails` is satisfied by ANY failure, including a broken fixture, so those cases could never warn anyone: they are green today because the assertion fails, and they would stay green if the fixture stopped reaching a turn at all. They are removed rather than left standing as a false signal. What each one described, so the intent is not lost:

1. An empty turn on Daytona whose transcript holds no error still ends `ok: true`. The reader this PR adds can only recover an error Pi actually wrote.
2. An empty turn on a non-Pi harness (Claude, Codex) is silent everywhere, because the swallowed-error probe is Pi-only.
3. An empty turn is still recorded as the session's last good turn, so the next turn restores that state and fails the same way.
4. A turn whose whole answer was pi-acp's startup banner is stripped down to empty output and `ok: true`.
5. A turn that called a tool and then died stays silent even on the local path, because the probe is skipped whenever the turn emitted a tool call.

Related open issues for that epic: #5326 (a provider credit error shows as the no-output message), #6022 (a provider auth failure surfaces as an ordinary agent reply), #6102 (a slow tool call ends the whole turn).

The four fixture guards that backed those cases assert real behavior and stay, retitled off "guards the expectation below": a Daytona turn reaches a real turn and closes it, a non-Pi harness answers, the fixture puts a tool call in the stream, and banner stripping yields empty output. No test that asserts real behavior changed, and the two Daytona cases this PR flipped to passing are untouched.

## Merge-back note
`release/v0.112.3` carries the #6113 versions of these test files, with seven `it.fails` cases. When the release merges back into main, resolve conflicts in `daytona-transcript-recovery.test.ts`, `silent-turn.ts`, and `silent-turn-contract.test.ts` by taking this PR's versions: two of those seven are fixed here and now plain `it`, the other five are dropped as unactionable placeholders, and the fixture honors the daemon contract. `it.fails` inverts once the fix exists, so the release's un-flipped Daytona tests would go red on a branch that contains this fix. `sandbox-agent-pi-error.test.ts` is byte-identical with the release branch and should merge clean.

## What to QA
- In the cloud playground, run a Pi agent whose provider key is invalid or out of quota. The chat shows the provider's real error instead of "The agent produced no output."
- Regression: a normal Pi run on cloud still answers, and a genuinely empty successful turn is not turned into an error.