### PR TITLE
feat(frontend): Let each build kit tool be switched off individually

### DIFF
--- a/web/packages/agenta-entities/src/workflow/index.ts
+++ b/web/packages/agenta-entities/src/workflow/index.ts
@@ -84,6 +84,8 @@ export {
 export {
     workflowAgentTemplateOverlayAtomFamily,
     workflowBuildKitEnabledAtomFamily,
+    workflowBuildKitDisabledOpsAtomFamily,
+    type BuildKitUiState,
     workflowBuildKitOverlayReadyAtomFamily,
     type AgentTemplate,
 } from "./state"

--- a/web/packages/agenta-entities/src/workflow/state/index.ts
+++ b/web/packages/agenta-entities/src/workflow/state/index.ts
@@ -88,6 +88,8 @@ export {
     workflowIsEphemeralAtomFamily,
     workflowAgentTemplateOverlayAtomFamily,
     workflowBuildKitEnabledAtomFamily,
+    workflowBuildKitDisabledOpsAtomFamily,
+    type BuildKitUiState,
     workflowBuildKitOverlayReadyAtomFamily,
     type AgentTemplate,
     // Mutations

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -1416,6 +1416,17 @@ export const workflowBuildKitEnabledAtomFamily = atomFamily((_revisionId: string
     atom<boolean>(true),
 )
 
+/** The build kit's UI state: the master on/off plus the platform ops the user switched off. */
+export interface BuildKitUiState {
+    enabled: boolean
+    disabledOps: string[]
+}
+
+/** Platform ops switched off individually, by `op`. Empty = all on. In-memory like the master flag. */
+export const workflowBuildKitDisabledOpsAtomFamily = atomFamily((_revisionId: string) =>
+    atom<string[]>([]),
+)
+
 /**
  * Has the build-kit overlay for this revision settled? True once the overlay is either resolved
  * (present) or definitively absent — i.e. the underlying fetch(es) are no longer pending. The

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -197,10 +197,11 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
     const sectionBaseline = useRef<{
         config: Record<string, unknown>
         buildKit: BuildKitUiState
-        // The revision the draft was opened against — Save must write back to THIS one, not to
-        // whatever is active by then (the revision can change under an open drawer).
-        revision: string
     } | null>(null)
+    // The revision the open drawer was snapshotted against. State, not a ref: the drawer BODY reads
+    // it during render, and both its overlay and Save must stay on it even if the active revision
+    // changes underneath. Null whenever no section drawer is open.
+    const [sectionRevision, setSectionRevision] = useState<string | null>(null)
     const store = useStore()
     const revisionIdRef = useRef<string | null>(null)
     const applyDraftConfig = useCallback(
@@ -231,10 +232,10 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
             }
             setDraftConfig(snapshotConfig)
             setDraftBuildKit(snapshotBuildKit)
+            setSectionRevision(snapshotRevision)
             sectionBaseline.current = {
                 config: snapshotConfig,
                 buildKit: snapshotBuildKit,
-                revision: snapshotRevision,
             }
             setOpenSection(key)
         },
@@ -244,6 +245,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
         setOpenSection(null)
         setDraftConfig(null)
         setDraftBuildKit(null)
+        setSectionRevision(null)
         sectionBaseline.current = null
     }, [])
 
@@ -281,12 +283,20 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
             }
         }
         if (draftBuildKit !== null) {
-            const revision = sectionBaseline.current?.revision ?? revisionIdRef.current ?? ""
+            const revision = sectionRevision ?? revisionIdRef.current ?? ""
             store.set(workflowBuildKitEnabledAtomFamily(revision), draftBuildKit.enabled)
             store.set(workflowBuildKitDisabledOpsAtomFamily(revision), draftBuildKit.disabledOps)
         }
         closeSectionDraft()
-    }, [draftConfig, draftBuildKit, openSection, onChange, store, closeSectionDraft])
+    }, [
+        draftConfig,
+        draftBuildKit,
+        openSection,
+        sectionRevision,
+        onChange,
+        store,
+        closeSectionDraft,
+    ])
     // Enable Save only when the draft actually differs from what we opened with (config or build-kit).
     const sectionDirty = isCurrentSectionDirty()
 
@@ -1029,7 +1039,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
                         onChange={applyDraftConfig}
                         disabled={disabled}
                         withTooltip={withTooltip}
-                        revisionId={revisionId}
+                        revisionId={sectionRevision ?? revisionId}
                         buildKitOverride={draftBuildKitOverride}
                     />
                 </ChangedPathsProvider>
@@ -1053,7 +1063,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
                         onChange={applyDraftConfig}
                         disabled={disabled}
                         withTooltip={withTooltip}
-                        revisionId={revisionId}
+                        revisionId={sectionRevision ?? revisionId}
                         buildKitOverride={draftBuildKitOverride}
                     />
                 </ChangedPathsProvider>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -25,7 +25,12 @@ import {memo, useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import {toolActionAvailabilityKey, useToolActionAvailability} from "@agenta/entities/gatewayTool"
 import type {SchemaProperty} from "@agenta/entities/shared"
-import {agentCreationPrefsAtom, workflowBuildKitEnabledAtomFamily} from "@agenta/entities/workflow"
+import {
+    agentCreationPrefsAtom,
+    workflowBuildKitDisabledOpsAtomFamily,
+    workflowBuildKitEnabledAtomFamily,
+    type BuildKitUiState,
+} from "@agenta/entities/workflow"
 import {agentItemIdentity, stableStringify} from "@agenta/entities/workflow/commitDiff"
 import {draftConfigChangeSignalAtom, openAgentConfigSectionAtom} from "@agenta/shared/state"
 import {stripAgentaMetadataDeep} from "@agenta/shared/utils"
@@ -184,14 +189,15 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
 
     // Section drawers (Model & harness, Advanced) use a SCOPED draft: edits are buffered locally and
     // relayed to the entity only on Save (Cancel discards; Save is gated on a real diff vs. the value
-    // we opened with). The build-kit enable toggle lives OUTSIDE the config (a persisted atom), so it
-    // is buffered alongside the config draft and committed to the atom on Save.
+    // we opened with). The build-kit state lives OUTSIDE the config (playground-only atoms), so it is
+    // buffered alongside the config draft and committed to the atoms on Save.
     const [openSection, setOpenSection] = useState<null | "model-harness" | "advanced">(null)
     const [draftConfig, setDraftConfig] = useState<Record<string, unknown> | null>(null)
-    const [draftBuildKit, setDraftBuildKit] = useState<boolean | null>(null)
-    const sectionBaseline = useRef<{config: Record<string, unknown>; buildKit: boolean} | null>(
-        null,
-    )
+    const [draftBuildKit, setDraftBuildKit] = useState<BuildKitUiState | null>(null)
+    const sectionBaseline = useRef<{
+        config: Record<string, unknown>
+        buildKit: BuildKitUiState
+    } | null>(null)
     const store = useStore()
     const revisionIdRef = useRef<string | null>(null)
     const applyDraftConfig = useCallback(
@@ -205,7 +211,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
             openSection !== null &&
             sectionBaseline.current !== null &&
             (!deepEqual(draftConfig, sectionBaseline.current.config) ||
-                draftBuildKit !== sectionBaseline.current.buildKit),
+                !deepEqual(draftBuildKit, sectionBaseline.current.buildKit)),
         [openSection, draftConfig, draftBuildKit],
     )
     const openSectionDrawer = useCallback(
@@ -215,9 +221,11 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
             // Another section is open with unsaved edits: drop the request rather than clobber it.
             if (isCurrentSectionDirty()) return
             const snapshotConfig = (value ?? {}) as Record<string, unknown>
-            const snapshotBuildKit = store.get(
-                workflowBuildKitEnabledAtomFamily(revisionIdRef.current ?? ""),
-            )
+            const snapshotRevision = revisionIdRef.current ?? ""
+            const snapshotBuildKit: BuildKitUiState = {
+                enabled: store.get(workflowBuildKitEnabledAtomFamily(snapshotRevision)),
+                disabledOps: store.get(workflowBuildKitDisabledOpsAtomFamily(snapshotRevision)),
+            }
             setDraftConfig(snapshotConfig)
             setDraftBuildKit(snapshotBuildKit)
             sectionBaseline.current = {config: snapshotConfig, buildKit: snapshotBuildKit}
@@ -266,7 +274,9 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
             }
         }
         if (draftBuildKit !== null) {
-            store.set(workflowBuildKitEnabledAtomFamily(revisionIdRef.current ?? ""), draftBuildKit)
+            const revision = revisionIdRef.current ?? ""
+            store.set(workflowBuildKitEnabledAtomFamily(revision), draftBuildKit.enabled)
+            store.set(workflowBuildKitDisabledOpsAtomFamily(revision), draftBuildKit.disabledOps)
         }
         closeSectionDraft()
     }, [draftConfig, draftBuildKit, openSection, onChange, store, closeSectionDraft])
@@ -1013,7 +1023,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
                         disabled={disabled}
                         withTooltip={withTooltip}
                         revisionId={revisionId}
-                        buildKitEnabledOverride={draftBuildKitOverride}
+                        buildKitOverride={draftBuildKitOverride}
                     />
                 </ChangedPathsProvider>
             </SectionDrawer>
@@ -1037,7 +1047,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
                         disabled={disabled}
                         withTooltip={withTooltip}
                         revisionId={revisionId}
-                        buildKitEnabledOverride={draftBuildKitOverride}
+                        buildKitOverride={draftBuildKitOverride}
                     />
                 </ChangedPathsProvider>
             </SectionDrawer>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -197,6 +197,9 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
     const sectionBaseline = useRef<{
         config: Record<string, unknown>
         buildKit: BuildKitUiState
+        // The revision the draft was opened against — Save must write back to THIS one, not to
+        // whatever is active by then (the revision can change under an open drawer).
+        revision: string
     } | null>(null)
     const store = useStore()
     const revisionIdRef = useRef<string | null>(null)
@@ -228,7 +231,11 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
             }
             setDraftConfig(snapshotConfig)
             setDraftBuildKit(snapshotBuildKit)
-            sectionBaseline.current = {config: snapshotConfig, buildKit: snapshotBuildKit}
+            sectionBaseline.current = {
+                config: snapshotConfig,
+                buildKit: snapshotBuildKit,
+                revision: snapshotRevision,
+            }
             setOpenSection(key)
         },
         [value, store, openSection, isCurrentSectionDirty],
@@ -274,7 +281,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
             }
         }
         if (draftBuildKit !== null) {
-            const revision = revisionIdRef.current ?? ""
+            const revision = sectionBaseline.current?.revision ?? revisionIdRef.current ?? ""
             store.set(workflowBuildKitEnabledAtomFamily(revision), draftBuildKit.enabled)
             store.set(workflowBuildKitDisabledOpsAtomFamily(revision), draftBuildKit.disabledOps)
         }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection.tsx
@@ -27,12 +27,23 @@ export function formatPermissionValue(value: unknown): string {
     }
 }
 
+/** One togglable platform tool: its `op` key, its current state, and how the row presents. */
+export interface BuildKitPlatformTool {
+    op: string
+    enabled: boolean
+    descriptor: ItemDescriptor
+}
+
 export interface BuildKitSectionProps {
-    /** Build-kit on/off (the persisted atom, or a drawer's draft buffer). */
+    /** Build-kit master on/off (the persisted atom, or a drawer's draft buffer). */
     enabled: boolean
     onEnabledChange: (value: boolean) => void
     disabled?: boolean
-    platformTools: ItemDescriptor[]
+    platformTools: BuildKitPlatformTool[]
+    /** Switch one platform tool on or off. */
+    onToggleTool: (op: string, next: boolean) => void
+    /** Switch every platform tool on or off at once. */
+    onSetAllTools: (next: boolean) => void
     embeddedTools: ItemDescriptor[]
     embeddedSkills: ItemDescriptor[]
     /** Sandbox permission overlay, rendered read-only as `key → value` rows. */
@@ -41,17 +52,23 @@ export interface BuildKitSectionProps {
     defaultOpen?: boolean
 }
 
-/** The read-only build-kit block: enable switch, caption, and the overlay's items/permissions. */
+/** The build-kit block. Platform tools get a switch each; embeds and permissions stay read-only. */
 export function BuildKitSection({
     enabled,
     onEnabledChange,
     disabled,
     platformTools,
+    onToggleTool,
+    onSetAllTools,
     embeddedTools,
     embeddedSkills,
     permissions,
     defaultOpen = false,
 }: BuildKitSectionProps) {
+    // Per-tool switches only mean anything while the kit as a whole is on.
+    const toolsDisabled = Boolean(disabled) || !enabled
+    const enabledCount = platformTools.filter((tool) => tool.enabled).length
+    const allEnabled = enabledCount === platformTools.length
     return (
         <ConfigAccordionSection
             size="compact"
@@ -83,18 +100,45 @@ export function BuildKitSection({
                 </div>
             ) : null}
             {platformTools.length > 0 ? (
-                <RailField label="Platform tools">
-                    {platformTools.map((descriptor, index) => (
+                <RailField
+                    wide
+                    label={
+                        <span className="flex flex-col items-start gap-1">
+                            <span>Platform tools</span>
+                            <span className="text-[11px] leading-tight text-colorTextDescription">
+                                {enabledCount} of {platformTools.length} enabled
+                            </span>
+                            <button
+                                type="button"
+                                disabled={toolsDisabled}
+                                onClick={() => onSetAllTools(!allEnabled)}
+                                className="cursor-pointer border-0 bg-transparent p-0 text-[11px] underline underline-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                {allEnabled ? "Disable all" : "Enable all"}
+                            </button>
+                        </span>
+                    }
+                >
+                    {platformTools.map((tool) => (
                         <ItemRow
-                            key={`build-kit-platform-tool-${index}`}
-                            descriptor={descriptor}
-                            locked
+                            key={`build-kit-platform-tool-${tool.op}`}
+                            descriptor={tool.descriptor}
+                            inactive={!tool.enabled || !enabled}
+                            extra={
+                                <Switch
+                                    size="sm"
+                                    checked={tool.enabled}
+                                    disabled={toolsDisabled}
+                                    onCheckedChange={(next) => onToggleTool(tool.op, next)}
+                                    aria-label={`Enable the ${tool.op} playground tool`}
+                                />
+                            }
                         />
                     ))}
                 </RailField>
             ) : null}
             {embeddedTools.length > 0 ? (
-                <RailField label="Embedded tools">
+                <RailField wide label="Embedded tools">
                     {embeddedTools.map((descriptor, index) => (
                         <ItemRow
                             key={`build-kit-embedded-tool-${index}`}
@@ -105,7 +149,7 @@ export function BuildKitSection({
                 </RailField>
             ) : null}
             {embeddedSkills.length > 0 ? (
-                <RailField label="Embedded skills">
+                <RailField wide label="Embedded skills">
                     {embeddedSkills.map((descriptor, index) => (
                         <ItemRow
                             key={`build-kit-embedded-skill-${index}`}
@@ -116,7 +160,7 @@ export function BuildKitSection({
                 </RailField>
             ) : null}
             {permissions && Object.keys(permissions).length > 0 ? (
-                <RailField label="Sandbox permissions">
+                <RailField wide label="Sandbox permissions">
                     <div className="flex flex-col gap-1.5 opacity-70">
                         {Object.entries(permissions).map(([key, value]) => (
                             <div

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
@@ -88,6 +88,9 @@ export function ItemAvatar({descriptor}: {descriptor: ItemDescriptor}) {
  * `locked` renders a read-only variant (muted fill, a "Locked" tag, no chevron/remove and no
  * interaction) — used for platform-owned items that can be shown but not edited, e.g. the
  * playground build kit. Passing no `onEdit` also makes the row non-interactive.
+ *
+ * `extra` slots a control (e.g. a per-item switch) ahead of the tags; `inactive` dims the identity
+ * half so a switched-off row reads as off without going fully `locked`.
  */
 export function ItemRow({
     descriptor,
@@ -95,6 +98,8 @@ export function ItemRow({
     onRemove,
     disabled,
     locked,
+    inactive,
+    extra,
     status,
 }: {
     descriptor: ItemDescriptor
@@ -102,6 +107,8 @@ export function ItemRow({
     onRemove?: () => void
     disabled?: boolean
     locked?: boolean
+    inactive?: boolean
+    extra?: ReactNode
     status?: ItemRowStatus
 }) {
     const interactive = Boolean(onEdit) && !locked
@@ -134,7 +141,10 @@ export function ItemRow({
                           }
                         : undefined
                 }
-                className="flex min-w-0 flex-1 items-center gap-2.5"
+                className={cn(
+                    "flex min-w-0 flex-1 items-center gap-2.5 transition-opacity",
+                    inactive && "opacity-50",
+                )}
             >
                 <ItemAvatar descriptor={descriptor} />
                 <div className="min-w-0 flex-1">
@@ -160,6 +170,7 @@ export function ItemRow({
                     </Tag>
                 ))}
                 {locked ? <Tag className={TAG_CLS}>Locked</Tag> : null}
+                {extra}
                 {onRemove && !disabled && !locked ? (
                     <button
                         type="button"

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
@@ -4,10 +4,11 @@
  * The default agent config carries a server-side overlay of playground-only tools, skills, and
  * sandbox permissions that help the assistant build and revise the agent. None of it is part of the
  * published agent (the backend strips it on commit). This hook reads that overlay (keyed by the open
- * revision) plus the user's build-kit on/off toggle, and returns:
+ * revision) plus the user's build-kit state — the master on/off and the platform ops switched off
+ * individually — and returns:
  *   - `hasBuildKitOverlay`: whether to render the build-kit block / extend the Advanced section,
- *   - `buildKitSection`: the read-only drawer block (platform tools, embedded tools/skills, sandbox
- *     permissions) with the enable/disable switch,
+ *   - `buildKitSection`: the drawer block (platform tools with a switch each, read-only embedded
+ *     tools/skills and sandbox permissions) under the master enable/disable switch,
  *   - `permissionOverrideHint`: the inline warning to show above SandboxPermissionControl when the
  *     build kit overrides one of the user's permission values.
  *
@@ -18,7 +19,9 @@ import {useMemo} from "react"
 
 import {
     workflowAgentTemplateOverlayAtomFamily,
+    workflowBuildKitDisabledOpsAtomFamily,
     workflowBuildKitEnabledAtomFamily,
+    type BuildKitUiState,
 } from "@agenta/entities/workflow"
 import {Wrench} from "@phosphor-icons/react"
 import {useAtom, useAtomValue} from "jotai"
@@ -98,16 +101,13 @@ export function useBuildKit({
     revisionId,
     sandboxPermissions,
     disabled,
-    enabledOverride,
+    stateOverride,
 }: {
     revisionId: string | null
     sandboxPermissions: Record<string, unknown> | null
     disabled?: boolean
-    /**
-     * When set, the enable toggle reads/writes this buffer instead of the persisted atom — so a
-     * section drawer can scope the change to its draft and commit it to the atom only on Save.
-     */
-    enabledOverride?: {value: boolean; onChange: (value: boolean) => void}
+    /** When set, the switches read/write this draft buffer instead of the persisted atoms. */
+    stateOverride?: {value: BuildKitUiState; onChange: (next: BuildKitUiState) => void}
 }) {
     const agentTemplateOverlay = useAtomValue(
         useMemo(() => workflowAgentTemplateOverlayAtomFamily(revisionId ?? ""), [revisionId]),
@@ -115,8 +115,19 @@ export function useBuildKit({
     const [atomBuildKitEnabled, setAtomBuildKitEnabled] = useAtom(
         useMemo(() => workflowBuildKitEnabledAtomFamily(revisionId ?? ""), [revisionId]),
     )
-    const buildKitEnabled = enabledOverride ? enabledOverride.value : atomBuildKitEnabled
-    const setBuildKitEnabled = enabledOverride ? enabledOverride.onChange : setAtomBuildKitEnabled
+    const [atomDisabledOps, setAtomDisabledOps] = useAtom(
+        useMemo(() => workflowBuildKitDisabledOpsAtomFamily(revisionId ?? ""), [revisionId]),
+    )
+    const buildKitEnabled = stateOverride ? stateOverride.value.enabled : atomBuildKitEnabled
+    const disabledOps = stateOverride ? stateOverride.value.disabledOps : atomDisabledOps
+    const write = (next: BuildKitUiState) => {
+        if (stateOverride) stateOverride.onChange(next)
+        else {
+            setAtomBuildKitEnabled(next.enabled)
+            setAtomDisabledOps(next.disabledOps)
+        }
+    }
+    const setDisabledOps = (next: string[]) => write({enabled: buildKitEnabled, disabledOps: next})
 
     const overlayTools = useMemo(
         () => (Array.isArray(agentTemplateOverlay?.tools) ? agentTemplateOverlay.tools : []),
@@ -156,12 +167,31 @@ export function useBuildKit({
         [buildKitEnabled, sandboxPermissions, overlayPermissions],
     )
 
+    const platformToolRows = useMemo(
+        () =>
+            platformOverlayTools.map((tool) => {
+                const op = typeof tool.op === "string" ? tool.op : "platform tool"
+                return {
+                    op,
+                    enabled: !disabledOps.includes(op),
+                    descriptor: describeBuildKitPlatformTool(tool),
+                }
+            }),
+        [platformOverlayTools, disabledOps],
+    )
+    const toggleTool = (op: string, next: boolean) =>
+        setDisabledOps(next ? disabledOps.filter((entry) => entry !== op) : [...disabledOps, op])
+    const setAllTools = (next: boolean) =>
+        setDisabledOps(next ? [] : platformToolRows.map((tool) => tool.op))
+
     const buildKitSection = hasBuildKitOverlay ? (
         <BuildKitSection
             enabled={buildKitEnabled}
-            onEnabledChange={setBuildKitEnabled}
+            onEnabledChange={(next) => write({enabled: next, disabledOps})}
             disabled={disabled}
-            platformTools={platformOverlayTools.map(describeBuildKitPlatformTool)}
+            platformTools={platformToolRows}
+            onToggleTool={toggleTool}
+            onSetAllTools={setAllTools}
             embeddedTools={embeddedOverlayTools.map((tool) => describeBuildKitEmbed(tool, "tool"))}
             embeddedSkills={embeddedOverlaySkills.map((skill) =>
                 describeBuildKitEmbed(skill, "skill"),

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -14,6 +14,7 @@ import {
     harnessCapabilitiesAtomFamily,
     harnessCatalogFailedAtom,
     retryHarnessCatalogAtom,
+    type BuildKitUiState,
 } from "@agenta/entities/workflow"
 import {getEnabledSandboxProviders} from "@agenta/shared/api"
 import {normalizeProviderFamily} from "@agenta/shared/utils"
@@ -74,7 +75,7 @@ export function useModelHarness({
     disabled,
     withTooltip,
     revisionId,
-    buildKitEnabledOverride,
+    buildKitOverride,
 }: {
     schema?: SchemaProperty | null
     config: Record<string, unknown>
@@ -83,7 +84,7 @@ export function useModelHarness({
     withTooltip?: boolean
     revisionId?: string | null
     /** Draft buffer for the build-kit toggle (used by the section drawer's scoped-edit mode). */
-    buildKitEnabledOverride?: {value: boolean; onChange: (value: boolean) => void}
+    buildKitOverride?: {value: BuildKitUiState; onChange: (next: BuildKitUiState) => void}
 }) {
     const props = (schema?.properties ?? {}) as Record<string, SchemaProperty>
     const subProps = useCallback(
@@ -373,7 +374,7 @@ export function useModelHarness({
         revisionId: revisionId ?? null,
         sandboxPermissions: (sandbox.permissions as Record<string, unknown> | null) ?? null,
         disabled,
-        enabledOverride: buildKitEnabledOverride,
+        stateOverride: buildKitOverride,
     })
 
     // Which Advanced sub-sections own an uncommitted change (see `ChangedPathsProvider`). Drives

--- a/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
@@ -11,6 +11,7 @@
  */
 import type {ReactNode} from "react"
 
+import {cn} from "@agenta/ui/styles"
 import {
     Button,
     Popover,
@@ -37,6 +38,8 @@ export interface RailFieldProps {
      * something did. Opt-in: without a path (or a provider) the row renders exactly as before.
      */
     path?: string
+    /** Drop the `max-w-prose` cap — for full-width lists rather than form inputs. @default false */
+    wide?: boolean
     children: ReactNode
 }
 
@@ -116,7 +119,7 @@ function ChangedDetail({
     )
 }
 
-export function RailField({label, align = "top", path, children}: RailFieldProps) {
+export function RailField({label, align = "top", path, wide, children}: RailFieldProps) {
     const changed = useChangedPath(path)
     const detail = useChangedDetail(path)
     const revert = useRevertPath(path)
@@ -153,7 +156,12 @@ export function RailField({label, align = "top", path, children}: RailFieldProps
                     label
                 )}
             </div>
-            <div className="flex min-w-0 max-w-prose flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3">
+            <div
+                className={cn(
+                    "flex min-w-0 flex-1 flex-col border-0 border-l border-solid border-[var(--ag-colorBorderSecondary)] pl-3",
+                    !wide && "max-w-prose",
+                )}
+            >
                 {children}
             </div>
         </div>

--- a/web/packages/agenta-playground/src/state/execution/agentRequest.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentRequest.ts
@@ -27,6 +27,7 @@
 import {
     workflowAgentTemplateOverlayAtomFamily,
     workflowBuildKitEnabledAtomFamily,
+    workflowBuildKitDisabledOpsAtomFamily,
     workflowMolecule,
     type AgentTemplate,
 } from "@agenta/entities/workflow"
@@ -324,6 +325,9 @@ export async function buildAgentRequest(
     // The execution sections (`harness`/`runner`/`sandbox`) are nested in the template at
     // `parameters.agent`. Default them, never overriding values the resolved config carries.
     const buildKitEnabled = store.get(workflowBuildKitEnabledAtomFamily(entityId)) as boolean
+    const buildKitDisabledOps = store.get(
+        workflowBuildKitDisabledOpsAtomFamily(entityId),
+    ) as string[]
     const agentTemplateOverlay = store.get(
         workflowAgentTemplateOverlayAtomFamily(entityId),
     ) as AgentTemplate | null
@@ -332,6 +336,7 @@ export async function buildAgentRequest(
             withAgentRunDefaults(config ?? {}) as Record<string, unknown>,
             agentTemplateOverlay,
             buildKitEnabled,
+            buildKitDisabledOps,
         ),
     ) as Record<string, unknown>
 

--- a/web/packages/agenta-playground/src/state/execution/buildKitOverlay.ts
+++ b/web/packages/agenta-playground/src/state/execution/buildKitOverlay.ts
@@ -128,6 +128,22 @@ export function applyBuildKitOverlay(
     return result
 }
 
+// A switched-off op is simply absent from the run copy — the wire tool config forbids extra fields.
+const withoutDisabledOps = (
+    overlay: AgentTemplate,
+    disabledOps: readonly string[],
+): AgentTemplate => {
+    if (disabledOps.length === 0 || !Array.isArray(overlay.tools)) return overlay
+    const disabled = new Set(disabledOps)
+    return {
+        ...overlay,
+        tools: (overlay.tools as unknown[]).filter(
+            (entry) =>
+                !(isRecord(entry) && entry.type === "platform" && disabled.has(entry.op as string)),
+        ),
+    }
+}
+
 /**
  * Apply the overlay to the run parameters. Handles both shapes `buildAgentRequest` produces: a
  * `{agent: <template>}` wrapper and a bare template (no `agent` key). Skipping the bare shape would
@@ -137,13 +153,15 @@ export const withBuildKitOverlay = (
     parameters: Record<string, unknown>,
     overlay: AgentTemplate | null,
     enabled: boolean,
+    disabledOps: readonly string[] = [],
 ): Record<string, unknown> => {
     if (!enabled || !overlay) return parameters
+    const effective = withoutDisabledOps(overlay, disabledOps)
     if (isRecord(parameters.agent)) {
         return {
             ...parameters,
-            agent: applyBuildKitOverlay(parameters.agent as AgentTemplate, overlay),
+            agent: applyBuildKitOverlay(parameters.agent as AgentTemplate, effective),
         }
     }
-    return applyBuildKitOverlay(parameters as AgentTemplate, overlay) as Record<string, unknown>
+    return applyBuildKitOverlay(parameters as AgentTemplate, effective) as Record<string, unknown>
 }

--- a/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentRequest.test.ts
@@ -44,6 +44,7 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
 
 import {
     workflowAgentTemplateOverlayAtomFamily,
+    workflowBuildKitDisabledOpsAtomFamily,
     workflowBuildKitEnabledAtomFamily,
     workflowMolecule,
 } from "@agenta/entities/workflow"
@@ -79,6 +80,7 @@ function seed(
         isDirty?: boolean
         overlay?: Record<string, unknown> | null
         buildKitEnabled?: boolean
+        buildKitDisabledOps?: string[]
     },
 ) {
     set(
@@ -97,6 +99,10 @@ function seed(
     store.set(
         workflowBuildKitEnabledAtomFamily(id) as PrimitiveAtom<unknown>,
         over.buildKitEnabled ?? true,
+    )
+    store.set(
+        workflowBuildKitDisabledOpsAtomFamily(id) as PrimitiveAtom<unknown>,
+        over.buildKitDisabledOps ?? [],
     )
 }
 
@@ -426,6 +432,79 @@ describe("buildAgentRequest", () => {
         const template = (req!.requestBody.data as any).parameters.agent
 
         expect(template.sandbox.permissions).toEqual({execute_code: "deny"})
+        expect(template.tools).toEqual([{type: "client", name: "weather"}])
+        expect(template.skills).toBeUndefined()
+    })
+
+    it("omits the platform tools the user switched off, keeping the rest of the kit", async () => {
+        // Per-tool switches (#6026): a disabled op is ABSENT from the run copy — the wire tool
+        // config forbids extra fields, so there is no "off" flag to send.
+        const config = {agent: {tools: [{type: "client", name: "weather"}]}}
+        seed(store, "e", {
+            config,
+            overlay: {
+                sandbox: {permissions: {execute_code: "allow"}},
+                tools: [
+                    {type: "platform", op: "discover_tools"},
+                    {type: "platform", op: "commit_revision"},
+                    requestConnectionTool,
+                ],
+                skills: [authoringSkill],
+            },
+            buildKitEnabled: true,
+            buildKitDisabledOps: ["commit_revision"],
+        })
+
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        const template = (req!.requestBody.data as any).parameters.agent
+
+        expect(template.tools).toEqual([
+            {type: "client", name: "weather"},
+            {type: "platform", op: "discover_tools"},
+            requestConnectionTool,
+        ])
+        // The master switch still governs permissions and the embedded items.
+        expect(template.sandbox.permissions).toMatchObject({execute_code: "allow"})
+        expect(template.skills).toEqual([authoringSkill])
+    })
+
+    it("keeps embeds and permissions when every platform tool is switched off", async () => {
+        const config = {agent: {tools: [{type: "client", name: "weather"}]}}
+        seed(store, "e", {
+            config,
+            overlay: {
+                sandbox: {permissions: {write_files: "allow"}},
+                tools: [
+                    {type: "platform", op: "discover_tools"},
+                    {type: "platform", op: "commit_revision"},
+                    requestConnectionTool,
+                ],
+                skills: [authoringSkill],
+            },
+            buildKitEnabled: true,
+            buildKitDisabledOps: ["discover_tools", "commit_revision"],
+        })
+
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        const template = (req!.requestBody.data as any).parameters.agent
+
+        expect(template.tools).toEqual([{type: "client", name: "weather"}, requestConnectionTool])
+        expect(template.sandbox.permissions).toMatchObject({write_files: "allow"})
+        expect(template.skills).toEqual([authoringSkill])
+    })
+
+    it("ignores the per-tool set entirely when the master switch is off", async () => {
+        const config = {agent: {tools: [{type: "client", name: "weather"}]}}
+        seed(store, "e", {
+            config,
+            overlay: {tools: [{type: "platform", op: "discover_tools"}], skills: [authoringSkill]},
+            buildKitEnabled: false,
+            buildKitDisabledOps: ["commit_revision"],
+        })
+
+        const req = await buildAgentRequest("e", [], {sessionId: "s1", store})
+        const template = (req!.requestBody.data as any).parameters.agent
+
         expect(template.tools).toEqual([{type: "client", name: "weather"}])
         expect(template.skills).toBeUndefined()
     })

--- a/web/packages/agenta-ui/src/components/ui/switch.tsx
+++ b/web/packages/agenta-ui/src/components/ui/switch.tsx
@@ -7,9 +7,9 @@ import {cn} from "./utils"
 
 /**
  * Switch — a Radix + cva primitive in @agenta/ui, following shadcn's source conventions (no
- * `forwardRef`, `data-slot` on Root AND Thumb). Re-skinned to antd's Switch geometry via the shared control scale
- * (`h-switch`/`w-switch`/`size-switch-thumb`), so nothing here uses raw pixels except the
- * theme-invariant 2px track padding (antd `trackPadding`) and the handle shadow (no token).
+ * `forwardRef`, `data-slot` on Root AND Thumb). Re-skinned to antd's Switch geometry via the shared
+ * control scale (`h-switch`/`w-switch`/`size-switch-thumb`). Dimensions come from tokens; the thumb
+ * TRAVEL is literal px because it must resolve under Tailwind v3 and v4 alike (see the variants).
  *
  * SCOPE: the bare toggle only. antd's `loading` (spinner in the handle) and rich checked/
  * unchecked labels are NOT part of this primitive — compose them if ever needed. No
@@ -41,19 +41,24 @@ const switchVariants = cva(
                 // antd press-stretch (switchHandleActiveInset -30%): on root :active the handle
                 // grows 30% toward the press-opposite side — unchecked grows right (anchor left,
                 // translate stays 0), checked grows left (anchor right, so shrink the travel by
-                // 0.3×thumb). Keyed on the ROOT's :active applied to the thumb (antd's mechanism),
-                // token-pure via theme() (×1.3/×0.3 = antd's -30% constant).
+                // 0.3×thumb). Keyed on the ROOT's :active applied to the thumb (antd's mechanism).
+                // Literal px, not theme()/translate-x-*: v4 (web/mobile) resolves neither, so the
+                // composed transform computed to `none` there. Values track controlScale.ts.
                 default: [
                     "h-switch w-switch",
-                    "active:data-[state=unchecked]:[&_[data-slot=switch-thumb]]:w-[calc(theme(width.switch-thumb)_*_1.3)]",
-                    "active:data-[state=checked]:[&_[data-slot=switch-thumb]]:w-[calc(theme(width.switch-thumb)_*_1.3)]",
-                    "active:data-[state=checked]:[&_[data-slot=switch-thumb]]:translate-x-[calc(theme(width.switch)_-_theme(width.switch-thumb)_-_4px_-_theme(width.switch-thumb)_*_0.3)]",
+                    // 18 × 1.3
+                    "active:data-[state=unchecked]:[&_[data-slot=switch-thumb]]:w-[23.4px]",
+                    "active:data-[state=checked]:[&_[data-slot=switch-thumb]]:w-[23.4px]",
+                    // 44 − 18 − 4 − 18×0.3
+                    "active:data-[state=checked]:[&_[data-slot=switch-thumb]]:[transform:translateX(16.6px)]",
                 ],
                 sm: [
                     "h-switch-sm w-switch-sm",
-                    "active:data-[state=unchecked]:[&_[data-slot=switch-thumb]]:w-[calc(theme(width.switch-thumb-sm)_*_1.3)]",
-                    "active:data-[state=checked]:[&_[data-slot=switch-thumb]]:w-[calc(theme(width.switch-thumb-sm)_*_1.3)]",
-                    "active:data-[state=checked]:[&_[data-slot=switch-thumb]]:translate-x-[calc(theme(width.switch-sm)_-_theme(width.switch-thumb-sm)_-_4px_-_theme(width.switch-thumb-sm)_*_0.3)]",
+                    // 12 × 1.3
+                    "active:data-[state=unchecked]:[&_[data-slot=switch-thumb]]:w-[15.6px]",
+                    "active:data-[state=checked]:[&_[data-slot=switch-thumb]]:w-[15.6px]",
+                    // 28 − 12 − 4 − 12×0.3
+                    "active:data-[state=checked]:[&_[data-slot=switch-thumb]]:[transform:translateX(8.4px)]",
                 ],
             },
         },
@@ -66,15 +71,15 @@ const switchThumbVariants = cva(
         "pointer-events-none block rounded-full bg-white",
         // antd handle shadow (`handleShadow`, theme-invariant) — `switch-handle` bridge token.
         "shadow-switch-handle",
-        "transition-transform data-[state=unchecked]:translate-x-0",
+        "transition-transform data-[state=unchecked]:[transform:translateX(0)]",
     ],
     {
         variants: {
             size: {
                 // travel = trackWidth − thumb − 2×trackPadding(2px) → 44−18−4=22 / 28−12−4=12.
-                default:
-                    "size-switch-thumb data-[state=checked]:translate-x-[calc(theme(width.switch)_-_theme(width.switch-thumb)_-_4px)]",
-                sm: "size-switch-thumb-sm data-[state=checked]:translate-x-[calc(theme(width.switch-sm)_-_theme(width.switch-thumb-sm)_-_4px)]",
+                // Literal px + arbitrary `transform` — see the root variants for why not theme().
+                default: "size-switch-thumb data-[state=checked]:[transform:translateX(22px)]",
+                sm: "size-switch-thumb-sm data-[state=checked]:[transform:translateX(12px)]",
             },
         },
         defaultVariants: {size: "default"},

--- a/web/storybook/stories/entity-ui/BuildKitSection.stories.tsx
+++ b/web/storybook/stories/entity-ui/BuildKitSection.stories.tsx
@@ -9,6 +9,7 @@ import {Switch as AntSwitch, Tag as AntTag, Tooltip as AntTooltip, Typography} f
 // Imported from source: agentTemplate internals are not re-exported from the DrillInView barrel.
 import {
     BuildKitSection,
+    type BuildKitPlatformTool,
     PermissionOverrideHint,
     formatPermissionValue,
 } from "../../../packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection"
@@ -41,30 +42,28 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-const PLATFORM_TOOLS: ItemDescriptor[] = [
-    {
-        name: "agenta.write_file",
-        description: "Platform-owned playground tool",
-        mono: "",
-        color: "#0d9488",
-        icon: <Wrench size={15} weight="fill" />,
-        tags: ["platform"],
-        typeLabel: "platform",
-        typeColor: "cyan",
-        subtitle: "Platform tool",
-    },
-    {
-        name: "agenta.run_code",
-        description: "Platform-owned playground tool",
-        mono: "",
-        color: "#0d9488",
-        icon: <Wrench size={15} weight="fill" />,
-        tags: ["platform"],
-        typeLabel: "platform",
-        typeColor: "cyan",
-        subtitle: "Platform tool",
-    },
-]
+const platformDescriptor = (name: string): ItemDescriptor => ({
+    name,
+    description: "Platform-owned playground tool",
+    mono: "",
+    color: "#0d9488",
+    icon: <Wrench size={15} weight="fill" />,
+    tags: ["platform"],
+    typeLabel: "platform",
+    typeColor: "cyan",
+    subtitle: "Platform tool",
+})
+
+const PLATFORM_OPS = ["discover_tools", "commit_revision", "query_spans", "test_run"]
+
+const platformTools = (disabledOps: string[] = []): BuildKitPlatformTool[] =>
+    PLATFORM_OPS.map((op) => ({
+        op,
+        enabled: !disabledOps.includes(op),
+        descriptor: platformDescriptor(op),
+    }))
+
+const PLATFORM_TOOLS = platformTools()
 
 const EMBEDDED_TOOLS: ItemDescriptor[] = [
     {
@@ -133,8 +132,8 @@ const AntdBuildKitSection = ({
             </div>
         ) : null}
         <RailField label="Platform tools">
-            {PLATFORM_TOOLS.map((descriptor, index) => (
-                <ItemRow key={`platform-${index}`} descriptor={descriptor} locked />
+            {PLATFORM_TOOLS.map((tool, index) => (
+                <ItemRow key={`platform-${index}`} descriptor={tool.descriptor} locked />
             ))}
         </RailField>
         <RailField label="Embedded tools">
@@ -177,6 +176,8 @@ const AntdPermissionOverrideHint = () => (
 
 const BASE = {
     platformTools: PLATFORM_TOOLS,
+    onToggleTool: () => undefined,
+    onSetAllTools: () => undefined,
     embeddedTools: EMBEDDED_TOOLS,
     embeddedSkills: EMBEDDED_SKILLS,
     permissions: PERMISSIONS,
@@ -184,8 +185,17 @@ const BASE = {
     defaultOpen: true,
 }
 
-const Live = ({initial = true, disabled}: {initial?: boolean; disabled?: boolean}) => {
+const Live = ({
+    initial = true,
+    disabled,
+    initialDisabledOps = [],
+}: {
+    initial?: boolean
+    disabled?: boolean
+    initialDisabledOps?: string[]
+}) => {
     const [enabled, setEnabled] = useState(initial)
+    const [disabledOps, setDisabledOps] = useState(initialDisabledOps)
     return (
         <div className="max-w-[560px]">
             <BuildKitSection
@@ -193,6 +203,13 @@ const Live = ({initial = true, disabled}: {initial?: boolean; disabled?: boolean
                 enabled={enabled}
                 onEnabledChange={setEnabled}
                 disabled={disabled}
+                platformTools={platformTools(disabledOps)}
+                onToggleTool={(op, next) =>
+                    setDisabledOps((prev) =>
+                        next ? prev.filter((entry) => entry !== op) : [...prev, op],
+                    )
+                }
+                onSetAllTools={(next) => setDisabledOps(next ? [] : PLATFORM_OPS)}
             />
         </div>
     )
@@ -216,12 +233,25 @@ export const Disabled: Story = {
     render: () => <Live disabled />,
 }
 
+/** Some platform tools switched off individually (#6026) — the rail counts and dims accordingly. */
+export const SomeToolsOff: Story = {
+    args: {
+        ...BASE,
+        enabled: true,
+        onEnabledChange: () => undefined,
+        platformTools: platformTools(["commit_revision", "test_run"]),
+    },
+    render: () => <Live initialDisabledOps={["commit_revision", "test_run"]} />,
+}
+
 /** A thin overlay: permissions only, no tools or skills. */
 export const PermissionsOnly: Story = {
     args: {
         enabled: true,
         onEnabledChange: () => undefined,
         platformTools: [],
+        onToggleTool: () => undefined,
+        onSetAllTools: () => undefined,
         embeddedTools: [],
         embeddedSkills: [],
         permissions: PERMISSIONS,
@@ -234,6 +264,8 @@ export const PermissionsOnly: Story = {
                 defaultOpen
                 onEnabledChange={() => undefined}
                 platformTools={[]}
+                onToggleTool={() => undefined}
+                onSetAllTools={() => undefined}
                 embeddedTools={[]}
                 embeddedSkills={[]}
                 permissions={PERMISSIONS}


### PR DESCRIPTION
## Context

Closes #6026 (AGE-4123). The playground build kit ships 16 platform tools that help the assistant build and revise an agent, all behind a single switch. It was every tool or none, so there was no way to expose only the two or three an agent actually needs.

## Changes

Each platform tool now carries its own switch, with an "N of M enabled" count and an Enable all / Disable all control on the rail.

The master switch keeps its current meaning. It governs the whole kit (platform tools, the embedded tools and skills, and the sandbox permissions) and gates the rows. It is not tri-state, and switching every tool off does not flip it. Embedded tools and skills stay locked, because Agenta owns them.

This is frontend only. The wire tool config is `extra="forbid"`, so there is no "off" flag to send. A switched-off op is expressed by leaving it out of the throwaway run copy, which is what the overlay merge already does for anything absent.

With the kit on, every op used to reach the agent:

```
tools: [
  {type: "platform", op: "discover_tools"},
  {type: "platform", op: "commit_revision"},
  ...
]
```

Switch `commit_revision` off and that entry is simply gone from `parameters.agent` in the `/invoke` payload. The remaining platform tools, the two `@ag.embed` tools and the sandbox permissions are untouched.

Per-tool state lives in a new `workflowBuildKitDisabledOpsAtomFamily`, in memory and keyed by revision, matching the existing master flag. The Advanced drawer buffers both halves of the state and commits them on Save.

### Second commit: a Switch bug this surfaced

Putting 16 switches on one screen exposed a pre-existing bug in `@agenta/ui`'s Switch, so it is fixed here as its own commit. The thumb travel was written as `translate-x-[calc(theme(width.switch) ...)]`, which only Tailwind v3 resolves. `web/mobile` runs v4, where neither `theme()` nor the `--tw-translate-*` chain resolves, so the composed transform computed to `none`. Every switch in the mobile app changed colour while its knob stayed put. It now emits a self-contained `transform: translateX(22px)`. The v3 geometry is byte-identical (22px and 12px travel, 23.4px and 15.6px press-stretch), so the antd parity baseline does not move.

## Tests

- Three new cases in `agentRequest.test.ts`: a switched-off op is absent from the merged tools, the embeds and permissions survive when every platform tool is off, and the per-tool set is ignored while the master switch is off. Full package suite green at 223 tests.
- Typecheck and lint clean across `@agenta/ui`, `@agenta/entities`, `@agenta/entity-ui` and `@agenta/playground`.
- Verified the Switch fix against the running v4 app. `translateX(12px)` and `translateX(22px)` now compute where they were `transform: none` before.
- Not done yet: the Storybook light and dark pass, and an end to end run against the local docker stack.

Two known gaps, both small and worth settling in review:

- `useBuildKit.tsx` gives a tool with a non-string `op` the synthetic identity `"platform tool"`, which the run-path filter cannot match. Switching such a tool off would update the UI while the tool still reaches the agent. It needs a malformed overlay to trigger, since `agentBuildKitOverlaySchema` declares `tools?: unknown[]` and never validates the entries.
- `disabledOps` is diffed as an ordered array, so toggling a tool off and back on reorders it against the baseline and enables Save with no effective change.

## What to QA

- Open an agent playground, then the Advanced drawer. The build kit lists every platform tool with its own switch and an accurate "N of M enabled" count.
- Switch two tools off and press Save. Send a message, then check the trace. Those ops are gone from `parameters.agent.tools`, while the rest, the two `@ag.embed` tools and the sandbox permissions are still there.
- Press "Disable all", then run. Only the embeds and the permissions merge.
- Turn the master switch off. The rows grey out and the run sends the bare config, exactly as before this PR.
- Cancel discards per-tool edits. A reload resets every tool to enabled, which is intended, because the state is in memory by design.
- Regression in the mobile app: any switch anywhere, including the kit master, slides its knob when you click it instead of only changing colour.
