### PR TITLE
fix(frontend): stop the evaluation run page minting an atom per read

### DIFF
--- a/web/oss/src/components/EvalRunDetails/atoms/annotations.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/annotations.ts
@@ -10,6 +10,7 @@ import axios from "@/oss/lib/api/assets/axiosConfig"
 import {getProjectValues} from "@/oss/state/project"
 import {workspaceMembersAtom} from "@/oss/state/workspace/atoms/selectors"
 
+import {sameFamilyKey} from "./familyKeys"
 import {activePreviewRunIdAtom, effectiveProjectIdAtom} from "./run"
 
 const annotationBatcherCache = new Map<string, BatchFetcher<string, AnnotationDto[] | null>>()
@@ -123,6 +124,7 @@ export const evaluationAnnotationBatcherFamily = atomFamily(
 
             return batcher
         }),
+    sameFamilyKey,
 )
 
 export const evaluationAnnotationQueryAtomFamily = atomFamily(
@@ -150,6 +152,7 @@ export const evaluationAnnotationQueryAtomFamily = atomFamily(
                 },
             }
         }),
+    sameFamilyKey,
 )
 
 export const scenarioAnnotationsQueryAtomFamily = atomFamily(
@@ -190,4 +193,5 @@ export const scenarioAnnotationsQueryAtomFamily = atomFamily(
                 },
             }
         }),
+    sameFamilyKey,
 )

--- a/web/oss/src/components/EvalRunDetails/atoms/familyKeys.test.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/familyKeys.test.ts
@@ -1,0 +1,107 @@
+import {atom} from "jotai"
+import {atomFamily} from "jotai/utils"
+import {describe, expect, it} from "vitest"
+
+import {sameFamilyKey} from "./familyKeys"
+
+/**
+ * The bug these guard against: jotai's `atomFamily` keys its cache by REFERENCE unless it
+ * is given an `areEqual`. Every family in this folder is called with a fresh object
+ * literal, so without a comparator each call minted a new atom. For the query families
+ * that is self-driving — each generation mounts an observer, the observer emits, the emit
+ * invalidates the atom that created it — and React eventually throws #185.
+ */
+describe("sameFamilyKey", () => {
+    it("treats two distinct objects with equal fields as the same key", () => {
+        expect(
+            sameFamilyKey({scenarioId: "s1", runId: "r1"}, {scenarioId: "s1", runId: "r1"}),
+        ).toBe(true)
+    })
+
+    it("separates keys that differ in any field", () => {
+        expect(
+            sameFamilyKey({scenarioId: "s1", runId: "r1"}, {scenarioId: "s2", runId: "r1"}),
+        ).toBe(false)
+        expect(
+            sameFamilyKey({scenarioId: "s1", runId: "r1"}, {scenarioId: "s1", runId: "r2"}),
+        ).toBe(false)
+    })
+
+    it("treats an absent key and an explicit undefined as equal", () => {
+        // `family({scenarioId})` and `family({scenarioId, runId: undefined})` mean the same
+        // thing to every caller here, and must not mint two atoms.
+        expect(sameFamilyKey({scenarioId: "s1"}, {scenarioId: "s1", runId: undefined})).toBe(true)
+    })
+
+    it("normalises a nullish key to an empty object", () => {
+        // `scenarioStepsBatcherFamily(undefined)` and `...Family({})` are the same lookup.
+        expect(sameFamilyKey(undefined, {})).toBe(true)
+        expect(sameFamilyKey(undefined, undefined)).toBe(true)
+    })
+
+    it("compares a nested column descriptor by value, not by reference", () => {
+        const left = {scenarioId: "s1", runId: "r1", column: {id: "c1", path: "outputs.0"}}
+        const right = {scenarioId: "s1", runId: "r1", column: {id: "c1", path: "outputs.0"}}
+        expect(sameFamilyKey(left, right)).toBe(true)
+    })
+
+    it("separates columns that share an id but address a different path", () => {
+        const left = {scenarioId: "s1", column: {id: "c1", path: "outputs.0"}}
+        const right = {scenarioId: "s1", column: {id: "c1", path: "outputs.1"}}
+        expect(sameFamilyKey(left, right)).toBe(false)
+    })
+
+    it("compares scalar arrays such as pathSegments by element", () => {
+        const left = {column: {id: "c1", pathSegments: ["outputs", "0"]}}
+        const right = {column: {id: "c1", pathSegments: ["outputs", "0"]}}
+        const other = {column: {id: "c1", pathSegments: ["outputs", "1"]}}
+        expect(sameFamilyKey(left, right)).toBe(true)
+        expect(sameFamilyKey(left, other)).toBe(false)
+    })
+})
+
+describe("atomFamily keyed with sameFamilyKey", () => {
+    it("returns the SAME atom for equal keys built fresh each call", () => {
+        let created = 0
+        const family = atomFamily(({scenarioId, runId}: {scenarioId: string; runId?: string}) => {
+            created += 1
+            return atom(`${scenarioId}:${runId ?? ""}`)
+        }, sameFamilyKey)
+
+        const first = family({scenarioId: "s1", runId: "r1"})
+        const second = family({scenarioId: "s1", runId: "r1"})
+
+        expect(second).toBe(first)
+        expect(created).toBe(1)
+    })
+
+    it("still separates genuinely different keys", () => {
+        let created = 0
+        const family = atomFamily(({scenarioId}: {scenarioId: string}) => {
+            created += 1
+            return atom(scenarioId)
+        }, sameFamilyKey)
+
+        family({scenarioId: "s1"})
+        family({scenarioId: "s2"})
+        family({scenarioId: "s1"})
+
+        expect(created).toBe(2)
+    })
+
+    it("without a comparator, jotai mints a new atom per call (the bug being guarded)", () => {
+        // Pins the jotai behaviour the fix depends on. If a future jotai keys object params
+        // by value on its own, this fails and the comparators become redundant rather than
+        // load-bearing — which is worth knowing.
+        let created = 0
+        const family = atomFamily(({scenarioId}: {scenarioId: string}) => {
+            created += 1
+            return atom(scenarioId)
+        })
+
+        family({scenarioId: "s1"})
+        family({scenarioId: "s1"})
+
+        expect(created).toBe(2)
+    })
+})

--- a/web/oss/src/components/EvalRunDetails/atoms/familyKeys.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/familyKeys.ts
@@ -1,0 +1,67 @@
+/**
+ * Value equality for `atomFamily` keys.
+ *
+ * jotai's `atomFamily(initializeAtom, areEqual?)` keys its cache by REFERENCE when
+ * `areEqual` is omitted — jotai 2.20's implementation is a plain `atoms.get(param)`
+ * against a `Map`. Every family in this folder is keyed by an object literal that is
+ * rebuilt at each call site (`get(scenarioStepsQueryFamily({scenarioId, runId}))`), so
+ * without a comparator the `Map` never hits and each call mints a BRAND NEW atom.
+ *
+ * That is unbounded, and for a query atom it is self-driving: each generation mounts its
+ * own observer, the observer emits, the emit invalidates the atom that created it, the
+ * re-read mints the next generation. React sees an update per generation and eventually
+ * throws error #185, "Maximum update depth exceeded". Measured on a 25-scenario run
+ * before this comparator existed: 10,744 step-query atoms in 20 seconds, still climbing,
+ * where ~200 cells should have created ~200 atoms once.
+ *
+ * So: every object-keyed `atomFamily` in this folder passes {@link sameFamilyKey}.
+ *
+ * The keys here are flat records of scalars, sometimes carrying a column descriptor
+ * (itself flat, with a `pathSegments` string array), so one level of nesting plus arrays
+ * of scalars is all the comparison needs. A nullish key normalises to `{}`, because
+ * `family(undefined)` and `family({})` mean the same thing to every caller here.
+ */
+
+const isPlainObject = (value: unknown): value is Record<string, unknown> =>
+    typeof value === "object" && value !== null && !Array.isArray(value)
+
+const sameArray = (a: unknown[], b: unknown[]): boolean =>
+    a.length === b.length && a.every((item, index) => Object.is(item, b[index]))
+
+/** One level of value comparison: scalars by `Object.is`, arrays and flat records by element. */
+const sameValue = (a: unknown, b: unknown): boolean => {
+    if (Object.is(a, b)) return true
+    if (Array.isArray(a) && Array.isArray(b)) return sameArray(a, b)
+    if (isPlainObject(a) && isPlainObject(b)) return sameRecord(a, b)
+    return false
+}
+
+/** Compares the UNION of both key sets, so an absent key and an explicit `undefined` match. */
+const sameRecord = (a: Record<string, unknown>, b: Record<string, unknown>): boolean => {
+    const keys = new Set([...Object.keys(a), ...Object.keys(b)])
+    for (const key of keys) {
+        const left = a[key]
+        const right = b[key]
+        if (Object.is(left, right)) continue
+        if (Array.isArray(left) && Array.isArray(right) && sameArray(left, right)) continue
+        // Only ONE level deeper: the column descriptor is flat, and going arbitrarily deep
+        // would make the comparator the expensive part of every family lookup.
+        if (isPlainObject(left) && isPlainObject(right)) {
+            const nested = new Set([...Object.keys(left), ...Object.keys(right)])
+            if ([...nested].every((k) => sameValue(left[k], right[k]))) continue
+        }
+        return false
+    }
+    return true
+}
+
+/**
+ * `areEqual` for an object-keyed `atomFamily`. Pass this as the second argument to EVERY
+ * such family, or the family mints a new atom per call. See the module docstring.
+ */
+export const sameFamilyKey = <T>(a: T, b: T): boolean => {
+    const left = a ?? {}
+    const right = b ?? {}
+    if (!isPlainObject(left) || !isPlainObject(right)) return Object.is(a, b)
+    return sameRecord(left, right)
+}

--- a/web/oss/src/components/EvalRunDetails/atoms/invocationTraceSummary.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/invocationTraceSummary.ts
@@ -5,6 +5,7 @@ import type {TraceData, TraceNode} from "@/oss/lib/evaluations"
 
 import {resolveInvocationTraceValue} from "../utils/traceValue"
 
+import {sameFamilyKey} from "./familyKeys"
 import {activePreviewRunIdAtom} from "./run"
 import {scenarioStepsQueryFamily} from "./scenarioSteps"
 import {evaluationRunIndexAtomFamily} from "./table/run"
@@ -145,6 +146,7 @@ export const scenarioHasInvocationAtomFamily = atomFamily(
 
             return Boolean(traceId)
         }),
+    sameFamilyKey,
 )
 
 export const invocationTraceSummaryAtomFamily = atomFamily(
@@ -323,4 +325,5 @@ export const invocationTraceSummaryAtomFamily = atomFamily(
                 errorCount,
             }
         }),
+    sameFamilyKey,
 )

--- a/web/oss/src/components/EvalRunDetails/atoms/metrics.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/metrics.ts
@@ -14,6 +14,7 @@ import {previewEvalTypeAtom} from "../state/evalType"
 import {resolveValueBySegments, splitPath} from "../utils/valueAccess"
 
 import {isTerminalStatus} from "./compare"
+import {sameFamilyKey} from "./familyKeys"
 import {
     createMetricProcessor,
     isLegacyValueLeaf,
@@ -665,123 +666,127 @@ const extractMetricValueFromData = (
     return undefined
 }
 
-export const evaluationMetricBatcherFamily = atomFamily(({runId}: {runId?: string | null} = {}) =>
-    atom((get) => {
-        const projectId = resolveProjectId(get)
-        const effectiveRunId = resolveEffectiveRunId(get, runId)
-        const evalTypeFromAtom = get(previewEvalTypeAtom)
+export const evaluationMetricBatcherFamily = atomFamily(
+    ({runId}: {runId?: string | null} = {}) =>
+        atom((get) => {
+            const projectId = resolveProjectId(get)
+            const effectiveRunId = resolveEffectiveRunId(get, runId)
+            const evalTypeFromAtom = get(previewEvalTypeAtom)
 
-        // Derive evaluation type from run.data.steps - this is the reliable source of truth
-        // Do NOT use meta.evaluation_kind as it's flaky and unreliable
-        const runQuery = effectiveRunId
-            ? get(evaluationRunQueryAtomFamily(effectiveRunId))
-            : undefined
-        const rawRun = runQuery?.data?.rawRun
-        const evalTypeFromRun = rawRun ? deriveEvaluationKind(rawRun) : null
-        const evaluationType = evalTypeFromAtom || evalTypeFromRun
+            // Derive evaluation type from run.data.steps - this is the reliable source of truth
+            // Do NOT use meta.evaluation_kind as it's flaky and unreliable
+            const runQuery = effectiveRunId
+                ? get(evaluationRunQueryAtomFamily(effectiveRunId))
+                : undefined
+            const rawRun = runQuery?.data?.rawRun
+            const evalTypeFromRun = rawRun ? deriveEvaluationKind(rawRun) : null
+            const evaluationType = evalTypeFromAtom || evalTypeFromRun
 
-        if (!projectId || !effectiveRunId) return null
+            if (!projectId || !effectiveRunId) return null
 
-        const cacheKey = `${projectId}:${effectiveRunId}:${evaluationType || "auto"}`
-        let batcher = metricBatcherCache.get(cacheKey)
-        if (!batcher) {
-            metricBatcherCache.clear()
-            batcher = createBatchFetcher<string, ScenarioMetricData | null>({
-                serializeKey: (key) => key,
-                batchFn: async (scenarioIds) => {
-                    const unique = Array.from(new Set(scenarioIds.filter(Boolean)))
-                    if (!unique.length) {
-                        return {}
-                    }
-
-                    const fetchMetrics = async () => {
-                        const metricPayload: Record<string, any> = {}
-                        // metricPayload.run_id = effectiveRunId
-                        if (unique.length) {
-                            // For scenario-scoped queries, do not constrain by run_ids to avoid over-filtering.
-                            metricPayload.scenario_ids = unique
-                        } else {
-                            metricPayload.run_ids = [effectiveRunId]
+            const cacheKey = `${projectId}:${effectiveRunId}:${evaluationType || "auto"}`
+            let batcher = metricBatcherCache.get(cacheKey)
+            if (!batcher) {
+                metricBatcherCache.clear()
+                batcher = createBatchFetcher<string, ScenarioMetricData | null>({
+                    serializeKey: (key) => key,
+                    batchFn: async (scenarioIds) => {
+                        const unique = Array.from(new Set(scenarioIds.filter(Boolean)))
+                        if (!unique.length) {
+                            return {}
                         }
 
-                        const response = await axios.post(
-                            `/evaluations/metrics/query`,
-                            {
-                                metrics: {
-                                    ...metricPayload,
+                        const fetchMetrics = async () => {
+                            const metricPayload: Record<string, any> = {}
+                            // metricPayload.run_id = effectiveRunId
+                            if (unique.length) {
+                                // For scenario-scoped queries, do not constrain by run_ids to avoid over-filtering.
+                                metricPayload.scenario_ids = unique
+                            } else {
+                                metricPayload.run_ids = [effectiveRunId]
+                            }
+
+                            const response = await axios.post(
+                                `/evaluations/metrics/query`,
+                                {
+                                    metrics: {
+                                        ...metricPayload,
+                                    },
                                 },
-                            },
-                            {
-                                params: {project_id: projectId},
-                            },
-                        )
-
-                        return Array.isArray(response.data?.metrics) ? response.data.metrics : []
-                    }
-
-                    const resolveMetrics = async (): Promise<
-                        Record<string, ScenarioMetricData | null>
-                    > => {
-                        const processMetrics = async ({
-                            entries,
-                            source,
-                            triggerRefresh,
-                        }: {
-                            entries: any[]
-                            source: string
-                            triggerRefresh: boolean
-                        }) => {
-                            const processor = createMetricProcessor({
-                                projectId,
-                                runId: effectiveRunId,
-                                source,
-                                evaluationType,
-                            })
-
-                            // Get scenario statuses from cache for terminal state detection
-                            const scenarioStatuses = getScenarioStatuses(unique)
-
-                            const grouped = buildGroupedMetrics(
-                                unique,
-                                entries,
-                                processor,
-                                scenarioStatuses,
+                                {
+                                    params: {project_id: projectId},
+                                },
                             )
-                            const flushResult = await processor.flush({triggerRefresh})
-                            return {grouped, flushResult}
+
+                            return Array.isArray(response.data?.metrics)
+                                ? response.data.metrics
+                                : []
                         }
 
-                        const initial = await processMetrics({
-                            entries: await fetchMetrics(),
-                            source: "scenario-metric-batcher",
-                            triggerRefresh: true,
-                        })
+                        const resolveMetrics = async (): Promise<
+                            Record<string, ScenarioMetricData | null>
+                        > => {
+                            const processMetrics = async ({
+                                entries,
+                                source,
+                                triggerRefresh,
+                            }: {
+                                entries: any[]
+                                source: string
+                                triggerRefresh: boolean
+                            }) => {
+                                const processor = createMetricProcessor({
+                                    projectId,
+                                    runId: effectiveRunId,
+                                    source,
+                                    evaluationType,
+                                })
 
-                        let grouped = initial.grouped
-                        let flushResult = initial.flushResult
+                                // Get scenario statuses from cache for terminal state detection
+                                const scenarioStatuses = getScenarioStatuses(unique)
 
-                        // Re-fetch after refresh to get updated metrics
-                        if (flushResult.refreshed) {
-                            const retry = await processMetrics({
+                                const grouped = buildGroupedMetrics(
+                                    unique,
+                                    entries,
+                                    processor,
+                                    scenarioStatuses,
+                                )
+                                const flushResult = await processor.flush({triggerRefresh})
+                                return {grouped, flushResult}
+                            }
+
+                            const initial = await processMetrics({
                                 entries: await fetchMetrics(),
-                                source: "scenario-metric-batcher:retry",
-                                triggerRefresh: false,
+                                source: "scenario-metric-batcher",
+                                triggerRefresh: true,
                             })
 
-                            grouped = retry.grouped
+                            let grouped = initial.grouped
+                            let flushResult = initial.flushResult
+
+                            // Re-fetch after refresh to get updated metrics
+                            if (flushResult.refreshed) {
+                                const retry = await processMetrics({
+                                    entries: await fetchMetrics(),
+                                    source: "scenario-metric-batcher:retry",
+                                    triggerRefresh: false,
+                                })
+
+                                grouped = retry.grouped
+                            }
+
+                            return grouped
                         }
 
-                        return grouped
-                    }
+                        return resolveMetrics()
+                    },
+                })
+                metricBatcherCache.set(cacheKey, batcher)
+            }
 
-                    return resolveMetrics()
-                },
-            })
-            metricBatcherCache.set(cacheKey, batcher)
-        }
-
-        return batcher
-    }),
+            return batcher
+        }),
+    sameFamilyKey,
 )
 
 export const evaluationMetricBatcherAtom = atom((get) => get(evaluationMetricBatcherFamily({})))
@@ -821,6 +826,7 @@ export const evaluationMetricQueryAtomFamily = atomFamily(
                 },
             }
         }),
+    sameFamilyKey,
 )
 
 export const scenarioMetricValueAtomFamily = atomFamily(
@@ -861,6 +867,7 @@ export const scenarioMetricValueAtomFamily = atomFamily(
             },
             deepEqual,
         ),
+    sameFamilyKey,
 )
 
 export const scenarioMetricMetaAtomFamily = atomFamily(
@@ -879,45 +886,50 @@ export const scenarioMetricMetaAtomFamily = atomFamily(
             (a, b) =>
                 a.isLoading === b.isLoading && a.isFetching === b.isFetching && a.error === b.error,
         ),
+    sameFamilyKey,
 )
 
-export const runLevelMetricQueryAtomFamily = atomFamily(({runId}: {runId?: string | null} = {}) =>
-    atomWithQuery<RunLevelMetricData | null>((get) => {
-        const effectiveRunId = resolveEffectiveRunId(get, runId)
-        const projectId = resolveProjectId(get)
+export const runLevelMetricQueryAtomFamily = atomFamily(
+    ({runId}: {runId?: string | null} = {}) =>
+        atomWithQuery<RunLevelMetricData | null>((get) => {
+            const effectiveRunId = resolveEffectiveRunId(get, runId)
+            const projectId = resolveProjectId(get)
 
-        return {
-            queryKey: ["preview", "run-level-metrics", projectId, effectiveRunId],
-            enabled: Boolean(projectId && effectiveRunId),
-            staleTime: 30_000,
-            gcTime: 5 * 60 * 1000,
-            refetchOnWindowFocus: false,
-            refetchOnReconnect: false,
-            queryFn: async () => {
-                if (!projectId || !effectiveRunId) return null
+            return {
+                queryKey: ["preview", "run-level-metrics", projectId, effectiveRunId],
+                enabled: Boolean(projectId && effectiveRunId),
+                staleTime: 30_000,
+                gcTime: 5 * 60 * 1000,
+                refetchOnWindowFocus: false,
+                refetchOnReconnect: false,
+                queryFn: async () => {
+                    if (!projectId || !effectiveRunId) return null
 
-                const response = await axios.post(
-                    `/evaluations/metrics/query`,
-                    {
-                        metrics: {
-                            run_ids: [effectiveRunId],
-                            scenario_ids: false,
-                            timestamps: false,
+                    const response = await axios.post(
+                        `/evaluations/metrics/query`,
+                        {
+                            metrics: {
+                                run_ids: [effectiveRunId],
+                                scenario_ids: false,
+                                timestamps: false,
+                            },
                         },
-                    },
-                    {params: {project_id: projectId}},
-                )
+                        {params: {project_id: projectId}},
+                    )
 
-                const entries = Array.isArray(response.data?.metrics) ? response.data.metrics : []
+                    const entries = Array.isArray(response.data?.metrics)
+                        ? response.data.metrics
+                        : []
 
-                if (!entries.length) {
-                    return {metrics: [], raw: {}, flat: {}}
-                }
+                    if (!entries.length) {
+                        return {metrics: [], raw: {}, flat: {}}
+                    }
 
-                return buildRunLevelMetricData(entries)
-            },
-        }
-    }),
+                    return buildRunLevelMetricData(entries)
+                },
+            }
+        }),
+    sameFamilyKey,
 )
 
 /**

--- a/web/oss/src/components/EvalRunDetails/atoms/scenarioColumnValues.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/scenarioColumnValues.ts
@@ -17,6 +17,7 @@ import {
 } from "../utils/valueAccess"
 
 import {evaluationAnnotationQueryAtomFamily} from "./annotations"
+import {sameFamilyKey} from "./familyKeys"
 import {scenarioMetricMetaAtomFamily, scenarioMetricValueAtomFamily} from "./metrics"
 import {activePreviewRunIdAtom} from "./run"
 import {scenarioStepsQueryFamily} from "./scenarioSteps"
@@ -1184,11 +1185,13 @@ const scenarioColumnValueBaseAtomFamily = atomFamily(
 
             return defaultResult
         }),
+    sameFamilyKey,
 )
 
 export const scenarioColumnValueAtomFamily = atomFamily(
     ({scenarioId, runId, column}: ScenarioColumnValueAtomParams) =>
         atom((get) => get(scenarioColumnValueBaseAtomFamily({scenarioId, runId, column}))),
+    sameFamilyKey,
 )
 
 export interface ScenarioColumnValueSelection {
@@ -1229,4 +1232,5 @@ export const scenarioColumnValueSelectionAtomFamily = atomFamily(
                 prev.isLoading === next.isLoading &&
                 prev.stepError === next.stepError,
         ),
+    sameFamilyKey,
 )

--- a/web/oss/src/components/EvalRunDetails/atoms/scenarioSteps.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/scenarioSteps.ts
@@ -9,6 +9,7 @@ import {snakeToCamelCaseKeys} from "@/oss/lib/helpers/casing"
 import {getProjectValues} from "@/oss/state/project"
 
 import {isTerminalStatus} from "./compare"
+import {sameFamilyKey} from "./familyKeys"
 import {activePreviewRunIdAtom, effectiveProjectIdAtom} from "./run"
 import {evaluationRunQueryAtomFamily} from "./table/run"
 import type {ScenarioStepsBatchResult} from "./types"
@@ -26,100 +27,104 @@ export const invalidateScenarioStepsBatcherCache = () => {
 const resolveEffectiveRunId = (get: any, runId?: string | null) =>
     runId ?? get(activePreviewRunIdAtom) ?? undefined
 
-export const scenarioStepsBatcherFamily = atomFamily(({runId}: {runId?: string | null} = {}) =>
-    atom((get) => {
-        const effectiveRunId = resolveEffectiveRunId(get, runId)
-        const {projectId: globalProjectId} = getProjectValues()
-        const projectId = globalProjectId ?? get(effectiveProjectIdAtom)
-        if (!effectiveRunId || !projectId) return null
+export const scenarioStepsBatcherFamily = atomFamily(
+    ({runId}: {runId?: string | null} = {}) =>
+        atom((get) => {
+            const effectiveRunId = resolveEffectiveRunId(get, runId)
+            const {projectId: globalProjectId} = getProjectValues()
+            const projectId = globalProjectId ?? get(effectiveProjectIdAtom)
+            if (!effectiveRunId || !projectId) return null
 
-        const cacheKey = `${projectId}:${effectiveRunId}`
-        let batcher = scenarioStepsBatcherCache.get(cacheKey)
-        if (!batcher) {
-            scenarioStepsBatcherCache.clear()
-            batcher = createBatchFetcher<string, ScenarioStepsBatchResult>({
-                serializeKey: (key) => key,
-                batchFn: async (scenarioIds) => {
-                    if (scenarioIds.length === 0) {
-                        return {}
-                    }
+            const cacheKey = `${projectId}:${effectiveRunId}`
+            let batcher = scenarioStepsBatcherCache.get(cacheKey)
+            if (!batcher) {
+                scenarioStepsBatcherCache.clear()
+                batcher = createBatchFetcher<string, ScenarioStepsBatchResult>({
+                    serializeKey: (key) => key,
+                    batchFn: async (scenarioIds) => {
+                        if (scenarioIds.length === 0) {
+                            return {}
+                        }
 
-                    const validScenarioIds = scenarioIds.filter(
-                        (id) =>
-                            typeof id === "string" &&
-                            id.length > 0 &&
-                            !id.startsWith("skeleton-") &&
-                            !id.startsWith("placeholder-"),
-                    )
+                        const validScenarioIds = scenarioIds.filter(
+                            (id) =>
+                                typeof id === "string" &&
+                                id.length > 0 &&
+                                !id.startsWith("skeleton-") &&
+                                !id.startsWith("placeholder-"),
+                        )
 
-                    if (validScenarioIds.length === 0) {
-                        const empty: Record<string, ScenarioStepsBatchResult> = Object.create(null)
-                        scenarioIds.forEach((scenarioId) => {
-                            empty[scenarioId] = {
-                                scenarioId,
-                                steps: [],
-                                count: 0,
-                                next: undefined,
-                            }
-                        })
-                        return empty
-                    }
+                        if (validScenarioIds.length === 0) {
+                            const empty: Record<string, ScenarioStepsBatchResult> =
+                                Object.create(null)
+                            scenarioIds.forEach((scenarioId) => {
+                                empty[scenarioId] = {
+                                    scenarioId,
+                                    steps: [],
+                                    count: 0,
+                                    next: undefined,
+                                }
+                            })
+                            return empty
+                        }
 
-                    const response = await axios.post<{results?: any[]; steps?: any[]}>(
-                        `/evaluations/results/query?project_id=${projectId}`,
-                        {
-                            result: {
-                                run_id: effectiveRunId,
-                                run_ids: [effectiveRunId],
-                                scenario_ids: validScenarioIds,
+                        const response = await axios.post<{results?: any[]; steps?: any[]}>(
+                            `/evaluations/results/query?project_id=${projectId}`,
+                            {
+                                result: {
+                                    run_id: effectiveRunId,
+                                    run_ids: [effectiveRunId],
+                                    scenario_ids: validScenarioIds,
+                                },
+                                windowing: {},
                             },
-                            windowing: {},
-                        },
-                    )
+                        )
 
-                    const rawSteps = Array.isArray(response.data?.results)
-                        ? response.data?.results
-                        : Array.isArray(response.data?.steps)
-                          ? response.data?.steps
-                          : []
+                        const rawSteps = Array.isArray(response.data?.results)
+                            ? response.data?.results
+                            : Array.isArray(response.data?.steps)
+                              ? response.data?.steps
+                              : []
 
-                    const grouped: Record<string, ScenarioStepsBatchResult> = Object.create(null)
+                        const grouped: Record<string, ScenarioStepsBatchResult> =
+                            Object.create(null)
 
-                    for (const rawStep of rawSteps) {
-                        const camel = snakeToCamelCaseKeys(rawStep) as IStepResponse
-                        const scenarioId = (camel as any).scenarioId as string | undefined
-                        if (!scenarioId) continue
-                        const bucket = (grouped[scenarioId] ||= {
-                            scenarioId,
-                            steps: [],
-                            count: 0,
-                            next: undefined,
-                        })
-                        bucket.steps.push(camel)
-                    }
-
-                    for (const scenarioId of scenarioIds) {
-                        if (!grouped[scenarioId]) {
-                            grouped[scenarioId] = {
+                        for (const rawStep of rawSteps) {
+                            const camel = snakeToCamelCaseKeys(rawStep) as IStepResponse
+                            const scenarioId = (camel as any).scenarioId as string | undefined
+                            if (!scenarioId) continue
+                            const bucket = (grouped[scenarioId] ||= {
                                 scenarioId,
                                 steps: [],
                                 count: 0,
                                 next: undefined,
+                            })
+                            bucket.steps.push(camel)
+                        }
+
+                        for (const scenarioId of scenarioIds) {
+                            if (!grouped[scenarioId]) {
+                                grouped[scenarioId] = {
+                                    scenarioId,
+                                    steps: [],
+                                    count: 0,
+                                    next: undefined,
+                                }
                             }
                         }
-                    }
 
-                    Object.values(grouped).forEach((bucket) => {
-                        bucket.count = bucket.steps.length
-                    })
+                        Object.values(grouped).forEach((bucket) => {
+                            bucket.count = bucket.steps.length
+                        })
 
-                    return grouped
-                },
-            })
-            scenarioStepsBatcherCache.set(cacheKey, batcher)
-        }
-        return batcher
-    }),
+                        return grouped
+                    },
+                })
+                scenarioStepsBatcherCache.set(cacheKey, batcher)
+            }
+            return batcher
+        }),
+    sameFamilyKey,
 )
 
 export const scenarioStepsBatcherAtom = atom((get) => get(scenarioStepsBatcherFamily(undefined)))
@@ -157,4 +162,5 @@ export const scenarioStepsQueryFamily = atomFamily(
                 },
             }
         }),
+    sameFamilyKey,
 )

--- a/web/oss/src/components/EvalRunDetails/atoms/scenarioTestcase.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/scenarioTestcase.ts
@@ -15,6 +15,7 @@ import {testcase} from "@/oss/state/entities/testcase"
 import type {FlattenedTestcase} from "@/oss/state/entities/testcase/schema"
 import {testcaseQueryAtomFamily} from "@/oss/state/entities/testcase/testcaseEntity"
 
+import {sameFamilyKey} from "./familyKeys"
 import {activePreviewRunIdAtom} from "./run"
 import {scenarioStepsQueryFamily} from "./scenarioSteps"
 
@@ -55,6 +56,7 @@ export const scenarioTestcaseIdAtomFamily = atomFamily(
             const steps = stepsQuery.data?.steps ?? []
             return extractTestcaseIdFromSteps(steps)
         }),
+    sameFamilyKey,
 )
 
 /**
@@ -75,6 +77,7 @@ export const scenarioTestcaseEntityAtomFamily = atomFamily(
             // Use the global testcase entity atom for caching and consistency
             return get(testcase.selectors.data(testcaseId))
         }),
+    sameFamilyKey,
 )
 
 /**
@@ -117,6 +120,7 @@ export const scenarioTestcaseMetaAtomFamily = atomFamily(
                 hasTestcase: true,
             }
         }),
+    sameFamilyKey,
 )
 
 /**
@@ -168,6 +172,7 @@ export const scenarioTestcaseValueAtomFamily = atomFamily(
                 return a === b
             },
         ),
+    sameFamilyKey,
 )
 
 /**
@@ -190,4 +195,5 @@ export const scenarioHasEmbeddedInputsAtomFamily = atomFamily(
 
             return false
         }),
+    sameFamilyKey,
 )

--- a/web/oss/src/components/EvalRunDetails/atoms/table/testcases.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/table/testcases.ts
@@ -8,6 +8,7 @@ import type {PreviewTestCase} from "@/oss/lib/Types"
 import {getProjectValues} from "@/oss/state/project"
 
 import {resolveTestcaseValueByPath, splitPath} from "../../utils/valueAccess"
+import {sameFamilyKey} from "../familyKeys"
 import {activePreviewRunIdAtom, effectiveProjectIdAtom} from "../run"
 
 const testcaseBatcherCache = new Map<string, BatchFetcher<string, PreviewTestCase | null>>()
@@ -36,59 +37,61 @@ const normalizeTestcase = (raw: any): PreviewTestCase | null => {
 const resolveEffectiveRunId = (get: any, runId?: string | null) =>
     runId ?? get(activePreviewRunIdAtom) ?? undefined
 
-export const evaluationTestcaseBatcherFamily = atomFamily(({runId}: {runId?: string | null} = {}) =>
-    atom((get) => {
-        const {projectId: globalProjectId} = getProjectValues()
-        const projectId = globalProjectId ?? get(effectiveProjectIdAtom)
-        const effectiveRunId = resolveEffectiveRunId(get, runId)
-        if (!projectId) return null
+export const evaluationTestcaseBatcherFamily = atomFamily(
+    ({runId}: {runId?: string | null} = {}) =>
+        atom((get) => {
+            const {projectId: globalProjectId} = getProjectValues()
+            const projectId = globalProjectId ?? get(effectiveProjectIdAtom)
+            const effectiveRunId = resolveEffectiveRunId(get, runId)
+            if (!projectId) return null
 
-        const cacheKey = `${projectId}:${effectiveRunId ?? "preview"}`
-        let batcher = testcaseBatcherCache.get(cacheKey)
-        if (!batcher) {
-            testcaseBatcherCache.clear()
-            batcher = createBatchFetcher<string, PreviewTestCase | null>({
-                serializeKey: (key) => key,
-                batchFn: async (testcaseIds) => {
-                    const uniqueIds = Array.from(new Set(testcaseIds.filter(Boolean)))
-                    if (uniqueIds.length === 0) {
-                        return {}
-                    }
-
-                    const response = await axios.post(
-                        `/testcases/query`,
-                        {testcase_ids: uniqueIds},
-                        {
-                            params: {project_id: projectId},
-                        },
-                    )
-
-                    const rows = Array.isArray(response.data?.testcases)
-                        ? response.data.testcases
-                        : []
-
-                    const result: Record<string, PreviewTestCase | null> = Object.create(null)
-                    rows.forEach((row: any) => {
-                        const normalized = normalizeTestcase(row)
-                        if (normalized?.id) {
-                            result[normalized.id] = normalized
+            const cacheKey = `${projectId}:${effectiveRunId ?? "preview"}`
+            let batcher = testcaseBatcherCache.get(cacheKey)
+            if (!batcher) {
+                testcaseBatcherCache.clear()
+                batcher = createBatchFetcher<string, PreviewTestCase | null>({
+                    serializeKey: (key) => key,
+                    batchFn: async (testcaseIds) => {
+                        const uniqueIds = Array.from(new Set(testcaseIds.filter(Boolean)))
+                        if (uniqueIds.length === 0) {
+                            return {}
                         }
-                    })
 
-                    uniqueIds.forEach((id) => {
-                        if (typeof result[id] === "undefined") {
-                            result[id] = null
-                        }
-                    })
+                        const response = await axios.post(
+                            `/testcases/query`,
+                            {testcase_ids: uniqueIds},
+                            {
+                                params: {project_id: projectId},
+                            },
+                        )
 
-                    return result
-                },
-            })
-            testcaseBatcherCache.set(cacheKey, batcher)
-        }
+                        const rows = Array.isArray(response.data?.testcases)
+                            ? response.data.testcases
+                            : []
 
-        return batcher
-    }),
+                        const result: Record<string, PreviewTestCase | null> = Object.create(null)
+                        rows.forEach((row: any) => {
+                            const normalized = normalizeTestcase(row)
+                            if (normalized?.id) {
+                                result[normalized.id] = normalized
+                            }
+                        })
+
+                        uniqueIds.forEach((id) => {
+                            if (typeof result[id] === "undefined") {
+                                result[id] = null
+                            }
+                        })
+
+                        return result
+                    },
+                })
+                testcaseBatcherCache.set(cacheKey, batcher)
+            }
+
+            return batcher
+        }),
+    sameFamilyKey,
 )
 
 export const evaluationTestcaseBatcherAtom = atom((get) =>
@@ -120,6 +123,7 @@ export const evaluationTestcaseQueryAtomFamily = atomFamily(
                 },
             }
         }),
+    sameFamilyKey,
 )
 
 export const testcaseValueAtomFamily = atomFamily(
@@ -129,6 +133,7 @@ export const testcaseValueAtomFamily = atomFamily(
             (queryState) => resolveTestcaseValueByPath(queryState.data, splitPath(path)),
             Object.is,
         ),
+    sameFamilyKey,
 )
 
 export const testcaseQueryMetaAtomFamily = atomFamily(
@@ -143,4 +148,5 @@ export const testcaseQueryMetaAtomFamily = atomFamily(
             (a, b) =>
                 a.isLoading === b.isLoading && a.isFetching === b.isFetching && a.error === b.error,
         ),
+    sameFamilyKey,
 )

--- a/web/oss/src/components/EvalRunDetails/atoms/traces.ts
+++ b/web/oss/src/components/EvalRunDetails/atoms/traces.ts
@@ -12,6 +12,8 @@ import type {TraceSpanNode} from "@/oss/services/tracing/types"
 
 import {resolveInvocationTraceValue} from "../utils/traceValue"
 
+import {sameFamilyKey} from "./familyKeys"
+
 /**
  * Invalidate the trace batcher cache.
  * Now delegates to the shared trace entity cache invalidation.
@@ -240,6 +242,7 @@ export const evaluationTraceQueryAtomFamily = atomFamily(
                 a.isFetching === b.isFetching &&
                 a.error === b.error,
         ),
+    sameFamilyKey,
 )
 
 export const traceValueAtomFamily = atomFamily(
@@ -284,6 +287,7 @@ export const traceValueAtomFamily = atomFamily(
             },
             Object.is,
         ),
+    sameFamilyKey,
 )
 
 export const traceQueryMetaAtomFamily = atomFamily(
@@ -302,4 +306,5 @@ export const traceQueryMetaAtomFamily = atomFamily(
             (a, b) =>
                 a.isLoading === b.isLoading && a.isFetching === b.isFetching && a.error === b.error,
         ),
+    sameFamilyKey,
 )

--- a/web/oss/src/components/EvalRunDetails/hooks/useScenarioStepsSelectors.ts
+++ b/web/oss/src/components/EvalRunDetails/hooks/useScenarioStepsSelectors.ts
@@ -6,6 +6,7 @@ import {atomFamily} from "jotai/utils"
 
 import type {IStepResponse} from "@/oss/lib/evaluations"
 
+import {sameFamilyKey} from "../atoms/familyKeys"
 import {activePreviewRunIdAtom} from "../atoms/run"
 import {scenarioStepsQueryFamily} from "../atoms/scenarioSteps"
 import {evaluationRunIndexAtomFamily} from "../atoms/table/run"
@@ -60,7 +61,7 @@ const buildScenarioStepsSelector = (kind: "input" | "invocation" | "annotation")
                 isFetching: Boolean(query.isFetching),
             }
         })
-    })
+    }, sameFamilyKey)
 
 export const scenarioInputStepsAtomFamily = buildScenarioStepsSelector("input")
 export const scenarioInvocationStepsAtomFamily = buildScenarioStepsSelector("invocation")


### PR DESCRIPTION
## Context

Opening an evaluation run threw "Minified React error #185" and the error boundary replaced the page. React #185 is "Maximum update depth exceeded", so something was updating state without settling.

`atomFamily` in jotai keys its cache by **reference** unless you give it an `areEqual`. Version 2.20's implementation is a plain `atoms.get(param)` against a `Map`:

```js
if (areEqual === undefined) {
  item = atoms.get(param)     // reference equality for an object key
}
```

Every family under `EvalRunDetails` is keyed by an object literal rebuilt at the call site. `scenarioColumnValues.ts:485` is the load-bearing one:

```ts
const stepsQuery = get(scenarioStepsQueryFamily({scenarioId, runId}))
```

That literal is new on every evaluation, so the `Map` never hits and the family mints a brand-new atom each time. For the query families that is self-driving: each generation mounts its own `QueryObserver`, the observer emits, the emit invalidates the atom that created it, and the re-read mints the next generation. React counts an update per generation and eventually throws.

## Why it never reproduced on an empty project

I could not reproduce this for a long time, and the reason is in the gate at `scenarioSteps.ts:147`:

```ts
enabled: Boolean(effectiveRunId && batcher && scenarioId)
```

No scenarios means no cells, which means nothing ever reads the family. A run also has to be non-terminal to be at its worst, because `refetchInterval: runTerminal ? false : 5000` keeps every generation's observer emitting on a timer.

## The measurement

I seeded a 25-scenario non-terminal run through the API and counted atom creations. About 200 cells should create about 200 atoms, once.

```
before    2.5s     486 column-value atoms,   1504 step-query atoms
          20s     3244 column-value atoms,  10744 step-query atoms, still climbing

after     2.5s     144 column-value atoms,     24 step-query atoms
          20s      144 column-value atoms,     24 step-query atoms, flat
```

Before, the counters grew by roughly 2,584 step-query atoms every five seconds, which is the refetch timer driving each generation. After, they reach their real size and stop.

## Changes

Adds `atoms/familyKeys.ts` with `sameFamilyKey`, and passes it to the 24 object-keyed families across 9 files. The comparator compares the union of both key sets, so an absent key and an explicit `undefined` match, and it goes one level deeper for the column descriptor, whose `pathSegments` is an array of scalars.

Families keyed by a plain **string** are deliberately left alone. Giving those an `areEqual` makes jotai walk the whole `Map` linearly instead of hashing, so it would be a regression, not a fix. Three of them were caught and reverted while preparing this.

## A note on where the bug came from

The atoms are byte-identical to v0.112.3. `git diff v0.112.3..HEAD -- web/oss/src/components/EvalRunDetails` is nine files of pure import-path and type swaps. This churn is older than the release.

What #6065 changed is the engine underneath: the antd table became the virtualized `InfiniteVirtualTable`, which re-renders cells far more often. That is what pushed a latent, bounded-looking churn past React's update-depth limit. Worth remembering when triaging the next "the extraction broke X": the extraction can be the trigger without being the author.

## Tests

- `atoms/familyKeys.test.ts`, 10 cases: the comparator's own behaviour, that an `atomFamily` given it returns the *same* atom for equal keys built fresh, that it still separates genuinely different keys, and one test that pins jotai's reference-keying so we find out if a future version makes these comparators redundant.
- `@agenta/oss` suite: 45 files, 442 passed, 1 skipped.
- `tsc --noEmit` clean for `@agenta/oss` and `@agenta/ee`.
- `pnpm lint-fix` in `web/`: 25/25. Prettier 3.7.4 clean on all touched files.
- One `@agenta/oss` production build.
- Live on a v0.113.0 build from this branch: the run page renders its 19 virtualized rows, no error boundary, no update-depth error, and the network goes quiet once the queries settle.

## What to QA

- Open an evaluation run that has scenarios, on the Scenarios tab. It renders instead of showing "An Error Occurred", and stays up while you leave it open.
- Do it on a run that is still executing. That is the worst case, because the steps query polls every five seconds; the page should stay stable rather than degrading.
- Scroll the scenario table and open a scenario. Cell values, inputs, metrics and annotations all still resolve, since they read through the families this touches.
- Switch between Overview, Scenarios and Configuration, then use Compare in the header.
- Regression to watch: the families now dedupe by value rather than by reference, so the thing to check is that data still *updates*. Watch a running run and confirm the cells fill in as scenarios complete, rather than freezing on their first value.
