### PR TITLE
[fix] Record agent run cost on the workflow root

### DIFF
--- a/api/oss/src/apis/fastapi/otlp/extractors/adapters/logfire_adapter.py
+++ b/api/oss/src/apis/fastapi/otlp/extractors/adapters/logfire_adapter.py
@@ -161,6 +161,8 @@ GENAI_SEMCONV_ATTRIBUTES_EXACT: List[Tuple[str, str]] = [
     ("gen_ai.usage.input_tokens", "ag.metrics.unit.tokens.prompt"),
     ("gen_ai.usage.output_tokens", "ag.metrics.unit.tokens.completion"),
     ("gen_ai.usage.total_tokens", "ag.metrics.unit.tokens.total"),
+    # See semconv.py: instrumentation-reported cost wins over any estimate.
+    ("gen_ai.usage.cost", "ag.metrics.unit.costs.total"),
     ("gen_ai.system", "ag.meta.system"),
     ("gen_ai.request.base_url", "ag.meta.request.base_url"),
     ("gen_ai.request.endpoint", "ag.meta.request.endpoint"),

--- a/api/oss/src/apis/fastapi/otlp/opentelemetry/semconv.py
+++ b/api/oss/src/apis/fastapi/otlp/opentelemetry/semconv.py
@@ -18,6 +18,10 @@ V_0_4_1_ATTRIBUTES_EXACT = [
     ("gen_ai.usage.prompt_tokens", "ag.metrics.unit.tokens.prompt"),
     ("gen_ai.usage.completion_tokens", "ag.metrics.unit.tokens.completion"),
     ("gen_ai.usage.total_tokens", "ag.metrics.unit.tokens.total"),
+    # Cost reported by the instrumentation itself. Authoritative: a harness or
+    # gateway knows the price actually charged, which a public pricing table
+    # cannot reproduce for proxied or negotiated models.
+    ("gen_ai.usage.cost", "ag.metrics.unit.costs.total"),
     ("llm.headers", "ag.meta.request.headers"),
     ("llm.request.type", "ag.type.node"),
     ("llm.top_k", "ag.meta.request.top_k"),

--- a/api/oss/src/core/tracing/utils/trees.py
+++ b/api/oss/src/core/tracing/utils/trees.py
@@ -315,8 +315,24 @@ def cumulate_costs(
         if span.attributes is None:
             span.attributes = {}
 
+        incremental = (
+            span.attributes.get("ag", {})
+            .get("metrics", {})
+            .get("costs", {})
+            .get("incremental", {})
+        )
+        has_reported_total = (
+            isinstance(incremental, dict)
+            and "total" in incremental
+            and "prompt" not in incremental
+            and "completion" not in incremental
+        )
+        if has_reported_total:
+            costs = _get_incremental(span)
+
         if (
-            costs.get("prompt", 0.0) != 0.0
+            has_reported_total
+            or costs.get("prompt", 0.0) != 0.0
             or costs.get("completion", 0.0) != 0.0
             or costs.get("total", 0.0) != 0.0
         ):
@@ -601,6 +617,20 @@ def calculate_costs(span_idx: Dict[str, OTelFlatSpan]):
                 .get("tokens", {})
                 .get("incremental", {})
             )
+
+            incremental_costs = (
+                attr.get("ag", {})
+                .get("metrics", {})
+                .get("costs", {})
+                .get("incremental", {})
+            )
+            if (
+                isinstance(incremental_costs, dict)
+                and "total" in incremental_costs
+                and "prompt" not in incremental_costs
+                and "completion" not in incremental_costs
+            ):
+                continue
 
             prompt_tokens = tokens.get("prompt", 0.0)
 

--- a/api/oss/tests/pytest/unit/otlp/test_logfire_adapter.py
+++ b/api/oss/tests/pytest/unit/otlp/test_logfire_adapter.py
@@ -708,6 +708,14 @@ class TestAttributeMapUpdates:
 
         assert features.metrics["unit.tokens.cache_read"] == 2304
 
+    def test_reported_cost_mapped(self, adapter):
+        """A harness or gateway that measured the real cost reports it here."""
+        bag = _make_bag({"gen_ai.usage.cost": 0.004242})
+        features = SpanFeatures()
+        adapter.process(bag, features)
+
+        assert features.metrics["unit.costs.total"] == 0.004242
+
     def test_provider_name_mapped(self, adapter):
         bag = _make_bag({"gen_ai.provider.name": "openai"})
         features = SpanFeatures()

--- a/api/oss/tests/pytest/unit/otlp/test_semconv.py
+++ b/api/oss/tests/pytest/unit/otlp/test_semconv.py
@@ -1,0 +1,8 @@
+from oss.src.apis.fastapi.otlp.opentelemetry.semconv import V_0_4_1_MAPS
+
+
+def test_reported_genai_cost_maps_to_agenta_cost_metric():
+    mappings = V_0_4_1_MAPS["attributes"]["exact"]
+
+    assert mappings["from"]["gen_ai.usage.cost"] == "ag.metrics.unit.costs.total"
+    assert mappings["to"]["ag.metrics.unit.costs.total"] == "gen_ai.usage.cost"

--- a/api/oss/tests/pytest/unit/tracing/utils/test_trees.py
+++ b/api/oss/tests/pytest/unit/tracing/utils/test_trees.py
@@ -120,6 +120,40 @@ def test_parse_span_dtos_to_span_idx_and_tree_hierarchy():
     assert list(tree[ROOT_UUID].keys()) == [CHILD_A_UUID]
 
 
+@pytest.mark.parametrize("reported_cost", [0.0, 0.0042])
+def test_workflow_root_uses_its_reported_usage_as_cumulative(reported_cost):
+    root = _span(
+        span_id=ROOT_UUID,
+        span_name="_agent",
+        span_type=SpanType.WORKFLOW,
+        prompt_tokens=100,
+        completion_tokens=20,
+    )
+    root.attributes["ag"]["metrics"]["costs"]["incremental"] = {"total": reported_cost}
+    child = _span(
+        span_id=CHILD_A_UUID,
+        parent_id=ROOT_UUID,
+        span_name="chat",
+        prompt_cost=0.003,
+        completion_cost=0.0012,
+        start_offset_s=1,
+    )
+
+    result, _ = calculate_and_propagate_metrics([root, child])
+    metrics = result.attributes["ag"]["metrics"]
+
+    assert metrics["tokens"]["cumulative"] == {
+        "prompt": 100,
+        "completion": 20,
+        "total": 120,
+    }
+    assert metrics["costs"]["cumulative"] == {
+        "prompt": 0.0,
+        "completion": 0.0,
+        "total": reported_cost,
+    }
+
+
 def test_cumulate_tokens_and_costs_propagate_from_children_to_parent():
     root = _span(
         span_id=ROOT_UUID,
@@ -233,6 +267,27 @@ def test_calculate_costs_sets_incremental_values_for_cost_supported_types(monkey
 
     costs = span_idx[ROOT_UUID].attributes["ag"]["metrics"]["costs"]["incremental"]
     assert costs == {"prompt": 0.12, "completion": 0.34, "total": 0.46}
+
+
+def test_calculate_costs_preserves_instrumentation_reported_total(monkeypatch):
+    span = _span(
+        span_id=ROOT_UUID,
+        span_name="root",
+        prompt_tokens=10,
+        completion_tokens=20,
+        span_type=SpanType.CHAT,
+    )
+    span.attributes["ag"]["metrics"]["costs"]["incremental"] = {"total": 0.0042}
+
+    monkeypatch.setattr(
+        "oss.src.core.tracing.utils.trees.cost_calculator.cost_per_token",
+        lambda **_: (0.12, 0.34),
+    )
+
+    calculate_costs({span.span_id: span})
+
+    costs = span.attributes["ag"]["metrics"]["costs"]["incremental"]
+    assert costs == {"total": 0.0042}
 
 
 def test_calculate_costs_swallows_calculation_errors(monkeypatch):

--- a/sdks/python/agenta/sdk/agents/tracing.py
+++ b/sdks/python/agenta/sdk/agents/tracing.py
@@ -218,19 +218,32 @@ def record_usage(usage: Optional[Dict[str, Any]]) -> None:
     Setting ``gen_ai.usage.*`` here records them directly on that span (the root of its
     batch), so the trace shows the run's tokens and cost. Best-effort.
     """
-    if not usage or not usage.get("total"):
+    if not usage:
         return
     try:
         span = otel_trace.get_current_span()
-        input_tokens = int(usage.get("input") or 0)
-        output_tokens = int(usage.get("output") or 0)
-        span.set_attribute("gen_ai.usage.input_tokens", input_tokens)
-        span.set_attribute("gen_ai.usage.output_tokens", output_tokens)
-        span.set_attribute("gen_ai.usage.prompt_tokens", input_tokens)
-        span.set_attribute("gen_ai.usage.completion_tokens", output_tokens)
-        span.set_attribute("gen_ai.usage.total_tokens", int(usage.get("total") or 0))
+        input_tokens = usage.get("input")
+        output_tokens = usage.get("output")
+        total_tokens = usage.get("total")
+
+        if any(
+            value is not None for value in (input_tokens, output_tokens, total_tokens)
+        ):
+            input_tokens = int(input_tokens or 0)
+            output_tokens = int(output_tokens or 0)
+            total_tokens = int(
+                total_tokens
+                if total_tokens is not None
+                else input_tokens + output_tokens
+            )
+            span.set_attribute("gen_ai.usage.input_tokens", input_tokens)
+            span.set_attribute("gen_ai.usage.output_tokens", output_tokens)
+            span.set_attribute("gen_ai.usage.prompt_tokens", input_tokens)
+            span.set_attribute("gen_ai.usage.completion_tokens", output_tokens)
+            span.set_attribute("gen_ai.usage.total_tokens", total_tokens)
+
         cost = usage.get("cost")
-        if cost:
+        if cost is not None:
             span.set_attribute("gen_ai.usage.cost", float(cost))
     except Exception:  # pylint: disable=broad-except
         log.warning("agent: failed to record usage on workflow span", exc_info=True)

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_finish_reason.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_finish_reason.py
@@ -149,6 +149,27 @@ async def test_handler_does_not_duplicate_done_when_result_agrees() -> None:
 
 
 @pytest.mark.asyncio
+async def test_handler_records_terminal_runner_usage() -> None:
+    usage = {"input": 100, "output": 20, "total": 120, "cost": 0.0042}
+    records = _paused_records(done_stop_reason="stop", result_stop_reason="stop")
+    records[-1]["result"]["usage"] = usage
+    harness = _FakeHarness(records)
+    recorded = []
+
+    _ = [
+        event
+        async for event in agent_event_stream(
+            harness,
+            object(),
+            [],
+            record_usage=recorded.append,
+        )
+    ]
+
+    assert recorded == [usage]
+
+
+@pytest.mark.asyncio
 async def test_handler_stream_then_adapter_carries_paused_end_to_end() -> None:
     """End to end: the handler's neutral stream fed straight into the live adapter yields a
     finish frame with the paused reason, proving the two halves compose."""

--- a/sdks/python/oss/tests/pytest/unit/agents/test_tracing.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_tracing.py
@@ -8,6 +8,8 @@ from __future__ import annotations
 
 from types import SimpleNamespace
 
+import pytest
+
 from agenta.sdk.agents import RunContextTrace, RunContextWorkflow
 
 from agenta.sdk.agents import tracing
@@ -31,6 +33,50 @@ def test_trace_context_none_without_traceparent_or_authorization(monkeypatch):
     monkeypatch.setattr(tracing, "inject", lambda _headers: {})
 
     assert tracing.trace_context() is None
+
+
+def test_record_usage_stamps_runner_totals_on_active_workflow_span(monkeypatch):
+    attributes = {}
+    span = SimpleNamespace(
+        set_attribute=lambda key, value: attributes.__setitem__(key, value)
+    )
+    monkeypatch.setattr(tracing.otel_trace, "get_current_span", lambda: span)
+
+    tracing.record_usage({"input": 100, "output": 20, "total": 120, "cost": 0.0042})
+
+    assert attributes == {
+        "gen_ai.usage.input_tokens": 100,
+        "gen_ai.usage.output_tokens": 20,
+        "gen_ai.usage.prompt_tokens": 100,
+        "gen_ai.usage.completion_tokens": 20,
+        "gen_ai.usage.total_tokens": 120,
+        "gen_ai.usage.cost": 0.0042,
+    }
+
+
+def test_record_usage_derives_total_from_input_and_output(monkeypatch):
+    attributes = {}
+    span = SimpleNamespace(
+        set_attribute=lambda key, value: attributes.__setitem__(key, value)
+    )
+    monkeypatch.setattr(tracing.otel_trace, "get_current_span", lambda: span)
+
+    tracing.record_usage({"input": 100, "output": 20})
+
+    assert attributes["gen_ai.usage.total_tokens"] == 120
+
+
+@pytest.mark.parametrize("cost", [0.0, 0.0042])
+def test_record_usage_keeps_cost_without_token_total(monkeypatch, cost):
+    attributes = {}
+    span = SimpleNamespace(
+        set_attribute=lambda key, value: attributes.__setitem__(key, value)
+    )
+    monkeypatch.setattr(tracing.otel_trace, "get_current_span", lambda: span)
+
+    tracing.record_usage({"cost": cost})
+
+    assert attributes == {"gen_ai.usage.cost": cost}
 
 
 def test_run_context_keeps_trace_when_workflow_capture_fails(monkeypatch):


### PR DESCRIPTION
## Context

Agent runs showed zero cost on the workflow root, which is the span used by the Observability list and analytics. The runner already returns the final token and cost totals to the SDK, but the SDK discarded summaries without a token total and the API did not map `gen_ai.usage.cost` into Agenta's cost metric.

## Changes

The SDK now records each usage field returned by the runner independently. It preserves cost even when token totals are unavailable, preserves a real zero cost, and derives the token total when the runner provides only input and output counts.

The API now maps `gen_ai.usage.cost` through both OTLP conversion paths. Existing per-batch metric processing copies the workflow root's own reported usage into its cumulative values. It also keeps an instrumentation-reported total instead of replacing it with a LiteLLM estimate, including when the reported cost is exactly zero.

Before:

```text
runner result cost: 0.0042
workflow root cost: missing
```

After:

```text
runner result cost:              0.0042
workflow root incremental cost:  0.0042
workflow root cumulative cost:   0.0042
```

This revision deliberately does not reload or rewrite the stored trace. It removes the previous recomputation service, DAO method, database locks, cross-batch tree policy, and their tests.

## How to review

1. Read `sdks/python/agenta/sdk/agents/tracing.py` for the runner-result to workflow-root handoff.
2. Check the two API mappings for `gen_ai.usage.cost`.
3. Read `api/oss/src/core/tracing/utils/trees.py` for reported-cost precedence and cumulative zero handling.
4. Read the SDK tests for terminal usage forwarding and root attribute stamping, then the API tests for conversion and root cumulative behavior.

## Tests

- Ruff 0.14.0 format and lint passed on every changed Python file.
- API unit suite: 2,675 passed, 73 skipped.
- Focused API tracing and OTLP path: 65 passed.
- Focused SDK usage path: 19 passed.
- SDK agents suite: 934 passed, 4 skipped. One unrelated cross-package assertion failed because the currently applied runner emits an `environment_starting` event before rejecting an empty request.

## What to QA

- Run a funded agent and open its Observability row. The workflow root shows the runner's non-zero token and cost totals.
- Check analytics for the same run. Its total matches the workflow root instead of reading as zero.
- Run an agent whose harness reports cost without a token total. The workflow root still records the cost.
- Run a zero-cost model. The workflow root stores cumulative cost as `0`, not missing.
