### PR TITLE
fix(frontend): visual regressions from the package extraction

### DIFF
--- a/web/ee/src/components/pages/app-management/components/ApiKeyInput.tsx
+++ b/web/ee/src/components/pages/app-management/components/ApiKeyInput.tsx
@@ -3,7 +3,8 @@ import {useMemo, useState} from "react"
 import {fetchAllProjects} from "@agenta/entities/project"
 import {createApiKey} from "@agenta/settings"
 import {message} from "@agenta/ui/app-message"
-import {Button, Input, Space, Typography} from "antd"
+import {LoadingButton} from "@agenta/ui/ui"
+import {Input, Space, Typography} from "antd"
 
 import {useOrgData} from "@/oss/state/org"
 import {getProjectValues} from "@/oss/state/project"
@@ -101,9 +102,9 @@ const ApiKeyInput: React.FC<ApiKeyInputProps> = ({apiKeyValue, onApiKeyChange}) 
                     onChange={(e) => onApiKeyChange(e.target.value)}
                 />
 
-                <Button type="primary" loading={isLoadingApiKey} onClick={handleGenerateApiKey}>
+                <LoadingButton loading={isLoadingApiKey} onClick={handleGenerateApiKey}>
                     Generate API Key
-                </Button>
+                </LoadingButton>
             </Space>
         </Space>
     )

--- a/web/oss/src/components/pages/app-management/components/ApiKeyInput.tsx
+++ b/web/oss/src/components/pages/app-management/components/ApiKeyInput.tsx
@@ -3,7 +3,8 @@ import {useMemo, useState} from "react"
 import {fetchAllProjects} from "@agenta/entities/project"
 import {createApiKey} from "@agenta/settings"
 import {message} from "@agenta/ui/app-message"
-import {Button, Input, Space, Typography} from "antd"
+import {LoadingButton} from "@agenta/ui/ui"
+import {Input, Space, Typography} from "antd"
 
 import {useOrgData} from "@/oss/state/org"
 import {getProjectValues} from "@/oss/state/project"
@@ -121,9 +122,9 @@ const ApiKeyInput: React.FC<ApiKeyInputProps> = ({apiKeyValue, onApiKeyChange}) 
                     onChange={(e) => onApiKeyChange(e.target.value)}
                 />
 
-                <Button type="primary" loading={isLoadingApiKey} onClick={handleGenerateApiKey}>
+                <LoadingButton loading={isLoadingApiKey} onClick={handleGenerateApiKey}>
                     Generate API Key
-                </Button>
+                </LoadingButton>
             </Space>
         </Space>
     )

--- a/web/packages/agenta-ui/src/components/presentational/layout/PanelSection.tsx
+++ b/web/packages/agenta-ui/src/components/presentational/layout/PanelSection.tsx
@@ -110,7 +110,12 @@ export const PanelSection = ({
                       // then pins to a box that never scrolls — i.e. `sticky` silently does
                       // nothing. `clip` establishes no scrollport, so the header pins to the
                       // real scroller ({@link PanelScroll}) as intended.
-                      "shrink-0 overflow-clip rounded-xl border border-solid border-colorBorderSecondary bg-colorBgElevated"
+                      //
+                      // The card carries the warm tinted surface rather than plain white, so the
+                      // rail reads as one object against the page. Light only: dark restores
+                      // colorBgElevated, where the tint would flatten into the page ground. The
+                      // frame, the header and the body all state it, so no slot stays white.
+                      "shrink-0 overflow-clip rounded-xl border border-solid border-colorBorderSecondary bg-[var(--ag-surface-paper)] dark:bg-colorBgElevated"
                     : ""
             } ${minHeightClassName ?? ""}`}
         >
@@ -118,7 +123,7 @@ export const PanelSection = ({
                 ref={headerRef}
                 className={`ag-panel-section-header flex shrink-0 items-center justify-between gap-2 ${
                     isRail
-                        ? `bg-colorBgElevated px-4 pb-2 pt-4 ${sticky ? "sticky top-0 z-10" : ""}`
+                        ? `bg-[var(--ag-surface-paper)] px-4 pb-2 pt-4 dark:bg-colorBgElevated ${sticky ? "sticky top-0 z-10" : ""}`
                         : `px-2 pb-2 pt-2 ${
                               // The page surface is colorBgContainer (#141414 dark / #fff light);
                               // colorBgLayout is pure black and paints a bar the page never uses.
@@ -144,9 +149,11 @@ export const PanelSection = ({
                 list's own sticky heading — resolves to something opaque. Without it those
                 headings are transparent and rows scroll visibly THROUGH them. */}
             <div
-                className={`${isRail ? "bg-colorBgElevated" : "bg-colorBgContainer"} ${
-                    bodyClassName ?? "flex flex-col gap-0.5 px-2 pb-3"
-                }`}
+                className={`${
+                    isRail
+                        ? "bg-[var(--ag-surface-paper)] dark:bg-colorBgElevated"
+                        : "bg-colorBgContainer"
+                } ${bodyClassName ?? "flex flex-col gap-0.5 px-2 pb-3"}`}
             >
                 {children}
             </div>

--- a/web/packages/agenta-ui/src/components/ui/split-pane.tsx
+++ b/web/packages/agenta-ui/src/components/ui/split-pane.tsx
@@ -16,9 +16,10 @@ import {cn} from "./utils"
  * step it (Shift for a coarse step), Home/End jump to the bounds, and every path — pointer or
  * key — runs the same `onResizeStart → onResize → onResizeEnd` cycle through the same clamp.
  *
- * The divider is the agent playground's gutter: a 9px channel (`--ag-surface-gutter`) with a
- * centred hairline and a grip pill that takes a primary tint on hover/drag (ported from
- * `.playground-splitter-agent` in globals.css).
+ * The divider is the agent playground's seam: the panes sit FLUSH and the divider is painted on
+ * the seam itself — a 2px hairline plus a grip pill that takes a primary tint on hover/drag
+ * (ported from `.playground-splitter-agent` in globals.css). The bar carries no layout width, so
+ * the grab target is a wider invisible overlay centred on the seam.
  */
 export interface SplitPaneProps {
     /** Which side the driven pane sits on. */
@@ -52,7 +53,16 @@ export interface SplitPaneProps {
     barClassName?: string
 }
 
-const BAR_WIDTH = 9
+/**
+ * The bar carries NO layout width: the agent playground's panes sit flush and the divider is
+ * PAINTED on the seam, which is what `.playground-splitter-agent` did (`flex-basis: 0; width: 0`).
+ * A tinted gutter channel here made the two seams read differently from each other, because each
+ * one's neighbouring surfaces differ.
+ */
+const BAR_WIDTH = 0
+
+/** Invisible hit-slop centred on the seam — the visible pixels are only 2-4px wide. */
+const BAR_HIT_WIDTH = 12
 
 /** The pane slide's duration. Slow it down to inspect the motion — see `paneSlideMs` below. */
 export const PANE_SLIDE_MS = 240
@@ -322,7 +332,9 @@ export function SplitPane({
             onPointerCancel={barHidden ? undefined : handlePointerFinish}
             onKeyDown={barHidden ? undefined : handleKeyDown}
             className={cn(
-                "group relative z-[5] box-border h-full shrink-0 touch-none select-none overflow-hidden bg-[var(--ag-surface-gutter)]",
+                // `overflow-visible`: the hairline, the grip and the hit-slop all paint OUTSIDE
+                // the zero-width bar box, centred on the seam.
+                "group relative z-[5] box-border h-full shrink-0 touch-none select-none overflow-visible",
                 resizable &&
                     !barHidden &&
                     "cursor-col-resize outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-1 focus-visible:outline-focus-ring",
@@ -337,17 +349,20 @@ export function SplitPane({
                 transition: `flex-basis ${slideMs}ms ${PANE_SLIDE_CURVE}, height ${slideMs}ms ${PANE_SLIDE_CURVE}`,
             }}
         >
-            {/* Centre hairline — strengthens to the border tone on hover/drag. */}
-            <span
-                aria-hidden
-                className={cn(
-                    "absolute inset-y-0 left-1/2 w-px -translate-x-1/2 bg-colorFillQuaternary transition-colors duration-150",
-                    resizable && "group-hover:bg-colorBorder",
-                    dragging && "bg-colorBorder",
-                )}
-            />
+            {/* Centre hairline — strengthens to the border tone on hover/drag. A hidden bar
+                paints nothing: the box no longer clips, so this has to be gated explicitly. */}
+            {barHidden ? null : (
+                <span
+                    aria-hidden
+                    className={cn(
+                        "absolute inset-y-0 left-1/2 w-0.5 -translate-x-1/2 bg-colorBorderSecondary transition-colors duration-150",
+                        resizable && "group-hover:bg-colorBorder",
+                        dragging && "bg-colorBorder",
+                    )}
+                />
+            )}
             {/* Grip pill — quiet at rest, a longer primary tint under the pointer. */}
-            {resizable ? (
+            {resizable && !barHidden ? (
                 <span
                     aria-hidden
                     className={cn(
@@ -356,6 +371,16 @@ export function SplitPane({
                         "group-hover:h-9 group-hover:bg-colorPrimary group-hover:opacity-70",
                         dragging && "h-9 bg-colorPrimary opacity-70",
                     )}
+                />
+            ) : null}
+            {/* Hit-slop: the visible pixels are 2-4px wide, so the grab target is a wider
+                invisible overlay centred on the seam (antd's dragger was 12px). Its pointer
+                events bubble to the bar's own handlers. */}
+            {resizable && !barHidden ? (
+                <span
+                    aria-hidden
+                    className="absolute inset-y-0 left-1/2 -translate-x-1/2 cursor-col-resize"
+                    style={{width: BAR_HIT_WIDTH}}
                 />
             ) : null}
         </div>


### PR DESCRIPTION
## Context

Three desktop surfaces look wrong on v0.113.0 next to the shipped v0.112.3. Mahmoud found all three during release QA. Two are real losses from the package extraction (#6065); the third turns out not to be a regression at all, and the section on it says why it is still worth changing.

## 1. Home rail cards are white instead of the warm surface

On Home, the three cards on the right ("Your agents", "Next triggers", "Usage") paint plain white against the warm page background, so they read as three floating boxes rather than one rail.

v0.112.3 put the tint on the rail wrapper in `StripHome.tsx`:

```
[&_.ag-panel-section]:bg-[var(--ag-surface-paper)]
dark:[&_.ag-panel-section]:bg-colorBgElevated
```

with the note "The rail's cards carry the warm tinted surface rather than plain white, so they read as one object against the page."

In v0.113.0 `StripHome` renders `<HomeOverview>` and no longer owns a rail div, and the rail wrapper in `@agenta/home-ui` never got the classes. The loss happened in `6549aac263`, the merge of `release/v0.112.1` into the extraction lane, not in the extraction commit itself: the tint landed on the release line after the lane forked, and the resolution kept the lane's `HomeOverview` rail. The cards then fell back to `bg-colorBgElevated`, which is `#ffffff` in light mode. Dark mode was always `colorBgElevated`, so this is light-mode only.

The token is fine. `--ag-surface-paper` still resolves, `#fbfaf8` light and `#272727` dark.

The fix puts the tint in `PanelSection`'s rail variant, which is the single place the card's three surfaces are stated. All three had to move together, because **v0.113.0 gave the card body its own background**. Restoring only the two selectors v0.112.3 had would have left the body white inside a paper frame.

Doing it here rather than on `HomeOverview` also repairs the agent overview rail, which lost the identical override in `AgentOverviewBody.tsx`.

Measured on a live v0.113.0 build, all three slots of all three cards:

```
before:  rgb(255,255,255)
after:   rgb(251,250,248)   = #fbfaf8 = --ag-surface-paper
```

The main column's `variant="page"` sections are untouched, and dark mode still resolves to `colorBgElevated`.

## 2. Playground dividers do not match each other

The seam between the settings pane and the chat looks different from the seam between the chat and the files pane, and both differ from v0.112.3.

`packages/agenta-ui/src/components/ui/split-pane.tsx` is a new file from the extraction. Its docstring says the divider is "ported from `.playground-splitter-agent` in globals.css", but that CSS says the opposite of what shipped:

| | v0.112.3 CSS | v0.113.0 SplitPane |
| --- | --- | --- |
| bar box | `flex-basis: 0; width: 0`, panes flush | `BAR_WIDTH = 9`, painted with `--ag-surface-gutter` |
| hairline | `2px`, `--ag-colorBorderSecondary` | `1px`, `colorFillQuaternary` |
| hit target | invisible `12px` dragger | the 9px painted box |
| grip pill | 4x24 growing to 36 | same, correct |

Two things follow. `colorFillQuaternary` is 2 to 4 percent alpha, so a 1px hairline painted on top of an opaque band is invisible; what you actually see as "the line" is the band's edges. And because the band is opaque, each seam takes its appearance from its neighbours: in light mode the gutter `#f6f5f3` is byte-identical to the app ground, so the settings seam swallows it, while the files seam sits against the white chat canvas and shows a clear grey stripe. In v0.112.3 the two matched by construction, and `RightPanelSplit.tsx` said so: "this divider renders EXACTLY like the config pane's, so all vertical seams match."

Worth noting that `--ag-surface-gutter` existed in v0.112.3 with zero consumers. The extraction started painting a token nothing had ever painted.

The fix restores the flush seam: `BAR_WIDTH` goes to 0, the gutter background goes away, `overflow-hidden` becomes `overflow-visible`, the hairline goes back to 2px `colorBorderSecondary`, and a 12px invisible overlay carries the grab target the way antd's dragger did. The hairline and grip are now gated on `!barHidden`, which the old zero width plus `overflow-hidden` used to handle for free.

All the geometry (`readTotal`, the ResizeObserver, the pointer math, the `aria-value*` bounds) already reads the live `barWidth`, so a zero-width bar flows through unchanged.

## 3. "Generate API key" button, and why this one is not a regression

In Deployment, in the "How to use API" drawer, the button reads as the wrong colour.

I could not find a regression, and I looked hard. `DeploymentsDashboard/**` is byte-identical to v0.112.3. In `ApiKeyInput.tsx` the only change is that `createApiKey` moved from `@/oss/services/apiKeys/api` to `@agenta/settings`; the JSX still says `<Button type="primary" loading={...}>` in both revisions. No `ConfigProvider` was lost, the antd button tokens are not in the diff, antd is 6.3.7 in both lockfiles, and no global CSS reaches it.

What actually changed is everything around it. This is one of the last antd-native `type="primary"` buttons sitting on a surface whose chrome is now a shadcn Sheet, so it no longer matches the migrated primary actions beside it: different shadow, radius and height ramp, antd control geometry against the `control-*` scale.

So the fix is the migration the rest of the app already had: `LoadingButton` from `@agenta/ui/ui`, which is the documented mapping for `type="primary"`.

**Both copies had to change.** `web/ee/tsconfig.json` maps `"@/oss/*"` to `["./src/*", "../oss/src/*"]`, so the dynamic import in `UseApiContent.tsx` resolves to the **EE** `ApiKeyInput` inside the EE app. Patching only the OSS file would have changed nothing on staging.

## Tests

- `@agenta/ui` unit tests: 85/85 across 12 files, including `SplitPaneSingleMount.render.test.tsx`.
- `tsc --noEmit` clean for `@agenta/oss` and `@agenta/ee`; `pnpm turbo run build --filter=@agenta/ui` clean.
- `pnpm lint-fix` in `web/`: 25/25. Prettier 3.7.4 clean on all four files.
- One `@agenta/oss` production build.
- Divider behaviour checked live on a v0.113.0 build after the change: pointer drag on the new hit target moves `aria-valuenow` 440 to 400, and the keyboard path still works (ArrowLeft 400 to 336, ArrowRight to 368, Home to 300, End to 440).

## What to QA

- Open Home with at least one agent. The three cards on the right sit on the same warm surface as the rail instead of reading as white boxes. Switch to dark mode: they go back to the elevated grey, unchanged from today.
- Open an agent playground. The seam between the configuration pane and the chat is a thin flush hairline with a centred grip, with no grey channel behind it. Open the files pane: that seam looks identical to the first one. Check dark mode too, where the old channel was loudest.
- Drag both dividers, then focus one and use the arrow keys, Home and End. Resizing still works and the grip still tints on hover.
- Deployment, "How to use API" drawer: the "Generate API Key" button matches the other primary buttons in the app. Click it and confirm a key still appears in the field. Check this in the EE build, not only OSS.
- Regression to watch: `PanelSection` is shared, so glance at the agent overview rail (`/apps/<id>/overview`) and at Agents and Sessions. Their cards should look the same as Home's, not white.
