### PR TITLE
[fix] Resume a stranded connection instead of requesting a new one

### DIFF
--- a/api/oss/src/core/gateway/connections/service.py
+++ b/api/oss/src/core/gateway/connections/service.py
@@ -142,6 +142,40 @@ class ConnectionsService:
     # Writes
     # -----------------------------------------------------------------------
 
+    async def _find_resumable_connection(
+        self,
+        *,
+        project_id: UUID,
+        provider_key: str,
+        integration_key: str,
+        slug: Optional[str],
+    ) -> Optional[Connection]:
+        """The row this slug should re-drive, if any.
+
+        Only an active row whose handshake never completed resumes. A valid row is a real
+        connection and an inactive one was switched off deliberately, so both keep raising
+        the DAO's slug conflict.
+        """
+        if not slug:
+            return None
+
+        connections = await self.query_connections(
+            project_id=project_id,
+            provider_key=provider_key,
+            integration_key=integration_key,
+            is_active=None,
+        )
+
+        connection = next((c for c in connections if c.slug == slug), None)
+
+        if connection is None or connection.id is None:
+            return None
+
+        if connection.is_valid or not connection.is_active:
+            return None
+
+        return connection
+
     async def initiate_connection(
         self,
         *,
@@ -150,9 +184,24 @@ class ConnectionsService:
         #
         connection_create: ConnectionCreate,
     ) -> Connection:
-        """Initiate a provider connection and persist it locally in pending state."""
+        """Initiate a provider connection and persist it locally in pending state.
+
+        A row whose handshake never completed is re-driven in place. Without that, a
+        half-finished connection can only ever be duplicated under a fresh slug, and the
+        stranded row stays unusable forever.
+        """
         provider_key = connection_create.provider_key.value
         integration_key = connection_create.integration_key
+
+        # Resolve locally BEFORE touching the provider: a duplicate would otherwise mint a
+        # real auth config and connected account and only then hit the DAO's slug conflict,
+        # stranding that provider-side state.
+        resumable = await self._find_resumable_connection(
+            project_id=project_id,
+            provider_key=provider_key,
+            integration_key=integration_key,
+            slug=connection_create.slug,
+        )
 
         adapter = self.adapter_registry.get(provider_key)
 
@@ -192,16 +241,38 @@ class ConnectionsService:
         data: Dict[str, Any] = dict(provider_result.connection_data)
         data["project_id"] = str(project_id)
         data["auth_scheme"] = auth_scheme
-        connection_create.data = data
 
         # Validity is server-owned, never client-supplied. An auth-backed connection is
         # not valid until its OAuth callback flips is_valid; a no-auth toolkit has no
         # flow, so the server marks it valid up front (only after the adapter confirmed
         # no-auth via connection_data). Drop client flags so a caller can't mark a
         # pending OAuth connection valid.
+        is_valid = bool(data.get("no_auth"))
+
+        if resumable is not None:
+            # Resume in place. data_update merges, so redirect_url is written explicitly
+            # (the adapter omits it when there is no flow) rather than leaving the previous
+            # attempt's dead link behind — same reason refresh_connection overwrites it.
+            updated = await self.connections_dao.update_connection(
+                project_id=project_id,
+                connection_id=resumable.id,
+                #
+                is_active=True,
+                is_valid=is_valid,
+                data_update={**data, "redirect_url": provider_result.redirect_url},
+            )
+
+            if updated is None:
+                raise ConnectionNotFoundError(
+                    connection_id=str(resumable.id),
+                )
+
+            return updated
+
+        connection_create.data = data
         connection_create.flags = {
             "is_active": True,
-            "is_valid": bool(data.get("no_auth")),
+            "is_valid": is_valid,
         }
 
         # Persist locally

--- a/api/oss/src/core/tools/service.py
+++ b/api/oss/src/core/tools/service.py
@@ -603,10 +603,14 @@ class ToolsService:
             provider_key=provider_key,
             integration_key=integration_key,
         )
-        # Suggest a free slug: an inactive/invalid row may already hold
-        # ``<integration>-main``, and resolve_connection_by_slug can't disambiguate
-        # duplicate slugs, so don't propose one that already exists.
-        existing_slugs = {c.slug for c in connections if c.slug}
+        # Suggest a free slug, skipping any the DAO's unique constraint would reject. A row
+        # that is active but not valid is the exception: initiate_connection re-drives that
+        # one, so proposing its slug resumes it instead of stranding it behind a ``-2``.
+        existing_slugs = {
+            c.slug
+            for c in connections
+            if c.slug and not (c.is_active and not c.is_valid)
+        }
         connect_slug = f"{integration_key}-main"
         suffix = 2
         while connect_slug in existing_slugs:

--- a/api/oss/src/core/triggers/service.py
+++ b/api/oss/src/core/triggers/service.py
@@ -691,8 +691,13 @@ class TriggersService:
             provider_key=provider_key,
             integration_key=integration_key,
         )
+        # Skip slugs the unique constraint would reject; an active-but-invalid row is the
+        # exception, since initiate_connection re-drives that one instead of duplicating it.
         existing_slugs = {
-            connection.slug for connection in connections if connection.slug
+            connection.slug
+            for connection in connections
+            if connection.slug
+            and not (connection.is_active and not connection.is_valid)
         }
         connect_slug = f"{integration_key}-main"
         suffix = 2

--- a/api/oss/tests/pytest/unit/tools/test_connection_resume.py
+++ b/api/oss/tests/pytest/unit/tools/test_connection_resume.py
@@ -1,0 +1,187 @@
+"""Issue #5911: a connection whose handshake never completed must resume, not duplicate.
+
+An api-key or OAuth row is persisted ``is_valid: False`` and only the provider callback flips
+it. When that callback never lands, the row is stranded: discovery reports the integration as
+not-ready, the agent asks to connect again, and the next slug in the ladder mints a SECOND row
+while the first stays unusable forever. ``initiate_connection`` now re-drives the stranded row
+in place, which is also what lets discovery propose its slug again.
+"""
+
+from __future__ import annotations
+
+from uuid import uuid4
+
+import pytest
+
+from oss.src.core.gateway.connections import service as connections_service_mod
+from oss.src.core.gateway.connections.dtos import (
+    Connection,
+    ConnectionCreate,
+    ConnectionProviderKind,
+    ConnectionResponse,
+)
+from oss.src.core.gateway.connections.exceptions import ConnectionNotFoundError
+from oss.src.core.gateway.connections.service import ConnectionsService
+
+
+class _Adapter:
+    def __init__(self):
+        self.calls = 0
+
+    async def initiate_connection(self, *, request):
+        self.calls += 1
+        return ConnectionResponse(
+            provider_connection_id="acc_new",
+            redirect_url="https://composio/redirect/new",
+            connection_data={
+                "connected_account_id": "acc_new",
+                "auth_config_id": "ac_new",
+                "redirect_url": "https://composio/redirect/new",
+            },
+        )
+
+
+class _Dao:
+    def __init__(self, rows: list[Connection], *, update_returns_row: bool = True):
+        self.rows = rows
+        self.created: list[ConnectionCreate] = []
+        self.updated: list[dict] = []
+        self.update_returns_row = update_returns_row
+
+    async def query_connections(self, **_kwargs):
+        return self.rows
+
+    async def create_connection(self, *, project_id, user_id, connection_create):
+        self.created.append(connection_create)
+        return connection_create
+
+    async def update_connection(self, *, project_id, connection_id, **kwargs):
+        self.updated.append({"connection_id": connection_id, **kwargs})
+        if not self.update_returns_row:
+            return None
+        row = next(r for r in self.rows if r.id == connection_id)
+        merged = {**(row.data or {}), **(kwargs.get("data_update") or {})}
+        return row.model_copy(update={"data": merged})
+
+
+class _FakeEnv:
+    class agenta:
+        crypt_key = "x" * 32
+        api_url = "http://test"
+
+
+def _row(*, slug="telegram-main", is_active=True, is_valid=False) -> Connection:
+    return Connection(
+        id=uuid4(),
+        slug=slug,
+        provider_key=ConnectionProviderKind.COMPOSIO,
+        integration_key="telegram",
+        data={
+            "connected_account_id": "acc_old",
+            "redirect_url": "https://composio/redirect/old",
+            "project_id": str(uuid4()),
+        },
+        flags={"is_active": is_active, "is_valid": is_valid},
+    )
+
+
+def _service(monkeypatch, dao: _Dao, adapter: _Adapter) -> ConnectionsService:
+    service = object.__new__(ConnectionsService)
+    service.connections_dao = dao
+
+    class _Registry:
+        def get(self, _key):
+            return adapter
+
+    service.adapter_registry = _Registry()
+    monkeypatch.setattr(connections_service_mod, "env", _FakeEnv)
+    monkeypatch.setattr(
+        connections_service_mod, "make_oauth_state", lambda **_: "state"
+    )
+    return service
+
+
+def _create(slug="telegram-main") -> ConnectionCreate:
+    return ConnectionCreate(
+        slug=slug,
+        provider_key=ConnectionProviderKind.COMPOSIO,
+        integration_key="telegram",
+    )
+
+
+async def test_stranded_row_resumes_in_place(monkeypatch):
+    row = _row()
+    dao = _Dao([row])
+    adapter = _Adapter()
+    service = _service(monkeypatch, dao, adapter)
+
+    result = await service.initiate_connection(
+        project_id=uuid4(), user_id=uuid4(), connection_create=_create()
+    )
+
+    assert dao.created == []  # no second row for the same slug
+    assert len(dao.updated) == 1
+    assert dao.updated[0]["connection_id"] == row.id
+    assert dao.updated[0]["is_active"] is True
+    assert dao.updated[0]["is_valid"] is False  # still pending its callback
+    # The caller drives the FRESH redirect; the previous attempt's dead link must not survive.
+    assert result.data["redirect_url"] == "https://composio/redirect/new"
+    assert result.data["connected_account_id"] == "acc_new"
+
+
+async def test_a_valid_row_is_left_alone_so_the_slug_conflict_still_fires(monkeypatch):
+    """A usable connection under that slug is real — Settings needs the 409 to name a second
+    account, and discovery ladders past it rather than sending anyone here."""
+    dao = _Dao([_row(is_valid=True)])
+    adapter = _Adapter()
+    service = _service(monkeypatch, dao, adapter)
+
+    await service.initiate_connection(
+        project_id=uuid4(), user_id=uuid4(), connection_create=_create()
+    )
+
+    assert dao.updated == []
+    assert len(dao.created) == 1
+
+
+async def test_an_inactive_row_is_not_revived(monkeypatch):
+    """It was switched off deliberately; refresh_connection refuses these too."""
+    dao = _Dao([_row(is_active=False)])
+    adapter = _Adapter()
+    service = _service(monkeypatch, dao, adapter)
+
+    await service.initiate_connection(
+        project_id=uuid4(), user_id=uuid4(), connection_create=_create()
+    )
+
+    assert dao.updated == []
+    assert len(dao.created) == 1
+
+
+async def test_a_different_slug_still_creates(monkeypatch):
+    """Resuming is per-slug: a second account under a new slug is an ordinary create."""
+    dao = _Dao([_row()])
+    adapter = _Adapter()
+    service = _service(monkeypatch, dao, adapter)
+
+    await service.initiate_connection(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        connection_create=_create(slug="telegram-second"),
+    )
+
+    assert dao.updated == []
+    assert len(dao.created) == 1
+
+
+async def test_a_lost_row_is_reported_not_returned_without_a_redirect(monkeypatch):
+    """update_connection swallows its errors and returns None. Returning the stale row would
+    hand the caller a connection with no redirect_url, which reads as 'no flow needed'."""
+    dao = _Dao([_row()], update_returns_row=False)
+    adapter = _Adapter()
+    service = _service(monkeypatch, dao, adapter)
+
+    with pytest.raises(ConnectionNotFoundError):
+        await service.initiate_connection(
+            project_id=uuid4(), user_id=uuid4(), connection_create=_create()
+        )

--- a/api/oss/tests/pytest/unit/tools/test_discovery.py
+++ b/api/oss/tests/pytest/unit/tools/test_discovery.py
@@ -397,6 +397,55 @@ async def test_connection_state_ready_needs_auth_needs_input(monkeypatch):
     assert needs_input.connect is not None
 
 
+async def test_connection_state_proposes_the_stranded_slug_so_it_resumes(monkeypatch):
+    """Issue #5911: a row stuck mid-handshake used to be skipped, so the agent was handed
+    ``telegram-main-2`` and the stranded row could never be repaired. ``initiate_connection``
+    now re-drives an active-but-invalid row, so its slug is proposed again."""
+    service = _service_with(
+        monkeypatch,
+        connections_by_integration={
+            "telegram": [
+                _fake_connection(slug="telegram-main", is_valid=False),
+            ],
+        },
+        auth_schemes={"telegram": [ToolAuthScheme.API_KEY]},
+    )
+
+    requirement = await service._discovery_connection_state(
+        project_id=uuid4(), provider_key="composio", integration_key="telegram"
+    )
+
+    assert requirement.state == ToolConnectionState.NEEDS_INPUT
+    assert requirement.connect.body["connection"]["slug"] == "telegram-main"
+
+
+async def test_connection_state_still_ladders_past_rows_that_cannot_resume(monkeypatch):
+    """A valid row is a real connection and an inactive one was switched off deliberately;
+    both keep the unique-slug conflict, so a second account still needs a fresh slug."""
+    service = _service_with(
+        monkeypatch,
+        connections_by_integration={
+            # Valid, but no provider account -> not ready, and not resumable either.
+            "slack": [_fake_connection(slug="slack-main", provider_id=None)],
+            "notion": [_fake_connection(slug="notion-main", is_active=False)],
+        },
+        auth_schemes={
+            "slack": [ToolAuthScheme.OAUTH],
+            "notion": [ToolAuthScheme.OAUTH],
+        },
+    )
+
+    slack = await service._discovery_connection_state(
+        project_id=uuid4(), provider_key="composio", integration_key="slack"
+    )
+    assert slack.connect.body["connection"]["slug"] == "slack-main-2"
+
+    notion = await service._discovery_connection_state(
+        project_id=uuid4(), provider_key="composio", integration_key="notion"
+    )
+    assert notion.connect.body["connection"]["slug"] == "notion-main-2"
+
+
 async def test_discover_capabilities_end_to_end(monkeypatch):
     service = _service_with(
         monkeypatch,

--- a/api/oss/tests/pytest/unit/tools/test_no_auth_connection.py
+++ b/api/oss/tests/pytest/unit/tools/test_no_auth_connection.py
@@ -241,6 +241,10 @@ async def _capture_created_flags(
             return _Adapter()
 
     class _Dao:
+        # initiate_connection reads before it writes, to resume an unfinished row.
+        async def query_connections(self, **_kwargs):
+            return []
+
         async def create_connection(self, *, project_id, user_id, connection_create):
             captured["flags"] = dict(connection_create.flags or {})
             captured["data"] = dict(connection_create.data or {})

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/ConnectToolWidget.tsx
@@ -39,7 +39,9 @@ const KNOWN_CONNECT_REASONS = new Set(["declined", "cancelled", "timeout"])
 
 const ConnectToolWidget = ({meta, settle}: ClientToolHandlerProps) => {
     const {label, phase, errorText, outcome, manuallyConnected, modeResolving, runConnect, cancel} =
-        useConnectFlow(meta, settle)
+        // `active: false` — this row is a passive marker; the InteractionDock owns the live
+        // parked call, so only that instance may settle it (including the reuse auto-settle).
+        useConnectFlow(meta, settle, false)
 
     // A runner-deferred sibling settles as an error carrying the deferral sentinel (not a real
     // connection failure); see DEFERRED_SENTINEL.

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.reuse.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.reuse.test.tsx
@@ -1,0 +1,176 @@
+/**
+ * Issue #5911: the agent asked to connect a provider the project had already connected, and the
+ * flow offered Connect anyway — nothing ever looked at what the project holds.
+ *
+ * Two behaviours are pinned here. A still-parked call settles against an existing usable
+ * connection without attempting a create, and only on the ACTIVE instance — the dock and the
+ * inline marker both mount this hook for the same call, so an automatic settle on both would be
+ * the double-`addToolOutput` the module contract forbids. And a call that settled as a false
+ * failure (the OAuth callback lands server-side even when the popup never posts back) stops
+ * reading as failed, without repainting cards rehydrated from an older transcript.
+ */
+import {act} from "react"
+
+import type {ClientToolMeta, SettleClientTool} from "@agenta/chat/skin"
+import {createRoot, type Root} from "react-dom/client"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+import {useConnectFlow} from "./useConnectFlow"
+
+const handleCreate = vi.fn()
+const connectionsRef = {current: [] as {slug: string; flags: Record<string, boolean>}[]}
+
+// `vi.mock` is hoisted above the imports; the factories read the refs above only when called.
+vi.mock("@agenta/entities/gatewayTool", () => ({
+    useToolIntegrationDetail: () => ({integration: {auth_schemes: ["api_key"]}, isLoading: false}),
+    useToolIntegrationConnections: () => ({connections: connectionsRef.current, isLoading: false}),
+    isConnectionActive: (c: {flags?: Record<string, boolean>}) => !!c.flags?.is_active,
+    isConnectionValid: (c: {flags?: Record<string, boolean>}) => !!c.flags?.is_valid,
+}))
+
+vi.mock("@agenta/settings-ui", () => ({
+    useToolsConnections: () => ({handleCreate, invalidate: vi.fn()}),
+}))
+
+vi.mock("@/oss/lib/helpers/api", () => ({
+    getAgentaApiUrl: () => "https://api.example.test",
+}))
+
+const READY = {slug: "telegram-main", flags: {is_active: true, is_valid: true}}
+const STRANDED = {slug: "telegram-main", flags: {is_active: true, is_valid: false}}
+
+const meta = (over: Partial<ClientToolMeta> = {}): ClientToolMeta =>
+    ({
+        toolCallId: "call-1",
+        toolName: "request_connection",
+        renderKind: "connect",
+        state: "input-available",
+        // The slug the ladder handed the agent — NOT the one the project actually holds.
+        input: {integration: "telegram", slug: "telegram-main-2", mode: "api_key"},
+        output: undefined,
+        settled: false,
+        part: {},
+        ...over,
+    }) as ClientToolMeta
+
+let container: HTMLDivElement
+let root: Root
+let latest: ReturnType<typeof useConnectFlow>
+
+const Harness = ({
+    meta: m,
+    settle,
+    active,
+}: {
+    meta: ClientToolMeta
+    settle: SettleClientTool
+    active: boolean
+}) => {
+    latest = useConnectFlow(m, settle, active)
+    return null
+}
+
+const render = async (m: ClientToolMeta, settle: SettleClientTool, active = true) => {
+    await act(async () => {
+        root.render(<Harness meta={m} settle={settle} active={active} />)
+    })
+}
+
+beforeEach(() => {
+    ;(globalThis as {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+    connectionsRef.current = []
+})
+
+afterEach(async () => {
+    await act(async () => {
+        root.unmount()
+    })
+    container.remove()
+    vi.clearAllMocks()
+})
+
+describe("useConnectFlow — reuse the project's existing connection", () => {
+    it("settles a parked call against the existing row, and never calls create", async () => {
+        connectionsRef.current = [READY]
+        const settle = vi.fn()
+        await render(meta(), settle)
+
+        expect(handleCreate).not.toHaveBeenCalled()
+        expect(settle).toHaveBeenCalledTimes(1)
+        // The EXISTING slug, not the `-2` the agent was handed: that reference is what the
+        // runner re-resolves on the next turn.
+        expect(settle.mock.calls[0][0]).toMatchObject({
+            output: {connected: true, integration: "telegram", slug: "telegram-main"},
+        })
+    })
+
+    it("stays silent on the inactive instance, so the two mounted flows can't both settle", async () => {
+        connectionsRef.current = [READY]
+        const settle = vi.fn()
+        await render(meta(), settle, false)
+
+        expect(settle).not.toHaveBeenCalled()
+    })
+
+    it("still needs a real connect when the only row is stranded mid-handshake", async () => {
+        connectionsRef.current = [STRANDED]
+        const settle = vi.fn()
+        await render(meta(), settle)
+
+        expect(settle).not.toHaveBeenCalled()
+    })
+
+    it("leaves a runner-deferred sibling alone — it arrives already settled and the agent re-asks", async () => {
+        connectionsRef.current = [READY]
+        const settle = vi.fn()
+        await render(meta({state: "output-error", settled: true}), settle)
+
+        expect(settle).not.toHaveBeenCalled()
+    })
+
+    it("waits for a complete input — a partial `input-streaming` call has no integration yet", async () => {
+        connectionsRef.current = [READY]
+        const settle = vi.fn()
+        await render(meta({state: "input-streaming"}), settle)
+
+        expect(settle).not.toHaveBeenCalled()
+    })
+})
+
+describe("useConnectFlow — a connection that actually succeeded stops reading as failed", () => {
+    it("corrects the chip once the requery finds the connection the popup never reported", async () => {
+        // The inline marker: parked, nothing usable yet.
+        connectionsRef.current = [STRANDED]
+        const settle = vi.fn()
+        await render(meta(), settle, false)
+        expect(latest.manuallyConnected).toBe(false)
+
+        // The dock settles it as a timeout, and the callback turns out to have landed anyway.
+        connectionsRef.current = [READY]
+        await render(meta({settled: true, output: {reason: "timeout"}}), settle, false)
+
+        expect(latest.manuallyConnected).toBe(true)
+    })
+
+    it("leaves an explicit 'Not now' standing — a decision, not a mishap", async () => {
+        connectionsRef.current = [STRANDED]
+        const settle = vi.fn()
+        await render(meta(), settle, false)
+
+        connectionsRef.current = [READY]
+        await render(meta({settled: true, output: {reason: "declined"}}), settle, false)
+
+        expect(latest.manuallyConnected).toBe(false)
+    })
+
+    it("leaves a card rehydrated from the transcript alone — that attempt's result is history", async () => {
+        connectionsRef.current = [READY]
+        const settle = vi.fn()
+        await render(meta({settled: true, output: {reason: "timeout"}}), settle, false)
+
+        expect(latest.manuallyConnected).toBe(false)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.test.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.test.ts
@@ -8,10 +8,12 @@
  * error surfaced anywhere — see the ConnectToolWidget KNOWN_CONNECT_REASONS branch this
  * message feeds).
  */
+import type {ToolConnection} from "@agenta/entities/gatewayTool"
 import {describe, expect, it} from "vitest"
 
 import {
     extractConnectErrorMessage,
+    findReusableConnection,
     isConnectModeResolving,
     resolveConnectMode,
 } from "./useConnectFlow"
@@ -100,5 +102,43 @@ describe("extractConnectErrorMessage", () => {
             "Connection failed. Please try again.",
         )
         expect(extractConnectErrorMessage(null)).toBe("Connection failed. Please try again.")
+    })
+})
+
+describe("findReusableConnection", () => {
+    const conn = (slug: string, flags: Record<string, boolean>) =>
+        ({slug, flags}) as unknown as ToolConnection
+
+    it("issue #5911: picks the project's usable connection so the agent stops asking for one it has", () => {
+        expect(
+            findReusableConnection([conn("telegram-main", {is_active: true, is_valid: true})])
+                ?.slug,
+        ).toBe("telegram-main")
+    })
+
+    it("skips a stranded row — active but never finished its handshake, so the server would reject it at invoke time", () => {
+        expect(
+            findReusableConnection([conn("telegram-main", {is_active: true, is_valid: false})]),
+        ).toBeNull()
+    })
+
+    it("skips a row switched off, even a valid one", () => {
+        expect(
+            findReusableConnection([conn("telegram-main", {is_active: false, is_valid: true})]),
+        ).toBeNull()
+    })
+
+    it("picks the usable row out of a mixed list rather than the first one", () => {
+        expect(
+            findReusableConnection([
+                conn("telegram-main", {is_active: true, is_valid: false}),
+                conn("telegram-main-2", {is_active: true, is_valid: true}),
+            ])?.slug,
+        ).toBe("telegram-main-2")
+    })
+
+    it("reports nothing for an empty or missing list", () => {
+        expect(findReusableConnection([])).toBeNull()
+        expect(findReusableConnection(undefined)).toBeNull()
     })
 })

--- a/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.ts
+++ b/web/oss/src/components/AgentChatSlice/components/clientTools/useConnectFlow.ts
@@ -16,6 +16,11 @@
  * message with the connection's `slug`/`integration`, so when several connect flows are live at
  * once each settles only on its OWN completion (never on a sibling's).
  *
+ * Reuse comes first (#5911): when the project already holds a usable connection for the
+ * integration, the parked call settles against THAT row and no create is attempted — the agent
+ * can ask to connect something it already has, and discovery is not always right about it. Only
+ * the ACTIVE instance does this, so the two mounted flows can't both settle the same call.
+ *
  * Settle on every terminal path (design §"Settle on every path"), so the run never hangs:
  *   success → {connected:true, integration, slug} · decline → {connected:false, reason:"declined"}
  *   · cancel/abandon → {connected:false, reason:"cancelled"} · timeout → {connected:false,
@@ -28,7 +33,13 @@
 import {useCallback, useEffect, useRef, useState} from "react"
 
 import type {ClientToolMeta, SettleClientTool} from "@agenta/chat/skin"
-import {useToolIntegrationDetail} from "@agenta/entities/gatewayTool"
+import {
+    isConnectionActive,
+    isConnectionValid,
+    useToolIntegrationConnections,
+    useToolIntegrationDetail,
+    type ToolConnection,
+} from "@agenta/entities/gatewayTool"
 import {useToolsConnections} from "@agenta/settings-ui"
 
 import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
@@ -112,6 +123,16 @@ export const extractConnectErrorMessage = (err: unknown): string => {
     return "Connection failed. Please try again."
 }
 
+/**
+ * The project's usable connection for this integration, if it already has one. Active AND valid
+ * mirrors what the server accepts at invoke time (`resolve_connection_by_slug`), so reusing one
+ * here can't hand the agent a reference that fails to resolve on the next turn.
+ */
+export const findReusableConnection = (
+    connections: ToolConnection[] | undefined,
+): ToolConnection | null =>
+    connections?.find((c) => isConnectionActive(c) && isConnectionValid(c)) ?? null
+
 /** Read the API origin the OAuth callback page posts from; null if it can't be resolved. */
 const agentaApiOrigin = (): string | null => {
     try {
@@ -160,6 +181,11 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     // mode: `modeResolving`/`modeResolvingRef` gate it shut until the lookup settles.
     const {integration: integrationDetail, isLoading: integrationDetailLoading} =
         useToolIntegrationDetail(integration)
+    // What the project already holds for this integration. The agent can ask to connect one it
+    // has, and the OAuth callback can land without this flow hearing about it, so both the parked
+    // call and the settled chip are answered from here rather than from a create attempt.
+    const {connections, isLoading: connectionsLoading} = useToolIntegrationConnections(integration)
+    const reusable = findReusableConnection(connections)
     // Bounded: a stuck/never-resolving lookup (dead network, an endpoint outage) must NOT
     // permanently disable Connect — past this bound, fall back to the agent's hinted mode same
     // as `resolveConnectMode` already does for "no schemes reported" (a wrong-but-triable guess
@@ -167,16 +193,18 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     // `isConnectModeResolving`'s own bail-outs), so it never fires needlessly.
     const [modeResolveTimedOut, setModeResolveTimedOut] = useState(false)
     useEffect(() => {
-        if (!integration || !integrationDetailLoading) {
+        if (!integration || !(integrationDetailLoading || connectionsLoading)) {
             setModeResolveTimedOut(false)
             return
         }
         const timer = window.setTimeout(() => setModeResolveTimedOut(true), MODE_RESOLVE_TIMEOUT_MS)
         return () => window.clearTimeout(timer)
-    }, [integration, integrationDetailLoading])
+    }, [integration, integrationDetailLoading, connectionsLoading])
+    // The connections lookup shares this gate: a click landing before it resolves would create a
+    // duplicate of a connection the project already has.
     const modeResolving = isConnectModeResolving({
         hasIntegrationKey: !!integration,
-        queryIsLoading: integrationDetailLoading,
+        queryIsLoading: integrationDetailLoading || connectionsLoading,
         timedOut: modeResolveTimedOut,
     })
     const modeResolvingRef = useRef(modeResolving)
@@ -206,6 +234,10 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     // One-shot guard so THIS instance settles the parked call at most once, plus shared cleanup for
     // the running popup's listener/poll/timeout. `meta.settled` covers the OTHER instance's settle.
     const settledRef = useRef(false)
+    // Whether the part arrived already settled. A card rehydrated from the transcript belongs to a
+    // past attempt, so the recovery below must not repaint it — only a settle that happened while
+    // this instance was mounted is this session's.
+    const settledAtMountRef = useRef(meta.settled)
     const activeRef = useRef(active)
     activeRef.current = active
     const popupRef = useRef<Window | null>(null)
@@ -243,6 +275,35 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
         }
         return () => teardown()
     }, [active, teardown])
+
+    // Reuse before create. Settling with the EXISTING slug is the point: that reference is what
+    // the runner re-resolves, so the agent binds the connection the project already has instead
+    // of asking for one it does not need. Gated on `active` because two instances mount for the
+    // same call (dock + inline marker) and only the live one may settle it.
+    useEffect(() => {
+        if (!active || !reusable || phase === "connecting") return
+        if (settledRef.current || meta.settled) return
+        // `input-streaming` can still carry a partial input whose `integration` is empty, and a
+        // settled sibling arrives as `output-error`; only a genuinely parked call may settle here.
+        if (meta.state !== "input-available") return
+        finish({connected: true, integration, slug: reusable.slug ?? slug})
+    }, [active, reusable, phase, meta.settled, meta.state, integration, slug, finish])
+
+    // The OAuth callback activates the row server-side keyed on the connected account, independent
+    // of the `tools:oauth:complete` message this flow waits on. So an auth that actually succeeded
+    // can settle as "cancelled"/"timeout" and paint a failure. Once the requery sees the
+    // connection, correct the chip — the settled call can't be re-resolved, but the agent's re-ask
+    // now resolves against this row. Runs on the INLINE instance too, since that is what renders
+    // the settled chip; `settledAtMountRef` is what keeps it off old transcripts.
+    useEffect(() => {
+        if (!reusable || manuallyConnected || settledAtMountRef.current) return
+        if (!meta.settled && !settledRef.current) return
+        const output = (meta.output ?? {}) as ConnectOutput
+        if (output.connected === true || outcome?.connected) return
+        // "Not now" is a decision, not a mishap: leave the user's refusal standing.
+        if ((outcome?.reason ?? output.reason) === "declined") return
+        setManuallyConnected(true)
+    }, [reusable, manuallyConnected, meta.settled, meta.output, outcome])
 
     /**
      * Run the Agenta OAuth flow: create the connection, open the popup, and watch its three terminal
@@ -334,8 +395,10 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
 
                 const poll = window.setInterval(() => {
                     if (!popupRef.current?.closed || succeeded) return
-                    // Abandon: closed without a success message.
+                    // Abandon: closed without a success message. The callback may still have
+                    // landed server-side, so requery before giving up (see the recovery effect).
                     teardown()
+                    invalidate()
                     if (settleParkedCall && !activeRef.current) return
                     if (settleParkedCall)
                         finish({connected: false, integration, slug, reason: "cancelled"})
@@ -345,6 +408,7 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
                 const timeout = window.setTimeout(() => {
                     if (succeeded) return
                     teardown()
+                    invalidate()
                     if (settleParkedCall && !activeRef.current) return
                     if (settleParkedCall)
                         finish({connected: false, integration, slug, reason: "timeout"})
@@ -389,10 +453,12 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     // call is already settled — a manual retry — just stop).
     const cancel = useCallback(() => {
         teardown()
+        // Same as the abandon poll: the auth may have completed before the click.
+        invalidate()
         if (!settledRef.current && !meta.settled)
             finish({connected: false, integration, slug, reason: "cancelled"})
         else setPhase("idle")
-    }, [finish, teardown, integration, slug, meta.settled])
+    }, [finish, teardown, invalidate, integration, slug, meta.settled])
 
     // The user's "Not now": a structured refusal (NOT an error), so the run resumes and the agent
     // can respond gracefully / offer an alternative. Distinct from "cancelled" (abandoned popup) so


### PR DESCRIPTION
## Context

A user connected Telegram, and the agent asked them to connect it again. It requested `telegram-main-2`, then `telegram`, while the working `telegram-main` sat unused ([#5911](https://github.com/Agenta-AI/agenta/issues/5911)).

The `-2` came from the server, not the model. A connection is written `is_valid: false` and only the provider's OAuth callback ever flips it. When that callback does not land, the row is stranded: discovery reports the integration as not-ready, and `_discovery_connection_state` walks the project's existing slugs to mint one that is free. Every later ask produced another row, and the original stayed unusable forever, because nothing could re-drive it. Re-creating the same slug hit the unique constraint and 409'd instead.

The connect flow made this worse from the other side. It never looked at what the project already held, so it discovered duplicates only from the 409 that came back after the user clicked Connect.

## Changes

`ConnectionsService.initiate_connection` now resolves the row for `(project, provider, integration, slug)` before it calls the provider, and re-drives an active-but-invalid one in place.

Before, a second request for a stranded slug:

```
POST /tools/connections/  {slug: "telegram-main"}
  -> Composio: create auth config + connected account
  -> INSERT -> 409, provider-side state orphaned
```

After:

```
POST /tools/connections/  {slug: "telegram-main"}
  -> row found, active, is_valid: false
  -> Composio: create auth config + connected account
  -> UPDATE that row (fresh redirect_url) -> caller drives the popup
```

A valid row and an inactive row are untouched and still raise the conflict. The first is a real connection, and Settings needs that feedback to name a second account. The second was switched off deliberately, and `refresh_connection` already refuses to revive one.

Because a stranded slug can now be resumed, the ladders in `tools/service.py` and `triggers/service.py` skip only the slugs the unique constraint would actually reject. A stranded `telegram-main` gets proposed again. A working one still ladders to `telegram-main-2`, so second accounts keep working.

On the frontend, `useConnectFlow` reads the project's connections. A parked call settles against an existing usable row and returns *that* row's slug, which is the reference the runner re-resolves, so the agent binds the connection the project already has. Separately, the OAuth callback activates the row server-side even when the popup never posts its `tools:oauth:complete` message back, so a connect that really succeeded could settle as `cancelled` or `timeout` and paint a failure. The abandon, timeout, and cancel paths now invalidate the connections query, and a card whose failure settled while it was mounted repaints as connected once the requery sees the row.

Two instances of the hook mount per call (the `InteractionDock` and the inline transcript marker), so both settles are scoped to avoid a double `addToolOutput`. The reuse settle is gated on `active`, and the inline marker now passes `active: false` to match what it already is. The repaint is gated on a mount-time snapshot of `meta.settled`, so cards rehydrated from an older transcript keep their recorded result.

## Tests / notes

- `api/oss/tests/pytest/unit/tools/test_connection_resume.py` is new: a stranded row updates in place with no insert, a valid row and an inactive row still conflict, a different slug still creates, and a lost row raises rather than returning a connection with no `redirect_url`.
- Discovery cases in `test_discovery.py` pin both ladder outcomes.
- `useConnectFlow.reuse.test.tsx` is new and covers the reuse settle, the `active` gate, the `input-streaming` guard, and the three repaint cases.
- Full API unit suite green (2533 passed). `pnpm lint-fix` and `tsc --noEmit` clean.
- Not fixed here, and worth a look during review: if a superseded popup is completed *after* the replacement flow finishes, its callback carries the old `connected_account_id`, matches no row, and shows a stray "could not be activated" card. The connection is already valid by then. The fixes I considered would mark rows valid against unauthorized accounts, which is worse.

## What to QA

- Start a Telegram connect and close the popup before it finishes. Confirm in `gateway_connections` that the row is `is_active: true, is_valid: false`. Then ask an agent for something that needs Telegram. It must resume `telegram-main`, with no `telegram-main-2` and no second row.
- With a working Telegram connection, start a fresh agent session and ask for something that needs it. The connect card reads "Telegram connected" with no click, and the agent binds `telegram-main`.
- Finish the auth on the provider page, then close the popup before it posts back. The card reads connected, not "Connection not completed".
- Regression: in Settings, Tools, connect a second account for an integration you already have. It still creates a new connection, and re-using an existing valid slug still reports that the connection already exists.
- Regression: click "Not now" on a connect card for an integration that is already connected. The card stays declined and does not flip to connected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
