### PR TITLE
fix(mobile): keep tool-row labels whole in the chat

### DIFF
--- a/web/mobile/src/features/chat/TurnRow.tsx
+++ b/web/mobile/src/features/chat/TurnRow.tsx
@@ -98,7 +98,10 @@ const ToolLines = ({item}: {item: ToolsItem}) => (
             const midText =
                 summary && shownName.toLowerCase().endsWith(summary.toLowerCase()) ? null : summary
             return (
-                <p key={key} className="m-0 flex min-w-0 items-center gap-2 text-xs">
+                <p
+                    key={key}
+                    className="m-0 flex min-w-0 items-center gap-2 overflow-hidden text-xs"
+                >
                     {awaiting ? (
                         <Wrench className="text-colorWarning size-3.5 shrink-0" />
                     ) : denied ? (
@@ -110,7 +113,14 @@ const ToolLines = ({item}: {item: ToolsItem}) => (
                     ) : (
                         <CircleDashed className="text-colorTextTertiary size-3.5 shrink-0 motion-safe:animate-spin" />
                     )}
-                    <span className="text-colorText min-w-0 truncate font-medium">{shownName}</span>
+                    {/* The sentence never yields, as on the desktop row: the detail and the status
+                        beside it absorb the squeeze. With `min-w-0` here instead, every child was
+                        equally shrinkable, so a long argument took the width and left "Listed
+                        files" as "Li…" on a phone. `max-w-full` caps a sentence that is wider than
+                        the row on its own, and the row clips what is left. */}
+                    <span className="text-colorText max-w-full shrink-0 truncate font-medium">
+                        {shownName}
+                    </span>
                     {display.detail ? (
                         <span className="text-colorTextSecondary min-w-0 truncate font-mono">
                             {display.detail}


### PR DESCRIPTION
## Context

On the mobile app at `/m`, a tool row that carries an argument loses its label. The release QA pass measured "Listed files" at 24px, so it read as "Li…", and "Read a file" at 23px, so it read as "R…". The argument beside them kept its full width. A row with no argument, such as "Renamed this chat", got 108px and read correctly.

The cause is in `web/mobile/src/features/chat/TurnRow.tsx:113`. Every child of the row carried `min-w-0 truncate`, so every child was equally shrinkable. Flexbox spreads the squeeze in proportion to each child's natural width, and the argument is far wider than the label, so the label collapsed to a sliver while the argument kept most of the row.

The desktop row does not do this. `web/oss/src/components/AgentChatSlice/components/ToolActivity.tsx:173` pins the sentence with `max-w-full shrink-0` and lets the detail and the status absorb the squeeze. The comment there already states the intent: "The sentence never yields".

## Changes

The mobile label now follows the same rule as the desktop one.

```
before:  className="text-colorText min-w-0 truncate font-medium"
after:   className="text-colorText max-w-full shrink-0 truncate font-medium"
```

The row itself gained `overflow-hidden` (`TurnRow.tsx:101`). That part is phone-only. `shrink-0` means a sentence wider than the row no longer shrinks, and with a 390px viewport an over-long sentence then pushed the page sideways. Measured without the clip, the document scroll width grew from 390px to 400px. With it, the page stays at 390px.

Label widths at a 390px viewport, measured in headless Chromium on a harness that reproduces the row's flex rules:

| Row | Before | After |
| --- | --- | --- |
| Listed files | 32px, truncated | 64px, whole |
| Read a file | 29px, truncated | 63px, whole |
| Renamed this chat (no argument) | 113px | 113px, unchanged |

## Tests / notes

- `pnpm --filter @agenta/mobile test`: 92 tests in 13 files, all passed.
- `tsc --noEmit` in `web/mobile`: clean.
- `pnpm --filter @agenta/mobile lint`: 0 errors. The 4 `react-hooks/exhaustive-deps` warnings are pre-existing and are in other files.
- `pnpm --filter @agenta/mobile build` (Next 16): the route summary printed for all 18 routes.
- `prettier@3.7.4 --check` on the touched file: clean.
- No new test. `web/mobile` runs vitest in a node environment over `tests/unit/**/*.test.ts` only, with no React render harness, so there is nowhere to assert a layout rule without adding one.
- Not verified in the running app. The numbers above come from a standalone harness at 390px, not from the `/m` chat. Please confirm on a real phone.
- One residual case. A sentence wider than the whole row is now cut at the row edge instead of ending in an ellipsis, because `max-w-full` measures the row while the label starts after the status icon. No sentence the tool resolver builds today comes near that length, which is about 60 characters at this size. The desktop row has the same property.

## What to QA

- Open the `/m` chat on a phone, or on a 390px viewport with the device gate, and send a message that makes the agent list files and then read a file. Expect "Listed files" and "Read a file" in full, with the path or the output beside them truncated by an ellipsis.
- Check a row that carries no argument, such as "Renamed this chat" or "Renamed the agent". It must look the same as before.
- Check a failed row, such as "Reading a file failed". The sentence and the file name must both read in full.
- Swipe the transcript sideways. The page must not move, and no row may stick out past the right edge.
- Desktop chat rows are untouched by this change, but a quick look at the playground tool rows confirms nothing shifted.
