### PR TITLE
fix(frontend): keep the chat composer above the phone keyboard

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -18,6 +18,7 @@ import {
 import {type getPendingApprovals} from "@agenta/chat/model"
 import {chatPanelMaximizedAtom} from "@agenta/chat/state"
 import {openAgentConfigSectionAtom} from "@agenta/shared/state"
+import {hasCoarsePointer} from "@agenta/ui/hooks"
 import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import {HarnessTooltip, SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
 import {Button, LoadingButton} from "@agenta/ui/ui"
@@ -160,6 +161,19 @@ const AgentComposerDock = ({
             richInputRef.current?.blur()
         }, [richInputRef]),
     })
+    // Sending on a touch device dismisses the on-screen keyboard, which returns the page to its
+    // full height and puts the transcript back in view — the message you just sent is the thing
+    // you want to read next. Guarded by the pointer type: on desktop the editor keeps focus after
+    // Enter so the next message can be typed straight away.
+    const submitMessage = useCallback(
+        (text: string) => {
+            const result = onSubmit(text)
+            if (hasCoarsePointer()) richInputRef.current?.blur()
+            return result
+        },
+        [onSubmit, richInputRef],
+    )
+
     // Restoring focus can only happen AFTER the picker unmounts: a focus() call in the handler is
     // undone when the still-focused panel (or Radix popover) leaves the DOM.
     const hadPickerRef = useRef(slash.picker)
@@ -370,7 +384,7 @@ const AgentComposerDock = ({
                         fallback={<ComposerSkeleton className={CHAT_COLUMN} />}
                         // Onboarding: submit = commit the ephemeral — Enter creates the agent
                         // (matching the composer's "↵ Send" hint).
-                        onSubmit={onboardingActive ? () => handleCreateAgent() : onSubmit}
+                        onSubmit={onboardingActive ? () => handleCreateAgent() : submitMessage}
                         disabled={onboardingActive ? ideHandoffActive : modelBlocked}
                         hideSendButton={onboardingActive}
                         placeholder={

--- a/web/oss/src/components/Playground/Playground.tsx
+++ b/web/oss/src/components/Playground/Playground.tsx
@@ -8,6 +8,7 @@ import {
 } from "@agenta/playground-ui"
 import {useLocalDraftWarning} from "@agenta/playground-ui/hooks"
 import {preloadEditorPlugins} from "@agenta/ui"
+import {useVisualViewportHeight} from "@agenta/ui/hooks"
 import {useAtomValue} from "jotai"
 import dynamic from "next/dynamic"
 
@@ -51,6 +52,12 @@ const Playground: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
     // Mount imperative playground state sync (store.sub subscriptions)
     // This replaces the old usePlaygroundUrlSync hook with React-free subscriptions
     useAtomValue(playgroundSyncAtom)
+
+    // Phone browsers open the keyboard over the page, so the bottom of this `dvh`-tall frame —
+    // the chat composer — ends up under it. Track the visual viewport and size the frame against
+    // it while the keyboard is open. Idle on desktop and on Android, where the viewport meta's
+    // `interactive-widget=resizes-content` already shrinks `dvh`.
+    useVisualViewportHeight()
 
     // Playground-native onboarding: mint + drive an ephemeral agent inside this real playground (so it
     // reuses all the machinery above). Fully inert when `onboarding` is false — normal playground path.
@@ -99,7 +106,7 @@ const Playground: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
     const content = (
         <OSSPlaygroundShell providers={providers}>
             <PlaygroundPageTitle onboarding={onboarding} />
-            <div className="flex flex-col w-full h-dvh overflow-hidden">
+            <div className="flex flex-col w-full h-[var(--ag-viewport-height,100dvh)] overflow-hidden">
                 {prefetchAgentCatalogs ? <AgentCatalogPrefetcher /> : null}
                 <PlaygroundOnboarding />
                 <PlaygroundHeader key={`${uri}-header`} />

--- a/web/oss/src/components/Scripts/GlobalScripts.tsx
+++ b/web/oss/src/components/Scripts/GlobalScripts.tsx
@@ -12,6 +12,19 @@ const GlobalScripts = () => {
         <>
             <Head>
                 <title>Agenta – the open-source workspace for building and running agents</title>
+                {/*
+                 * Next ships `width=device-width` by default. The addition that matters is
+                 * `interactive-widget=resizes-content`: it makes the on-screen keyboard shrink the
+                 * layout viewport, so `100dvh` frames (the playground) stop hiding their bottom
+                 * edge — the chat composer — behind the keyboard. Chrome and Android honour it;
+                 * iOS Safari ignores it and is handled by `useVisualViewportHeight` instead.
+                 * `viewport-fit` stays at its default: the app draws no safe-area insets, so
+                 * `cover` would push content under the notch.
+                 */}
+                <meta
+                    name="viewport"
+                    content="width=device-width, initial-scale=1, interactive-widget=resizes-content"
+                />
                 <link rel="shortcut icon" href="/assets/favicon.ico" />
             </Head>
             {isDemo() ? <CloudScripts /> : null}

--- a/web/packages/agenta-ui/src/hooks/index.ts
+++ b/web/packages/agenta-ui/src/hooks/index.ts
@@ -8,3 +8,13 @@ export {useSelectionState, type UseSelectionStateResult} from "./useSelectionSta
 export {useRunAllShortcut, type UseRunAllShortcutParams} from "./useRunAllShortcut"
 export {useDefaultStoreAtomValue} from "./useDefaultStoreAtomValue"
 export {useMediaQuery, useIsNarrowScreen, NARROW_SCREEN_QUERY} from "./useMediaQuery"
+export {
+    useVisualViewportHeight,
+    hasCoarsePointer,
+    keyboardInset,
+    viewportHeightOverride,
+    COARSE_POINTER_QUERY,
+    KEYBOARD_INSET_MIN_PX,
+    VIEWPORT_HEIGHT_VAR,
+    type VisualViewportSample,
+} from "./useVisualViewport"

--- a/web/packages/agenta-ui/src/hooks/useVisualViewport.ts
+++ b/web/packages/agenta-ui/src/hooks/useVisualViewport.ts
@@ -1,0 +1,126 @@
+/**
+ * Page height that follows the on-screen keyboard.
+ *
+ * A phone browser opens the keyboard OVER the page instead of resizing it. The layout viewport —
+ * what `100dvh` measures — keeps its full height, so the bottom of a `dvh`-tall column sits under
+ * the keyboard. In a chat surface that bottom is the composer, and the page cannot scroll to
+ * reveal it because the column is exactly as tall as the layout viewport.
+ *
+ * Chrome and Android solve this declaratively with `interactive-widget=resizes-content` in the
+ * viewport meta: the layout viewport itself shrinks and `dvh` follows. This hook then measures an
+ * inset of zero and stays idle. iOS Safari ignores that directive, so there the visual viewport is
+ * the only signal, and this hook publishes it as a CSS variable for the page to size against.
+ *
+ * Desktop is unaffected by construction: with no keyboard the inset is always zero, the variable
+ * is never set, and every consumer keeps its `100dvh` fallback.
+ */
+import {useEffect} from "react"
+
+/** The CSS variable this hook writes on the document element. Consumers fall back to `100dvh`. */
+export const VIEWPORT_HEIGHT_VAR = "--ag-viewport-height"
+
+/**
+ * Below this many pixels the inset is browser chrome — a collapsing URL bar, a find bar — not a
+ * keyboard. Overriding the page height for those would resize the layout during an ordinary
+ * scroll. No soft keyboard is anywhere near this short.
+ */
+export const KEYBOARD_INSET_MIN_PX = 120
+
+/** Touch input, where sending a message should also dismiss the on-screen keyboard. */
+export const COARSE_POINTER_QUERY = "(pointer: coarse)"
+
+/** The four numbers the rules below need, so they can be tested without a browser. */
+export interface VisualViewportSample {
+    /** The layout viewport height (`window.innerHeight`), which the keyboard does not shrink. */
+    innerHeight: number
+    /** The visual viewport height: the part of the page the user can actually see. */
+    height: number
+    /** How far the visual viewport sits below the top of the layout viewport. */
+    offsetTop: number
+    /** The pinch-zoom scale. Anything above 1 means the user zoomed in. */
+    scale: number
+}
+
+/**
+ * The number of pixels an interactive widget covers at the bottom of the layout viewport.
+ *
+ * Pinch zoom also shrinks the visual viewport, so a scale above 1 reports no inset: resizing the
+ * page while the user zooms would fight the gesture.
+ */
+export function keyboardInset(sample: VisualViewportSample): number {
+    if (sample.scale > 1.01) return 0
+    const inset = sample.innerHeight - sample.height - sample.offsetTop
+    return inset > 0 ? inset : 0
+}
+
+/**
+ * The value for `VIEWPORT_HEIGHT_VAR`, or `null` when the page must keep its `100dvh` height.
+ *
+ * The height is `height + offsetTop`, not `height`. The page still starts at the top of the layout
+ * viewport, so its bottom edge must land at `offsetTop + height` to sit on the bottom of what the
+ * user sees after the browser pushed the visual viewport down.
+ */
+export function viewportHeightOverride(sample: VisualViewportSample): string | null {
+    if (keyboardInset(sample) < KEYBOARD_INSET_MIN_PX) return null
+    return `${Math.round(sample.height + sample.offsetTop)}px`
+}
+
+/** True on a touch device. False during server render and on every mouse-driven browser. */
+export function hasCoarsePointer(): boolean {
+    if (typeof window === "undefined" || !window.matchMedia) return false
+    return window.matchMedia(COARSE_POINTER_QUERY).matches
+}
+
+function readVisualViewport(): VisualViewportSample | null {
+    if (typeof window === "undefined") return null
+    const viewport = window.visualViewport
+    if (!viewport) return null
+    return {
+        innerHeight: window.innerHeight,
+        height: viewport.height,
+        offsetTop: viewport.offsetTop,
+        scale: viewport.scale,
+    }
+}
+
+/**
+ * Track the visual viewport and publish its height as `VIEWPORT_HEIGHT_VAR` on `:root` while a
+ * soft keyboard is open. Call it once, from the component that owns the full-height frame.
+ *
+ * Writes are coalesced into an animation frame because iOS emits a visual-viewport `scroll` event
+ * for every pixel the keyboard animates.
+ */
+export function useVisualViewportHeight(): void {
+    useEffect(() => {
+        const viewport = typeof window === "undefined" ? undefined : window.visualViewport
+        if (!viewport) return
+
+        const root = document.documentElement
+        let frame: number | null = null
+
+        const apply = () => {
+            frame = null
+            const sample = readVisualViewport()
+            const override = sample ? viewportHeightOverride(sample) : null
+            if (override) root.style.setProperty(VIEWPORT_HEIGHT_VAR, override)
+            else root.style.removeProperty(VIEWPORT_HEIGHT_VAR)
+        }
+        const sync = () => {
+            if (frame !== null) return
+            frame = window.requestAnimationFrame(apply)
+        }
+
+        apply()
+        viewport.addEventListener("resize", sync)
+        viewport.addEventListener("scroll", sync)
+        window.addEventListener("orientationchange", sync)
+
+        return () => {
+            if (frame !== null) window.cancelAnimationFrame(frame)
+            viewport.removeEventListener("resize", sync)
+            viewport.removeEventListener("scroll", sync)
+            window.removeEventListener("orientationchange", sync)
+            root.style.removeProperty(VIEWPORT_HEIGHT_VAR)
+        }
+    }, [])
+}

--- a/web/packages/agenta-ui/tests/unit/visualViewport.test.ts
+++ b/web/packages/agenta-ui/tests/unit/visualViewport.test.ts
@@ -1,0 +1,78 @@
+/**
+ * Unit tests for the two pure rules behind `useVisualViewportHeight`.
+ *
+ * The load-bearing case is the desktop one: with no keyboard the layout viewport and the visual
+ * viewport are the same height, the override must be `null`, and the page keeps its `100dvh`
+ * height. A rule that returned a pixel height there would pin every desktop page to a measured
+ * value and break on every window resize the hook does not observe.
+ */
+import {describe, expect, it} from "vitest"
+
+import {
+    KEYBOARD_INSET_MIN_PX,
+    keyboardInset,
+    viewportHeightOverride,
+    type VisualViewportSample,
+} from "../../src/hooks/useVisualViewport"
+
+/** A 844pt iPhone viewport, the numbers iOS reports with no keyboard. */
+const sample = (over: Partial<VisualViewportSample> = {}): VisualViewportSample => ({
+    innerHeight: 844,
+    height: 844,
+    offsetTop: 0,
+    scale: 1,
+    ...over,
+})
+
+describe("keyboardInset", () => {
+    it("is zero when the visual viewport fills the layout viewport", () => {
+        expect(keyboardInset(sample())).toBe(0)
+    })
+
+    it("measures the covered strip when a keyboard is open", () => {
+        expect(keyboardInset(sample({height: 508}))).toBe(336)
+    })
+
+    it("counts the pushed-down offset as covered too", () => {
+        // Safari scrolls the visual viewport down to reveal the focused field: the strip the user
+        // cannot see is the keyboard PLUS whatever scrolled off the top.
+        expect(keyboardInset(sample({height: 508, offsetTop: 40}))).toBe(296)
+    })
+
+    it("reports nothing while the user pinch-zooms", () => {
+        // Zoom shrinks the visual viewport the same way a keyboard does. Resizing the page here
+        // would fight the gesture.
+        expect(keyboardInset(sample({height: 400, scale: 2}))).toBe(0)
+    })
+
+    it("never returns a negative inset", () => {
+        expect(keyboardInset(sample({height: 900}))).toBe(0)
+    })
+})
+
+describe("viewportHeightOverride", () => {
+    it("returns null with no keyboard, so the page keeps 100dvh", () => {
+        expect(viewportHeightOverride(sample())).toBeNull()
+    })
+
+    it("returns null for browser chrome smaller than the keyboard threshold", () => {
+        const chromeOnly = sample({height: 844 - (KEYBOARD_INSET_MIN_PX - 1)})
+        expect(viewportHeightOverride(chromeOnly)).toBeNull()
+    })
+
+    it("returns the visible height once the keyboard is open", () => {
+        expect(viewportHeightOverride(sample({height: 508}))).toBe("508px")
+    })
+
+    it("adds the offset so the page bottom lands on the visible bottom", () => {
+        expect(viewportHeightOverride(sample({height: 508, offsetTop: 40}))).toBe("548px")
+    })
+
+    it("rounds to whole pixels", () => {
+        expect(viewportHeightOverride(sample({height: 507.5}))).toBe("508px")
+    })
+
+    it("stays out of the way while the user pinch-zooms", () => {
+        expect(viewportHeightOverride(sample({height: 300, scale: 2}))).toBeNull()
+    })
+})


### PR DESCRIPTION
## Context

Found on a phone browser, testing the desktop app (not `/m`). Opening the keyboard hides part of the chat composer, and nothing scrolls it back into view. After sending a message the page stays in that state.

The playground frame is `h-dvh` ([Playground.tsx:102](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/Playground/Playground.tsx#L102)). `100dvh` measures the *layout* viewport, and a phone keyboard opens over the page instead of resizing it, so the layout viewport keeps its full height. The composer is the last flow child of that frame ([AgentConversation.tsx:648](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/AgentChatSlice/AgentConversation.tsx#L648) holds the column, the transcript takes the slack with `flex-1`), so the composer sits at the very bottom, under the keyboard. Nothing is `fixed` or `sticky`, and the frame is `overflow-hidden` and exactly as tall as the layout viewport, so the page cannot scroll to reveal it either.

The app also served no `<meta name="viewport">` of its own. It got Next's built-in default, `width=device-width`, with no `interactive-widget` directive.

## Changes

**Chrome and Android, declaratively.** The viewport meta now sets `interactive-widget=resizes-content` ([GlobalScripts.tsx](web/oss/src/components/Scripts/GlobalScripts.tsx), the shared `next/head` both OSS and EE render). That directive makes the keyboard shrink the layout viewport, so `dvh` follows it and every `100dvh` frame in the app stops hiding its bottom edge. `viewport-fit` stays at its default: the app draws no safe-area insets, so `cover` would push content under the notch.

**iOS Safari, which ignores that directive.** A new hook, `useVisualViewportHeight` ([packages/agenta-ui/src/hooks/useVisualViewport.ts](web/packages/agenta-ui/src/hooks/useVisualViewport.ts)), tracks `window.visualViewport` and publishes the visible height as a CSS variable on `:root`. The playground frame sizes against it:

```
- <div className="flex flex-col w-full h-dvh overflow-hidden">
+ <div className="flex flex-col w-full h-[var(--ag-viewport-height,100dvh)] overflow-hidden">
```

Shrinking the frame is enough on its own. The composer is the bottom of a flex column, so it moves up with the frame's new bottom edge and the transcript absorbs the loss. No `scrollIntoView` call is involved, which keeps this clear of the composer's existing focus arbitration around the slash palette ([AgentComposerDock.tsx:159-175](web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx#L159)).

The hook writes the variable only while a keyboard-sized inset is present. Two rules keep it quiet otherwise, both pure functions with unit tests:

- An inset under 120px is browser chrome (a collapsing URL bar), not a keyboard, and produces `null` so the page keeps `100dvh`.
- A pinch-zoom scale above 1 shrinks the visual viewport the same way a keyboard does, and also produces `null`, so resizing the page never fights the gesture.

Desktop therefore keeps its exact current height by construction: with no keyboard the inset is always zero, the variable is never set, and the `100dvh` fallback applies. Android is the same once the meta shrinks the layout viewport, since the inset the hook measures then goes back to zero. The two mechanisms cannot double up.

**Returning to normal after send.** Sending on a touch device now blurs the editor, which closes the keyboard and restores the full height. It is guarded by `(pointer: coarse)`, so desktop keeps focus after Enter and you can type the next message straight away. The wrapper sits in the app's composer dock rather than in the shared `submitEditorAsMarkdown`, so `web/mobile` and every other `ChatComposer` consumer is untouched. Both send paths (plain Enter and the send button) go through it.

The trade-off worth naming: a tablet with a hardware keyboard reports `pointer: coarse` too, so it also loses focus after send. The cost there is one tap, against the phone case where keeping the keyboard up hides the reply you just asked for.

## Tests / notes

- New unit tests for the two viewport rules: `pnpm --filter @agenta/ui test:unit` (96 passed, 11 new).
- `pnpm --filter @agenta/chat test:unit` (371 passed), `npx vitest run src/components/AgentChatSlice` in `web/oss` (310 passed).
- `npx tsc --noEmit` clean in both `web/oss` and `web/ee`; `types:check` clean for `@agenta/ui`.
- `pnpm lint-fix` in `web/` (25/25 tasks, no findings) and `prettier@3.7.4 --check` on every touched file.
- One production build of `@agenta/oss` (`next build`).
- **Not verified on a device.** No phone or emulator was available in this session. Mahmoud re-checks on his phone after the staging redeploy.
- The viewport meta is app-wide, so it reaches every page, not just the playground. That is intended: any `100dvh` surface behaves better with it. It does not touch `web/mobile`, which sets its own meta.

## What to QA

On a phone browser, on the desktop app (not `/m`), signed in to a project with an agent:

1. Open an agent playground and tap the composer. The whole composer, including the send button and the toolbar under it, stays visible above the keyboard. Before this change the bottom of it was cut off.
2. Type a message and press Enter. The keyboard closes, the page returns to full height, and the message you sent is visible in the transcript.
3. Tap the composer again and dismiss the keyboard with the browser's own control instead of sending. The page returns to full height, with no leftover gap at the bottom.
4. Rotate to landscape with the keyboard open. The composer stays visible.
5. Pinch-zoom into the transcript. The page must not resize or jump while you zoom.
6. Regression, desktop: open the same playground on a laptop. The frame height, the composer position, and Enter-to-send keeping focus in the editor must all be exactly as before.
7. Regression, any page with a full-height frame on a phone (human evaluations, the evaluator configuration drawer): scrolling must behave as before when no keyboard is open.
