### PR TITLE
fix(frontend): restore the Help & Docs menu icons and the trace popover sizing

### DIFF
--- a/web/packages/agenta-navigation-ui/src/NavMenu.tsx
+++ b/web/packages/agenta-navigation-ui/src/NavMenu.tsx
@@ -206,37 +206,65 @@ const FlyoutChildren = ({
     onItemSelect?: NavMenuProps["onItemSelect"]
 }) => (
     <>
-        {items.map((child) =>
-            child.isPlaceholder || child.isGroupLabel ? (
-                <DropdownMenuLabel key={child.key} className="text-xs text-colorTextTertiary">
-                    {child.title}
-                </DropdownMenuLabel>
-            ) : child.divider ? (
-                <DropdownMenuSeparator key={child.key} />
-            ) : (
-                <DropdownMenuItem
-                    key={child.key}
-                    disabled={child.disabled}
-                    className={clsx(selectedKeys.includes(child.key) && "font-medium")}
-                    asChild={Boolean(child.link)}
-                    onSelect={child.link ? undefined : () => child.onClick?.(undefined as never)}
-                >
-                    {child.link ? (
-                        <Link
-                            href={child.link}
-                            className="!text-inherit no-underline"
-                            target={isExternal(child.link) ? "_blank" : undefined}
-                            rel={isExternal(child.link) ? "noopener noreferrer" : undefined}
-                            onClick={linkClickHandler(child, onItemSelect)}
-                        >
-                            {child.title}
-                        </Link>
-                    ) : (
-                        <span>{child.title}</span>
-                    )}
-                </DropdownMenuItem>
-            ),
-        )}
+        {items.map((child) => {
+            if (child.isPlaceholder || child.isGroupLabel) {
+                return (
+                    <DropdownMenuLabel key={child.key} className="text-xs text-colorTextTertiary">
+                        {child.title}
+                    </DropdownMenuLabel>
+                )
+            }
+            // The icon is the row's leading glyph on every other path (LeafRow, the group row,
+            // the collapsed trigger). The flyout has to draw it too, or Help & Docs loses the
+            // icons the antd menu always rendered through its own `icon` slot.
+            const body = (
+                <>
+                    {child.icon ? (
+                        <span className="flex shrink-0 items-center">{child.icon}</span>
+                    ) : null}
+                    <span className="min-w-0 truncate">{child.title}</span>
+                </>
+            )
+            return (
+                <Fragment key={child.key}>
+                    <DropdownMenuItem
+                        disabled={child.disabled}
+                        // gap-[10px] over the item's default gap-2: antd's Menu icon margin.
+                        // It rides on `className` (which goes through tailwind-merge) rather
+                        // than on the Link, because `asChild` merges classes by concatenation
+                        // and would leave both gaps in the list.
+                        className={clsx(
+                            "gap-[10px]",
+                            selectedKeys.includes(child.key) && "font-medium",
+                        )}
+                        asChild={Boolean(child.link)}
+                        onSelect={
+                            child.link
+                                ? undefined
+                                : (event) => child.onClick?.(event as unknown as MouseEvent)
+                        }
+                    >
+                        {child.link ? (
+                            <Link
+                                href={child.link}
+                                className="!text-inherit no-underline"
+                                target={isExternal(child.link) ? "_blank" : undefined}
+                                rel={isExternal(child.link) ? "noopener noreferrer" : undefined}
+                                onClick={linkClickHandler(child, onItemSelect)}
+                            >
+                                {body}
+                            </Link>
+                        ) : (
+                            body
+                        )}
+                    </DropdownMenuItem>
+                    {/* `divider` means "a rule FOLLOWS this row", which is the contract the
+                        inline path and the old antd menu both implement. Treating it as "this
+                        row IS a rule" replaced the Documentation item with a hairline. */}
+                    {child.divider ? <DropdownMenuSeparator /> : null}
+                </Fragment>
+            )
+        })}
     </>
 )
 

--- a/web/packages/agenta-observability-ui/src/primitives/Pill.tsx
+++ b/web/packages/agenta-observability-ui/src/primitives/Pill.tsx
@@ -65,8 +65,11 @@ export const Pill = memo(
                 <PopoverTrigger asChild>
                     <span className="inline-flex">{pill}</span>
                 </PopoverTrigger>
-                {/* antd anchored this below and sized it 240px wide. */}
-                <PopoverContent side="bottom" className="w-60">
+                {/* antd anchored this below and centred it: 240px wide, 12px inner padding,
+                    and the app's 14px text. PopoverContent is deliberately padding-less and
+                    size-less, and it portals out of the app's font scope with preflight off,
+                    so without these the panel inherits <body>'s 16px and no inset at all. */}
+                <PopoverContent side="bottom" align="center" className="w-60 p-3 text-sm">
                     {popoverContent}
                 </PopoverContent>
             </Popover>

--- a/web/packages/agenta-observability-ui/src/traceDrawer/EvaluatorDetailsPopover.tsx
+++ b/web/packages/agenta-observability-ui/src/traceDrawer/EvaluatorDetailsPopover.tsx
@@ -152,7 +152,13 @@ const EvaluatorDetailsPopover = ({
                     {children || <span>{evaluatorName}</span>}
                 </span>
             </PopoverTrigger>
-            <PopoverContent side="bottom" align="start" className="w-auto max-w-[420px]">
+            {/* Same inset and text size the antd popover carried, for the same reason as the
+                Tokens & Cost pill: this panel portals out of the app's font scope. */}
+            <PopoverContent
+                side="bottom"
+                align="start"
+                className="w-auto max-w-[420px] p-3 text-sm"
+            >
                 {popoverContent}
             </PopoverContent>
         </Popover>


### PR DESCRIPTION
## Context

Two more surfaces Mahmoud found on staging that look wrong against v0.112.3. Both come from the package extraction (#6065). The first one is worse than it looked: a menu entry is not just unstyled, it is missing.

## 1. Help & Docs lost its icons, and lost the Documentation entry

The sidebar's bottom section is declared `mode: "vertical"` (`bottomSection.tsx:145`). In `NavMenu`, `inline` is `mode === "inline" && !collapsed`, so for a vertical section the guard at `NavMenu.tsx:260` always takes the Radix flyout branch. The inline submenu path is dead for this menu, expanded rail or not. One renderer, `FlyoutChildren`, draws it in every state.

That renderer has two bugs.

**It never reads `child.icon`.** The item model is fine: `buildHelpDocsNavItem` sets an icon on every child (`supportLinks.ts:44-68`) and `bottomSection.tsx:107-113` passes real nodes, unchanged since v0.112.3. Every other row path in the file renders the icon (`LeafRow` at `:192`, the group row at `:344`, the collapsed trigger at `:302`). The flyout is the one that forgot, so the icons antd used to draw through its own `icon` slot simply never reach the DOM.

**It misreads `divider`.** Everywhere else `divider` means "a rule follows this row". The inline path says so at `NavMenu.tsx:393`, and the old antd menu did the same:

```js
return item.divider ? [menuItem, {type: "divider", key: ...}] : [menuItem]
```

`FlyoutChildren` treated it as a discriminator instead: `child.divider ? <Separator/> : <Item/>`. `docs` carries `divider: true`, so **the Documentation row was replaced by a hairline**. The menu that shipped is:

```
before:  ────────────────        after:   📄  Documentation
         GitHub Support                   ────────────────
         Slack Support                    🐙  GitHub Support
         Book a call                      💬  Slack Support
                                          📞  Book a call
```

No icons, no Documentation, and a stray rule on top. `divider` is used nowhere else in the repo (only the two spots in `supportLinks.ts`), so this dropdown is the only victim and the change cannot affect another menu.

While rewriting that map I also fixed a latent crash it carried: `onSelect={... () => child.onClick?.(undefined as never)}`. The Live Chat toggle does `e.preventDefault()` on that argument, so it would throw. It only renders on demo with Crisp enabled, which is why nobody hit it. Radix hands `onSelect` a real `Event`, so forwarding it costs nothing and removes the trap.

## 2. The trace "Tokens & Cost" popover renders oversized

In Observability, open a trace, then click the Tokens & Cost pill. The breakdown panel is too big and its text sits flush against the panel edges.

The popover moved from antd `Popover` to the Radix `PopoverContent` in `@agenta/ui`, and the port carried the width across but not the other two properties that made it small:

| | v0.112.3 (antd) | v0.113.0 |
| --- | --- | --- |
| width | 240px | 240px, unchanged |
| padding | 12px (antd's `innerPadding`) | none |
| font size | 14px (antd sets it on `.ant-popover`) | 16px, inherited from `<body>` |

The font is the part worth understanding. `PopoverContent` is deliberately padding-less and size-less; 30 of its 42 call sites pass their own padding. It also portals to `document.body`, and Tailwind preflight is off in this app (`tailwind.config.ts:466`), so nothing sets a base size and the panel picks up the browser default. Every glyph came out 14 percent larger and every row 3px taller.

Fixed at the call site with `p-3 text-sm`, not in the shared default, which would double-pad the other 30 callers. `align="center"` restores antd's `placement="bottom"` centering.

Measured live on the same DOM element, with and without the two classes:

```
before:  padding 0px    font 16px   row line-height 25.14px   height 58px
after:   padding 12px   font 14px   row line-height 22px      height 76px
```

22px is exactly antd's number (14 x 1.5714), which the per-row `leading-[1.5714...]` in `TraceDetails.tsx` was already asking for.

`EvaluatorDetailsPopover`, in the same trace drawer, lost the same two properties in the same way and gets the same one-line fix. It is one line, in the same file group, and the same defect, so it is here rather than in a follow-up.

## Tests

- Verified live on a v0.113.0 build from this branch. Help & Docs now renders four rows, each with an icon (`svg: 1`), a separator after Documentation, `gap: 10px` and `font-size: 14px`. The Tokens & Cost numbers are the before/after table above.
- `tsc --noEmit` clean for `@agenta/oss` and `@agenta/ee`.
- `pnpm turbo run build lint` for `@agenta/navigation-ui` and `@agenta/observability-ui`: 22/22 tasks pass.
- `@agenta/ui` 98 tests across 13 files, `@agenta/observability` 70 across 6. All pass.
- `pnpm lint-fix` in `web/`: 25/25. Prettier 3.7.4 clean on all three files.
- One `@agenta/oss` production build.

To reach the trace popover I seeded a span through `POST /tracing/spans/ingest` rather than running an agent, so the check needs no model key.

## What to QA

- Click Help & Docs at the bottom of the sidebar. Four rows, each with its icon: Documentation, then a separator, then GitHub Support, Slack Support, Book a call. Documentation is the one to look for, it was missing entirely.
- Collapse the sidebar and open it again. Same menu both ways; this menu always renders as a flyout.
- Go to Observability, click a trace, and find "Tokens & Cost" in the Trace info panel on the right. Click the pill. The breakdown is compact, with an even inset around the text, and centred under the pill.
- In the same drawer's Annotations section, click an evaluator name. That panel should have the same inset and text size.
- Regression to watch: `FlyoutChildren` renders every collapsed-rail flyout, so collapse the sidebar and open Prompts, Agents and Sessions. Their rows should look normal, with icons, and clicking one should still navigate.
