### PR TITLE
[feat] Offer Claude Opus in the agent model picker

### DIFF
--- a/sdks/python/agenta/sdk/agents/capabilities.py
+++ b/sdks/python/agenta/sdk/agents/capabilities.py
@@ -151,10 +151,9 @@ PROVIDER_DEFAULT_MODELS: Dict[str, List[str]] = {
         "openai/gpt-5.6-terra",
         "openai/gpt-5.6-sol",
     ],
-    # ``anthropic/claude-opus-5`` belongs here too, but the pinned pi-ai catalog predates it;
-    # add it when the ``sync-model-catalog`` skill regenerates ``data/pi_models.generated.json``.
     "anthropic": [
         "anthropic/claude-fable-5",
+        "anthropic/claude-opus-5",
         "anthropic/claude-sonnet-5",
         "anthropic/claude-haiku-4-5",
     ],
@@ -168,7 +167,7 @@ PROVIDER_DEFAULT_MODELS: Dict[str, List[str]] = {
     ],
     "groq": [
         "groq/openai/gpt-oss-120b",
-        "groq/llama-3.1-8b-instant",
+        "groq/openai/gpt-oss-20b",
     ],
     "minimax": [
         "minimax/MiniMax-M3",
@@ -184,7 +183,7 @@ PROVIDER_DEFAULT_MODELS: Dict[str, List[str]] = {
         "openrouter/deepseek/deepseek-v4-pro",
         "openrouter/openai/gpt-5.6-luna",
         "openrouter/xiaomi/mimo-v2.5",
-        "openrouter/tencent/hy3",
+        "openrouter/tencent/hy3-preview",
     ],
 }
 
@@ -192,11 +191,15 @@ PROVIDER_DEFAULT_MODELS: Dict[str, List[str]] = {
 # A harness that selects by alias (Claude) names a TIER, not a model id, so a curated id has to
 # be translated before it can be matched. Keyed by prefix because the alias tracks the tier
 # across versions (``claude-sonnet-5`` and its successor both answer to ``sonnet``). Only ids a
-# harness could otherwise not name belong here: ``claude-fable-5`` is its own alias, and opus has
-# no curated default until the catalog refresh adds ``claude-opus-5``.
+# harness could otherwise not name belong here: ``claude-fable-5`` is its own alias, so it needs
+# no entry. Opus maps to the bracketed ``opus[1m]`` rather than a bare ``opus`` because that
+# bracketed spelling is the exact value Claude Code publishes for the Opus tier in its accepted
+# alias set (see :data:`CLAUDE_MODEL_ALIASES`), and a harness only advertises defaults it can
+# actually select, so any other spelling would be dropped instead of offered.
 MODEL_ID_ALIASES: Dict[str, str] = {
     "anthropic/claude-sonnet-": "sonnet",
     "anthropic/claude-haiku-": "haiku",
+    "anthropic/claude-opus-": "opus[1m]",
 }
 
 

--- a/sdks/python/agenta/sdk/agents/data/claude_models.curated.json
+++ b/sdks/python/agenta/sdk/agents/data/claude_models.curated.json
@@ -58,7 +58,7 @@
       "id": "opus[1m]",
       "provider": "anthropic",
       "source": "curated",
-      "name": "Claude Opus 4.8",
+      "name": "Claude Opus 5",
       "pricing": {
         "input_per_mtok": 5.0,
         "output_per_mtok": 25.0,
@@ -69,7 +69,7 @@
       "context_window": 1000000,
       "modalities": ["text", "image"],
       "label": "Opus (1M context)",
-      "description": "Strong reasoning below Fable, at a lower price, with the 1M-token context window.",
+      "description": "The current Opus tier: strong reasoning below Fable, at a lower price, with the 1M-token context window.",
       "ratings": {"cost": 3, "intelligence": 4, "speed": 3}
     },
     {

--- a/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
@@ -257,16 +257,17 @@ def test_default_models_are_published_per_harness_in_its_own_spelling():
     assert pi_defaults["openai"] == ["gpt-5.6-luna", "gpt-5.6-terra", "gpt-5.6-sol"]
     assert pi_defaults["anthropic"] == [
         "anthropic/claude-fable-5",
+        "anthropic/claude-opus-5",
         "anthropic/claude-sonnet-5",
         "anthropic/claude-haiku-4-5",
     ]
     assert pi_defaults["openrouter"] == PROVIDER_DEFAULT_MODELS["openrouter"]
 
-    # Claude selects by alias: `claude-fable-5` is its own alias, and the versioned sonnet and
-    # haiku ids arrive under the tier alias Claude actually accepts. Opus is absent because it
-    # is not curated yet, not because the alias is missing.
+    # Claude selects by alias: `claude-fable-5` is its own alias, and the versioned opus, sonnet
+    # and haiku ids arrive under the tier alias Claude actually accepts. Opus arrives as the
+    # bracketed `opus[1m]` because that is the spelling Claude publishes for the Opus tier.
     assert catalog["claude"]["capabilities"]["default_models"] == {
-        "anthropic": ["claude-fable-5", "sonnet", "haiku"]
+        "anthropic": ["claude-fable-5", "opus[1m]", "sonnet", "haiku"]
     }
     # Codex reaches openai only, and names its models bare.
     assert catalog["codex"]["capabilities"]["default_models"] == {


### PR DESCRIPTION
## Context

The agent model picker offered Fable 5, Sonnet 5, and Haiku 4.5 under Anthropic. Opus never showed up, so anyone driving an agent with a Claude Code subscription could not pick the Opus tier from the picker at all.

The cause is a one-line gap. Claude Code selects a model by alias, not by id, so `_harness_default_models` translates a curated id through `MODEL_ID_ALIASES` before publishing it. That table had entries for Sonnet and Haiku only. Claude Code has accepted the `opus[1m]` alias the whole time, so the tier was always selectable. It was just never offered.

## Changes

`MODEL_ID_ALIASES` now maps the `anthropic/claude-opus-` prefix to `opus[1m]`, and `anthropic/claude-opus-5` joins the Anthropic defaults. The bracketed spelling is deliberate: it is the exact value `CLAUDE_MODEL_ALIASES` publishes for the Opus tier, and a spelling the harness does not publish gets dropped rather than offered.

Before, the Claude picker published:

```
{"anthropic": ["claude-fable-5", "sonnet", "haiku"]}
```

After:

```
{"anthropic": ["claude-fable-5", "opus[1m]", "sonnet", "haiku"]}
```

The catalog entry for `opus[1m]` still read "Claude Opus 4.8" while carrying the price of the current tier. Since the `opus` alias tracks whichever Opus is current, the entry is renamed to Claude Opus 5. The pricing was already correct and is unchanged, because Opus 4.7, 4.8, and 5 all price identically at 5 dollars in and 25 dollars out per million tokens.

Two other defaults in the same table were being dropped in silence. Groq named `llama-3.1-8b-instant`, which Groq has retired, and OpenRouter spelled `tencent/hy3` while the catalog spells it `tencent/hy3-preview`. A curated default the harness cannot match is discarded rather than reported, which is why neither was noticed. Both are corrected.

## Depends on

This needs #6184 to merge first. The guard test `test_curated_default_models_exist_in_the_pinned_pi_catalog` requires every curated default to exist in the Pi catalog, and the Claude Opus 5 facts land in that pull request. Until it merges, this branch's tests fail on that one assertion.

## Tests

- `pytest oss/tests/pytest/unit/agents/connections/` passes: 260 passed with #6184 applied.
- Printed the published capability document directly and confirmed the Claude harness returns `["claude-fable-5", "opus[1m]", "sonnet", "haiku"]` and Groq returns two live models.
- `ruff format --check` and `ruff check` are clean.

## What to QA

- Open an agent and pick the Claude Code harness with a subscription connection. The Anthropic model list shows Opus alongside Fable and Haiku.
- Select Opus and run a turn. It completes, and the run reports against the Opus tier.
- Regression: switch the same agent to the Pi harness with an Anthropic key. The model list still renders and Sonnet and Haiku still resolve.
