### PR TITLE
chore: drop Soon badge from Codex on marketing site

### DIFF
--- a/website/src/components/OpenStandards.astro
+++ b/website/src/components/OpenStandards.astro
@@ -78,7 +78,7 @@ const rows: Row[] = [
     chips: [
       { name: "Claude Code", logo: local("anthropic"), href: "https://claude.com/claude-code" },
       { name: "pi.dev", logo: local("pidev"), href: "https://pi.dev" },
-      { name: "Codex", soon: true, logo: local("openai"), href: "https://openai.com/codex" },
+      { name: "Codex", soon: false, logo: local("openai"), href: "https://openai.com/codex" },
       { name: "OpenCode", soon: true, logo: local("opencode"), href: "https://opencode.ai" },
       { name: "Hermes", soon: true, logo: local("hermes") },
     ],

--- a/website/src/components/TemplateExplorer.tsx
+++ b/website/src/components/TemplateExplorer.tsx
@@ -31,7 +31,7 @@ const LOGO: Record<string, string> = {
 type Harness = { name: string; logo: string | null; soon?: boolean };
 const HARNESSES: Harness[] = [
   { name: "Claude Code", logo: "/logos/tools/anthropic.svg" },
-  { name: "Codex", logo: "/logos/tools/openai.svg", soon: true },
+  { name: "Codex", logo: "/logos/tools/openai.svg", soon: false },
   { name: "pi.dev", logo: "/logos/tools/pidev.svg" },
 ];
 


### PR DESCRIPTION
## Summary
The marketing site marked Codex as "Soon" in two places, so visitors read it as unavailable rather than something they can use now. This PR drops the badge and lets Codex render like Claude Code and pi.dev.

Changed `soon: true` to `soon: false` on the Codex entry in:
- `website/src/components/TemplateExplorer.tsx` (HARNESSES row on the homepage templates section)
- `website/src/components/OpenStandards.astro` (open-standards marquee)

Only Codex was changed, OpenCode and Hermes keep their "Soon" badges in `OpenStandards.astro`.

FIxes #6149 

## Testing
### Verified locally
Ran the website locally with `pnpm dev` and confirmed:
- The Codex chip in the HARNESS row (homepage templates section) no longer shows the "Soon" badge, and renders identically to Claude Code and pi.dev.
- The Codex chip in the open-standards marquee no longer shows the "Soon" badge and is no longer dimmed or sorted after the other chips.
- OpenCode and Hermes chips are unaffected and still show their "Soon" badge.

### Added or updated tests
N/A — this is a static content/config change (boolean flag flip), no logic to test.

### QA follow-up
N/A

## Demo
<img width="1440" height="864" alt="Screenshot 2026-08-21 at 3 06 55 PM" src="https://github.com/user-attachments/assets/042520ae-9e8c-4697-beb3-3b2ea92508f4" />

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me