### PR TITLE
fix(mobile): make web/mobile build and run locally again (#6188)

### DIFF
--- a/web/mobile/AGENTS.md
+++ b/web/mobile/AGENTS.md
@@ -82,3 +82,11 @@ specifics), `vercel:shadcn`, `vercel:react-best-practices`.
 - Build: `pnpm build-mobile`
 - Lint / types: `pnpm --filter @agenta/mobile lint` / `pnpm --filter @agenta/mobile types:check`
 - Token bridge: `pnpm --filter @agenta/mobile generate:tokens`
+
+Mobile is the only app on Next 16; oss, ee and storybook stay on Next 15. `web/package.json`
+therefore must NOT declare an npm `workspaces` array. npm and `npx` read that field, treat
+`web/` as the project root from any subdirectory, and resolve `next` to the Next 15 copy in
+`web/node_modules`. `npx next build` in `web/mobile` then runs the Next 15 CLI against a
+Next 16 app and dies with `Cannot read properties of undefined (reading 'AmpStateContext')`.
+The repo drives every workspace through `pnpm-workspace.yaml`, so the field bought nothing.
+See issue #6188.

--- a/web/mobile/next.config.ts
+++ b/web/mobile/next.config.ts
@@ -31,6 +31,11 @@ const nextConfig: NextConfig = {
         "@agenta/playground-ui",
         "@agenta/chat",
     ],
+    // Next 16 appends a managed "nextjs-agent-rules" block to AGENTS.md on every
+    // `next dev`. This repo curates its own agent instructions (see the root
+    // AGENTS.md compartmentalization playbook), so keep the framework out of that
+    // file — otherwise every mobile dev run dirties a tracked file.
+    agentRules: false,
     reactStrictMode: true,
     pageExtensions: ["ts", "tsx"],
     productionBrowserSourceMaps: true,

--- a/web/package.json
+++ b/web/package.json
@@ -1,14 +1,6 @@
 {
     "name": "agenta-web",
     "version": "0.113.0",
-    "workspaces": [
-        "ee",
-        "mobile",
-        "oss",
-        "tests",
-        "variants-state",
-        "packages/*"
-    ],
     "dependencies": {
         "ajv-formats": "^3.0.1",
         "jotai-eager": "^0.2.6",


### PR DESCRIPTION
## Context

Nobody could build or run the mobile app locally. `cd web/mobile && npx next build` died while prerendering `/w/[workspace_id]` with `TypeError: Cannot read properties of undefined (reading 'AmpStateContext')`, and `next dev` served 500s. CI and the Docker image were fine, so only the local developer loop was broken.

The cause is `web/package.json`. It carried an npm `workspaces` array. npm and `npx` read that field, decide `web/` is the project root no matter which subdirectory you are in, and resolve binaries from `web/node_modules`. Mobile is the only app on Next 16; oss, ee and storybook stay on Next 15, and `web/` itself depends on `next@15.5.21`. So `npx next` inside `web/mobile` ran the **Next 15 CLI against the Next 16 app**. `AmpStateContext` is a Next 15 pages-router internal, and it blew up at prerender time.

Resolution measured from `web/mobile`, before and after:

```
./node_modules/.bin/next --version   Next.js v16.3.0   (correct, always was)
pnpm exec next --version             Next.js v16.3.0   (correct, always was)
npx next --version                   Next.js v15.5.21  BEFORE
npx next --version                   Next.js v16.3.0   AFTER
```

Deleting only the `workspaces` field flipped that last line, with nothing else touched.

## Changes

Removed the `workspaces` array from `web/package.json`. It bought nothing: every workspace is driven through `pnpm-workspace.yaml`, and the array was already stale. It listed a `variants-state` directory that does not exist and omitted `storybook`. oss and ee each declare their own `next@15.5.21`, so they keep resolving the same version they did before.

Two smaller items, both about the same local loop:

- `agentRules: false` in `web/mobile/next.config.ts`. Next 16 appends its own agent-rules block to `AGENTS.md` on every `next dev`, which dirtied a tracked file the repo curates deliberately. Now `next dev` leaves the tree clean.
- A note in `web/mobile/AGENTS.md` recording why the `workspaces` field must not come back. A deleted JSON key leaves no trace, and the symptom is hard to connect to the cause.

## Tests / notes

Run from the branch tip in a fresh worktree off `release/v0.113.0`.

| Check | Result |
| --- | --- |
| `cd web/mobile && npx next build` | exit 0, 18 routes, Next 16.3.0 on Turbopack |
| `npx next dev -p 3123`, `curl /m/auth` | HTTP 200 in about 3 s, page renders "Sign in" |
| `pnpm --filter @agenta/mobile test` | 17 files, 124 tests passed |
| `cd web/mobile && npx tsc --noEmit` | exit 0 |
| `pnpm --filter @agenta/mobile lint` | 0 errors (4 pre-existing hook warnings) |
| `cd web/oss && npx next build` | exit 0, still Next 15.5.21 |
| prettier 3.7.4 on the three touched files | clean |

Two things reviewers may want to poke at. The build now runs on Turbopack rather than webpack, which is the Next 16 default and is what the Docker image already did, so the `turbopack.resolveAlias` entries in the mobile config finally apply. And the dual-major package resolution the issue suspected turned out to be harmless: the shared `@agenta/*-ui` packages do resolve their own Next 15 copy of `next/router`, and the Next 16 build handles it without any aliasing, so no `resolveAlias` or pnpm override was needed.

Closes #6188
