### PR TITLE
feat(sdk): carry Gemini 3.6 Flash and Claude Opus 5 in the model catalog

### DIFF
--- a/.agents/skills/sync-model-catalog/SKILL.md
+++ b/.agents/skills/sync-model-catalog/SKILL.md
@@ -23,7 +23,8 @@ Three JSON data files under `sdks/python/agenta/sdk/agents/data/`, loaded by
 - `pi_models.generated.json` — machine-generated from pi-ai. Objective facts only (name / pricing /
   context_window / modalities), `source: "pi_generated"`. **Never hand-edit.**
 - `pi_models.curated.json` — human overlay for the generated file (id -> `{label?, description?,
-  ratings?}`), merged onto the generated facts at load. Survives regeneration.
+  ratings?}`), merged onto the generated facts at load. Survives regeneration. Its `additions`
+  list holds whole entries for models the pinned pi-ai release predates (see below).
 - `claude_models.curated.json` — hand-curated Claude alias entries (facts + judgments),
   `source: "curated"`.
 
@@ -49,6 +50,18 @@ node .agents/skills/sync-model-catalog/generate_pi_models.mjs "$MODELS" \
 Detect the bump from a lockfile diff on `@earendil-works+pi-ai@<version>`. The `_generator` field
 in the output records the exact pi-ai version. The curated overlay is untouched — only the
 `.generated.json` is rewritten, so the merge on load re-applies the human judgments.
+
+#### Adding a model pi-ai does not carry yet
+
+A model released after the pinned pi-ai snapshot has no generated entry, so it has no catalog entry
+at all: the picker can only show its bare id, and `PROVIDER_DEFAULT_MODELS` drops it (a curated
+default must exist in the catalog or the accepted set). The overlay cannot fix this, because an
+overlay key only decorates an id the generated file already has.
+
+Put the whole entry in the `additions` list of `pi_models.curated.json` instead, with
+`source: "curated"` and every fact sourced from the vendor's own pages. Do not hand-edit the
+generated file. A generated entry of the same id always wins at load, so the addition retires
+itself the moment a regeneration carries the model. Prune superseded additions after job 1.
 
 ### 2. Sync Claude to the live accepted set (needs a running runner)
 

--- a/sdks/python/agenta/sdk/agents/capabilities.py
+++ b/sdks/python/agenta/sdk/agents/capabilities.py
@@ -158,7 +158,10 @@ PROVIDER_DEFAULT_MODELS: Dict[str, List[str]] = {
         "anthropic/claude-sonnet-5",
         "anthropic/claude-haiku-4-5",
     ],
+    # ``gemini-3.6-flash`` postdates the pinned pi-ai catalog, so its facts ride the curated
+    # ``additions`` list in ``data/pi_models.curated.json`` until a regeneration carries it.
     "gemini": [
+        "gemini/gemini-3.6-flash",
         "gemini/gemini-3.5-flash",
         "gemini/gemini-3.1-pro-preview",
     ],

--- a/sdks/python/agenta/sdk/agents/data/pi_models.curated.json
+++ b/sdks/python/agenta/sdk/agents/data/pi_models.curated.json
@@ -2,8 +2,8 @@
   "schema_version": "1",
   "_curation": {
     "target": "pi_models.generated.json",
-    "note": "Human overlay for the generated Pi catalog. Keyed by the entry `id` (the `provider/model` join key). Only `label`, `description`, and `ratings` may appear here; the objective facts (name/pricing/context_window/modalities) always come from the generated file. The SDK loader merges this on top of the generated facts, so a pi-ai regeneration never overwrites these judgments. Ratings: 1-5, higher is better; `cost` is cost-efficiency (5 = cheapest). Sourced from the current lineup (Fable 5 is the Anthropic frontier, above Opus), not a model's memory. Uncurated ids are valid and fall back to `name` in the picker; seed only the models worth a description.",
-    "sources": "@earendil-works/pi-ai@0.80.6; vendor model + pricing pages"
+    "note": "Human overlay for the generated Pi catalog. Keyed by the entry `id` (the `provider/model` join key). Only `label`, `description`, and `ratings` may appear here; the objective facts (name/pricing/context_window/modalities) always come from the generated file. The SDK loader merges this on top of the generated facts, so a pi-ai regeneration never overwrites these judgments. Ratings: 1-5, higher is better; `cost` is cost-efficiency (5 = cheapest). Sourced from the current lineup (Fable 5 is the Anthropic frontier, above Opus), not a model's memory. Uncurated ids are valid and fall back to `name` in the picker; seed only the models worth a description. The separate `additions` list carries WHOLE entries (facts included, `source`: `curated`) for models released after the pinned pi-ai snapshot, which the generated file cannot carry at all. A generated entry of the same id always wins, so an addition retires itself on the next regeneration; drop it then.",
+    "sources": "@earendil-works/pi-ai@0.80.6; vendor model + pricing pages. gemini/gemini-3.6-flash facts from ai.google.dev/gemini-api/docs/pricing and the vendor model page, checked 2026-08-21."
   },
   "overlay": {
     "anthropic/claude-fable-5": {
@@ -34,5 +34,17 @@
       "description": "Google's flagship Gemini 3 Pro, large context and multimodal input.",
       "ratings": {"cost": 4, "intelligence": 4, "speed": 4}
     }
-  }
+  },
+  "additions": [
+    {
+      "id": "gemini/gemini-3.6-flash",
+      "provider": "gemini",
+      "source": "curated",
+      "name": "Gemini 3.6 Flash",
+      "pricing": {"input_per_mtok": 0.75, "output_per_mtok": 3.75, "currency": "USD"},
+      "context_window": 1048576,
+      "modalities": ["text", "image"],
+      "description": "Google's high-efficiency Flash model for everyday agentic and coding work, with a one-million-token context window."
+    }
+  ]
 }

--- a/sdks/python/agenta/sdk/agents/data/pi_models.curated.json
+++ b/sdks/python/agenta/sdk/agents/data/pi_models.curated.json
@@ -3,7 +3,7 @@
   "_curation": {
     "target": "pi_models.generated.json",
     "note": "Human overlay for the generated Pi catalog. Keyed by the entry `id` (the `provider/model` join key). Only `label`, `description`, and `ratings` may appear here; the objective facts (name/pricing/context_window/modalities) always come from the generated file. The SDK loader merges this on top of the generated facts, so a pi-ai regeneration never overwrites these judgments. Ratings: 1-5, higher is better; `cost` is cost-efficiency (5 = cheapest). Sourced from the current lineup (Fable 5 is the Anthropic frontier, above Opus), not a model's memory. Uncurated ids are valid and fall back to `name` in the picker; seed only the models worth a description. The separate `additions` list carries WHOLE entries (facts included, `source`: `curated`) for models released after the pinned pi-ai snapshot, which the generated file cannot carry at all. A generated entry of the same id always wins, so an addition retires itself on the next regeneration; drop it then.",
-    "sources": "@earendil-works/pi-ai@0.80.6; vendor model + pricing pages. gemini/gemini-3.6-flash facts from ai.google.dev/gemini-api/docs/pricing and the vendor model page, checked 2026-08-21."
+    "sources": "@earendil-works/pi-ai@0.80.6; vendor model + pricing pages. gemini/gemini-3.6-flash facts from ai.google.dev/gemini-api/docs/pricing and the vendor model page, checked 2026-08-21. anthropic/claude-opus-5 facts from the Anthropic pricing page, cross-checked against litellm 1.92.0's cost table, checked 2026-08-22."
   },
   "overlay": {
     "anthropic/claude-fable-5": {
@@ -45,6 +45,16 @@
       "context_window": 1048576,
       "modalities": ["text", "image"],
       "description": "Google's high-efficiency Flash model for everyday agentic and coding work, with a one-million-token context window."
+    },
+    {
+      "id": "anthropic/claude-opus-5",
+      "provider": "anthropic",
+      "source": "curated",
+      "name": "Claude Opus 5",
+      "pricing": {"input_per_mtok": 5.0, "output_per_mtok": 25.0, "cache_read_per_mtok": 0.5, "cache_write_per_mtok": 6.25, "currency": "USD"},
+      "context_window": 1000000,
+      "modalities": ["text", "image"],
+      "description": "The current Opus tier: strong reasoning below Fable, at a lower price, with a one-million-token context window."
     }
   ]
 }

--- a/sdks/python/agenta/sdk/agents/model_catalog.py
+++ b/sdks/python/agenta/sdk/agents/model_catalog.py
@@ -15,7 +15,10 @@ code:
 - ``data/pi_models.generated.json`` — machine-generated from ``@earendil-works/pi-ai``. Objective
   facts only; curated fields absent.
 - ``data/pi_models.curated.json`` — human overlay (id -> ``{label?, description?, ratings?}``),
-  merged onto the generated facts at load time so a regeneration never overwrites judgments.
+  merged onto the generated facts at load time so a regeneration never overwrites judgments. Its
+  ``additions`` list carries whole entries for models the pinned pi-ai release predates; a
+  generated entry of the same id always wins, so an addition retires itself on the next
+  regeneration.
 - ``data/claude_models.curated.json`` — hand-curated Claude alias entries (facts + judgments).
 - ``data/codex_models.curated.json``: hand-curated Codex entries (facts + judgments), with the
   same shape as the Claude catalog.
@@ -96,24 +99,39 @@ def _read_json(name: str) -> dict:
 
 
 def load_pi_model_catalog() -> ModelCatalog:
-    """The Pi catalog: generated facts with the human overlay merged on by id.
+    """The Pi catalog: generated facts with the human overlay merged on by id, plus additions.
 
     The overlay only ever supplies ``label`` / ``description`` / ``ratings``; every objective fact
     comes from the generated file. ``pydantic`` validates each entry on construction (including the
     1-5 rating range), so a malformed data file fails loud here.
+
+    ``additions`` carries whole hand-written entries (``source: "curated"``) for models released
+    after the pinned pi-ai snapshot. Without them such a model has no catalog entry at all, so the
+    picker can only show its bare id and ``PROVIDER_DEFAULT_MODELS`` cannot offer it. A generated
+    entry of the same id always wins: the addition is a stopgap that retires itself the moment a
+    regeneration carries the model, rather than shadowing fresher sourced facts.
     """
     generated = _read_json("pi_models.generated.json")
-    overlay = _read_json("pi_models.curated.json").get("overlay", {})
+    curated_file = _read_json("pi_models.curated.json")
+    overlay = curated_file.get("overlay", {})
+    additions = curated_file.get("additions", [])
 
     entries: List[ModelCatalogEntry] = []
+    generated_ids = set()
     for raw in generated.get("models", []):
         merged = dict(raw)
+        generated_ids.add(raw.get("id"))
         curated = overlay.get(raw.get("id"))
         if curated:
             for field in _OVERLAY_FIELDS:
                 if field in curated:
                     merged[field] = curated[field]
         entries.append(ModelCatalogEntry.model_validate(merged))
+
+    for raw in additions:
+        if raw.get("id") in generated_ids:
+            continue
+        entries.append(ModelCatalogEntry.model_validate(raw))
 
     return ModelCatalog(schema_version="1", models=entries)
 

--- a/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
@@ -17,6 +17,7 @@ from agenta.sdk.agents.capabilities import (
     PROVIDER_DEFAULT_MODELS,
     harness_catalog_document,
 )
+from agenta.sdk.agents import model_catalog as model_catalog_module
 from agenta.sdk.agents.model_catalog import (
     ModelCatalogEntry,
     ModelRatings,
@@ -85,7 +86,8 @@ def test_pi_ids_are_unique_and_provider_prefixed():
     for entry in entries:
         # id is the provider/model join key; its prefix is the entry's provider.
         assert entry.id.startswith(f"{entry.provider}/"), entry.id
-        assert entry.source == "pi_generated"
+        # Generated facts, or a hand-written addition for a model the pinned pi-ai predates.
+        assert entry.source in ("pi_generated", "curated"), entry.id
 
 
 def test_pi_overlay_merges_without_overwriting_facts():
@@ -112,6 +114,70 @@ def test_uncurated_pi_entry_is_valid_with_absent_curated_fields():
     assert uncurated, "expected some uncurated Pi entries"
     sample = uncurated[0]
     assert sample.name is not None  # frontend falls back to name
+
+
+def test_gemini_3_6_flash_is_published_with_its_display_name():
+    # The model postdates the pinned pi-ai snapshot, so it reaches the catalog through the curated
+    # `additions` list. Without an entry the picker can only show the bare id, which is the bug
+    # this pins: the Model row must read "Gemini 3.6 Flash".
+    entries = model_catalog_entries("pi_core")
+    entry = next(
+        (item for item in entries if item["id"] == "gemini/gemini-3.6-flash"), None
+    )
+    assert entry is not None, "gemini/gemini-3.6-flash missing from the pi catalog"
+    assert entry["name"] == "Gemini 3.6 Flash"
+    assert entry["provider"] == "gemini"
+    assert entry["source"] == "curated"
+    assert entry["context_window"] == 1048576
+
+
+def test_gemini_3_6_flash_is_offered_as_a_default_model():
+    # A curated default is dropped when the harness cannot select it, so the catalog entry and the
+    # PROVIDER_DEFAULT_MODELS line only work together.
+    assert "gemini/gemini-3.6-flash" in PROVIDER_DEFAULT_MODELS["gemini"]
+    defaults = harness_catalog_document()["pi_core"]["capabilities"]["default_models"]
+    assert "gemini/gemini-3.6-flash" in defaults["gemini"]
+
+
+def test_a_curated_addition_never_shadows_a_generated_entry(monkeypatch):
+    # The addition is a stopgap until a regeneration carries the model. When both files name the
+    # same id the generated facts win, so an addition left behind cannot mask fresher facts.
+    generated = {
+        "models": [
+            {
+                "id": "gemini/overlapping",
+                "provider": "gemini",
+                "source": "pi_generated",
+                "name": "From pi-ai",
+            }
+        ]
+    }
+    curated = {
+        "overlay": {},
+        "additions": [
+            {
+                "id": "gemini/overlapping",
+                "provider": "gemini",
+                "source": "curated",
+                "name": "Hand written",
+            },
+            {
+                "id": "gemini/only-curated",
+                "provider": "gemini",
+                "source": "curated",
+                "name": "Only curated",
+            },
+        ],
+    }
+    monkeypatch.setattr(
+        model_catalog_module,
+        "_read_json",
+        lambda name: generated if "generated" in name else curated,
+    )
+
+    names = {entry.id: entry.name for entry in load_pi_model_catalog().models}
+    assert names["gemini/overlapping"] == "From pi-ai"
+    assert names["gemini/only-curated"] == "Only curated"
 
 
 def test_claude_catalog_covers_exactly_the_accepted_alias_set():

--- a/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
@@ -360,6 +360,6 @@ def test_curated_default_models_exist_in_the_pinned_pi_catalog():
     for provider, models in PROVIDER_DEFAULT_MODELS.items():
         for model_id in models:
             assert model_id in catalog_ids, (provider, model_id)
-    # Pending a catalog refresh: the founder-approved Anthropic list also names Opus 5, which
-    # the pinned pi-ai version does not carry yet (see the note in capabilities.py).
-    assert "anthropic/claude-opus-5" not in catalog_ids
+    # Opus 5 postdates the pinned pi-ai snapshot, so it reaches the catalog through the curated
+    # `additions` list rather than the generated file. The loop above is what proves it arrived.
+    assert "anthropic/claude-opus-5" in catalog_ids


### PR DESCRIPTION
## Context

The agent model picker shows `gemini/gemini-3.6-flash` as a bare id instead of a readable name, and the model is not offered as a Gemini default at all.

The picker reads the SDK's curated model catalog. That catalog is generated from the pinned `@earendil-works/pi-ai@0.80.6`, whose snapshot was taken on 2026-07-12. Gemini 3.6 Flash shipped on 2026-07-21, so the pinned catalog has no entry for it, and a model with no entry has no name to show. The curated overlay could not fix this on its own: an overlay key only decorates an id the generated file already carries.

That gap also blocks the default list. `_harness_default_models` drops a curated default the harness cannot select, and `test_curated_default_models_exist_in_the_pinned_pi_catalog` asserts every curated default exists in the catalog. So the catalog entry and the `PROVIDER_DEFAULT_MODELS` line only work as a pair.

## Changes

`pi_models.curated.json` gains an `additions` list holding whole entries (`source: "curated"`) for models the pinned pi-ai release predates, and `load_pi_model_catalog` appends them after the generated ones. A generated entry of the same id always wins, so an addition retires itself the moment a regeneration carries the model rather than shadowing fresher sourced facts. The generated file is not hand-edited.

Before, for `gemini/gemini-3.6-flash`:

```
no catalog entry -> the picker renders the raw id, and the model is not a Gemini default
```

After:

```
{"id": "gemini/gemini-3.6-flash", "provider": "gemini", "source": "curated",
 "name": "Gemini 3.6 Flash", "context_window": 1048576, ...}
```

`PROVIDER_DEFAULT_MODELS["gemini"]` now leads with the new id and keeps 3.5 Flash and 3.1 Pro Preview, so nothing that was offered before disappears. The `sync-model-catalog` skill documents the new mechanism and says to prune superseded additions after a regeneration.

Facts come from the vendor's own pages, checked 2026-08-21: 1,048,576-token context window, and $0.75 per million input tokens with $3.75 per million output. Two notes for the reviewer. That price is promotional through 2026-12-31 and returns to $1.50 / $7.50 on 2027-01-01, so the next curation pass has to revisit it. And the entry carries no `ratings`, because the skill forbids writing a rating from memory and this one needs a human judgment; `modalities` stays `["text", "image"]`, the only vocabulary the runtime delivery gate and every other Gemini entry use.

## Tests

Three new tests in `test_model_catalog.py`: the catalog publishes `gemini/gemini-3.6-flash` with the name "Gemini 3.6 Flash" through the harness capability record, the id reaches `default_models` for Pi, and a curated addition never shadows a generated entry of the same id. `test_pi_ids_are_unique_and_provider_prefixed` now accepts a `curated` source alongside `pi_generated`, since the pi catalog is no longer uniformly generated.

Reverting the data file and the loader turns all three red, plus the existing curated-defaults test, which is the coupling described above. With the change the catalog module is 29 passed and the SDK agent unit suite is 922 passed, 3 skipped. `ruff format` and `ruff check` are clean.

## Added: Claude Opus 5 (second commit)

Claude Opus 5 has the same problem this branch was opened to fix, for the same reason. It postdates the pinned pi-ai snapshot, so the generated catalog has no entry for it and the picker can only show a bare id with no price and no context window. The `additions` list this branch introduces is exactly the mechanism for that case, so the entry goes here rather than duplicating the pattern in another branch.

```
{"id": "anthropic/claude-opus-5", "provider": "anthropic", "source": "curated",
 "name": "Claude Opus 5", "context_window": 1000000,
 "pricing": {"input_per_mtok": 5.0, "output_per_mtok": 25.0,
             "cache_read_per_mtok": 0.5, "cache_write_per_mtok": 6.25}}
```

Facts come from Anthropic's pricing page, cross-checked against the cost table in litellm 1.92.0. Like the Gemini entry it carries no `ratings`, because the `sync-model-catalog` skill forbids writing a rating from memory.

`test_curated_default_models_exist_in_the_pinned_pi_catalog` ended with an assertion that Opus 5 was absent from the catalog, left as a placeholder pending this refresh. That assertion is now flipped to assert it is present.

This branch does not add Opus 5 to `PROVIDER_DEFAULT_MODELS`. That change lives in #6198, which needs this pull request to merge first.

## What to QA

- Open the agent playground and pick a Gemini connection. The model list offers Gemini 3.6 Flash and the Model row reads "Gemini 3.6 Flash", not the raw id.
- Regression: Gemini 3.5 Flash and Gemini 3.1 Pro Preview are still offered and still render their names.
- Regression: the Anthropic, OpenAI, and OpenRouter model lists are unchanged.

