### PR TITLE
fix(frontend): cover every desktop frame with the phone keyboard fix

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -18,7 +18,7 @@ import {
 import {type getPendingApprovals} from "@agenta/chat/model"
 import {chatPanelMaximizedAtom} from "@agenta/chat/state"
 import {openAgentConfigSectionAtom} from "@agenta/shared/state"
-import {hasCoarsePointer} from "@agenta/ui/hooks"
+import {dismissSoftKeyboardAfterSend} from "@agenta/ui/hooks"
 import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 import {HarnessTooltip, SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
 import {Button, LoadingButton} from "@agenta/ui/ui"
@@ -163,12 +163,17 @@ const AgentComposerDock = ({
     })
     // Sending on a touch device dismisses the on-screen keyboard, which returns the page to its
     // full height and puts the transcript back in view — the message you just sent is the thing
-    // you want to read next. Guarded by the pointer type: on desktop the editor keeps focus after
-    // Enter so the next message can be typed straight away.
+    // you want to read next. On desktop the editor keeps focus after Enter so the next message can
+    // be typed straight away, so the helper checks the pointer type.
+    //
+    // It also DEFERS the blur, which is the part that matters: `submitEditorAsMarkdown` clears the
+    // editor on the statement after this handler returns, and that reconcile writes a fresh DOM
+    // selection, which re-focuses the editor and pops the keyboard straight back up. A blur called
+    // inline here is undone before the user sees it.
     const submitMessage = useCallback(
         (text: string) => {
             const result = onSubmit(text)
-            if (hasCoarsePointer()) richInputRef.current?.blur()
+            dismissSoftKeyboardAfterSend(() => richInputRef.current?.blur())
             return result
         },
         [onSubmit, richInputRef],

--- a/web/oss/src/components/Evaluators/components/ConfigureEvaluator/index.tsx
+++ b/web/oss/src/components/Evaluators/components/ConfigureEvaluator/index.tsx
@@ -104,7 +104,7 @@ const ConfigureEvaluatorPageInner = () => {
         <OSSPlaygroundShell providers={providers}>
             {/* Definite height, not `h-full`: the chain would collapse to content height and
              * strand the empty state at the top. 29px matches Layout's full-height frame. */}
-            <div className="flex flex-col w-full h-[calc(100dvh-29px)] overflow-hidden">
+            <div className="flex flex-col w-full h-[calc(var(--ag-viewport-height,100dvh)-29px)] overflow-hidden">
                 <EvaluatorPlaygroundHeader />
                 <PlaygroundMainView
                     mode="evaluator"

--- a/web/oss/src/components/Layout/Layout.tsx
+++ b/web/oss/src/components/Layout/Layout.tsx
@@ -3,6 +3,7 @@ import {memo, useCallback, useEffect, useMemo, useRef, useState, type ReactNode}
 import {workflowLatestRevisionQueryAtomFamily} from "@agenta/entities/workflow"
 import {SETTINGS_SIDEBAR_SCOPE_ID} from "@agenta/navigation"
 import AppMessageContext from "@agenta/ui/app-message"
+import {useVisualViewportHeight} from "@agenta/ui/hooks"
 import {ConfigProvider, Layout, Modal, theme} from "antd"
 import clsx from "clsx"
 import {atom} from "jotai"
@@ -400,7 +401,7 @@ const AppWithVariants = memo(
                                             <ConfigProvider theme={contentThemeConfig}>
                                                 <div
                                                     className={clsx("w-full", {
-                                                        "flex min-h-0 flex-col gap-6 h-[calc(100dvh-29px)] overflow-hidden":
+                                                        "flex min-h-0 flex-col gap-6 h-[calc(var(--ag-viewport-height,100dvh)-29px)] overflow-hidden":
                                                             isFullHeight,
                                                         "flex flex-col":
                                                             !isFullHeight && !isAppRoute,
@@ -426,6 +427,13 @@ const App: React.FC<LayoutProps> = ({children}) => {
     const classes = useStyles({themeMode: appTheme})
     const {isHumanEval, isPlayground, isAppRoute, isAuthRoute, isEvaluator, isFullHeight} =
         useCommittedLayoutFlags()
+
+    // One owner for the whole app. A phone keyboard opens over the page, so every frame sized
+    // against the layout viewport hides its bottom edge behind it. This publishes the visible
+    // height as `--ag-viewport-height`, and each full-height frame reads it with a `100dvh`
+    // fallback. Mounting it here rather than per page means the playground, the agent overview,
+    // sessions, annotations and the auth screens are all covered by one call. Idle on desktop.
+    useVisualViewportHeight()
 
     const [, contextHolder] = Modal.useModal()
 

--- a/web/oss/src/components/Playground/Playground.tsx
+++ b/web/oss/src/components/Playground/Playground.tsx
@@ -8,7 +8,6 @@ import {
 } from "@agenta/playground-ui"
 import {useLocalDraftWarning} from "@agenta/playground-ui/hooks"
 import {preloadEditorPlugins} from "@agenta/ui"
-import {useVisualViewportHeight} from "@agenta/ui/hooks"
 import {useAtomValue} from "jotai"
 import dynamic from "next/dynamic"
 
@@ -52,12 +51,6 @@ const Playground: FC<{onboarding?: boolean}> = ({onboarding = false}) => {
     // Mount imperative playground state sync (store.sub subscriptions)
     // This replaces the old usePlaygroundUrlSync hook with React-free subscriptions
     useAtomValue(playgroundSyncAtom)
-
-    // Phone browsers open the keyboard over the page, so the bottom of this `dvh`-tall frame —
-    // the chat composer — ends up under it. Track the visual viewport and size the frame against
-    // it while the keyboard is open. Idle on desktop and on Android, where the viewport meta's
-    // `interactive-widget=resizes-content` already shrinks `dvh`.
-    useVisualViewportHeight()
 
     // Playground-native onboarding: mint + drive an ephemeral agent inside this real playground (so it
     // reuses all the machinery above). Fully inert when `onboarding` is false — normal playground path.

--- a/web/oss/src/components/PlaygroundRouter/PlaygroundLoadingShell.tsx
+++ b/web/oss/src/components/PlaygroundRouter/PlaygroundLoadingShell.tsx
@@ -27,7 +27,7 @@ const PlaygroundLoadingShell = ({agent, children}: PlaygroundLoadingShellProps =
     const earlyAgent = useAtomValue(playgroundEarlyAgentStateAtom) === "agent"
     const isAgent = agent ?? earlyAgent
     return (
-        <div className="flex flex-col w-full h-dvh overflow-hidden">
+        <div className="flex flex-col w-full h-[var(--ag-viewport-height,100dvh)] overflow-hidden">
             <div
                 className={`flex items-center justify-between gap-4 px-2.5 py-2 ${bgColors.active}`}
             >

--- a/web/oss/src/styles/human-evals.css
+++ b/web/oss/src/styles/human-evals.css
@@ -2,8 +2,10 @@ body {
     --not-available-stripe: #eaeff5;
     --not-available-bg: transparent;
 
+    /* `--ag-viewport-height` is set only while a phone keyboard is open (see
+       useVisualViewportHeight); everywhere else this stays 100dvh. */
     :has(.human-eval) {
-        height: 100dvh;
+        height: var(--ag-viewport-height, 100dvh);
         overflow: hidden;
     }
 


### PR DESCRIPTION
> Stacked on [#6189](https://github.com/Agenta-AI/agenta/pull/6189), which carries the shared `@agenta/ui` helper this uses. Base is `fix/m-phone-keyboard`, so this diff shows only the desktop-app changes. Merge #6189 first.

## Context

[#6169](https://github.com/Agenta-AI/agenta/pull/6169) mounted the visual-viewport hook in `Playground.tsx` and nowhere else, so the phone-keyboard fix reached exactly one frame. Every other full-height frame in the desktop app still sizes itself against the layout viewport, which a phone keyboard does not shrink.

The gap that matters most is the **agent overview page**. It hosts a real `RichChatInput` composer at [AgentOverview.tsx:89](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/pages/overview/agent/AgentOverview.tsx#L89), and it renders inside `Layout.tsx`'s `h-[calc(100dvh-29px)]` frame because it sets `layoutFullHeightRequestAtom`. That same frame governs sessions, agents, annotations, evaluations, testsets and observability.

A second, smaller problem: `PlaygroundLoadingShell` uses plain `h-dvh` on the same route the playground uses, so the frame jumped at hand-off once the playground's own frame started shrinking.

## Changes

The hook moves up one level. `useVisualViewportHeight()` now runs once in the shared `Layout`, which wraps every route in both editions, and `Playground.tsx` drops its own call. One component owns the property and its cleanup, instead of two writing the same value and either one removing it on unmount.

The frames that read the variable:

| Frame | Before | After |
| --- | --- | --- |
| `Layout.tsx:403` (agent overview, sessions, agents, annotations, evaluations, testsets, observability) | `h-[calc(100dvh-29px)]` | `h-[calc(var(--ag-viewport-height,100dvh)-29px)]` |
| `ConfigureEvaluator/index.tsx:107` (evaluator playground) | `h-[calc(100dvh-29px)]` | same substitution |
| `PlaygroundLoadingShell.tsx:30` | `h-dvh` | `h-[var(--ag-viewport-height,100dvh)]` |
| `human-evals.css:6` | `height: 100dvh` | `height: var(--ag-viewport-height, 100dvh)` |

Every one keeps `100dvh` as the fallback, and the variable is only ever set while a phone keyboard is open, so desktop rendering is unchanged.

**The blur after send is also fixed.** #6169 called `blur()` inline inside the submit handler, and it never took effect:

```ts
onSubmit(trimmed)                                   // #6169 blurred here
editor.update(() => {root.clear(); root.append($createParagraphNode())})
```

The second line reconciles a fresh DOM selection through lexical's `setDOMSelectionBaseAndExtent`, and writing a selection into a `contenteditable` focuses it. The blur was reversed one statement later, so on a phone the keyboard reopened immediately. The editor already documents the behaviour at [RichChatInput.tsx:198](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx#L198): "A focused editor re-asserts its selection on the next reconcile." `AgentComposerDock` now uses `dismissSoftKeyboardAfterSend`, which defers past that reconcile and still no-ops on a mouse-driven browser.

## Tests / notes

- `npx vitest run src/components/AgentChatSlice` in `web/oss`: 310 passed.
- `tsc --noEmit` clean in `web/oss` and `web/ee`. `pnpm lint-fix` in `web/`: 25/25, no errors. `prettier@3.7.4 --check` clean on every touched file.
- One production build of `@agenta/oss`: exit 0. The generated stylesheet contains both arbitrary values, so the Tailwind classes really are emitted: `calc(var(--ag-viewport-height,100dvh) - 29px)` and `height:var(--ag-viewport-height,100dvh)`.
- **Not verified on a device.** The reported bug is on `/m`, which #6189 fixes; this PR closes the same class of gap on the desktop app, where only the playground was covered.
- `WorkflowRevisionDrawer`, which also hosts a chat, was left alone on purpose. antd sizes it off the fixed containing block so a Tailwind class cannot reach it, and at a fixed 1100px width it is not a phone surface.

## What to QA

On a phone browser, on the desktop app (not `/m`):

1. Open an agent's **overview** page and tap its composer. The whole composer stays above the keyboard. This surface was never covered before.
2. Send a message from there with Enter. The keyboard closes and the layout returns to full height.
3. Open the playground and repeat. It behaved correctly for the frame already; confirm the Enter step now closes the keyboard, which it did not do before.
4. Open a sessions list and tap the filters sheet's search field. The sheet stays reachable above the keyboard.

Desktop regressions on a laptop, all of which must look exactly as before: the playground frame height, Enter keeping focus in the editor so the next message can be typed straight away, and the full-height pages (sessions, agents, annotations, evaluations, testsets, observability, evaluator playground, human evaluation).
