### PR TITLE
fix(frontend): keep Invite Teammate in the sidebar across an org switch

### DIFF
--- a/web/oss/src/components/Sidebar/scopes/bottomSection.tsx
+++ b/web/oss/src/components/Sidebar/scopes/bottomSection.tsx
@@ -22,7 +22,7 @@ import useURL from "@/oss/hooks/useURL"
 import {useWorkspacePermissions} from "@/oss/hooks/useWorkspacePermissions"
 import {isDemo} from "@/oss/lib/helpers/utils"
 import {openWidgetAtom} from "@/oss/lib/onboarding"
-import {useOrgData} from "@/oss/state/org"
+import {selectedOrgIdAtom} from "@/oss/state/org/selectors/org"
 
 interface SidebarBottomSectionOptions {
     includeSettingsLink?: boolean
@@ -38,7 +38,10 @@ export const useSidebarBottomSection = ({
     includeSettingsLink = true,
 }: SidebarBottomSectionOptions = {}): SidebarSection => {
     const {doesSessionExist} = useSession()
-    const {selectedOrg} = useOrgData()
+    // Route-derived and synchronous, so it survives the org switch's cache eviction:
+    // `changeSelectedOrg` removes the ["selectedOrg", id] query BEFORE navigating, which left
+    // this row hidden for a whole GET /organizations/{id} round-trip on every switch.
+    const selectedOrgId = useAtomValue(selectedOrgIdAtom)
     const {canInviteMembers} = useWorkspacePermissions()
     const {toggle, isVisible, isCrispEnabled} = useCrispChat()
     const {projectURL} = useURL()
@@ -80,9 +83,9 @@ export const useSidebarBottomSection = ({
             buildInviteTeammateNavItem({
                 projectURL: hasProjectURL ? projectURL : "",
                 icon: <PaperPlaneIcon size={14} />,
-                isHidden: !doesSessionExist || !selectedOrg || !canInviteMembers,
+                isHidden: !doesSessionExist || !selectedOrgId || !canInviteMembers,
             }),
-        [canInviteMembers, doesSessionExist, hasProjectURL, projectURL, selectedOrg],
+        [canInviteMembers, doesSessionExist, hasProjectURL, projectURL, selectedOrgId],
     )
 
     const sharedItems = useMemo<SidebarConfig[]>(


### PR DESCRIPTION
## Context

Switch organizations and the "Invite Teammate" row disappears from the sidebar, then comes back a moment later. It happens on every switch, from any page.

`changeSelectedOrg` throws away the cached org before it navigates. `web/oss/src/state/org/hooks.ts:139` calls `queryClient.removeQueries({queryKey: ["selectedOrg", selectedOrgId]})`, and only then resolves the new workspace and pushes the route. So `useOrgData().selectedOrg` is `undefined` for one full `GET /organizations/{id}` round-trip. The Invite Teammate row gated on exactly that value (`web/oss/src/components/Sidebar/scopes/bottomSection.tsx:83`), so it hid itself for the length of that request.

This is not new in v0.113.0. I diffed the whole sidebar gating chain against `v0.112.3` and every file in it is identical apart from import paths, so the blink predates the package extraction. It is worth fixing anyway: Mahmoud hit it during release QA, and it is one line.

## Changes

Gate the row on `selectedOrgIdAtom` instead of the fetched org object.

That atom resolves from the route plus the `workspaceOrgMap` that `changeSelectedOrg` writes at `hooks.ts:152`, which happens *before* the navigation. So it already holds the new org's id on the first frame after the switch, and the cache eviction cannot touch it.

Before, during a switch:

```
selectedOrg   = undefined   -> isHidden: true   (row gone)
selectedOrgId = "01a0…"     (already correct)
```

After, the row reads the id and stays put. The permission gate (`canInviteMembers`) and the session gate are unchanged, so a user who may not invite still does not see it.

This also drops an `orgs + projects + selectedOrg` subscription from the sidebar, since the rail no longer needs the fetched org object at all.

## Tests

- `tsc --noEmit` clean for `@agenta/oss` and `@agenta/ee`.
- `pnpm lint-fix` in `web/`: 25/25 tasks pass.
- Prettier 3.7.4 clean on the touched file.

## What to QA

- On any project page, open the org switcher and move to a different organization. "Invite Teammate" stays in the sidebar for the whole switch instead of vanishing and reappearing.
- Do it as a member without invite permission. The row is still absent, as before.
- Regression: click Invite Teammate after switching. It opens the invite modal on the *new* org's workspace, not the previous one.

## Not in this PR

Two other things make sidebar rows go quiet on an org switch. Both predate v0.113.0 and both need a larger change, so I left them alone and wrote them up in the QA notes:

1. The dynamic submenus (Prompts, Agents, Sessions) fall back to their disabled placeholder rows, because `useSidebarDynamicChildren` keys its previous-children cache on `projectURL` and a new org means a new key.
2. The entire rail greys out when a switch lands on a project-less `/w/<wsId>`, which is what `changeSelectedOrg` navigates to the first time you enter an org with no remembered project.
