### PR TITLE
[R4b] fix(frontend): evaluations list update-depth loop with metric columns

### DIFF
--- a/web/oss/src/components/EvaluationRunsTablePOC/atoms/evaluatorOutputTypes.test.ts
+++ b/web/oss/src/components/EvaluationRunsTablePOC/atoms/evaluatorOutputTypes.test.ts
@@ -1,0 +1,124 @@
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+import {
+    createEvaluatorOutputTypesKey,
+    getOutputTypesMap,
+    setOutputTypesMap,
+    subscribeToOutputTypes,
+} from "./evaluatorOutputTypes"
+
+/**
+ * `/evaluations` (the LIST page) died with React error #185, "Maximum update depth exceeded",
+ * as soon as a run carried `data.mappings` that produce evaluator METRIC columns.
+ *
+ * `setOutputTypesMap` notified its listeners unconditionally. Its only caller is the metric
+ * GROUP header, which rebuilds the map from the evaluator's schema on render and passes a NEW
+ * Map with the SAME content every time. `useEvaluationRunsColumns` subscribes here and its
+ * listener calls `setOutputTypesVersion(v => v + 1)`, so the write drove a re-render, the
+ * re-render rebuilt the map, and the rebuild wrote again:
+ *
+ *     write -> notify -> setState -> re-render -> rebuild map -> write -> notify -> ...
+ *
+ * The metric columns are what armed it, because the group header is the only caller — which is
+ * why an empty project never reproduced it.
+ *
+ * These tests pin the property that makes the loop impossible: an equal-content write is not a
+ * change, so it must not notify. A distinct key ensures each test starts from an empty cache,
+ * since the cache is module-level and shared.
+ */
+
+let counter = 0
+const freshKey = () => {
+    counter += 1
+    return createEvaluatorOutputTypesKey(`project-${counter}`, `evaluator-${counter}`)
+}
+
+describe("setOutputTypesMap", () => {
+    let key: string
+
+    beforeEach(() => {
+        key = freshKey()
+    })
+
+    it("does not notify when the same content is written again", () => {
+        const listener = vi.fn()
+        const unsubscribe = subscribeToOutputTypes(key, listener)
+
+        setOutputTypesMap(key, new Map([["score", "number"]]))
+        expect(listener).toHaveBeenCalledTimes(1)
+
+        // What the group header does on every render: a NEW Map, identical content.
+        setOutputTypesMap(key, new Map([["score", "number"]]))
+        setOutputTypesMap(key, new Map([["score", "number"]]))
+
+        expect(listener).toHaveBeenCalledTimes(1)
+        unsubscribe()
+    })
+
+    it("still notifies when a value changes", () => {
+        const listener = vi.fn()
+        const unsubscribe = subscribeToOutputTypes(key, listener)
+
+        setOutputTypesMap(key, new Map([["score", "number"]]))
+        setOutputTypesMap(key, new Map([["score", "string"]]))
+
+        expect(listener).toHaveBeenCalledTimes(2)
+        expect(getOutputTypesMap(key).get("score")).toBe("string")
+        unsubscribe()
+    })
+
+    it("still notifies when a key is added or removed", () => {
+        const listener = vi.fn()
+        const unsubscribe = subscribeToOutputTypes(key, listener)
+
+        setOutputTypesMap(key, new Map([["score", "number"]]))
+        setOutputTypesMap(
+            key,
+            new Map([
+                ["score", "number"],
+                ["verdict", "string"],
+            ]),
+        )
+        setOutputTypesMap(key, new Map([["score", "number"]]))
+
+        expect(listener).toHaveBeenCalledTimes(3)
+        unsubscribe()
+    })
+
+    it("treats a null output type as a value, not as absence", () => {
+        const listener = vi.fn()
+        const unsubscribe = subscribeToOutputTypes(key, listener)
+
+        setOutputTypesMap(key, new Map([["score", null]]))
+        setOutputTypesMap(key, new Map([["score", null]]))
+        expect(listener).toHaveBeenCalledTimes(1)
+
+        // Same size, same key, different value: a real change.
+        setOutputTypesMap(key, new Map([["score", "number"]]))
+        expect(listener).toHaveBeenCalledTimes(2)
+        unsubscribe()
+    })
+
+    it("keeps the stored map readable after a skipped write", () => {
+        setOutputTypesMap(key, new Map([["score", "number"]]))
+        setOutputTypesMap(key, new Map([["score", "number"]]))
+
+        expect(getOutputTypesMap(key).get("score")).toBe("number")
+        expect(getOutputTypesMap(key).size).toBe(1)
+    })
+
+    it("does not let one key's write notify another key's listener", () => {
+        const otherKey = freshKey()
+        const listener = vi.fn()
+        const otherListener = vi.fn()
+        const unsubscribe = subscribeToOutputTypes(key, listener)
+        const unsubscribeOther = subscribeToOutputTypes(otherKey, otherListener)
+
+        setOutputTypesMap(key, new Map([["score", "number"]]))
+
+        expect(listener).toHaveBeenCalledTimes(1)
+        expect(otherListener).not.toHaveBeenCalled()
+        unsubscribe()
+        unsubscribeOther()
+    })
+})

--- a/web/oss/src/components/EvaluationRunsTablePOC/atoms/evaluatorOutputTypes.ts
+++ b/web/oss/src/components/EvaluationRunsTablePOC/atoms/evaluatorOutputTypes.ts
@@ -35,10 +35,40 @@ export const getOutputTypesMap = (key: string): Map<string, string | null> => {
     return outputTypesCache.get(key) ?? new Map()
 }
 
+/** Same keys, same values — a rebuilt map with identical content is not a change. */
+const sameOutputTypes = (
+    a: Map<string, string | null> | undefined,
+    b: Map<string, string | null>,
+): boolean => {
+    if (a === b) return true
+    if (!a || a.size !== b.size) return false
+    for (const [key, value] of a) {
+        if (!b.has(key) || b.get(key) !== value) return false
+    }
+    return true
+}
+
 /**
  * Sets the output types map for a given key and notifies listeners.
+ *
+ * The equality check is load-bearing, not an optimisation. Callers rebuild the map from an
+ * evaluator's schema on render and hand over a NEW Map with the SAME content every time.
+ * `useEvaluationRunsColumns` subscribes here and its listener calls `setOutputTypesVersion`,
+ * so notifying unconditionally meant: write -> notify -> setState -> re-render -> the caller
+ * rebuilds the map and writes again -> notify... React stopped that with "Maximum update depth
+ * exceeded" (error #185) and the `/evaluations` list page died.
+ *
+ * The loop needed evaluator METRIC columns to exist, because the only caller is the metric
+ * group header — which is why it reproduced solely on runs whose `data.mappings` produce
+ * metric columns, and never on an empty project.
  */
 export const setOutputTypesMap = (key: string, map: Map<string, string | null>): void => {
+    if (sameOutputTypes(outputTypesCache.get(key), map)) {
+        // Keep the cached instance: replacing it with an equal one would hand subscribers a
+        // new identity for no reason.
+        return
+    }
+
     outputTypesCache.set(key, map)
     globalVersion += 1
 


### PR DESCRIPTION
## The bug

Opening `/evaluations` threw React error #185, "Maximum update depth exceeded", and the error boundary replaced the page. Hit twice by Mahmoud on staging; also reproduced by QA on staging with a real pipeline run.

It only happened once a run carried `data.mappings` that produce evaluator **metric columns** — which is why an empty project never reproduced it, and why a first round of seeded data (runs with evaluator references but no mappings) came back clean.

## Regression from #6065

The defective write is older than this release: `setOutputTypesMap` and its subscriber both arrived in `abcd1c770c` ("metric display fixes"), which **is** an ancestor of `v0.112.3`. Production renders these pages fine, so the write alone is not sufficient.

What changed in v0.113.0 is the renderer. #6065 (`lane/mobile-extracted-packages`) contains both `cfb8c27974` ("TanStack Table and Virtual drive the table") and `7628e20346` ("make @agenta/ui runtime antd-free, deleting the antd table"); neither is in `v0.112.3`. `toTanstackColumns` builds **anonymous** header component functions, so a rebuilt column list is a new component *type* and React **remounts** the header subtree instead of updating it. Under the old antd table the same rebuild updated in place. That remount re-runs the group header's write, which closes the loop.

**Regression from #6065: the table switched to the TanStack renderer, whose per-rebuild anonymous header components remount header subtrees, turning a pre-existing non-idempotent cache write into a self-sustaining loop.**

## Root cause

`setOutputTypesMap` notified its listeners unconditionally:

```ts
outputTypesCache.set(key, map)
globalVersion += 1
listeners.forEach((listener) => listener())
```

Its only caller is `MetricGroupHeader`, which rebuilds the map from the evaluator's schema on render and hands over a **new `Map` with the same content** every time. `useEvaluationRunsColumns` subscribes to that key and its listener calls `setOutputTypesVersion(v => v + 1)`. So:

```
write -> notify -> setState -> re-render -> rebuild map -> write -> notify -> ...
```

An infinite synchronous loop through a module-level cache — exactly what React reports: a component sets state from an effect whose dependency changes on every render.

**The fix:** compare the map's content and return early — no version bump, no notify — when nothing changed.

## Isolation matrix

Measured on a live repro, each state loaded fresh, same data:

| State | Result |
|---|---|
| neither fix | CRASH (0 rows, 0 headers) |
| the `evaluatorWorkflowQueryAtomFamily` comparator (#6203) ONLY | CRASH (0 rows, 0 headers) |
| this idempotent write ONLY | WORKS (6 rows, metric columns render) |
| both | WORKS |

The idempotent write is necessary **and** sufficient. #6203 stays a separate hardening PR.

## Why every stack trace pointed somewhere else

The reported error always surfaced inside Radix `composeRefs` under `ColumnVisibilityTrigger`:

```
dispatchSetState <- setRef <- Array.map <- setRef <- ... <- safelyDetachRef <- commitDeletionEffectsOnFiber
```

That is where the loop **surfaces**, not where it starts. `docs/design/observability-chrome/evaluations-render-loop.md` and `SimpleTooltip`'s own docstring both name that trigger and mark the bug unresolved. Five hypotheses in the table chrome were eliminated by experiment (horizontal overflow, the trigger's tooltip, `MetricColumnHeader` content, `RunMetricCellContent` content, the `ColumnVisibilityHeader` ref callback) before instrumenting identity changes found it: the hook's inputs were all stable (`rows` 3, everything else 1–2 across 129 renders) while its output churned 69 times, which led through `metricNodes` → `isMetricHidden` → `outputTypesVersion` to this write.

## Independent agreement

Two independent reviews reached the same cycle. Codex (gpt-5.6, read-only, clean checkout) named `MetricGroupHeader` as the cache writer and `toTanstackColumns`'s anonymous header components as the remount mechanism, and proposed essentially this diff. A third static review named the same write, the same listener, and the same conclusion that the Radix anchor ref is only the last update React sees. Codex additionally argued the atom-family comparator is the essential change; the matrix above tests that and shows it is not.

## The "existing data" bump — checked, and deliberately not changed here

`useEvaluationRunsColumns` also does an unconditional bump:

```ts
if (hasExistingData) {
    setOutputTypesVersion((v) => v + 1)   // index.tsx:442
}
```

That is genuinely not idempotent. It is **not** the driver here, because the effect's dependency (`metricGroupsForRendering`) resolves to the memoized `evaluatorMetricGroups` array in this scenario and so is stable in practice (measured: 3 identity changes across 129 renders). Making it idempotent is not a small change in the same spirit — it would need to track what the columns were last built from, which nothing records today. The cheap correct fix is to memoize `metricGroupsForRendering` (that expression at `index.tsx:407` is unmemoized while being an effect dependency). Left out to keep this PR minimal; listed below.

## Verification

Dev build of this branch's exact content against a real EE API, six seeded runs whose mappings produce metric columns, mixed statuses with some non-terminal:

| | Result |
|---|---|
| before | crashed, 0 rows, 0 headers |
| after | 6 rows, and the metric columns render **for the first time** — "Contains JSON", "Exact Match", "Quality Rating", each with Score and Verdict |
| after reload with column-visibility state persisted | still clean, 6 rows, groups intact |

The reload case matters: it is the exact condition the old design doc says was required for the earlier instance of this crash.

## What I ran

- `pnpm --filter @agenta/oss exec vitest run` — 48 files, 455 passed, 1 skipped
- `pnpm --filter @agenta/oss exec tsc --noEmit --incremental false` — clean
- `npx prettier --check` on both touched files — clean
- `pnpm build-oss` — 10 successful, 10 total, exit 0

Six tests on the rule the loop violated; **two are red without the guard** (verified by removing it and re-running).

## Follow-ups, not in this PR

An ownership smell worth fixing properly: the header mutates the state that produced the header. `MetricGroupHeader` resolves evaluator output types *after* mount and writes them into a cache that the column builder reads. The durable fix is to resolve output types **before** constructing columns and keep headers pure renderers; that is a refactor, not a release fix.

Hygiene items found along the way, to file as one issue after the release:

1. `useSmartResizableColumns` returns a fresh `headerComponents` object literal every render.
2. `metricGroupsForRendering` is unmemoized while being an effect dependency (see above).
3. `VirtualTable.tsx:485` spreads `onHeaderCell` resize props onto a native `<th>` — the source of the permanent `minWidth` / `onResizeStart` / `onResizeStop` console warnings.
4. `toTanstackColumns` builds anonymous header components — a remount hazard by construction, and the mechanism behind this regression.