### PR TITLE
fix(mobile): open sessions in the chat view, not the configuration

### DIFF
--- a/web/mobile/src/features/chat/SessionWorkspace.tsx
+++ b/web/mobile/src/features/chat/SessionWorkspace.tsx
@@ -9,6 +9,7 @@ import dynamic from "next/dynamic"
 
 import {AppShell} from "../nav/AppShell"
 
+import {resolveSessionPanes} from "./sessionPanes"
 import {SessionsPane} from "./SessionsPane"
 import {SessionTabs} from "./SessionTabs"
 import {SessionTopBar} from "./SessionTopBar"
@@ -57,11 +58,6 @@ export const SessionWorkspace = ({
     // Collapsing the config panel is separate from the Build/Chat mode: the desktop keeps you in
     // Build with the panel out of the way, and the top bar's "»" brings it back.
     const configCollapsed = useAtomValue(configPanelCollapsedAtom)
-    const showConfig = !chatMaximized && !configCollapsed && Boolean(entityId)
-    // The sessions rail stands in for the config panel ONLY in maximized mode, as on the desktop.
-    // Collapsing config collapses the PANE and gives the width to the conversation; swapping the
-    // rail in instead means the collapse never actually frees any space.
-    const showPane = showConfig || chatMaximized
     // Files dock as a resizable right-edge pane, as they do on the desktop, rather than an
     // overlay drawer. Scope is the AGENT, not the session: opening files then switching session
     // must not snap the pane shut.
@@ -69,6 +65,14 @@ export const SessionWorkspace = ({
     const {open: filesOpen} = useSessionFilesPane(filesScope, sessionId)
     // Tailwind's `md`. Client-only, so the first paint is the phone layout — the right guess here.
     const twoPane = useMediaQuery("(min-width: 768px)")
+    // Which half is on screen. The rule is in `sessionPanes.ts`, with its tests: on a phone the
+    // pane replaces the conversation, so getting it wrong puts the composer out of reach.
+    const {showConfig, showPane} = resolveSessionPanes({
+        chatMaximized,
+        configCollapsed,
+        twoPane,
+        hasEntity: Boolean(entityId),
+    })
     // Controlled px, as on the desktop: the dragged width persists for the mount; 440 is the
     // config panel's cap and its default.
     const [paneSize, setPaneSize] = useState(440)

--- a/web/mobile/src/features/chat/sessionPanes.ts
+++ b/web/mobile/src/features/chat/sessionPanes.ts
@@ -1,0 +1,43 @@
+/**
+ * Which half of the session workspace is on screen.
+ *
+ * The split holds the pane (configuration, or the sessions rail) beside the conversation. With two
+ * panes both are visible and this only picks what sits on the left. On a phone there is no room
+ * for two, so the pane REPLACES the conversation: anything that turns the pane on takes the chat,
+ * and its composer, off the screen. That is why the rule lives here with tests rather than inline.
+ */
+export interface SessionPaneInputs {
+    /** The Build/Chat switch. Shared with the desktop playground through localStorage. */
+    chatMaximized: boolean
+    /** The config pane's collapse state, which `configPanelCollapsedAtom` defaults per device. */
+    configCollapsed: boolean
+    /** True at `md` and wider. False on a phone, where the pane replaces the conversation. */
+    twoPane: boolean
+    /** False when the session has no revision to configure yet, such as a session with no turns. */
+    hasEntity: boolean
+}
+
+export interface SessionPanes {
+    /** Put the configuration in the pane slot. Otherwise the slot holds the sessions rail. */
+    showConfig: boolean
+    /** Give the pane slot the screen. On a phone this hides the conversation. */
+    showPane: boolean
+}
+
+export const resolveSessionPanes = ({
+    chatMaximized,
+    configCollapsed,
+    twoPane,
+    hasEntity,
+}: SessionPaneInputs): SessionPanes => {
+    const showConfig = !chatMaximized && !configCollapsed && hasEntity
+    // The sessions rail stands in for the config panel ONLY in maximized mode, as on the desktop.
+    // Collapsing config collapses the PANE and gives the width to the conversation; swapping the
+    // rail in instead means the collapse never actually frees any space.
+    //
+    // That swap needs two panes to mean anything. On a phone it put the sessions list where the
+    // chat belongs, with no way out: `/m` reads the maximized flag and never writes it, and the
+    // desktop playground writes it to the same origin. A phone in maximized mode shows the
+    // conversation, and the tab rail above it still reaches every session.
+    return {showConfig, showPane: showConfig || (twoPane && chatMaximized)}
+}

--- a/web/mobile/tests/unit/sessionPanes.test.ts
+++ b/web/mobile/tests/unit/sessionPanes.test.ts
@@ -1,0 +1,54 @@
+/**
+ * The phone cases are the load-bearing ones. On a phone the pane replaces the conversation, so
+ * every rule that turns the pane on also takes the composer off the screen. Both defects this
+ * file guards did exactly that: the config pane opened by default, and the maximized flag the
+ * desktop stores under the same origin put the sessions rail where the chat belongs.
+ */
+import {describe, expect, it} from "vitest"
+
+import {resolveSessionPanes} from "@/features/chat/sessionPanes"
+
+const phone = {twoPane: false, hasEntity: true, chatMaximized: false, configCollapsed: true}
+
+describe("resolveSessionPanes on a phone", () => {
+    it("shows the conversation when the config pane is collapsed", () => {
+        expect(resolveSessionPanes(phone)).toEqual({showConfig: false, showPane: false})
+    })
+
+    it("shows the configuration once the reader asks for it", () => {
+        expect(resolveSessionPanes({...phone, configCollapsed: false})).toEqual({
+            showConfig: true,
+            showPane: true,
+        })
+    })
+
+    it("keeps the conversation in maximized mode instead of the sessions rail", () => {
+        expect(resolveSessionPanes({...phone, chatMaximized: true})).toEqual({
+            showConfig: false,
+            showPane: false,
+        })
+    })
+
+    it("shows the conversation when there is no revision to configure yet", () => {
+        expect(resolveSessionPanes({...phone, configCollapsed: false, hasEntity: false})).toEqual({
+            showConfig: false,
+            showPane: false,
+        })
+    })
+})
+
+describe("resolveSessionPanes with two panes", () => {
+    it("keeps the desktop swap: the sessions rail stands in for the config panel", () => {
+        expect(resolveSessionPanes({...phone, twoPane: true, chatMaximized: true})).toEqual({
+            showConfig: false,
+            showPane: true,
+        })
+    })
+
+    it("shows the configuration beside the conversation by default", () => {
+        expect(resolveSessionPanes({...phone, twoPane: true, configCollapsed: false})).toEqual({
+            showConfig: true,
+            showPane: true,
+        })
+    })
+})

--- a/web/packages/agenta-chat/src/state/index.ts
+++ b/web/packages/agenta-chat/src/state/index.ts
@@ -3,6 +3,13 @@ export * from "./messageStamps"
 export * from "./turnClock"
 export * from "./sessionEphemera"
 export * from "./sessionMessages"
-export {chatPanelMaximizedAtom, configPanelCollapsedAtom} from "./panelLayout"
+export {
+    chatPanelMaximizedAtom,
+    configPanelCollapsedAtom,
+    configPanelCollapsedPreferenceAtom,
+    phoneViewportAtom,
+    resolveConfigPanelCollapsed,
+    PHONE_VIEWPORT_QUERY,
+} from "./panelLayout"
 
 export {sessionLocalSettledAtAtomFamily} from "./sessionMessages"

--- a/web/packages/agenta-chat/src/state/panelLayout.ts
+++ b/web/packages/agenta-chat/src/state/panelLayout.ts
@@ -1,3 +1,4 @@
+import {atom} from "jotai"
 import {atomWithStorage} from "jotai/utils"
 
 /**
@@ -10,9 +11,70 @@ import {atomWithStorage} from "jotai/utils"
  */
 export const chatPanelMaximizedAtom = atomWithStorage("agenta:chat:panel-maximized", false)
 
+/**
+ * Below this width the config pane and the transcript cannot share the screen: the pane alone
+ * asks for 300-440px and the transcript for 420px more. A phone therefore shows the config pane
+ * and nothing else, which is not where a chat starts. The number is antd's `md` breakpoint, the
+ * same "too small for the desktop layout" line `NoMobilePageWrapper` already draws.
+ */
+export const PHONE_VIEWPORT_QUERY = "(max-width: 767.98px)"
+
+const readPhoneViewport = (): boolean => {
+    if (typeof window === "undefined" || !window.matchMedia) return false
+    return window.matchMedia(PHONE_VIEWPORT_QUERY).matches
+}
+
+/**
+ * Live "the window is phone-width" flag. Seeded at module load rather than on mount so the first
+ * paint of the playground is already correct — the playground is a client-only chunk, so there is
+ * no server render to disagree with, and a mount-time read would flash the config pane first.
+ */
+export const phoneViewportAtom = atom(readPhoneViewport())
+phoneViewportAtom.onMount = (set) => {
+    if (typeof window === "undefined" || !window.matchMedia) return
+    const list = window.matchMedia(PHONE_VIEWPORT_QUERY)
+    set(list.matches)
+    const sync = (event: MediaQueryListEvent) => set(event.matches)
+    list.addEventListener("change", sync)
+    return () => list.removeEventListener("change", sync)
+}
+
+/**
+ * The stored answer to "did the user collapse the config pane?", or `null` when the user has never
+ * touched either control. The tri-state is what makes a per-device default possible: a plain
+ * `false` default cannot tell "I want the config pane" apart from "I have never said".
+ *
+ * `getOnInit` reads localStorage synchronously, so a stored preference applies to the first paint
+ * instead of arriving one render later.
+ */
+export const configPanelCollapsedPreferenceAtom = atomWithStorage<boolean | null>(
+    "agenta:chat:config-panel-collapsed",
+    null,
+    undefined,
+    {getOnInit: true},
+)
+
+/**
+ * The default when nothing is stored: hidden on a phone, visible everywhere else.
+ *
+ * A stored preference always wins, in both directions. Collapsing the pane on a phone is one tap
+ * on the `»` reveal button in the chat header, and that tap stores `false`, so the phone default
+ * never fights a user who wants the config pane.
+ */
+export const resolveConfigPanelCollapsed = (
+    stored: boolean | null,
+    phoneViewport: boolean,
+): boolean => stored ?? phoneViewport
+
 /** Build mode's config pane collapsed to 0. Separate from the maximize flag: collapsing the pane
  * in Build is not the same as switching to Chat. */
-export const configPanelCollapsedAtom = atomWithStorage<boolean>(
-    "agenta:chat:config-panel-collapsed",
-    false,
+export const configPanelCollapsedAtom = atom(
+    (get) =>
+        resolveConfigPanelCollapsed(
+            get(configPanelCollapsedPreferenceAtom),
+            get(phoneViewportAtom),
+        ),
+    (_get, set, collapsed: boolean) => {
+        set(configPanelCollapsedPreferenceAtom, collapsed)
+    },
 )

--- a/web/packages/agenta-chat/tests/unit/state/panelLayout.test.ts
+++ b/web/packages/agenta-chat/tests/unit/state/panelLayout.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Unit tests for the config-pane default rule.
+ *
+ * The load-bearing case is the stored `false` on a phone: the user asked for the config pane with
+ * the `»` reveal button, and a per-device default that overruled that would make the button look
+ * broken. `stored ?? phoneViewport` is the whole rule, and it exists because the atom's old plain
+ * `false` default could not tell "I want the pane" apart from "I have never said".
+ */
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {
+    configPanelCollapsedAtom,
+    configPanelCollapsedPreferenceAtom,
+    phoneViewportAtom,
+    resolveConfigPanelCollapsed,
+} from "../../../src/state/panelLayout"
+
+describe("resolveConfigPanelCollapsed", () => {
+    it("keeps the config pane visible on a desktop with no preference stored", () => {
+        expect(resolveConfigPanelCollapsed(null, false)).toBe(false)
+    })
+
+    it("hides the config pane on a phone with no preference stored", () => {
+        expect(resolveConfigPanelCollapsed(null, true)).toBe(true)
+    })
+
+    it("honours a stored preference to show the pane, phone included", () => {
+        expect(resolveConfigPanelCollapsed(false, true)).toBe(false)
+    })
+
+    it("honours a stored preference to hide the pane, desktop included", () => {
+        expect(resolveConfigPanelCollapsed(true, false)).toBe(true)
+    })
+})
+
+describe("configPanelCollapsedAtom", () => {
+    it("reads the phone default and stops doing so once the user chooses", () => {
+        const store = createStore()
+        store.set(phoneViewportAtom, true)
+        expect(store.get(configPanelCollapsedAtom)).toBe(true)
+
+        // The `»` reveal button: one tap turns the per-device default into a real preference.
+        store.set(configPanelCollapsedAtom, false)
+        expect(store.get(configPanelCollapsedPreferenceAtom)).toBe(false)
+        expect(store.get(configPanelCollapsedAtom)).toBe(false)
+    })
+
+    it("follows the viewport only while no preference is stored", () => {
+        const store = createStore()
+        expect(store.get(configPanelCollapsedAtom)).toBe(false)
+
+        // Rotating a phone, or resizing a desktop window down, moves the default with it.
+        store.set(phoneViewportAtom, true)
+        expect(store.get(configPanelCollapsedAtom)).toBe(true)
+
+        store.set(configPanelCollapsedAtom, true)
+        store.set(phoneViewportAtom, false)
+        expect(store.get(configPanelCollapsedAtom)).toBe(true)
+    })
+})


### PR DESCRIPTION
## Context

On the mobile app at `/m`, opening a session lands on the configuration pane. The conversation and its composer are off screen until the reader taps "Hide configuration". A new agent's first message goes the same way. QA reproduced it on oss.preview, which runs the same mobile bundle as staging.

The `/m` session workspace holds one split: the pane on the left, the conversation beside it (`web/mobile/src/features/chat/SessionWorkspace.tsx:112`). At `md` and wider both are visible. On a phone there is no room for two (the pane asks for 300 to 440px and the conversation for 420 more), so the pane **replaces** the conversation: `fillClassName={!twoPane && showPane ? "hidden" : undefined}` at line 124. Anything that turns the pane on therefore takes the composer off the screen. Two separate rules did.

**The config pane opened by default.** `configPanelCollapsedAtom` was a plain boolean defaulting to `false`, so the pane was visible for everyone. A plain boolean cannot tell "I want the config pane" apart from "I have never said", so the default could not vary by device.

**The maximized flag then did it a second way.** `showPane` was `showConfig || chatMaximized`, which swaps the sessions rail in for the config pane in maximized mode. That swap makes sense with two panes. On a phone it puts the sessions list where the chat belongs. Worse, it is a dead end: `/m` only reads `chatPanelMaximizedAtom` and never writes it (the only writer is the desktop `AgentComposerDock`), and the desktop playground stores it under the same origin. A reader who had used Chat mode on the desktop opened `/m` with no conversation and no control to get one back.

## Changes

The first rule is fixed by the same commit as [#6170](https://github.com/Agenta-AI/agenta/pull/6170), cherry-picked here so this PR stands on its own. `configPanelCollapsedAtom` becomes tri-state: the stored value may be `null`, and `stored ?? phoneViewport` resolves it. Nothing stored means hidden on a phone and visible everywhere else. A stored preference still wins in both directions, and `/m` already has both controls: `»` "Show configuration" in the session tab rail, and `«` "Hide configuration" in the pane header. If #6170 merges first, that commit is identical content and this PR reduces to the mobile diff below.

The second rule is fixed here.

```
before:  const showPane = showConfig || chatMaximized
after:   showPane: showConfig || (twoPane && chatMaximized)
```

That rule moved out of the component into `web/mobile/src/features/chat/sessionPanes.ts` with unit tests, next to the other tested policy modules in the same folder. It decides whether a phone reader can reach the composer, which is more than an inline boolean should carry.

There is no server-render flash. Both `/m` routes return `null` until the router resolves their query, so the prerendered HTML holds no workspace and the client's first render of it already has the right value.

## Tests / notes

- `pnpm --filter @agenta/mobile test`: 98 tests in 14 files, all passed. 6 are new, in `tests/unit/sessionPanes.test.ts`.
- `pnpm --filter @agenta/chat test`: 371 tests in 39 files, all passed. That includes the 6 cherry-picked tests for the tri-state rule.
- `tsc --noEmit` in `web/mobile`: clean.
- `pnpm --filter @agenta/mobile lint`: 0 errors. The 4 `react-hooks/exhaustive-deps` warnings are pre-existing and in other files.
- `pnpm --filter @agenta/mobile build` (Next 16): the route summary printed for all 18 routes.
- `prettier@3.7.4 --check` on every touched file: clean.
- The atom's setter narrowed from `SetStateAction<boolean>` to `boolean`. Every writer in `web/oss` and `web/mobile` already passes a plain boolean, so no caller changed.
- Not verified in the running app. The rules are unit-tested, but nobody has opened `/m` on a phone with this build. Please do that.

## What to QA

Do these on a real phone, or on a 390px viewport with the device gate.

- Open an existing session from the sessions list. Expect the conversation and the composer, not the configuration pane.
- Send a first message to a brand new agent. Expect the turn to appear in the conversation you are already looking at.
- Tap `»` "Show configuration" in the tab rail above the chat. The configuration takes the screen. Tap `«` "Hide configuration" in its header to come back.
- Reload after tapping `»`. The configuration must still be there. The per-device default must not overrule that choice, in either direction.
- The cross-app case, which needs setup: on the desktop playground on the same host, switch the agent chat to Chat mode, then open `/m` and open a session. Expect the conversation, not the sessions rail.
- Regression to watch: on a tablet or a desktop window at 768px and wider, `/m` must still show the configuration beside the conversation by default, and Chat mode must still put the sessions rail in the pane.
- Regression to watch on the desktop app: the playground config pane still opens by default on a normal window, and `«` and `»` still work. That behavior comes from the cherry-picked commit and is what #6170 covers.
