### PR TITLE
doc(design): in-place mount credential refresh

### DIFF
--- a/docs/design/mount-credential-refresh/README.md
+++ b/docs/design/mount-credential-refresh/README.md
@@ -1,0 +1,67 @@
+# Mount credential refresh: swap fresh credentials into a running mount
+
+Planning workspace for the long-term fix behind a v0.112.3 release finding. Mount
+credentials cannot be renewed inside a running geesefs mount today, so the runner
+rebuilds sandboxes at turn boundaries to install fresh ones, and a turn that outlives
+its lease loses file access mid-run. This project teaches the mount to pick up fresh
+credentials while running, so a run of any length keeps live files and warm sessions
+never need a credential-driven rebuild.
+
+Predecessor: [docs/design/fix-sts-mount-expiry/](../fix-sts-mount-expiry/) made the
+credential lifetime real and made the runner rebuild before expiry. This project
+removes the need to rebuild at all.
+
+## What each file answers
+
+| File | Question it answers |
+| --- | --- |
+| [context.md](context.md) | What still breaks or costs us today, and why this work exists now. |
+| [research.md](research.md) | How credentials enter a mount today, what the pinned geesefs SDK actually supports for refresh (verified against its source), why the push model keeps the security boundary intact, and what happens to in-flight file operations at rotation. |
+| [plan.md](plan.md) | The chosen mechanism, the changes per file, the slice order, the test plan, and the live QA plan. |
+| [decisions.md](decisions.md) | Every decision this design embeds, its trade-off, and how to back it out. |
+| [status.md](status.md) | Where this work stands right now. |
+
+## Domain nouns, one sentence each
+
+- **Runner**: the Node sidecar (`services/runner/`) that executes one agent turn per
+  HTTP `/run` request.
+- **Sandbox**: the isolated environment a turn runs in; "local" means the runner's own
+  container, "remote" means a Daytona cloud sandbox.
+- **Turn**: one user-message-to-agent-reply exchange; the runner's unit of work.
+- **Session pool**: the runner's in-memory table of live environments parked between
+  turns so the next turn continues warm instead of rebuilding.
+- **Mount**: a directory in the sandbox whose contents live in the object store; each
+  mount is one geesefs daemon holding one set of store credentials.
+- **Mount credentials / lease**: the temporary, prefix-scoped S3 key, secret, and
+  session token a mount's daemon uses; signed by the API, they expire at a TTL.
+- **geesefs**: the FUSE filesystem binary (pinned v0.43.0) that presents an S3 prefix
+  as a local directory; it vendors a fork of aws-sdk-go v1 for credentials.
+- **credential_process**: an AWS SDK config-file directive that names a command the
+  SDK re-runs to obtain credentials whenever the previous ones expire.
+- **Lease file**: the JSON file, written by the runner, that the credential_process
+  command reads; rewriting it is how fresh credentials reach a running daemon.
+- **Refresher**: the runner-side loop that re-signs leases before they expire and
+  rewrites the lease files, locally by direct write, remotely by pushing into the
+  sandbox.
+- **Installed lease / credential epoch**: the session pool's record of when the
+  credentials actually installed in an environment's daemons expire; today it drives
+  evict-before-expiry, after this project it advances on every refresh.
+- **STS**: the "Security Token Service" protocol for minting temporary scoped S3
+  credentials; both SeaweedFS (bundled store) and AWS implement it.
+- **EACCES**: "Permission denied"; what every file operation returns once the store
+  answers 403 to an expired lease.
+- **ENOTCONN**: "Transport endpoint is not connected"; what the kernel returns when a
+  FUSE daemon has died. A different failure, already handled, untouched here.
+
+## Related work
+
+- [docs/design/fix-sts-mount-expiry/](../fix-sts-mount-expiry/): the predecessor.
+  Its research.md section 3 is the mechanism catalog this project extends, and its
+  decisions.md item 2 is the deferral this project resolves.
+- The v0.112.3 patch-release mitigation (shipped separately, on its own lane):
+  balances the run deadline (11 h) under the lease TTL (12 h) so no turn can outlive
+  its lease. It is a numbers truce, not a fix; this project is the fix.
+- The lifecycle migration (`services/runner/src/lifecycle/`): moved the session
+  decision logic into `session-coordinator.ts` and introduced live routes that
+  reconfigure a running environment instead of rebuilding it. This project adds the
+  mount-lease equivalent of that idea.

--- a/docs/design/mount-credential-refresh/context.md
+++ b/docs/design/mount-credential-refresh/context.md
@@ -1,0 +1,83 @@
+# Context: why in-place mount credential refresh, and why now
+
+## What happens today
+
+A geesefs mount reads its store credentials exactly once, at daemon start, from
+static environment variables. Nothing can renew them while the daemon runs. Two
+consequences follow:
+
+1. **A turn that outlives its lease loses its files mid-run.** Once the lease
+   expires, the store answers 403, geesefs maps it to EACCES, and every file
+   operation in the working directory and the durable agent folder fails with
+   "Permission denied" until the environment is rebuilt.
+2. **Warm sessions are rebuilt for credential reasons alone.** The session pool
+   tracks the installed lease and evicts a parked environment to a cold rebuild
+   before a worst-case turn could cross expiry. On the local sandbox a rebuild costs
+   seconds. On Daytona a credential eviction maps to `runtime-incompatible`, which
+   deletes the remote sandbox; the next turn pays a full create.
+
+The v0.112.3 release surfaced the first consequence in the field: a long run hit its
+lease boundary mid-turn. The patch-release mitigation (shipped separately) balances
+the numbers, run deadline 11 hours against lease TTL 12 hours, so that no turn can
+start on a lease it could outlive. That mitigation works, but it couples two knobs
+that have no business being coupled, forces a 12-hour credential lifetime (every
+extra hour of lease lifetime is an hour a leaked prefix-scoped credential stays
+usable), and still pays a cold rebuild whenever an active conversation crosses a
+lease boundary.
+
+## What this project changes
+
+Teach the mount to pick up fresh credentials while running. The runner re-signs each
+mount's lease before it expires and places the fresh lease where the running daemon's
+SDK re-reads it. Then:
+
+- A run of any length keeps live files: the lease under a running turn is renewed,
+  not outlived.
+- Warm sessions never rebuild for credential reasons: the installed lease advances
+  instead of running out.
+- The run deadline and the lease TTL decouple: the deadline becomes a product
+  decision, the TTL a security decision, and neither constrains the other.
+- The TTL can come back down (shorter leases, smaller leak window), because renewal
+  is continuous and free.
+
+## The security constraint that shapes everything
+
+The sandbox runs untrusted agent code. Nothing inside the sandbox may hold API
+authentication or long-lived keys. This is why the predecessor project deferred
+in-place refresh: the obvious designs put a credential-fetching helper, and therefore
+API auth, inside the sandbox. The design here inverts the flow: the runner, which
+already holds per-run API auth outside the sandbox, signs fresh leases and pushes
+them in. The sandbox only ever contains what it already contains today, a
+prefix-scoped short-lived lease. See research.md section 4 for the full argument.
+
+## Goals
+
+- A turn keeps live files for its whole length, on the local sandbox and on
+  Daytona, against SeaweedFS and against real AWS. Stated precisely: a turn never
+  starts on a lease it cannot cover without a successful refresh first, and an
+  active turn never sees EACCES unless signing stays broken past the remaining
+  real lease lifetime (and then self-heals on the first successful retry). The
+  unconditional "any length, never EACCES" holds only while the TTL exceeds the
+  turn budget; below that, the signer is a runtime dependency
+  (research.md section 7).
+- No credential-driven evictions: `credentials-expiring` and `credentials-expired`
+  stop occurring in a healthy deployment, and the Daytona delete-and-recreate they
+  cause disappears with them.
+- The sandbox trust boundary is unchanged: no API auth and no long-lived keys inside
+  the sandbox, ever.
+- The existing machinery stays as a backstop: if refresh fails, behavior degrades to
+  exactly today's evict-before-expiry, never to silent EACCES.
+- First slice shippable alone.
+
+## Non-goals
+
+- Upgrading geesefs. The pinned v0.43.0 already supports the chosen mechanism
+  (research.md section 2); an upgrade is a separate risk with no payoff here.
+- Retuning the run deadline and TTL defaults inside the first two slices. Slice 3
+  proposes the retune; Mahmoud decides the numbers (they trade run length against
+  leak window).
+- Mid-turn EACCES detection in the agent event stream. Still false-positive-prone,
+  and unnecessary once leases never expire under a turn (the predecessor's analysis
+  stands).
+- Per-mount RoleSessionName and other signing hygiene. Orthogonal, still deferred.
+- The E2B provider beyond what the shared remote-mount code path gives for free.

--- a/docs/design/mount-credential-refresh/decisions.md
+++ b/docs/design/mount-credential-refresh/decisions.md
@@ -1,0 +1,267 @@
+# Decisions: what was chosen, why, and how to back each choice out
+
+Every decision this design embeds, with its trade-off and the cheapest reversal.
+Ordered from the ones that shape the design down to mechanical details. "Backtrack"
+states what changing the decision costs later.
+
+## 1. credential_process in push form, not the container-credentials endpoint
+
+The predecessor deferred in-place refresh and named the container-credentials
+endpoint (mechanism 4 in its table) as the intended follow-up. Reading the pinned
+SDK fork revised that: `AWS_CONTAINER_CREDENTIALS_FULL_URI` accepts ONLY loopback
+hosts in geesefs v0.43.0, with no HTTPS exception (research.md section 2), so the
+endpoint would have to be served from INSIDE each sandbox, which needs an
+in-sandbox daemon that itself needs a credential source. credential_process with
+`cat <lease file>` needs no daemon, no port, and no logic inside the sandbox; the
+refresh trigger (the SDK re-running the process at the reported expiration) is
+identical in kind.
+
+- Trade-off: the refresh moment is controlled by the `Expiration` written into the
+  file rather than by the endpoint provider's built-in 5-minute early window; the
+  design re-creates that window explicitly (decision 3).
+- Backtrack: for the LOCAL sandbox only, a loopback endpoint served by the runner
+  would also work; switch by swapping the config file for the env var. There is no
+  remote backtrack onto the endpoint within this geesefs pin.
+
+## 2. The runner pushes leases; nothing inside the sandbox ever fetches them
+
+The sign endpoints are called only by the runner, with the per-run credential it
+already holds, and the result travels into the sandbox as file content over the
+provider's authenticated channel. The sandbox's credential inventory is unchanged
+from today: one prefix-scoped short-lived lease (research.md section 4). This is
+the resolution of the security concern that caused the original deferral, not a
+relaxation of it.
+
+- Trade-off: refresh requires the runner to be alive and holding a valid run
+  credential, which confines refresh to turn time (decision 4).
+- Backtrack: none sensible; any pull design moves credential-fetching authority
+  into the sandbox, which the trust boundary forbids.
+
+## 3. The lease file reports an early expiration (real minus a margin)
+
+The vendored processcreds has a zero expiry window, so the SDK rotates exactly at
+the reported expiration. Reporting `real - margin` (120 s at the default TTL, with
+a 30 s floor for tiny QA TTLs) makes the SDK rotate while the old lease is still
+valid. The margin is a bound, not a proof: it holds while request-admission delay
+plus total clock skew stays under it, which is the stated assumption
+(research.md section 5); the margin is also the ONLY skew absorber on the refresh
+path, since `MOUNT_LEASE_SKEW_MS` feeds only the (gated) coordinator horizon
+check.
+
+- Trade-off: each lease's usable life shortens by the margin; at TTL 3600 that is
+  3.3 percent.
+- Backtrack: one constant in `mount-lease.ts`.
+
+## 4. The refresher runs only while a turn is in flight, armed with a live accessor, plus a preflight at arm
+
+Turn time is when a lease can die under I/O, and it is also when the runner holds a
+valid signing credential. That credential is held as a live ACCESSOR
+(`() => string`), never a snapshot: the run secret's own TTL is ~15 minutes and the
+alive watchdog re-mints it (`alive.ts:196`), so a snapshot would go stale before
+the first refresh at any sane TTL. Parked windows are bounded far below any TTL
+(idle 60 s / 120 s, approval 10 min), and a Daytona parked-to-stopped sandbox has
+no running daemons and remounts fresh on reattach (research.md section 6). The
+awaited PREFLIGHT refresh at arm time closes the gap where a turn checks out near
+a boundary, and its failure is load-bearing: when the remaining lease cannot cover
+the horizon, a failed preflight fails the acquisition over to a cold rebuild
+instead of starting the turn on a bet. This is what makes gating the coordinator's
+horizon check (decision 5) honest.
+
+- Trade-off: a pathological configuration (approval TTL raised above the lease
+  TTL) could still park a lease to death. The unchanged `credentials-expired`
+  eviction catches exactly that, at the cost of a rebuild.
+- Backtrack: a standing runner-held service credential would allow refresh while
+  parked; that is a new credential surface and needs its own review. Nothing in
+  this design blocks adding it.
+
+## 5. The evict-before-expiry machinery stays, demoted to a backstop — with its limit stated
+
+`installedMountExpiries`, the parked epoch, `credentials-expired`, the mount-lost
+probe, and the ENOTCONN remounts all remain. Every successful refresh advances the
+installed lease, so in healthy operation the expiry checks simply never trip; when
+refresh fails, the bookkeeping stops advancing and today's dispatch-time behavior
+returns without any mode switch. Two checks are gated rather than removed:
+`credentials-expiring` (the worst-case-turn horizon) and the `lease-short` warning
+are skipped for refresh-managed environments, because both encode the assumption
+that a turn runs on the credentials it starts with, and a refresh-managed turn
+does not.
+
+Stated honestly, because the first draft overclaimed here: the coordinator backstop
+protects the POOL (no environment is reused or parked on a dead lease), not the
+ACTIVE turn; it can only evict at the next dispatch. What protects the active turn
+is decision 4's preflight (no turn starts inside the horizon without a proven
+renewal) plus retry-and-self-heal during the turn. Once the TTL drops below the
+turn budget, a signer outage that outlasts the remaining real lease breaks the
+active turn's mount until recovery; no backstop can prevent that, only the TTL
+choice can (plan.md open question 3).
+
+- Trade-off: dual-path complexity in the coordinator until slice 3 cleans up.
+- Backtrack: the gate is one boolean per branch; deleting the boolean (and the
+  preflight failover) restores the predecessor's behavior exactly.
+
+## 6. Local sandbox first, Daytona second
+
+Slice 1 is local-only: it exercises the whole mechanism (config file, lease file,
+refresher, coordinator gating) with a same-filesystem write path and no provider
+API in the loop, and it is independently shippable because Daytona stays protected
+by the patch-release numbers. Slice 2 adds only the remote write path and the
+extra mounts.
+
+- Trade-off: Daytona keeps paying credential-driven sandbox deletes until slice 2.
+- Backtrack: none; this is ordering, not architecture.
+
+## 7. Refresh ships default-on with a kill switch
+
+`AGENTA_RUNNER_MOUNT_REFRESH=off` restores the static-env spawn path byte for
+byte. Default-on is proposed (open question 2) because a default-off mechanism is
+an untested claim: the gate would exercise the old path while the new one rots.
+The kill switch is per-acquisition, so flipping it never leaves one environment
+half-managed.
+
+- Trade-off: the first release with slice 1 changes every local mount's spawn
+  shape at once.
+- Backtrack: set the env var; one deploy, no code.
+
+## 8. Timing is specified as invariants; the derived constants are defaults, not knobs
+
+The load-bearing spec is three invariants (plan.md): the reported expiration
+precedes the real one by more than worst-case admission delay plus skew; a fresh
+file lands before the SDK looks, with room for retries; and below a minimum TTL
+refresh refuses to arm. The `clamp(ttl/k, floor, cap)` formulas are one concrete
+satisfaction of those invariants, chosen so QA TTLs scale automatically and
+operators get zero new numbers to mis-set (repeating the predecessor's reasoning
+for the skew constant). Codex's review called the bare fractions "magic"; the
+review was right that the invariants needed stating and floors, jitter, and
+timeouts were missing (all added), and we kept the no-knobs position it did not
+contest.
+
+- Trade-off: unusual deployments cannot tune the rotation window without a code
+  change.
+- Backtrack: promote any constant to an env knob later; each is one line in
+  `mount-lease.ts`.
+
+## 9. The dispatch's up-front sign is not reused as a refresh vehicle
+
+Every dispatch already signs fresh cwd credentials for the pool key; pushing that
+sign into live environments on warm hits was considered and rejected: it covers
+only one of the mounts, only at boundaries, and adds lease-writing to the dispatch
+hot path. The refresher owns all renewals through one code path (research.md
+section 6). The known waste of the dispatch sign stays out of scope, as the
+predecessor already recorded.
+
+- Backtrack: none needed; a future lazy-sign restructure of the dispatch is
+  orthogonal.
+
+## 10. Harness transcript mounts join the lease epoch (REVERSED from the first draft)
+
+The first draft kept them out of `installedMountExpiries`, extending the
+predecessor's argument (signed seconds apart at the same TTL, so never the
+minimum). Codex's review broke that argument for the refresh world: the exclusion
+was only sound while all mounts aged in lockstep, and independent per-mount
+refresh failures end the lockstep — cwd can advance while a transcript mount
+quietly dies, and the pool would park a false healthy epoch. So slice 2 replaces
+the fixed `{cwd, agent}` shape (`session-identity.ts:633`) with a map over every
+installed daemon, gives `mountHarnessSessionDirs` a real result contract instead
+of `Promise<void>` (`mount.ts:727`), and the epoch stays the minimum over all of
+them. This also closes what was open question 3.
+
+- Trade-off: a failing transcript mount now costs a backstop eviction where before
+  it silently degraded; that is the point.
+- Backtrack: drop the extra map entries; `installedMountLease` reduces over
+  whatever exists.
+
+## 11. geesefs stays pinned at v0.43.0
+
+The chosen mechanism exists and was verified in the pinned source. A geesefs
+upgrade (newer releases rebase the vendored SDK) is a separate change with its own
+regression surface and buys nothing this design needs.
+
+- Backtrack: if an upgrade ever lands, re-verify three facts against the new
+  vendored SDK: profile-beats-env resolution order, processcreds re-run semantics,
+  and the FULL_URI loopback rule. They are the load-bearing assumptions
+  (research.md section 2).
+
+## 12. Retuning the deadline and TTL defaults is deferred to slice 3, with Mahmoud
+
+The patch-release numbers (11 h deadline, 12 h TTL) stay in place through slices 1
+and 2 so the mitigation and the fix overlap rather than hand off. Refresh makes
+the coupling unnecessary, not the numbers wrong; the deadline is a product
+decision about maximum run length, and the TTL is a security decision about leak
+windows. Recommendation recorded in plan.md open question 1: deadline stays, TTL
+back to 3600 s.
+
+- Backtrack: env knobs on both sides; no code.
+
+## 13. Slice 0: the mechanism is proven against the pinned binary before any manager code
+
+The source citations support the narrow conclusion (profile selects
+credential_process, `Expiration` makes it refreshing, re-run at reported expiry)
+but not the operational claims (no negative caching, late self-heal, per-part
+multipart signing, profile precedence under the real env-merging spawn). One
+scripted probe against the v0.43.0 binary and SeaweedFS at TTL 120 settles all of
+them in a day (plan.md slice 0). If any leg fails, the mechanism table gets
+re-litigated before slice 1.
+
+- Trade-off: one day of spike work before feature code.
+- Backtrack: none; the probe script is reused as the low-TTL gate variant.
+
+## 14. Lease files are hardened, per-acquisition, and cleaned up
+
+Acquisition-unique roots (a deterministic session path collides across
+acquisitions sharing an artifact mount), 0700 directories, 0600 files, exclusive
+randomly-named temps with `O_NOFOLLOW`, same-directory rename, `/usr/bin/cat --`
+with a quoted absolute path, and deletion at unmount/destroy. Same-user sandbox
+tampering is treated as an expected attack, not a curiosity, and still-valid
+leases must not accumulate under `/tmp`.
+
+- Trade-off: slightly more file plumbing than "write a JSON file".
+- Backtrack: none sensible; each measure is a line or two.
+
+## 15. The renewable-stream property is accepted, eyes open
+
+Refresh gives a live malicious sandbox a renewable stream of prefix-scoped leases
+for the duration of the turn: exfiltrating each replacement extends external
+access to turn-end plus one TTL (research.md section 4). Accepted because the
+stream is turn-bounded, adds no scope, every leaked token stays TTL-bounded, and
+the alternative delivering the same run length (a TTL above the maximum turn,
+today 12 h) leaks strictly more per token. Countermeasures that would matter
+(revocation on turn end, per-refresh RoleSessionName for audit) stay on the
+signing-hygiene backlog, out of scope here.
+
+## 16. E2B is out of scope, explicitly
+
+The provider registry rejects `e2b` as planned-but-unsupported
+(`provider.ts:230`), so no code path inherits the mechanism today. The first
+draft's open question offered "untested inheritance"; that was wrong on the
+facts. When an E2B provider lands, it must register its mounts with the
+refresher like Daytona's or state why not.
+
+## Codex review, 2026-08-20: what it changed and where we pushed back
+
+An xhigh-effort Codex review of this workspace requested changes; the mechanism
+choice survived, the lifecycle around it did not. Accepted and folded in: the
+preflight-or-rebuild redesign of the backstop claim (decisions 4, 5 — the first
+draft's "degrades exactly to today's behavior" was false for the active turn);
+the live credential accessor (decision 4); transcript mounts into the epoch
+(decision 10, reversed); refresher cancellation/draining/generation semantics,
+timeouts, backoff floors, redactor seeding, and observability (plan.md); lease
+file hardening and cleanup (decision 14); the slice-0 spike (decision 13); the
+honest goal statement and skew accounting (context.md, research.md sections 5
+and 7); E2B scoped out on the facts (decision 16); keeping the horizon check out
+of the slice-3 deletion list.
+
+Pushed back or nuanced, recorded rather than silently dropped:
+
+- **Derived timing fractions**: Codex called `ttl/6`-style fractions magic and
+  wanted invariants. Invariants are now stated and floors/jitter added, but the
+  derived-defaults-no-knobs decision stands (decision 8); Codex did not argue for
+  knobs, so this is a framing fix, not a reversal.
+- **"Local daemons die with the runner"**: Codex noted the detached, unref'd
+  spawn (`mount.ts:335`) does not by itself prove this. Our claim rests on the
+  container pid-namespace dying with the runner process (node is the container's
+  main process), which holds for container restarts; a process-only restart
+  inside a still-living container is not a deployment mode we run. Kept, with
+  the assumption now written down here.
+- **Renewable capability stream**: accepted as a real sharpening, but weighed and
+  accepted rather than treated as a blocker (decision 15); the reviewer's own
+  framing agreed each token stays TTL-bounded.

--- a/docs/design/mount-credential-refresh/plan.md
+++ b/docs/design/mount-credential-refresh/plan.md
@@ -1,0 +1,459 @@
+# Plan: refresh a running mount's credentials from the runner
+
+Runner-only change. The API signing path, the wire contract, and the geesefs pin are
+all untouched. Four slices; slice 0 is a one-day empirical spike that gates the
+rest, and slice 1 is shippable alone.
+
+## The fix in one paragraph
+
+Instead of handing geesefs static credentials in its process environment, the runner
+starts each daemon with `--profile agenta-mount --shared-config <config file>` where
+the config file's one directive is `credential_process = cat <lease file>`. The
+vendored SDK re-runs that `cat` whenever the lease file's reported `Expiration`
+passes, so rewriting the file IS the refresh: no remount, no daemon restart, no
+interruption to in-flight I/O. The runner re-signs each mount's lease shortly before
+it expires, during turns, with the per-run credential it already holds, and rewrites
+the file (a local write for the local sandbox, a push through the provider's
+authenticated API for Daytona). The lease file reports an expiration slightly
+earlier than the real one, so the SDK rotates while the old lease is still valid
+and no request straddles expiry within the stated skew and delay bounds. Arming the
+refresher performs an awaited PREFLIGHT refresh before the turn's first mounted
+I/O whenever the remaining lease cannot cover the turn; if the preflight fails,
+acquisition falls back to today's cold rebuild, so the backstop protects the
+active turn, not just the next dispatch. The session pool's installed-lease
+bookkeeping is updated by every refresh, which turns the existing
+evict-before-expiry machinery into the refresh-failure backstop. Warm reuse stops
+being bounded by the lease, and a turn keeps live files for its whole length
+(bounded guarantee: research.md section 7).
+
+## Mechanism spec
+
+Shared by both sandboxes; paths differ.
+
+- **Config file** (written once per mount, at mount time):
+
+  ```ini
+  [agenta-mount]
+  credential_process = /usr/bin/cat -- "<abs path to lease.json>"
+  ```
+
+  Absolute binary path (the command runs through `sh -c`; no PATH resolution), a
+  `--` guard, and a quoted path. The section header without the `profile ` prefix
+  is accepted by the vendored loader (research.md section 2). The file never
+  changes after mount.
+
+- **Lease file** `lease.json` (rewritten by every refresh):
+
+  ```json
+  {
+    "Version": 1,
+    "AccessKeyId": "...",
+    "SecretAccessKey": "...",
+    "SessionToken": "...",
+    "Expiration": "<RFC3339: real expiry minus the rotation margin>"
+  }
+  ```
+
+  `Expiration` must always be present; an absent one makes the SDK treat the
+  credentials as permanently static (research.md section 2).
+
+- **Write atomicity and file hygiene**: temp file created exclusively in the SAME
+  directory as the target (random suffix, `O_EXCL`, `O_NOFOLLOW`), then renamed
+  over `lease.json`; `cat` therefore never reads a torn file and a same-user
+  symlink plant cannot redirect the write. Remotely the push uploads to a unique
+  temp path in the target directory, verifies the upload completed, then runs
+  `mv -f -- <tmp> <target>` through the provider exec and checks its exit status
+  (rename(2) within one directory is the atomic step; the upload itself need not
+  be atomic because the temp path is unpublished). Orphaned temps are cleaned on
+  the next write.
+
+- **geesefs invocation in refresh mode**: `geesefsArgs` gains
+  `--profile agenta-mount --shared-config <config path>`, and the spawn passes NO
+  `AWS_*` credential variables. The explicit profile also defends against stray
+  `AWS_*` variables in the runner container env, because a passed profile wins the
+  whole resolution (research.md section 2; the local spawn merges the full runner
+  env, `mount.ts:341`, which is why slice 0 tests precedence with deliberately
+  invalid ambient `AWS_*` set).
+
+- **File locations, ownership, cleanup**:
+  - Local: `<runner state dir>/mount-leases/<acquisition id>/<mount name>/`, on
+    the runner's own filesystem, outside every mount (never inside a mounted
+    path: the lease must not land in the durable store, and the mount cannot
+    bootstrap from a file behind itself). The root is per-ACQUISITION-unique, not
+    per-session: a deterministic session path collides when two acquisitions
+    share an artifact mount. Directories 0700, files 0600.
+  - Remote: `/tmp/agenta/mount-leases/<acquisition id>/<mount name>/` inside the
+    sandbox.
+  - Cleanup: unmount/destroy deletes the mount's lease directory (local and
+    remote), so still-valid credentials never accumulate on disk after the
+    daemon that needed them is gone.
+
+- **Timing invariants**, with derived defaults, no new operator knobs. The
+  invariants are what matter; the formulas are one concrete satisfaction of them:
+  - Invariant A (margin): the reported expiration precedes the real one by more
+    than the worst-case request-admission delay plus clock skew between runner,
+    store, and sandbox. Default: `margin = clamp(ttl / 6, 30 s, 120 s)`. The
+    refresher assumes total skew under 30 s and states it; nothing else in the
+    refresh path absorbs skew (`MOUNT_LEASE_SKEW_MS` only feeds the coordinator's
+    horizon arithmetic, `session-identity.ts:689`, and that check is gated for
+    refresh-managed environments).
+  - Invariant B (lead): a fresh file must be in place before the SDK looks, with
+    room for sign, write, and several retries. Default:
+    `lead = clamp(ttl / 3, 60 s, 600 s)`, measured from the reported expiration.
+  - Invariant C (minimum TTL): below `3 x margin floor` (90 s) refresh mode
+    refuses to arm and logs; the static path and today's eviction apply. A
+    too-small TTL cannot be made safe by any schedule.
+  - Retries: bounded exponential backoff with jitter, floor 1 s, cap
+    `min(15 s, lead / 4)`, continuing past real expiry while a turn is active (a
+    late success self-heals the mount with no remount; research.md section 5).
+    Every sign and every remote write is timeout-bounded (`AbortSignal.timeout`;
+    the existing signer fetch has no timeout, `mount.ts:68`, and an un-bounded
+    awaited preflight would hang the turn).
+  - At the default TTL 3600 s: margin 120 s, lead 600 s, one refresh roughly every
+    48 minutes per mount. At QA TTL 120 s: margin 30 s, lead 60 s.
+
+## New runner modules
+
+- `src/environment/mount-lease.ts`: pure lease/config file content builders
+  (`leaseFileJson(creds, reportedExpiryIso)`, `leaseConfigIni(leasePath)`) plus the
+  atomic local writer. Pure functions so the unit tests assert bytes.
+- `src/environment/mount-refresh.ts`: `MountLeaseRefresher`, owned by the
+  environment. Registry of managed leases, one entry per mounted daemon, identity
+  and category kept separate:
+  `{ category: "cwd" | "agent" | "harness-dir", mountId: string,
+  sign: (authorization: string) => Promise<MountCredentials | null>,
+  publish: (creds, reportedExpiryIso) => Promise<void>, realExpiryMs }`.
+  - `armForTurn(credential: () => string)`: stores the turn's sign authority as a
+    live ACCESSOR, never a snapshot — the run credential is an ephemeral ~15-min
+    secret the alive watchdog re-mints (`alive.ts:196`), and `RunTurnOptions`
+    already carries `credential?: () => string` for exactly this
+    (`runtime-contracts.ts:175`). Arming performs the PREFLIGHT: an awaited
+    refresh of any lease whose remaining life is below its lead, so the turn's
+    first file operations cannot race the push. Preflight failure is reported to
+    the caller (see slice 1: it can fail the acquisition over to a cold rebuild);
+    it is the one refresh failure that is not swallowed. Then per-lease timers at
+    `reported - lead`.
+  - Concurrency contract: refreshes are serialized per mount; each arm carries a
+    generation token, and a completion from a stale generation (after `disarm()`,
+    after a newer arm, during destroy) is discarded without publishing. Clearing
+    timers alone does not cancel an in-flight sign or remote write, so every
+    in-flight call holds an abort token tied to its generation.
+  - `disarm()`: aborts and AWAITS in-flight work, cancels timers, drops the
+    accessor. Called in the turn's `finally`. Environment `destroy()` calls it
+    and drains before unmount/teardown, joining the existing quiesce contract
+    (`environment.ts:369`).
+  - On each successful refresh: publish the lease file, update `realExpiryMs`,
+    stamp `environment.installedMountExpiries` for every registered mount so the
+    parked epoch keeps telling the truth, and seed the new secret values into the
+    turn's live redactor — the redactor is seeded only with turn-start
+    credentials today (`run-turn.ts:274`), and a refreshed lease echoed by the
+    agent must not escape trace/persistence redaction.
+  - On scheduled-refresh failure: keep the old file, do NOT advance the
+    bookkeeping, log and count it (see observability), retry on the backoff
+    above. Never throw into the turn.
+  - Observability: structured, low-cardinality counters/log fields for refresh
+    attempt, success, sign failure, publish failure, lateness (published after
+    reported expiry), seconds-remaining at publish, retry count, and backstop
+    eviction; labeled by provider and mount category, never by session id, and
+    never carrying secret material.
+
+## Slice 0: prove the mechanism with the pinned binary (gates everything)
+
+One scripted probe, run before any manager code is written, using the actual
+geesefs v0.43.0 binary from the runner image against a local SeaweedFS with
+`AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=120`:
+
+1. Export deliberately INVALID ambient `AWS_*` variables, then mount through the
+   explicit profile and a counting `credential_process` wrapper (proves profile
+   precedence in the real invocation, and counts re-runs).
+2. Atomically publish two fresh leases across multiple reported and real expiries
+   while I/O runs (proves re-run at reported expiration and rotation under load).
+3. Hold a stale lease past REAL expiry, then publish late; verify EACCES during
+   the gap and recovery without remount (proves no negative caching and late
+   self-heal).
+4. Run one large multipart write across a rotation (proves per-part signing
+   interleaves across leases).
+5. Record the observed timing bounds; they validate or correct the margin floor.
+
+Pass/fail is binary: if any of 1-4 fails, the mechanism table in research.md
+section 2 gets re-litigated before any slice-1 work starts. The probe script is
+kept (it becomes the base of the low-TTL gate variant below).
+
+## Slice 1: local sandbox (shippable alone)
+
+Default behavior for local mounts, with a kill switch
+(`AGENTA_RUNNER_MOUNT_REFRESH=off` restores today's static-env path; read once via
+`loadRunnerConfig`, applied per acquisition so one environment is never half-and-half).
+
+Changes per file:
+
+1. `src/engines/sandbox_agent/mount.ts`
+   - `geesefsArgs(creds, cwd, endpoint, foreground, leaseConfigPath?)`: append
+     `--profile agenta-mount --shared-config <path>` when given.
+   - `mountStorage` accepts an optional `lease` argument
+     `{ configPath, leasePath }`; when present it spawns with the profile args and
+     an EMPTY credential env instead of `credEnv(creds)`.
+2. `src/environment/mount-lease.ts`, `src/environment/mount-refresh.ts`: as above.
+3. `src/environment/mount-lifecycle.ts`
+   - `mountLocalDurableCwd` / `mountLocalAgentCwd`: in refresh mode, write the
+     config + initial lease files first, mount with the `lease` argument, and on
+     success register the mount with `env.mountRefresh` (sign closure: the same
+     `deps.signMount` / `deps.signAgentMount` already used by the ENOTCONN
+     helpers). `commitLocalMount` keeps stamping `installedMountExpiries` exactly
+     as today.
+   - The ENOTCONN re-sign helpers keep working unchanged: they re-sign and remount,
+     and in refresh mode the remount rewrites the lease files (a remount is a
+     superset of a refresh).
+4. `src/engines/sandbox_agent/runtime-contracts.ts`
+   - `SessionEnvironment` gains `mountRefresh: MountLeaseRefresher | undefined`.
+     `mountRefreshManaged` is derived: a refresher exists and every installed mount
+     is registered with it.
+5. Turn arming (engine side, `run-turn.ts` call path in `engine.ts`)
+   - Arm `env.mountRefresh` with the LIVE credential accessor
+     (`RunTurnOptions.credential`, watchdog-refreshed; artifact runs without a
+     watchdog pass a constant accessor over the request credential) before the
+     harness prompt is sent; disarm in the turn's `finally`. Both the cold path
+     and the warm continuation path go through `runTurn`, so one site covers
+     both.
+   - The awaited preflight runs inside arming, BEFORE the first mounted I/O. If
+     the preflight fails and the remaining lease does not cover the turn horizon,
+     the acquisition fails over to a cold rebuild instead of starting the turn on
+     a bet (research.md section 7); if the remaining lease does cover the
+     horizon, the turn proceeds and the scheduled refresher keeps retrying.
+6. `src/lifecycle/session-coordinator.ts`
+   - The idle-branch and approval-branch `credentials-expiring` checks are skipped
+     when the parked environment is refresh-managed (`mountCredentialsExpireBy`
+     still runs for everything else). This skip is safe only because of the
+     arming preflight above: the pair together mean "reuse now, but prove renewal
+     works before mounted I/O, and rebuild if it does not". `credentials-expired`
+     keeps evicting unconditionally: a dead lease at checkout means refresh
+     failed for a whole park, and the backstop must fire.
+   - The `lease-short` warning is skipped for refresh-managed environments.
+7. `config/runner-config.ts`: the kill switch.
+8. Lease-file lifecycle: created at mount, deleted at unmount/destroy (both the
+   per-mount files and the acquisition root when its last mount goes).
+
+Definition of done for the slice: the local live QA below passes, including one
+single turn longer than the TTL, and the keepalive suite is green.
+
+## Slice 2: remote sandbox (Daytona)
+
+Same mechanism; the writes travel through the provider's authenticated channel.
+
+1. `mountStorageRemote` (`mount.ts`): in refresh mode, before starting geesefs,
+   create the lease dir and place config + initial lease in the sandbox; spawn with
+   the profile args and no credential env on the `runProcess` call.
+2. Lease push: `pushLeaseFile(sandbox, path, json)` using the same in-sandbox file
+   delivery primitive the workspace/system-prompt uploads use, then an atomic `mv`
+   via `runProcess`. Lives beside `mount-lease.ts`; the refresher entry's `write`
+   closure binds it to `environment.sandbox`.
+3. Registration: the remote cwd and agent mount sites (`environment.ts:668-683`,
+   `740-760`) register with the refresher on success, mirroring the local sites.
+4. Harness session/transcript mounts (`mountHarnessSessionDirs`): each mounted dir
+   registers its own lease entry, signed by name through the existing
+   `signSessionMountCredentials(sessionId, deps, name)`, and they JOIN the lease
+   epoch. The predecessor excluded them from `installedMountExpiries` because all
+   mounts were signed seconds apart at the same TTL, so they could never be the
+   minimum; independent per-mount refresh failures break that argument (cwd can
+   advance while a transcript mount quietly dies, and the pool would park a false
+   healthy epoch). `InstalledMountExpiries` therefore grows from the fixed
+   `{cwd, agent}` shape (`session-identity.ts:633`) to a map over every installed
+   daemon, and `installedMountLease` keeps reducing to the minimum. This requires
+   `mountHarnessSessionDirs` to stop hiding its outcomes behind `Promise<void>`
+   (`mount.ts:727`): it returns per-dir results (mounted or skipped, credentials
+   expiry) so the epoch and the refresher registry see exactly what is running.
+   Reverses decision 10; recorded there.
+5. Reattach of a stopped sandbox is already a fresh mount
+   (`mountStorageRemote` force-detaches first), so it flows through step 1
+   naturally.
+
+No Daytona snapshot change: the geesefs binary is already in the image, and every
+new file is written at mount time.
+
+## Slice 3: retune and simplify (decision slice, with Mahmoud)
+
+Nothing here is needed for correctness; it harvests what refresh makes possible.
+
+1. Decouple the v0.112.3 patch numbers: the run deadline
+   (`AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS`, 11 h in the patch) becomes a pure product
+   knob; the lease TTL (`AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS`, 12 h in the patch)
+   becomes a pure security knob and can drop back to 3600 s or lower, shrinking the
+   leak window of any exfiltrated lease. Numbers are Mahmoud's call (open question
+   1).
+2. Documentation sync (`keep-docs-in-sync`): the operator note "keep the TTL above
+   the turn budget plus skew" and the `lease-short` guidance in the predecessor's
+   rollout notes become conditional on the kill switch; the hosting docs inherit
+   the new default story.
+3. Optional cleanup once gate evidence is in: remove the kill switch and the
+   static-env spawn path. The horizon check and the `credentials-expired` eviction
+   are NOT deletion candidates at any point: they are rare-incident backstops, and
+   "never fired in healthy production" is exactly the wrong evidence for removing
+   one. Deliberately NOT part of slices 1 and 2.
+
+## Failure modes, walked
+
+- **Preflight refresh fails at arm**: the one non-swallowed failure. Lease covers
+  the horizon: proceed, scheduled retries continue. Lease does not cover it: fail
+  the acquisition over to a cold rebuild; the turn never starts on a bet.
+- **Sign endpoint down mid-turn**: retries on backoff; if the real expiry passes,
+  the mount EACCESes, then self-heals without remount on the first successful
+  retry (slice-0-verified behavior). The epoch was never advanced, so the next
+  dispatch takes the backstop eviction path. This is the honest limit of the
+  guarantee once TTL is below the turn budget (research.md section 7).
+- **Sign or write hangs**: every call is timeout-bounded; a hung preflight cannot
+  hang the turn past its timeout, a hung scheduled refresh is aborted and retried.
+- **One mount refreshes while another fails**: per-mount entries fail
+  independently; the epoch is the minimum over ALL registered mounts (slice 2), so
+  a single dead mount drags the epoch and the backstop evicts at next dispatch
+  instead of parking a false healthy state.
+- **Stale completion after disarm/destroy**: generation tokens; a completion from
+  a previous arm publishes nothing. `destroy()` drains in-flight refreshes before
+  unmounting.
+- **Runner crashes between sign and publish**: the old file stays authoritative;
+  nothing observed the new lease. Between publish and epoch update: the file is
+  fresher than the bookkeeping, which is the conservative direction (worst case an
+  unnecessary rebuild).
+- **Publish succeeds but geesefs never consumes it**: the epoch says "installed"
+  for credentials no daemon has read. Harmless while the daemon keeps using its
+  current lease (it re-reads at its own reported expiration); if the daemon is
+  dead, the ENOTCONN/mount-lost backstops catch it, not the epoch.
+- **Run credential expires mid-turn**: prevented by arming with the live accessor
+  (watchdog re-mints ~15-min secrets); artifact runs without a watchdog stop
+  refreshing when the request credential dies and fall to the backstop.
+- **Sign returns null or an invalid/absent `expiresAt`**: treated as a failed
+  refresh (keep old file, retry); never publish a lease file without a valid
+  future expiration (an absent one would freeze the SDK on static credentials
+  forever, research.md section 2).
+- **Retry amplification**: backoff has a 1 s floor and jitter, and refresh runs
+  only during turns, so a fleet-wide signer outage produces at most a few requests
+  per active turn per backoff cap, not a synchronized storm.
+- **Refreshed lease leaks through logs/traces**: every published secret is seeded
+  into the live redactor at publish time (the turn-start seeding at
+  `run-turn.ts:274` alone would miss them).
+- **Refresher never armed (turn crashed early, or kill switch off)**: bookkeeping
+  never advances; the coordinator behaves byte-for-byte as today.
+- **Lease file deleted or corrupted inside the sandbox by agent code**: the SDK's
+  `cat` fails or parses garbage, the SDK surfaces a credentials error, geesefs I/O
+  fails; the agent can only break its own mount, which it could already do with
+  `fusermount -u`. The next refresh rewrite restores the file; the mount-lost and
+  ENOTCONN backstops cover the rest.
+- **Runner restarts mid-turn**: same as today; local daemons die with the runner,
+  Daytona sandboxes are reattached or rebuilt through the existing continuity path,
+  and mounts are re-established fresh.
+- **Clock skew**: the margin is the ONLY thing absorbing API/store/runner/sandbox
+  clock disagreement on the refresh path; `MOUNT_LEASE_SKEW_MS` feeds the
+  coordinator's horizon arithmetic (`session-identity.ts:689`), which is exactly
+  the check that is gated for refresh-managed environments, so it protects
+  nothing here. Hence the 30 s margin floor and the stated assumption: total skew
+  plus request-admission delay stays under the margin. The refresher works off
+  the store-reported `expiresAt` exactly as the epoch does today.
+
+## Tests
+
+### Runner unit tests (vitest)
+
+- New `tests/unit/mount-lease-refresh.test.ts`:
+  - `leaseFileJson`: schema (`Version: 1`, all four fields), reported expiration is
+    real minus margin, margin/lead derivation at TTL 3600 and TTL 120.
+  - Atomic write: tmp + rename ordering via an injected fs seam.
+  - Refresher scheduling with fake timers: arm schedules at `reported - lead`;
+    the preflight fires when armed inside the lead window and is awaited; disarm
+    cancels; a failed sign retries with backoff and never advances
+    `installedMountExpiries`; a late success updates the file and the expiries.
+  - Concurrency and lifecycle: a sign resolving after `disarm()` (or after a
+    newer arm) publishes nothing; refreshes for one mount serialize; `destroy()`
+    drains in-flight work before completing; every sign/write observes its
+    timeout.
+  - Preflight failover: arm with a lease below the horizon and a failing sign
+    reports failure to the caller (the acquisition-failover case); with a
+    covering lease it proceeds and schedules retries.
+  - Redaction: a published refresh seeds its secret values into the injected
+    redactor.
+- `tests/unit/sandbox-agent-mount.test.ts` (existing seams): refresh-mode argv
+  contains `--profile agenta-mount --shared-config <path>` and the spawn env
+  carries NO `AWS_ACCESS_KEY_ID`; kill-switch mode reproduces today's argv and env
+  byte-identically; remote variant asserted through the fake `SandboxExec`.
+- `tests/unit/session-keepalive-dispatch.test.ts` (fake engine + real pool):
+  - A refresh-managed parked environment whose lease falls inside the horizon
+    window is REUSED (`hit-continue`), where the same setup without the flag
+    evicts `credentials-expiring` (the existing case, kept as the contrast).
+  - A refresh-managed environment with a lease already past expiry still evicts
+    `credentials-expired`.
+  - A mid-turn refresh (fake engine advances `installedMountExpiries` during
+    `runTurn`) re-parks with the advanced lease.
+- Coordinator characterization suites
+  (`lifecycle-session-coordinator.test.ts`,
+  `session-lifecycle-characterization.test.ts`) updated for the two gated
+  branches, everything else pinned unchanged.
+
+### Release gate (agent-release-gate skill)
+
+- The `warm` journey (three turns, one daemon, one sandbox id, `hit-continue` in
+  the runner log) and the `mount` journey across the local and Daytona cells; the
+  lifecycle cells (`matrix_l1_lifecycle_routes.py`, `matrix_l3_abandoned_approval.py`,
+  `matrix_l5_live_route_observed.py`) must stay green.
+- One dedicated low-TTL local gate variant: TTL 120 s, then the `warm` journey run
+  with deliberate pauses so the three turns span at least three lease cycles. The
+  assertion that matters: the turn ledger still shows ONE sandbox id, and the
+  runner log shows `mount-refresh` lines and ZERO `credentials-expiring`
+  evictions.
+
+### Live QA (local OSS stack, SeaweedFS, then Daytona)
+
+Numbers: `AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=120` (margin 30 s, lead 60 s).
+
+1. **The previously impossible case**: one single turn that runs longer than the
+   TTL. Prompt the agent to loop for 5 minutes appending a timestamp to a mounted
+   file every 10 seconds and then print the file. Expect: every write succeeds,
+   the file shows an unbroken series across at least two lease boundaries, runner
+   log shows two `mount-refresh` renewals, zero EACCES.
+2. **Warm reuse across many leases**: turns every ~45 s for 10 minutes. Expect:
+   `hit-continue` on every turn, zero `credentials-expiring`, one environment
+   throughout.
+3. **Backstop**: stop the API container mid-run (or point the sign closure at a
+   dead port via the test seam in a rehearsal), let the lease die, confirm EACCES
+   then self-heal after the API returns, and confirm a parked environment with a
+   dead lease evicts `credentials-expired` at next dispatch.
+4. **Kill switch**: `AGENTA_RUNNER_MOUNT_REFRESH=off`, rerun scenario 2, confirm
+   today's periodic `credentials-expiring` cold rebuild returns (proves the
+   fallback path stayed intact).
+5. Repeat 1 and 2 against a Daytona cell after slice 2.
+6. Restore defaults; run the standard gate.
+
+Per the QA-recording rule, capture scenario 1 as an MP4 for the PR.
+
+## Rollout
+
+- Slice 1 ships alone: local mounts refresh, Daytona unchanged (still protected by
+  the patch-release numbers). Mixed operation is safe because the refresh flag and
+  machinery are per-environment.
+- Slice 2 ships next: Daytona refreshes; credential-driven sandbox deletes stop.
+- Slice 3 is a knobs-and-docs pass gated on Mahmoud's decisions and gate evidence.
+- Runner-only images; no API redeploy, no compose change required (the existing TTL
+  knob passthroughs from the predecessor suffice for QA). No wire change, so no
+  SDK/service coordination.
+
+## Open questions for Mahmoud
+
+1. **Post-refresh defaults** (slice 3): keep the run deadline at the patch's 11 h or
+   restore 45 min? Drop the TTL from the patch's 12 h back to 3600 s, or lower,
+   now that renewal is free? Recommendation: deadline stays a product choice
+   (11 h seems intended), TTL back to 3600 s.
+2. **Kill switch default**: the plan ships refresh ON with
+   `AGENTA_RUNNER_MOUNT_REFRESH=off` as the escape hatch, on the argument that a
+   default-off mechanism never gets exercised and skipped paths are untested
+   claims. Confirm, or ask for default-off-first.
+3. **Availability trade under a short TTL** (folds into question 1): once the TTL
+   drops below the turn budget, a signer outage longer than the remaining lease
+   breaks an active turn's mount until recovery (research.md section 7). Accept
+   that with TTL 3600 s, or keep the TTL above the deadline and take the larger
+   leak window? The design recommends accepting it: the outage must outlast the
+   full remaining lease mid-turn, the mount self-heals, and the eviction backstop
+   bounds the damage to one turn.
+
+Two questions from the first draft were closed by the Codex review rather than
+left to taste: transcript mounts now JOIN the lease epoch in slice 2 (independent
+refresh failures break the predecessor's exclusion argument; decisions.md item
+10), and E2B is explicitly out of scope because the provider currently rejects
+`e2b` as planned-but-unsupported (`provider.ts:230`), so nothing inherits the
+mechanism today; re-open when an E2B provider actually lands.

--- a/docs/design/mount-credential-refresh/research.md
+++ b/docs/design/mount-credential-refresh/research.md
@@ -1,0 +1,383 @@
+# Research: how a running geesefs mount can be given fresh credentials
+
+All repo paths are relative to the repo root; line numbers reference the current
+tree. External source: geesefs v0.43.0, the pinned binary
+(`services/runner/docker/Dockerfile.gh:34`, `Dockerfile.dev`, and
+`services/runner/images/sandbox/daytona/build_snapshot.py`). Its vendored AWS SDK
+fork lives under `s3ext/` in that release; every SDK claim below was verified against
+that source, not against upstream aws-sdk-go docs. The predecessor's research
+([../fix-sts-mount-expiry/research.md](../fix-sts-mount-expiry/research.md)) covers
+the signing path, the expiry enforcement, and the session pool; this file only
+restates what this design builds on.
+
+## 1. Where credentials enter a mount today
+
+Every mount gets its credentials exactly once, as static environment variables on the
+geesefs process:
+
+- **Local sandbox** (the runner's own container): `mountStorage` spawns
+  `geesefs --no-detect --fsync-on-close -f -o allow_other <bucket>:<prefix> <cwd>`
+  (`services/runner/src/engines/sandbox_agent/mount.ts:214`) with
+  `AWS_ACCESS_KEY_ID` / `AWS_SECRET_ACCESS_KEY` / `AWS_SESSION_TOKEN` in the child
+  env (`credEnv`, `mount.ts:237`, spawned at `mount.ts:341`).
+- **Remote sandbox** (Daytona): `mountStorageRemote` runs the same argv inside the
+  sandbox through the provider's exec API, credentials again as process env
+  (`mount.ts:644`, env at `mount.ts:667-671`).
+- **Install sites.** Local: `mountLocalDurableCwd` and `mountLocalAgentCwd`
+  (`services/runner/src/environment/mount-lifecycle.ts:190,229`), called at acquire
+  (`environment.ts:500,503`) and by the ENOTCONN re-sign helpers
+  (`mount-lifecycle.ts:274,315`). Remote: the durable cwd at
+  `environment.ts:668-683`, the agent mount at `environment.ts:740-760`, and the
+  per-harness session/transcript mounts at `environment.ts:694`
+  (`mountHarnessSessionDirs`, `mount.ts:727`, one sign + one mount per directory).
+- **Lease bookkeeping.** Each successful mount stamps
+  `environment.installedMountExpiries.{cwd,agent}` from the credentials it used
+  (local via `commitLocalMount`,
+  `src/environment/acquire-context-impl.ts:144-165`; remote inline at
+  `environment.ts:679,749`). The session pool parks that record as the credential
+  epoch (`parkedEpoch`, `src/lifecycle/session-coordinator.ts:678-685`) and evicts
+  before a worst-case turn could cross it (`requiredValidThroughMs`,
+  `session-coordinator.ts:300-302`; the `credentials-expiring` branch,
+  `session-coordinator.ts:905-911`; the approval branch, `1124-1140`; the
+  `lease-short` warning, `833-843`).
+- **Signing.** The runner calls `POST /sessions/mounts/sign` and
+  `POST /mounts/agents/sign` with the per-run credential; both land in
+  `MountsService.sign_mount_credentials` (`api/oss/src/core/mounts/service.py:856`)
+  at `env.mounts.credentials_ttl_seconds` (`service.py:880`, knob
+  `AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS`, `api/oss/src/utils/env.py:1212-1224`).
+  Backends: SeaweedFS `AssumeRoleWithWebIdentity` or AWS/MinIO `GetFederationToken`,
+  both scoped by one inline session policy
+  (`api/oss/src/core/store/storage.py:146,201`).
+
+Two facts to carry forward. First, the store enforces expiry per request: each S3
+call presents the session token and gets 403 once it is expired; there is no
+connection-level session to renew, so "refresh" means only "sign new HTTP requests
+with newer credentials". Second, signing a new lease does not revoke the old one;
+both backends let independently signed leases overlap until each one's own expiry.
+
+## 2. What the pinned SDK actually supports, verified against v0.43.0 source
+
+geesefs builds its AWS config in `core/cfg/conf_s3.go` (`ToAwsConfig`). Explicit
+`--access-key` flags become static credentials; otherwise it constructs a session
+with `session.NewSessionWithOptions({Profile: c.Profile, SharedConfigFiles:
+c.SharedConfig, SharedConfigState: session.SharedConfigEnable})`. The flags exist:
+`--profile` and `--shared-config` (`core/cfg/flags.go:218-225`, wired at
+`flags.go:924-925`).
+
+### Credential resolution order (`s3ext/aws/session/credentials.go:25-48`)
+
+1. **An explicitly passed profile wins over everything**, including environment
+   variables: `case len(sessOpts.Profile) != 0` is checked before
+   `envCfg.Creds.HasKeys()`. Passing `--profile` therefore pins resolution to the
+   shared config file even if stray `AWS_*` variables exist in the daemon's env.
+2. Environment credentials (static, never refresh).
+3. The default profile from the shared config files.
+
+Within profile resolution (`resolveCredsFromProfile`,
+`credentials.go:85-146`): static keys in the file win, then SSO, then
+`credential_process` (`case len(sharedCfg.CredentialProcess) != 0` builds
+`processcreds.NewCredentials`). The config key is `credential_process`
+(`session/shared_config.go:51`), and the section lookup accepts both `[name]` and
+`[profile name]` headers (`shared_config.go:288-292`).
+
+### credential_process semantics (`s3ext/aws/credentials/processcreds/provider.go`)
+
+- The command runs through `sh -c` (`prepareCommand`, around line 300) and must
+  print JSON: `{"Version": 1, "AccessKeyId": ..., "SecretAccessKey": ...,
+  "SessionToken": ..., "Expiration": <RFC3339>}` (`credentialProcessResponse`,
+  lines 229-235).
+- **`Expiration` present means refreshing**: `p.SetExpiration(*resp.Expiration,
+  p.ExpiryWindow)` (line 277). The shared `credentials.Credentials` object checks
+  `IsExpired()` before signing each S3 request and re-runs the process when true
+  (lines 275-296). `Expiration` absent means the credentials are treated as static
+  forever (`p.staticCreds = resp.Expiration == nil`, line 275), so the lease file
+  must always carry an expiry.
+- geesefs never sets `ExpiryWindow` for processcreds, so it defaults to zero: the
+  SDK re-runs the process exactly when the reported `Expiration` passes, not
+  before. The refresh moment is therefore fully controlled by the `Expiration` the
+  lease file reports, which is the lever section 5 uses.
+
+This is the mechanism the design uses: the "process" is `cat <lease-file>`, and the
+runner rewrites the lease file. The predecessor ruled out rewriting the SHARED
+CREDENTIALS file because `SharedCredentialsProvider` reads it once and never again
+(`shared_credentials_provider.go`, `IsExpired` returns `!p.retrieved`); that finding
+stands and does not apply here, because processcreds re-reads by re-running the
+command.
+
+### What the citations prove, and what they do not
+
+The citations establish the narrow conclusion: an explicit profile selects
+`credential_process`, a present `Expiration` makes the credentials refreshing, and
+the command is re-run once the reported expiration passes. They do NOT prove the
+operational claims the design also leans on: that stale expired output is re-tried
+on every subsequent request with no negative caching, that a late successful
+rewrite self-heals after earlier retrieval failures, that every multipart part
+request is signed with the then-current credentials, that requests already
+constructed before rotation pick up the new lease, or that the real geesefs
+invocation honors profile precedence when ambient `AWS_*` variables are present
+(the local spawn merges the full runner env into the child,
+`services/runner/src/engines/sandbox_agent/mount.ts:341`). Plan slice 0 is a
+mandatory empirical spike against the pinned binary that settles all of these
+before any manager code is written.
+
+### Container-credentials endpoint: loopback-only in this fork
+
+`AWS_CONTAINER_CREDENTIALS_FULL_URI` is supported
+(`s3ext/aws/defaults/defaults.go:116-118`), refreshes with a 5-minute expiry window,
+and honors `AWS_CONTAINER_AUTHORIZATION_TOKEN` (`httpCredProvider`,
+`defaults.go:188-196`). But `localHTTPCredProvider` (`defaults.go:158-186`) rejects
+ANY non-loopback host, with no HTTPS exception: "invalid endpoint host, %q, only
+loopback hosts are allowed". So the endpoint must listen on 127.0.0.1 inside the
+geesefs process's own network namespace. For a Daytona mount that means a listener
+INSIDE the sandbox, which would itself need a way to obtain fresh leases, which is
+the same problem again plus a daemon. This finding revises the predecessor's
+decisions.md item 2, which named the container endpoint as the intended follow-up:
+in this SDK generation the endpoint cannot be served from outside the sandbox at
+all, so credential_process in push form is the better carrier of the same idea.
+
+### The full mechanism table, updated
+
+| Mechanism | Refreshes? | Verdict for in-place refresh |
+| --- | --- | --- |
+| Static `AWS_*` env (today) | No | Status quo; what this project replaces. |
+| Rewriting the shared credentials file | No (read once) | Ruled out, unchanged. |
+| `credential_process` = `cat <lease-file>`, runner rewrites the file | Yes, re-runs at the reported `Expiration` | **Chosen.** No daemon, no port, no credential-fetching logic inside the sandbox; the runner pushes. |
+| Container endpoint (`FULL_URI`) | Yes (5-min window) | Loopback-only in this fork; remote would need an in-sandbox serving daemon. Rejected. |
+| IMDS emulation, `--iam`, `--role-arn` | various | Rejected by the predecessor for reasons that still hold (link-local ownership, non-SigV4 signing, bucket-wide base keys). |
+| Evict-and-rebuild at the boundary (today's designed behavior) | N/A | Becomes the BACKSTOP for refresh failure, no longer the primary mechanism. |
+
+## 3. The push model: who writes the lease file, and with what authority
+
+The runner signs; the sandbox reads a file. Concretely:
+
+- **Local**: the geesefs daemons are children of the runner container. The runner
+  writes `<lease-dir>/<mount>/lease.json` on its own filesystem and the daemon's
+  `credential_process` cats it. No new channel.
+- **Remote (Daytona)**: the runner writes the lease file into the sandbox through
+  the provider's authenticated exec/upload API, the same channel that already
+  installs workspaces, system prompts, and the mounts themselves. The provider API
+  credential stays in the runner; the sandbox receives only the file's content.
+
+The re-sign itself uses the existing sign endpoints with the per-run credential the
+runner already holds during a turn (`runCredential(request)`,
+`environment-setup.ts:108`; the same authority the ENOTCONN re-sign helpers use,
+`mount-lifecycle.ts:289,330`).
+
+## 4. Why this preserves the sandbox trust boundary
+
+The constraint: untrusted agent code runs in the sandbox, so no API auth and no
+long-lived keys may exist inside it. Inventory of what each party holds under the
+push model:
+
+- Inside the sandbox, before: a prefix-scoped STS lease. On remote it is set via the
+  provider exec env, plainly agent-readable. On LOCAL the picture must be verified,
+  not asserted: the daemon runs on the runner host as the same user agent code runs
+  as (`provider.ts:243` spawns the sandbox server on this host; the production image
+  runs everything as `node`, `docker/Dockerfile.gh:109`; no filesystem jail exists),
+  which suggests `/proc/<pid>/environ` is readable, yet the module doc claims the
+  opposite ("the signed credentials never enter agent-reachable space",
+  `mount.ts:9`). One of those statements is wrong. Slice 0 verifies the actual
+  local exposure empirically; the design does not rest on either answer, but the
+  "unchanged exposure" claim below is conditional on it.
+- Inside the sandbox, after: the same prefix-scoped STS lease, in a file. On remote
+  this changes nothing (the env was already readable). On local, if the env turns
+  out to be agent-readable, the file is the same exposure in an easier-to-find
+  place; if the env turns out NOT to be readable, the file is a new local exposure
+  and the lease directory permissions below are what bounds it. Either way the
+  lease grants only what the agent can already do THROUGH the mount, plus direct
+  store-API access to the same prefix over an endpoint the sandbox must reach
+  anyway for geesefs to work.
+- File handling is part of the boundary, not a detail: lease directories are
+  per-acquisition-unique, mode 0700, files 0600; temp files are created exclusively
+  (random name, `O_EXCL`, `O_NOFOLLOW`) and renamed within the same directory; the
+  config invokes `/usr/bin/cat -- "<abs path>"` (no PATH resolution, no option
+  injection); lease and config files are deleted at unmount/destroy so valid
+  credentials never accumulate on disk. A fixed, predictable temp path would be
+  raceable and symlink-attackable by same-user code and is not acceptable.
+- Never inside the sandbox: the per-run API credential (stays in the runner, used to
+  call the sign endpoints), the store master keys (stay in the API service), the
+  provider API key (stays in the runner).
+
+The deferred designs failed exactly this inventory: a credential_process that CALLS
+the sign endpoint would carry the API credential into the sandbox, and a
+container-credentials listener reachable from the sandbox would be a credential
+server the agent can query. `cat` carries nothing.
+
+Two residual sharpenings, worth stating honestly. First, a fresh lease file gives
+the agent a lease with LONGER remaining lifetime than the aging one it replaces;
+each individual lease stays TTL-bounded. Second, and stronger: refresh turns the
+sandbox's credential into a RENEWABLE STREAM for the duration of the turn. A
+malicious agent that exfiltrates each replacement lease as it lands holds live
+external access to the prefix for as long as the turn keeps refreshing, plus one
+TTL after the last refresh; before this project the same agent got turn-start plus
+one TTL. The stream is turn-bounded (the refresher disarms at turn end) and grants
+no new scope, and the alternative that provides the same run length today (a TTL
+above the maximum turn, currently 12 hours) leaks strictly more per token. Slice
+3's proposal to SHORTEN the TTL (possible only because refresh exists) shrinks the
+per-token window versus the 12-hour patch state; the stream property is the price
+of in-place refresh and is accepted, recorded in decisions.md.
+
+## 5. What happens to in-flight file operations at the rotation moment
+
+Rotation should be invisible to I/O, by construction, given one margin; the claims
+below follow from the cited SDK structure but the load-bearing ones are verified
+empirically in slice 0 rather than trusted:
+
+- The SDK's credentials object is process-wide and mutex-guarded; each S3 request
+  checks `IsExpired()` before signing. Requests already in flight complete under the
+  old lease; the store validates the token at request time, and the old lease is
+  still valid because nothing revoked it (section 1).
+- Multipart uploads are expected to sign every part request independently, so parts
+  signed under the old and new lease interleave harmlessly. Expected, not proven:
+  slice 0 runs a large multipart write across a rotation to confirm it.
+- The race that must be engineered away: with `ExpiryWindow` zero, the SDK switches
+  at exactly the reported `Expiration`. A request signed a moment BEFORE that
+  instant, with real expiry equal to it, could reach the store a moment after and
+  get 403. Fix: the lease file reports an EARLY expiration,
+  `reported = real - margin`. The SDK then rotates while the old lease is still
+  valid for the full margin. The margin does not make straddling impossible; it
+  bounds the race under an assumed maximum of request-admission delay plus clock
+  skew, which is why the margin has a floor and the skew assumption is stated
+  explicitly in the plan. The runner controls the JSON, so this costs one
+  subtraction.
+- FUSE-level consequence: none. The daemon, the kernel mount, the inode cache, and
+  open file handles are untouched; only the bytes used to sign future HTTP requests
+  change. There is no unmount, no remount, and no window where the path is absent.
+  This is the whole point over the evict-and-rebuild status quo.
+
+Failure ordering: if the runner fails to rewrite the file before the reported
+expiration, the SDK re-runs `cat`, gets the stale JSON, sees an already-past
+expiration, and is expected to re-run `cat` on every subsequent request until the
+file changes (no negative caching), so operations fail with EACCES only after the
+REAL expiry passes (the margin and then some) and the mount self-heals the moment a
+fresh file lands, with no remount. The re-try-on-every-request and late-self-heal
+behaviors are exactly the kind of provider-internal detail the citations do not
+prove; slice 0 verifies both (hold a stale lease past real expiry, publish late,
+confirm recovery without remount). If they hold, this failure mode is strictly
+better than today's; the eviction backstop behind it is section 7, with its limits
+stated there.
+
+## 6. When refresh must run, and what authority is available then
+
+The refresher needs the per-run API credential to call the sign endpoints. Where the
+environment spends its life:
+
+- **In a turn** (the case that matters; only here can a lease die under I/O): a
+  signing credential is available, but NOT as a fixed string. The incoming run
+  credential is an ephemeral secret with a TTL around 15 minutes; the session alive
+  watchdog re-mints it on a heartbeat cadence precisely so long turns never 401
+  (`src/sessions/alive.ts:196`), and `RunTurnOptions` carries
+  `credential?: () => string` as a live accessor for exactly this reason
+  (`runtime-contracts.ts:175`). The refresher must be armed with that ACCESSOR and
+  read it at each sign, never with a snapshot taken at turn start; a snapshot goes
+  stale long before the first mount refresh at any sane TTL. Artifact-scoped runs
+  that have no session watchdog arm with the request credential and accept that
+  refresh stops signing when it expires, at which point the backstop path applies.
+  A turn-scoped refresher then covers runs of unbounded length.
+- **Parked idle**: 60 s local, 120 s Daytona (`DEFAULT_TTL_MS`,
+  `DEFAULT_DAYTONA_TTL_MS`, `session-identity.ts:39,54`). Far below any sane TTL;
+  no refresh needed while parked.
+- **Parked awaiting approval**: 10 minutes by default. Still far below the TTL.
+- **Daytona parked-to-stopped** (`PARK_CLEAN_RESUMABLE_TURNS`, `teardown.ts:51`): a
+  stopped sandbox has no running daemons, and reattach already force-detaches and
+  remounts with freshly signed credentials (`mountStorageRemote`'s unmount-first,
+  `mount.ts:652-654`). Nothing to refresh.
+
+So a refresher that is ARMED AT TURN START and DISARMED AT TURN END is sufficient,
+with one addition: an eager refresh at arm time when the installed lease's remaining
+life is below the refresh lead, so a turn checked out near the boundary does not
+race its first file operations against the push. Between-turn gaps are covered by
+the pool TTLs being two orders of magnitude below the lease TTL; the coordinator's
+existing expiry checks remain as the backstop for pathological gaps.
+
+A convenient near-miss worth noting and not using: every dispatch already signs
+fresh cwd credentials up front (`resolveKeepaliveMount`,
+`session-coordinator.ts:272`), which the predecessor flagged as waste. Pushing that
+sign into the live environment on warm hits was considered and rejected: it covers
+only the cwd mount (not the agent or transcript mounts), only at turn boundaries,
+and would put lease-writing on the dispatch hot path. The turn-scoped refresher
+re-signs everything it manages through one code path instead. The dispatch sign
+stays what it is, a pool-key input.
+
+## 7. What the refresh mechanism simplifies, and what stays
+
+Once the installed lease advances instead of running out:
+
+- `credentials-expiring` (`session-coordinator.ts:905-911`, and the approval-branch
+  twin at `1124-1140`) stops firing in healthy operation, because
+  `installedMountExpiries` is updated by every refresh and the parked epoch is
+  stamped from it at park time. The check STAYS, unchanged, as the refresh-failure
+  backstop: if signing breaks, the lease stops advancing and today's
+  evict-before-expiry behavior returns automatically. No coordinator surgery is
+  needed for slice 1 beyond the horizon question below.
+- The lease-horizon arithmetic (`requiredValidThroughMs = now + turn budget + skew`)
+  embeds the assumption that a turn runs on the credentials it starts with. With
+  refresh active that assumption is false in the good direction, and left alone it
+  would still evict any warm session whose remaining lease is shorter than the FULL
+  turn budget (with the patch numbers, any session older than one hour of a 12-hour
+  lease against an 11-hour budget). Slice 1 gates the horizon check on "is this
+  environment refresh-managed", but the gate is only honest when paired with a
+  PREFLIGHT: reusing an environment inside the old horizon is a bet that the turn
+  will renew the lease, and if the renewal machinery is broken the bet loses
+  mid-turn, which is worse than today. So arming performs an awaited refresh
+  BEFORE the turn's first mounted I/O whenever the remaining lease does not cover
+  the horizon; if that preflight fails, the acquisition fails over to a cold
+  rebuild, which is exactly the outcome the ungated check would have produced, paid
+  at the same moment. The next-dispatch eviction is NOT protection for an active
+  turn and this design does not claim it is. Hard expiry (`credentials-expired`)
+  keeps evicting even for refresh-managed environments; a dead lease at checkout
+  means the refresher failed its whole park, which is the backstop doing its job.
+- The honest limit, stated once: once the TTL is allowed to drop below the maximum
+  turn length, "a turn of any length never sees EACCES" is not a guarantee anyone
+  can make. The signer becomes a runtime availability dependency: a signer outage
+  longer than the remaining real lease breaks the active turn's mount until the
+  first successful retry (self-heal, no remount). The real guarantee is: an active
+  turn keeps its files as long as signing and delivery recover within the
+  remaining real lease lifetime, and a turn never STARTS on a lease it cannot
+  cover without a successful preflight. Deployments that want the old absolute
+  guarantee keep the TTL above the turn budget, which refresh makes safe to do
+  with a short deadline or a long one; that trade is Mahmoud's slice-3 call.
+- The `lease-short` warning (`session-coordinator.ts:833-843`) becomes vestigial for
+  refresh-managed environments and is skipped for them; a short TTL with refresh is
+  a legitimate configuration, not a misconfiguration.
+- The teardown mapping (`credentials* -> runtime-incompatible -> delete`,
+  `session-coordinator.ts:581`, `teardown.ts`) stays byte-identical; it just stops
+  being exercised for credential reasons.
+- The run-deadline / TTL coupling (the v0.112.3 patch's 11 h / 12 h truce)
+  dissolves: `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS` and
+  `AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS` become independent knobs. Retuning their
+  defaults is slice 3, with Mahmoud.
+- **Stays untouched**: the ENOTCONN machinery (hard daemon death is a different
+  failure; `mount-lifecycle.ts:274-385`), the `isMountAlive` backstop probe
+  (`session-coordinator.ts:148`), the acquisition probe (`isMounted`,
+  `mount.ts:255`), fail-closed signing on the API, and the API signing path
+  entirely (this project is runner-only; the sign endpoints are reused as-is, no
+  wire change, no API change).
+
+## 8. Test infrastructure
+
+- **Runner unit tests** (vitest, `services/runner/tests/unit/`):
+  `sandbox-agent-mount.test.ts` has injectable `runGeesefs` / `checkMounted` seams
+  for argv and env assertions; `session-keepalive-dispatch.test.ts` and
+  `session-keepalive-engine.test.ts` drive the real coordinator + pool with a fake
+  `KeepaliveEngine` whose environments a test can stamp
+  (`installedMountExpiries`, and now the refresh-managed flag);
+  `lifecycle-session-coordinator.test.ts` and
+  `session-lifecycle-characterization.test.ts` pin the decision table;
+  `session-steer-mount-loss.test.ts` covers the mount-lost backstop. Fake timers
+  (`vi.useFakeTimers({toFake: ["Date"]})`) are the established pattern for lease
+  clocks.
+- **Release gate** (`.agents/skills/agent-release-gate/`): the `warm` journey
+  asserts three turns on ONE live daemon over a store-backed cwd (turn ledger:
+  one harness session id, one sandbox id; runner log: `[keepalive] hit-continue`),
+  and the `mount` journey asserts durable file round-trips. The lifecycle cells
+  (`resources/matrix_l1_lifecycle_routes.py`, `matrix_l3_abandoned_approval.py`,
+  `matrix_l5_live_route_observed.py`) assert warm reuse across lifecycle events.
+  These are exactly the assertions that must keep passing while a QA-shortened TTL
+  cycles many times underneath them.
+- **Live reproduction lever**: SeaweedFS honors sub-900-second effective lifetimes
+  through the web-identity token expiry (predecessor's finding, still true), so
+  `AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=120` on a local OSS stack makes a lease
+  cycle 2 minutes long. The definitive new scenario, impossible before this
+  project: one single turn that runs LONGER than the TTL while writing files
+  throughout, and never sees EACCES.

--- a/docs/design/mount-credential-refresh/status.md
+++ b/docs/design/mount-credential-refresh/status.md
@@ -1,0 +1,50 @@
+# Status
+
+**State**: planned, not implemented; Codex-reviewed and revised. Awaiting Mahmoud's
+answers to the open questions and a go-ahead for slice 0 (the binary spike) and
+slice 1.
+
+- 2026-08-20 (later): xhigh-effort Codex review of the whole workspace. Verdict:
+  the credential_process mechanism stands, the lifecycle around it needed rework.
+  Major revisions folded in: the arming preflight that fails an acquisition over
+  to a cold rebuild instead of betting a turn on a broken signer (the first
+  draft's backstop claim overpromised for the active turn); the refresher holds a
+  live credential accessor, not a turn-start snapshot; transcript mounts join the
+  lease epoch (decision 10 reversed); a mandatory slice-0 empirical spike against
+  the pinned binary; cancellation/draining semantics, timeouts, backoff floors,
+  redactor seeding, observability; hardened per-acquisition lease files with
+  cleanup; honest goal and skew statements; E2B scoped out (the provider rejects
+  it today). Pushback recorded in decisions.md ("Codex review" section).
+
+- 2026-08-20: workspace created, as the long-term fix behind the v0.112.3 release
+  finding (a run outlived its mount lease mid-turn). The patch-release mitigation
+  (run deadline 11 h under lease TTL 12 h) is shipping separately on its own lane
+  and is assumed in place; this project removes the need for it.
+- Research done against the pinned geesefs v0.43.0 source (vendored aws-sdk-go
+  fork under `s3ext/`), the current runner tree (post lifecycle-migration:
+  `session-coordinator.ts`, `mount-lifecycle.ts`, `acquire-context-impl.ts`), and
+  the predecessor workspace `docs/design/fix-sts-mount-expiry/`. Two findings
+  materially shaped the design:
+  1. The container-credentials endpoint the predecessor earmarked as the follow-up
+     is loopback-only in this SDK fork (no HTTPS exception), so it cannot be
+     served from outside a Daytona sandbox at all.
+  2. `credential_process` re-runs its command whenever the lease file's reported
+     `Expiration` passes, which makes "runner rewrites a file the process cats"
+     a complete refresh mechanism with nothing credential-fetching inside the
+     sandbox.
+- Chosen mechanism: geesefs spawns with `--profile agenta-mount --shared-config`
+  pointing at a config whose `credential_process` cats a runner-written lease
+  file; the runner re-signs during turns and rewrites the file (local write /
+  Daytona push), reporting an early expiration so rotation happens while the old
+  lease is still valid. The existing evict-before-expiry machinery stays as the
+  refresh-failure backstop.
+- Slices: (0) empirical spike proving the mechanism against the pinned binary;
+  (1) local sandbox, shippable alone, default-on with
+  `AGENTA_RUNNER_MOUNT_REFRESH=off` kill switch; (2) Daytona, including the
+  harness transcript mounts, which join the lease epoch; (3) retune the
+  deadline/TTL defaults and clean up, gated on Mahmoud.
+- Open questions needing Mahmoud (full text in plan.md): post-refresh deadline and
+  TTL defaults; confirm default-on rollout; accept the short-TTL availability
+  trade (signer outage can break an active turn once TTL < turn budget).
+- Nothing implemented, nothing committed; the workspace directory is the only
+  change in the tree.


### PR DESCRIPTION
## Context

Design-only PR; no code changes. It adds the planning workspace `docs/design/mount-credential-refresh/` for the long-term fix behind the v0.112.3 release finding: a geesefs mount reads its store credentials once at daemon start, so a turn that outlives its lease loses file access mid-run, and warm sessions get rebuilt (on Daytona, deleted and recreated) for credential reasons alone. The shipped patch mitigation ([#6136](https://github.com/Agenta-AI/agenta/pull/6136)) balances the run deadline under the lease TTL; this design removes the need for that coupling.

## The mechanism

Instead of static `AWS_*` env vars, the runner spawns geesefs with `--profile agenta-mount --shared-config <file>` where the config's one directive is `credential_process = /usr/bin/cat -- "<lease.json>"`. The vendored SDK in the pinned geesefs v0.43.0 re-runs that cat whenever the lease file's reported `Expiration` passes, so the runner rewriting the file is the refresh: no remount, no daemon restart, no interruption to in-flight I/O. The runner re-signs leases during turns with the per-run credential it already holds and pushes the file in (local write, or Daytona's authenticated upload channel). The lease file reports an early expiration so rotation happens while the old lease is still valid. Nothing credential-fetching ever runs inside the sandbox; the existing evict-before-expiry machinery stays as the refresh-failure backstop, and arming performs a preflight refresh that fails an acquisition over to a cold rebuild rather than starting a turn on a lease it cannot cover.

## Slices

0. Empirical spike proving the mechanism against the pinned binary (profile precedence, re-run semantics, late self-heal, multipart rotation). Gates the rest.
1. Local sandbox, shippable alone, default-on with an `AGENTA_RUNNER_MOUNT_REFRESH=off` kill switch.
2. Daytona: the remote push path, plus the harness transcript mounts, which join the lease epoch.
3. Decision slice with Mahmoud: decouple and retune the run deadline and lease TTL defaults, then clean up.

## Open questions for Mahmoud

1. Post-refresh defaults: keep the 11 h run deadline? Drop the TTL from 12 h back to 3600 s or lower?
2. Confirm default-on rollout with the kill switch as escape hatch, or default-off first.
3. Accept the short-TTL availability trade: once TTL is below the turn budget, a signer outage longer than the remaining lease breaks an active turn's mount until it self-heals.
4. Two questions from the first draft were closed by review rather than left open (transcript mounts join the epoch; E2B is scoped out because the provider rejects it today). Veto if either closure is wrong.

## Codex review

Codex (xhigh effort) reviewed the whole workspace before this PR. It endorsed the credential_process mechanism and rejected the first draft's lifecycle claims around it. Folded in as a result: the preflight-or-rebuild redesign of the backstop story (the draft's "degrades exactly to today's behavior" was false for the active turn); the refresher holds a live credential accessor instead of a turn-start snapshot (the run secret only lives about 15 minutes); transcript mounts join the lease epoch; a mandatory slice-0 binary spike; cancellation, draining, timeout, backoff, redaction-seeding, and observability semantics; hardened per-acquisition lease files with cleanup; honest goal and clock-skew statements. Recorded pushback (decisions.md, "Codex review" section): the derived timing constants stay (invariants now stated; no new operator knobs), the "local daemons die with the runner" claim stays with its pid-namespace assumption written down, and the renewable-lease-stream sharpening is accepted as a trade-off rather than a blocker. No unresolved disagreement blocks the design.
