### PR TITLE
fix(frontend): fix the phone keyboard on /m, on every frame, and after Enter

### DIFF
--- a/web/mobile/src/components/ScreenScaffold.tsx
+++ b/web/mobile/src/components/ScreenScaffold.tsx
@@ -68,7 +68,9 @@ export const ScreenScaffold = ({
 }: ScreenScaffoldProps) => (
     <div
         className={`bg-background text-foreground flex min-h-0 flex-col ${
-            embedded ? "h-full" : "h-dvh pt-[env(safe-area-inset-top)]"
+            embedded
+                ? "h-full"
+                : "h-[var(--ag-viewport-height,100dvh)] pt-[env(safe-area-inset-top)]"
         }`}
     >
         {header}

--- a/web/mobile/src/features/chat/Composer.tsx
+++ b/web/mobile/src/features/chat/Composer.tsx
@@ -7,6 +7,7 @@ import {
     VoiceInputButton,
 } from "@agenta/chat/components"
 import {stagedFilesToParts, useComposerAttachments, useVoiceComposer} from "@agenta/chat/hooks"
+import {dismissSoftKeyboardAfterSend} from "@agenta/ui/hooks"
 import type {RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import type {FileUIPart} from "ai"
 import {AnimatePresence, motion} from "motion/react"
@@ -61,6 +62,11 @@ export const Composer = ({
         // is still in flight; a second pass would re-send the same staged tray.
         if (sending.current) return
         sending.current = true
+        // Close the on-screen keyboard. It covered the transcript while you typed, and the reply
+        // to the message you just sent is the thing you want to see next. The helper defers the
+        // blur past the editor's own clear, whose reconcile would otherwise re-focus the input and
+        // pop the keyboard straight back up.
+        dismissSoftKeyboardAfterSend(() => richInputRef.current?.blur())
         try {
             await runSubmit(text, extraFiles)
         } finally {

--- a/web/mobile/src/features/chat/SessionWorkspace.tsx
+++ b/web/mobile/src/features/chat/SessionWorkspace.tsx
@@ -101,7 +101,7 @@ export const SessionWorkspace = ({
         <AppShell workspaceId={workspaceId} projectId={projectId}>
             {/* The workspace column: the shared playground top bar, then the panes under it. The
                 column owns the top safe-area inset (the bar is the topmost chrome). */}
-            <div className="ag-app-ground flex h-dvh min-w-0 flex-col pt-[env(safe-area-inset-top)]">
+            <div className="ag-app-ground flex h-[var(--ag-viewport-height,100dvh)] min-w-0 flex-col pt-[env(safe-area-inset-top)]">
                 <SessionTopBar
                     entityId={entityId}
                     agentId={agentId}

--- a/web/mobile/src/features/nav/AppShell.tsx
+++ b/web/mobile/src/features/nav/AppShell.tsx
@@ -26,7 +26,7 @@ export const AppShell = ({
     useTrackLastNonSettingsPath()
 
     return (
-        <div className="flex h-dvh">
+        <div className="flex h-[var(--ag-viewport-height,100dvh)]">
             <NavRail workspaceId={workspaceId} projectId={projectId} scope={scope} />
             <main className="min-w-0 flex-1">{children}</main>
         </div>

--- a/web/mobile/src/pages/_app.tsx
+++ b/web/mobile/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import AppMessageContext from "@agenta/ui/app-message"
+import {useVisualViewportHeight} from "@agenta/ui/hooks"
 import type {AppProps} from "next/app"
 import Head from "next/head"
 
@@ -12,12 +13,23 @@ import "@/styles/globals.css"
 // only what the data layer needs: query client + jotai default store + SDK
 // host pin + route→project sync.
 export default function App({Component, pageProps}: AppProps) {
+    // iOS Safari ignores `interactive-widget`, so on that browser the keyboard still opens over the
+    // page and every `dvh` frame keeps its full height. This publishes the visible height as
+    // `--ag-viewport-height`, which ScreenScaffold, AppShell and SessionWorkspace read with a
+    // `100dvh` fallback. One mount here covers every screen. Idle when no keyboard is open.
+    useVisualViewportHeight()
+
     return (
         <>
             <Head>
+                {/* `interactive-widget=resizes-content` makes the on-screen keyboard shrink
+                    the LAYOUT viewport, so every `dvh` frame below stops hiding its bottom edge —
+                    the composer — behind the keyboard. Chrome and Android honour it. iOS Safari
+                    ignores it, and `useVisualViewportHeight` below covers that half.
+                    `viewport-fit=cover` stays: this app draws real safe-area insets. */}
                 <meta
                     name="viewport"
-                    content="width=device-width, initial-scale=1, viewport-fit=cover"
+                    content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
                 />
             </Head>
             <AppProviders>

--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -18,7 +18,7 @@ import {
 import {type getPendingApprovals} from "@agenta/chat/model"
 import {chatPanelMaximizedAtom} from "@agenta/chat/state"
 import {openAgentConfigSectionAtom} from "@agenta/shared/state"
-import {hasCoarsePointer} from "@agenta/ui/hooks"
+import {dismissSoftKeyboardAfterSend} from "@agenta/ui/hooks"
 import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import {HarnessTooltip, SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
 import {Button, LoadingButton} from "@agenta/ui/ui"
@@ -163,12 +163,17 @@ const AgentComposerDock = ({
     })
     // Sending on a touch device dismisses the on-screen keyboard, which returns the page to its
     // full height and puts the transcript back in view — the message you just sent is the thing
-    // you want to read next. Guarded by the pointer type: on desktop the editor keeps focus after
-    // Enter so the next message can be typed straight away.
+    // you want to read next. On desktop the editor keeps focus after Enter so the next message can
+    // be typed straight away, so the helper checks the pointer type.
+    //
+    // It also DEFERS the blur, which is the part that matters: `submitEditorAsMarkdown` clears the
+    // editor on the statement after this handler returns, and that reconcile writes a fresh DOM
+    // selection, which re-focuses the editor and pops the keyboard straight back up. A blur called
+    // inline here is undone before the user sees it.
     const submitMessage = useCallback(
         (text: string) => {
             const result = onSubmit(text)
-            if (hasCoarsePointer()) richInputRef.current?.blur()
+            dismissSoftKeyboardAfterSend(() => richInputRef.current?.blur())
             return result
         },
         [onSubmit, richInputRef],

--- a/web/oss/src/components/Evaluators/components/ConfigureEvaluator/index.tsx
+++ b/web/oss/src/components/Evaluators/components/ConfigureEvaluator/index.tsx
@@ -104,7 +104,7 @@ const ConfigureEvaluatorPageInner = () => {
         <OSSPlaygroundShell providers={providers}>
             {/* Definite height, not `h-full`: the chain would collapse to content height and
              * strand the empty state at the top. 29px matches Layout's full-height frame. */}
-            <div className="flex flex-col w-full h-[calc(100dvh-29px)] overflow-hidden">
+            <div className="flex flex-col w-full h-[calc(var(--ag-viewport-height,100dvh)-29px)] overflow-hidden">
                 <EvaluatorPlaygroundHeader />
                 <PlaygroundMainView
                     mode="evaluator"

--- a/web/oss/src/components/Layout/Layout.tsx
+++ b/web/oss/src/components/Layout/Layout.tsx
@@ -3,6 +3,7 @@ import {memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode}
 import {workflowLatestRevisionQueryAtomFamily} from "@agenta/entities/workflow"
 import {SETTINGS_SIDEBAR_SCOPE_ID} from "@agenta/navigation"
 import AppMessageContext from "@agenta/ui/app-message"
+import {useVisualViewportHeight} from "@agenta/ui/hooks"
 import {ConfigProvider, Layout, Modal, theme} from "antd"
 import clsx from "clsx"
 import {atom} from "jotai"
@@ -400,7 +401,7 @@ const AppWithVariants = memo(
                                             <ConfigProvider theme={contentThemeConfig}>
                                                 <div
                                                     className={clsx("w-full", {
-                                                        "flex min-h-0 flex-col gap-6 h-[calc(100dvh-29px)] overflow-hidden":
+                                                        "flex min-h-0 flex-col gap-6 h-[calc(var(--ag-viewport-height,100dvh)-29px)] overflow-hidden":
                                                             isFullHeight,
                                                         "flex flex-col":
                                                             !isFullHeight && !isAppRoute,
@@ -426,6 +427,13 @@ const App: React.FC<LayoutProps> = ({children}) => {
     const classes = useStyles({themeMode: appTheme})
     const {isHumanEval, isPlayground, isAppRoute, isAuthRoute, isEvaluator, isFullHeight} =
         useCommittedLayoutFlags()
+
+    // One owner for the whole app. A phone keyboard opens over the page, so every frame sized
+    // against the layout viewport hides its bottom edge behind it. This publishes the visible
+    // height as `--ag-viewport-height`, and each full-height frame reads it with a `100dvh`
+    // fallback. Mounting it here rather than per page means the playground, the agent overview,
+    // sessions, annotations and the auth screens are all covered by one call. Idle on desktop.
+    useVisualViewportHeight()
 
     const [, contextHolder] = Modal.useModal()
 

--- a/web/oss/src/components/Playground/Playground.tsx
+++ b/web/oss/src/components/Playground/Playground.tsx
@@ -8,7 +8,6 @@ import {
 } from "@agenta/playground-ui"
 import {useLocalDraftWarning} from "@agenta/playground-ui/hooks"
 import {preloadEditorPlugins} from "@agenta/ui"
-import {useVisualViewportHeight} from "@agenta/ui/hooks"
 import {useAtomValue} from "jotai"
 import dynamic from "next/dynamic"
 
@@ -52,12 +51,6 @@ const Playground: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
     // Mount imperative playground state sync (store.sub subscriptions)
     // This replaces the old usePlaygroundUrlSync hook with React-free subscriptions
     useAtomValue(playgroundSyncAtom)
-
-    // Phone browsers open the keyboard over the page, so the bottom of this `dvh`-tall frame —
-    // the chat composer — ends up under it. Track the visual viewport and size the frame against
-    // it while the keyboard is open. Idle on desktop and on Android, where the viewport meta's
-    // `interactive-widget=resizes-content` already shrinks `dvh`.
-    useVisualViewportHeight()
 
     // Playground-native onboarding: mint + drive an ephemeral agent inside this real playground (so it
     // reuses all the machinery above). Fully inert when `onboarding` is false — normal playground path.

--- a/web/oss/src/components/PlaygroundRouter/PlaygroundLoadingShell.tsx
+++ b/web/oss/src/components/PlaygroundRouter/PlaygroundLoadingShell.tsx
@@ -27,7 +27,7 @@ const PlaygroundLoadingShell = ({agent, children}: PlaygroundLoadingShellProps =
     const earlyAgent = useAtomValue(playgroundEarlyAgentStateAtom) === "agent"
     const isAgent = agent ?? earlyAgent
     return (
-        <div className="flex flex-col w-full h-dvh overflow-hidden">
+        <div className="flex flex-col w-full h-[var(--ag-viewport-height,100dvh)] overflow-hidden">
             <div
                 className={`flex items-center justify-between gap-4 px-2.5 py-2 ${bgColors.active}`}
             >

--- a/web/oss/src/styles/human-evals.css
+++ b/web/oss/src/styles/human-evals.css
@@ -2,8 +2,10 @@ body {
     --not-available-stripe: #eaeff5;
     --not-available-bg: transparent;
 
+    /* `--ag-viewport-height` is set only while a phone keyboard is open (see
+       useVisualViewportHeight); everywhere else this stays 100dvh. */
     :has(.human-eval) {
-        height: 100dvh;
+        height: var(--ag-viewport-height, 100dvh);
         overflow: hidden;
     }
 

--- a/web/packages/agenta-ui/src/hooks/index.ts
+++ b/web/packages/agenta-ui/src/hooks/index.ts
@@ -11,6 +11,8 @@ export {useMediaQuery, useIsNarrowScreen, NARROW_SCREEN_QUERY} from "./useMediaQ
 export {
     useVisualViewportHeight,
     hasCoarsePointer,
+    dismissSoftKeyboardAfterSend,
+    KEYBOARD_SETTLE_MS,
     keyboardInset,
     viewportHeightOverride,
     COARSE_POINTER_QUERY,

--- a/web/packages/agenta-ui/src/hooks/useVisualViewport.ts
+++ b/web/packages/agenta-ui/src/hooks/useVisualViewport.ts
@@ -29,6 +29,12 @@ export const KEYBOARD_INSET_MIN_PX = 120
 /** Touch input, where sending a message should also dismiss the on-screen keyboard. */
 export const COARSE_POINTER_QUERY = "(pointer: coarse)"
 
+/**
+ * How long a keyboard takes to slide away. Some iOS builds close it without emitting a
+ * visual-viewport `resize`, so a blur schedules one more read after this delay.
+ */
+export const KEYBOARD_SETTLE_MS = 400
+
 /** The four numbers the rules below need, so they can be tested without a browser. */
 export interface VisualViewportSample {
     /** The layout viewport height (`window.innerHeight`), which the keyboard does not shrink. */
@@ -75,6 +81,25 @@ export function hasCoarsePointer(): boolean {
     return window.matchMedia(COARSE_POINTER_QUERY).matches
 }
 
+/**
+ * Close the on-screen keyboard after a message is sent. Does nothing on a mouse-driven browser,
+ * where the editor must keep focus so the next message can be typed straight away.
+ *
+ * The blur MUST be deferred, and that is the whole point of this helper. A rich-text editor clears
+ * itself immediately after it hands the message to `onSubmit`, and that update reconciles a fresh
+ * DOM selection with `setBaseAndExtent`. Writing a selection into a `contenteditable` focuses it,
+ * so a blur called inside the submit handler is undone one statement later and the keyboard springs
+ * back up. Two animation frames put the blur after the reconcile and after the re-render it causes.
+ */
+export function dismissSoftKeyboardAfterSend(blur: () => void): void {
+    if (!hasCoarsePointer()) return
+    if (typeof window === "undefined" || !window.requestAnimationFrame) {
+        blur()
+        return
+    }
+    window.requestAnimationFrame(() => window.requestAnimationFrame(blur))
+}
+
 function readVisualViewport(): VisualViewportSample | null {
     if (typeof window === "undefined") return null
     const viewport = window.visualViewport
@@ -115,16 +140,34 @@ export function useVisualViewportHeight(): void {
             frame = window.requestAnimationFrame(apply)
         }
 
+        // Some iOS builds close the keyboard without emitting a visual-viewport `resize`. The page
+        // would then stay pinned to the shrunken height, with dead space where the keyboard was —
+        // which looks exactly like the bug this hook exists to fix. A blur is the reliable signal
+        // that the keyboard is going away, so read the viewport again when focus leaves a field,
+        // and once more after the close animation has finished.
+        let settle: number | null = null
+        const syncAfterBlur = () => {
+            sync()
+            if (settle !== null) window.clearTimeout(settle)
+            settle = window.setTimeout(() => {
+                settle = null
+                apply()
+            }, KEYBOARD_SETTLE_MS)
+        }
+
         apply()
         viewport.addEventListener("resize", sync)
         viewport.addEventListener("scroll", sync)
         window.addEventListener("orientationchange", sync)
+        window.addEventListener("focusout", syncAfterBlur)
 
         return () => {
             if (frame !== null) window.cancelAnimationFrame(frame)
+            if (settle !== null) window.clearTimeout(settle)
             viewport.removeEventListener("resize", sync)
             viewport.removeEventListener("scroll", sync)
             window.removeEventListener("orientationchange", sync)
+            window.removeEventListener("focusout", syncAfterBlur)
             root.style.removeProperty(VIEWPORT_HEIGHT_VAR)
         }
     }, [])

--- a/web/packages/agenta-ui/tests/unit/visualViewportPlumbing.render.test.tsx
+++ b/web/packages/agenta-ui/tests/unit/visualViewportPlumbing.render.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Wiring tests for `useVisualViewportHeight` and `dismissSoftKeyboardAfterSend`.
+ *
+ * The pure rules had unit tests from the start and were never the problem. What shipped broken was
+ * everything around them: whether the hook actually writes the variable a frame lands in, whether
+ * it CLEARS it when the keyboard goes away, and whether the blur that closes the keyboard survives
+ * the editor's own clear. All three are covered here.
+ */
+import {createElement} from "react"
+
+import {act} from "react"
+import {createRoot, type Root} from "react-dom/client"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+import {
+    KEYBOARD_SETTLE_MS,
+    VIEWPORT_HEIGHT_VAR,
+    dismissSoftKeyboardAfterSend,
+    useVisualViewportHeight,
+} from "../../src/hooks/useVisualViewport"
+
+;(globalThis as {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+/** A stand-in for `window.visualViewport` whose numbers the test drives. */
+class FakeViewport extends EventTarget {
+    height = 844
+    offsetTop = 0
+    scale = 1
+}
+
+let viewport: FakeViewport
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+const Probe = () => {
+    useVisualViewportHeight()
+    return null
+}
+
+const mount = () => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => root?.render(createElement(Probe)))
+}
+
+const readVar = () => document.documentElement.style.getPropertyValue(VIEWPORT_HEIGHT_VAR)
+
+/** Drive one viewport change and let the hook's animation frame run. */
+const emit = (event: "resize" | "scroll") => {
+    act(() => {
+        viewport.dispatchEvent(new Event(event))
+        vi.advanceTimersByTime(20)
+    })
+}
+
+beforeEach(() => {
+    vi.useFakeTimers()
+    // jsdom has no rAF tied to fake timers; a timeout keeps the coalescing path real.
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+        setTimeout(() => cb(0), 16) as unknown as number,
+    )
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id))
+    viewport = new FakeViewport()
+    vi.stubGlobal("visualViewport", viewport)
+    Object.defineProperty(window, "innerHeight", {value: 844, configurable: true, writable: true})
+})
+
+afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    container?.remove()
+    container = null
+    document.documentElement.style.removeProperty(VIEWPORT_HEIGHT_VAR)
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+})
+
+describe("useVisualViewportHeight", () => {
+    it("sets no variable when no keyboard is open, so the page keeps 100dvh", () => {
+        mount()
+        expect(readVar()).toBe("")
+    })
+
+    it("publishes the visible height while the keyboard is open", () => {
+        mount()
+        viewport.height = 508
+        emit("resize")
+        expect(readVar()).toBe("508px")
+    })
+
+    it("clears the variable when the keyboard closes", () => {
+        mount()
+        viewport.height = 508
+        emit("resize")
+        expect(readVar()).toBe("508px")
+
+        viewport.height = 844
+        emit("resize")
+        expect(readVar()).toBe("")
+    })
+
+    it("clears the variable on blur even when the browser reports no viewport change", () => {
+        // The iOS case this exists for: the keyboard closes, the page is left pinned to the short
+        // height, and no visual-viewport `resize` ever arrives. Without the focusout fallback the
+        // composer would sit above a strip of dead space.
+        mount()
+        viewport.height = 508
+        emit("resize")
+        expect(readVar()).toBe("508px")
+
+        viewport.height = 844
+        act(() => {
+            window.dispatchEvent(new Event("focusout"))
+            vi.advanceTimersByTime(KEYBOARD_SETTLE_MS + 50)
+        })
+        expect(readVar()).toBe("")
+    })
+
+    it("removes the variable when it unmounts", () => {
+        mount()
+        viewport.height = 508
+        emit("resize")
+        expect(readVar()).toBe("508px")
+
+        act(() => root?.unmount())
+        root = null
+        expect(readVar()).toBe("")
+    })
+})
+
+describe("dismissSoftKeyboardAfterSend", () => {
+    const setPointer = (coarse: boolean) => {
+        vi.stubGlobal("matchMedia", (query: string) => ({
+            matches: coarse && query.includes("coarse"),
+            media: query,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+        }))
+    }
+
+    it("does nothing on a mouse-driven browser, so Enter keeps focus for the next message", () => {
+        setPointer(false)
+        const blur = vi.fn()
+        dismissSoftKeyboardAfterSend(blur)
+        vi.advanceTimersByTime(100)
+        expect(blur).not.toHaveBeenCalled()
+    })
+
+    it("blurs on a touch device, but only after the editor has reconciled", () => {
+        setPointer(true)
+        const blur = vi.fn()
+        dismissSoftKeyboardAfterSend(blur)
+        // The load-bearing assertion: NOT synchronous. The caller clears the editor on the next
+        // statement, and that clear writes a DOM selection that would re-focus the input and undo
+        // an inline blur.
+        expect(blur).not.toHaveBeenCalled()
+
+        vi.advanceTimersByTime(100)
+        expect(blur).toHaveBeenCalledTimes(1)
+    })
+})


### PR DESCRIPTION
## Context

[#6169](https://github.com/Agenta-AI/agenta/pull/6169) was supposed to fix F1, the phone keyboard hiding the chat composer. Mahmoud re-tested on staging after the redeploy and reported it is still broken. This PR fixes the three separate reasons it did not work.

**Reason 1: the mobile app at `/m` was never touched.** #6169 changed the desktop app only. `/m` is a separate Next app with its own viewport meta, its own frames and its own composer. Checked against the deployed staging build:

```
$ curl -s https://staging.preview.agenta.dev/auth | grep -o '<meta name="viewport"[^>]*>'
<meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" ...>

$ curl -s https://staging.preview.agenta.dev/m | grep -o '<meta name="viewport"[^>]*>'
<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" ...>
```

No `interactive-widget` on `/m`, no visual-viewport handling anywhere in `web/mobile`, and no blur after send. On `/m` the bug was untouched on both browser families. The staging mobile gate does not redirect phone user agents, so which app a phone lands in depends on the URL, and `/m` is the one being tested for the mobile rollout.

**Reason 2: on the desktop app only the playground frame was covered.** The hook ran in `Playground.tsx` alone. Every other full-height frame still sized itself against the layout viewport, including the **agent overview composer**, which is a `RichChatInput` inside `Layout.tsx`'s `h-[calc(100dvh-29px)]` frame ([AgentOverview.tsx:89](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/pages/overview/agent/AgentOverview.tsx#L89)), plus the evaluator playground, the human-evaluation surface, and the playground's own loading shell.

**Reason 3: the blur after send never took effect.** This is the "the enter hiding it" half of the report, and it was a real defect in #6169. The send path is:

```ts
onSubmit(trimmed)                                  // ← #6169 blurred here
editor.update(() => {root.clear(); root.append($createParagraphNode())})
```

That second line reconciles a fresh DOM selection through `setDOMSelectionBaseAndExtent` ([lexical 0.46.0](https://github.com/facebook/lexical)). Writing a selection into a `contenteditable` focuses it, so the blur was undone one statement later and the keyboard came straight back. The repository already documents this behaviour, in the composer's own words at [RichChatInput.tsx:198](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx#L198): "A focused editor re-asserts its selection on the next reconcile."

## Changes

**`/m` gets the whole fix.** `web/mobile/src/pages/_app.tsx` adds `interactive-widget=resizes-content` to its meta, keeping `viewport-fit=cover` because this app draws real safe-area insets. It also mounts `useVisualViewportHeight()` once for every screen. The three frames that size against the viewport read the variable with a `100dvh` fallback: `ScreenScaffold`, `AppShell`, and `SessionWorkspace` (the chat screen's height owner). `Composer.tsx` dismisses the keyboard after send.

**The desktop hook moves up one level.** `useVisualViewportHeight()` now runs in the shared `Layout`, which wraps every route in both editions, instead of in `Playground.tsx`. One owner, and the property is no longer written by two components. The frames that read it:

| Frame | Before | After |
| --- | --- | --- |
| `Layout.tsx:403` (agent overview, sessions, annotations, evaluations, agents, testsets) | `h-[calc(100dvh-29px)]` | `h-[calc(var(--ag-viewport-height,100dvh)-29px)]` |
| `ConfigureEvaluator/index.tsx:107` | `h-[calc(100dvh-29px)]` | same substitution |
| `PlaygroundLoadingShell.tsx:30` | `h-dvh` | `h-[var(--ag-viewport-height,100dvh)]` |
| `human-evals.css:6` | `height: 100dvh` | `height: var(--ag-viewport-height, 100dvh)` |

**`dismissSoftKeyboardAfterSend`** replaces the inline blur in both apps. It checks the pointer type, then defers the blur across two animation frames so it lands after the editor's clear and after the re-render that clear causes. Desktop still keeps focus after Enter.

**The height variable now also clears on `focusout`.** Some iOS builds close the keyboard without emitting a visual-viewport `resize`. The page would then stay pinned to the short height with a strip of dead space under the composer, which looks identical to the original bug. A blur is the reliable signal, so the hook re-reads the viewport when focus leaves and once more after the close animation.

`viewportHeightOverride`'s pinch-zoom behaviour from [#6181](https://github.com/Agenta-AI/agenta/pull/6181) is unchanged, and the `focusout` path goes through the same rule, so zooming still holds the height.

## Tests / notes

- New wiring tests, `visualViewportPlumbing.render.test.tsx`, cover exactly what round 1 got wrong: the variable is published while the keyboard is open, cleared when it closes, cleared on blur when no resize arrives, and the blur is **not** synchronous. `pnpm --filter @agenta/ui test:unit`: 105 passed.
- `pnpm --filter @agenta/chat test:unit`: 378 passed. `pnpm --filter @agenta/mobile test`: 124 passed.
- `tsc --noEmit` clean for `web/oss`, `web/ee` and `@agenta/ui`; `pnpm --filter @agenta/mobile types:check` clean.
- `pnpm lint-fix` in `web/`: 25/25, no errors. `prettier@3.7.4 --check` clean on all touched files.
- One production build of `@agenta/oss`: exit 0. Both generated stylesheets contain the arbitrary-value rules, so the Tailwind classes really are emitted: `calc(var(--ag-viewport-height,100dvh) - 29px)` and `height:var(--ag-viewport-height,100dvh)` in the OSS bundle, and the same `height` rule in the mobile bundle.
- **`web/mobile`'s production build fails locally, and it fails identically on the pristine release tip with none of this branch applied.** The error is `TypeError: Cannot read properties of undefined (reading 'AmpStateContext')` during prerender. `AmpStateContext` is a Next 15 pages-router internal, and `web/mobile` is on Next 16 inside a workspace that also holds Next 15, so a shared package resolves the wrong copy. It is a local workspace-resolution problem, not a regression here. CI builds the mobile image and `/m` returns 200 on staging, so the Docker build path is unaffected. Its `next dev` fails locally for a related reason. Flagged separately for the release.
- **Not verified on a device.** No phone or emulator was available. Because of the local mobile build problem above, the `/m` meta could not be checked from a running local server either. After the next staging deploy this one command confirms delivery: `curl -s https://staging.preview.agenta.dev/m | grep -o '<meta name="viewport"[^>]*>'` must show `interactive-widget=resizes-content`.
- The revision drawer that hosts a chat (`WorkflowRevisionDrawer`) was deliberately left alone. antd sizes it off the fixed containing block so a class cannot reach it, and at a fixed 1100px width it is not a phone surface.

## What to QA

On a phone, **on `/m` first**, since that is where the bug was completely unfixed:

1. Open a session and tap the composer. The whole composer stays above the keyboard. The transcript shrinks rather than the composer sliding under.
2. Type a message and press Enter. The keyboard closes, the page returns to full height, and the reply streams into a transcript you can see. This is the exact step that failed before.
3. Tap the composer and dismiss the keyboard with the browser's own control instead of sending. The page returns to full height with no dead space at the bottom.
4. Rotate to landscape with the keyboard open, then pinch-zoom the transcript. The page must not jump while zooming.

Then repeat 1 to 3 on the desktop app in a phone browser, in the playground, and once more on an agent's **overview** page, whose composer was never covered before.

Desktop regressions to confirm on a laptop: the playground frame height is unchanged, Enter keeps focus in the editor so you can type the next message, and the full-height pages (sessions, agents, annotations, evaluations) look exactly as before.
