### PR TITLE
feat(frontend): whole-toolkit mode for the agent tools drawer

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
@@ -66,6 +66,12 @@ interface ToolkitDraft {
 
 const DEFAULT_TOOLKIT_PERMISSION: ToolPermission = "ask"
 
+const newToolkitDraft = (): ToolkitDraft => ({
+    scope: "all",
+    actions: new Set<string>(),
+    permission: DEFAULT_TOOLKIT_PERMISSION,
+})
+
 const TOOLKIT_PERMISSION_OPTIONS = [
     {value: "allow", title: "Allow", help: "Every action runs without asking"},
     {value: "ask", title: "Ask", help: "A human approves each action call"},
@@ -256,25 +262,13 @@ function ToolCatalogContent({
         [],
     )
     const draftFor = useCallback(
-        (conn: ToolConnection): ToolkitDraft =>
-            drafts[connKey(conn)] ?? {
-                scope: "all",
-                actions: new Set<string>(),
-                permission: DEFAULT_TOOLKIT_PERMISSION,
-            },
+        (conn: ToolConnection): ToolkitDraft => drafts[connKey(conn)] ?? newToolkitDraft(),
         [drafts, connKey],
     )
     const updateDraft = useCallback(
         (conn: ToolConnection, patch: (draft: ToolkitDraft) => ToolkitDraft) => {
             const key = connKey(conn)
-            setDrafts((prev) => {
-                const current = prev[key] ?? {
-                    scope: "all" as ToolkitScope,
-                    actions: new Set<string>(),
-                    permission: DEFAULT_TOOLKIT_PERMISSION,
-                }
-                return {...prev, [key]: patch(current)}
-            })
+            setDrafts((prev) => ({...prev, [key]: patch(prev[key] ?? newToolkitDraft())}))
         },
         [connKey],
     )

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
@@ -29,17 +29,48 @@ import {
 } from "@agenta/entities/gatewayTool"
 import {message} from "@agenta/ui"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
-import {Button} from "@agenta/ui/ui"
-import {Plugs} from "@phosphor-icons/react"
+import {Button, Segmented} from "@agenta/ui/ui"
+import {Check, Plugs} from "@phosphor-icons/react"
 import {useSetAtom} from "jotai"
 
 import {CatalogChooser} from "../../../drawers/shared/CatalogChooser"
 import ConnectDrawer from "../../../gatewayTool/drawers/ConnectDrawer"
 import {useReconnectToolConnection} from "../../../gatewayTool/hooks/useReconnectToolConnection"
+import type {ToolPermission} from "../toolPermission"
 import type {ToolSelectionMeta} from "../ToolSelectorPopover"
-import {gatewayToolIdentity, type ToolObj} from "../toolUtils"
+import {
+    buildGatewayToolkit,
+    gatewayToolIdentity,
+    gatewayToolkitIdentity,
+    type ToolObj,
+} from "../toolUtils"
+
+import {PermissionPolicySelect} from "./PermissionPolicySelect"
 
 type CatalogIntegrationItem = ToolCatalogIntegration | ToolCatalogIntegrationDetails
+
+// The catalog offers two ways to add: per action (legacy, one tool per action) or the whole app
+// (one `gateway_toolkit` entry, resolved server-side into a search + execute meta-tool).
+type CatalogMode = "actions" | "toolkit"
+
+// When the whole app is picked, either every action is allowed, or a chosen subset.
+type ToolkitScope = "all" | "include"
+
+// Per-connection toolkit draft — the sub-scope, the chosen actions (subset), and the permission
+// default the entry carries. Keyed by connection id so switching accounts keeps each draft.
+interface ToolkitDraft {
+    scope: ToolkitScope
+    actions: Set<string>
+    permission: ToolPermission
+}
+
+const DEFAULT_TOOLKIT_PERMISSION: ToolPermission = "ask"
+
+const TOOLKIT_PERMISSION_OPTIONS = [
+    {value: "allow", title: "Allow", help: "Every action runs without asking"},
+    {value: "ask", title: "Ask", help: "A human approves each action call"},
+    {value: "deny", title: "Deny", help: "Every action call is refused"},
+]
 
 export interface AgentIntegrationDrawerProps {
     open: boolean
@@ -125,6 +156,85 @@ function useToolActionList(integrationKey: string) {
     }
 }
 
+/**
+ * ToolkitAddPanel — the connection-level "add the whole app" affordance, rendered inside the
+ * selected-connection detail (via {@link CatalogChooser}'s `renderConnectionExtra`). It writes ONE
+ * `gateway_toolkit` entry instead of one tool per action. When the scope is "Choose actions" the
+ * action list below doubles as the picker (each pick toggles the subset).
+ */
+function ToolkitAddPanel({
+    integrationName,
+    draft,
+    added,
+    onScopeChange,
+    onPermissionChange,
+    onAdd,
+    onRemove,
+}: {
+    integrationName: string
+    draft: ToolkitDraft
+    added: boolean
+    onScopeChange: (scope: ToolkitScope) => void
+    onPermissionChange: (permission: ToolPermission) => void
+    onAdd: () => void
+    onRemove: () => void
+}) {
+    const includeEmpty = draft.scope === "include" && draft.actions.size === 0
+    return (
+        <div className="ag-drawer-card mt-4 flex flex-col gap-2.5 rounded-lg border border-solid border-[var(--ag-colorBorder)] p-3">
+            <div className="flex items-center justify-between gap-2">
+                <span className="min-w-0 truncate text-xs font-medium">
+                    Add the whole {integrationName} app
+                </span>
+                {added && (
+                    <span className="inline-flex shrink-0 items-center gap-1 text-xs text-[var(--ag-colorSuccess)]">
+                        <Check size={12} /> Added
+                    </span>
+                )}
+            </div>
+            <Segmented
+                block
+                size="sm"
+                value={draft.scope}
+                onChange={(value) => onScopeChange(value as ToolkitScope)}
+                options={[
+                    {label: "All actions", value: "all"},
+                    {label: "Choose actions", value: "include"},
+                ]}
+            />
+            {draft.scope === "include" && (
+                <span className="text-xs text-[var(--ag-colorTextTertiary)]">
+                    {draft.actions.size > 0
+                        ? `${draft.actions.size} selected — tap actions in the list below to change.`
+                        : "Pick the allowed actions from the list below."}
+                </span>
+            )}
+            <div className="flex items-center gap-2">
+                <span className="shrink-0 text-xs text-[var(--ag-colorTextSecondary)]">
+                    On an action call
+                </span>
+                <div className="min-w-0 flex-1">
+                    <PermissionPolicySelect
+                        value={draft.permission}
+                        onChange={(value) => onPermissionChange(value as ToolPermission)}
+                        options={TOOLKIT_PERMISSION_OPTIONS}
+                        aria-label="Toolkit permission"
+                    />
+                </div>
+            </div>
+            {added ? (
+                <Button variant="outline" onClick={onRemove}>
+                    Remove app
+                </Button>
+            ) : (
+                <Button variant="default" disabled={includeEmpty} onClick={onAdd}>
+                    Add app
+                </Button>
+            )}
+        </div>
+    )
+}
+
 // Body — mounted only while the drawer is open (Drawer destroyOnClose), so catalog queries don't
 // run in the background.
 function ToolCatalogContent({
@@ -134,8 +244,66 @@ function ToolCatalogContent({
     defaultIntegrationKey,
 }: Omit<AgentIntegrationDrawerProps, "open" | "onClose">) {
     const [pending, setPending] = useState<string | null>(null)
+    const [mode, setMode] = useState<CatalogMode>("actions")
+    // Per-connection toolkit drafts (scope / chosen subset / permission), keyed by connection id.
+    const [drafts, setDrafts] = useState<Record<string, ToolkitDraft>>({})
     const {connections} = useToolConnectionsQuery()
     const {reconnect, reconnectingId} = useReconnectToolConnection()
+
+    // A stable key per connection for the draft map (id, else slug, else the integration key).
+    const connKey = useCallback(
+        (conn: ToolConnection) => conn.id ?? conn.slug ?? conn.integration_key,
+        [],
+    )
+    const draftFor = useCallback(
+        (conn: ToolConnection): ToolkitDraft =>
+            drafts[connKey(conn)] ?? {
+                scope: "all",
+                actions: new Set<string>(),
+                permission: DEFAULT_TOOLKIT_PERMISSION,
+            },
+        [drafts, connKey],
+    )
+    const updateDraft = useCallback(
+        (conn: ToolConnection, patch: (draft: ToolkitDraft) => ToolkitDraft) => {
+            const key = connKey(conn)
+            setDrafts((prev) => {
+                const current = prev[key] ?? {
+                    scope: "all" as ToolkitScope,
+                    actions: new Set<string>(),
+                    permission: DEFAULT_TOOLKIT_PERMISSION,
+                }
+                return {...prev, [key]: patch(current)}
+            })
+        },
+        [connKey],
+    )
+    // Identity of the `gateway_toolkit` entry for a connection — the added-state and remove key.
+    const toolkitIdFor = useCallback(
+        (conn: ToolConnection) =>
+            gatewayToolkitIdentity({
+                provider: conn.provider_key ?? "composio",
+                integration: conn.integration_key,
+                connection: conn.slug ?? "",
+            }),
+        [],
+    )
+    const addToolkit = useCallback(
+        (conn: ToolConnection) => {
+            const draft = draftFor(conn)
+            onAddTool(
+                buildGatewayToolkit({
+                    provider: conn.provider_key ?? "composio",
+                    integration: conn.integration_key,
+                    connection: conn.slug ?? "",
+                    mode: draft.scope,
+                    actions: [...draft.actions],
+                    permission: draft.permission,
+                }) as ToolObj,
+            )
+        },
+        [draftFor, onAddTool],
+    )
 
     // The in-flight spinner is still keyed by slug; the added-state is keyed by identity.
     const slugFor = useCallback(
@@ -222,8 +390,21 @@ function ToolCatalogContent({
         [slugFor, idFor, selectedGatewayIds, onAddTool, onRemoveToolByIdentity],
     )
 
+    const toolkitMode = mode === "toolkit"
+
     return (
-        <div className="min-h-0 flex-1 overflow-hidden">
+        <div className="flex min-h-0 flex-1 flex-col overflow-hidden">
+            <div className="shrink-0 px-6 pb-1 pt-4">
+                <Segmented
+                    size="sm"
+                    value={mode}
+                    onChange={(value) => setMode(value as CatalogMode)}
+                    options={[
+                        {label: "Individual actions", value: "actions"},
+                        {label: "Whole app", value: "toolkit"},
+                    ]}
+                />
+            </div>
             <CatalogChooser<CatalogIntegrationItem, ToolCatalogAction, ToolConnection>
                 connections={connections}
                 cardVariant="subtle"
@@ -258,14 +439,52 @@ function ToolCatalogContent({
                     readOnly: (a) => a.read_only ?? undefined,
                     deprecated: (a) => /^\s*deprecated\b/i.test(a.description ?? ""),
                 }}
-                itemsLabel="Choose an action"
+                itemsLabel={toolkitMode ? "Actions in this app" : "Choose an action"}
                 itemsSearchPlaceholder="Search actions"
                 emptyItemsText="No actions for this app"
-                onPickItem={(conn, action) => void toggle(conn, action)}
+                onPickItem={(conn, action) => {
+                    // Whole-app mode: a pick toggles the subset (include scope) or is inert (all scope).
+                    // Individual mode: add/remove the action as its own tool.
+                    if (toolkitMode) {
+                        if (draftFor(conn).scope !== "include") return
+                        updateDraft(conn, (draft) => {
+                            const actions = new Set(draft.actions)
+                            if (actions.has(action.key)) actions.delete(action.key)
+                            else actions.add(action.key)
+                            return {...draft, actions}
+                        })
+                        return
+                    }
+                    void toggle(conn, action)
+                }}
                 itemState={(conn, action) => {
+                    if (toolkitMode) {
+                        const draft = draftFor(conn)
+                        if (draft.scope === "all") return "selected"
+                        return draft.actions.has(action.key) ? "selected" : "add"
+                    }
                     if (pending === slugFor(conn, action.key)) return "pending"
                     return selectedGatewayIds.has(idFor(conn, action.key)) ? "selected" : "add"
                 }}
+                renderConnectionExtra={
+                    toolkitMode
+                        ? (conn, integration) => (
+                              <ToolkitAddPanel
+                                  integrationName={integration?.name ?? conn.integration_key}
+                                  draft={draftFor(conn)}
+                                  added={selectedGatewayIds.has(toolkitIdFor(conn))}
+                                  onScopeChange={(scope) =>
+                                      updateDraft(conn, (draft) => ({...draft, scope}))
+                                  }
+                                  onPermissionChange={(permission) =>
+                                      updateDraft(conn, (draft) => ({...draft, permission}))
+                                  }
+                                  onAdd={() => addToolkit(conn)}
+                                  onRemove={() => onRemoveToolByIdentity?.(toolkitIdFor(conn))}
+                              />
+                          )
+                        : undefined
+                }
                 renderConnect={(integration, handlers) => (
                     <ConnectDrawer
                         open

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
@@ -19,7 +19,7 @@ import {atomWithStorage} from "jotai/utils"
 
 import type {ConfigItemView} from "../ConfigItemDrawer"
 import {CollapsibleProviderGroup, SubSectionHeader} from "../sectionGroups"
-import {isHarnessBuiltinTool, parseGatewayTool} from "../toolUtils"
+import {isHarnessBuiltinTool, parseGatewayTool, parseGatewayToolkit} from "../toolUtils"
 
 import {describeTool, isFunctionTool} from "./itemDescriptors"
 import {ITEM_KINDS} from "./itemKinds"
@@ -295,12 +295,15 @@ export function ToolManagementList({
                     references.push({item, index})
                     return
                 }
-                const gw = parseGatewayTool(item)
-                if (gw) {
-                    let group = groups.get(gw.integration)
+                // Per-action gateway tool OR a connection-level toolkit entry — both group under
+                // their integration in the Connected apps section.
+                const integrationKey =
+                    parseGatewayTool(item)?.integration ?? parseGatewayToolkit(item)?.integration
+                if (integrationKey) {
+                    let group = groups.get(integrationKey)
                     if (!group) {
-                        group = {key: gw.integration, items: []}
-                        groups.set(gw.integration, group)
+                        group = {key: integrationKey, items: []}
+                        groups.set(integrationKey, group)
                     }
                     group.items.push({item, index})
                     return

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
@@ -5,7 +5,7 @@
  */
 import {FileText, GraphIcon, Plugs} from "@phosphor-icons/react"
 
-import {parseGatewayTool, type ToolObj} from "../toolUtils"
+import {parseGatewayTool, parseGatewayToolkit, type ToolObj} from "../toolUtils"
 
 /** How a config-item row presents itself: avatar, name + description, and type tags. */
 export interface ItemDescriptor {
@@ -168,6 +168,30 @@ export function describeTool(tool: unknown): ItemDescriptor {
             typeLabel: "workflow",
             typeColor: "geekblue",
             subtitle: target ? `Referenced workflow · ${target}` : "Referenced workflow",
+        }
+    }
+
+    // Connection-level toolkit entry: one config item that grants a whole connected app. Rendered
+    // as a single row (unlike the per-action gateway tool below, which is one row per action).
+    const toolkit = parseGatewayToolkit(t)
+    if (toolkit) {
+        const count = toolkit.actions.length
+        return {
+            name:
+                toolkit.mode === "all"
+                    ? "All actions"
+                    : `${count} ${count === 1 ? "action" : "actions"}`,
+            monoName: false,
+            description:
+                toolkit.mode === "all"
+                    ? `Whole ${toolkit.integration} toolkit`
+                    : toolkit.actions.map(humanizeActionKey).join(", ") || undefined,
+            mono: monogram(toolkit.integration),
+            color: "#1c2c3d",
+            tags: [toolkit.integration, "toolkit"],
+            typeLabel: "toolkit",
+            typeColor: "geekblue",
+            subtitle: `Whole connected app · ${toolkit.integration}`,
         }
     }
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
@@ -8,7 +8,13 @@ import {useCallback, useMemo, type MutableRefObject} from "react"
 import type {WorkflowReferenceBridge, WorkflowReferencePayload} from "@agenta/ui/drill-in"
 
 import type {ToolSelectionMeta} from "../ToolSelectorPopover"
-import {gatewayToolIdentity, parseGatewayTool, type ToolObj} from "../toolUtils"
+import {
+    gatewayToolIdentity,
+    gatewayToolkitIdentity,
+    parseGatewayTool,
+    parseGatewayToolkit,
+    type ToolObj,
+} from "../toolUtils"
 
 import {isBuiltinPayloadMatch, toolName, toolReferenceSlug} from "./itemDescriptors"
 import type {ItemKind} from "./itemKinds"
@@ -140,7 +146,9 @@ export function useAgentTools({
                 tools
                     .map((t) => {
                         const v = parseGatewayTool(t)
-                        return v ? gatewayToolIdentity(v) : null
+                        if (v) return gatewayToolIdentity(v)
+                        const tk = parseGatewayToolkit(t)
+                        return tk ? gatewayToolkitIdentity(tk) : null
                     })
                     .filter((s): s is string => Boolean(s)),
             ),
@@ -156,6 +164,11 @@ export function useAgentTools({
                     if (removed) return true
                     const v = parseGatewayTool(t)
                     if (v && gatewayToolIdentity(v) === identity) {
+                        removed = true
+                        return false
+                    }
+                    const tk = parseGatewayToolkit(t)
+                    if (tk && gatewayToolkitIdentity(tk) === identity) {
                         removed = true
                         return false
                     }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolUtils.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolUtils.ts
@@ -44,6 +44,65 @@ export interface ParsedGatewayTool {
     permission?: string
 }
 
+/**
+ * A connection-level toolkit entry (`{type: "gateway_toolkit"}`): one config item that grants a
+ * whole connected app instead of one entry per action. It resolves server-side into a search and an
+ * execute meta-tool. `mode: "all"` allows every action; `mode: "include"` limits to `actions`.
+ */
+export interface ParsedGatewayToolkit {
+    provider: string
+    integration: string
+    connection: string
+    mode: "all" | "include"
+    /** Allowed Agenta action keys — only meaningful when `mode === "include"`. */
+    actions: string[]
+    /** Per-entry permission default (top-level, same slot as a per-action gateway tool). */
+    permission?: string
+}
+
+/** Normalize a `gateway_toolkit` entry into one view; null if it isn't one. */
+export function parseGatewayToolkit(tool: unknown): ParsedGatewayToolkit | null {
+    if (!tool || typeof tool !== "object" || Array.isArray(tool)) return null
+    const t = tool as Record<string, unknown>
+    if (t.type !== "gateway_toolkit") return null
+    const integration = typeof t.integration === "string" ? t.integration : ""
+    const connection = typeof t.connection === "string" ? t.connection : ""
+    if (!integration || !connection) return null
+    const provider = typeof t.provider === "string" && t.provider ? t.provider : "composio"
+    const policy =
+        t.tools && typeof t.tools === "object" && !Array.isArray(t.tools)
+            ? (t.tools as Record<string, unknown>)
+            : {}
+    const mode = policy.mode === "include" ? "include" : "all"
+    const actions = Array.isArray(policy.actions)
+        ? policy.actions.filter((a): a is string => typeof a === "string")
+        : []
+    const permission = typeof t.permission === "string" ? t.permission : undefined
+    return {provider, integration, connection, mode, actions, permission}
+}
+
+/** Build a `gateway_toolkit` config entry from a drawer selection (the persisted contract). */
+export function buildGatewayToolkit(input: {
+    provider: string
+    integration: string
+    connection: string
+    mode: "all" | "include"
+    actions?: string[]
+    permission?: string
+}): Record<string, unknown> {
+    return {
+        type: "gateway_toolkit",
+        provider: input.provider || "composio",
+        integration: input.integration,
+        connection: input.connection,
+        tools:
+            input.mode === "include"
+                ? {mode: "include", actions: input.actions ?? []}
+                : {mode: "all"},
+        ...(input.permission ? {permission: input.permission} : {}),
+    }
+}
+
 /** Normalize either encoding of a connected-app tool into one view. */
 export function parseGatewayTool(tool: unknown): ParsedGatewayTool | null {
     if (!tool || typeof tool !== "object" || Array.isArray(tool)) return null
@@ -85,6 +144,16 @@ export function gatewayToolIdentity(view: ParsedGatewayTool): string {
     return [view.provider, view.integration, view.action, view.connection].join(
         GATEWAY_IDENTITY_SEP,
     )
+}
+
+/** Stable identity for a `gateway_toolkit` entry (one per connection). The `toolkit` prefix keeps it
+ *  disjoint from a per-action identity, so a toolkit and an action never collide in the added-set. */
+export function gatewayToolkitIdentity(view: {
+    provider: string
+    integration: string
+    connection: string
+}): string {
+    return ["toolkit", view.provider, view.integration, view.connection].join(GATEWAY_IDENTITY_SEP)
 }
 
 // ============================================================================

--- a/web/packages/agenta-entity-ui/src/drawers/shared/CatalogChooser.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/CatalogChooser.tsx
@@ -110,6 +110,12 @@ export interface CatalogChooserProps<I, T, C> {
         integration: I,
         handlers: {onClose: () => void; onSuccess: () => void},
     ) => ReactNode
+    /**
+     * Optional slot rendered inside the selected-connection detail, above the item list. Lets a
+     * consumer add a connection-level affordance (e.g. the agent drawer's "add the whole toolkit"
+     * panel) without a parallel chooser. Omitted → nothing extra renders (triggers drawer).
+     */
+    renderConnectionExtra?: (connection: C, integration: I | undefined) => ReactNode
     defaultIntegrationKey?: string
     /** App-tile appearance. "subtle" drops the rest border (agent playground). @default "bordered" */
     cardVariant?: "bordered" | "subtle"
@@ -865,6 +871,10 @@ export function CatalogChooser<I, T, C>(props: CatalogChooserProps<I, T, C>) {
                                                 </button>
                                             )
                                         })()}
+                                    {props.renderConnectionExtra?.(
+                                        selectedConn,
+                                        selectedIntegration,
+                                    )}
                                     <div className="mb-2 mt-4 flex items-center justify-between gap-2">
                                         <span className="text-[12px] uppercase tracking-wide text-[var(--ag-colorTextDescription)]">
                                             {props.itemsLabel}


### PR DESCRIPTION
## What

Adds a **"Whole app"** mode to the agent-playground tools drawer so an author can add one
connection-level entry for a Composio integration instead of one tool per action. Today a full
toolkit means up to ~100 per-action rows in the config; this writes a single `gateway_toolkit`
entry that the backend resolves into a search + execute meta-tool.

This is Part 3 (frontend) of the Composio tools rework. It writes the config shape the backend
accepts; the existing per-action `gateway` path is untouched, so old agents keep working.

## The config it writes

Exactly the shared contract from `api-design.md`:

```jsonc
{
  "type": "gateway_toolkit",
  "provider": "composio",
  "integration": "github",
  "connection": "github-main",
  "tools": { "mode": "all" },          // or { "mode": "include", "actions": ["CREATE_ISSUE", ...] }
  "permission": "ask"                    // optional (allow | ask | deny)
}
```

`actions` are Agenta action keys (the catalog's `action.key`), not Composio slugs.

## Before / after (the drawer)

- **Before:** one flow. Pick an integration → a connection → tap each action, and each tap appends
  one `function` tool. A full toolkit is ~100 rows.
- **After:** a `Individual actions | Whole app` toggle at the top of the drawer.
  - **Individual actions** — unchanged legacy per-action picker.
  - **Whole app** — pick an integration and a connection, then a card offers **All actions** or
    **Choose actions**, a permission default (allow/ask/deny), and one **Add app** button. In
    "Choose actions" the existing action list below doubles as the subset picker (each tap toggles
    an action into the `include` list). Result: one row in the config.

## How it stays minimal (no parallel system)

- Reuses the shared `CatalogChooser` (app grid + connections rail + action list) and the same
  catalog/connection hooks. The only addition to `CatalogChooser` is one optional
  `renderConnectionExtra` render slot (other consumers, e.g. the triggers drawer, are unaffected).
- New parse/build/identity helpers live beside the existing gateway helpers in `toolUtils.ts`
  (`parseGatewayToolkit`, `buildGatewayToolkit`, `gatewayToolkitIdentity`).
- Toolkit entries dedupe (added-state), render as one row in the **Connected apps** provider group,
  and remove — via the same machinery the per-action tools use.

## Notes / open items

- A toolkit row currently opens the JSON editor when clicked to edit (it has no structured form
  yet); it is fully removable and re-addable. A structured editor can follow.
- Per-tool `permission` for toolkits uses the same `allow | ask | deny` triple as per-action
  gateway tools. Backend must accept the top-level `permission` on `gateway_toolkit`.

## Testing

- `tsc --noEmit` clean for `@agenta/entity-ui`.
- `eslint` clean on all changed files.
