### PR TITLE
fix(frontend): key the evaluator-reference atom families by value

### DIFF
--- a/web/oss/src/components/References/atoms/entityReferences.ts
+++ b/web/oss/src/components/References/atoms/entityReferences.ts
@@ -272,6 +272,22 @@ const extractMetricsFromWorkflow = (workflow: any): EvaluatorReferenceMetric[] =
  * Uses the provided projectId directly — no dependency on shared
  * projectIdAtom/sessionAtom, so it works in scoped Jotai stores
  * (e.g., the evaluations page).
+ *
+ * The `areEqual` below is not a micro-optimisation. `atomFamily` keys its cache by
+ * REFERENCE when the comparator is omitted, so an object-literal key never hits the cache
+ * and every read mints a BRAND NEW atom. `evaluatorReferenceAtomFamily` reads this family
+ * from inside its own read function, so each generation mounts its own query observer, the
+ * observer emits, the emit invalidates the reader that created it, and the re-read mints
+ * the next generation.
+ *
+ * Measured on this family, that settles at two atoms rather than running away: the query
+ * carries `staleTime: 5 * 60_000` with no polling and no refetch-on-focus, so generation
+ * two reads settled cached data and emits nothing further. The cost today is therefore one
+ * duplicated atom and one duplicated fetch per call site, not a hang. It becomes unbounded
+ * the moment anything makes this query re-emit — adding a `refetchInterval` would be
+ * enough, which is exactly how the sibling families in `EvalRunDetails` reached React error
+ * #185 (see `EvalRunDetails/atoms/familyKeys.ts`). Keep the comparator on every
+ * object-keyed family in this file.
  */
 export const evaluatorWorkflowQueryAtomFamily = atomFamily(
     ({projectId, revisionId}: {projectId: string; revisionId: string}) =>
@@ -300,12 +316,18 @@ export const evaluatorWorkflowQueryAtomFamily = atomFamily(
             staleTime: 5 * 60_000,
             refetchOnWindowFocus: false,
         })),
+    (a, b) => a.projectId === b.projectId && a.revisionId === b.revisionId,
 )
 
 /**
  * Resolves evaluator reference (name, slug, metrics) from the workflow
  * entity system. Uses a self-contained query that works in any Jotai
  * store — no dependency on shared projectIdAtom/sessionAtom.
+ *
+ * `areEqual` is required here for the same reason as the family above. Callers spell the
+ * absent half of the key both ways — `useEvaluatorHeaderReference` passes `undefined`,
+ * `ReferenceLabels` passes `null` — so the comparator normalises the two, or the same
+ * evaluator would occupy two cache entries and fetch twice.
  */
 export const evaluatorReferenceAtomFamily = atomFamily(
     ({projectId, slug, id}: {projectId: string | null; slug?: string | null; id?: string | null}) =>
@@ -416,6 +438,10 @@ export const evaluatorReferenceAtomFamily = atomFamily(
                 isError: false,
             }
         }),
+    (a, b) =>
+        a.projectId === b.projectId &&
+        (a.slug ?? null) === (b.slug ?? null) &&
+        (a.id ?? null) === (b.id ?? null),
 )
 
 // ─────────────────────────────────────────────────────────────────────────────

--- a/web/oss/src/components/References/atoms/evaluatorReferenceFamilyKeys.test.ts
+++ b/web/oss/src/components/References/atoms/evaluatorReferenceFamilyKeys.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it} from "vitest"
+
+import {evaluatorReferenceAtomFamily, evaluatorWorkflowQueryAtomFamily} from "./entityReferences"
+
+/**
+ * `atomFamily` keys its cache by REFERENCE unless it is given an `areEqual`: the lookup is a
+ * plain `Map.get(param)`. Both families below are keyed by an object literal that callers
+ * rebuild at every call site, so without a comparator the `Map` never hits and each call
+ * mints a BRAND NEW atom — a duplicated atom and a duplicated fetch per call site.
+ *
+ * `evaluatorReferenceAtomFamily` reads `evaluatorWorkflowQueryAtomFamily` from inside its own
+ * read function, so a missing comparator also feeds back: each generation mounts its own
+ * query observer, the observer emits, and the emit invalidates the reader that created it.
+ * Measured, that settles at two atoms, because the query has a 5 minute `staleTime` and no
+ * polling. It would run away if anything ever made the query re-emit, which is how the
+ * sibling families in `EvalRunDetails` reached React error #185.
+ *
+ * The list page reaches these through `MetricColumnHeader` -> `useEvaluatorHeaderReference`,
+ * one header per evaluator metric column, and through `ReferenceLabels`.
+ *
+ * These tests assert the property that removes the whole class — an equal-but-not-identical
+ * key returns the SAME atom — so a dropped comparator fails here in a second. They only
+ * compare atom identity and never read an atom's value, so no query ever runs.
+ */
+
+describe("evaluatorWorkflowQueryAtomFamily", () => {
+    it("returns the same atom for an equal key built twice", () => {
+        const first = evaluatorWorkflowQueryAtomFamily({projectId: "p1", revisionId: "r1"})
+        const second = evaluatorWorkflowQueryAtomFamily({projectId: "p1", revisionId: "r1"})
+
+        expect(second).toBe(first)
+    })
+
+    it("still separates different keys", () => {
+        const a = evaluatorWorkflowQueryAtomFamily({projectId: "p1", revisionId: "r1"})
+        const b = evaluatorWorkflowQueryAtomFamily({projectId: "p1", revisionId: "r2"})
+        const c = evaluatorWorkflowQueryAtomFamily({projectId: "p2", revisionId: "r1"})
+
+        expect(b).not.toBe(a)
+        expect(c).not.toBe(a)
+    })
+
+    it("does not grow the cache when the same key is read many times", () => {
+        // Call sites build a fresh literal on every read. With a comparator all 50 reads
+        // collapse onto one atom; without one this set holds 50 distinct atoms.
+        const minted = new Set(
+            Array.from({length: 50}, () =>
+                evaluatorWorkflowQueryAtomFamily({projectId: "p1", revisionId: "r1"}),
+            ),
+        )
+
+        expect(minted.size).toBe(1)
+    })
+})
+
+describe("evaluatorReferenceAtomFamily", () => {
+    it("returns the same atom for an equal key built twice", () => {
+        const first = evaluatorReferenceAtomFamily({projectId: "p1", slug: "s1", id: "i1"})
+        const second = evaluatorReferenceAtomFamily({projectId: "p1", slug: "s1", id: "i1"})
+
+        expect(second).toBe(first)
+    })
+
+    it("treats an absent half of the key as equal whether it is null or undefined", () => {
+        // `useEvaluatorHeaderReference` passes `undefined`; `ReferenceLabels` passes `null`.
+        // They mean the same evaluator, so they must share one atom and one fetch.
+        const withUndefined = evaluatorReferenceAtomFamily({
+            projectId: "p1",
+            slug: undefined,
+            id: "i1",
+        })
+        const withNull = evaluatorReferenceAtomFamily({projectId: "p1", slug: null, id: "i1"})
+        const omitted = evaluatorReferenceAtomFamily({projectId: "p1", id: "i1"})
+
+        expect(withNull).toBe(withUndefined)
+        expect(omitted).toBe(withUndefined)
+    })
+
+    it("still separates different evaluators", () => {
+        const a = evaluatorReferenceAtomFamily({projectId: "p1", id: "i1"})
+        const b = evaluatorReferenceAtomFamily({projectId: "p1", id: "i2"})
+        const c = evaluatorReferenceAtomFamily({projectId: "p1", slug: "s1"})
+
+        expect(b).not.toBe(a)
+        expect(c).not.toBe(a)
+    })
+})

--- a/web/oss/src/components/References/atoms/evaluatorReferenceLoop.test.ts
+++ b/web/oss/src/components/References/atoms/evaluatorReferenceLoop.test.ts
@@ -1,0 +1,100 @@
+// @vitest-environment jsdom
+import {QueryClient} from "@tanstack/react-query"
+import {atom, createStore} from "jotai"
+import {atomFamily} from "jotai-family"
+import {queryClientAtom} from "jotai-tanstack-query"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+import {evaluatorReferenceAtomFamily, evaluatorWorkflowQueryAtomFamily} from "./entityReferences"
+
+/**
+ * Drives the real `/evaluations` code path in a jotai store and MEASURES how many query
+ * atoms one subscribed evaluator column creates. The sibling file asserts the rule; this
+ * one asserts the observable consequence.
+ *
+ * `evaluatorReferenceAtomFamily` reads `evaluatorWorkflowQueryAtomFamily` from inside its
+ * own read function with a key it rebuilds on every read. Without an `areEqual` on the inner
+ * family, each read mints a new query atom, the new atom mounts its own observer, the
+ * observer emits, and the emit invalidates the reader that created it.
+ *
+ * Measured trajectory over 200 ticks with the comparator removed: 1, 2, 2, 2, 2 — it settles
+ * at two, because this query has a 5 minute `staleTime` and neither polls nor refetches on
+ * focus, so generation two reads settled cached data and emits nothing further. So the bug
+ * this guards is a duplicated atom and a duplicated fetch, NOT the runaway that produced
+ * React error #185 on the run-details page (that family polled while a run was non-terminal,
+ * which is what compounded). Adding a `refetchInterval` here would turn this into that bug.
+ *
+ * One subscription must create exactly ONE query atom.
+ */
+
+// The entities package reaches the network and pulls in a large module graph. Only the
+// handful of bindings `entityReferences` actually uses are stubbed here; the workflow query
+// resolves immediately so the loop, if present, runs at full speed instead of waiting on IO.
+vi.mock("@agenta/entities/workflow", () => ({
+    fetchWorkflow: vi.fn(async () => ({id: "wf1", workflow_id: "wf1", slug: "evaluator-slug"})),
+    fetchWorkflowRevisionById: vi.fn(async () => ({
+        id: "rev1",
+        workflow_id: "wf1",
+        slug: "evaluator-slug",
+        data: {uri: "agenta://workflow/evaluator", service: {}},
+    })),
+    parseWorkflowKeyFromUri: () => "evaluator",
+    resolveOutputSchemaProperties: () => ({score: {type: "number", title: "Score"}}),
+    workflowMolecule: {selectors: {query: () => atom({data: null, isPending: false})}},
+    workflowsListQueryStateAtom: atom({data: [] as unknown[], isPending: false}),
+    workflowArtifactScopedQueryAtomFamily: atomFamily(
+        (_key: {projectId: string; workflowId: string}) => atom({data: {name: "Evaluator"}}),
+        (a, b) => a.projectId === b.projectId && a.workflowId === b.workflowId,
+    ),
+}))
+
+vi.mock("@agenta/entities/environment", () => ({
+    appEnvironmentsQueryAtomFamily: atomFamily((_k: unknown) => atom({data: []})),
+}))
+
+vi.mock("@agenta/entities/testset", () => ({
+    testsetQueryAtomFamily: atomFamily((_k: unknown) => atom({data: null, isPending: false})),
+}))
+
+const flush = async (ticks: number) => {
+    for (let i = 0; i < ticks; i += 1) {
+        await new Promise((resolve) => setTimeout(resolve, 0))
+    }
+}
+
+describe("evaluatorReferenceAtomFamily does not mint an atom per read", () => {
+    let store: ReturnType<typeof createStore>
+    let unsub: (() => void) | undefined
+
+    beforeEach(() => {
+        store = createStore()
+        store.set(
+            queryClientAtom,
+            new QueryClient({
+                defaultOptions: {queries: {retry: false, gcTime: Infinity, staleTime: Infinity}},
+            }),
+        )
+    })
+
+    afterEach(() => {
+        unsub?.()
+        unsub = undefined
+    })
+
+    it("creates exactly one workflow query atom for one subscribed evaluator column", async () => {
+        // What `MetricColumnHeader` -> `useEvaluatorHeaderReference` mounts: one evaluator
+        // column, resolved by id, which is the branch that reads the inner query family.
+        const referenceAtom = evaluatorReferenceAtomFamily({projectId: "p1", id: "rev1"})
+        unsub = store.sub(referenceAtom, () => {
+            // Reading inside the subscriber is what the React binding does, and it is what
+            // re-enters the read function once the query emits.
+            store.get(referenceAtom)
+        })
+        store.get(referenceAtom)
+
+        await flush(50)
+
+        const minted = [...evaluatorWorkflowQueryAtomFamily.getParams()].length
+        expect(minted).toBe(1)
+    })
+})

--- a/web/oss/src/state/queries/atoms/fetcher.ts
+++ b/web/oss/src/state/queries/atoms/fetcher.ts
@@ -21,6 +21,17 @@ import type {
 import {projectIdAtom} from "@/oss/state/project"
 
 /**
+ * Identity for the payload-keyed families below. `atomFamily` keys by REFERENCE without an
+ * `areEqual`, so an object-literal key never hits the cache and every read mints a new atom
+ * and a new fetch. `evaluationRunsQueryOptionsAtom` reads the first family from inside a
+ * derived atom, where that feedback compounds; today it is safe only because that call site
+ * passes hoisted constants, which is one refactor away from breaking. The payload is an
+ * arbitrary filter object, so compare it the same way the query key already does.
+ */
+const samePayload = (a?: QueryQueryRequest, b?: QueryQueryRequest) =>
+    JSON.stringify(a ?? {}) === JSON.stringify(b ?? {})
+
+/**
  * List queries with optional filters (payload) using atom family
  */
 export const queriesQueryAtomFamily = atomFamily(
@@ -38,6 +49,7 @@ export const queriesQueryAtomFamily = atomFamily(
                 enabled: enabled && !!projectId,
             }
         }),
+    (a, b) => (a?.enabled ?? true) === (b?.enabled ?? true) && samePayload(a?.payload, b?.payload),
 )
 
 /**
@@ -115,10 +127,14 @@ export const unarchiveQueryAtom = atom(
 /**
  * Small selectors
  */
-export const queriesListAtomFamily = atomFamily((payload?: QueryQueryRequest) =>
-    selectAtom(queriesQueryAtomFamily({payload}), (q) => q.data?.queries ?? []),
+export const queriesListAtomFamily = atomFamily(
+    (payload?: QueryQueryRequest) =>
+        selectAtom(queriesQueryAtomFamily({payload}), (q) => q.data?.queries ?? []),
+    samePayload,
 )
 
-export const queriesCountAtomFamily = atomFamily((payload?: QueryQueryRequest) =>
-    selectAtom(queriesQueryAtomFamily({payload}), (q) => q.data?.count ?? 0),
+export const queriesCountAtomFamily = atomFamily(
+    (payload?: QueryQueryRequest) =>
+        selectAtom(queriesQueryAtomFamily({payload}), (q) => q.data?.count ?? 0),
+    samePayload,
 )


### PR DESCRIPTION
## What

Give the two evaluator-reference `atomFamily`s in `web/oss/src/components/References/atoms/entityReferences.ts` an `areEqual` comparator, plus the three payload-keyed families in `web/oss/src/state/queries/atoms/fetcher.ts`.

## Why

`atomFamily` keys its cache by **reference** unless it is given an `areEqual` — the lookup is a plain `Map.get(param)`. Both families are keyed by an object literal that callers rebuild at every call site, so the `Map` never hits and each read mints a brand-new atom and a brand-new fetch.

The neighbouring families in the same file already declare comparators. `workflowArtifactScopedQueryAtomFamily` is read fifteen lines away inside the same function and is safe purely because of it — these two were the outliers, not the design.

`evaluatorReferenceAtomFamily` reads the query family from inside its own read function, so the miss also feeds back: each generation mounts its own query observer, the observer emits, and the emit invalidates the reader that created it.

## What this is not

**This is not the fix for the React error #185 on the `/evaluations` list page.** I opened this investigation on that theory and the measurement disproved it. With the comparator removed, the atom count over 200 ticks is:

```
atoms: 1, 2, 2, 2, 2, 2, 2, 2, 2, 2    notifications: 1
```

It settles at two rather than running away, because this query carries `staleTime: 5 * 60_000` and neither polls nor refetches on focus, so generation two reads settled cached data and emits nothing further. The family that *did* run away in #6196 polled while a run was non-terminal, and that is what compounded. Adding a `refetchInterval` here would turn this into that bug.

So the defect being fixed is a duplicated atom and a duplicated fetch per call site, and a latent loop. Real, worth fixing, not release-blocking.

## Scope note

`queriesQueryAtomFamily` is included because `evaluationRunsQueryOptionsAtom` reads it from inside a derived atom **on this very page**, and is safe today only because that call site happens to pass hoisted module constants — one refactor away from breaking.

## Tests

Two files, both red without the comparators and green with them:

- `evaluatorReferenceFamilyKeys.test.ts` — asserts the rule: an equal-but-not-identical key returns the **same** atom, different keys still separate, and `null` and `undefined` normalise to one entry (`useEvaluatorHeaderReference` passes `undefined`, `ReferenceLabels` passes `null`; without normalising, one evaluator gets two cache entries and two fetches).
- `evaluatorReferenceLoop.test.ts` — drives the real code path in a jotai store and counts the query atoms one subscribed evaluator column creates. Must be exactly one.

Verification run: `pnpm --filter @agenta/oss exec vitest run` — 47 files, 449 passed, 1 skipped.

Also checked live: brought this branch's frontend up against a real EE API with six seeded runs carrying evaluator references and mixed statuses, and the list page renders and resolves evaluator names correctly, with no console errors.
