### PR TITLE
feat(services): allow extra CORS origins via AGENTA_SERVICES_ALLOWED_ORIGINS

### DIFF
--- a/hosting/docker-compose/ee/README.md
+++ b/hosting/docker-compose/ee/README.md
@@ -147,6 +147,12 @@ Most optional variables can be left empty. A few are worth calling out:
 - **SSO / OAuth** (`GOOGLE_OAUTH_CLIENT_ID`, `GITHUB_OAUTH_CLIENT_ID`, etc.): Set a provider's `CLIENT_ID` and `CLIENT_SECRET` to enable it. The frontend auto-detects which providers are configured. Leave empty to use email/password authentication only.
 - **Database** (`POSTGRES_USER`, `POSTGRES_PASSWORD`, `POSTGRES_URI_*`): The compose stack includes Postgres with working defaults. Override these only if you bring your own database. **Change the default password in production.**
 
+### Development and Debugging
+
+| Variable | Description |
+|----------|-------------|
+| `AGENTA_SERVICES_ALLOWED_ORIGINS` | Comma-separated web origins that may call the services API. Set this when the development web app runs on a different origin from `AGENTA_SERVICES_URL`, for example `http://localhost:3000,http://192.0.2.10:8680`. Recreate the `services` container after changing it. |
+
 The example file lists all variables with descriptions, grouped by category.
 
 ## Architecture Overview

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -196,6 +196,8 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # AGENTA_SERVICES_CODE_SANDBOX_RUNNER=local
 # AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED=true
 # AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED=true
+# Comma-separated web origins allowed to call services in split-origin development setups:
+# AGENTA_SERVICES_ALLOWED_ORIGINS=http://localhost:3000,http://192.0.2.10:8680
 
 # ================================================================== #
 # Agenta - Egress (SSRF protection)

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -200,6 +200,8 @@ AGENTA_RUNNER_TOKEN=replace-me
 # AGENTA_SERVICES_CODE_SANDBOX_RUNNER=local
 # AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED=true
 # AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED=true
+# Comma-separated web origins allowed to call services in split-origin development setups:
+# AGENTA_SERVICES_ALLOWED_ORIGINS=http://localhost:3000,http://192.0.2.10:8680
 
 # ================================================================== #
 # Agenta - Egress (SSRF protection)

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -198,6 +198,8 @@ NEXT_PUBLIC_AGENT_FILE_UPLOADS=true
 # AGENTA_SERVICES_CODE_SANDBOX_RUNNER=local
 # AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED=true
 # AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED=true
+# Comma-separated web origins allowed to call services in split-origin development setups:
+# AGENTA_SERVICES_ALLOWED_ORIGINS=http://localhost:3000,http://192.0.2.10:8680
 
 # ================================================================== #
 # Agenta - Egress (SSRF protection)

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -200,6 +200,8 @@ AGENTA_RUNNER_TOKEN=replace-me
 # AGENTA_SERVICES_CODE_SANDBOX_RUNNER=local
 # AGENTA_SERVICES_MIDDLEWARE_AUTH_ENABLED=true
 # AGENTA_SERVICES_MIDDLEWARE_CACHING_ENABLED=true
+# Comma-separated web origins allowed to call services in split-origin development setups:
+# AGENTA_SERVICES_ALLOWED_ORIGINS=http://localhost:3000,http://192.0.2.10:8680
 
 # ================================================================== #
 # Agenta - Egress (SSRF protection)

--- a/services/entrypoints/main.py
+++ b/services/entrypoints/main.py
@@ -1,3 +1,5 @@
+from os import getenv
+
 from fastapi import FastAPI, Request
 from fastapi.middleware.cors import CORSMiddleware
 from starlette.types import ASGIApp
@@ -112,6 +114,11 @@ app = FastAPI(
 )
 
 
+def _extra_allowed_origins() -> list:
+    raw = getenv("AGENTA_SERVICES_ALLOWED_ORIGINS", "")
+    return [origin.strip() for origin in raw.split(",") if origin.strip()]
+
+
 app.add_middleware(MockMiddleware)
 
 app.add_middleware(
@@ -121,6 +128,9 @@ app.add_middleware(
         "http://localhost:3001",
         "http://0.0.0.0:3000",
         "http://0.0.0.0:3001",
+        # A dev stack may serve the web app from a different origin than this service, and the
+        # browser then needs that origin allowed here. Comma-separated; empty everywhere else.
+        *_extra_allowed_origins(),
     ],
     allow_origin_regex=r"https://.*\.vercel\.app",
     allow_credentials=True,


### PR DESCRIPTION
## Context

Run a dev stack where the web app is served from a different origin than the API, and every agent run dies. The playground shows "The agent run failed / Failed to fetch" and the browser console reports the preflight was blocked.

The agent service is the one rejecting it. Its CORS allowlist is a literal in `services/entrypoints/main.py` holding four localhost entries, so a browser on any other origin gets `400 Disallowed CORS origin` with no `Access-Control-Allow-Origin` header. There was no way to add an origin short of editing the file.

This is easy to misdiagnose, so it is worth naming the trap. There *is* an `AGENTA_USE_CORS` env var, but it belongs to the SDK's own middleware (`sdks/python/agenta/sdk/middlewares/routing/cors.py`), which `create_app` applies per mounted sub-app and which already allows `*`. That permissive layer never runs, because the outer app's allowlist answers the preflight first and short-circuits. `AGENTA_USE_CORS` only switches the inner layer off, which is the wrong direction.

## Changes

`AGENTA_SERVICES_ALLOWED_ORIGINS` adds origins to the existing list. It is a comma-separated string, empty by default, so nothing changes for anyone who does not set it.

```
AGENTA_SERVICES_ALLOWED_ORIGINS=http://your-dev-host:8680
```

Before, with that origin:

```
OPTIONS /services/agent/v0/invoke   Origin: http://your-dev-host:8680
-> 400 Disallowed CORS origin, no Access-Control-Allow-Origin
```

After:

```
OPTIONS /services/agent/v0/invoke   Origin: http://your-dev-host:8680
-> 200, Access-Control-Allow-Origin: http://your-dev-host:8680
```

## Tests

Verified against a local EE dev stack, setting the variable in the compose env file and recreating the `services` container. The variable is read when the container is created, so a restart is not enough.

- The configured origin passes its preflight with a matching `Access-Control-Allow-Origin` header.
- `http://localhost:3000` still passes, unchanged.
- An origin that is not in the list still gets `400`, so the widening is scoped to what you configure.
- With the variable set, a real agent run completed end to end from the second origin: the turn streamed its tool calls and the agent it was asked to build was created. Before the change the same run failed with "Failed to fetch".

`ruff format` and `ruff check` are clean on the changed file.
