### PR TITLE
ci(website): Allow approved previews for fork PRs

### DIFF
--- a/.github/workflows/15-website-preview-deploy.yml
+++ b/.github/workflows/15-website-preview-deploy.yml
@@ -1,0 +1,410 @@
+name: "15 - website preview deploy"
+
+on:
+  # Internal branches keep their automatic preview. Forks stop after the
+  # secretless build until a maintainer approves the exact head SHA.
+  workflow_run:
+    workflows: ["15 - website preview"]
+    types: [completed]
+  issue_comment:
+    types: [created]
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "Pull request number"
+        required: true
+        type: string
+      head_sha:
+        description: "Reviewed pull request head SHA (full or 7+ character prefix)"
+        required: true
+        type: string
+
+# This workflow has credentials, so it runs only trusted default-branch code.
+# It treats the downloaded website as untrusted static data and never executes it.
+permissions:
+  actions: read
+  contents: read
+  issues: write
+  pull-requests: write
+
+concurrency:
+  group: website-preview-deploy-${{ github.event.issue.number || inputs.pr_number || github.event.workflow_run.pull_requests[0].number || github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+env:
+  WRANGLER_VERSION: "4.113.0"
+  R2_FONTS_BUCKET: agenta-brand-fonts
+
+jobs:
+  resolve:
+    name: Resolve approved preview artifact
+    if: >-
+      github.repository == 'Agenta-AI/agenta' &&
+      ((github.event_name == 'workflow_run' &&
+        github.event.workflow_run.event == 'pull_request' &&
+        github.event.workflow_run.conclusion == 'success') ||
+       (github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        startsWith(github.event.comment.body, '/preview')) ||
+       github.event_name == 'workflow_dispatch')
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    outputs:
+      approval_required: ${{ steps.resolve.outputs.approval_required }}
+      artifact_name: ${{ steps.resolve.outputs.artifact_name }}
+      head_sha: ${{ steps.resolve.outputs.head_sha }}
+      pr_number: ${{ steps.resolve.outputs.pr_number }}
+      run_id: ${{ steps.resolve.outputs.run_id }}
+      should_deploy: ${{ steps.resolve.outputs.should_deploy }}
+    steps:
+      - name: Resolve pull request, approval, and build run
+        id: resolve
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        with:
+          script: |
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const repository = `${owner}/${repo}`;
+            const buildWorkflow = '15-website-preview.yml';
+
+            async function getPullRequest(number) {
+              return (await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: number,
+              })).data;
+            }
+
+            async function requireMaintainer(username) {
+              const { data } = await github.rest.repos.getCollaboratorPermissionLevel({
+                owner,
+                repo,
+                username,
+              });
+              if (!['admin', 'maintain', 'write'].includes(data.permission)) {
+                core.setFailed(`@${username} does not have permission to approve previews.`);
+                return false;
+              }
+              return true;
+            }
+
+            async function findSuccessfulBuild(pr, headSha) {
+              const runs = await github.paginate(github.rest.actions.listWorkflowRuns, {
+                owner,
+                repo,
+                workflow_id: buildWorkflow,
+                event: 'pull_request',
+                head_sha: headSha,
+                per_page: 100,
+              });
+              return runs.find((run) =>
+                run.status === 'completed' &&
+                run.conclusion === 'success' &&
+                run.head_sha === headSha &&
+                run.head_branch === pr.head.ref &&
+                run.head_repository?.full_name === pr.head.repo?.full_name
+              );
+            }
+
+            async function findWorkflowRunPullRequest(run) {
+              const pullReference = (run.pull_requests || [])[0];
+              if (pullReference) {
+                return getPullRequest(pullReference.number);
+              }
+
+              // GitHub leaves workflow_run.pull_requests empty for public fork
+              // PRs. Resolve those from the immutable run owner + branch pair,
+              // then bind the result back to the run's exact head SHA.
+              const headOwner = run.head_repository?.owner?.login;
+              if (!headOwner || !run.head_branch) {
+                return null;
+              }
+              const candidates = await github.paginate(github.rest.pulls.list, {
+                owner,
+                repo,
+                state: 'open',
+                head: `${headOwner}:${run.head_branch}`,
+                per_page: 100,
+              });
+              return candidates.find((pull) =>
+                pull.head.sha === run.head_sha &&
+                pull.head.repo?.full_name === run.head_repository?.full_name
+              ) || null;
+            }
+
+            let approvalRequired = false;
+            let buildRun;
+            let headSha;
+            let pr;
+            let shouldDeploy = false;
+
+            if (context.eventName === 'workflow_run') {
+              buildRun = context.payload.workflow_run;
+              pr = await findWorkflowRunPullRequest(buildRun);
+              if (!pr) {
+                core.setFailed('The completed build is not associated with a pull request.');
+                return;
+              }
+
+              headSha = buildRun.head_sha;
+              if (pr.head.sha !== headSha) {
+                core.notice(`Skipping stale build ${headSha}; PR #${pr.number} is now ${pr.head.sha}.`);
+                return;
+              }
+
+              const internalBranch = pr.head.repo?.full_name === repository;
+              const trustedActor = buildRun.actor?.login !== 'dependabot[bot]';
+              shouldDeploy = internalBranch && trustedActor;
+              approvalRequired = !shouldDeploy;
+            } else {
+              if (!(await requireMaintainer(context.actor))) {
+                return;
+              }
+
+              let prNumber;
+              let requestedSha;
+              if (context.eventName === 'issue_comment') {
+                const match = context.payload.comment.body.trim().match(/^\/preview\s+([0-9a-f]{7,40})$/i);
+                if (!match) {
+                  core.setFailed('Use `/preview <head-sha>` with a 7 to 40 character commit SHA.');
+                  return;
+                }
+                prNumber = context.payload.issue.number;
+                requestedSha = match[1].toLowerCase();
+              } else {
+                prNumber = Number('${{ inputs.pr_number }}');
+                requestedSha = '${{ inputs.head_sha }}'.trim().toLowerCase();
+                if (!Number.isInteger(prNumber) || !/^[0-9a-f]{7,40}$/.test(requestedSha)) {
+                  core.setFailed('Provide a valid PR number and a 7 to 40 character head SHA.');
+                  return;
+                }
+              }
+
+              pr = await getPullRequest(prNumber);
+              headSha = pr.head.sha.toLowerCase();
+              if (!headSha.startsWith(requestedSha)) {
+                core.setFailed(`Reviewed SHA ${requestedSha} does not match current PR head ${headSha}.`);
+                return;
+              }
+
+              buildRun = await findSuccessfulBuild(pr, headSha);
+              if (!buildRun) {
+                core.setFailed(`No successful website preview build found for PR #${pr.number} at ${headSha}.`);
+                return;
+              }
+              shouldDeploy = true;
+            }
+
+            core.setOutput('approval_required', String(approvalRequired));
+            core.setOutput('artifact_name', `website-preview-${pr.number}-${headSha}`);
+            core.setOutput('head_sha', headSha);
+            core.setOutput('pr_number', String(pr.number));
+            core.setOutput('run_id', String(buildRun.id));
+            core.setOutput('should_deploy', String(shouldDeploy));
+
+  announce:
+    name: Request maintainer approval
+    needs: resolve
+    if: needs.resolve.outputs.approval_required == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Post approval instructions
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+        with:
+          script: |
+            const marker = '<!-- website-preview -->';
+            const prNumber = Number(process.env.PR_NUMBER);
+            const headSha = process.env.HEAD_SHA;
+            const body = [
+              marker,
+              '### Website preview',
+              '',
+              `A secretless build is ready for \`${headSha}\`.`,
+              '',
+              'A maintainer can deploy this exact artifact by commenting:',
+              '',
+              `\`/preview ${headSha}\``,
+              '',
+              'A new push requires a new approval.',
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }
+
+  deploy:
+    name: Deploy approved website preview
+    needs: resolve
+    if: needs.resolve.outputs.should_deploy == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Check out trusted deploy configuration
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          ref: ${{ github.event.repository.default_branch }}
+          persist-credentials: false
+
+      - name: Install Wrangler
+        run: npm install --global "wrangler@${WRANGLER_VERSION}"
+
+      - name: Download preview artifact
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: ${{ needs.resolve.outputs.artifact_name }}
+          path: ${{ runner.temp }}/website-preview
+          run-id: ${{ needs.resolve.outputs.run_id }}
+          github-token: ${{ github.token }}
+
+      - name: Validate and stage static artifact
+        env:
+          ARTIFACT_DIR: ${{ runner.temp }}/website-preview
+          DEPLOY_DIR: ${{ github.workspace }}/website/dist
+        run: |
+          set -euo pipefail
+
+          test -f "$ARTIFACT_DIR/index.html" || {
+            echo "::error::Preview artifact has no index.html"
+            exit 1
+          }
+
+          unexpected=$(find "$ARTIFACT_DIR" -mindepth 1 ! -type f ! -type d -print -quit)
+          test -z "$unexpected" || {
+            echo "::error::Preview artifact contains a non-regular entry: $unexpected"
+            exit 1
+          }
+
+          file_count=$(find "$ARTIFACT_DIR" -type f -printf '.' | wc -c)
+          total_bytes=$(find "$ARTIFACT_DIR" -type f -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }')
+          test "$file_count" -le 10000 || {
+            echo "::error::Preview artifact contains too many files: $file_count"
+            exit 1
+          }
+          test "$total_bytes" -le 157286400 || {
+            echo "::error::Preview artifact is too large: $total_bytes bytes"
+            exit 1
+          }
+
+          mkdir -p "$DEPLOY_DIR"
+          cp -R --no-preserve=mode,ownership "$ARTIFACT_DIR"/. "$DEPLOY_DIR"/
+
+      - name: Inject licensed fonts with trusted code
+        env:
+          R2_S3_ENDPOINT: ${{ secrets.R2_S3_ENDPOINT }}
+          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+        run: |
+          set -euo pipefail
+          node website/scripts/fetch-fonts.mjs
+          mkdir -p website/dist/fonts
+          for font in \
+            GT-Alpina-Light.woff2 \
+            GT-Alpina-Light-Italic.woff2 \
+            GT-Alpina-Regular.woff2 \
+            GT-Alpina-Regular-Italic.woff2 \
+            GT-Alpina-Medium.woff2 \
+            PPMondwest-Regular.woff2
+          do
+            test -s "website/public/fonts/$font" || {
+              echo "::error::Licensed preview font is missing: $font"
+              exit 1
+            }
+            install -m 0644 "website/public/fonts/$font" "website/dist/fonts/$font"
+          done
+
+      - name: Deploy preview version
+        id: deploy
+        working-directory: website
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+        run: |
+          set -euo pipefail
+          alias="pr-${PR_NUMBER}"
+          log_file="${RUNNER_TEMP}/wrangler.log"
+          wrangler versions upload --config wrangler.jsonc \
+            --preview-alias "$alias" 2>&1 | tee "$log_file"
+          url=$(grep -oiE 'Version Preview Alias URL: https://[a-z0-9.-]+\.workers\.dev' "$log_file" | sed 's/.*: //' | head -1)
+          if [ -z "$url" ]; then
+            echo "::error::Could not extract preview alias URL from Wrangler output"
+            exit 1
+          fi
+          echo "url=$url" >> "$GITHUB_OUTPUT"
+
+      - name: Verify preview serves the site
+        env:
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+        run: |
+          for attempt in 1 2 3 4 5; do
+            code=$(curl -sS -o /dev/null -w '%{http_code}' "$PREVIEW_URL/")
+            [ "$code" = "200" ] && exit 0
+            sleep 5
+          done
+          echo "::error::Preview URL did not return 200 (last code: $code)"
+          exit 1
+
+      - name: Comment preview URL
+        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b # v7
+        env:
+          HEAD_SHA: ${{ needs.resolve.outputs.head_sha }}
+          PREVIEW_URL: ${{ steps.deploy.outputs.url }}
+          PR_NUMBER: ${{ needs.resolve.outputs.pr_number }}
+        with:
+          script: |
+            const marker = '<!-- website-preview -->';
+            const prNumber = Number(process.env.PR_NUMBER);
+            const body = [
+              marker,
+              '### Website preview',
+              '',
+              `Preview URL: ${process.env.PREVIEW_URL}`,
+              '',
+              `Built from \`${process.env.HEAD_SHA}\`. This comment updates in place on every deployment.`,
+            ].join('\n');
+
+            const comments = await github.paginate(github.rest.issues.listComments, {
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: prNumber,
+              per_page: 100,
+            });
+            const existing = comments.find((comment) => comment.body?.includes(marker));
+            if (existing) {
+              await github.rest.issues.updateComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                comment_id: existing.id,
+                body,
+              });
+            } else {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: prNumber,
+                body,
+              });
+            }

--- a/.github/workflows/15-website-preview.yml
+++ b/.github/workflows/15-website-preview.yml
@@ -6,49 +6,37 @@ on:
     paths:
       - 'website/**'
       - '.github/workflows/15-website-preview.yml'
-  workflow_dispatch:
-    inputs:
-      pr_number:
-        description: "PR number to comment the preview URL on"
-        required: true
-        type: string
+      - '.github/workflows/15-website-preview-deploy.yml'
 
+# This workflow executes pull-request code. Keep it read-only and secretless so
+# GitHub can run it safely for fork PRs after the normal maintainer approval.
 permissions:
   contents: read
-  pull-requests: write
 
 concurrency:
-  group: website-preview-${{ github.event.pull_request.number || inputs.pr_number || github.ref_name }}
+  group: website-preview-build-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
-env:
-  WRANGLER_VERSION: "4.113.0"
-  R2_FONTS_BUCKET: agenta-brand-fonts
-
 jobs:
-  deploy:
-    name: Build and deploy preview
+  build:
+    name: Build website preview
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
-    # Fork PRs get no secrets: skip when the head repo is not this repo.
-    # Dependabot PRs run without repository secrets (GitHub policy), so the
-    # deploy could never succeed there; skip them cleanly instead of failing.
-    if: >-
-      github.event_name == 'workflow_dispatch' ||
-      (github.event.pull_request.head.repo.full_name == github.repository &&
-       !github.event.pull_request.draft &&
-       github.actor != 'dependabot[bot]')
-    env:
-      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+    timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6
+        with:
+          # Do not leave even the fork-safe, read-only token in git config for
+          # contributor-controlled install or build scripts to discover.
+          persist-credentials: false
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1 # v4
         with:
           package_json_file: website/package.json
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: 24
           cache: 'pnpm'
@@ -57,53 +45,28 @@ jobs:
       - name: Install dependencies
         run: cd website && pnpm install --frozen-lockfile
 
-      - name: Build site
+      - name: Build secretless preview artifact
         env:
-          R2_S3_ENDPOINT: ${{ secrets.R2_S3_ENDPOINT }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
-          # Preview deploys are public workers.dev URLs: keep them out of search
-          # indexes (noindex <meta> + disallow-all robots.txt) so they never rank
-          # as duplicate content against production. Production build (workflow 16)
-          # deliberately does NOT set this.
+          # Public preview URLs must not appear in search results. Licensed
+          # fonts are intentionally absent here and are injected later by the
+          # trusted deploy workflow.
           PUBLIC_NOINDEX: "true"
         run: cd website && pnpm run build
 
-      - name: Deploy preview version
-        id: deploy
-        env:
-          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
-          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+      - name: Enforce preview artifact limits
         run: |
-          cd website
-          alias="pr-${PR_NUMBER}"
-          pnpm dlx "wrangler@${WRANGLER_VERSION}" versions upload \
-            --preview-alias "$alias" 2>&1 | tee /tmp/wrangler.log
-          url=$(grep -oiE 'Version Preview Alias URL: https://[a-z0-9.-]+\.workers\.dev' /tmp/wrangler.log | sed 's/.*: //' | head -1)
-          if [ -z "$url" ]; then
-            echo "::error::Could not extract preview alias URL from wrangler output"
-            exit 1
-          fi
-          echo "url=$url" >> "$GITHUB_OUTPUT"
+          set -euo pipefail
+          test -f website/dist/index.html
+          file_count=$(find website/dist -type f -printf '.' | wc -c)
+          total_bytes=$(find website/dist -type f -printf '%s\n' | awk '{ total += $1 } END { print total + 0 }')
+          test "$file_count" -le 10000
+          test "$total_bytes" -le 157286400
 
-      - name: Verify preview serves the site
-        run: |
-          for i in 1 2 3 4 5; do
-            code=$(curl -s -o /dev/null -w '%{http_code}' "${{ steps.deploy.outputs.url }}/")
-            [ "$code" = "200" ] && exit 0
-            sleep 5
-          done
-          echo "::error::Preview URL did not return 200 (last code: $code)"
-          exit 1
-
-      - name: Comment preview URL
-        uses: marocchino/sticky-pull-request-comment@v2
+      - name: Upload static preview artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          header: website-preview
-          number: ${{ github.event.pull_request.number || inputs.pr_number }}
-          message: |
-            ### Website preview
-
-            Preview URL: ${{ steps.deploy.outputs.url }}
-
-            Built from `${{ github.event.pull_request.head.sha || github.sha }}`. This comment updates in place on every push.
+          name: website-preview-${{ github.event.pull_request.number }}-${{ github.event.pull_request.head.sha }}
+          path: website/dist
+          if-no-files-found: error
+          retention-days: 7
+          compression-level: 6

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -64,26 +64,38 @@ The rule: **proprietary/large assets live in the deployed output, never in git.*
 
 ## CI preview deploys
 
-Every PR that touches `website/**` gets an automatically deployed preview, via
-`.github/workflows/15-website-preview.yml`.
+Every non-draft PR that touches `website/**` gets a secretless static build through
+`.github/workflows/15-website-preview.yml`. The build has a read-only GitHub token,
+does not receive repository secrets, and uploads only `website/dist` as a seven-day
+artifact. This is the only workflow that checks out and executes pull-request code.
 
-- **How:** the workflow builds the site and runs `wrangler versions upload
-  --preview-alias pr-<number>` against the single `agenta-website-preview` worker.
-  This publishes a new *version* with its own shareable preview URL and does **not**
-  touch the worker's production deployment, so one worker serves every PR's preview
-  (no per-PR worker sprawl, no cleanup job). The stable alias makes the URL
-  deterministic per PR: `https://pr-<number>-agenta-website-preview.<subdomain>.workers.dev`.
-- **Where the URL appears:** a single sticky PR comment (header `website-preview`)
-  that updates in place on every push, so pushes never spam new comments.
-- **Secrets (GitHub Actions, referenced by name — never commit values):**
-  `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` for the deploy, and the four R2
-  vars (`R2_S3_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, and the
-  non-secret `R2_FONTS_BUCKET`, set inline in the workflow) so the licensed fonts are
-  fetched into the preview build. Without the R2 secrets the build still succeeds with
-  fallback fonts (see the asset-hosting section above).
-- **Fork PRs:** deployment is skipped for PRs from forks (the job guards on
-  `head.repo.full_name == github.repository`), so secrets are never exposed to
-  untrusted code. Fork PRs simply get no preview comment.
+`.github/workflows/15-website-preview-deploy.yml` is the trusted half of the flow. It
+runs from the default branch, downloads the static artifact, rejects special files and
+oversized artifacts, injects the licensed fonts with the trusted default-branch script,
+and uploads the files to Cloudflare. It never checks out or executes contributor code.
+
+- **Internal PRs:** a successful build deploys automatically, preserving the normal
+  contributor workflow.
+- **Fork and Dependabot PRs:** the workflow posts an approval request containing the
+  exact current head SHA. A maintainer with write access approves it by commenting
+  `/preview <head-sha>`. The deploy workflow verifies the commenter's repository
+  permission, the current PR head, and the successful build run before downloading
+  anything. Every new push requires a new SHA-specific approval. A maintainer can use
+  the deploy workflow's manual dispatch with the same PR number and reviewed SHA as a
+  backup.
+- **How:** the deployer runs `wrangler versions upload --preview-alias pr-<number>`
+  against the single `agenta-website-preview` worker. This publishes a new version with
+  its own shareable preview URL and does not touch the worker's production deployment,
+  so one worker serves every PR preview without per-PR cleanup. The stable alias makes
+  the URL deterministic: `https://pr-<number>-agenta-website-preview.<subdomain>.workers.dev`.
+- **Where the URL appears:** one sticky PR comment (`<!-- website-preview -->`) changes
+  from approval instructions to the deployed URL. New pushes update it in place.
+- **Secrets (GitHub Actions, referenced by name, never commit values):**
+  `CLOUDFLARE_API_TOKEN`, `CLOUDFLARE_ACCOUNT_ID` for the deploy, and
+  `R2_S3_ENDPOINT`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`, plus the non-secret
+  `R2_FONTS_BUCKET`. Only the trusted deploy workflow receives them. The secretless
+  build uses fallback fonts; the deployer adds the six licensed files directly to
+  `dist/fonts` before upload.
 
 ## CI production deploy
 


### PR DESCRIPTION
## Context

External contributors can open website pull requests, but the current preview job skips every fork because the build and Cloudflare deployment share one secret-bearing job. Approving the GitHub Actions run does not restore repository secrets, and giving those secrets to contributor-controlled install or build scripts would expose them.

For example, PR #6151 changed two website components but could not produce a preview. Its GitHub job was skipped and its Vercel status required contributor authorization.

## Changes

The website preview now has two trust levels.

The `pull_request` workflow checks out the PR with a read-only token, installs and builds without secrets, enforces artifact limits, and uploads only the generated `dist` directory. Internal PRs deploy automatically after that build.

Fork and Dependabot PRs instead receive one sticky approval comment. A maintainer deploys the reviewed artifact with `/preview <head-sha>`. The trusted default-branch workflow verifies the maintainer's repository permission, the current PR head, the source fork and branch, and the successful build run before it downloads anything. A new push changes the SHA and requires a new approval.

The privileged job never checks out or executes contributor code. It validates the static artifact, injects the six licensed fonts with the trusted default-branch script, deploys to the existing preview-only Cloudflare Worker, verifies HTTP 200, and updates the sticky comment with the preview URL. All actions in both workflows are pinned to immutable commit SHAs.

Before: fork PRs always ended with a skipped website preview job.

After: fork PRs build without secrets, then a maintainer can approve and deploy one exact commit.

## How to review

1. Read `.github/workflows/15-website-preview.yml` first. Confirm that PR code receives no repository secrets or write permissions and that the artifact contains only `website/dist`.
2. Read the resolver in `.github/workflows/15-website-preview-deploy.yml`. Check the maintainer permission gate, exact-SHA comparison, fork repository and branch binding, and stale-run rejection.
3. Read the deploy job. Confirm that it checks out only the default branch, treats the artifact as static data, validates its type and size, and injects credentials only into trusted steps.
4. Read `website/AGENTS.md` for the contributor and maintainer operating flow.

## Tests / notes

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.12 .github/workflows/15-website-preview.yml .github/workflows/15-website-preview-deploy.yml`
- `pnpm install --frozen-lockfile` in `website/`
- A no-secret `PUBLIC_NOINDEX=true pnpm run build` produced all 48 static pages with 230 files. The generated homepage contains `noindex, nofollow`, and `robots.txt` disallows all crawling.
- `git diff --check`
- `pnpm check` currently prompts to add undeclared `@astrojs/check` and `typescript` dependencies, so it cannot run without changing the website package. This PR does not change dependencies.

The trusted deploy workflow must exist on the default branch before GitHub will deliver `workflow_run` and `issue_comment` events to it. After merge, rerun PR #6151's website build, confirm the SHA-specific approval comment appears, then use its `/preview <head-sha>` command and verify the resulting URL.

Closes #6199
