### PR TITLE
fix(frontend): Validate the skill name before an agent config saves

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
@@ -31,6 +31,7 @@ import {File as FileIcon, Info, Plus, Trash} from "@phosphor-icons/react"
 import {CodeEditor, codeLanguageFromPath} from "./CodeEditor"
 import {MarkdownEditor} from "./MarkdownEditor"
 import {
+    NOT_TEXT,
     SKILL_BODY_MAX,
     SKILL_DESCRIPTION_MAX,
     SKILL_NAME_MAX,
@@ -164,23 +165,29 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
     )
     const [bodyTouched, setBodyTouched] = useState(() => Boolean(String(skill.body ?? "").trim()))
 
-    const name = (skill.name as string | undefined) ?? ""
-    const description = (skill.description as string | undefined) ?? ""
-    const nameError = skillNameError(name, {touched: nameTouched})
+    // The JSON view can put any type here, and a cast alone would let `.trim()` / spread throw.
+    const asText = (value: unknown) => (typeof value === "string" ? value : "")
+    const notText = (value: unknown) => value != null && typeof value !== "string"
+    const name = asText(skill.name)
+    const description = asText(skill.description)
+    const body = asText(skill.body)
+    const nameError = skillNameError(skill.name, {touched: nameTouched})
     const nameSuggestion = nameError && name.trim() ? slugifySkillName(name) : ""
     const showNameSuggestion = Boolean(nameSuggestion) && nameSuggestion !== name
-    const descriptionError =
-        descriptionTouched && !description.trim()
-            ? "Required."
-            : [...description].length > SKILL_DESCRIPTION_MAX
-              ? `Max ${SKILL_DESCRIPTION_MAX} characters.`
-              : undefined
-    const bodyError =
-        bodyTouched && !String(skill.body ?? "").trim()
-            ? "Required."
-            : [...String(skill.body ?? "")].length > SKILL_BODY_MAX
-              ? `Max ${SKILL_BODY_MAX} characters.`
-              : undefined
+    const descriptionError = notText(skill.description)
+        ? NOT_TEXT
+        : descriptionTouched && !description.trim()
+          ? "Required."
+          : [...description].length > SKILL_DESCRIPTION_MAX
+            ? `Max ${SKILL_DESCRIPTION_MAX} characters.`
+            : undefined
+    const bodyError = notText(skill.body)
+        ? NOT_TEXT
+        : bodyTouched && !body.trim()
+          ? "Required."
+          : [...body].length > SKILL_BODY_MAX
+            ? `Max ${SKILL_BODY_MAX} characters.`
+            : undefined
 
     const set = (key: string, fieldValue: unknown) => {
         const next = {...skill}
@@ -398,7 +405,7 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                         error={bodyError}
                     >
                         <MarkdownEditor
-                            value={(skill.body as string | undefined) ?? ""}
+                            value={body}
                             onChange={(v) => {
                                 setBodyTouched(true)
                                 set("body", v)

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
@@ -157,8 +157,7 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
         : []
 
     const [selected, setSelected] = useState<Selection>("skill")
-    // Validation messages stay quiet on a pristine "New skill" draft and switch on as soon as the
-    // user (or an upload) puts something in the field, so the drawer doesn't open shouting.
+    // Quiet on a pristine draft; on once the user or an upload touches the field.
     const [nameTouched, setNameTouched] = useState(() => Boolean(String(skill.name ?? "").trim()))
     const [descriptionTouched, setDescriptionTouched] = useState(() =>
         Boolean(String(skill.description ?? "").trim()),
@@ -169,6 +168,7 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
     const description = (skill.description as string | undefined) ?? ""
     const nameError = skillNameError(name, {touched: nameTouched})
     const nameSuggestion = nameError && name.trim() ? slugifySkillName(name) : ""
+    const showNameSuggestion = Boolean(nameSuggestion) && nameSuggestion !== name
     const descriptionError =
         descriptionTouched && !description.trim()
             ? "Required."
@@ -221,14 +221,12 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
     // Merge an uploaded/parsed skill into the draft (only overwrite what the upload provides).
     const applyParsed = (parsed: ParsedSkill) => {
         const next = {...skill}
-        if (parsed.name) {
-            next.name = parsed.name
-            setNameTouched(true)
-        }
-        if (parsed.description) {
-            next.description = parsed.description
-            setDescriptionTouched(true)
-        }
+        if (parsed.name) next.name = parsed.name
+        if (parsed.description) next.description = parsed.description
+        // Touched regardless of what the upload carried, so a package missing a name or
+        // description shows "Required." instead of only a dead Save button.
+        setNameTouched(true)
+        setDescriptionTouched(true)
         // body/files are always present on a parsed upload; assign unconditionally so a
         // replacement with an empty body or no bundled files clears the previous draft.
         next.body = parsed.body
@@ -338,7 +336,7 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                         nameError ? (
                             <span>
                                 {nameError}
-                                {nameSuggestion && nameSuggestion !== name.trim() ? (
+                                {showNameSuggestion ? (
                                     <>
                                         {" "}
                                         <button
@@ -348,7 +346,7 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                                                 set("name", nameSuggestion)
                                             }}
                                             disabled={disabled}
-                                            className="cursor-pointer border-0 bg-transparent p-0 font-[inherit] text-xs text-error underline"
+                                            className="cursor-pointer rounded-sm border-0 bg-transparent p-0 font-[inherit] text-xs text-error underline underline-offset-2 outline-none hover:no-underline hover:opacity-80 focus-visible:ring-2 focus-visible:ring-error/50 disabled:cursor-not-allowed disabled:no-underline disabled:opacity-50"
                                         >
                                             Use &quot;{nameSuggestion}&quot;
                                         </button>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
@@ -30,6 +30,13 @@ import {File as FileIcon, Info, Plus, Trash} from "@phosphor-icons/react"
 
 import {CodeEditor, codeLanguageFromPath} from "./CodeEditor"
 import {MarkdownEditor} from "./MarkdownEditor"
+import {
+    SKILL_BODY_MAX,
+    SKILL_DESCRIPTION_MAX,
+    SKILL_NAME_MAX,
+    skillNameError,
+    slugifySkillName,
+} from "./skillName"
 import {mergePastedSkill, type ParsedSkill, type SkillFileEntry} from "./skillUpload"
 import {SkillUploadZone} from "./SkillUploadZone"
 
@@ -150,6 +157,30 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
         : []
 
     const [selected, setSelected] = useState<Selection>("skill")
+    // Validation messages stay quiet on a pristine "New skill" draft and switch on as soon as the
+    // user (or an upload) puts something in the field, so the drawer doesn't open shouting.
+    const [nameTouched, setNameTouched] = useState(() => Boolean(String(skill.name ?? "").trim()))
+    const [descriptionTouched, setDescriptionTouched] = useState(() =>
+        Boolean(String(skill.description ?? "").trim()),
+    )
+    const [bodyTouched, setBodyTouched] = useState(() => Boolean(String(skill.body ?? "").trim()))
+
+    const name = (skill.name as string | undefined) ?? ""
+    const description = (skill.description as string | undefined) ?? ""
+    const nameError = skillNameError(name, {touched: nameTouched})
+    const nameSuggestion = nameError && name.trim() ? slugifySkillName(name) : ""
+    const descriptionError =
+        descriptionTouched && !description.trim()
+            ? "Required."
+            : [...description].length > SKILL_DESCRIPTION_MAX
+              ? `Max ${SKILL_DESCRIPTION_MAX} characters.`
+              : undefined
+    const bodyError =
+        bodyTouched && !String(skill.body ?? "").trim()
+            ? "Required."
+            : [...String(skill.body ?? "")].length > SKILL_BODY_MAX
+              ? `Max ${SKILL_BODY_MAX} characters.`
+              : undefined
 
     const set = (key: string, fieldValue: unknown) => {
         const next = {...skill}
@@ -190,11 +221,18 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
     // Merge an uploaded/parsed skill into the draft (only overwrite what the upload provides).
     const applyParsed = (parsed: ParsedSkill) => {
         const next = {...skill}
-        if (parsed.name) next.name = parsed.name
-        if (parsed.description) next.description = parsed.description
+        if (parsed.name) {
+            next.name = parsed.name
+            setNameTouched(true)
+        }
+        if (parsed.description) {
+            next.description = parsed.description
+            setDescriptionTouched(true)
+        }
         // body/files are always present on a parsed upload; assign unconditionally so a
         // replacement with an empty body or no bundled files clears the previous draft.
         next.body = parsed.body
+        setBodyTouched(true)
         if (parsed.files.length) next.files = parsed.files
         else delete next.files
         onChange(next)
@@ -292,10 +330,43 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
 
             {/* Right: skill-level fields + the selected file's editor + behaviour toggles. */}
             <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-y-auto pr-1">
-                <Field label="Name">
+                <Field
+                    label="Name"
+                    required
+                    tooltip="Lowercase letters, digits and single hyphens — this becomes the skill's directory name and its /skill:name handle, so the harness rejects anything else"
+                    error={
+                        nameError ? (
+                            <span>
+                                {nameError}
+                                {nameSuggestion && nameSuggestion !== name.trim() ? (
+                                    <>
+                                        {" "}
+                                        <button
+                                            type="button"
+                                            onClick={() => {
+                                                setNameTouched(true)
+                                                set("name", nameSuggestion)
+                                            }}
+                                            disabled={disabled}
+                                            className="cursor-pointer border-0 bg-transparent p-0 font-[inherit] text-xs text-error underline"
+                                        >
+                                            Use &quot;{nameSuggestion}&quot;
+                                        </button>
+                                    </>
+                                ) : null}
+                            </span>
+                        ) : undefined
+                    }
+                >
                     <Input
-                        value={(skill.name as string | undefined) ?? ""}
-                        onChange={(e) => set("name", e.target.value)}
+                        value={name}
+                        onChange={(e) => {
+                            setNameTouched(true)
+                            set("name", e.target.value)
+                        }}
+                        onBlur={() => setNameTouched(true)}
+                        maxLength={SKILL_NAME_MAX}
+                        aria-invalid={nameError ? true : undefined}
                         placeholder="my-skill"
                         disabled={disabled}
                     />
@@ -303,12 +374,19 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
 
                 <Field
                     label="Description"
+                    required
                     tooltip="The trigger the model matches when deciding to use this skill"
+                    error={descriptionError}
                 >
                     <AutosizeTextarea
-                        value={(skill.description as string | undefined) ?? ""}
-                        onChange={(e) => set("description", e.target.value)}
+                        value={description}
+                        onChange={(e) => {
+                            setDescriptionTouched(true)
+                            set("description", e.target.value)
+                        }}
+                        onBlur={() => setDescriptionTouched(true)}
                         autoSize={{minRows: 2, maxRows: 4}}
+                        aria-invalid={descriptionError ? true : undefined}
                         placeholder="When the agent should reach for this skill"
                         disabled={disabled}
                     />
@@ -317,11 +395,16 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                 {showSkill ? (
                     <Field
                         label="SKILL.md"
+                        required
                         tooltip="The Markdown body the harness reads, written after the composed frontmatter"
+                        error={bodyError}
                     >
                         <MarkdownEditor
                             value={(skill.body as string | undefined) ?? ""}
-                            onChange={(v) => set("body", v)}
+                            onChange={(v) => {
+                                setBodyTouched(true)
+                                set("body", v)
+                            }}
                             placeholder={
                                 "# My skill\n\nStep-by-step instructions the agent follows…"
                             }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
@@ -164,10 +164,7 @@ export const ITEM_KINDS: Record<ItemKind, ItemKindDef> = {
         jsonOnly: (draft) => isEmbedRefSkill(draft),
         isReadOnly: (item) => isStaticSkill(item),
         createSeed: () => ({name: "", description: "", body: ""}),
-        // `@ag.embed` skill references carry no name and are always valid (they round-trip as-is).
-        // Everything else is checked against the same rules the SDK enforces at run time
-        // (see `skillName.ts`) — a capitalised name or an empty description/body parses fine as
-        // JSON but fails `parse_skill_templates` on the first run, taking the whole agent with it.
+        // `@ag.embed` references round-trip as-is; everything else must pass the SDK's own rules.
         draftInvalid: (draft) => !isEmbedRefSkill(draft) && skillDraftError(draft) !== undefined,
     },
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemKinds.tsx
@@ -10,6 +10,7 @@ import {GraduationCap, Plugs, Wrench} from "@phosphor-icons/react"
 import type {ConfigItemView} from "../ConfigItemDrawer"
 import {McpServerFormView} from "../McpServerFormView"
 import {SkillFormView} from "../SkillFormView"
+import {skillDraftError} from "../skillName"
 import {ToolFormView} from "../ToolFormView"
 import {parseGatewayTool} from "../toolUtils"
 
@@ -164,6 +165,9 @@ export const ITEM_KINDS: Record<ItemKind, ItemKindDef> = {
         isReadOnly: (item) => isStaticSkill(item),
         createSeed: () => ({name: "", description: "", body: ""}),
         // `@ag.embed` skill references carry no name and are always valid (they round-trip as-is).
-        draftInvalid: (draft) => !isEmbedRefSkill(draft) && !String(draft.name ?? "").trim(),
+        // Everything else is checked against the same rules the SDK enforces at run time
+        // (see `skillName.ts`) — a capitalised name or an empty description/body parses fine as
+        // JSON but fails `parse_skill_templates` on the first run, taking the whole agent with it.
+        draftInvalid: (draft) => !isEmbedRefSkill(draft) && skillDraftError(draft) !== undefined,
     },
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/skillName.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/skillName.ts
@@ -1,0 +1,75 @@
+/**
+ * skillName
+ *
+ * Client-side mirror of the skill-package rules the SDK enforces with pydantic
+ * (`sdks/python/agenta/sdk/agents/skills/models.py`, `SkillTemplate`) and the runner re-checks on
+ * the untrusted wire (`services/runner/src/engines/skills.ts`).
+ *
+ * Why this exists: a skill whose `name` is not a lowercase-hyphen slug (e.g. `My Skill`,
+ * `Weather`) saves fine — the config is just JSON to the backend — and then fails the whole run
+ * the first time the agent is invoked, because `AgentTemplate.from_params` parses `skills` through
+ * `parse_skill_templates` and raises `SkillValidationError`. Validating here turns that late,
+ * opaque run failure into an inline message at authoring time.
+ *
+ * The slug rule is not ours to relax: the harnesses (Pi / Claude / OpenCode / Antigravity) key a
+ * skill by its directory name and invoke it as `/skill:name`, so the name has to be a safe,
+ * lowercase path segment.
+ *
+ * Keep the constants below in sync with the pydantic field bounds.
+ */
+
+/** `^[a-z0-9]+(-[a-z0-9]+)*$` — lowercase alphanumerics joined by single hyphens. */
+export const SKILL_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/
+export const SKILL_NAME_MAX = 64
+export const SKILL_DESCRIPTION_MAX = 1024
+export const SKILL_BODY_MAX = 50_000
+
+/** Best-effort slug for a human-written name, used to suggest a fix in the error message. */
+export function slugifySkillName(name: string): string {
+    return name
+        .normalize("NFKD")
+        .replace(/[\u0300-\u036f]/g, "")
+        .toLowerCase()
+        .replace(/[^a-z0-9]+/g, "-")
+        .replace(/^-+|-+$/g, "")
+        .slice(0, SKILL_NAME_MAX)
+        .replace(/-+$/g, "")
+}
+
+/**
+ * Validate a skill `name`, returning a terse message to show under the field or `undefined` when it
+ * is valid. `touched=false` (a still-empty field on a fresh draft) suppresses the "required"
+ * message so a new skill drawer does not open shouting at the user — Save stays blocked either way.
+ */
+export function skillNameError(rawName: unknown, {touched = true} = {}): string | undefined {
+    const name = String(rawName ?? "").trim()
+    if (!name) return touched ? "Required." : undefined
+    if ([...name].length > SKILL_NAME_MAX) return `Max ${SKILL_NAME_MAX} characters.`
+    if (SKILL_NAME_PATTERN.test(name)) return undefined
+    // Keep it to one short line — the full rule is in the field's tooltip, and the form offers the
+    // slugified name as a one-click fix beside this message.
+    return "Lowercase, digits and hyphens only."
+}
+
+/** True when `name` is a valid skill slug. */
+export function isValidSkillName(name: unknown): boolean {
+    return skillNameError(name) === undefined
+}
+
+/**
+ * Validate the whole inline skill draft the way the SDK will. Returns the first blocking message,
+ * or `undefined` when the draft would parse. `description` and `body` are `min_length=1` on the
+ * model, so an empty one fails the run exactly like a bad name does.
+ */
+export function skillDraftError(draft: Record<string, unknown>): string | undefined {
+    const nameError = skillNameError(draft.name)
+    if (nameError) return nameError
+    const description = String(draft.description ?? "").trim()
+    if (!description) return "Description is required."
+    if ([...description].length > SKILL_DESCRIPTION_MAX)
+        return `Description: max ${SKILL_DESCRIPTION_MAX} characters.`
+    const body = String(draft.body ?? "").trim()
+    if (!body) return "SKILL.md content is required."
+    if ([...body].length > SKILL_BODY_MAX) return `SKILL.md: max ${SKILL_BODY_MAX} characters.`
+    return undefined
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/skillName.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/skillName.ts
@@ -1,30 +1,18 @@
 /**
- * skillName
- *
- * Client-side mirror of the skill-package rules the SDK enforces with pydantic
- * (`sdks/python/agenta/sdk/agents/skills/models.py`, `SkillTemplate`) and the runner re-checks on
- * the untrusted wire (`services/runner/src/engines/skills.ts`).
- *
- * Why this exists: a skill whose `name` is not a lowercase-hyphen slug (e.g. `My Skill`,
- * `Weather`) saves fine — the config is just JSON to the backend — and then fails the whole run
- * the first time the agent is invoked, because `AgentTemplate.from_params` parses `skills` through
- * `parse_skill_templates` and raises `SkillValidationError`. Validating here turns that late,
- * opaque run failure into an inline message at authoring time.
- *
- * The slug rule is not ours to relax: the harnesses (Pi / Claude / OpenCode / Antigravity) key a
- * skill by its directory name and invoke it as `/skill:name`, so the name has to be a safe,
- * lowercase path segment.
- *
- * Keep the constants below in sync with the pydantic field bounds.
+ * Client-side mirror of the skill rules pydantic enforces in
+ * `sdks/python/agenta/sdk/agents/skills/models.py` and the runner re-checks on the untrusted wire
+ * in `services/runner/src/engines/skills.ts`. A name that fails them saves fine (the config is
+ * plain JSON to the backend) and then fails the whole agent run on first invoke, so the checks
+ * have to exist here too. Keep the constants in sync with the pydantic field bounds.
  */
 
-/** `^[a-z0-9]+(-[a-z0-9]+)*$` — lowercase alphanumerics joined by single hyphens. */
+/** Lowercase alphanumerics joined by single hyphens: the harness uses it as a dir name and `/skill:name`. */
 export const SKILL_NAME_PATTERN = /^[a-z0-9]+(-[a-z0-9]+)*$/
 export const SKILL_NAME_MAX = 64
 export const SKILL_DESCRIPTION_MAX = 1024
 export const SKILL_BODY_MAX = 50_000
 
-/** Best-effort slug for a human-written name, used to suggest a fix in the error message. */
+/** Best-effort slug for a human-written name, offered as a one-click fix. */
 export function slugifySkillName(name: string): string {
     return name
         .normalize("NFKD")
@@ -42,12 +30,14 @@ export function slugifySkillName(name: string): string {
  * message so a new skill drawer does not open shouting at the user — Save stays blocked either way.
  */
 export function skillNameError(rawName: unknown, {touched = true} = {}): string | undefined {
-    const name = String(rawName ?? "").trim()
-    if (!name) return touched ? "Required." : undefined
+    // Checked UNTRIMMED: the form stores what was typed, so trimming here would pass a value the
+    // SDK's pattern later rejects.
+    const name = String(rawName ?? "")
+    if (!name.trim()) return touched ? "Required." : undefined
     if ([...name].length > SKILL_NAME_MAX) return `Max ${SKILL_NAME_MAX} characters.`
     if (SKILL_NAME_PATTERN.test(name)) return undefined
-    // Keep it to one short line — the full rule is in the field's tooltip, and the form offers the
-    // slugified name as a one-click fix beside this message.
+    // "weather " looks fine, so the generic rule would read like a false positive.
+    if (SKILL_NAME_PATTERN.test(name.trim())) return "No leading or trailing spaces."
     return "Lowercase, digits and hyphens only."
 }
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/skillName.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/skillName.ts
@@ -12,6 +12,9 @@ export const SKILL_NAME_MAX = 64
 export const SKILL_DESCRIPTION_MAX = 1024
 export const SKILL_BODY_MAX = 50_000
 
+/** Shown for a non-string value, which pydantic rejects rather than coerces. */
+export const NOT_TEXT = "Must be text."
+
 /** Best-effort slug for a human-written name, offered as a one-click fix. */
 export function slugifySkillName(name: string): string {
     return name
@@ -30,9 +33,13 @@ export function slugifySkillName(name: string): string {
  * message so a new skill drawer does not open shouting at the user — Save stays blocked either way.
  */
 export function skillNameError(rawName: unknown, {touched = true} = {}): string | undefined {
+    if (rawName === undefined || rawName === null) return touched ? "Required." : undefined
+    // Rejected, not coerced: `name` is a pydantic `str`, which refuses 123 outright, while
+    // String(123) would sail through the slug pattern below.
+    if (typeof rawName !== "string") return NOT_TEXT
     // Checked UNTRIMMED: the form stores what was typed, so trimming here would pass a value the
     // SDK's pattern later rejects.
-    const name = String(rawName ?? "")
+    const name = rawName
     if (!name.trim()) return touched ? "Required." : undefined
     if ([...name].length > SKILL_NAME_MAX) return `Max ${SKILL_NAME_MAX} characters.`
     if (SKILL_NAME_PATTERN.test(name)) return undefined
@@ -52,14 +59,18 @@ export function isValidSkillName(name: unknown): boolean {
  * model, so an empty one fails the run exactly like a bad name does.
  */
 export function skillDraftError(draft: Record<string, unknown>): string | undefined {
-    const nameError = skillNameError(draft.name)
-    if (nameError) return nameError
-    const description = String(draft.description ?? "").trim()
-    if (!description) return "Description is required."
-    if ([...description].length > SKILL_DESCRIPTION_MAX)
-        return `Description: max ${SKILL_DESCRIPTION_MAX} characters.`
-    const body = String(draft.body ?? "").trim()
-    if (!body) return "SKILL.md content is required."
-    if ([...body].length > SKILL_BODY_MAX) return `SKILL.md: max ${SKILL_BODY_MAX} characters.`
+    return (
+        skillNameError(draft.name) ??
+        textFieldError(draft.description, "Description", SKILL_DESCRIPTION_MAX) ??
+        textFieldError(draft.body, "SKILL.md content", SKILL_BODY_MAX)
+    )
+}
+
+/** Required, string-typed and within `max`, matching the pydantic field it mirrors. */
+function textFieldError(value: unknown, label: string, max: number): string | undefined {
+    if (value === undefined || value === null || value === "") return `${label} is required.`
+    if (typeof value !== "string") return `${label} must be text.`
+    if (!value.trim()) return `${label} is required.`
+    if ([...value].length > max) return `${label}: max ${max} characters.`
     return undefined
 }

--- a/web/packages/agenta-entity-ui/tests/unit/skillName.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/skillName.test.ts
@@ -54,6 +54,28 @@ describe("skillNameError", () => {
         expect(slugifySkillName("Café Notes")).toBe("cafe-notes")
     })
 
+    it("rejects non-string values instead of coercing them", () => {
+        // pydantic's `name: str` refuses 123 outright, but String(123) is "123", a valid slug.
+        for (const value of [123, 1.2, true, {}, []])
+            expect(skillNameError(value), JSON.stringify(value)).toBe("Must be text.")
+        expect(isValidSkillName(123)).toBe(false)
+        expect(skillDraftError({name: 123, description: "d", body: "b"})).toBe("Must be text.")
+        expect(skillDraftError({name: "ok", description: 5, body: "b"})).toBe(
+            "Description must be text.",
+        )
+        expect(skillDraftError({name: "ok", description: "d", body: 5})).toBe(
+            "SKILL.md content must be text.",
+        )
+        // A digit string is still a legal slug, and pydantic accepts it.
+        expect(skillNameError("123")).toBeUndefined()
+    })
+
+    it("treats null and undefined as the required case, not as bad text", () => {
+        expect(skillNameError(null)).toBe("Required.")
+        expect(skillNameError(undefined)).toBe("Required.")
+        expect(skillNameError(null, {touched: false})).toBeUndefined()
+    })
+
     it("stays quiet on an untouched empty field but still reports it as invalid", () => {
         expect(skillNameError("", {touched: false})).toBeUndefined()
         expect(skillNameError("")).toBe("Required.")

--- a/web/packages/agenta-entity-ui/tests/unit/skillName.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/skillName.test.ts
@@ -1,9 +1,4 @@
-/**
- * The frontend skill-name/draft guard mirrors the SDK's pydantic rules
- * (`sdks/python/agenta/sdk/agents/skills/models.py`). A name the SDK rejects must be rejected
- * here too: it saves as plain JSON but blows up `parse_skill_templates` on the first run, so the
- * whole agent fails rather than just the skill.
- */
+/** Mirrors the SDK's pydantic rules: a name the SDK rejects must be rejected here too. */
 import {describe, expect, it} from "vitest"
 
 import {
@@ -36,6 +31,21 @@ describe("skillNameError", () => {
         for (const name of ["my_skill", "my skill", "-lead", "trail-", "double--hyphen", "a.b"])
             expect(skillNameError(name), name).toBeDefined()
         expect(skillNameError("a".repeat(65))).toBe("Max 64 characters.")
+    })
+
+    it("rejects surrounding whitespace, which the form stores untrimmed", () => {
+        expect(skillNameError("weather ")).toBe("No leading or trailing spaces.")
+        expect(skillNameError(" weather")).toBe("No leading or trailing spaces.")
+        expect(isValidSkillName("weather ")).toBe(false)
+        expect(skillDraftError({name: "weather ", description: "d", body: "b"})).toBe(
+            "No leading or trailing spaces.",
+        )
+        expect(skillNameError(" My Skill ")).toBe("Lowercase, digits and hyphens only.")
+    })
+
+    it("slugifies away the whitespace so the one-click fix resolves it", () => {
+        expect(slugifySkillName("weather ")).toBe("weather")
+        expect(slugifySkillName(" My Skill ")).toBe("my-skill")
     })
 
     it("slugifies a human-written name for the one-click fix", () => {

--- a/web/packages/agenta-entity-ui/tests/unit/skillName.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/skillName.test.ts
@@ -1,0 +1,84 @@
+/**
+ * The frontend skill-name/draft guard mirrors the SDK's pydantic rules
+ * (`sdks/python/agenta/sdk/agents/skills/models.py`). A name the SDK rejects must be rejected
+ * here too: it saves as plain JSON but blows up `parse_skill_templates` on the first run, so the
+ * whole agent fails rather than just the skill.
+ */
+import {describe, expect, it} from "vitest"
+
+import {
+    isValidSkillName,
+    skillDraftError,
+    skillNameError,
+    slugifySkillName,
+} from "../../src/DrillInView/SchemaControls/skillName"
+
+import {ITEM_KINDS} from "../../src/DrillInView/SchemaControls/agentTemplate/itemKinds"
+
+describe("skillNameError", () => {
+    it("accepts the lowercase-hyphen slugs the harness requires", () => {
+        for (const name of ["my-skill", "release-notes", "a", "skill1", "a-b-c9"])
+            expect(skillNameError(name)).toBeUndefined()
+    })
+
+    it("rejects capitalised names — the reported break", () => {
+        expect(skillNameError("Weather")).toBe("Lowercase, digits and hyphens only.")
+        expect(skillNameError("My Skill")).toBe("Lowercase, digits and hyphens only.")
+        expect(isValidSkillName("Weather")).toBe(false)
+    })
+
+    it("keeps the message to one short line — the fix is offered as a separate action", () => {
+        const error = skillNameError("My Skill") ?? ""
+        expect(error.length).toBeLessThanOrEqual(40)
+    })
+
+    it("rejects the other shapes pydantic rejects", () => {
+        for (const name of ["my_skill", "my skill", "-lead", "trail-", "double--hyphen", "a.b"])
+            expect(skillNameError(name), name).toBeDefined()
+        expect(skillNameError("a".repeat(65))).toBe("Max 64 characters.")
+    })
+
+    it("slugifies a human-written name for the one-click fix", () => {
+        expect(slugifySkillName("My Skill")).toBe("my-skill")
+        expect(slugifySkillName("Release Notes!")).toBe("release-notes")
+        expect(slugifySkillName("Café Notes")).toBe("cafe-notes")
+    })
+
+    it("stays quiet on an untouched empty field but still reports it as invalid", () => {
+        expect(skillNameError("", {touched: false})).toBeUndefined()
+        expect(skillNameError("")).toBe("Required.")
+        expect(isValidSkillName("")).toBe(false)
+    })
+})
+
+describe("skillDraftError", () => {
+    const draft = {name: "my-skill", description: "when to use it", body: "# do this"}
+
+    it("passes a complete draft", () => {
+        expect(skillDraftError(draft)).toBeUndefined()
+    })
+
+    it("reports the required fields the SDK enforces with min_length=1", () => {
+        expect(skillDraftError({...draft, description: "  "})).toBe("Description is required.")
+        expect(skillDraftError({...draft, body: ""})).toBe("SKILL.md content is required.")
+    })
+
+    it("reports the name first", () => {
+        expect(skillDraftError({name: "Weather", description: "", body: ""})).toBe(
+            "Lowercase, digits and hyphens only.",
+        )
+    })
+})
+
+describe("the skill item kind blocks Save on an invalid draft", () => {
+    const {draftInvalid} = ITEM_KINDS.skill
+
+    it("blocks a capitalised name", () => {
+        expect(draftInvalid({name: "Weather", description: "d", body: "b"})).toBe(true)
+        expect(draftInvalid({name: "weather", description: "d", body: "b"})).toBe(false)
+    })
+
+    it("still lets `@ag.embed` references through untouched", () => {
+        expect(draftInvalid({"@ag.embed": {uri: "agenta://workflows/some-skill"}})).toBe(false)
+    })
+})


### PR DESCRIPTION
## Context

Give a skill a name like `Weather` or `My Skill` in the agent playground and the save succeeds, but every run of that agent then fails. Not just the skill: the whole agent.

The config is plain JSON to the backend, so nothing checks the name on the way in. The name is checked much later, twice, and both checks are invisible to the author:

1. `AgentTemplate.from_params` parses `parameters.agent.skills` through `parse_skill_templates`, whose pydantic model pins `name` to `^[a-z0-9]+(-[a-z0-9]+)*$`. A capitalised name raises `SkillValidationError` before the agent starts.
2. If a request somehow gets past the SDK, the runner re-validates the same pattern on the untrusted wire and silently skips the skill.

The slug rule is not something we can relax. The harnesses (Pi, Claude, OpenCode, Antigravity) key a skill by its on-disk directory name and invoke it as `/skill:name`, so it has to be a safe lowercase path segment. The gap was that the frontend never said so.

## Changes

`skillName.ts` mirrors the SDK's pydantic rules on the client: the name pattern plus the 64 / 1024 / 50k character caps, and a slugifier for the suggested fix. The skill drawer's `draftInvalid` gate now runs that check, so **Create** and **Save** are disabled while the draft would fail at run time. `@ag.embed` skill references carry no name and still pass through untouched.

The drawer shows the reason inline. Name, Description and SKILL.md all get an error line, since `description` and `body` are `min_length=1` on the model and an empty one kills a run exactly like a bad name does. Messages stay quiet on a pristine draft and switch on once a field is touched or filled by an upload or paste.

Before, typing `Weather`:

```
Name: [Weather]          <- saves fine, agent dies on first run
```

After:

```
Name: [Weather]
      Lowercase, digits and hyphens only.  Use "weather"
```

`Use "weather"` is a button that applies the slug. The full rule lives in the field's tooltip, so the message itself stays to one short line.

## Tests

- 11 unit tests in `skillName.test.ts` covering the accepted slugs, the rejected shapes (capitals, spaces, underscores, leading and trailing hyphens, over-length), the slugifier, and the `draftInvalid` gate including the `@ag.embed` passthrough. One test asserts the name message stays under 40 characters so it cannot creep back into a paragraph.
- Full `@agenta/entity-ui` suite green (465 tests, 34 files). `tsc --noEmit` and `pnpm lint-fix` clean.
- I did not get a browser check in. Storybook's webpack build never came up locally across three attempts, so the rendered error line is verified by types and tests but not by eye. Worth a look during QA.

## What to QA

- Agent playground, add a skill, type `Weather` in Name. An error appears under the field and **Create** is disabled. Click `Use "weather"` and the field becomes `weather`, the error clears, Create enables.
- Save that skill and run the agent. It runs, and the skill is available.
- Clear the Description or the SKILL.md body on a valid skill. Save is blocked with `Required.` under the offending field.
- Open an existing skill that already has a bad name. It opens with the error showing and Save blocked until you fix the name, which is intended: that skill's agent cannot run today.
- Regression: open a skill that is an `@ag.embed` reference. It still opens JSON-only and still saves unchanged.
- Regression: drop a folder or `.zip` onto the drawer. The parsed name and description land in the fields, and a capitalised name from the uploaded `SKILL.md` shows the error rather than saving silently.

## Preview
<img width="500"  alt="image" src="https://github.com/user-attachments/assets/3ddaf3ca-8df6-4608-823a-39cc0afd084a" />

