### PR TITLE
fix(frontend): start a phone in the chat view, not the configuration

### DIFF
--- a/web/packages/agenta-chat/src/state/index.ts
+++ b/web/packages/agenta-chat/src/state/index.ts
@@ -3,6 +3,13 @@ export * from "./messageStamps"
 export * from "./turnClock"
 export * from "./sessionEphemera"
 export * from "./sessionMessages"
-export {chatPanelMaximizedAtom, configPanelCollapsedAtom} from "./panelLayout"
+export {
+    chatPanelMaximizedAtom,
+    configPanelCollapsedAtom,
+    configPanelCollapsedPreferenceAtom,
+    phoneViewportAtom,
+    resolveConfigPanelCollapsed,
+    PHONE_VIEWPORT_QUERY,
+} from "./panelLayout"
 
 export {sessionLocalSettledAtAtomFamily} from "./sessionMessages"

--- a/web/packages/agenta-chat/src/state/panelLayout.ts
+++ b/web/packages/agenta-chat/src/state/panelLayout.ts
@@ -1,3 +1,4 @@
+import {atom} from "jotai"
 import {atomWithStorage} from "jotai/utils"
 
 /**
@@ -10,9 +11,70 @@ import {atomWithStorage} from "jotai/utils"
  */
 export const chatPanelMaximizedAtom = atomWithStorage("agenta:chat:panel-maximized", false)
 
+/**
+ * Below this width the config pane and the transcript cannot share the screen: the pane alone
+ * asks for 300-440px and the transcript for 420px more. A phone therefore shows the config pane
+ * and nothing else, which is not where a chat starts. The number is antd's `md` breakpoint, the
+ * same "too small for the desktop layout" line `NoMobilePageWrapper` already draws.
+ */
+export const PHONE_VIEWPORT_QUERY = "(max-width: 767.98px)"
+
+const readPhoneViewport = (): boolean => {
+    if (typeof window === "undefined" || !window.matchMedia) return false
+    return window.matchMedia(PHONE_VIEWPORT_QUERY).matches
+}
+
+/**
+ * Live "the window is phone-width" flag. Seeded at module load rather than on mount so the first
+ * paint of the playground is already correct — the playground is a client-only chunk, so there is
+ * no server render to disagree with, and a mount-time read would flash the config pane first.
+ */
+export const phoneViewportAtom = atom(readPhoneViewport())
+phoneViewportAtom.onMount = (set) => {
+    if (typeof window === "undefined" || !window.matchMedia) return
+    const list = window.matchMedia(PHONE_VIEWPORT_QUERY)
+    set(list.matches)
+    const sync = (event: MediaQueryListEvent) => set(event.matches)
+    list.addEventListener("change", sync)
+    return () => list.removeEventListener("change", sync)
+}
+
+/**
+ * The stored answer to "did the user collapse the config pane?", or `null` when the user has never
+ * touched either control. The tri-state is what makes a per-device default possible: a plain
+ * `false` default cannot tell "I want the config pane" apart from "I have never said".
+ *
+ * `getOnInit` reads localStorage synchronously, so a stored preference applies to the first paint
+ * instead of arriving one render later.
+ */
+export const configPanelCollapsedPreferenceAtom = atomWithStorage<boolean | null>(
+    "agenta:chat:config-panel-collapsed",
+    null,
+    undefined,
+    {getOnInit: true},
+)
+
+/**
+ * The default when nothing is stored: hidden on a phone, visible everywhere else.
+ *
+ * A stored preference always wins, in both directions. Collapsing the pane on a phone is one tap
+ * on the `»` reveal button in the chat header, and that tap stores `false`, so the phone default
+ * never fights a user who wants the config pane.
+ */
+export const resolveConfigPanelCollapsed = (
+    stored: boolean | null,
+    phoneViewport: boolean,
+): boolean => stored ?? phoneViewport
+
 /** Build mode's config pane collapsed to 0. Separate from the maximize flag: collapsing the pane
  * in Build is not the same as switching to Chat. */
-export const configPanelCollapsedAtom = atomWithStorage<boolean>(
-    "agenta:chat:config-panel-collapsed",
-    false,
+export const configPanelCollapsedAtom = atom(
+    (get) =>
+        resolveConfigPanelCollapsed(
+            get(configPanelCollapsedPreferenceAtom),
+            get(phoneViewportAtom),
+        ),
+    (_get, set, collapsed: boolean) => {
+        set(configPanelCollapsedPreferenceAtom, collapsed)
+    },
 )

--- a/web/packages/agenta-chat/tests/unit/state/panelLayout.test.ts
+++ b/web/packages/agenta-chat/tests/unit/state/panelLayout.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the config-pane default rule.
+ *
+ * The load-bearing case is the stored `false` on a phone: the user asked for the config pane with
+ * the `»` reveal button, and a per-device default that overruled that would make the button look
+ * broken. `stored ?? phoneViewport` is the whole rule, and it exists because the atom's old plain
+ * `false` default could not tell "I want the pane" apart from "I have never said".
+ */
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {
+    configPanelCollapsedAtom,
+    configPanelCollapsedPreferenceAtom,
+    phoneViewportAtom,
+    resolveConfigPanelCollapsed,
+} from "../../../src/state/panelLayout"
+
+describe("resolveConfigPanelCollapsed", () => {
+    it("keeps the config pane visible on a desktop with no preference stored", () => {
+        expect(resolveConfigPanelCollapsed(null, false)).toBe(false)
+    })
+
+    it("hides the config pane on a phone with no preference stored", () => {
+        expect(resolveConfigPanelCollapsed(null, true)).toBe(true)
+    })
+
+    it("honours a stored preference to show the pane, phone included", () => {
+        expect(resolveConfigPanelCollapsed(false, true)).toBe(false)
+    })
+
+    it("honours a stored preference to hide the pane, desktop included", () => {
+        expect(resolveConfigPanelCollapsed(true, false)).toBe(true)
+    })
+})
+
+describe("configPanelCollapsedAtom", () => {
+    it("reads the phone default and stops doing so once the user chooses", () => {
+        const store = createStore()
+        store.set(phoneViewportAtom, true)
+        expect(store.get(configPanelCollapsedAtom)).toBe(true)
+
+        // The `»` reveal button: one tap turns the per-device default into a real preference.
+        store.set(configPanelCollapsedAtom, false)
+        expect(store.get(configPanelCollapsedPreferenceAtom)).toBe(false)
+        expect(store.get(configPanelCollapsedAtom)).toBe(false)
+    })
+
+    it("follows the viewport only while no preference is stored", () => {
+        const store = createStore()
+        expect(store.get(configPanelCollapsedAtom)).toBe(false)
+
+        // Rotating a phone, or resizing a desktop window down, moves the default with it.
+        store.set(phoneViewportAtom, true)
+        expect(store.get(configPanelCollapsedAtom)).toBe(true)
+
+        store.set(configPanelCollapsedAtom, true)
+        store.set(phoneViewportAtom, false)
+        expect(store.get(configPanelCollapsedAtom)).toBe(true)
+    })
+})


### PR DESCRIPTION
## Context

Found on a phone browser, testing the desktop app (not `/m`). Create a new agent, send the first message, and the playground opens on the configuration pane with the transcript off-screen. The reply lands somewhere the user cannot see. The expected landing place is the chat.

The pane and the transcript cannot share a phone screen at all: the config pane asks for 300-440px ([MainLayout/index.tsx:238](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/Playground/Components/MainLayout/index.tsx#L238)) and the transcript for 420px more (`fillMin`), so at phone width the config pane wins the whole viewport.

Which pane shows is decided by one line, [MainLayout/index.tsx:259-261](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/Playground/Components/MainLayout/index.tsx#L259):

```ts
const configCollapsed = !isComparisonView && isAgentConfig && (chatMaximized || configPanelCollapsed)
```

`chatPanelMaximizedAtom` is the Build/Chat switch, and that switch is parked off (`SHOW_MODE_SWITCH = false`), so it is unreachable. `configPanelCollapsedAtom` is the only live lever, and it defaulted to `false` for everyone. Nothing in the agent creation path ([useAgentOnboarding.ts](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/pages/agent-home/PlaygroundOnboarding/useAgentOnboarding.ts), `useCreateAgent.ts`, `useFirstRunSeed.ts`) touches either atom, so a brand-new agent lands wherever the default points.

## Changes

A plain boolean default cannot carry a per-device rule. `false` means both "I want the config pane" and "I have never said", so making phones differ would have overruled people who really do want the pane. The stored value is now tri-state, in [panelLayout.ts](web/packages/agenta-chat/src/state/panelLayout.ts):

```ts
// before
export const configPanelCollapsedAtom = atomWithStorage<boolean>("agenta:chat:config-panel-collapsed", false)

// after: the raw preference, plus a derived atom that resolves the unset case
export const configPanelCollapsedPreferenceAtom =
    atomWithStorage<boolean | null>("agenta:chat:config-panel-collapsed", null, undefined, {getOnInit: true})

export const resolveConfigPanelCollapsed = (stored: boolean | null, phoneViewport: boolean): boolean =>
    stored ?? phoneViewport
```

`null` is the new default and means nothing is stored. It resolves to collapsed on a phone and visible everywhere else. The exported `configPanelCollapsedAtom` keeps its name and its `boolean` read and write types, so all five call sites are unchanged.

A stored preference still wins in both directions, on every device. The `»` reveal button in the chat header ([ShowConfigPanelButton.tsx](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/AgentChatSlice/components/ShowConfigPanelButton.tsx)) writes `false`, so a phone user who wants the configuration is one tap away and stays there on the next visit. That button renders exactly when `!chatMaximized && configPanelCollapsed`, which is the phone default state, so the escape hatch is present from the first paint. This is also why the fix uses this atom and not `chatPanelMaximizedAtom`: in the maximized state that reveal button is not rendered at all, and the switch that would bring it back is parked off.

Two smaller details:

- The phone-width flag is a jotai atom seeded at module load and kept live by a `matchMedia` subscription in `onMount`, so the very first paint is already right. A mount-time read would show the config pane for one frame and then collapse it. The playground is a client-only chunk (`ssr: false` in `PlaygroundRouter`), so there is no server render to disagree with.
- `getOnInit: true` makes a stored preference apply to the first paint instead of one render later. Without it the atom starts at its default on every mount and hydrates afterwards. This matches the same fix already made for the session atoms.

The breakpoint is 767.98px, antd's `md`, the same "too small for the desktop layout" line `NoMobilePageWrapper` already draws.

Desktop is unchanged: with a wide window the flag is false, the default resolves to `false`, and the config pane shows exactly as before. The rule is also gated by `isAgentConfig`, so prompt playgrounds and the comparison view are untouched.

## Tests / notes

- New unit tests for the default rule, both the pure function and the atom: `pnpm --filter @agenta/chat test:unit` (371 passed, 6 new).
- `npx vitest run src/components/AgentChatSlice` in `web/oss` (310 passed), which covers the two suites that drive these atoms.
- `npx tsc --noEmit` clean in both `web/oss` and `web/ee`; `types:check` clean for `@agenta/chat`.
- `pnpm lint-fix` in `web/` (25/25 tasks, no findings) and `prettier@3.7.4 --check` on every touched file.
- One production build of `@agenta/oss` (`next build`).
- **Not verified on a device.** No phone or emulator was available in this session. Mahmoud re-checks on his phone after the staging redeploy.
- Anyone who has already used the app has `false` stored under `agenta:chat:config-panel-collapsed` only if they clicked one of the two controls. A reviewer testing the phone default on a browser that has visited the playground before should clear that key first.

## What to QA

On a phone browser, on the desktop app (not `/m`):

1. Clear site data (or use a private window), then create a new agent and send the first message. The playground opens on the chat with the configuration hidden, and the reply streams into a transcript you can see.
2. Tap `»` in the chat header. The configuration pane opens.
3. Reload the page. The configuration pane is still open, because tapping the button stored a real preference.
4. Clear site data again and open an existing agent from the agents list. It opens on the chat, same as a new one.
5. Regression, desktop: open any agent playground on a laptop with site data cleared. The configuration pane shows on the left, exactly as before.
6. Regression, desktop: collapse the pane with `«`, reload, and confirm it stays collapsed.
7. Regression: open a prompt playground (not an agent) on a phone. Its layout is unchanged by this PR.
