### PR TITLE
ci(railway): serve the mobile app at /m in PR previews and the template

### DIFF
--- a/.github/workflows/42-railway-build.yml
+++ b/.github/workflows/42-railway-build.yml
@@ -108,6 +108,7 @@ jobs:
         image_name:
           - agenta-api
           - agenta-web
+          - agenta-web-mobile
           - agenta-services
           - agenta-runner
         arch:
@@ -125,6 +126,12 @@ jobs:
           - image_name: agenta-web
             context: web
             dockerfile: web/oss/docker/Dockerfile.gh
+          # The mobile app is a second Next app in the same `web` workspace, so
+          # it builds from the same context as agenta-web; only the Dockerfile
+          # differs. Built with basePath "/m" and served at /m by the gateway.
+          - image_name: agenta-web-mobile
+            context: web
+            dockerfile: web/mobile/docker/Dockerfile.gh
           - image_name: agenta-services
             context: .
             dockerfile: services/oss/docker/Dockerfile.gh
@@ -306,6 +313,7 @@ jobs:
         image_name:
           - agenta-api
           - agenta-web
+          - agenta-web-mobile
           - agenta-services
           - agenta-runner
     steps:

--- a/hosting/railway/oss/README.md
+++ b/hosting/railway/oss/README.md
@@ -21,6 +21,7 @@ baseline.
 - Keep deployment scriptable and repeatable.
 - Use a single public gateway domain with path routing:
   - `/` -> web
+  - `/m`, `/m/*` -> web-mobile (no prefix strip: the app is built with basePath `/m`)
   - `/api/` -> api
   - `/services/` -> services
 
@@ -42,7 +43,7 @@ baseline.
 - `scripts/deploy-gateway.sh` - deploy gateway image from local Dockerfile
 - `scripts/smoke.sh` - quick health checks
 - `scripts/upgrade.sh` - run full in-place upgrade flow
-- `scripts/build-and-push-images.sh` - build local `api/web/services/runner` images and push tags
+- `scripts/build-and-push-images.sh` - build local `api/web/web-mobile/services/runner` images and push tags
 - `scripts/deploy-from-images.sh` - deploy Railway services from explicit image tags
 - `scripts/preview-clone-create.sh` - create or update a PR preview environment (issue #5650)
 - `scripts/preview-clone-destroy.sh` - delete a PR preview environment (plus `--stale-hours` sweep)
@@ -206,6 +207,26 @@ export RAILWAY_ENVIRONMENT_NAME="staging"
 ./hosting/railway/oss/scripts/deploy-services.sh
 ./hosting/railway/oss/scripts/smoke.sh
 ```
+
+#### The mobile app (`/m`)
+
+The mobile web app is **opt-in** while it is pre-GA, the same way the compose
+stack keeps it behind the `with-web-mobile` profile (`run.sh --with-mobile`).
+Set the flag before `bootstrap.sh` and it creates a `web-mobile` service; the
+gateway already routes `/m` and `/m/*` to it:
+
+```bash
+export AGENTA_RAILWAY_WITH_MOBILE=true
+# Turn the device gate on so phones landing on a desktop route go to /m:
+export AGENTA_MOBILE_GATE=true
+# Let desktop browsers open /m directly instead of being bounced back:
+export AGENTA_MOBILE_REVERSE_GATE=false
+```
+
+`bootstrap.sh` is the only place the flag is read. `configure.sh` and
+`deploy-from-images.sh` configure and deploy the service whenever it exists,
+so an existing deployment picks it up by re-running bootstrap with the flag.
+`ghcr.io/agenta-ai/agenta-web-mobile` must be readable by Railway.
 
 ### Upgrade Existing Deployment
 

--- a/hosting/railway/oss/gateway/nginx.conf
+++ b/hosting/railway/oss/gateway/nginx.conf
@@ -53,6 +53,21 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # Mobile app. The Next app is BUILT with basePath "/m", so it owns the
+        # prefix and it must NOT be stripped (assets, links and routes all live
+        # under /m). This regex is the nginx equivalent of the compose Traefik
+        # rule Path(`/m`) || PathPrefix(`/m/`): it matches /m and /m/..., but
+        # not /mobile. A regex location outranks the `/` catch-all below and
+        # never steals /api/ or /services/, which this pattern cannot match.
+        location ~ ^/m(/|$) {
+            set $web_mobile_upstream "web-mobile.railway.internal:8080";
+            proxy_pass http://$web_mobile_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location / {
             set $web_upstream "web.railway.internal:8080";
             proxy_pass http://$web_upstream;

--- a/hosting/railway/oss/images/gateway/nginx.conf
+++ b/hosting/railway/oss/images/gateway/nginx.conf
@@ -53,6 +53,21 @@ http {
             proxy_set_header X-Forwarded-Proto $scheme;
         }
 
+        # Mobile app. The Next app is BUILT with basePath "/m", so it owns the
+        # prefix and it must NOT be stripped (assets, links and routes all live
+        # under /m). This regex is the nginx equivalent of the compose Traefik
+        # rule Path(`/m`) || PathPrefix(`/m/`): it matches /m and /m/..., but
+        # not /mobile. A regex location outranks the `/` catch-all below and
+        # never steals /api/ or /services/, which this pattern cannot match.
+        location ~ ^/m(/|$) {
+            set $web_mobile_upstream "web-mobile.railway.internal:8080";
+            proxy_pass http://$web_mobile_upstream;
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+        }
+
         location / {
             set $web_upstream "web.railway.internal:8080";
             proxy_pass http://$web_upstream;

--- a/hosting/railway/oss/scripts/bootstrap.sh
+++ b/hosting/railway/oss/scripts/bootstrap.sh
@@ -14,6 +14,12 @@ ENV_NAME="${RAILWAY_ENVIRONMENT_NAME:-staging}"
 SOURCE_COMPOSE_FILE="${RAILWAY_SOURCE_COMPOSE_FILE:-$(railway_source_compose_file "$ROOT_DIR")}"
 
 WEB_IMAGE="${AGENTA_WEB_IMAGE:-ghcr.io/agenta-ai/agenta-web:latest}"
+WEB_MOBILE_IMAGE="${AGENTA_WEB_MOBILE_IMAGE:-ghcr.io/agenta-ai/agenta-web-mobile:latest}"
+# The mobile app (/m) is opt-in while it is pre-GA, mirroring the compose
+# `with-web-mobile` profile (run.sh --with-mobile). Everything downstream
+# (configure.sh, deploy-from-images.sh) keys off whether the service exists,
+# so this flag is the single switch.
+WITH_MOBILE="${AGENTA_RAILWAY_WITH_MOBILE:-false}"
 API_IMAGE="${AGENTA_API_IMAGE:-ghcr.io/agenta-ai/agenta-api:latest}"
 SERVICES_IMAGE="${AGENTA_SERVICES_IMAGE:-ghcr.io/agenta-ai/agenta-services:latest}"
 RUNNER_IMAGE="${AGENTA_RUNNER_IMAGE:-ghcr.io/agenta-ai/agenta-runner:latest}"
@@ -268,6 +274,9 @@ main() {
     fi
 
     add_service_image web "$WEB_IMAGE"
+    if [ "$WITH_MOBILE" = "true" ]; then
+        add_service_image web-mobile "$WEB_MOBILE_IMAGE"
+    fi
     add_service_image api "$API_IMAGE"
     add_service_image services "$SERVICES_IMAGE"
     add_service_image runner "$RUNNER_IMAGE"

--- a/hosting/railway/oss/scripts/build-and-push-images.sh
+++ b/hosting/railway/oss/scripts/build-and-push-images.sh
@@ -22,6 +22,7 @@ fi
 
 API_IMAGE="${REGISTRY}/${NAMESPACE}/agenta-api:${TAG}"
 WEB_IMAGE="${REGISTRY}/${NAMESPACE}/agenta-web:${TAG}"
+WEB_MOBILE_IMAGE="${REGISTRY}/${NAMESPACE}/agenta-web-mobile:${TAG}"
 SERVICES_IMAGE="${REGISTRY}/${NAMESPACE}/agenta-services:${TAG}"
 RUNNER_IMAGE="${REGISTRY}/${NAMESPACE}/agenta-runner:${TAG}"
 
@@ -29,6 +30,9 @@ printf "Building local images with tag '%s'\n" "$TAG"
 
 docker build -t "$API_IMAGE" -f "$ROOT_DIR/api/oss/docker/Dockerfile.gh" "$ROOT_DIR"
 docker build -t "$WEB_IMAGE" -f "$ROOT_DIR/web/oss/docker/Dockerfile.gh" "$ROOT_DIR/web"
+# The mobile app is a second Next app in the same workspace: same build
+# context as the web image, different Dockerfile.
+docker build -t "$WEB_MOBILE_IMAGE" -f "$ROOT_DIR/web/mobile/docker/Dockerfile.gh" "$ROOT_DIR/web"
 docker build -t "$SERVICES_IMAGE" -f "$ROOT_DIR/services/oss/docker/Dockerfile.gh" "$ROOT_DIR"
 RUNNER_DOCKERFILE="$ROOT_DIR/services/runner/docker/Dockerfile.gh"
 if [ ! -f "$RUNNER_DOCKERFILE" ]; then
@@ -40,6 +44,7 @@ if [ "$PUSH_IMAGES" = "true" ]; then
     printf "Pushing images to %s/%s\n" "$REGISTRY" "$NAMESPACE"
     docker push "$API_IMAGE"
     docker push "$WEB_IMAGE"
+    docker push "$WEB_MOBILE_IMAGE"
     docker push "$SERVICES_IMAGE"
     docker push "$RUNNER_IMAGE"
 else
@@ -49,6 +54,7 @@ fi
 cat > "$OUTPUT_FILE" <<EOF
 export AGENTA_API_IMAGE="$API_IMAGE"
 export AGENTA_WEB_IMAGE="$WEB_IMAGE"
+export AGENTA_WEB_MOBILE_IMAGE="$WEB_MOBILE_IMAGE"
 export AGENTA_SERVICES_IMAGE="$SERVICES_IMAGE"
 export AGENTA_RUNNER_IMAGE="$RUNNER_IMAGE"
 EOF
@@ -56,5 +62,6 @@ EOF
 printf "Wrote image exports to %s\n" "$OUTPUT_FILE"
 printf "AGENTA_API_IMAGE=%s\n" "$API_IMAGE"
 printf "AGENTA_WEB_IMAGE=%s\n" "$WEB_IMAGE"
+printf "AGENTA_WEB_MOBILE_IMAGE=%s\n" "$WEB_MOBILE_IMAGE"
 printf "AGENTA_SERVICES_IMAGE=%s\n" "$SERVICES_IMAGE"
 printf "AGENTA_RUNNER_IMAGE=%s\n" "$RUNNER_IMAGE"

--- a/hosting/railway/oss/scripts/configure.sh
+++ b/hosting/railway/oss/scripts/configure.sh
@@ -20,6 +20,11 @@ POSTGRES_PASSWORD="${POSTGRES_PASSWORD:-}"
 AGENTA_STORE_ACCESS_KEY="${AGENTA_STORE_ACCESS_KEY:-}"
 AGENTA_STORE_SECRET_KEY="${AGENTA_STORE_SECRET_KEY:-}"
 AGENTA_STORE_BUCKET="${AGENTA_STORE_BUCKET:-agenta-store}"
+# Mobile device gate. Same names and defaults as the compose stack: the gate is
+# off unless the operator turns it on, and the mobile app bounces desktop
+# browsers off /m unless the reverse gate is turned off.
+AGENTA_MOBILE_GATE="${AGENTA_MOBILE_GATE:-false}"
+AGENTA_MOBILE_REVERSE_GATE="${AGENTA_MOBILE_REVERSE_GATE:-true}"
 AGENTA_STORE_SIGNING_KEY="${AGENTA_STORE_SIGNING_KEY:-}"
 # RSA key the API signs its store web-identity token with; the bundled SeaweedFS verifies it
 # against the API's JWKS.
@@ -355,6 +360,30 @@ main() {
     set_optional_vars web \
         "POSTHOG_API_KEY=${POSTHOG_API_KEY:-}" \
         "SENDGRID_API_KEY=${SENDGRID_API_KEY:-}"
+
+    set_vars web \
+        AGENTA_MOBILE_GATE="$AGENTA_MOBILE_GATE"
+
+    # The mobile app is opt-in (bootstrap.sh creates web-mobile only when
+    # AGENTA_RAILWAY_WITH_MOBILE=true), so configure it only when it exists —
+    # same idiom as the optional redis service below. It runs the same
+    # entrypoint as web and takes the same runtime config.
+    if railway service web-mobile >/dev/null 2>&1; then
+        set_vars web-mobile \
+            AGENTA_WEB_URL="https://${public_domain_ref}" \
+            AGENTA_API_URL="https://${public_domain_ref}/api" \
+            AGENTA_SERVICES_URL="https://${public_domain_ref}/services" \
+            AGENTA_AUTH_KEY="$AGENTA_AUTH_KEY" \
+            AGENTA_CRYPT_KEY="$AGENTA_CRYPT_KEY" \
+            AGENTA_MOBILE_GATE="$AGENTA_MOBILE_GATE" \
+            AGENTA_MOBILE_REVERSE_GATE="$AGENTA_MOBILE_REVERSE_GATE"
+
+        set_optional_vars web-mobile \
+            "POSTHOG_API_KEY=${POSTHOG_API_KEY:-}" \
+            "SENDGRID_API_KEY=${SENDGRID_API_KEY:-}"
+
+        unset_vars web-mobile AGENTA_LICENSE PORT SCRIPT_NAME REDIS_URI REDIS_URI_VOLATILE REDIS_URI_DURABLE SUPERTOKENS_CONNECTION_URI AGENTA_API_INTERNAL_URL ALEMBIC_CFG_PATH_CORE ALEMBIC_CFG_PATH_TRACING
+    fi
 
     set_vars api \
         AGENTA_WEB_URL="https://${public_domain_ref}" \

--- a/hosting/railway/oss/scripts/deploy-from-images.sh
+++ b/hosting/railway/oss/scripts/deploy-from-images.sh
@@ -29,6 +29,8 @@ SEAWEEDFS_IMAGE="${SEAWEEDFS_IMAGE:-chrislusf/seaweedfs:4.37}"
 
 AGENTA_API_IMAGE="${AGENTA_API_IMAGE:-}"
 AGENTA_WEB_IMAGE="${AGENTA_WEB_IMAGE:-}"
+# Optional: the mobile app is opt-in (see bootstrap.sh AGENTA_RAILWAY_WITH_MOBILE).
+AGENTA_WEB_MOBILE_IMAGE="${AGENTA_WEB_MOBILE_IMAGE:-}"
 AGENTA_SERVICES_IMAGE="${AGENTA_SERVICES_IMAGE:-}"
 AGENTA_RUNNER_IMAGE="${AGENTA_RUNNER_IMAGE:-}"
 
@@ -208,6 +210,19 @@ CMD ["sh", "-lc", "/app/entrypoint.sh node /app/oss/server.js"]
 EOF
 }
 
+render_web_mobile_wrapper() {
+    local dir="$TMP_DIR/web-mobile"
+    mkdir -p "$dir"
+    cat > "$dir/Dockerfile" <<EOF
+FROM ${AGENTA_WEB_MOBILE_IMAGE}
+
+ENV HOSTNAME=0.0.0.0
+ENV AGENTA_LICENSE=oss
+
+CMD ["sh", "-lc", "/app/entrypoint.sh node /app/mobile/server.js"]
+EOF
+}
+
 render_alembic_wrapper() {
     local dir="$TMP_DIR/alembic"
     mkdir -p "$dir"
@@ -259,6 +274,9 @@ render_api_wrapper
 render_services_wrapper
 render_runner_wrapper
 render_web_wrapper
+if [ -n "$AGENTA_WEB_MOBILE_IMAGE" ]; then
+    render_web_mobile_wrapper
+fi
 render_alembic_wrapper
 render_redis_wrapper
 render_seaweedfs_wrapper
@@ -299,6 +317,10 @@ railway_call up "$TMP_DIR/runner" --path-as-root --service runner --detach
 railway_call up "$TMP_DIR/services" --path-as-root --service services --detach
 railway_call up "$TMP_DIR/cron" --path-as-root --service cron --detach
 railway_call up "$TMP_DIR/web" --path-as-root --service web --detach
+# Deploy the mobile app only when both the image and the service are present.
+if [ -n "$AGENTA_WEB_MOBILE_IMAGE" ] && railway_call service web-mobile >/dev/null 2>&1; then
+    railway_call up "$TMP_DIR/web-mobile" --path-as-root --service web-mobile --detach
+fi
 
 sleep "$APP_SETTLE_SECONDS"
 "$ROOT_DIR/hosting/railway/oss/scripts/deploy-gateway.sh"

--- a/hosting/railway/oss/scripts/preview-clone-create.sh
+++ b/hosting/railway/oss/scripts/preview-clone-create.sh
@@ -230,17 +230,24 @@ apply_ci_auth_key() {
     local svc svc_id
     # Every service legacy configure.sh gave the key to: the workers use it for
     # internal calls while processing evaluation runs, so partial coverage
-    # split-brains auth and evaluations finish with status "errors".
-    for svc in web api services worker-queues worker-streams cron alembic; do
+    # split-brains auth and evaluations finish with status "errors". web-mobile
+    # carries AGENTA_AUTH_KEY for the same reason web does (same image
+    # entrypoint, same runtime config), so it needs the CI key too.
+    for svc in web web-mobile api services worker-queues worker-streams cron alembic; do
         svc_id="$(clone_service_id "$svc")"
-        [ -n "$svc_id" ] || { printf "No serviceId for '%s' while applying the CI auth key.\n" "$svc" >&2; return 1; }
+        if [ -z "$svc_id" ]; then
+            # A service the clone does not have yet (see OPTIONAL_SERVICES) is
+            # skipped here too; anything else missing is still fatal.
+            skip_absent_service "$svc" || return 1
+            continue
+        fi
         rw_graphql \
             'mutation($in: VariableCollectionUpsertInput!) { variableCollectionUpsert(input: $in) }' \
             "$(jq -nc --arg p "$PROJECT_ID" --arg e "$CLONE_ENV_ID" --arg s "$svc_id" --arg v "$AGENTA_AUTH_KEY" \
                 '{in: {projectId: $p, environmentId: $e, serviceId: $s, skipDeploys: true, replace: false, variables: {AGENTA_AUTH_KEY: $v}}}')" \
             >/dev/null || return 1
     done
-    printf "CI auth key applied to api and services.\n"
+    printf "CI auth key applied to every service that consumes it.\n"
 }
 
 clone_service_id() {

--- a/hosting/railway/oss/scripts/preview-clone-create.sh
+++ b/hosting/railway/oss/scripts/preview-clone-create.sh
@@ -13,7 +13,7 @@
 #      template with skipInitialDeploys. environmentCreate can 504 while the
 #      environment is still created in the background, so an ambiguous failure
 #      is reconciled by polling environments-by-name, never by re-creating.
-#   2. Patches the eight app-service images to the run's pinned tag with ONE
+#   2. Patches the nine app-service images to the run's pinned tag with ONE
 #      environmentPatchCommit; Railway auto-deploys every service whose config
 #      actually CHANGED. Services whose image already equals the target are
 #      deployed explicitly instead, because environmentPatchCommit silently
@@ -62,8 +62,8 @@
 #                             RAILWAY_TOKEN, the CLI treats that name as
 #                             project-scoped).
 #   AGENTA_API_IMAGE_REPO / AGENTA_WEB_IMAGE_REPO /
-#   AGENTA_SERVICES_IMAGE_REPO / AGENTA_RUNNER_IMAGE_REPO
-#                             Image repository overrides.
+#   AGENTA_WEB_MOBILE_IMAGE_REPO / AGENTA_SERVICES_IMAGE_REPO /
+#   AGENTA_RUNNER_IMAGE_REPO  Image repository overrides.
 #   RW_INFRA_WAIT_SECONDS     Postgres wait per attempt (default 420).
 #   RW_ALEMBIC_WAIT_SECONDS   Alembic wait (default 420).
 #   RW_DEPLOY_WAIT_SECONDS    Late-services wait (default 900).
@@ -118,16 +118,28 @@ fi
 
 API_REPO="${AGENTA_API_IMAGE_REPO:-ghcr.io/agenta-ai/agenta-api}"
 WEB_REPO="${AGENTA_WEB_IMAGE_REPO:-ghcr.io/agenta-ai/agenta-web}"
+WEB_MOBILE_REPO="${AGENTA_WEB_MOBILE_IMAGE_REPO:-ghcr.io/agenta-ai/agenta-web-mobile}"
 SERVICES_REPO="${AGENTA_SERVICES_IMAGE_REPO:-ghcr.io/agenta-ai/agenta-services}"
 RUNNER_REPO="${AGENTA_RUNNER_IMAGE_REPO:-ghcr.io/agenta-ai/agenta-runner}"
 
-# The eight image-patched app services; the api image backs five of them.
-APP_SERVICES=(api worker-streams worker-queues cron alembic web services runner)
+# The nine image-patched app services; the api image backs five of them.
+APP_SERVICES=(api worker-streams worker-queues cron alembic web web-mobile services runner)
 # supertokens must deploy AFTER alembic: it needs the agenta_oss_supertokens
 # database that alembic's startCommand creates (spike finding Q12).
 INFRA_SERVICES=(Postgres redis seaweedfs)
-LATE_SERVICES=(supertokens api worker-streams worker-queues runner services cron web gateway)
+LATE_SERVICES=(supertokens api worker-streams worker-queues runner services cron web web-mobile gateway)
 ALL_SERVICES=("${INFRA_SERVICES[@]}" alembic "${LATE_SERVICES[@]}")
+
+# Services a clone may legitimately not have yet. Adding a service to the
+# template only reaches clones once apply.sh has converged the template
+# environment (template/README.md step 4, "Apply on merge"), so during that
+# window a clone of the OLD template has no such service. A preview must
+# deploy anyway instead of dying on a missing serviceId; every other service
+# staying absent is still fatal.
+OPTIONAL_SERVICES=(web-mobile)
+REQUIRED_SERVICE_COUNT=$(( ${#ALL_SERVICES[@]} - ${#OPTIONAL_SERVICES[@]} ))
+# Filled in by patch_commit_images / deploy_all for the run summary.
+MISSING_SERVICES=""
 
 Q_ENV_SERVICES='query($id: String!) { environment(id: $id) { serviceInstances { edges { node { serviceId serviceName source { image } latestDeployment { status } domains { serviceDomains { domain } } } } } } }'
 Q_ENVS='query($p: String!) { environments(projectId: $p, first: 100) { edges { node { id name } } } }'
@@ -148,6 +160,7 @@ image_for() {
     case "$1" in
         api | worker-streams | worker-queues | cron | alembic) printf '%s:%s' "$API_REPO" "$IMAGE_TAG" ;;
         web) printf '%s:%s' "$WEB_REPO" "$IMAGE_TAG" ;;
+        web-mobile) printf '%s:%s' "$WEB_MOBILE_REPO" "$IMAGE_TAG" ;;
         services) printf '%s:%s' "$SERVICES_REPO" "$IMAGE_TAG" ;;
         runner) printf '%s:%s' "$RUNNER_REPO" "$IMAGE_TAG" ;;
         *) return 1 ;;
@@ -249,6 +262,25 @@ clone_service_image() {
         <<<"$CLONE_SERVICES_JSON" | head -n1
 }
 
+clone_has_service() {
+    [ -n "$(clone_service_id "$1")" ]
+}
+
+# skip_absent_service <service>: 0 when the service may be missing (recorded
+# and skipped), 1 when its absence is fatal.
+skip_absent_service() {
+    local svc="$1"
+    if contains_word "${OPTIONAL_SERVICES[*]}" "$svc"; then
+        contains_word "$MISSING_SERVICES" "$svc" || {
+            MISSING_SERVICES="$MISSING_SERVICES $svc"
+            printf "Service '%s' is not in this clone; skipping it. The template environment has not been converged yet (template/README.md 'Apply on merge').\n" "$svc" >&2
+        }
+        return 0
+    fi
+    printf "No serviceId for '%s'.\n" "$svc" >&2
+    return 1
+}
+
 # Wait until the clone's serviceInstances are fully materialized (reads can
 # lag writes right after environmentCreate).
 wait_clone_populated() {
@@ -256,10 +288,10 @@ wait_clone_populated() {
     while :; do
         refresh_clone_services || return 1
         count="$(jq -r '[.data.environment.serviceInstances.edges[].node] | length' <<<"$CLONE_SERVICES_JSON")"
-        [ "$count" -ge "${#ALL_SERVICES[@]}" ] && return 0
+        [ "$count" -ge "$REQUIRED_SERVICE_COUNT" ] && return 0
         waited=$((waited + interval))
         if [ "$waited" -ge "$max" ]; then
-            printf 'Environment has %s/%s service instances after %ss.\n' "$count" "${#ALL_SERVICES[@]}" "$max" >&2
+            printf 'Environment has %s/%s service instances after %ss.\n' "$count" "$REQUIRED_SERVICE_COUNT" "$max" >&2
             return 1
         fi
         sleep "$interval"
@@ -362,7 +394,10 @@ patch_commit_images() {
     UNCHANGED_SERVICES=""
     for svc in "${APP_SERVICES[@]}"; do
         svc_id="$(clone_service_id "$svc")"
-        [ -n "$svc_id" ] || { printf "No serviceId for '%s'.\n" "$svc" >&2; return 1; }
+        if [ -z "$svc_id" ]; then
+            skip_absent_service "$svc" || return 1
+            continue
+        fi
         img="$(image_for "$svc")"
         live="$(clone_service_image "$svc")"
         if [ "$live" = "$img" ]; then
@@ -409,6 +444,7 @@ deploy_all() {
     # Infra first. In an existing environment green services are left alone.
     refresh_clone_services || return 1
     for svc in "${INFRA_SERVICES[@]}"; do
+        clone_has_service "$svc" || { skip_absent_service "$svc" || return 1; continue; }
         if needs_explicit_deploy "$svc"; then
             deploy_service "$svc" || return 1
         fi
@@ -432,6 +468,7 @@ deploy_all() {
 
     # alembic must be green before supertokens deploys.
     refresh_clone_services || return 1
+    clone_has_service alembic || { skip_absent_service alembic || return 1; }
     if needs_explicit_deploy alembic; then
         deploy_service alembic || return 1
     fi
@@ -443,12 +480,15 @@ deploy_all() {
     # deploying; deploy the rest that are not green (supertokens, gateway, and
     # any app service the patch skipped because its image was unchanged).
     refresh_clone_services || return 1
+    local present_late=()
     for svc in "${LATE_SERVICES[@]}"; do
+        clone_has_service "$svc" || { skip_absent_service "$svc" || return 1; continue; }
         if needs_explicit_deploy "$svc"; then
             deploy_service "$svc" || return 1
         fi
+        present_late+=("$svc")
     done
-    wait_services_success "${RW_DEPLOY_WAIT_SECONDS:-900}" "${LATE_SERVICES[@]}"
+    wait_services_success "${RW_DEPLOY_WAIT_SECONDS:-900}" "${present_late[@]}"
 }
 
 check_endpoint() {
@@ -524,6 +564,9 @@ main() {
     local preview_url="https://${GATEWAY_DOMAIN}/w"
     local logs_url="https://railway.com/project/${PROJECT_ID}/logs?environmentId=${CLONE_ENV_ID}"
     printf 'Preview ready (%s): %s\n' "$clone_mode" "$preview_url"
+    if [ -n "$MISSING_SERVICES" ]; then
+        printf 'Skipped (not in this clone):%s\n' "$MISSING_SERVICES"
+    fi
     printf 'Timings: created=%ss deployed=%ss smoked=%ss total=%ss api_calls=%s\n' \
         "$t_created" "$t_deployed" "$t_smoked" "$total_s" "$calls"
     rw_report_calls "preview-clone-create ($clone_mode)"

--- a/hosting/railway/oss/scripts/preview-clone-create.sh
+++ b/hosting/railway/oss/scripts/preview-clone-create.sh
@@ -137,7 +137,6 @@ ALL_SERVICES=("${INFRA_SERVICES[@]}" alembic "${LATE_SERVICES[@]}")
 # deploy anyway instead of dying on a missing serviceId; every other service
 # staying absent is still fatal.
 OPTIONAL_SERVICES=(web-mobile)
-REQUIRED_SERVICE_COUNT=$(( ${#ALL_SERVICES[@]} - ${#OPTIONAL_SERVICES[@]} ))
 # Filled in by patch_commit_images / deploy_all for the run summary.
 MISSING_SERVICES=""
 
@@ -281,17 +280,38 @@ skip_absent_service() {
     return 1
 }
 
+# required_missing_services: the required services absent from the clone, as a
+# leading-space-separated list. Empty means the clone is fully materialized.
+required_missing_services() {
+    local svc out=""
+    for svc in "${ALL_SERVICES[@]}"; do
+        if contains_word "${OPTIONAL_SERVICES[*]}" "$svc"; then
+            continue
+        fi
+        if ! clone_has_service "$svc"; then
+            out="$out $svc"
+        fi
+    done
+    printf '%s' "$out"
+}
+
 # Wait until the clone's serviceInstances are fully materialized (reads can
 # lag writes right after environmentCreate).
+#
+# Checks every REQUIRED service by name rather than counting instances. A count
+# is unsound once the set has an optional member: a converged clone that has
+# web-mobile plus 12 of its 13 required services also totals 13, so a count
+# check would return while a required service was still missing and the deploy
+# loop would fail instead of waiting.
 wait_clone_populated() {
-    local waited=0 interval=5 max="${RW_CLONE_POPULATE_SECONDS:-120}" count
+    local waited=0 interval=5 max="${RW_CLONE_POPULATE_SECONDS:-120}" missing
     while :; do
         refresh_clone_services || return 1
-        count="$(jq -r '[.data.environment.serviceInstances.edges[].node] | length' <<<"$CLONE_SERVICES_JSON")"
-        [ "$count" -ge "$REQUIRED_SERVICE_COUNT" ] && return 0
+        missing="$(required_missing_services)"
+        [ -z "$missing" ] && return 0
         waited=$((waited + interval))
         if [ "$waited" -ge "$max" ]; then
-            printf 'Environment has %s/%s service instances after %ss.\n' "$count" "$REQUIRED_SERVICE_COUNT" "$max" >&2
+            printf 'Environment is still missing required service(s) after %ss:%s\n' "$max" "$missing" >&2
             return 1
         fi
         sleep "$interval"

--- a/hosting/railway/oss/template/README.md
+++ b/hosting/railway/oss/template/README.md
@@ -5,7 +5,7 @@ environment** (design: issue #5650; live proof:
 `docs/design/railway-preview-clone-spike/`). This directory makes that template
 code in the repo:
 
-- `template.json` — the full definition of the template environment: 13
+- `template.json` — the full definition of the template environment: 14
   services with images (tags parameterized), startCommands, restart policies,
   volumes, healthcheck policy, deploy-ordering constraints, and every managed
   variable by NAME. It contains **no secret values**.
@@ -38,6 +38,12 @@ the same additive-first discipline:
    service lands in the template *before* the code that requires it (old code
    ignores the extra config); removal lands *after* no supported code path
    needs it. This keeps every open PR's clone deployable throughout.
+
+   A service added here does not reach existing clones until step 4 runs, so
+   `preview-clone-create.sh` treats the names in its `OPTIONAL_SERVICES` list
+   as skippable: a clone made from the not-yet-converged template deploys
+   without them instead of failing on a missing `serviceId`. Add a new service
+   to that list in the same PR, and drop it once the template is applied.
 3. **Test on a clone first.** Create a scratch clone of `pr-template` (or reuse
    a preview clone), then converge *it* against your edited definition:
 
@@ -82,10 +88,13 @@ variables query per service) against the token's 1000/hour Hobby budget.
 
 Four tag parameters in `template.json`:
 
-- `app_tag` — the four Agenta app images (`agenta-api`, `agenta-web`,
-  `agenta-services`, `agenta-runner`), pinned to a release tag. Clones patch
-  these to `pr-<n>-<sha>` tags per PR via `environmentPatchCommit`.
-  Overridable via `--app-tag` or `AGENTA_TEMPLATE_APP_TAG`.
+- `app_tag` — the five Agenta app images (`agenta-api`, `agenta-web`,
+  `agenta-web-mobile`, `agenta-services`, `agenta-runner`), pinned to a release
+  tag. Clones patch these to `pr-<n>-<sha>` tags per PR via
+  `environmentPatchCommit`. Overridable via `--app-tag` or
+  `AGENTA_TEMPLATE_APP_TAG`. **`agenta-web-mobile` was first published at
+  `v0.111.0`**, so an `app_tag` older than that leaves `web-mobile` unable to
+  pull its image; keep the parameter on a release that shipped all five.
 - `gateway_tag` / `redis_tag` / `seaweedfs_tag` — one content-addressed tag
   per preview wrapper image
   (`ghcr.io/agenta-ai/agenta-preview-{gateway,redis,seaweedfs}`, built by
@@ -164,9 +173,16 @@ deployments are irrelevant to clones — clones copy config, not deployments).
 
 - **startCommand:** services whose image owns its entrypoint (Postgres,
   supertokens, and the three wrapper images) must have it empty/unset. The
-  eight app services carry explicit startCommands because one image backs
+  nine app services carry explicit startCommands because one image backs
   several services (`agenta-api` alone backs api, worker-streams,
-  worker-queues, cron, alembic).
+  worker-queues, cron, alembic) and because `web` and `web-mobile` share an
+  entrypoint but start different servers.
+- **Mobile app:** `web-mobile` serves `/m`. The gateway routes `/m` and `/m/*`
+  to it with **no** prefix strip, because the Next app is built with
+  `basePath: "/m"` and owns the prefix. Preview gate policy: `web` sets
+  `AGENTA_MOBILE_GATE=true` so a phone is redirected from a desktop route to
+  `/m`, and `web-mobile` sets `AGENTA_MOBILE_REVERSE_GATE=false` so a reviewer
+  on a laptop can open `/m` directly.
 - **Healthchecks:** unset on all services, matching the live-proven template
   (10/10 green clone cycles). The standalone deployment path
   (`../scripts/configure.sh`) sets healthchecks on gateway/api/services/runner;

--- a/hosting/railway/oss/template/template.json
+++ b/hosting/railway/oss/template/template.json
@@ -7,17 +7,18 @@
     "project-location": "The template lives in project 'agenta-oss-clone-spike', environment 'pr-template'. CI resolves the same location from the repo variables RAILWAY_TEMPLATE_PROJECT / RAILWAY_TEMPLATE_ENV (falling back to these values), and the preview scripts accept the same names as env vars. Moving the template = converge the new project's environment with apply.sh --project, then update 'project' here and the two repo variables.",
     "variable-classes": "A variable value that contains a ${{...}} Railway reference is PER-ENVIRONMENT-UNIQUE: Railway re-resolves it inside every clone (proven, findings.md Q2). A literal string value is SHARED: byte-identical in the template and every clone. An object {\"secret\": NAME} is a SHARED SECRET: the value is never stored in this file; apply.sh resolves it at apply time from the process environment, from the value already live on a sibling service, or from the declared generator, in that order.",
     "system-variables": "Railway injects RAILWAY_* variables (RAILWAY_ENVIRONMENT*, RAILWAY_PROJECT_*, RAILWAY_SERVICE_*, RAILWAY_PRIVATE_DOMAIN, ...) into every service. The diff ignores any RAILWAY_* name UNLESS it is declared here (declared ones, e.g. redis's RAILWAY_RUN_UID, are managed and diffed like any other).",
-    "start-command-policy": "Services whose image owns its entrypoint (Postgres, supertokens, and the three WP1 wrapper images gateway/redis/seaweedfs) MUST have startCommand empty/unset. The eight app services carry explicit startCommands because one image backs several services (agenta-api alone backs api, worker-streams, worker-queues, cron, and alembic). API fact: startCommand null in serviceInstanceUpdate is a NO-OP; \"\" clears the override (findings.md close-out addendum).",
+    "start-command-policy": "Services whose image owns its entrypoint (Postgres, supertokens, and the three WP1 wrapper images gateway/redis/seaweedfs) MUST have startCommand empty/unset. The nine app services carry explicit startCommands because one image backs several services (agenta-api alone backs api, worker-streams, worker-queues, cron, and alembic), and because web/web-mobile share an entrypoint but run different servers. API fact: startCommand null in serviceInstanceUpdate is a NO-OP; \"\" clears the override (findings.md close-out addendum).",
     "tag-policy": "Template image tags must NEVER equal a PR image tag (pr-<n>-<sha>) and must NEVER be 'latest': environmentPatchCommit silently no-ops when a patched tag equals the template's tag, which strands a clone on template images (findings.md, deploy-mode section). apply.sh enforces this.",
-    "healthchecks": "healthcheckPath is unset on all services, matching the live-proven template (10/10 green clone cycles). The standalone deployment path (scripts/configure.sh) sets healthchecks for gateway/api/services/runner; adding them to the template is a deliberate change to this file, not silent drift."
+    "healthchecks": "healthcheckPath is unset on all services, matching the live-proven template (10/10 green clone cycles). The standalone deployment path (scripts/configure.sh) sets healthchecks for gateway/api/services/runner; adding them to the template is a deliberate change to this file, not silent drift.",
+    "mobile-app": "The mobile app is the web-mobile service, served at /m by the gateway (location ~ ^/m(/|$) -> web-mobile, NO prefix strip: the Next app is built with basePath /m and owns the prefix). Its image ships web/entrypoint.sh, so it takes the same runtime config as web and writes the same __env.js. Preview gate policy: web carries AGENTA_MOBILE_GATE=true so a phone landing on a desktop route is redirected to /m, and web-mobile carries AGENTA_MOBILE_REVERSE_GATE=false so a reviewer on a laptop can open /m directly instead of being bounced back."
   },
   "parameters": {
     "app_tag": {
-      "default": "v0.108.0",
-      "description": "Tag for the four Agenta app images (agenta-api, agenta-web, agenta-services, agenta-runner). Pinned to a release tag; per-PR clones patch these images to pr-<n>-<sha> tags via environmentPatchCommit. Never 'latest', never a pr-* tag (see notes.tag-policy)."
+      "default": "v0.112.3",
+      "description": "Tag for the five Agenta app images (agenta-api, agenta-web, agenta-web-mobile, agenta-services, agenta-runner). Pinned to a release tag; per-PR clones patch these images to pr-<n>-<sha> tags via environmentPatchCommit. Never 'latest', never a pr-* tag (see notes.tag-policy). MUST be a release that published agenta-web-mobile too: that image starts at v0.111.0, so an older app_tag leaves web-mobile unable to pull."
     },
     "gateway_tag": {
-      "default": "content-778baa45f18f",
+      "default": "content-82ae55a2360a",
       "description": "Content-addressed tag for ghcr.io/agenta-ai/agenta-preview-gateway, built by workflow 42 from hosting/railway/oss/images/gateway. When the wrapper source changes, regenerate with images/compute-tag.sh (see template/README.md). Never 'latest', never a pr-* tag."
     },
     "redis_tag": {
@@ -44,6 +45,7 @@
         "supertokens",
         "api",
         "web",
+        "web-mobile",
         "services",
         "runner",
         "worker-streams",
@@ -117,7 +119,35 @@
           "secret": "AGENTA_CRYPT_KEY"
         },
         "AGENTA_LICENSE": "oss",
+        "AGENTA_MOBILE_GATE": "true",
         "HOSTNAME": "0.0.0.0"
+      },
+      "optionalVariables": [
+        "POSTHOG_API_KEY",
+        "SENDGRID_API_KEY"
+      ]
+    },
+    "web-mobile": {
+      "image": "ghcr.io/agenta-ai/agenta-web-mobile:{app_tag}",
+      "startCommand": "sh -lc '/app/entrypoint.sh node /app/mobile/server.js'",
+      "healthcheckPath": null,
+      "restartPolicyType": "ON_FAILURE",
+      "restartPolicyMaxRetries": 10,
+      "volumes": [],
+      "variables": {
+        "AGENTA_WEB_URL": "https://${{gateway.RAILWAY_PUBLIC_DOMAIN}}",
+        "AGENTA_API_URL": "https://${{gateway.RAILWAY_PUBLIC_DOMAIN}}/api",
+        "AGENTA_SERVICES_URL": "https://${{gateway.RAILWAY_PUBLIC_DOMAIN}}/services",
+        "AGENTA_AUTH_KEY": {
+          "secret": "AGENTA_AUTH_KEY"
+        },
+        "AGENTA_CRYPT_KEY": {
+          "secret": "AGENTA_CRYPT_KEY"
+        },
+        "AGENTA_LICENSE": "oss",
+        "AGENTA_MOBILE_GATE": "true",
+        "HOSTNAME": "0.0.0.0",
+        "AGENTA_MOBILE_REVERSE_GATE": "false"
       },
       "optionalVariables": [
         "POSTHOG_API_KEY",


### PR DESCRIPTION
## Context

The Agenta mobile app is built and published (`ghcr.io/agenta-ai/agenta-web-mobile`), and the compose stack already serves it at `/m` behind Traefik. Railway PR previews never got it: the preview pipeline enumerates exactly four app images, and the preview gateway has no `/m` route. A reviewer opening a preview has no way to see the mobile app, on a phone or on a laptop.

This adds `agenta-web-mobile` as a fifth app image everywhere the Railway pipeline names one, and gives the preview template a `web-mobile` service that the gateway routes `/m` and `/m/*` to.

## Changes

| Where | What |
|---|---|
| `.github/workflows/42-railway-build.yml` | `agenta-web-mobile` joins the per-arch build matrix and the manifest merge. Context `web`, dockerfile `web/mobile/docker/Dockerfile.gh`, same cache scopes and non-root check as `agenta-web`. |
| `hosting/railway/oss/gateway/nginx.conf`, `images/gateway/nginx.conf` | New `location ~ ^/m(/\|$)` proxying to `web-mobile`. Both copies stay byte-identical, so `images/verify-wrappers.sh` still passes. |
| `template/template.json` | New `web-mobile` service, an exact mirror of `web` plus the gate flags. `web` gains `AGENTA_MOBILE_GATE=true`. `deployOrder` gains `web-mobile`. `gateway_tag` moves to the new content hash, `app_tag` to `v0.112.3`. |
| `scripts/preview-clone-create.sh` | Patches and deploys `web-mobile` with the other app images, and tolerates a service the clone does not have yet (see rollout below). |
| `scripts/bootstrap.sh`, `configure.sh`, `deploy-from-images.sh`, `build-and-push-images.sh` | The self-host path can create, configure and deploy `web-mobile`, opt-in via `AGENTA_RAILWAY_WITH_MOBILE=true`. |
| `README.md`, `template/README.md` | Route table, image list, service count, gate policy, and the opt-in flag. |

**No prefix strip.** The mobile app is built with `basePath: "/m"`, so it owns the prefix. The nginx location passes the URI through unchanged, matching the compose Traefik rule `Path(/m) || PathPrefix(/m/)`. The regex matches `/m` and `/m/...` but not `/mobile`, and it cannot shadow `/api/` or `/services/`.

**Gate policy for previews.** `web` gets `AGENTA_MOBILE_GATE=true` so a phone landing on a desktop route is redirected to `/m`. `web-mobile` gets `AGENTA_MOBILE_REVERSE_GATE=false` so a reviewer on a laptop can open `/m` directly instead of being bounced back to the desktop app. Both are read at request time, so an operator can flip either one without a rebuild.

**`app_tag` moves from `v0.108.0` to `v0.112.3`.** `agenta-web-mobile` was first published at `v0.111.0`, so the old pin would have left `web-mobile` pointing at an image that does not exist. `v0.112.3` is the newest release tag that has all five images. Clones patch every app image to `pr-<n>-<sha>` immediately, so this only moves the template baseline and the starting point of a fresh clone.

## Rollout: this needs two steps, in order

A service added to `template.json` does not reach clones until `apply.sh` converges the live `pr-template` environment. That is the documented protocol (`template/README.md` step 4, "Apply on merge"), and the daily drift check fails by design in between. So:

1. Merge this PR.
2. Run `hosting/railway/oss/template/apply.sh` against `pr-template`. Previews created after that serve `/m`.

To keep every open PR deployable during that window, `preview-clone-create.sh` now skips services listed in `OPTIONAL_SERVICES` when a clone does not have them, instead of failing on a missing `serviceId`. Absence of any other service is still fatal. `web-mobile` should come off that list once the template is applied.

## Live verification: `/m` works

Verified end to end on a scratch environment cloned from `pr-template`, converged with
`apply.sh` against this PR's `template.json`, and deployed on this PR's own images
(`pr-6175-faf4b77`). All 14 services reached SUCCESS, `web-mobile` on
`ghcr.io/agenta-ai/agenta-web-mobile:pr-6175-faf4b77` and the gateway on the new
`content-82ae55a2360a`.

| Check | Result |
|---|---|
| `/m` | 200, serves the mobile app |
| `/m/auth` | 200 (a real mobile route, not just the root) |
| `/m/_next/static/chunks/1z3vy0gmmlpjx.css` | 200 `text/css`, taken from the page's own markup, so the `/m` prefix is genuinely not stripped |
| `/m/__env.js` | 200, so `entrypoint.sh` mirrored the runtime config |
| iPhone UA + `Accept: text/html` + `sec-ch-ua-mobile: ?1` on `/w` | 307 to `/m/`, follows to 200 |
| Desktop UA on `/m/` | stays on `/m`, 200, not bounced |
| Desktop UA on `/w` | stays on `/w`, 200, not pulled into `/m` |
| `/w`, `/api/health`, `/services/health` | 200, 200, 200 |

A bare `/m/` answers 308 to `/m` first. That is Next's trailing-slash normalization for a
`basePath` app, not the gateway and not the gate.

The scratch environment was destroyed after the run.

**The GHCR blocker this PR originally hit is cleared.** `agenta-web-mobile` was a private
package, so the build failed with `denied: permission_denied: read_package`. It is now
public with `Agenta-AI/agenta` granted Write under Manage Actions access, and both
`agenta-web-mobile` arch builds plus the manifest merge are green.

## After merge: converge the live template

`/m` reaches PR previews only once the live `pr-template` environment is converged. That is
the documented protocol (`template/README.md` step 4). From a checkout of the merged branch:

```bash
hosting/railway/oss/template/apply.sh --dry-run   # read the drift report
hosting/railway/oss/template/apply.sh             # converge pr-template
```

Expect it to create `web-mobile`, upsert its nine variables, patch the gateway to
`content-82ae55a2360a`, add `AGENTA_MOBILE_GATE` to `web`, and move the five app images to
`v0.112.3`. Re-run once if a `volume-missing` line remains; Railway throttles back-to-back
volume creates. Done when it prints `CLEAN: live environment matches the definition`.

Until that runs, a preview clone has no `web-mobile` service, so `preview-clone-create.sh`
skips it (`OPTIONAL_SERVICES`) and the preview deploys normally without `/m`. That is why
this PR's own preview does not serve `/m`.

## Review follow-ups

Both CodeRabbit findings were real and are fixed. Neither weakens the `/m` behavior or the
tolerance path.

**`ae87e07ae6` — wait for each required service, not a count.** My own change had made the
count check unsound: `ALL_SERVICES` is 14 with `web-mobile` optional, so the threshold was
13, and a converged clone carrying `web-mobile` plus 12 of its 13 required services also
totals 13. `wait_clone_populated` could return while a required service was still
materializing, and the deploy loop would then fail instead of waiting. It now checks every
required service by name and names the missing ones on timeout.

**`26cb7f46d9` — give `web-mobile` the CI auth key.** `apply_ci_auth_key` upserted the CI
`AGENTA_AUTH_KEY` onto every service that consumes it except `web-mobile`, which carries the
variable for the same reason `web` does. A clone would have run the mobile service on the
template's own generated key while the rest of the stack used the CI key. Absence stays
tolerated, through the same `skip_absent_service` helper, so pre-convergence clones are
unaffected.

Re-verified against the stubbed Railway API in three clone shapes: converged (14 services,
9 images patched), pre-convergence (13 services, `web-mobile` skipped, 8 patched), and a new
fixture for exactly the case CodeRabbit described (13 services, `web-mobile` present,
required `cron` absent). The third now waits and reports `Environment is still missing
required service(s) after 4s: cron` instead of proceeding.

## Preview run history

The first fresh preview after the GHCR fix failed at setup with
`FAILED: /services/health after 300s`, while `/w` and `/api/health` were both OK. That was a
Railway/container-startup problem, not this PR: a clone's gateway is the template's image
rather than this PR's, Railway reported the `services` deployment as SUCCESS with no timeout
or crash line, and an A/B run of the pre-PR and post-PR scripts against the same stubbed API
produces an identical patch set and identical deploy order on a 13-service clone. The
re-triggered run confirmed it: **setup and deploy both green**, gateway 200 on `/w`.

## Breaks nothing existing

**Tests.** Three preview runs tell the whole story:

| Run | Head | API acceptance | Rest | Reading |
|---|---|---|---|---|
| 32517197241 | `642fc0b5` | success | 12 green, web acceptance red | matched sibling #6190 job for job, 14 jobs |
| 32563226014 | `ed304e6` | red, 256 × `Application not found` + 502 | 11 green | preview not serving; infrastructure, not code |
| 32564671719 | `ed304e6` | success | 12 green, web acceptance pending | clean comparison on the head with both fixes |

The only persistently red job anywhere is `run-web-tests (acceptance)`, the known
stale-selector suite that fails on every branch. Nothing is red here and green on the
sibling. That is what the diff predicts: this PR touches only
`.github/workflows/42-railway-build.yml` and `hosting/railway/**` and changes no
application code.

**Clone-preview test.** Workflow 48 runs three consecutive full clone cycles with the
production scripts, and has been green on every run, each cycle exercising the
`OPTIONAL_SERVICES` skip path because the clones predate the template being converged.

**Desktop UI walk.** Run against a converged scratch clone on this PR's own images
(`pr-6175-ed304e6`), because the PR preview kept going dark: setup and deploy would pass
and minutes later all 13 services read `NONE` with the gateway 404ing.

| Page | Landed on | Fresh console errors |
|---|---|---|
| `/auth` | `/auth`, full sign-in renders | 0 |
| `/w` | `/auth?redirectToPath=%2Fw`, correct signed-out redirect | 0 |
| `/m` | `/m/auth`, title `Sign in · Agenta` | 2, both `401` from a signed-out session |

Gateway paths on that clone: `/w`, `/api/health`, `/services/health`, `/__env.js`, `/m` and
`/m/__env.js` all 200. Screenshots in `qa/ui-regression/railway-6175--{auth,app,mobile}.png`,
each carrying an in-page banner showing the host and path so the image proves its own
origin. Not signed in: the scratch clone had no CI auth key, so the walk covers signed-out
pages only.

## Tests / notes

Verified without Railway credentials:

- **Gateway routing, against the real image.** Built `images/gateway` and ran it with four echo upstreams, swapping only Railway's DNS resolver and the upstream hostnames for local ones. `nginx -t` passes on the rendered config, and every route lands where it should with the path intact:

  | Request | Reaches | Path seen by upstream |
  |---|---|---|
  | `/`, `/w` | web | `/`, `/w` |
  | `/m`, `/m/`, `/m/auth`, `/m/_next/static/x.js` | web-mobile | unchanged, prefix kept |
  | `/mobile` | web | `/mobile` (no over-match) |
  | `/api/health`, `/services/health` | api, services | `/health` (prefix still stripped) |

- **The clone script's new skip path**, twice. Offline first, running the real `preview-clone-create.sh` against a stubbed Railway API: a clone that has `web-mobile` patches nine images, a clone that lacks it skips it with a warning and patches the other eight, and a clone missing `api` still fails. Then live: **workflow 48 passed**, three full clone cycles against the real template project with the production scripts. Those clones came from the not-yet-converged template, so they exercised exactly the skip path, and every cycle created, deployed, smoked and destroyed cleanly.
- `images/verify-wrappers.sh` passes, so the two gateway sources have not drifted. `compute-tag.sh` confirms `gateway_tag` moved and `redis_tag` / `seaweedfs_tag` did not.
- `bash -n` and shellcheck on every touched script (no new findings), `template.json` parses, and the workflow 42 matrix expands to 10 build jobs and 5 merge jobs with the right context and dockerfile per image.

Not verified live. The mobile container has never been deployed on Railway, because the image is unpullable there until the package is public. The nginx `/m` upstream port (8080) mirrors `web`, which declares no `PORT` and is reached on 8080 today, so Railway resolves it identically for both Next standalone images.

## What to QA

Do this after the template has been applied and the package is public.

- Open a preview URL on a laptop and go to `/m`. The mobile app loads. You are not bounced to `/w`.
- On the same preview, hard-reload `/m/` and check the network tab. Assets under `/m/_next/...` return 200, not 404. A 404 here means the prefix is being stripped somewhere.
- Open the preview root on a phone. You land on `/m`. Add `?view=desktop` and you stay on the desktop app.
- Regression to watch: the paths this change sits next to. `/w` still loads the desktop app, `/api/health` and `/services/health` still return 200, and `/mobile` (if any route uses it) still goes to the desktop app.