### PR TITLE
chore(mobile): bump web/mobile version to 0.113.0

### DIFF
--- a/web/mobile/package.json
+++ b/web/mobile/package.json
@@ -1,6 +1,6 @@
 {
     "name": "@agenta/mobile",
-    "version": "0.112.3",
+    "version": "0.113.0",
     "private": true,
     "engines": {
         "node": "24.x"


### PR DESCRIPTION
## Context

The v0.113.0 version bump commit landed before #6065, and #6065 is what added the `web/mobile` bump step to the release-branch workflow. So `web/mobile/package.json` still says 0.112.3 while oss and ee say 0.113.0, and the mobile app's drawer reports v0.112.3 on the v0.113.0 stages (finding M1 in the release QA).

## Change

One line: `web/mobile/package.json` version 0.112.3 -> 0.113.0. No lockfile change (workspace packages' own versions are not recorded there).

## QA

On staging `/m`, open the drawer: it must read v0.113.0 after the next deploy.