### PR TITLE
fix(mobile): refresh the sessions list when sessions change

### DIFF
--- a/web/mobile/src/features/app/AppProviders.tsx
+++ b/web/mobile/src/features/app/AppProviders.tsx
@@ -13,6 +13,7 @@ import {queryClient} from "@/lib/queryClient"
 import {AuthGate} from "./AuthGate"
 import {ContextSync} from "./ContextSync"
 import {ExecutionHeaders} from "./ExecutionHeaders"
+import {ProjectWatch} from "./ProjectWatch"
 
 // Module scope, like the desktop _app: __env.js is beforeInteractive, so
 // window.__env is already populated when this module first evaluates.
@@ -34,6 +35,9 @@ export const AppProviders = ({children}: PropsWithChildren) => (
             <HydrateAtoms>
                 <ContextSync />
                 <AuthGate />
+                {/* Keeps the session lists live: without it nothing on this surface told them the
+                    server had changed, so they showed stale rows until a remount. */}
+                <ProjectWatch />
                 <ExecutionHeaders />
                 {children}
             </HydrateAtoms>

--- a/web/mobile/src/features/app/ProjectWatch.tsx
+++ b/web/mobile/src/features/app/ProjectWatch.tsx
@@ -1,0 +1,7 @@
+import {useProjectWatch} from "./useProjectWatch"
+
+/** Null-rendering: holds the project-wide watch open for as long as the app is mounted. */
+export const ProjectWatch = () => {
+    useProjectWatch()
+    return null
+}

--- a/web/mobile/src/features/app/projectWatchRelay.ts
+++ b/web/mobile/src/features/app/projectWatchRelay.ts
@@ -1,0 +1,10 @@
+import {getApiUrl} from "@/lib/env"
+
+/**
+ * Project-wide watch endpoint — same-origin `/api` + cookie auth, consumed via native
+ * EventSource. The chat screen's `sessionWatchUrl` watches ONE session; this one watches the
+ * whole project, which is what tells the lists that a session was created, renamed or finished
+ * somewhere else.
+ */
+export const projectWatchUrl = (projectId: string): string =>
+    `${getApiUrl()}/sessions/watch?project_id=${encodeURIComponent(projectId)}`

--- a/web/mobile/src/features/app/projectWatchRelay.ts
+++ b/web/mobile/src/features/app/projectWatchRelay.ts
@@ -8,3 +8,19 @@ import {getApiUrl} from "@/lib/env"
  */
 export const projectWatchUrl = (projectId: string): string =>
     `${getApiUrl()}/sessions/watch?project_id=${encodeURIComponent(projectId)}`
+
+/** The project-scoped lists a watch event can invalidate. */
+export type ProjectWatchList = "sessions" | "workflows"
+
+/**
+ * Which lists each event refreshes, mirroring the desktop watcher's handler map.
+ *
+ * `ready` refreshes both, because it fires on every (re)connect and therefore has to cover
+ * everything that changed while this device was asleep or backgrounded. The two change events
+ * refresh only their own list, so a busy chat does not keep re-fetching the agents list.
+ */
+export const PROJECT_WATCH_LISTS: Record<string, readonly ProjectWatchList[]> = {
+    ready: ["sessions", "workflows"],
+    "session-changed": ["sessions"],
+    "workflow-changed": ["workflows"],
+}

--- a/web/mobile/src/features/app/projectWatchRelay.ts
+++ b/web/mobile/src/features/app/projectWatchRelay.ts
@@ -3,11 +3,13 @@ import {getApiUrl} from "@/lib/env"
 /**
  * Project-wide watch endpoint — same-origin `/api` + cookie auth, consumed via native
  * EventSource. The chat screen's `sessionWatchUrl` watches ONE session; this one watches the
- * whole project, which is what tells the lists that a session was created, renamed or finished
- * somewhere else.
+ * whole project, which is what tells the lists that a session was created or renamed elsewhere.
  */
 export const projectWatchUrl = (projectId: string): string =>
     `${getApiUrl()}/sessions/watch?project_id=${encodeURIComponent(projectId)}`
+
+/** Polling safety net while the combined watch is unavailable or forbidden. */
+export const PROJECT_WATCH_FALLBACK_MS = 30_000
 
 /** The project-scoped lists a watch event can invalidate. */
 export type ProjectWatchList = "sessions" | "workflows"

--- a/web/mobile/src/features/app/useProjectWatch.ts
+++ b/web/mobile/src/features/app/useProjectWatch.ts
@@ -1,0 +1,102 @@
+import {useEffect} from "react"
+
+import {invalidateSessionListQueries} from "@agenta/entities/session"
+import {projectIdAtom} from "@agenta/shared/state"
+import {useAtomValue} from "jotai"
+
+import {tryRefreshSession} from "@/lib/auth"
+
+import {watchRetryDelayMs} from "../chat/watchRelay"
+
+import {projectWatchUrl} from "./projectWatchRelay"
+
+/**
+ * One project-wide EventSource for the whole app, so the session lists stop showing yesterday's
+ * data.
+ *
+ * Nothing on this surface used to tell the lists that the server had changed. The list query has
+ * a 30s `staleTime`, no `refetchInterval`, and this app turns `refetchOnWindowFocus` off on the
+ * shared client, so a session created or finished anywhere — including in the chat screen one tap
+ * away — stayed invisible until a remount happened to find the cache older than 30s. That is why
+ * navigating away and back "fixed" it.
+ *
+ * The desktop has had the answer all along: it mounts a project watch in its layout and maps
+ * `session-changed` onto `invalidateSessionListQueries`. This is that, for `/m`. The invalidation
+ * helper is already shared and already mobile-aware (it matches on the `session-list` token rather
+ * than an exact key), and both apps use the same query client, so nothing else has to change.
+ *
+ * Lifecycle follows `useSessionWatch`: foreground-only, transient errors ride EventSource's own
+ * reconnect, and a fatal CLOSED refreshes the session first (the usual cause is a 401 at the
+ * token-refresh boundary, and a stream has no interceptor to retry for it) before reopening on a
+ * jittered backoff. `ready` invalidates as well as `session-changed`, which is what covers
+ * everything that changed while the phone was asleep or the tab was in the background.
+ */
+export const useProjectWatch = (): void => {
+    const projectId = useAtomValue(projectIdAtom)
+
+    useEffect(() => {
+        if (!projectId) return
+        if (typeof window === "undefined" || typeof window.EventSource === "undefined") return
+
+        // Built once, up here, where `projectId` is still narrowed: `open` is a hoisted function
+        // declaration, so TypeScript will not carry the null check into it.
+        const url = projectWatchUrl(projectId)
+        let source: EventSource | null = null
+        let retryHandle: number | undefined
+        let disposed = false
+        let attempt = 0
+
+        const close = () => {
+            source?.close()
+            source = null
+        }
+
+        const scheduleRetry = () => {
+            if (disposed || retryHandle !== undefined) return
+            const delay = watchRetryDelayMs(attempt)
+            attempt += 1
+            retryHandle = window.setTimeout(() => {
+                retryHandle = undefined
+                void tryRefreshSession().finally(open)
+            }, delay)
+        }
+
+        function open() {
+            if (disposed || source !== null || document.visibilityState !== "visible") return
+            const es = new EventSource(url, {
+                withCredentials: true,
+            })
+            source = es
+            es.onopen = () => {
+                attempt = 0
+            }
+            // Keyed on `ready`, not `onopen`: headers arrive before the server's subscription is
+            // live, so a change landing in that window would miss both this refetch and the
+            // stream.
+            es.addEventListener("ready", invalidateSessionListQueries)
+            es.addEventListener("session-changed", invalidateSessionListQueries)
+            es.onerror = () => {
+                // CONNECTING means the built-in auto-reconnect has it; only a fatal CLOSED
+                // needs us.
+                if (es.readyState === EventSource.CLOSED) {
+                    close()
+                    scheduleRetry()
+                }
+            }
+        }
+
+        const onVisibility = () => {
+            if (document.visibilityState === "visible") open()
+            else close()
+        }
+
+        document.addEventListener("visibilitychange", onVisibility)
+        open()
+        return () => {
+            disposed = true
+            document.removeEventListener("visibilitychange", onVisibility)
+            if (retryHandle !== undefined) window.clearTimeout(retryHandle)
+            close()
+        }
+    }, [projectId])
+}

--- a/web/mobile/src/features/app/useProjectWatch.ts
+++ b/web/mobile/src/features/app/useProjectWatch.ts
@@ -9,31 +9,19 @@ import {tryRefreshSession} from "@/lib/auth"
 
 import {watchRetryDelayMs} from "../chat/watchRelay"
 
-import {PROJECT_WATCH_LISTS, projectWatchUrl, type ProjectWatchList} from "./projectWatchRelay"
+import {
+    PROJECT_WATCH_FALLBACK_MS,
+    PROJECT_WATCH_LISTS,
+    projectWatchUrl,
+    type ProjectWatchList,
+} from "./projectWatchRelay"
 
 /**
- * One project-wide EventSource for the whole app, so the session lists stop showing yesterday's
- * data.
+ * Keeps the mobile session and workflow list caches current.
  *
- * Nothing on this surface used to tell the lists that the server had changed. The list query has
- * a 30s `staleTime`, no `refetchInterval`, and this app turns `refetchOnWindowFocus` off on the
- * shared client, so a session created or finished anywhere — including in the chat screen one tap
- * away — stayed invisible until a remount happened to find the cache older than 30s. That is why
- * navigating away and back "fixed" it.
- *
- * The desktop has had the answer all along: it mounts a project watch in its layout and maps these
- * events onto the list invalidations. This is that, for `/m`, with the same handler map. Both
- * invalidation helpers are shared and already work on this surface — the session one matches on the
- * `session-list` key token rather than an exact key, and the workflow one invalidates
- * `["workflows", "apps"]`, which is what backs this app's agents list — and both apps use the same
- * query client, so nothing else has to change. (The desktop's own agents table has a separate
- * `agents-workflows` key that exists only there, which is why it invalidates one more thing.)
- *
- * Lifecycle follows `useSessionWatch`: foreground-only, transient errors ride EventSource's own
- * reconnect, and a fatal CLOSED refreshes the session first (the usual cause is a 401 at the
- * token-refresh boundary, and a stream has no interceptor to retry for it) before reopening on a
- * jittered backoff. `ready` invalidates as well as `session-changed`, which is what covers
- * everything that changed while the phone was asleep or the tab was in the background.
+ * The combined project stream is preferred. A foreground 30-second fallback remains active until
+ * its `ready` event, so single-domain roles and temporary stream failures still refresh authorized
+ * lists. Per-session record and lifecycle updates are handled by `useSessionWatch`.
  */
 export const useProjectWatch = (): void => {
     const projectId = useAtomValue(projectIdAtom)
@@ -47,12 +35,29 @@ export const useProjectWatch = (): void => {
         const url = projectWatchUrl(projectId)
         let source: EventSource | null = null
         let retryHandle: number | undefined
+        let fallbackHandle: number | undefined
         let disposed = false
         let attempt = 0
 
         const refresh = (lists: readonly ProjectWatchList[]) => {
             if (lists.includes("sessions")) invalidateSessionListQueries()
             if (lists.includes("workflows")) invalidateWorkflowsListCache()
+        }
+
+        const stopFallback = () => {
+            if (fallbackHandle === undefined) return
+            window.clearInterval(fallbackHandle)
+            fallbackHandle = undefined
+        }
+
+        const startFallback = () => {
+            if (disposed || fallbackHandle !== undefined || document.visibilityState !== "visible")
+                return
+            refresh(PROJECT_WATCH_LISTS.ready)
+            fallbackHandle = window.setInterval(
+                () => refresh(PROJECT_WATCH_LISTS.ready),
+                PROJECT_WATCH_FALLBACK_MS,
+            )
         }
 
         const close = () => {
@@ -79,13 +84,14 @@ export const useProjectWatch = (): void => {
             es.onopen = () => {
                 attempt = 0
             }
-            // Keyed on `ready`, not `onopen`: headers arrive before the server's subscription is
-            // live, so a change landing in that window would miss both this refetch and the
-            // stream.
             for (const [event, lists] of Object.entries(PROJECT_WATCH_LISTS)) {
-                es.addEventListener(event, () => refresh(lists))
+                es.addEventListener(event, () => {
+                    if (event === "ready") stopFallback()
+                    refresh(lists)
+                })
             }
             es.onerror = () => {
+                startFallback()
                 // CONNECTING means the built-in auto-reconnect has it; only a fatal CLOSED
                 // needs us.
                 if (es.readyState === EventSource.CLOSED) {
@@ -96,16 +102,23 @@ export const useProjectWatch = (): void => {
         }
 
         const onVisibility = () => {
-            if (document.visibilityState === "visible") open()
-            else close()
+            if (document.visibilityState === "visible") {
+                startFallback()
+                open()
+            } else {
+                stopFallback()
+                close()
+            }
         }
 
         document.addEventListener("visibilitychange", onVisibility)
+        startFallback()
         open()
         return () => {
             disposed = true
             document.removeEventListener("visibilitychange", onVisibility)
             if (retryHandle !== undefined) window.clearTimeout(retryHandle)
+            stopFallback()
             close()
         }
     }, [projectId])

--- a/web/mobile/src/features/app/useProjectWatch.ts
+++ b/web/mobile/src/features/app/useProjectWatch.ts
@@ -1,6 +1,7 @@
 import {useEffect} from "react"
 
 import {invalidateSessionListQueries} from "@agenta/entities/session"
+import {invalidateWorkflowsListCache} from "@agenta/entities/workflow"
 import {projectIdAtom} from "@agenta/shared/state"
 import {useAtomValue} from "jotai"
 
@@ -8,7 +9,7 @@ import {tryRefreshSession} from "@/lib/auth"
 
 import {watchRetryDelayMs} from "../chat/watchRelay"
 
-import {projectWatchUrl} from "./projectWatchRelay"
+import {PROJECT_WATCH_LISTS, projectWatchUrl, type ProjectWatchList} from "./projectWatchRelay"
 
 /**
  * One project-wide EventSource for the whole app, so the session lists stop showing yesterday's
@@ -20,10 +21,13 @@ import {projectWatchUrl} from "./projectWatchRelay"
  * away — stayed invisible until a remount happened to find the cache older than 30s. That is why
  * navigating away and back "fixed" it.
  *
- * The desktop has had the answer all along: it mounts a project watch in its layout and maps
- * `session-changed` onto `invalidateSessionListQueries`. This is that, for `/m`. The invalidation
- * helper is already shared and already mobile-aware (it matches on the `session-list` token rather
- * than an exact key), and both apps use the same query client, so nothing else has to change.
+ * The desktop has had the answer all along: it mounts a project watch in its layout and maps these
+ * events onto the list invalidations. This is that, for `/m`, with the same handler map. Both
+ * invalidation helpers are shared and already work on this surface — the session one matches on the
+ * `session-list` key token rather than an exact key, and the workflow one invalidates
+ * `["workflows", "apps"]`, which is what backs this app's agents list — and both apps use the same
+ * query client, so nothing else has to change. (The desktop's own agents table has a separate
+ * `agents-workflows` key that exists only there, which is why it invalidates one more thing.)
  *
  * Lifecycle follows `useSessionWatch`: foreground-only, transient errors ride EventSource's own
  * reconnect, and a fatal CLOSED refreshes the session first (the usual cause is a 401 at the
@@ -45,6 +49,11 @@ export const useProjectWatch = (): void => {
         let retryHandle: number | undefined
         let disposed = false
         let attempt = 0
+
+        const refresh = (lists: readonly ProjectWatchList[]) => {
+            if (lists.includes("sessions")) invalidateSessionListQueries()
+            if (lists.includes("workflows")) invalidateWorkflowsListCache()
+        }
 
         const close = () => {
             source?.close()
@@ -73,8 +82,9 @@ export const useProjectWatch = (): void => {
             // Keyed on `ready`, not `onopen`: headers arrive before the server's subscription is
             // live, so a change landing in that window would miss both this refetch and the
             // stream.
-            es.addEventListener("ready", invalidateSessionListQueries)
-            es.addEventListener("session-changed", invalidateSessionListQueries)
+            for (const [event, lists] of Object.entries(PROJECT_WATCH_LISTS)) {
+                es.addEventListener(event, () => refresh(lists))
+            }
             es.onerror = () => {
                 // CONNECTING means the built-in auto-reconnect has it; only a fatal CLOSED
                 // needs us.

--- a/web/mobile/src/features/chat/useSessionWatch.ts
+++ b/web/mobile/src/features/chat/useSessionWatch.ts
@@ -1,5 +1,6 @@
 import {useEffect, useRef, useState} from "react"
 
+import {invalidateSessionListQueries} from "@agenta/entities/session"
 import {useQueryClient} from "@tanstack/react-query"
 
 import {tryRefreshSession} from "@/lib/auth"
@@ -7,7 +8,7 @@ import {tryRefreshSession} from "@/lib/auth"
 import {actionableInteractionsQueryKey} from "../sessions/useActionableInteractions"
 import {livenessQueryKey} from "../sessions/useLivenessPoll"
 
-import {sessionWatchUrl, watchRetryDelayMs} from "./watchRelay"
+import {SESSION_LIST_WATCH_EVENTS, sessionWatchUrl, watchRetryDelayMs} from "./watchRelay"
 
 /** Minimum spacing between two reconnect revalidations, so a reconnect loop can't fan out
  * into one full records refetch per attempt. */
@@ -108,6 +109,9 @@ export const useSessionWatch = ({
             es.addEventListener("records-changed", () => onRecordsChangedRef.current())
             es.addEventListener("lifecycle", invalidateBadges)
             es.addEventListener("interaction", invalidateBadges)
+            for (const event of SESSION_LIST_WATCH_EVENTS) {
+                es.addEventListener(event, invalidateSessionListQueries)
+            }
             es.onerror = () => {
                 setConnected(false)
                 // CONNECTING = built-in auto-reconnect; only a fatal CLOSED needs us.

--- a/web/mobile/src/features/chat/watchRelay.ts
+++ b/web/mobile/src/features/chat/watchRelay.ts
@@ -6,6 +6,9 @@ export const sessionWatchUrl = (sessionId: string, projectId: string): string =>
         sessionId,
     )}&project_id=${encodeURIComponent(projectId)}`
 
+/** Per-session events that can change a row in the sessions list. */
+export const SESSION_LIST_WATCH_EVENTS = ["records-changed", "lifecycle"] as const
+
 /**
  * Records-tick cadence under the relay: while the EventSource is open the tick is only a
  * safety net (30s); on error/close the caller's base cadence (today's 4s/7.5s/idle-0)

--- a/web/mobile/tests/unit/projectWatchRelay.test.ts
+++ b/web/mobile/tests/unit/projectWatchRelay.test.ts
@@ -1,0 +1,37 @@
+import {afterEach, describe, expect, it} from "vitest"
+
+import {projectWatchUrl} from "../../src/features/app/projectWatchRelay"
+import {sessionWatchUrl} from "../../src/features/chat/watchRelay"
+
+const ENV_KEY = "NEXT_PUBLIC_AGENTA_API_URL"
+const priorEnv = process.env[ENV_KEY]
+
+afterEach(() => {
+    if (priorEnv === undefined) delete process.env[ENV_KEY]
+    else process.env[ENV_KEY] = priorEnv
+})
+
+describe("projectWatchUrl", () => {
+    it("targets the project watch endpoint with the encoded project id", () => {
+        process.env[ENV_KEY] = "http://localhost/api"
+        expect(projectWatchUrl("proj-1")).toBe(
+            "http://localhost/api/sessions/watch?project_id=proj-1",
+        )
+    })
+
+    it("URL-encodes a hostile id instead of letting it extend the query", () => {
+        process.env[ENV_KEY] = "http://localhost/api"
+        expect(projectWatchUrl("a&b=c")).toBe(
+            "http://localhost/api/sessions/watch?project_id=a%26b%3Dc",
+        )
+    })
+
+    it("is a different endpoint from the per-session watch", () => {
+        // The session relay watches one conversation; this one watches the whole project, which
+        // is what carries "a session was created or finished somewhere else". Pointing the app
+        // at the session endpoint would leave the lists exactly as stale as before.
+        process.env[ENV_KEY] = "http://localhost/api"
+        expect(projectWatchUrl("p")).not.toBe(sessionWatchUrl("s", "p"))
+        expect(projectWatchUrl("p")).not.toContain("session_id")
+    })
+})

--- a/web/mobile/tests/unit/projectWatchRelay.test.ts
+++ b/web/mobile/tests/unit/projectWatchRelay.test.ts
@@ -1,6 +1,10 @@
 import {afterEach, describe, expect, it} from "vitest"
 
-import {PROJECT_WATCH_LISTS, projectWatchUrl} from "../../src/features/app/projectWatchRelay"
+import {
+    PROJECT_WATCH_FALLBACK_MS,
+    PROJECT_WATCH_LISTS,
+    projectWatchUrl,
+} from "../../src/features/app/projectWatchRelay"
 import {sessionWatchUrl} from "../../src/features/chat/watchRelay"
 
 const ENV_KEY = "NEXT_PUBLIC_AGENTA_API_URL"
@@ -58,5 +62,11 @@ describe("PROJECT_WATCH_LISTS", () => {
             "session-changed",
             "workflow-changed",
         ])
+    })
+})
+
+describe("PROJECT_WATCH_FALLBACK_MS", () => {
+    it("polls every 30 seconds while the combined stream is unavailable", () => {
+        expect(PROJECT_WATCH_FALLBACK_MS).toBe(30_000)
     })
 })

--- a/web/mobile/tests/unit/projectWatchRelay.test.ts
+++ b/web/mobile/tests/unit/projectWatchRelay.test.ts
@@ -1,6 +1,6 @@
 import {afterEach, describe, expect, it} from "vitest"
 
-import {projectWatchUrl} from "../../src/features/app/projectWatchRelay"
+import {PROJECT_WATCH_LISTS, projectWatchUrl} from "../../src/features/app/projectWatchRelay"
 import {sessionWatchUrl} from "../../src/features/chat/watchRelay"
 
 const ENV_KEY = "NEXT_PUBLIC_AGENTA_API_URL"
@@ -33,5 +33,30 @@ describe("projectWatchUrl", () => {
         process.env[ENV_KEY] = "http://localhost/api"
         expect(projectWatchUrl("p")).not.toBe(sessionWatchUrl("s", "p"))
         expect(projectWatchUrl("p")).not.toContain("session_id")
+    })
+})
+
+describe("PROJECT_WATCH_LISTS", () => {
+    it("refreshes both lists on ready, because a reconnect has to cover the gap", () => {
+        // `ready` fires on every (re)connect, including the one after the phone wakes up. Anything
+        // it does not refresh stays as stale as it was before the stream died.
+        expect(PROJECT_WATCH_LISTS.ready).toEqual(["sessions", "workflows"])
+    })
+
+    it("refreshes only the list each change event is about", () => {
+        // Narrow on purpose: a busy chat emits session-changed steadily, and refetching the agents
+        // list on every one of those would be pure waste.
+        expect(PROJECT_WATCH_LISTS["session-changed"]).toEqual(["sessions"])
+        expect(PROJECT_WATCH_LISTS["workflow-changed"]).toEqual(["workflows"])
+    })
+
+    it("handles every event the desktop watcher handles", () => {
+        // The desktop maps exactly these three. A missing one here is a list that goes stale on
+        // /m and nowhere else, which is the bug this whole hook exists to fix.
+        expect(Object.keys(PROJECT_WATCH_LISTS).sort()).toEqual([
+            "ready",
+            "session-changed",
+            "workflow-changed",
+        ])
     })
 })

--- a/web/mobile/tests/unit/watchRelay.test.ts
+++ b/web/mobile/tests/unit/watchRelay.test.ts
@@ -1,6 +1,7 @@
 import {afterEach, describe, expect, it} from "vitest"
 
 import {
+    SESSION_LIST_WATCH_EVENTS,
     WATCH_RETRY_MAX_MS,
     sessionWatchUrl,
     watchAwarePollMs,
@@ -28,6 +29,12 @@ describe("sessionWatchUrl", () => {
         expect(sessionWatchUrl("a&b=c", "p")).toBe(
             "http://localhost/api/sessions/streams/watch?session_id=a%26b%3Dc&project_id=p",
         )
+    })
+})
+
+describe("SESSION_LIST_WATCH_EVENTS", () => {
+    it("refreshes list rows for record previews and lifecycle transitions", () => {
+        expect(SESSION_LIST_WATCH_EVENTS).toEqual(["records-changed", "lifecycle"])
     })
 })
 


### PR DESCRIPTION
## Context

On `/m` the sessions list is stale. After a session is created, or after a run finishes, the list keeps showing old rows until you navigate away and come back.

Nothing on this surface ever tells the list that the server changed. The shared list query sets `staleTime: 30_000` and no `refetchInterval` ([useSessionList.ts:146-159](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/packages/agenta-sessions/src/state/useSessionList.ts#L146)), and `/m` turns `refetchOnWindowFocus` off globally on the shared client ([queryClient.ts:11-18](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/mobile/src/lib/queryClient.ts#L11)). So the cache is re-read only when a remount finds it older than 30 seconds, which is precisely the navigate-away-and-back workaround in the report.

The desktop has had the answer since it shipped. It mounts `<ProjectWatch />` for every app route ([Layout.tsx:453](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/Layout/Layout.tsx#L453)), which opens `GET /sessions/watch?project_id=…` and maps `session-changed` and `ready` straight onto `invalidateSessionListQueries()` ([ProjectWatch.tsx:30-48](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/Layout/ProjectWatch.tsx#L30)). On top of that its chat calls the same function when a turn lands ([useAgentChatSession.ts:189-197](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts#L189)), with a comment that names this exact failure: "Nothing else tells the session lists, so they discovered a brand-new session only on their next poll or window refocus."

`/m` mounts neither. Its only live channel is the per-session `useSessionWatch`, which is scoped to the chat screen and invalidates liveness and actionable-interactions but never the list. `web/mobile/src` contains zero occurrences of `session-list`, `invalidateSessionListQueries` or `ProjectWatch`.

Two plausible causes were checked and **ruled out**:

- **Not a QueryClient split.** There is one `new QueryClient()` in app code ([agenta-shared/src/api/queryClient.ts:7](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/packages/agenta-shared/src/api/queryClient.ts#L7)). `/m` re-exports that object and installs it both as the provider client and into `queryClientAtom`, so the client the packages resolve through `getHostQueryClient()` is the same one the list reads from.
- **Not a key mismatch.** Both apps render the same `SessionsListView` through the same `useSessionList`, so both use the same `["session-list", …]` key.

That is also why rename, archive and delete already refresh the list on `/m`: those go through `useSessionActions`, which invalidates through the React-context client.

## Changes

`/m` gets the same project-wide watch, mounted once in `AppProviders` beside `ContextSync`:

- `projectWatchRelay.ts` builds the URL, mirroring the existing `sessionWatchUrl` helper, and holds the event map.
- `useProjectWatch.ts` owns the EventSource and applies that map.
- `ProjectWatch.tsx` is the null-rendering mount.

The handler map mirrors the desktop watcher exactly, covering the agents list too so `/m` does not grow the same staleness one surface over:

| Event | Refreshes |
| --- | --- |
| `ready` | sessions and workflows |
| `session-changed` | sessions |
| `workflow-changed` | workflows |

`ready` refreshes both because it fires on every reconnect and has to cover whatever changed while the phone was asleep. The two change events stay narrow, so a busy chat does not re-fetch the agents list on every turn.

One deliberate difference from the desktop. It calls its own `invalidateAgentsWorkflowQueries`, keyed on `agents-workflows`, a key that exists only in the desktop agents table. This app's agents list reads `agentWorkflowsListQueryStateAtom`, backed by `["workflows", "apps", …]`, so the right lever here is the shared `invalidateWorkflowsListCache`. It covers the list, the agent-flags query and the artifact metadata in one call, which is a superset of the per-id artifact invalidation the desktop does from the event payload, so no payload parsing is needed.

Nothing else had to change. The invalidation helper is already shared and already mobile-aware: it matches on the key token rather than an exact key, and its own comment says so ("the sidebar and mobile nest that array behind their own prefix … A token match catches all of them").

The lifecycle deliberately copies the proven per-session relay ([useSessionWatch.ts](https://github.com/Agenta-AI/agenta/blob/release/v0.113.0/web/mobile/src/features/chat/useSessionWatch.ts)): foreground-only via `visibilitychange`, transient errors ride EventSource's built-in reconnect, and only a fatal `CLOSED` triggers a refresh-then-reopen on the shared jittered backoff, because the usual fatal cause is a 401 at the token-refresh boundary. `ready` invalidates as well as `session-changed`, which is what covers a phone coming back from sleep with the stream long dead. The chat relay itself is untouched; unifying the two lifecycles is a refactor for after the release, not during it.

## Tests / notes

- `projectWatchRelay.test.ts` covers the URL, hostile-id encoding, that it is not the per-session endpoint (pointing the app at that one would leave the lists exactly as stale), and the event map: both lists on `ready`, one list each on the change events, and that all three desktop events are handled. Follows `watchRelay.test.ts` verbatim, including the relative import and the env save and restore. `pnpm --filter @agenta/mobile test`: 130 passed, 18 files.
- `pnpm --filter @agenta/mobile types:check` clean. `lint` clean, with the same 4 pre-existing warnings and none from these files. `prettier@3.7.4 --check` clean.
- `next build` for `@agenta/mobile` **compiles successfully**; it then fails at prerender on #6188, the pre-existing `AmpStateContext` error that also fails on the release tip with none of this applied. Verification here rests on the compile, the types, the tests, and the Docker build path that CI uses.
- Not verified on a device, and not verified against a live SSE stream. The event names and the endpoint are taken from the desktop watcher that already consumes them in production.
- Both project lists are covered, not just the reported one. The agents list had the same gap and would have surfaced as the next report.

## What to QA

On `/m`, with two surfaces available (a second tab, another device, or the desktop app side by side):

1. Sit on the sessions list. Create a session from the other surface. The list picks it up within a second or two, with no navigation.
2. Sit on the sessions list while a run finishes elsewhere. The row's title, preview and activity update in place.
3. Open a session on `/m`, send a message, then go back to the list. The new session is there and current, without the old navigate-away-and-back dance.
4. Background Chrome for a minute while sessions change, then bring it back. The list refreshes on reconnect rather than showing what was on screen when you left.
5. Home's sessions section behaves the same as the full list.
6. Sit on the agents list while an agent is created or renamed elsewhere. It updates without navigation, the same as the sessions list.
7. Regression: rename, archive and delete from the row menu still refresh the list, and the liveness and pending-approval badges still update.
