### PR TITLE
ci(frontend): unblock v0.113.0 web builds (heap cap) and fix release-tip styling

### DIFF
--- a/web/ee/docker/Dockerfile.gh
+++ b/web/ee/docker/Dockerfile.gh
@@ -20,7 +20,7 @@ RUN PNPM_VERSION=$(node -p "require('./package.json').packageManager.split('@')[
 
 FROM base AS builder
 
-ENV NODE_OPTIONS="--max_old_space_size=4096"
+ENV NODE_OPTIONS="--max_old_space_size=8192"
 ENV TURBO_CACHE_DIR="/app/.turbo"
 
 COPY docker/run-turbo-build.sh /usr/local/bin/run-turbo-build.sh

--- a/web/mobile/docker/Dockerfile.gh
+++ b/web/mobile/docker/Dockerfile.gh
@@ -20,7 +20,7 @@ RUN PNPM_VERSION=$(node -p "require('./package.json').packageManager.split('@')[
 
 FROM base AS builder
 
-ENV NODE_OPTIONS="--max_old_space_size=4096"
+ENV NODE_OPTIONS="--max_old_space_size=8192"
 ENV TURBO_CACHE_DIR="/app/.turbo"
 
 COPY docker/run-turbo-build.sh /usr/local/bin/run-turbo-build.sh

--- a/web/oss/docker/Dockerfile.gh
+++ b/web/oss/docker/Dockerfile.gh
@@ -20,7 +20,7 @@ RUN PNPM_VERSION=$(node -p "require('./package.json').packageManager.split('@')[
 
 FROM base AS builder
 
-ENV NODE_OPTIONS="--max_old_space_size=4096"
+ENV NODE_OPTIONS="--max_old_space_size=8192"
 ENV TURBO_CACHE_DIR="/app/.turbo"
 
 COPY docker/run-turbo-build.sh /usr/local/bin/run-turbo-build.sh

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
@@ -47,7 +47,6 @@ vi.mock("@agenta/entities/trace", () => ({
     markTraceAsFresh: vi.fn(),
 }))
 
-
 import {useAgentConversation} from "../../../src/hooks/useAgentConversation"
 import {markSessionFresh} from "../../../src/state/sessionEphemera"
 import {sessionMessagesAtom, sessionStatusAtomFamily} from "../../../src/state/sessionMessages"

--- a/web/packages/agenta-ui/tests/unit/EnhancedDrawerAntdProps.render.test.tsx
+++ b/web/packages/agenta-ui/tests/unit/EnhancedDrawerAntdProps.render.test.tsx
@@ -30,17 +30,23 @@ const open = {open: true, title: "Drawer title", children: <div>body content</di
 describe("EnhancedDrawer antd prop parity", () => {
     it("renders a close button by default", () => {
         render(<EnhancedDrawer {...open} />)
-        expect(screen.getByRole("dialog").querySelector("[data-slot=sheet-header] button")).not.toBeNull()
+        expect(
+            screen.getByRole("dialog").querySelector("[data-slot=sheet-header] button"),
+        ).not.toBeNull()
     })
 
     it("closeIcon={null} hides the close button (antd's 'no close icon')", () => {
         render(<EnhancedDrawer {...open} closeIcon={null} />)
-        expect(screen.getByRole("dialog").querySelector("[data-slot=sheet-header] button")).toBeNull()
+        expect(
+            screen.getByRole("dialog").querySelector("[data-slot=sheet-header] button"),
+        ).toBeNull()
     })
 
     it("closable={false} also hides it, and does not depend on closeIcon", () => {
         render(<EnhancedDrawer {...open} closable={false} />)
-        expect(screen.getByRole("dialog").querySelector("[data-slot=sheet-header] button")).toBeNull()
+        expect(
+            screen.getByRole("dialog").querySelector("[data-slot=sheet-header] button"),
+        ).toBeNull()
     })
 
     it("classNames.body reaches the body slot", () => {
@@ -52,15 +58,29 @@ describe("EnhancedDrawer antd prop parity", () => {
     })
 
     it("classNames.header and .footer reach their slots", () => {
-        render(<EnhancedDrawer {...open} footer={<span>f</span>} classNames={{header: "hdr-x", footer: "ftr-x"}} />)
+        render(
+            <EnhancedDrawer
+                {...open}
+                footer={<span>f</span>}
+                classNames={{header: "hdr-x", footer: "ftr-x"}}
+            />,
+        )
         const dialog = screen.getByRole("dialog")
         expect(dialog.querySelector("[data-slot=sheet-header]")?.className).toContain("hdr-x")
         expect(dialog.querySelector("[data-slot=sheet-footer]")?.className).toContain("ftr-x")
     })
 
     it("styles.body still applies alongside classNames.body", () => {
-        render(<EnhancedDrawer {...open} classNames={{body: "cls"}} styles={{body: {padding: "0px"}}} />)
-        const body = screen.getByRole("dialog").querySelector("[data-slot=drawer-body]") as HTMLElement
+        render(
+            <EnhancedDrawer
+                {...open}
+                classNames={{body: "cls"}}
+                styles={{body: {padding: "0px"}}}
+            />,
+        )
+        const body = screen
+            .getByRole("dialog")
+            .querySelector("[data-slot=drawer-body]") as HTMLElement
         expect(body.className).toContain("cls")
         expect(body.style.padding).toBe("0px")
     })


### PR DESCRIPTION
## Context

Two CI reds on the v0.113.0 line, both introduced by the package-extraction merge (#6065) and its follow-up (#6152).

## Changes

- **Raise the web build Node heap cap from 4096 MB to 8192 MB** in the three `Dockerfile.gh` files (oss, ee, mobile). The `@agenta/oss` Next build on #6152 dies with `FATAL ERROR: Reached heap limit` at exactly the 4 GB cap, on both architectures, twice in a row ([log](https://github.com/Agenta-AI/agenta/actions/runs/32483474248/job/96774881592)). The build runners have 15.6 GB, so 8192 is safe. The ee Dockerfile gets the same bump because the staging deploy builds it from the same package graph.
- **Prettier on two test files** that fail the `TypeScript format` check on the release tip itself ([log](https://github.com/Agenta-AI/agenta/actions/runs/32488967377)): `useAgentConversation.test.ts` and `EnhancedDrawerAntdProps.render.test.tsx`. Formatting only, no code change.

#6152 carries two more unformatted files of its own; those get a prettier commit on its head branch separately.

## Tests

- Prettier 3.7.4 (CI's version) with the repo config; `--check` passes on both files after the write.
- The heap bump is config only; the PR's own image build proves it.