### PR TITLE
fix(frontend): keep the /m composer above the phone keyboard and close it on send

### DIFF
--- a/web/mobile/src/components/ScreenScaffold.tsx
+++ b/web/mobile/src/components/ScreenScaffold.tsx
@@ -68,7 +68,9 @@ export const ScreenScaffold = ({
 }: ScreenScaffoldProps) => (
     <div
         className={`bg-background text-foreground flex min-h-0 flex-col ${
-            embedded ? "h-full" : "h-dvh pt-[env(safe-area-inset-top)]"
+            embedded
+                ? "h-full"
+                : "h-[var(--ag-viewport-height,100dvh)] pt-[env(safe-area-inset-top)]"
         }`}
     >
         {header}

--- a/web/mobile/src/features/chat/Composer.tsx
+++ b/web/mobile/src/features/chat/Composer.tsx
@@ -7,6 +7,7 @@ import {
     VoiceInputButton,
 } from "@agenta/chat/components"
 import {stagedFilesToParts, useComposerAttachments, useVoiceComposer} from "@agenta/chat/hooks"
+import {dismissSoftKeyboardAfterSend} from "@agenta/ui/hooks"
 import type {RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import type {FileUIPart} from "ai"
 import {AnimatePresence, motion} from "motion/react"
@@ -61,6 +62,11 @@ export const Composer = ({
         // is still in flight; a second pass would re-send the same staged tray.
         if (sending.current) return
         sending.current = true
+        // Close the on-screen keyboard. It covered the transcript while you typed, and the reply
+        // to the message you just sent is the thing you want to see next. The helper defers the
+        // blur past the editor's own clear, whose reconcile would otherwise re-focus the input and
+        // pop the keyboard straight back up.
+        dismissSoftKeyboardAfterSend(() => richInputRef.current?.blur())
         try {
             await runSubmit(text, extraFiles)
         } finally {

--- a/web/mobile/src/features/chat/SessionWorkspace.tsx
+++ b/web/mobile/src/features/chat/SessionWorkspace.tsx
@@ -101,7 +101,7 @@ export const SessionWorkspace = ({
         <AppShell workspaceId={workspaceId} projectId={projectId}>
             {/* The workspace column: the shared playground top bar, then the panes under it. The
                 column owns the top safe-area inset (the bar is the topmost chrome). */}
-            <div className="ag-app-ground flex h-dvh min-w-0 flex-col pt-[env(safe-area-inset-top)]">
+            <div className="ag-app-ground flex h-[var(--ag-viewport-height,100dvh)] min-w-0 flex-col pt-[env(safe-area-inset-top)]">
                 <SessionTopBar
                     entityId={entityId}
                     agentId={agentId}

--- a/web/mobile/src/features/nav/AppShell.tsx
+++ b/web/mobile/src/features/nav/AppShell.tsx
@@ -26,7 +26,7 @@ export const AppShell = ({
     useTrackLastNonSettingsPath()
 
     return (
-        <div className="flex h-dvh">
+        <div className="flex h-[var(--ag-viewport-height,100dvh)]">
             <NavRail workspaceId={workspaceId} projectId={projectId} scope={scope} />
             <main className="min-w-0 flex-1">{children}</main>
         </div>

--- a/web/mobile/src/pages/_app.tsx
+++ b/web/mobile/src/pages/_app.tsx
@@ -1,4 +1,5 @@
 import AppMessageContext from "@agenta/ui/app-message"
+import {useVisualViewportHeight} from "@agenta/ui/hooks"
 import type {AppProps} from "next/app"
 import Head from "next/head"
 
@@ -12,12 +13,23 @@ import "@/styles/globals.css"
 // only what the data layer needs: query client + jotai default store + SDK
 // host pin + route→project sync.
 export default function App({Component, pageProps}: AppProps) {
+    // iOS Safari ignores `interactive-widget`, so on that browser the keyboard still opens over the
+    // page and every `dvh` frame keeps its full height. This publishes the visible height as
+    // `--ag-viewport-height`, which ScreenScaffold, AppShell and SessionWorkspace read with a
+    // `100dvh` fallback. One mount here covers every screen. Idle when no keyboard is open.
+    useVisualViewportHeight()
+
     return (
         <>
             <Head>
+                {/* `interactive-widget=resizes-content` makes the on-screen keyboard shrink
+                    the LAYOUT viewport, so every `dvh` frame below stops hiding its bottom edge —
+                    the composer — behind the keyboard. Chrome and Android honour it. iOS Safari
+                    ignores it, and `useVisualViewportHeight` below covers that half.
+                    `viewport-fit=cover` stays: this app draws real safe-area insets. */}
                 <meta
                     name="viewport"
-                    content="width=device-width, initial-scale=1, viewport-fit=cover"
+                    content="width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content"
                 />
             </Head>
             <AppProviders>

--- a/web/packages/agenta-ui/src/hooks/index.ts
+++ b/web/packages/agenta-ui/src/hooks/index.ts
@@ -11,6 +11,8 @@ export {useMediaQuery, useIsNarrowScreen, NARROW_SCREEN_QUERY} from "./useMediaQ
 export {
     useVisualViewportHeight,
     hasCoarsePointer,
+    dismissSoftKeyboardAfterSend,
+    KEYBOARD_SETTLE_MS,
     keyboardInset,
     viewportHeightOverride,
     COARSE_POINTER_QUERY,

--- a/web/packages/agenta-ui/src/hooks/useVisualViewport.ts
+++ b/web/packages/agenta-ui/src/hooks/useVisualViewport.ts
@@ -29,6 +29,12 @@ export const KEYBOARD_INSET_MIN_PX = 120
 /** Touch input, where sending a message should also dismiss the on-screen keyboard. */
 export const COARSE_POINTER_QUERY = "(pointer: coarse)"
 
+/**
+ * How long a keyboard takes to slide away. Some iOS builds close it without emitting a
+ * visual-viewport `resize`, so a blur schedules one more read after this delay.
+ */
+export const KEYBOARD_SETTLE_MS = 400
+
 /** The four numbers the rules below need, so they can be tested without a browser. */
 export interface VisualViewportSample {
     /** The layout viewport height (`window.innerHeight`), which the keyboard does not shrink. */
@@ -75,6 +81,25 @@ export function hasCoarsePointer(): boolean {
     return window.matchMedia(COARSE_POINTER_QUERY).matches
 }
 
+/**
+ * Close the on-screen keyboard after a message is sent. Does nothing on a mouse-driven browser,
+ * where the editor must keep focus so the next message can be typed straight away.
+ *
+ * The blur MUST be deferred, and that is the whole point of this helper. A rich-text editor clears
+ * itself immediately after it hands the message to `onSubmit`, and that update reconciles a fresh
+ * DOM selection with `setBaseAndExtent`. Writing a selection into a `contenteditable` focuses it,
+ * so a blur called inside the submit handler is undone one statement later and the keyboard springs
+ * back up. Two animation frames put the blur after the reconcile and after the re-render it causes.
+ */
+export function dismissSoftKeyboardAfterSend(blur: () => void): void {
+    if (!hasCoarsePointer()) return
+    if (typeof window === "undefined" || !window.requestAnimationFrame) {
+        blur()
+        return
+    }
+    window.requestAnimationFrame(() => window.requestAnimationFrame(blur))
+}
+
 function readVisualViewport(): VisualViewportSample | null {
     if (typeof window === "undefined") return null
     const viewport = window.visualViewport
@@ -115,16 +140,34 @@ export function useVisualViewportHeight(): void {
             frame = window.requestAnimationFrame(apply)
         }
 
+        // Some iOS builds close the keyboard without emitting a visual-viewport `resize`. The page
+        // would then stay pinned to the shrunken height, with dead space where the keyboard was —
+        // which looks exactly like the bug this hook exists to fix. A blur is the reliable signal
+        // that the keyboard is going away, so read the viewport again when focus leaves a field,
+        // and once more after the close animation has finished.
+        let settle: number | null = null
+        const syncAfterBlur = () => {
+            sync()
+            if (settle !== null) window.clearTimeout(settle)
+            settle = window.setTimeout(() => {
+                settle = null
+                apply()
+            }, KEYBOARD_SETTLE_MS)
+        }
+
         apply()
         viewport.addEventListener("resize", sync)
         viewport.addEventListener("scroll", sync)
         window.addEventListener("orientationchange", sync)
+        window.addEventListener("focusout", syncAfterBlur)
 
         return () => {
             if (frame !== null) window.cancelAnimationFrame(frame)
+            if (settle !== null) window.clearTimeout(settle)
             viewport.removeEventListener("resize", sync)
             viewport.removeEventListener("scroll", sync)
             window.removeEventListener("orientationchange", sync)
+            window.removeEventListener("focusout", syncAfterBlur)
             root.style.removeProperty(VIEWPORT_HEIGHT_VAR)
         }
     }, [])

--- a/web/packages/agenta-ui/tests/unit/visualViewportPlumbing.render.test.tsx
+++ b/web/packages/agenta-ui/tests/unit/visualViewportPlumbing.render.test.tsx
@@ -1,0 +1,164 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Wiring tests for `useVisualViewportHeight` and `dismissSoftKeyboardAfterSend`.
+ *
+ * The pure rules had unit tests from the start and were never the problem. What shipped broken was
+ * everything around them: whether the hook actually writes the variable a frame lands in, whether
+ * it CLEARS it when the keyboard goes away, and whether the blur that closes the keyboard survives
+ * the editor's own clear. All three are covered here.
+ */
+import {createElement} from "react"
+
+import {act} from "react"
+import {createRoot, type Root} from "react-dom/client"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+import {
+    KEYBOARD_SETTLE_MS,
+    VIEWPORT_HEIGHT_VAR,
+    dismissSoftKeyboardAfterSend,
+    useVisualViewportHeight,
+} from "../../src/hooks/useVisualViewport"
+
+;(globalThis as {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
+
+/** A stand-in for `window.visualViewport` whose numbers the test drives. */
+class FakeViewport extends EventTarget {
+    height = 844
+    offsetTop = 0
+    scale = 1
+}
+
+let viewport: FakeViewport
+let root: Root | null = null
+let container: HTMLDivElement | null = null
+
+const Probe = () => {
+    useVisualViewportHeight()
+    return null
+}
+
+const mount = () => {
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+    act(() => root?.render(createElement(Probe)))
+}
+
+const readVar = () => document.documentElement.style.getPropertyValue(VIEWPORT_HEIGHT_VAR)
+
+/** Drive one viewport change and let the hook's animation frame run. */
+const emit = (event: "resize" | "scroll") => {
+    act(() => {
+        viewport.dispatchEvent(new Event(event))
+        vi.advanceTimersByTime(20)
+    })
+}
+
+beforeEach(() => {
+    vi.useFakeTimers()
+    // jsdom has no rAF tied to fake timers; a timeout keeps the coalescing path real.
+    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
+        setTimeout(() => cb(0), 16) as unknown as number,
+    )
+    vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id))
+    viewport = new FakeViewport()
+    vi.stubGlobal("visualViewport", viewport)
+    Object.defineProperty(window, "innerHeight", {value: 844, configurable: true, writable: true})
+})
+
+afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    container?.remove()
+    container = null
+    document.documentElement.style.removeProperty(VIEWPORT_HEIGHT_VAR)
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+})
+
+describe("useVisualViewportHeight", () => {
+    it("sets no variable when no keyboard is open, so the page keeps 100dvh", () => {
+        mount()
+        expect(readVar()).toBe("")
+    })
+
+    it("publishes the visible height while the keyboard is open", () => {
+        mount()
+        viewport.height = 508
+        emit("resize")
+        expect(readVar()).toBe("508px")
+    })
+
+    it("clears the variable when the keyboard closes", () => {
+        mount()
+        viewport.height = 508
+        emit("resize")
+        expect(readVar()).toBe("508px")
+
+        viewport.height = 844
+        emit("resize")
+        expect(readVar()).toBe("")
+    })
+
+    it("clears the variable on blur even when the browser reports no viewport change", () => {
+        // The iOS case this exists for: the keyboard closes, the page is left pinned to the short
+        // height, and no visual-viewport `resize` ever arrives. Without the focusout fallback the
+        // composer would sit above a strip of dead space.
+        mount()
+        viewport.height = 508
+        emit("resize")
+        expect(readVar()).toBe("508px")
+
+        viewport.height = 844
+        act(() => {
+            window.dispatchEvent(new Event("focusout"))
+            vi.advanceTimersByTime(KEYBOARD_SETTLE_MS + 50)
+        })
+        expect(readVar()).toBe("")
+    })
+
+    it("removes the variable when it unmounts", () => {
+        mount()
+        viewport.height = 508
+        emit("resize")
+        expect(readVar()).toBe("508px")
+
+        act(() => root?.unmount())
+        root = null
+        expect(readVar()).toBe("")
+    })
+})
+
+describe("dismissSoftKeyboardAfterSend", () => {
+    const setPointer = (coarse: boolean) => {
+        vi.stubGlobal("matchMedia", (query: string) => ({
+            matches: coarse && query.includes("coarse"),
+            media: query,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+        }))
+    }
+
+    it("does nothing on a mouse-driven browser, so Enter keeps focus for the next message", () => {
+        setPointer(false)
+        const blur = vi.fn()
+        dismissSoftKeyboardAfterSend(blur)
+        vi.advanceTimersByTime(100)
+        expect(blur).not.toHaveBeenCalled()
+    })
+
+    it("blurs on a touch device, but only after the editor has reconciled", () => {
+        setPointer(true)
+        const blur = vi.fn()
+        dismissSoftKeyboardAfterSend(blur)
+        // The load-bearing assertion: NOT synchronous. The caller clears the editor on the next
+        // statement, and that clear writes a DOM selection that would re-focus the input and undo
+        // an inline blur.
+        expect(blur).not.toHaveBeenCalled()
+
+        vi.advanceTimersByTime(100)
+        expect(blur).toHaveBeenCalledTimes(1)
+    })
+})

--- a/web/packages/agenta-ui/tests/unit/visualViewportPlumbing.render.test.tsx
+++ b/web/packages/agenta-ui/tests/unit/visualViewportPlumbing.render.test.tsx
@@ -20,7 +20,6 @@ import {
     dismissSoftKeyboardAfterSend,
     useVisualViewportHeight,
 } from "../../src/hooks/useVisualViewport"
-
 ;(globalThis as {IS_REACT_ACT_ENVIRONMENT?: boolean}).IS_REACT_ACT_ENVIRONMENT = true
 
 /** A stand-in for `window.visualViewport` whose numbers the test drives. */
@@ -59,8 +58,9 @@ const emit = (event: "resize" | "scroll") => {
 beforeEach(() => {
     vi.useFakeTimers()
     // jsdom has no rAF tied to fake timers; a timeout keeps the coalescing path real.
-    vi.stubGlobal("requestAnimationFrame", (cb: FrameRequestCallback) =>
-        setTimeout(() => cb(0), 16) as unknown as number,
+    vi.stubGlobal(
+        "requestAnimationFrame",
+        (cb: FrameRequestCallback) => setTimeout(() => cb(0), 16) as unknown as number,
     )
     vi.stubGlobal("cancelAnimationFrame", (id: number) => clearTimeout(id))
     viewport = new FakeViewport()


### PR DESCRIPTION
## Context

Reported by Mahmoud on Chrome, Pixel 8 Pro, at `/m`. Two halves:

1. When the keyboard opens the page does not move up, so the composer is partly covered.
2. After pressing Enter to send, the keyboard does not close and the composer does not return to normal.

The mobile app was never covered by the earlier desktop fix ([#6169](https://github.com/Agenta-AI/agenta/pull/6169)), which changed `web/oss` only. `/m` is a separate Next app with its own viewport meta, its own frames and its own composer wrapper. Measured on the deployed staging build:

```
$ curl -s https://staging.preview.agenta.dev/auth | grep -o '<meta name="viewport"[^>]*>'
<meta name="viewport" content="width=device-width, initial-scale=1, interactive-widget=resizes-content" ...>

$ curl -s https://staging.preview.agenta.dev/m | grep -o '<meta name="viewport"[^>]*>'
<meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover" ...>
```

Without `interactive-widget`, Android Chrome opens the keyboard **over** the page. The layout viewport keeps its full height, so the three `h-dvh` frames on the chat route keep theirs ([AppShell.tsx:29](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/mobile/src/features/nav/AppShell.tsx#L29), [SessionWorkspace.tsx:104](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/mobile/src/features/chat/SessionWorkspace.tsx#L104), [ScreenScaffold.tsx:71](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/mobile/src/components/ScreenScaffold.tsx#L71)). The composer is the last flow child of that column, nothing is `fixed` or `sticky`, and the frame is exactly as tall as the layout viewport, so the page cannot scroll to reveal what the keyboard covers. That is half 1.

Half 2 is a separate defect. Nothing in `web/mobile` ever blurred the input, so the keyboard stayed up after Enter.

## Changes

**Half 1, Android, which is the reported device.** `_app.tsx` now serves `width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content`. That directive makes the keyboard shrink the layout viewport, so `dvh` follows it and the composer stays above the keyboard. `viewport-fit=cover` stays because this app draws real safe-area insets (`ScreenScaffold`, `Composer`, `ApprovalDock` all use `env(safe-area-inset-*)`).

**Half 1, iOS, which ignores that directive.** `useVisualViewportHeight()` mounts once in `_app` and publishes the visible height as `--ag-viewport-height`. The three frames read it with a `100dvh` fallback:

```
- <div className="ag-app-ground flex h-dvh min-w-0 flex-col pt-[env(safe-area-inset-top)]">
+ <div className="ag-app-ground flex h-[var(--ag-viewport-height,100dvh)] min-w-0 flex-col pt-[env(safe-area-inset-top)]">
```

The two mechanisms cannot double up. On Android the layout viewport is already shrunk, so the inset the hook measures is zero and the variable is never set.

**Half 2.** `Composer.tsx` dismisses the keyboard after a send on touch devices, which closes it and returns the frame to full height. Both send paths are covered, because plain Enter ([SubmitPlugin.tsx:46](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/packages/agenta-ui/src/RichChatInput/plugins/SubmitPlugin.tsx#L46)) and the send button ([SendButton.tsx:49](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/packages/agenta-ui/src/RichChatInput/plugins/SendButton.tsx#L49)) both call `submitEditorAsMarkdown(editor, onSubmit)` with the same `onSubmit`, and `onSubmit` is the `submit` function this wraps.

The blur has to be **deferred**, and that is what `dismissSoftKeyboardAfterSend` exists for:

```ts
onSubmit(trimmed)                                   // an inline blur here is undone
editor.update(() => {root.clear(); root.append($createParagraphNode())})
```

The second line reconciles a fresh DOM selection through lexical's `setDOMSelectionBaseAndExtent`. Writing a selection into a `contenteditable` focuses it, so an inline blur is reversed one statement later and the keyboard springs back. The editor already documents this at [RichChatInput.tsx:198](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx#L198): "A focused editor re-asserts its selection on the next reconcile." Two animation frames put the blur after it.

**One more iOS hazard, fixed here.** The height variable now clears on `focusout` as well as on a visual-viewport resize. Some iOS builds close the keyboard without emitting a resize, which would leave the page pinned to the short height with dead space under the composer. That failure looks identical to the bug being fixed. #6181's pinch-zoom guard is untouched and the new path goes through the same rule.

## Tests / notes

- New wiring tests (`visualViewportPlumbing.render.test.tsx`): the variable is published while the keyboard is open, cleared when it closes, cleared on blur when no resize arrives, and the blur is **not** synchronous. `pnpm --filter @agenta/ui test:unit`: 105 passed.
- `pnpm --filter @agenta/mobile test`: 124 passed. `types:check` clean. `lint` clean (4 pre-existing warnings). `tsc --noEmit` in `web/oss` clean.
- The compiled mobile bundle carries the exact new string, so nothing downstream rewrites it: `grep -o "width=device-width[^\"]*" .next/server/chunks/7731.js` gives `width=device-width, initial-scale=1, viewport-fit=cover, interactive-widget=resizes-content`. The generated stylesheet contains `height:var(--ag-viewport-height,100dvh)`, so the arbitrary Tailwind class is really emitted.
- **`web/mobile`'s production build fails at prerender, and fails identically on the pristine release tip with none of this branch applied.** `TypeError: Cannot read properties of undefined (reading 'AmpStateContext')`. I attributed it by building three trees: this branch, this branch minus the `_app` hook, and `web/` reset entirely to `origin/release/v0.113.0`. All three fail the same way. `AmpStateContext` is a Next 15 pages-router internal and `web/mobile` runs Next 16 in a workspace that also holds Next 15, so a shared package resolves the wrong copy of `next/head`. `next dev` for mobile is broken locally for a related reason. CI builds the mobile image and `/m` returns 200 on staging, so the Docker path is unaffected. Worth its own issue; it is not a regression here.
- **Not verified on a device**, and because of that build problem the meta could not be checked from a running local server either. The delivery mechanism is already proven though: this edits the `content` of the very same `<Head>` tag that demonstrably serves the current string on staging today. After the next deploy, one command confirms it: `curl -s https://staging.preview.agenta.dev/m | grep -o '<meta name="viewport"[^>]*>'` must contain `interactive-widget=resizes-content`.

## What to QA

On `/m`, Chrome, an Android phone, in a session with an agent:

1. Tap the composer. The page moves up and the whole composer, input and send button, sits above the keyboard. This is the first half of the report.
2. Type a message and press Enter. The keyboard closes, the page returns to full height, and the reply streams into a transcript you can see. This is the second half.
3. Send again using the send button instead of Enter. Same result: keyboard closes, layout returns.
4. Tap the composer and dismiss the keyboard with the system back gesture instead of sending. The page returns to full height with no dead space at the bottom.
5. Rotate to landscape with the keyboard open. The composer stays visible.
6. Repeat 1 and 2 on an iPhone if one is available. That path uses the visual-viewport hook rather than the meta, and it is the half no browser has exercised yet.
7. Regression: the sessions list, home and settings screens on `/m` still fill the screen with no gap at the bottom when no keyboard is open.
