### PR TITLE
[release] fix(sdk): pin anthropic/claude-opus-5 in the curated pi catalog (from #6184)

### DIFF
--- a/.agents/skills/sync-model-catalog/SKILL.md
+++ b/.agents/skills/sync-model-catalog/SKILL.md
@@ -23,7 +23,8 @@ Three JSON data files under `sdks/python/agenta/sdk/agents/data/`, loaded by
 - `pi_models.generated.json` — machine-generated from pi-ai. Objective facts only (name / pricing /
   context_window / modalities), `source: "pi_generated"`. **Never hand-edit.**
 - `pi_models.curated.json` — human overlay for the generated file (id -> `{label?, description?,
-  ratings?}`), merged onto the generated facts at load. Survives regeneration.
+  ratings?}`), merged onto the generated facts at load. Survives regeneration. Its `additions`
+  list holds whole entries for models the pinned pi-ai release predates (see below).
 - `claude_models.curated.json` — hand-curated Claude alias entries (facts + judgments),
   `source: "curated"`.
 
@@ -49,6 +50,18 @@ node .agents/skills/sync-model-catalog/generate_pi_models.mjs "$MODELS" \
 Detect the bump from a lockfile diff on `@earendil-works+pi-ai@<version>`. The `_generator` field
 in the output records the exact pi-ai version. The curated overlay is untouched — only the
 `.generated.json` is rewritten, so the merge on load re-applies the human judgments.
+
+#### Adding a model pi-ai does not carry yet
+
+A model released after the pinned pi-ai snapshot has no generated entry, so it has no catalog entry
+at all: the picker can only show its bare id, and `PROVIDER_DEFAULT_MODELS` drops it (a curated
+default must exist in the catalog or the accepted set). The overlay cannot fix this, because an
+overlay key only decorates an id the generated file already has.
+
+Put the whole entry in the `additions` list of `pi_models.curated.json` instead, with
+`source: "curated"` and every fact sourced from the vendor's own pages. Do not hand-edit the
+generated file. A generated entry of the same id always wins at load, so the addition retires
+itself the moment a regeneration carries the model. Prune superseded additions after job 1.
 
 ### 2. Sync Claude to the live accepted set (needs a running runner)
 

--- a/sdks/python/agenta/sdk/agents/capabilities.py
+++ b/sdks/python/agenta/sdk/agents/capabilities.py
@@ -157,7 +157,10 @@ PROVIDER_DEFAULT_MODELS: Dict[str, List[str]] = {
         "anthropic/claude-sonnet-5",
         "anthropic/claude-haiku-4-5",
     ],
+    # ``gemini-3.6-flash`` postdates the pinned pi-ai catalog, so its facts ride the curated
+    # ``additions`` list in ``data/pi_models.curated.json`` until a regeneration carries it.
     "gemini": [
+        "gemini/gemini-3.6-flash",
         "gemini/gemini-3.5-flash",
         "gemini/gemini-3.1-pro-preview",
     ],

--- a/sdks/python/agenta/sdk/agents/data/pi_models.curated.json
+++ b/sdks/python/agenta/sdk/agents/data/pi_models.curated.json
@@ -2,8 +2,8 @@
   "schema_version": "1",
   "_curation": {
     "target": "pi_models.generated.json",
-    "note": "Human overlay for the generated Pi catalog. Keyed by the entry `id` (the `provider/model` join key). Only `label`, `description`, and `ratings` may appear here; the objective facts (name/pricing/context_window/modalities) always come from the generated file. The SDK loader merges this on top of the generated facts, so a pi-ai regeneration never overwrites these judgments. Ratings: 1-5, higher is better; `cost` is cost-efficiency (5 = cheapest). Sourced from the current lineup (Fable 5 is the Anthropic frontier, above Opus), not a model's memory. Uncurated ids are valid and fall back to `name` in the picker; seed only the models worth a description.",
-    "sources": "@earendil-works/pi-ai@0.80.6; vendor model + pricing pages"
+    "note": "Human overlay for the generated Pi catalog. Keyed by the entry `id` (the `provider/model` join key). Only `label`, `description`, and `ratings` may appear here; the objective facts (name/pricing/context_window/modalities) always come from the generated file. The SDK loader merges this on top of the generated facts, so a pi-ai regeneration never overwrites these judgments. Ratings: 1-5, higher is better; `cost` is cost-efficiency (5 = cheapest). Sourced from the current lineup (Fable 5 is the Anthropic frontier, above Opus), not a model's memory. Uncurated ids are valid and fall back to `name` in the picker; seed only the models worth a description. The separate `additions` list carries WHOLE entries (facts included, `source`: `curated`) for models released after the pinned pi-ai snapshot, which the generated file cannot carry at all. A generated entry of the same id always wins, so an addition retires itself on the next regeneration; drop it then.",
+    "sources": "@earendil-works/pi-ai@0.80.6; vendor model + pricing pages. gemini/gemini-3.6-flash facts from ai.google.dev/gemini-api/docs/pricing and the vendor model page, checked 2026-08-21."
   },
   "overlay": {
     "anthropic/claude-fable-5": {
@@ -34,5 +34,17 @@
       "description": "Google's flagship Gemini 3 Pro, large context and multimodal input.",
       "ratings": {"cost": 4, "intelligence": 4, "speed": 4}
     }
-  }
+  },
+  "additions": [
+    {
+      "id": "gemini/gemini-3.6-flash",
+      "provider": "gemini",
+      "source": "curated",
+      "name": "Gemini 3.6 Flash",
+      "pricing": {"input_per_mtok": 0.75, "output_per_mtok": 3.75, "currency": "USD"},
+      "context_window": 1048576,
+      "modalities": ["text", "image"],
+      "description": "Google's high-efficiency Flash model for everyday agentic and coding work, with a one-million-token context window."
+    }
+  ]
 }

--- a/sdks/python/agenta/sdk/agents/data/pi_models.curated.json
+++ b/sdks/python/agenta/sdk/agents/data/pi_models.curated.json
@@ -3,7 +3,7 @@
   "_curation": {
     "target": "pi_models.generated.json",
     "note": "Human overlay for the generated Pi catalog. Keyed by the entry `id` (the `provider/model` join key). Only `label`, `description`, and `ratings` may appear here; the objective facts (name/pricing/context_window/modalities) always come from the generated file. The SDK loader merges this on top of the generated facts, so a pi-ai regeneration never overwrites these judgments. Ratings: 1-5, higher is better; `cost` is cost-efficiency (5 = cheapest). Sourced from the current lineup (Fable 5 is the Anthropic frontier, above Opus), not a model's memory. Uncurated ids are valid and fall back to `name` in the picker; seed only the models worth a description. The separate `additions` list carries WHOLE entries (facts included, `source`: `curated`) for models released after the pinned pi-ai snapshot, which the generated file cannot carry at all. A generated entry of the same id always wins, so an addition retires itself on the next regeneration; drop it then.",
-    "sources": "@earendil-works/pi-ai@0.80.6; vendor model + pricing pages. gemini/gemini-3.6-flash facts from ai.google.dev/gemini-api/docs/pricing and the vendor model page, checked 2026-08-21."
+    "sources": "@earendil-works/pi-ai@0.80.6; vendor model + pricing pages. gemini/gemini-3.6-flash facts from ai.google.dev/gemini-api/docs/pricing and the vendor model page, checked 2026-08-21. anthropic/claude-opus-5 facts from the Anthropic pricing page, cross-checked against litellm 1.92.0's cost table, checked 2026-08-22."
   },
   "overlay": {
     "anthropic/claude-fable-5": {
@@ -45,6 +45,16 @@
       "context_window": 1048576,
       "modalities": ["text", "image"],
       "description": "Google's high-efficiency Flash model for everyday agentic and coding work, with a one-million-token context window."
+    },
+    {
+      "id": "anthropic/claude-opus-5",
+      "provider": "anthropic",
+      "source": "curated",
+      "name": "Claude Opus 5",
+      "pricing": {"input_per_mtok": 5.0, "output_per_mtok": 25.0, "cache_read_per_mtok": 0.5, "cache_write_per_mtok": 6.25, "currency": "USD"},
+      "context_window": 1000000,
+      "modalities": ["text", "image"],
+      "description": "The current Opus tier: strong reasoning below Fable, at a lower price, with a one-million-token context window."
     }
   ]
 }

--- a/sdks/python/agenta/sdk/agents/model_catalog.py
+++ b/sdks/python/agenta/sdk/agents/model_catalog.py
@@ -15,7 +15,10 @@ code:
 - ``data/pi_models.generated.json`` — machine-generated from ``@earendil-works/pi-ai``. Objective
   facts only; curated fields absent.
 - ``data/pi_models.curated.json`` — human overlay (id -> ``{label?, description?, ratings?}``),
-  merged onto the generated facts at load time so a regeneration never overwrites judgments.
+  merged onto the generated facts at load time so a regeneration never overwrites judgments. Its
+  ``additions`` list carries whole entries for models the pinned pi-ai release predates; a
+  generated entry of the same id always wins, so an addition retires itself on the next
+  regeneration.
 - ``data/claude_models.curated.json`` — hand-curated Claude alias entries (facts + judgments).
 - ``data/codex_models.curated.json``: hand-curated Codex entries (facts + judgments), with the
   same shape as the Claude catalog.
@@ -96,24 +99,39 @@ def _read_json(name: str) -> dict:
 
 
 def load_pi_model_catalog() -> ModelCatalog:
-    """The Pi catalog: generated facts with the human overlay merged on by id.
+    """The Pi catalog: generated facts with the human overlay merged on by id, plus additions.
 
     The overlay only ever supplies ``label`` / ``description`` / ``ratings``; every objective fact
     comes from the generated file. ``pydantic`` validates each entry on construction (including the
     1-5 rating range), so a malformed data file fails loud here.
+
+    ``additions`` carries whole hand-written entries (``source: "curated"``) for models released
+    after the pinned pi-ai snapshot. Without them such a model has no catalog entry at all, so the
+    picker can only show its bare id and ``PROVIDER_DEFAULT_MODELS`` cannot offer it. A generated
+    entry of the same id always wins: the addition is a stopgap that retires itself the moment a
+    regeneration carries the model, rather than shadowing fresher sourced facts.
     """
     generated = _read_json("pi_models.generated.json")
-    overlay = _read_json("pi_models.curated.json").get("overlay", {})
+    curated_file = _read_json("pi_models.curated.json")
+    overlay = curated_file.get("overlay", {})
+    additions = curated_file.get("additions", [])
 
     entries: List[ModelCatalogEntry] = []
+    generated_ids = set()
     for raw in generated.get("models", []):
         merged = dict(raw)
+        generated_ids.add(raw.get("id"))
         curated = overlay.get(raw.get("id"))
         if curated:
             for field in _OVERLAY_FIELDS:
                 if field in curated:
                     merged[field] = curated[field]
         entries.append(ModelCatalogEntry.model_validate(merged))
+
+    for raw in additions:
+        if raw.get("id") in generated_ids:
+            continue
+        entries.append(ModelCatalogEntry.model_validate(raw))
 
     return ModelCatalog(schema_version="1", models=entries)
 

--- a/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
@@ -17,6 +17,7 @@ from agenta.sdk.agents.capabilities import (
     PROVIDER_DEFAULT_MODELS,
     harness_catalog_document,
 )
+from agenta.sdk.agents import model_catalog as model_catalog_module
 from agenta.sdk.agents.model_catalog import (
     ModelCatalogEntry,
     ModelRatings,
@@ -85,7 +86,8 @@ def test_pi_ids_are_unique_and_provider_prefixed():
     for entry in entries:
         # id is the provider/model join key; its prefix is the entry's provider.
         assert entry.id.startswith(f"{entry.provider}/"), entry.id
-        assert entry.source == "pi_generated"
+        # Generated facts, or a hand-written addition for a model the pinned pi-ai predates.
+        assert entry.source in ("pi_generated", "curated"), entry.id
 
 
 def test_pi_overlay_merges_without_overwriting_facts():
@@ -112,6 +114,70 @@ def test_uncurated_pi_entry_is_valid_with_absent_curated_fields():
     assert uncurated, "expected some uncurated Pi entries"
     sample = uncurated[0]
     assert sample.name is not None  # frontend falls back to name
+
+
+def test_gemini_3_6_flash_is_published_with_its_display_name():
+    # The model postdates the pinned pi-ai snapshot, so it reaches the catalog through the curated
+    # `additions` list. Without an entry the picker can only show the bare id, which is the bug
+    # this pins: the Model row must read "Gemini 3.6 Flash".
+    entries = model_catalog_entries("pi_core")
+    entry = next(
+        (item for item in entries if item["id"] == "gemini/gemini-3.6-flash"), None
+    )
+    assert entry is not None, "gemini/gemini-3.6-flash missing from the pi catalog"
+    assert entry["name"] == "Gemini 3.6 Flash"
+    assert entry["provider"] == "gemini"
+    assert entry["source"] == "curated"
+    assert entry["context_window"] == 1048576
+
+
+def test_gemini_3_6_flash_is_offered_as_a_default_model():
+    # A curated default is dropped when the harness cannot select it, so the catalog entry and the
+    # PROVIDER_DEFAULT_MODELS line only work together.
+    assert "gemini/gemini-3.6-flash" in PROVIDER_DEFAULT_MODELS["gemini"]
+    defaults = harness_catalog_document()["pi_core"]["capabilities"]["default_models"]
+    assert "gemini/gemini-3.6-flash" in defaults["gemini"]
+
+
+def test_a_curated_addition_never_shadows_a_generated_entry(monkeypatch):
+    # The addition is a stopgap until a regeneration carries the model. When both files name the
+    # same id the generated facts win, so an addition left behind cannot mask fresher facts.
+    generated = {
+        "models": [
+            {
+                "id": "gemini/overlapping",
+                "provider": "gemini",
+                "source": "pi_generated",
+                "name": "From pi-ai",
+            }
+        ]
+    }
+    curated = {
+        "overlay": {},
+        "additions": [
+            {
+                "id": "gemini/overlapping",
+                "provider": "gemini",
+                "source": "curated",
+                "name": "Hand written",
+            },
+            {
+                "id": "gemini/only-curated",
+                "provider": "gemini",
+                "source": "curated",
+                "name": "Only curated",
+            },
+        ],
+    }
+    monkeypatch.setattr(
+        model_catalog_module,
+        "_read_json",
+        lambda name: generated if "generated" in name else curated,
+    )
+
+    names = {entry.id: entry.name for entry in load_pi_model_catalog().models}
+    assert names["gemini/overlapping"] == "From pi-ai"
+    assert names["gemini/only-curated"] == "Only curated"
 
 
 def test_claude_catalog_covers_exactly_the_accepted_alias_set():

--- a/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
@@ -361,6 +361,6 @@ def test_curated_default_models_exist_in_the_pinned_pi_catalog():
     for provider, models in PROVIDER_DEFAULT_MODELS.items():
         for model_id in models:
             assert model_id in catalog_ids, (provider, model_id)
-    # Pending a catalog refresh: the founder-approved Anthropic list also names Opus 5, which
-    # the pinned pi-ai version does not carry yet (see the note in capabilities.py).
-    assert "anthropic/claude-opus-5" not in catalog_ids
+    # Opus 5 postdates the pinned pi-ai snapshot, so it reaches the catalog through the curated
+    # `additions` list rather than the generated file. The loop above is what proves it arrived.
+    assert "anthropic/claude-opus-5" in catalog_ids


### PR DESCRIPTION
## Why

`release/v0.113.0`'s own CI is red on the SDK unit tests, and has been for every PR based on it:

```
FAILED oss/tests/pytest/unit/agents/connections/test_model_catalog.py::test_curated_default_models_exist_in_the_pinned_pi_catalog
AssertionError: ('anthropic', 'anthropic/claude-opus-5')
```

`PROVIDER_DEFAULT_MODELS` names `anthropic/claude-opus-5`, but Opus 5 postdates the pinned
`@earendil-works/pi-ai@0.80.6` snapshot the generated catalog is built from, so the catalog
has no entry for it. The picker could only show a bare id with no price and no context window.

This is not a defect of any PR on the branch. It needs the catalog data, and the release
build should carry it.

## What

Cherry-picked from #6184, which fixes this on `main`. Two commits, verbatim, no rewrite:

- `feat(sdk): list Gemini 3.6 Flash in the model catalog`
- `feat(sdk): carry Claude Opus 5 facts in the curated additions list`

### A note on scope

The Opus 5 entry alone is **inert on this branch**. It lands in the `additions` list, and
`additions` does not exist on `release/v0.113.0`: `load_pi_model_catalog` reads only
`overlay`, so the loader would ignore the new entry and the test would still fail. The
loader change is required, not optional, which is why the Gemini commit rides along — it is
what introduces `additions`, the entry Opus 5 needs, and the tests that cover the mechanism.

Both commits touch only the SDK catalog and its skill doc. Taking them verbatim also keeps
the eventual `main` -> release merge conflict-free.

## Tests

`cd sdks/python && uv sync --locked && uv run --no-sync pytest oss/tests/pytest/unit`

- The catalog file: **29 passed**.
- The previously failing test: **1 passed**. Removing just the `anthropic/claude-opus-5`
  entry again reproduces the exact CI assertion, so the fix is the entry and not a side
  effect.
- Whole unit suite: **2214 passed, 4 skipped, 16 xfailed**, versus 2210 before.
- `ruff@0.15.12 format --check` and `check` clean on the three touched Python files (0.15.12
  is what CI pins).

One unrelated test, `test_streaming.py::test_cli_stream_terminal_only_on_empty_request`,
fails on this dev box with a `JSONDecodeError`. It fails identically on the clean
`release/v0.113.0` tip with none of these commits applied, and it passes in CI, so it is a
local environment artifact rather than anything from this change.

## After this

#6184 stays open for `main` on its own merits. When it lands there, a `main` -> release
merge sees the same commits and no conflict.
