### PR TITLE
fix(frontend): preserve keyboard height during pinch zoom

### DIFF
--- a/web/packages/agenta-ui/src/hooks/useVisualViewport.ts
+++ b/web/packages/agenta-ui/src/hooks/useVisualViewport.ts
@@ -60,7 +60,11 @@ export function keyboardInset(sample: VisualViewportSample): number {
  * viewport, so its bottom edge must land at `offsetTop + height` to sit on the bottom of what the
  * user sees after the browser pushed the visual viewport down.
  */
-export function viewportHeightOverride(sample: VisualViewportSample): string | null {
+export function viewportHeightOverride(
+    sample: VisualViewportSample,
+    activeOverride: string | null = null,
+): string | null {
+    if (sample.scale > 1.01) return activeOverride
     if (keyboardInset(sample) < KEYBOARD_INSET_MIN_PX) return null
     return `${Math.round(sample.height + sample.offsetTop)}px`
 }
@@ -97,12 +101,13 @@ export function useVisualViewportHeight(): void {
 
         const root = document.documentElement
         let frame: number | null = null
+        let activeOverride: string | null = null
 
         const apply = () => {
             frame = null
             const sample = readVisualViewport()
-            const override = sample ? viewportHeightOverride(sample) : null
-            if (override) root.style.setProperty(VIEWPORT_HEIGHT_VAR, override)
+            activeOverride = sample ? viewportHeightOverride(sample, activeOverride) : null
+            if (activeOverride) root.style.setProperty(VIEWPORT_HEIGHT_VAR, activeOverride)
             else root.style.removeProperty(VIEWPORT_HEIGHT_VAR)
         }
         const sync = () => {

--- a/web/packages/agenta-ui/tests/unit/visualViewport.test.ts
+++ b/web/packages/agenta-ui/tests/unit/visualViewport.test.ts
@@ -75,4 +75,12 @@ describe("viewportHeightOverride", () => {
     it("stays out of the way while the user pinch-zooms", () => {
         expect(viewportHeightOverride(sample({height: 300, scale: 2}))).toBeNull()
     })
+
+    it("keeps the active keyboard height while the user pinch-zooms", () => {
+        expect(viewportHeightOverride(sample({height: 300, scale: 2}), "508px")).toBe("508px")
+    })
+
+    it("clears the active keyboard height after zoom and keyboard end", () => {
+        expect(viewportHeightOverride(sample(), "508px")).toBeNull()
+    })
 })


### PR DESCRIPTION
## Context\n\nOn iOS, pinch-zooming while the soft keyboard remained open removed the active visual viewport height override. The playground then jumped back to the full dynamic viewport height and placed the composer beneath the keyboard.\n\nPR #6169 merged while its reviewed correction was being pushed, so this follow-up carries only the missed two-file delta.\n\n## Changes\n\nThe viewport hook now remembers the active keyboard-sized height. During pinch zoom it keeps that value unchanged, then resumes normal measurement when zoom or keyboard state ends. A zoom gesture with no active keyboard override still leaves the page on its dynamic viewport fallback.\n\nThe unit suite covers both preserving the active height during zoom and clearing it afterward.\n\n## Tests / notes\n\n- Focused visual viewport suite: 13 tests passed.\n- Changed files pass Prettier and ESLint.\n- The package-wide local type check could not start because the shared dependency tree has a pre-existing missing Radix context-menu link and pnpm cannot repair a node_modules directory owned by another UID.\n\n## What to QA\n\n- Open the playground on iOS Safari, focus the composer, then pinch zoom while the keyboard stays open. The composer remains above the keyboard without a layout jump.\n- End the zoom or dismiss the keyboard. The page returns to its normally measured height.\n- Pinch zoom with the keyboard closed. The page keeps its dynamic viewport fallback.