### PR TITLE
fix(frontend): render a session that is parked on a tool approval

### DIFF
--- a/web/packages/agenta-entities/src/session/core/transcriptAdoption.ts
+++ b/web/packages/agenta-entities/src/session/core/transcriptAdoption.ts
@@ -24,12 +24,15 @@ export interface TranscriptAdoptionInput {
     /** This client is streaming the turn, so it — not the log — is the authority. */
     busy: boolean
     /**
-     * A card on screen is still awaiting THIS user (#5942).
+     * A card ON SCREEN is still awaiting THIS user (#5942).
      *
      * Adopting over a parked card discards whatever they have half-typed into its form. The local
      * copy is authoritative until the interaction row says the card ended, because a card replayed
      * from the durable log carries its harness-wrapped tool name with no `data-render` sibling —
      * so "the client no longer recognises it as waiting" is NOT evidence that it settled.
+     *
+     * It protects a RENDERED transcript, so it only applies when there is one — see the
+     * `localMessageCount` pairing below.
      */
     awaitingUser?: boolean
 }
@@ -46,8 +49,13 @@ export const shouldAdoptServerTranscript = ({
     if (serverMessageCount === 0) return false
     // A live local stream outranks the log until it settles.
     if (busy) return false
-    // A card still waiting on the user outranks it too — see `awaitingUser`.
-    if (awaitingUser) return false
+    // A card still waiting on the user outranks it too — but only a card that EXISTS. The guard
+    // preserves a rendered transcript; with nothing rendered there is no half-typed form to
+    // protect, and refusing here leaves a cold open (a session this browser never ran, opened
+    // from the sessions list or Home's "waiting on you") permanently blank — the pane paints its
+    // empty hero over a session the log has turns for, and the pending approval it is telling the
+    // user about becomes unreachable. So pair it with `localMessageCount`.
+    if (awaitingUser && localMessageCount > 0) return false
     // THE trigger: the log grew past what we render. An absent watermark reads as 0, so a
     // locally-streamed or pre-#5530 cache re-syncs from the server once on its next open.
     if (serverRecordCount <= (watermark ?? 0)) return false

--- a/web/packages/agenta-entities/tests/unit/transcriptAdoptionAwaiting.test.ts
+++ b/web/packages/agenta-entities/tests/unit/transcriptAdoptionAwaiting.test.ts
@@ -10,6 +10,14 @@ const row = (status: SessionInteractionRowState["status"]): SessionInteractionRo
     kind: "client_tool" as SessionInteractionRowState["kind"],
 })
 
+/** The shape the sessions API returns for a Terminal call parked on Approve/Deny. */
+const pendingApprovalRow = (): SessionInteractionRowState => ({
+    token: "0199a1e2-approval-token",
+    status: "pending",
+    kind: "user_approval" as SessionInteractionRowState["kind"],
+    toolCallId: "toolu_01Terminal",
+})
+
 const grown = {
     serverRecordCount: 10,
     serverMessageCount: 4,
@@ -37,5 +45,63 @@ describe("#5942 adoption guard", () => {
     it("treats absent rows as not waiting — the guard needs positive evidence", () => {
         expect(hasWaitingInteraction(undefined)).toBe(false)
         expect(hasWaitingInteraction(new Map())).toBe(false)
+    })
+})
+
+/**
+ * A session parked on an approval opened EMPTY on a browser that never ran it: the guard above
+ * refused the server transcript, nothing else calls `setMessages`, and the pane painted its
+ * "start a chat" hero over a session the log has turns for — with no way to answer the approval
+ * the user was told was waiting on them. The guard protects a rendered transcript, so with
+ * nothing rendered it must not fire.
+ */
+describe("cold open of a session parked on an approval", () => {
+    const coldOpen = {
+        serverRecordCount: 12,
+        serverMessageCount: 4,
+        // Nothing on screen: this browser never ran the session, so there is no cached transcript.
+        localMessageCount: 0,
+        // Never server-derived here, so no watermark to compare against.
+        watermark: undefined,
+        busy: false,
+    }
+
+    const rows = new Map([["0199a1e2-approval-token", pendingApprovalRow()]])
+
+    it("sees the pending user_approval row as waiting on the user", () => {
+        expect(hasWaitingInteraction(rows)).toBe(true)
+    })
+
+    it("adopts the server transcript even though an approval is pending", () => {
+        expect(
+            shouldAdoptServerTranscript({...coldOpen, awaitingUser: hasWaitingInteraction(rows)}),
+        ).toBe(true)
+    })
+
+    it("still refuses once that transcript is on screen — #5942 is intact", () => {
+        // The same session one commit later: hydration adopted, so the parked card now renders
+        // and its half-typed form is the thing the guard exists to protect.
+        expect(
+            shouldAdoptServerTranscript({
+                ...coldOpen,
+                localMessageCount: 4,
+                watermark: 12,
+                serverRecordCount: 14,
+                awaitingUser: hasWaitingInteraction(rows),
+            }),
+        ).toBe(false)
+    })
+
+    it("keeps every other refusal — an empty transcript is not a bypass", () => {
+        // `localMessageCount: 0` must not turn the guard into a blanket "always adopt".
+        expect(shouldAdoptServerTranscript({...coldOpen, busy: true, awaitingUser: true})).toBe(
+            false,
+        )
+        expect(
+            shouldAdoptServerTranscript({...coldOpen, serverMessageCount: 0, awaitingUser: true}),
+        ).toBe(false)
+        expect(shouldAdoptServerTranscript({...coldOpen, watermark: 12, awaitingUser: true})).toBe(
+            false,
+        )
     })
 })


### PR DESCRIPTION
## Context

Opening a session that is waiting on a tool approval showed an empty pane. You got the agent card, the Templates grid and the composer, but none of the session's turns and no Approve/Deny controls. This happened from the sessions list and from Home's "Waiting on you" entry. QA reproduced it 3/3 on staging; the five sessions on the same account without a pending approval rendered normally in the same pane.

The backend was never the problem. `POST /api/sessions/interactions/query` returned the turns and the pending `user_approval` row the whole time. The transcript was mapped correctly and then thrown away.

#5942 added an `awaitingUser` input to `shouldAdoptServerTranscript`. Its job is to stop a background poll from adopting the durable log over a card the user is still filling in, which would discard whatever they typed into its form. That intent is right. The problem is that the guard ran on every path, including a cold open, where `localMessageCount` is 0. There is no card on screen to protect there, so refusing the server transcript protects nothing and leaves the pane blank. Nothing else calls `setMessages` on that path. `hydratedEmpty` also stays false, because the transcript was not empty, so the user does not even get the "history unavailable" notice. The Templates grid only renders when `messages.length === 0`, which is exactly the reported symptom.

That is also why the split QA saw is 1 versus 5. All six sessions took the same cold-hydration path. The five without a pending interaction had `awaitingUser: false` and were adopted. The one parked on an approval was refused.

## Changes

`shouldAdoptServerTranscript` now pairs the guard with `localMessageCount`, so it only fires when there is a rendered transcript to preserve.

Before:

```ts
if (awaitingUser) return false
```

After:

```ts
if (awaitingUser && localMessageCount > 0) return false
```

Every background and revalidation path runs with a rendered transcript, so #5942 keeps its protection. The only case that changes is the one that was broken: a first paint with nothing on screen.

## Regression or pre-existing

This is a regression in v0.113.0. v0.112.3 has no `awaitingUser` input at all:

```
git show v0.112.3:web/packages/agenta-entities/src/session/core/transcriptAdoption.ts
```

It arrived in commit `c08a8248bc` ("rebuild #5942's adoption guard in the lane's idiom"), merged in PR #6065. The v0.112.3 release solved #5942 with different machinery in the app hook. The rebuild moved the rule into the shared predicate and lost the "only when we render something" precondition.

Blast radius is the desktop OSS and EE chat slice only. The `@agenta/chat` copy of the hook (`useAgentConversation.ts`) never passed `awaitingUser`, so mobile was never affected.

## Tests

Four cases added to `transcriptAdoptionAwaiting.test.ts`. They drive a real pending `user_approval` row through `hasWaitingInteraction` into the guard, so the wiring is covered, not just the predicate.

- The cold-open case fails without this change (`expected false to be true`) and passes with it.
- The #5942 case (same session, transcript now on screen) stays green in both directions.
- One case checks that `localMessageCount: 0` did not turn the guard into a blanket "always adopt": `busy`, an empty server transcript, and a watermark that has not moved all still refuse.

Verified: `@agenta/entities` 1334 unit tests pass, `@agenta/chat` 378 pass, `types:check` clean for both `@agenta/oss` and `@agenta/ee`, prettier 3.7.4 clean, and one production build via `pnpm build-oss` (10/10 tasks).

Not verified live. Reproducing a pending approval needs a stack, and every local stack is in use by another release task. The click path below is the handoff.

## Why it can look intermittent

It is not intermittent. It is deterministic for the first open of a session on a device, and it disappears the moment anything caches that session locally.

QA hit the empty pane 3/3 on cold opens. They then opened the same session on `/m` and went back to the desktop, where it rendered 7/7. That is the fix working by accident, not the bug going away. The mobile app drives the same session through `useAgentConversation` (`mobile/src/features/chat/LiveConversation.tsx:71`), and that hook never passes `awaitingUser` into the guard. So `/m` adopted the transcript and persisted it. Both apps read and write the same store, `agenta:agent-chat:messages:v2`, declared once in `packages/agenta-chat/src/state/sessionMessages.ts:52`. `/m` is a `basePath` on the same deployment, not a separate host, so it is the same origin and the same `localStorage` partition. After that write, every desktop open of that session takes the warm path: `initialMessages` is non-empty, the pane paints from cache, and the guard is never the thing standing between the user and their turns.

One detail if you try to reproduce the sequence. `tabLocalStorage` deletes jotai's `subscribe`, so a desktop tab that was already open when `/m` wrote does not pick the value up live. The warm path needs a fresh page load after the `/m` visit.

The practical consequence for review: test COLD. Use a fresh browser profile, or clear `agenta:agent-chat:messages:v2` before opening the session. A warm open exercises a path that was never broken and will pass either way.

## What to QA

- Start a session and get the agent to request a tool that needs approval, for example a Terminal command under an "ask" policy. Leave the approval pending.
- Open that session in a browser profile that never ran it, or clear `localStorage` first. The key is `agenta:agent-chat:messages:v2`. This is what makes it a cold open, and it is the only shape that was broken.
- Open it from the sessions list. The turns render and the Approve/Deny card is there and clickable. Before this change the pane showed the Templates grid instead.
- Open it from Home's "Waiting on you" entry. Same result.
- Regression to watch for, this is what #5942 protects: with the session already open and a card parked on you, type into that card's form and leave it for a minute while a background refresh ticks. Your typing must survive. The transcript must not jump back to an older state.
- Regression: the five-sessions-without-approvals case. Sessions with no pending interaction must still open normally from a cold browser.

