### PR TITLE
docs(design): runner-owned trace export for agent runs

### DIFF
--- a/docs/design/agent-trace-export/README.md
+++ b/docs/design/agent-trace-export/README.md
@@ -1,0 +1,200 @@
+# Runner-owned trace export for agent runs
+
+Agent runs send OpenTelemetry traces to Agenta. Today two different pieces of code build and
+send those traces, and one of them runs inside the agent sandbox and therefore needs an Agenta
+credential in there. This workspace designs a single path where the runner builds and sends
+every span, and no Agenta credential ever enters a sandbox.
+
+## Reading order
+
+| File | Answers |
+| --- | --- |
+| `README.md` (this file) | What breaks today, what the words mean, what we are and are not trying to fix. |
+| `design.md` | The target architecture, the harness-to-runner span record contract, and why each option won. |
+| `plan.md` | The ordered pull requests, the tests, the rollout, and the risks. |
+| `open-questions.md` | The calls that need the owner. |
+
+## Words used in these files
+
+**Runner.** The `services/runner` Node service. It receives a `/run` request from the Agenta
+API, starts a sandbox, drives the harness, and streams events back. It runs on Agenta
+infrastructure and is trusted.
+
+**Harness.** The coding agent program that actually talks to a model: Pi, Claude Code, or
+Codex. It runs inside the sandbox.
+
+**Sandbox.** The isolated place the harness runs in. Two placements exist. A **local**
+sandbox is a child process on the runner host. A **Daytona** sandbox is a remote container the
+runner reaches over the Daytona API. Sandbox code is untrusted: a prompt injection can make the
+harness read any file or environment variable the sandbox process can reach.
+
+**Pi extension.** A JavaScript bundle the runner installs into Pi's agent directory
+(`services/runner/src/extensions/agenta.ts`). Pi loads it and it subscribes to Pi's in-process
+lifecycle hooks. It runs inside the sandbox.
+
+**ACP event stream.** The Agent Client Protocol notifications (`session/update`) that the
+sandbox-agent daemon sends the runner while a turn runs. Every harness produces them. They
+carry message chunks, tool calls, tool results, and usage.
+
+**Relay directory.** A per-conversation scratch directory both the runner and the in-sandbox
+process can reach, used as a file channel between them
+(`services/runner/src/engines/sandbox_agent/run-plan.ts:644`). The runner reaches it with plain
+filesystem calls on a local sandbox and with Daytona filesystem API calls on a Daytona sandbox.
+The abstraction over that split is `RelayHost` (`services/runner/src/tools/relay.ts:227-261`).
+
+**Span record.** The new thing this design introduces. A single JSON line the harness writes
+describing one finished unit of work (a turn, a model call, a tool call). It carries no trace
+id, no span id, no endpoint, and no credential.
+
+**Run credential.** The short-lived `Secret ...` token the Agenta API mints for the caller and
+the SDK puts on the `/run` request. The runner uses it to call the Agenta API as the caller. It
+expires in 15 minutes (`api/oss/src/middlewares/auth.py`, `_SECRET_EXP`).
+
+## What happens today
+
+Where a span comes from depends on which harness and which sandbox placement a run uses. One
+line decides it, `services/runner/src/engines/sandbox_agent/run-turn.ts:293`:
+
+```ts
+emitSpans: !plan.isPi || plan.isDaytona,
+```
+
+`plan.isPi` is true when the harness is Pi (`run-plan.ts:487`). `plan.isDaytona` is true when
+the sandbox placement is Daytona (`run-plan.ts:488`). The resulting split:
+
+| Harness | Placement | Who builds spans | Who sends them | Credential inside the sandbox |
+| --- | --- | --- | --- | --- |
+| Pi | local | The Pi extension, inside the sandbox | The Pi extension, inside the sandbox | Yes |
+| Pi | Daytona | The runner, from the ACP event stream | The runner | No |
+| Claude Code | local or Daytona | The runner, from the ACP event stream | The runner | No |
+| Codex | local or Daytona | The runner, from the ACP event stream | The runner | No |
+
+The local Pi row is the odd one, and it is also the richest. The extension hooks Pi's
+`before_provider_request` and gets a real `chat <model>` span per model call, with the provider
+name, the request model, the response model, the response id, the finish reason, and per-call
+token and cost numbers (`services/runner/src/tracing/otel.ts:810-843`). It hooks
+`turn_start` and `turn_end` and gets real turn boundaries (`otel.ts:795-874`). The runner's
+ACP-derived tracer builds the same tree shape from `session/update` notifications
+(`otel.ts:1140-1160`), but it only knows what the ACP stream reports, so the model call is
+inferred rather than observed.
+
+### Consequence 1: a credential has to live inside the sandbox
+
+Because the extension sends the spans itself, it needs a bearer token for Agenta's OTLP
+endpoint. The runner writes one into the sandbox. On `main` it writes it once, at environment
+setup, to a mode 0600 file next to the relay directory
+(`services/runner/src/environment/runtime-lifecycle.ts:215`,
+`services/runner/src/engines/sandbox_agent/pi-assets.ts:552-563`). The path, not the value, is
+passed as the environment variable `AGENTA_AGENT_OTLP_AUTH_FILE`
+(`pi-assets.ts:491-496`). The extension reads the file once and deletes it
+(`services/runner/src/extensions/agenta.ts:66-81`).
+
+The file trick exists because putting the bearer in an environment variable would be worse. The
+code says so at `pi-assets.ts:468-473`:
+
+> The OTLP bearer is deliberately NOT placed in `OTEL_EXPORTER_OTLP_HEADERS` (or any other
+> plain env var): that env is inherited by the harness process, so a prompt-injected sandbox
+> could read/echo the caller's reusable Authorization bearer and impersonate the caller.
+
+A 0600 file is better than an environment variable. It is still a reusable Agenta credential
+sitting on a disk the model can be talked into reading.
+
+### Consequence 2: long turns lose their traces
+
+The run credential lives about 15 minutes. A turn can last hours. The extension reads the
+bearer once, at startup, and holds it. `services/runner/src/tracing/otel.ts:769-777` pins the
+export target when the run's root span starts, and the export happens at the end of the turn.
+On a turn longer than the token's life, the token is expired when the export runs and Agenta
+rejects the batch.
+
+The same expiry hits the runner's own export path. `createSandboxAgentOtel` captures the
+credential as a string at turn start (`otel.ts:1204`) and `registerRunTarget` freezes it for the
+whole run (`otel.ts:1138-1148`). So Daytona Pi, Claude, and Codex lose long-turn traces too,
+for the same reason, without any sandbox being involved.
+
+### Consequence 3: sandbox-exported spans skip the runner's redaction
+
+The runner seeds a redactor per run from the request's typed secret values and the mount
+credentials, and applies it to every span attribute right before export
+(`run-turn.ts:283-290`, `otel.ts:172-205`). The in-sandbox extension builds
+`createAgentaOtel` with no `redactor` at all (`extensions/agenta.ts:489-498`). So the one path
+that exports from inside the sandbox is also the one path whose spans are never checked against
+the run's known secret values.
+
+### Consequence 4: two code paths to keep in step
+
+Every span attribute, every tree change, and every content-capture rule has to be written twice,
+once in `createAgentaOtel` (`otel.ts:675-925`) and once in `createSandboxAgentOtel`
+(`otel.ts:1153-1748`). They already differ.
+
+## What pull request 6135 tried, and why it was rejected
+
+Branch `fix/otlp-per-turn-credential`, 5 commits, 27 files. It attacked consequence 2 by
+refreshing the credential rather than by moving the export.
+
+Two mechanisms:
+
+**A per-turn credential refresh into the sandbox.** The runner rewrote the 0600 file at the top
+of every turn with that turn's bearer (`refreshOtlpAuthFile`, `pi-assets.ts:565-583`, called
+from `run-turn.ts:263-271`). The extension re-read it on Pi's `before_agent_start` hook and
+assigned it onto the live export config (`createOtlpAuthRefresher`, `extensions/agenta.ts:84-104`,
+registered at `extensions/agenta.ts:500-511`).
+
+**A second, narrower token.** The API grew a token scope,
+`TRACE_INGEST_SCOPE = "trace-ingest"` (`api/oss/src/middlewares/auth.py:92`), confined to the
+single path `/otlp/v1/traces` by `_SCOPE_ALLOWED_PATHS` (`auth.py:97-99`) and enforced in
+`verify_secret_token` (`auth.py:921-940`). `GET /access/permissions/check` minted one on every
+call and returned it in a new `telemetry_credentials` response field
+(`api/oss/src/apis/fastapi/access/router.py:151-164`, `:27-40`) with a two hour default life
+(`AGENTA_OTLP_TOKEN_TTL_SECONDS`, `api/oss/src/utils/env.py:360-365`). The SDK carried it
+through `TracingContext.telemetry_credentials` and onto the wire as
+`telemetry.exporters.otlp.exportAuthorization` (`sdks/python/agenta/sdk/agents/dtos.py:441`,
+`sdks/python/agenta/sdk/agents/wire_models.py:196-198`). The runner chose between the two
+tokens with `exportAuthorizationOf` (`runtime-policy.ts:31-38`).
+
+The owner rejected it for three reasons.
+
+1. **A turn can run for 12 hours.** Refreshing at the top of a turn does not help a turn that is
+   still running when the token expires. The mechanism fixes the gap between turns, which was
+   never the hard case.
+2. **The refresh is a workaround, not a fix.** It keeps a credential inside the sandbox and adds
+   machinery to keep that credential fresh, on both sides of the boundary, forever.
+3. **The split ownership is the actual defect.** Two span builders, two export paths, and one
+   sandbox that needs a token exist only because local Pi exports its own spans. Fix that and
+   the credential problem disappears instead of getting managed.
+
+Two changes on that branch are worth keeping and are independent of the rest: an `iat` claim on
+every Secret token (`auth.py:1044`) and an `except HTTPException: raise` guard that stops a 401
+from being turned into a 500 (`auth.py:973-976`). `plan.md` lands those separately.
+
+## Goals
+
+1. The runner creates and exports every span for every agent run. One code path.
+2. Pi keeps owning span semantics. The runner does not go back to guessing the model call from
+   the ACP stream. Where Pi knows the provider request boundary, the model, the tokens, and the
+   tool arguments, that knowledge reaches the trace.
+3. No Agenta credential of any kind enters a sandbox, on any placement, at any time.
+4. A turn that runs for hours exports its trace with no credential ritual anywhere, and with no
+   work inside the sandbox.
+5. Local and Daytona use the same design and the same code. Placement changes the transport
+   call, not the architecture.
+6. The mechanism is reusable. When Claude Code or Codex gain a hook that reports something the
+   ACP stream does not carry, the same channel accepts it with no new plumbing.
+7. Every exported span passes the runner's redactor.
+
+## Non-goals
+
+1. **Changing the trace schema Agenta ingests.** Span names, `openinference.span.kind` values,
+   and `gen_ai.*` attributes stay exactly as they are today. A trace produced after this change
+   must look like a trace produced before it, on the local Pi path, plus the parts Daytona Pi
+   was missing.
+2. **Renaming `telemetry.exporters.otlp.headers.authorization`.** The run credential rides the
+   telemetry block on the `/run` wire, which is poor layering (`runtime-policy.ts:10-17`). That
+   is a separate contract migration touching four files and two contract tests, and it does not
+   help this problem. `open-questions.md` records it.
+3. **Changing how the Agenta API ingests spans.** `POST /otlp/v1/traces` is unchanged.
+4. **Live streaming of spans during a turn.** Spans still reach Agenta in one batch when the
+   turn ends, as they do today on every runner-exported path.
+5. **Touching the legacy SDK Daytona runner** (`sdks/python/agenta/sdk/engines/running/runners/daytona.py`),
+   which injects `AGENTA_CREDENTIALS` into a sandbox on a different code path. Goal 3 is scoped
+   to the runner-driven sandbox path. `open-questions.md` records the overlap.

--- a/docs/design/agent-trace-export/design.md
+++ b/docs/design/agent-trace-export/design.md
@@ -1,0 +1,483 @@
+# Design: the runner builds and sends every span
+
+## The target in one paragraph
+
+The Pi extension stops building OpenTelemetry spans and stops sending them. It keeps every hook
+it has today, and on each hook it appends one JSON line to a file in the relay directory
+describing what just finished: a turn, a model call, or a tool call. The runner drains that file
+while the turn runs, turns each line into a real span under the run's root span, and exports the
+whole tree in one batch when the turn ends, using a credential that lives only in the runner and
+that the runner refreshes for as long as the turn lasts. Harnesses that produce no records keep
+getting their spans built from the ACP event stream, exactly as today. Nothing changes in the
+Agenta API.
+
+```
+ sandbox (untrusted)                        runner (trusted)                    Agenta API
+ ------------------                         ----------------                    ----------
+ Pi                                         run-turn.ts
+  |  before_provider_request                 |
+  |  turn_start / turn_end        RelayHost  |  span-records.ts (drain)
+  |  tool_execution_start/end      read      |    |
+  v                              ---------->  |    v
+ agenta extension                            |  otel.ts createSandboxAgentOtel
+  |  append JSON line                        |    applySpanRecord -> real spans
+  v                                          |    root invoke_agent (runner-owned)
+ <relayDir>/.agenta-spans.jsonl              |    redactor applied at the sink
+                                             |    credential resolved at export time
+                                             |         |
+                                             |         v  one OTLP batch at turn end
+                                             |    ------------------------------->  /otlp/v1/traces
+```
+
+## Who owns what
+
+| Layer | Owns | Does not own |
+| --- | --- | --- |
+| Harness extension (in sandbox) | Observing the run. Knowing when a model call starts and ends, which model and provider served it, how many tokens it used, which tools ran with which arguments and results. Writing one span record per finished unit. | Trace ids, span ids, span names, span kinds, attribute keys, the OTLP endpoint, any credential, batching, retries, redaction. |
+| Relay channel | Moving bytes from the sandbox to the runner on both placements. Nothing else. | Any understanding of what the bytes mean. |
+| Runner tracing module | Creating the root span from the caller's trace context. Turning records into spans: names, kinds, attribute keys, parent links, timestamps. Enforcing content capture and size budgets. Redaction. Holding and refreshing the export credential. Batching and flushing. Retry and failure reporting. | Deciding when a model call happened. That is the harness's knowledge. |
+| Agenta API | Ingesting the OTLP batch at `POST /otlp/v1/traces`. | Anything new. This layer does not change. |
+
+The line that matters: **the harness reports facts, the runner decides span shape.** A harness
+that learns to report a new fact needs no runner change beyond a mapping. A change to span
+naming or attribute keys needs no sandbox change at all.
+
+## The span record contract
+
+One JSON object per line, appended to a file. Records are written when a unit **finishes**, so a
+record always carries both timestamps and is never amended.
+
+```jsonl
+{"v":1,"id":"t0","parent":null,"type":"turn","startedAtMs":1755870000123,"endedAtMs":1755870004567,"attributes":{"index":0}}
+{"v":1,"id":"c1","parent":"t0","type":"chat","startedAtMs":1755870000200,"endedAtMs":1755870002100,"attributes":{"provider":"openai","requestModel":"gpt-5.6-luna","responseModel":"gpt-5.6-luna","responseId":"resp_x","finishReason":"tool_use","usage":{"input":1200,"output":88,"total":1288,"cacheRead":1024,"cacheWrite":0,"cost":0.0031},"inputMessages":[],"outputMessages":[]}}
+{"v":1,"id":"k1","parent":"t0","type":"tool","startedAtMs":1755870002200,"endedAtMs":1755870004500,"attributes":{"name":"bash","callId":"call_abc","input":{"command":"ls"},"output":"README.md\n","isError":false}}
+```
+
+### Envelope fields
+
+Each field is classified by what it is, not by the feature it serves.
+
+| Field | Type | Role | Meaning |
+| --- | --- | --- | --- |
+| `v` | integer | protocol context | Contract version. Currently `1`. The runner drops a record whose `v` it does not know and counts the drop. |
+| `id` | string, 1 to 64 chars | protocol context | Correlation id, unique within one turn, minted by the harness. Never a span id. |
+| `parent` | string or `null` | protocol context | The `id` of the enclosing record, or `null` meaning "a direct child of the run root". |
+| `type` | `"turn"`, `"chat"`, `"tool"` | protocol context | Discriminator. A closed set. Adding one is a contract change. |
+| `startedAtMs` | number | data | Unix epoch milliseconds when the unit started. |
+| `endedAtMs` | number | data | Unix epoch milliseconds when it finished. |
+| `error` | string, optional | data | Present when the unit failed. Sets the span status to error with this message. |
+| `attributes` | object | data | Per-type facts. Table below. |
+
+There is no field for an endpoint, a header, a token, a project, or a trace id. That absence is
+the design: **the record contract carries no credentials, no routing, and no policy**, so a
+sandbox that can write records gains nothing it could spend anywhere else.
+
+### Per-type attributes
+
+| `type` | Attribute | Meaning |
+| --- | --- | --- |
+| `turn` | `index` | The turn number within the run. Optional. |
+| `chat` | `provider` | Provider that served the call, for example `openai`. |
+| | `requestModel` | Model the harness asked for. |
+| | `responseModel` | Model that answered, when it differs. |
+| | `responseId` | Provider response id. |
+| | `finishReason` | Why the call stopped. |
+| | `usage` | `{input, output, total, cacheRead, cacheWrite, cost}`. Any member may be absent. |
+| | `inputMessages` | The message array handed to the model. Content-gated. |
+| | `outputMessages` | The assistant message the model returned. Content-gated. |
+| `tool` | `name` | Tool name. |
+| | `callId` | The harness's tool call id, so the span can be correlated with the ACP `tool_call` event. |
+| | `input` | Tool arguments. Content-gated. |
+| | `output` | Tool result text. Content-gated. |
+| | `isError` | Whether the tool failed. |
+
+"Content-gated" means the harness omits the field when
+`AGENTA_AGENT_CONTENT_CAPTURE_ENABLED` is `false`, and the runner drops it if it arrives anyway.
+Both sides enforce it, because only the runner side is trustworthy.
+
+### How the runner turns a record into a span
+
+The mapping reproduces exactly what `createAgentaOtel` builds today, so a trace after the change
+looks like a trace before it.
+
+| Record | Span name | `openinference.span.kind` | Attributes set by the runner |
+| --- | --- | --- | --- |
+| `turn`, `index` present | `turn <index>` | `CHAIN` | `pi.turn.index` |
+| `turn`, no index | `turn` | `CHAIN` | none |
+| `chat`, `requestModel` present | `chat <requestModel>` | `LLM` | `gen_ai.operation.name=chat`, `gen_ai.system`, `gen_ai.request.model`, `gen_ai.response.model`, `gen_ai.response.id`, `gen_ai.response.finish_reasons`, the full `gen_ai.usage.*` set built by the existing helper at `services/runner/src/tracing/otel.ts:640-666`, `llm.input_messages`, `llm.output_messages` |
+| `chat`, no model | `chat` | `LLM` | same, minus the model keys |
+| `tool` | `execute_tool <name>` | `TOOL` | `gen_ai.operation.name=execute_tool`, `gen_ai.tool.name`, `gen_ai.tool.call.id`, `input.value`, `output.value` |
+
+The root span stays runner-owned and is unchanged: `invoke_agent`, kind `AGENT`,
+`gen_ai.agent.name`, `session.id`, `gen_ai.conversation.id`, `ag.meta.skills.loaded`, the run
+usage totals, and the prompt. The runner already builds it in `createSandboxAgentOtel.start`
+(`otel.ts:1387-1393`), and it already knows every one of those values without asking the
+sandbox.
+
+Timestamps come from the record, not from the clock. OpenTelemetry for JavaScript accepts an
+explicit `startTime` in `SpanOptions` and an explicit `endTime` in `span.end(endTime)`, so the
+runner materializes a finished span with the harness's own times whenever the record arrives.
+This is what makes lazy draining correct: a record read a minute after the event still produces
+a span with the right duration.
+
+### Skew between the two clocks
+
+The harness clock and the runner clock are the same clock on a local sandbox and different
+clocks on Daytona. The record times are used verbatim, so a Daytona sandbox with a skewed clock
+produces child spans whose times sit outside the runner-owned root. The runner clamps each
+record's `startedAtMs` and `endedAtMs` into the root span's own interval before creating the
+span, and stamps `ag.meta.trace.clock_clamped=true` on the root when it had to clamp. That keeps
+the tree renderable and makes the skew visible rather than silent.
+
+## The transport
+
+**Path.** `<relayDir>/.agenta-spans.jsonl`, a sibling of the existing usage file
+(`run-plan.ts:721`). The runner passes only the path, in a new environment variable
+`AGENTA_AGENT_SPAN_RECORD_PATH`, set in `buildPiExtensionEnv`
+(`pi-assets.ts:476-544`) beside the existing `AGENTA_AGENT_USAGE_CAPTURE_PATH`.
+
+**Why inside the relay directory.** The relay directory is deliberately kept off the object
+store mount because a mount write can fail with `ENOTCONN` (`run-plan.ts:644`, `:721`). It is
+reachable from both sides on both placements. The relay sweep only removes files whose names
+match the request and response suffixes (`isRelayFileName`, `services/runner/src/tools/relay.ts:494-504`),
+and the comment there already accounts for non-relay files living in the directory, so a
+dot-prefixed `.jsonl` is safe from the sweep with no code change.
+
+**Writing.** The harness appends one complete line per record with a single `appendFileSync`
+call. Appends of a small buffer to a regular file are atomic with respect to the file offset, so
+concurrent hooks cannot interleave halves of two records.
+
+**Reading.** The runner keeps a byte offset per turn. On each drain it reads the file through
+`RelayHost.read` (`relay.ts:227-261`), takes the bytes after the offset, consumes only up to the
+last newline, parses each complete line, and advances the offset to that newline. A partial tail
+line is left for the next drain. This is the only handling partial writes need.
+
+**Per-turn lifecycle.** The relay directory is created once per environment
+(`prepareWorkspace`, `services/runner/src/engines/sandbox_agent/workspace.ts:50`), and a warm
+session reuses it across turns. So the runner removes the record file and resets its offset to
+zero when it dispatches a turn, at the same point in `run-turn.ts` that writes per-turn sandbox
+state today (`run-turn.ts:263-271`, which this design deletes and replaces). The runner owns turn
+boundaries, so the runner owns the reset. One `RelayHost.remove` call per turn, which on Daytona
+is one daemon call, negligible next to the per-turn work already done.
+
+**Drain cadence.** Every 2 seconds while a turn is running, and once more after the prompt
+resolves and before the flush, at the same point `readRunUsage` is called today
+(`run-turn.ts:1149-1156`). Draining during the turn is not for latency, since nothing is exported
+until the end. It is so a turn that dies, or a sandbox that is destroyed, still yields the spans
+that had already been recorded.
+
+## Trace identity and parent and child
+
+The runner creates the root. `createSandboxAgentOtel.start` parses the caller's `traceparent`
+from `request.context.propagation.traceparent` and starts `invoke_agent` as a child of that
+remote span, so the run joins the caller's `/invoke` trace (`otel.ts:1387-1393`, mirroring the
+extension's own logic at `otel.ts:755-788`).
+
+Records are attached under it by resolving `parent`:
+
+- `parent: null` means a direct child of `invoke_agent`.
+- `parent: "<id>"` means a child of the span the runner already created for that `id`.
+- An unknown `parent` means the record arrived before its parent's record. The runner holds it
+  in a small pending map keyed by parent id and materializes it when the parent lands. In
+  practice this never happens, because a record is written when its unit finishes and a child
+  finishes before its parent. At the end of the drain, anything still pending is attached
+  directly to `invoke_agent` and counted.
+
+**The sandbox never sees a trace id or a span id.** The runner no longer sets `TRACEPARENT` or
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` in the sandbox environment (`pi-assets.ts:488-492`), so a
+forged record cannot name another trace, and an in-sandbox process cannot learn the caller's
+trace identity from its own environment.
+
+## The export credential
+
+This is the part that fixes long turns, and it is the smallest change in the design.
+
+Today the credential is captured as a string at turn start and frozen for the run. The string is
+read into `createSandboxAgentOtel` at `otel.ts:1204` and pinned onto the trace by
+`registerRunTarget` (`otel.ts:1138-1148`). The token lives 15 minutes
+(`_SECRET_EXP` in `api/oss/src/middlewares/auth.py`). The export happens at turn end. A turn
+longer than 15 minutes exports with a dead token.
+
+The runner already holds a live one. The alive watchdog refreshes the run credential every Nth
+heartbeat by calling `GET /access/permissions/check`, which always re-mints, and it exposes the
+current value through a getter, `credential: () => string`
+(`services/runner/src/sessions/alive.ts:193`, `:249`, refresh at `:226-232`, mechanism at
+`services/runner/src/sessions/auth.ts:18-35`). The records emitter and the heartbeat already use
+that getter rather than a snapshot.
+
+The change: `ExportTarget.authorization` becomes a function instead of a string.
+
+```ts
+interface ExportTarget {
+  endpoint: string;
+  /** Resolved at export time, never at run start: a turn can outlive the token. */
+  authorization?: () => string | undefined;
+}
+```
+
+`run-turn.ts` passes the watchdog's `credential` getter where it passes a string today. Runs with
+no watchdog, meaning one-shot runs outside a session, pass a closure over
+`runCredential(request)`, which is exactly today's behavior for those runs.
+
+`TraceBatchProcessor.flush` calls the function once, when it is about to export
+(`otel.ts:320-360`). Both existing consumers of the value keep working: the "skip a
+credential-less export to Agenta's own ingest" rule (`otel.ts:340-347`) and the export
+diagnostics.
+
+The exporter cache needs one adjustment. `OTLPTraceExporter` bakes its headers at construction,
+so a cache keyed by endpoint and credential together
+(`targetKey`, `otel.ts:207-212`) grows without bound once the credential rotates. Key it by
+endpoint alone and hold the credential it was built with; rebuild the entry when the resolved
+credential differs. An evicted exporter is left to finish any in-flight export and is not shut
+down eagerly, so a rotation cannot cancel a request already on the wire.
+
+Two properties follow, and they are the reason no ritual is needed anywhere:
+
+1. **A 12 hour turn exports with a credential minted minutes earlier**, because the watchdog has
+   been re-minting the whole time and the export reads the current value.
+2. **Nothing inside the sandbox is involved.** There is no file to refresh, no hook to fire, no
+   token to scope, and no TTL to tune.
+
+### Relationship to the write-only secret grant
+
+The run credential can carry the `secret-resolve` grant, which lets the platform runtime read
+write-only vault values in plaintext (`api/oss/src/middlewares/auth.py`, `SECRET_RESOLVE_GRANT`;
+enforcement in `api/oss/src/apis/fastapi/vault/router.py`). That grant travels forward across
+every credential refresh (`api/oss/src/apis/fastapi/access/router.py`, `_run_credential_grants`),
+so a leaked grant-bearing token is not bounded by its 15 minute life. Anything that can hold it
+can renew it.
+
+Under this design the runner is the only holder. The runner is trusted, runs outside every
+sandbox, and already uses that credential for session claims, mount signing, the turns ledger,
+and record ingest. Nothing new is exposed.
+
+Under `main`, and under the rejected pull request 6135, that is not true. On `main` the 0600
+`.otlp-auth` file inside a local Pi sandbox holds the general run credential, grant and all. Pull
+request 6135 narrowed the sandbox copy to a path-confined trace-ingest token, which was a real
+improvement, but it still put a credential in there. This design removes the file entirely, so
+the grant question stops existing on the runner-driven sandbox path.
+
+## Batching, flush, and failure
+
+Unchanged from today, and that is deliberate. `TraceBatchProcessor` buffers a trace's spans and
+exports them in one OTLP batch, because Agenta computes rolled-up token and cost metrics per
+ingest batch and a split trace loses the root aggregation (`otel.ts:288-296`).
+
+Order of operations at the end of a turn, in `run-turn.ts`:
+
+1. Stop the tool relay (already there, `run-turn.ts:1147`).
+2. Final drain of the record file, and materialize everything left.
+3. Read the run usage file and set it on the run (already there, `run-turn.ts:1149-1156`).
+4. `finish()` closes any span still open, then `await flush()`.
+
+Failure handling:
+
+- **A record fails to parse.** Skip the line, count it, continue. One bad line never costs the
+  rest of the tree.
+- **A record is unknown, oversized, or has an unknown version.** Same: skip and count.
+- **The drain read fails.** Best effort, same as `readRunUsage` today
+  (`services/runner/src/engines/sandbox_agent/usage.ts:6-26`). The runner keeps the offset and
+  retries on the next drain.
+- **Zero records arrived for a turn that produced tool calls.** Not an error and not a fallback
+  trigger, because the runner uploads the extension bundle into the sandbox on every run
+  (`pi-assets.ts:668-690` for Daytona, `:590-608` for local) so version skew cannot happen. The
+  runner logs a diagnostic through the existing export diagnostics path
+  (`services/runner/src/tracing/export-diagnostics.ts`) and stamps a counter on the root, so the
+  condition is visible rather than silent.
+- **The export fails or is rejected.** Unchanged. `logExportProblem` reports it and the run does
+  not fail (`otel.ts:340-372`).
+
+The counters the runner stamps on the root span, all under `ag.meta.trace.*`: `records.applied`,
+`records.dropped`, `records.orphaned`, `records.truncated`, `clock_clamped`. They cost one
+attribute each and they are the difference between "the trace looks thin" and "the trace looks
+thin and here is why".
+
+## Budgets
+
+Two, both enforced by the runner and both configurable through the runner's numeric env helper
+(`services/runner/src/env.ts`), which clamps a bad override rather than trusting it.
+
+| Name | Default | What it bounds |
+| --- | --- | --- |
+| `AGENTA_RUNNER_SPAN_RECORD_MAX_BYTES` | 262144 | One record. A larger line has its content-bearing attributes truncated, and `records.truncated` counts it. |
+| `AGENTA_RUNNER_SPAN_RECORD_MAX_PER_TURN` | 5000 | Records materialized in one turn. Beyond it, records are counted in `records.dropped` and not materialized. |
+
+The per-turn cap exists because a long turn buffers its whole tree in memory until the flush.
+That is already true today on every runner-exported path, so the cap is a new bound on an old
+behavior rather than a new constraint. The message array on a `chat` record is the large item,
+and it repeats the whole context on every model call, exactly as the trace does today.
+
+## Local and Daytona are the same
+
+| Step | Local sandbox | Daytona sandbox |
+| --- | --- | --- |
+| Install the extension | `copyFileSync` into the run's agent dir (`pi-assets.ts:590-608`) | `sandbox.writeFsFile` into the sandbox's Pi dir (`pi-assets.ts:668-690`) |
+| Pass the record path | `AGENTA_AGENT_SPAN_RECORD_PATH` in the daemon env | same variable in the Daytona `envVars` |
+| Harness writes records | `appendFileSync` | `appendFileSync` |
+| Runner resets the file | `localRelayHost().remove` (`relay.ts:264-292`) | `sandboxRelayHost().remove`, a `deleteFsEntry` daemon call (`relay.ts:294-351`) |
+| Runner drains | `localRelayHost().read` | `sandboxRelayHost().read`, a `readFsFile` daemon call |
+| Runner materializes, redacts, exports | identical | identical |
+
+Everything above the `RelayHost` line is one code path with no placement branch. The only
+placement-aware code is the `RelayHost` implementation that already exists and that the tool
+relay already uses on both.
+
+A consequence worth stating: **Daytona Pi traces get richer.** Today a Daytona Pi run is traced
+from the ACP stream only, so its model call span is inferred. After this change it carries the
+same observed provider, model, tokens, and cost that a local Pi run carries. The two placements
+stop producing different traces for the same run.
+
+## What the sandbox holds afterwards
+
+| Thing | On `main` | On pull request 6135 | After this design |
+| --- | --- | --- | --- |
+| Agenta bearer token in a sandbox file | Yes, the general run credential, written once | Yes, a trace-ingest scoped token, rewritten every turn | No file at all |
+| `AGENTA_AGENT_OTLP_AUTH_FILE` in sandbox env | Yes | Yes | Removed |
+| `TRACEPARENT` in sandbox env | Yes on local Pi | Yes on local Pi | Removed |
+| `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` in sandbox env | Yes on local Pi | Yes on local Pi | Removed |
+| OpenTelemetry SDK and OTLP exporter in the sandbox bundle | Yes | Yes | Removed |
+| Network path from sandbox to Agenta's ingest | Used on local Pi | Used on local Pi | Never used |
+
+On the runner-driven sandbox path, the number of Agenta credentials that cross the sandbox
+boundary becomes zero.
+
+## Trust: what a malicious sandbox can do with records
+
+The relay directory is writable by the sandbox by design, and the code already reasons about a
+process forging files in it (`services/runner/src/tools/relay-guard.ts:3-8`, on forged tool
+execution records). So assume a prompt-injected agent writes arbitrary span records.
+
+What it can do: put wrong or noisy spans into **its own run's trace**, in the caller's own
+project.
+
+What it cannot do, and why:
+
+| Attack | Blocked by |
+| --- | --- |
+| Send spans to another project or another trace | The record carries no trace id and no endpoint. The runner picks both from the request. |
+| Become the root span, or re-parent the tree | The runner creates the root itself and the record contract has no way to name it. `parent: null` means "under my root", never "replace my root". |
+| Obtain a credential | There is none to obtain. |
+| Exfiltrate through span content | The runner applies the run's redactor to every attribute at the export sink (`otel.ts:172-205`), which the current in-sandbox export path skips entirely. This design makes that path strictly better than today, not worse. |
+| Exhaust runner memory or the OTLP endpoint | The per-record and per-turn budgets above. |
+| Inject unknown attribute keys | The runner sets attribute keys itself from the record's typed fields. An unknown attribute in the record is not copied through. |
+
+Compared to today, the sandbox trades the ability to hold a reusable Agenta bearer token for the
+ability to write noise into a trace it already fully controls the content of. That is a clear
+improvement.
+
+## Decisions and the options behind them
+
+### Decision 1: the harness sends structured records over the relay channel
+
+| Option | Trade-off | Verdict |
+| --- | --- | --- |
+| **Structured span records over a file in the relay directory** | Reuses `RelayHost`, which already works on both placements. The runner sees typed data, so it can redact, cap, rename, and re-key without a sandbox change. Costs a new record contract and a new file. | **Chosen.** |
+| A local OTLP collector inside the runner, with the extension exporting to it | Almost no new contract. But there is no network path from a Daytona sandbox back to the runner, which is precisely why Daytona already traces from the ACP stream (`extensions/agenta.ts:481-486`). It would need a tunnel and would give local and Daytona different architectures. | Rejected. Fails the one-path goal. |
+| The extension writes serialized OTLP bytes and the runner forwards them | Smallest runner change. But the runner's redactor works on span attributes right before export (`otel.ts:172-205`), and opaque protobuf would bypass it. The sandbox would also own trace and span ids, which is the identity the record contract deliberately withholds. | Rejected. Bypasses redaction and hands identity to untrusted code. |
+| A new ACP event type carrying span data | Conceptually the cleanest single channel. But the ACP vocabulary is fixed by the sandbox-agent adapters, not by us, so it needs an upstream change and a new adapter release before anything ships. | Rejected. Wrong dependency for the timeline. |
+| Reuse the relay request and response protocol | Already has a poll loop and a sweep. But it is request and response with a runner-side authorization guard, built for tool execution. Span records are one way and fire and forget. | Rejected as a protocol. **The `RelayHost` transport under it is reused.** |
+
+### Decision 2: keep Pi's hooks rather than deriving everything from the ACP stream
+
+| Option | Trade-off | Verdict |
+| --- | --- | --- |
+| **Keep the hooks, change only their sink** | The trace keeps the provider request boundary, the real turn boundaries, the response model, the finish reason, and the per-call token and cost numbers. The extension shrinks, because the OpenTelemetry SDK leaves the bundle. | **Chosen.** |
+| Delete the extension's tracing and derive spans from the ACP stream | The simplest possible change: one span builder, one path, nothing new to write. But `chat <model>` becomes inferred, per-call usage is lost where the ACP stream does not report it, and the local Pi trace gets worse than it is today. | Rejected. Loses the richness the design is meant to preserve. |
+| Keep both, and reconcile them at the runner | Would give a safety net when records go missing. But reconciling two span sources for the same turn means deduplication rules nobody can verify by reading, and double counted tokens whenever the rules are wrong. | Rejected. Complexity with no failure mode it actually protects against, since the extension bundle ships with the runner on every run. |
+
+### Decision 3: records describe finished units, not started ones
+
+| Option | Trade-off | Verdict |
+| --- | --- | --- |
+| **One record per finished unit, carrying both timestamps** | A record is written once and never amended. The reader has no state machine. A crash loses only the units that had not finished. OpenTelemetry accepts explicit start and end times, so a late record still produces a correct span. | **Chosen.** |
+| A start record and an end record per unit | Would let the runner see work in flight. But nothing is exported until the turn ends anyway, so in-flight visibility buys nothing, and it doubles the record count and adds pairing logic and orphan handling. | Rejected. Cost with no benefit at this batching model. |
+
+### Decision 4: the export credential is resolved at export time from the runner's watchdog
+
+| Option | Trade-off | Verdict |
+| --- | --- | --- |
+| **A getter on the export target, backed by `AliveWatchdog.credential()`** | Fixes long turns for every placement, including the ones that never involved a sandbox. Uses a refresh loop that already exists and is already trusted for the turns ledger. About twenty lines. | **Chosen.** |
+| A longer-lived token scoped to the ingest path | This is what pull request 6135 built. It moves the ceiling from 15 minutes to 2 hours and adds a token type, a scope enforcement path, a response field, three SDK fields, and a wire field. A 12 hour turn still fails. | Rejected. New permanent surface that does not solve the stated case. |
+| The runner refreshes the token itself just before export | Would work, but it adds a network call on the export path, which then has its own failure mode at the worst moment. The watchdog already keeps the value fresh in the background. | Rejected. Same result, worse failure timing. |
+
+### Decision 5: the runner owns the record file's per-turn reset
+
+| Option | Trade-off | Verdict |
+| --- | --- | --- |
+| **The runner removes the file and resets its offset when it dispatches a turn** | One owner for the turn boundary, and it is the trusted side. Bounds sandbox disk. Each turn's records are self contained. Costs one `RelayHost.remove` per turn. | **Chosen.** |
+| The harness truncates on its first write of a turn | Mirrors how the usage file is overwritten today. But it puts the boundary in untrusted code, and a harness that gets it wrong silently mixes two turns' spans. | Rejected. |
+| Never reset, and carry a read offset across the whole session | No per-turn call at all. But the file grows for the life of a warm session, and a lost offset silently replays every earlier turn's spans. | Rejected. |
+
+## What gets deleted
+
+### From pull request 6135, all of it
+
+**Runner.** `refreshOtlpAuthFile` (`pi-assets.ts:565-583`), `exportAuthorizationOf`
+(`runtime-policy.ts:31-38`), `createOtlpAuthRefresher` (`extensions/agenta.ts:84-104`), the
+`before_agent_start` bearer hook (`extensions/agenta.ts:500-511`), the per-turn refresh call
+(`run-turn.ts:263-271`), the refresh call in `environment/runtime-lifecycle.ts:215-219`, and
+`OtlpExporter.exportAuthorization` (`services/runner/src/protocol.ts:102`).
+
+**API.** `TRACE_INGEST_SCOPE` and `_SCOPE_ALLOWED_PATHS`
+(`api/oss/src/middlewares/auth.py:92`, `:97-99`), the scope enforcement block in
+`verify_secret_token` (`auth.py:921-940`), the `scope` and `expires_in` parameters on
+`sign_secret_token` (`auth.py:1014-1015`), `Allow.telemetry_credentials`
+(`api/oss/src/apis/fastapi/access/router.py:27-40`), the mint block (`router.py:151-164`), and
+`OTLPConfig.token_ttl_seconds` with `AGENTA_OTLP_TOKEN_TTL_SECONDS`
+(`api/oss/src/utils/env.py:360-365`).
+
+**SDK.** `TraceContext.export_authorization` (`sdks/python/agenta/sdk/agents/dtos.py:441`) and
+its wire emission (`dtos.py:465-471`), `WireOtlpExporter.export_authorization`
+(`sdks/python/agenta/sdk/agents/wire_models.py:196-198`),
+`TracingContext.telemetry_credentials` (`sdks/python/agenta/sdk/contexts/tracing.py:16`), the
+`telemetry_credentials` keyword on the four `running.py` entry points, the two reads in
+`decorators/routing.py:631,659`, and the tuple return from `get_credentials`
+(`sdks/python/agenta/sdk/middlewares/routing/auth.py:77`) together with the dict-shaped cache
+value.
+
+**Tests.** `services/runner/tests/unit/otlp-auth-per-turn.test.ts`,
+`sdks/python/oss/tests/pytest/unit/test_auth_middleware_credentials.py`, the scope cases added
+to `api/oss/tests/pytest/unit/middlewares/test_auth_secret_token.py`, the `exportAuthorization`
+lines in `services/runner/tests/unit/wire-contract.test.ts` and the Python wire contract test,
+the golden entry in `sdks/python/oss/tests/pytest/unit/agents/golden/run_request.pi_core.json`,
+the masking case in `test_dtos_secret_repr.py`, and the fixture change in
+`services/oss/tests/pytest/unit/agent/test_subscription_status.py`.
+
+### From pull request 6135, kept
+
+The `iat` claim on every Secret token (`auth.py:1044`) and the `except HTTPException: raise`
+guard that stops a 401 becoming a 500 (`auth.py:973-976`). Both are independent of the credential
+split. `plan.md` lands them first, on their own.
+
+The exporter cache re-key (`otel.ts:217-233`) is independently required by the credential getter,
+so an equivalent change stays, restated to key by endpoint and hold the credential it was built
+with.
+
+### Already on `main`, now dead
+
+**The in-sandbox exporter.** `createAgentaOtel`'s export half in
+`services/runner/src/tracing/otel.ts:675-925` becomes a record writer with the same hooks and no
+OpenTelemetry dependency. The extension's `otel.flush()` on `agent_end`
+(`extensions/agenta.ts:513-514`) goes away.
+
+**The credential file.** `writeOtlpAuthFile` and `readOtlpAuthFile`
+(`pi-assets.ts:552-563`, `extensions/agenta.ts:66-81`), the environment variable
+`AGENTA_AGENT_OTLP_AUTH_FILE` (`pi-assets.ts:491-496`), `otlpAuthFilePath` on the run plan and
+in `runtime-lifecycle.ts:215`, and the `<relayDir>.otlp-auth` file itself.
+
+**The sandbox's tracing environment.** `TRACEPARENT` and
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` in `buildPiExtensionEnv` (`pi-assets.ts:488-492`), and the
+`hasTracing` gate derived from them (`extensions/agenta.ts:444-446`), replaced by a gate on the
+record path variable.
+
+**The `emitSpans` boolean.** `emitSpans: !plan.isPi || plan.isDaytona` (`run-turn.ts:293`) and
+the option it feeds (`otel.ts:1153-1159`) become a source selector:
+
+```ts
+spanSource: plan.isPi ? "records" : "acp",
+```
+
+`"records"` means the runner builds the tree from span records and still builds the `AgentEvent`
+log from the ACP stream. `"acp"` means the runner builds both from the ACP stream, which is what
+Claude and Codex do today. The third state, "nobody builds spans in the runner", disappears
+entirely, and with it the reason the two placements ever differed.

--- a/docs/design/agent-trace-export/open-questions.md
+++ b/docs/design/agent-trace-export/open-questions.md
@@ -1,0 +1,114 @@
+# Open questions
+
+Six calls that need the owner. Each one lists what happens if no answer comes, so nothing in
+`plan.md` is blocked on this file.
+
+---
+
+## 1. Is the scoped trace-ingest token wanted for anything other than the sandbox?
+
+`plan.md` step 5 deletes `TRACE_INGEST_SCOPE`, the `_SCOPE_ALLOWED_PATHS` enforcement, and the
+`telemetry_credentials` field on the `/access/permissions/check` response. It also deletes the
+generic `scope` claim machinery on `sign_secret_token`, because nothing else uses it.
+
+That machinery has a plausible second customer this design does not serve: a user's own process
+exporting spans to Agenta with a token that can do nothing else. Today such a user needs a full
+API key.
+
+**Options.** Delete all of it and rebuild later if that customer appears. Or delete the sandbox
+usage and keep the scope machinery dormant.
+
+**Recommendation, and the default if no answer comes.** Delete all of it. Dormant auth machinery
+is the kind of thing that gets wired to something years later by someone who did not read why it
+exists. Rebuilding a path-confined token is a day of work if the need is real.
+
+---
+
+## 2. Is the legacy SDK Daytona runner still a live path?
+
+This design makes "no Agenta credential enters a sandbox" true for the runner-driven path. It is
+not true everywhere. `sdks/python/agenta/sdk/engines/running/runners/daytona.py` injects
+`AGENTA_CREDENTIALS`, the caller's full `Secret ...` token, directly into a sandbox's environment
+variables. That token can carry the `secret-resolve` grant, and it can be renewed indefinitely by
+anything holding it.
+
+That is a materially worse exposure than the 0600 file this design removes, and it sits in an
+environment variable, which is the exact shape `services/runner/src/engines/sandbox_agent/pi-assets.ts`
+argues against.
+
+**Options.** Confirm the path is dead and delete it. Or treat it as live and give it its own
+design.
+
+**Recommendation, and the default if no answer comes.** Treat it as live until someone confirms
+otherwise, and file it as its own issue rather than widening this one. The security claim in
+`README.md` is already scoped to the runner-driven path, so nothing here overstates.
+
+---
+
+## 3. Should the run credential stop riding the telemetry block on the wire?
+
+`runCredential(request)` reads the caller's general Agenta credential out of
+`telemetry.exporters.otlp.headers.authorization`
+(`services/runner/src/engines/sandbox_agent/runtime-policy.ts:10-17`). That field claims to be an
+OTLP exporter header. It is actually the credential the runner uses for session claims, mount
+signing, the turns ledger, and record ingest. The name says routing and telemetry. The value is
+identity.
+
+`README.md` lists this as a non-goal, because fixing it means changing the `/run` wire, which
+means the golden fixtures, `protocol.ts`, `wire.py`, and both contract tests, and it does not help
+the problem this design solves.
+
+**Options.** Leave it. Or add a top-level `credential` field to `AgentRunRequest`, read from both
+for one release, then drop the old read.
+
+**Recommendation, and the default if no answer comes.** Leave it, and file the migration. After
+step 4 the telemetry block has exactly one remaining job, carrying the credential, which makes the
+naming worse, not better. That argues for doing it soon, but not inside this change.
+
+---
+
+## 4. Are the record budgets set at the right numbers?
+
+`design.md` proposes 262144 bytes per record and 5000 records per turn. Both are guesses. The
+per-record number needs to hold one `chat` record with a full model context, and a 200k token
+context serializes to well over 256 KB, so the default will truncate content on large-context
+runs.
+
+**What would settle it.** Capture the record file from three real turns: a short chat turn, a
+long coding turn with a large context, and a turn with several hundred tool calls. Set both
+numbers from the measurements before step 4 ships.
+
+**Recommendation, and the default if no answer comes.** Ship the numbers above, and treat the
+`ag.meta.trace.records.truncated` counter as the signal. If it is non-zero on ordinary runs, the
+number is wrong and the counter will say so.
+
+---
+
+## 5. Does the operator switch earn its place?
+
+`plan.md` adds `AGENTA_RUNNER_SPAN_SOURCE` so a tracing regression in production is a restart
+rather than a redeploy, and proposes removing it one release later.
+
+The argument against: it is a second code path that has to keep working, and the ACP-derived
+tracer is the fallback, which means the fallback is a strictly worse trace rather than a correct
+one. A revert is not much slower and is unambiguous.
+
+**Recommendation, and the default if no answer comes.** Keep it for one release. The runner is
+deployed in customer environments where a redeploy is not ours to schedule, and a thin trace beats
+no trace.
+
+---
+
+## 6. Should Claude Code and Codex start emitting records now, or later?
+
+The record contract is harness-agnostic on purpose. Claude Code has a hook API and Codex has a
+plugin surface, so either could write the same lines and gain the observed model call detail that
+Pi has and they do not.
+
+Doing it now would make all three harnesses identical. Doing it later keeps this change to one
+harness, which is the one whose export path is actually broken.
+
+**Recommendation, and the default if no answer comes.** Later, as its own project. This design's
+job is to make it possible, and after step 4 adding a harness is a writer plus a mapping, with no
+runner, API, or wire change at all. That is the reuse claim, and it should be proved by a second
+harness eventually, not by this pull request.

--- a/docs/design/agent-trace-export/plan.md
+++ b/docs/design/agent-trace-export/plan.md
@@ -1,0 +1,364 @@
+# Implementation plan
+
+Six pull requests. Each one is independently useful and independently revertible. The order
+front-loads the fix: step 2 stops long turns from losing traces on every placement, before any
+of the architecture work lands.
+
+Every step lists the files it touches, the tests that prove it, and how to verify it by hand.
+
+---
+
+## Step 1: untangle the stack and salvage the two good API fixes
+
+**Why first.** Pull request 6164 (`write-only-secrets-api`) is based on `fix/otlp-per-turn-credential`,
+not on `main`, so it currently carries all five of the rejected branch's commits. Nothing else can
+proceed cleanly until that base moves. Two changes on the rejected branch are worth keeping and
+belong on `main` on their own.
+
+**Do.**
+
+1. Close pull request 6135 as rejected, with a comment pointing at this workspace.
+2. Rebase `write-only-secrets-api` onto `main`, dropping the five commits `d99a8115cd`,
+   `9e82494e08`, `c09a75ad44`, `88e2f68ad0`, `f20bede3cb`. Re-target the pull request base to
+   `main`.
+3. Open a small pull request against `main` with only the two salvaged fixes:
+   - the `iat` claim on every Secret token (`api/oss/src/middlewares/auth.py`, in
+     `sign_secret_token`),
+   - the `except HTTPException: raise` guard placed before the catch-all in
+     `verify_secret_token`, so a 401 is not turned into a 500.
+4. Fix the one file on another lane that depends on the rejected work:
+   `api/oss/tests/pytest/unit/access/test_grant_exchange.py` imports `TRACE_INGEST_SCOPE` and
+   asserts on `body["telemetry_credentials"]`. Both go away. Drop the assertion and the import.
+
+**Files.** `api/oss/src/middlewares/auth.py`,
+`api/oss/tests/pytest/unit/middlewares/test_auth_secret_token.py`,
+`api/oss/tests/pytest/unit/access/test_grant_exchange.py`.
+
+**Tests.** A case asserting `iat` is present and `exp - iat` equals the default expiry. A case
+asserting an expired token yields 401 rather than 500. Run
+`cd api && py-run-tests --layer unit`.
+
+**Verify by hand.** `git log --oneline main..write-only-secrets-api` shows only that pull
+request's own commits.
+
+**Risk.** Low. The rebase is mechanical. The one cross-lane test import is known and named above.
+
+---
+
+## Step 2: resolve the export credential at export time
+
+**Why.** This alone fixes long turns for Daytona Pi, Claude, and Codex, which are already
+runner-exported. It needs none of the record work.
+
+**Do.** Change `ExportTarget.authorization` from `string | undefined` to
+`(() => string | undefined) | undefined` in `services/runner/src/tracing/otel.ts`. Resolve it in
+`TraceBatchProcessor.flush`, immediately before the export, so the credential-less-export skip
+and the export diagnostics both see the current value. Key the exporter cache by endpoint alone
+and hold the credential the entry was built with; rebuild the entry when the resolved value
+differs. Do not shut down an evicted exporter eagerly, so a rotation cannot cancel an export
+already on the wire.
+
+Feed it from the alive watchdog. `run-turn.ts` passes a string today
+(`services/runner/src/engines/sandbox_agent/run-turn.ts:280`). Pass the watchdog's
+`credential` getter instead (`services/runner/src/sessions/alive.ts:193`, `:249`), which the
+records emitter already uses. Runs with no watchdog pass a closure over `runCredential(request)`,
+which reproduces today's behavior for those runs. Confirm the watchdog handle is in scope at the
+`createSandboxAgentOtel` call site and thread it through the turn if it is not.
+
+**Files.** `services/runner/src/tracing/otel.ts`,
+`services/runner/src/engines/sandbox_agent/run-turn.ts`, and whichever of
+`services/runner/src/server.ts` or `services/runner/src/engines/sandbox_agent/runtime-contracts.ts`
+carries the watchdog handle into the turn.
+
+**Tests.** New `services/runner/tests/unit/otel-credential-refresh.test.ts`:
+
+- the getter is called at export time, not at run start (assert call ordering against a counter),
+- a credential that changes between run start and flush exports with the later value,
+- the exporter cache holds one entry per endpoint across three rotations, not three,
+- a getter returning empty against Agenta's own ingest still skips the export and logs
+  `outcome: "skipped"`, preserving the rule at `otel.ts:340-347`.
+
+Use the existing exporter-capture helper `services/runner/tests/utils/otel-export.ts`, which
+spies on the shared exporter base prototype because the module builds instances from an internal
+cache. Update `services/runner/tests/unit/otel-trace-target-attribution.test.ts` and
+`otel-export-diagnostics.test.ts` for the new type.
+
+Run: `cd services/runner && pnpm run test:unit` and `pnpm run typecheck`.
+
+**Verify by hand.** On the local dev stack, start a Pi Daytona run, wait past the 15 minute
+token life inside a single turn (a long-running tool works), and confirm the trace lands. Before
+this step the same run exports with an expired token and Agenta rejects the batch.
+
+**Risk.** Low and contained to the runner. The type change is compiler-enforced across every
+call site.
+
+---
+
+## Step 3: the span record contract and the extension writer
+
+**Why.** Ship the producer before the consumer, so the record file can be inspected on a real
+run before anything depends on it.
+
+**Do.**
+
+1. Add `services/runner/src/tracing/span-records.ts`: the `SpanRecord` types, a `parseSpanRecord`
+   that validates the envelope and returns a typed record or a drop reason, and the shared
+   constant for the environment variable name.
+2. Rewrite `createAgentaOtel` in `services/runner/src/tracing/otel.ts:675-925` into
+   `createSpanRecordWriter`. Keep every hook: `before_agent_start`, `agent_start`, `context`,
+   `turn_start`, `before_provider_request`, `message_end`, `tool_execution_start`,
+   `tool_execution_end`, `turn_end`, `agent_end`. Keep the usage accumulator, which the usage
+   writeback still needs. Replace `tracer.startSpan` with a pending map keyed by the harness's
+   own ids, and on each unit's end append one line with `appendFileSync`.
+3. In `services/runner/src/extensions/agenta.ts`, replace the `hasTracing` gate
+   (`:444-446`) with a gate on the record path variable, drop the `createOtlpAuthRefresher` hook
+   and the `otel.flush()` on `agent_end`, and keep the usage writeback unchanged.
+4. In `services/runner/src/engines/sandbox_agent/pi-assets.ts`, set
+   `AGENTA_AGENT_SPAN_RECORD_PATH` in `buildPiExtensionEnv` beside
+   `AGENTA_AGENT_USAGE_CAPTURE_PATH`, on both placements. Add `spanRecordPath` to the run plan
+   next to `usageOutPath` (`run-plan.ts:721`).
+5. Remove the OpenTelemetry SDK and OTLP exporter imports from the extension bundle's dependency
+   graph, and confirm the built bundle shrank.
+
+**Files.** `services/runner/src/tracing/span-records.ts` (new),
+`services/runner/src/tracing/otel.ts`, `services/runner/src/extensions/agenta.ts`,
+`services/runner/src/engines/sandbox_agent/pi-assets.ts`,
+`services/runner/src/engines/sandbox_agent/run-plan.ts`.
+
+**Tests.** New `services/runner/tests/unit/span-record-writer.test.ts`. Drive the real extension
+factory against a fake `ExtensionAPI` built as a plain object literal, the way
+`services/runner/tests/unit/extension-tools.test.ts:65` builds `fakePi`. Write to a temp file
+and read the lines back. Cases:
+
+- a turn with one model call and two tool calls produces exactly four records with the parent
+  links `turn -> null`, `chat -> turn`, `tool -> turn`,
+- a failed tool call sets `isError` and a failed assistant message sets `error`,
+- `AGENTA_AGENT_CONTENT_CAPTURE_ENABLED=false` omits `inputMessages`, `outputMessages`, `input`,
+  and `output`, and keeps every other field,
+- with no record path set, the extension writes nothing and still writes the usage file,
+- every emitted line parses as JSON and round-trips through `parseSpanRecord`.
+
+Commit the expected lines as fixtures under `services/runner/tests/fixtures/span-records/`, and
+have both this test and step 4's reader test read the same files, so the producer and the
+consumer can never drift against different copies. This mirrors how the wire contract goldens are
+shared between `sdks/python/oss/tests/pytest/unit/agents/golden/` and the runner's
+`tests/utils/golden.ts`.
+
+Run: `cd services/runner && pnpm run test:unit`.
+
+**Verify by hand.** Run a local Pi turn on the dev stack, then read
+`$TMPDIR/agenta/relay/<cwd-basename>/.agenta-spans.jsonl`. Traces still export from inside the
+sandbox at this step, so nothing user-visible changes yet.
+
+**Risk.** Medium. This rewrites the extension's tracing half. The mitigation is that its output
+is not consumed yet, so a defect shows up in the file and in tests rather than in a user's trace.
+
+---
+
+## Step 4: the runner drains, materializes, and exports
+
+**Why.** This is the change. Everything before it is preparation, everything after it is cleanup.
+
+**Do.**
+
+1. Add the drain to `services/runner/src/tracing/span-records.ts`:
+   `createSpanRecordDrain({ host, path, onRecord })`, holding a byte offset, reading through
+   `RelayHost.read` (`services/runner/src/tools/relay.ts:227-261`), consuming only up to the last
+   newline, and leaving a partial tail for the next pass.
+2. Add `applySpanRecord(record)` to `createSandboxAgentOtel` in
+   `services/runner/src/tracing/otel.ts`. Map records to spans per the table in `design.md`,
+   resolve `parent` through an id-to-span map, hold orphans in a pending map and attach any
+   leftovers to the root at the end of the drain, clamp timestamps into the root's interval, and
+   stamp the `ag.meta.trace.*` counters on the root.
+3. Replace `emitSpans` with `spanSource: "records" | "acp"`
+   (`services/runner/src/tracing/otel.ts:1153-1159`) and set it at the call site
+   (`run-turn.ts:293`) as `plan.isPi ? "records" : "acp"`, with an operator override
+   `AGENTA_RUNNER_SPAN_SOURCE` read through `services/runner/src/env.ts`.
+4. Wire the turn lifecycle in `run-turn.ts`: remove the record file and reset the offset when the
+   turn is dispatched (replacing the `refreshOtlpAuthFile` call at `:263-271`), drain every 2
+   seconds while the turn runs, drain once more after the prompt resolves at the point
+   `readRunUsage` is called (`:1149-1156`), then `finish()` and `await flush()`.
+5. Add the budgets `AGENTA_RUNNER_SPAN_RECORD_MAX_BYTES` (default 262144) and
+   `AGENTA_RUNNER_SPAN_RECORD_MAX_PER_TURN` (default 5000) through `services/runner/src/env.ts`,
+   which clamps a bad override rather than trusting it.
+6. Delete the in-sandbox export path: `writeOtlpAuthFile` and `readOtlpAuthFile`,
+   `AGENTA_AGENT_OTLP_AUTH_FILE`, `otlpAuthFilePath` on the plan and in
+   `services/runner/src/environment/runtime-lifecycle.ts:215-219`, the `<relayDir>.otlp-auth`
+   file, and `TRACEPARENT` and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` from `buildPiExtensionEnv`
+   (`pi-assets.ts:488-492`).
+
+**Files.** `services/runner/src/tracing/span-records.ts`,
+`services/runner/src/tracing/otel.ts`,
+`services/runner/src/engines/sandbox_agent/run-turn.ts`,
+`services/runner/src/engines/sandbox_agent/pi-assets.ts`,
+`services/runner/src/environment/runtime-lifecycle.ts`, `services/runner/src/env.ts`,
+`services/runner/src/engines/sandbox_agent/run-plan.ts`.
+
+**Tests.** New `services/runner/tests/unit/span-record-drain.test.ts`:
+
+- a file written in three appends is drained in three passes with no duplicates and no gaps,
+- a partial tail line is not consumed and is consumed on the next pass once completed,
+- a malformed line is skipped and counted, and the lines after it still apply,
+- an unknown `type` and an unknown `v` are skipped and counted,
+- a record over the byte budget has its content attributes truncated and is counted,
+- the per-turn cap stops materialization and counts the rest,
+- the drain works identically against a fake `RelayHost` whose `read` returns the whole file, so
+  the Daytona path is covered without a sandbox.
+
+New `services/runner/tests/unit/span-record-spans.test.ts`, reading the same fixtures step 3
+produced:
+
+- the fixture turn materializes as `invoke_agent` with a `turn 0` child, a `chat <model>` child
+  of the turn, and two `execute_tool <name>` children of the turn,
+- span names, `openinference.span.kind`, and every `gen_ai.*` key match what the current
+  in-sandbox builder produces for the same run,
+- a record whose `parent` never arrives attaches to the root and increments
+  `ag.meta.trace.records.orphaned`,
+- a record with times outside the root's interval is clamped and sets
+  `ag.meta.trace.clock_clamped`,
+- `spanSource: "acp"` ignores records entirely, and `spanSource: "records"` builds no spans from
+  ACP updates while still building the `AgentEvent` log from them.
+
+Extend `services/runner/tests/unit/wire-contract.test.ts` only if a wire field moved. It should
+not have.
+
+Run: `cd services/runner && pnpm run test:unit && pnpm run typecheck`, then
+`pnpm run test:integration` and `pnpm run test:acceptance`.
+
+**Verify by hand.** On the dev stack, run one local Pi turn and one Daytona Pi turn, then query
+the trace and compare the tree against a trace captured before the change. Confirm no
+`.otlp-auth` file is created, and confirm `env` inside the sandbox contains no `TRACEPARENT`, no
+`OTEL_EXPORTER_OTLP_TRACES_ENDPOINT`, and no Agenta credential.
+
+**Risk.** High, and it is the step to be careful on. See the risk table below.
+
+---
+
+## Step 5: delete the rejected credential surface from the API, the SDK, and the wire
+
+**Why.** After step 4 nothing reads any of it. Doing it separately keeps step 4's diff about
+tracing.
+
+**Do.** Delete everything listed under "From pull request 6135, all of it" in `design.md`, minus
+the two salvaged fixes step 1 already landed. Since pull request 6135 is closed, most of this is
+a matter of confirming the surface never reached `main`. What did reach other lanes, or reaches
+`main` on its own, is:
+
+- `OtlpExporter.exportAuthorization` in `services/runner/src/protocol.ts`, if it landed,
+- the `exportAuthorization` key in
+  `sdks/python/oss/tests/pytest/unit/agents/golden/run_request.pi_core.json`,
+- the SDK fields in `sdks/python/agenta/sdk/agents/dtos.py`,
+  `wire_models.py`, `contexts/tracing.py`, `decorators/running.py`, `decorators/routing.py`, and
+  `middlewares/routing/auth.py`.
+
+A changed golden is a contract change. Update `protocol.ts` and `KNOWN_REQUEST_KEYS` in the same
+pull request and read the golden diff before committing.
+
+**Files.** As listed. Then `ruff format` and `ruff check --fix` in `sdks/python` and `api`.
+
+**Tests.** `cd sdks/python && py-run-tests --layer unit`, `cd api && py-run-tests --layer unit`,
+`cd services/runner && pnpm run test:unit`. The two wire contract tests must agree:
+`sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py` and
+`services/runner/tests/unit/wire-contract.test.ts`, which reads the same golden files by relative
+path.
+
+**Risk.** Low, but the golden change touches both sides of the wire and must land atomically.
+
+---
+
+## Step 6: release gate coverage for trace trees
+
+**Why.** The agent release gate has no tracing coverage at all today. Every cell and journey in
+`.agents/skills/agent-release-gate/resources/` asserts on the streamed frames, on stored side
+effects read back through the REST API, or on runner log lines. Nothing queries a span. This
+design changes where every span comes from, so the gate needs a fourth evidence channel.
+
+**Do.** Add a `trace` journey to `JOURNEYS` in
+`.agents/skills/agent-release-gate/resources/qa_product.py`. It runs one turn that provokes a
+model call and at least one tool call, captures the `trace_id` the `/invoke` response already
+carries, polls until the spans are ingested, and asserts on the tree.
+
+Model the polling on `api/oss/tests/pytest/utils/polling.py`, which already handles
+asynchronous ingest against `/tracing/spans/query` and `/tracing/traces/{id}`. The endpoint shapes
+are documented by `api/oss/tests/pytest/acceptance/tracing/test_traces_preview.py`.
+
+Assert on structure, never on prose:
+
+- exactly one `invoke_agent` span with kind `AGENT`,
+- at least one `turn` span with kind `CHAIN`, parented to it,
+- at least one `chat` span with kind `LLM`, carrying `gen_ai.request.model` and non-zero
+  `gen_ai.usage.total_tokens`,
+- one `execute_tool` span per tool call the stream reported, with matching
+  `gen_ai.tool.call.id`,
+- no span attribute contains the run's API key or any value from the run's secret set.
+
+Run it on three cells, which together cover both placements and both span sources:
+
+| Cell | Harness and placement | Proves |
+| --- | --- | --- |
+| `C3` | `pi_core`, local | The record path replaces the in-sandbox exporter with no loss of richness. |
+| `C4` | `pi_core`, Daytona | The identical record path works over the Daytona filesystem API, and the tree gains the model call detail it did not have. |
+| `C1` | `claude`, local | The ACP-derived path is unchanged. |
+
+Add a second journey, `trace_long`, that holds one turn open past the run credential's 15 minute
+life and asserts the trace still lands. That is the case pull request 6135 could not satisfy, and
+it is the one that must not regress.
+
+Note for whoever runs the gate: `.agents/skills/agent-release-gate/SKILL.md` says `qa_product.py`
+is broken with unresolved conflict markers. That is stale. The file has no conflict markers and
+the cell definitions are clean. Fix the line while you are in there.
+
+**Files.** `.agents/skills/agent-release-gate/resources/qa_product.py`,
+`.agents/skills/agent-release-gate/resources/qa_matrix_lib.py` (a `trace_tree` helper next to
+`turn_ledger`), `.agents/skills/agent-release-gate/resources/coverage.md`,
+`.agents/skills/agent-release-gate/SKILL.md`.
+
+**Risk.** Low. Test-only, and it adds coverage that does not exist.
+
+---
+
+## Step 7: documentation
+
+Apply the `keep-docs-in-sync` skill. The changes that reach a reader:
+
+- The self-hosting reference loses `AGENTA_AGENT_OTLP_AUTH_FILE` and gains
+  `AGENTA_RUNNER_SPAN_SOURCE`, `AGENTA_RUNNER_SPAN_RECORD_MAX_BYTES`, and
+  `AGENTA_RUNNER_SPAN_RECORD_MAX_PER_TURN`.
+- Any page stating that a local Pi sandbox needs network access to Agenta's OTLP endpoint is now
+  wrong. It does not.
+- Any page describing what crosses into a sandbox should say that no Agenta credential does.
+- The interface inventory gains the span record contract and its version.
+
+---
+
+## Rollout
+
+**One operator switch, one release.** `AGENTA_RUNNER_SPAN_SOURCE` accepts `records` or `acp` and
+overrides the per-harness default. Setting it to `acp` puts every run back on the ACP-derived
+tracer without a code change or a rollback, at the cost of the model call detail. It exists so a
+tracing regression found in production is a restart, not a redeploy.
+
+Remove the switch one release after step 4 ships clean.
+
+**No feature flag on the wire.** The wire field removal in step 5 is compatible in both
+directions. A newer runner receiving `exportAuthorization` from an older SDK ignores it. An older
+runner receiving a request without it falls back to `runCredential(request)`, which is what it
+did before pull request 6135 existed. So the SDK and the runner can ship in either order.
+
+**Ship order across steps.** Steps 1 and 2 can go out immediately and independently. Step 3 is
+dark and can go out with step 2. Steps 4, 5, 6, and 7 go out together as one release, because
+step 4 is the behavior change and steps 5 through 7 describe it.
+
+---
+
+## Risks
+
+| Risk | Why it could happen | What we do about it |
+| --- | --- | --- |
+| The trace tree changes shape on the local Pi path, and a user notices before we do. | The span builder moves from the extension to the runner. A missed attribute is invisible until someone opens a trace. | Step 4's span test asserts every span name, kind, and `gen_ai.*` key against fixtures captured from the current builder. Step 6 asserts the tree on a live deployment. The `acp` switch is the escape hatch. |
+| Records are written but never drained, so a trace has only a root span. | A path mismatch, or a permission problem on the record file. | The runner stamps `ag.meta.trace.records.applied` on every root span. A root with zero applied records and a non-empty ACP tool call list logs a diagnostic. That makes the condition queryable rather than invisible. |
+| A long turn buffers too many spans and the runner runs out of memory. | A 12 hour turn with thousands of tool calls, each `chat` record repeating the full context. | `AGENTA_RUNNER_SPAN_RECORD_MAX_PER_TURN` and `AGENTA_RUNNER_SPAN_RECORD_MAX_BYTES`, both clamped through `services/runner/src/env.ts`. The behavior itself is not new: every runner-exported path buffers a whole turn today. |
+| Daytona clock skew produces child spans outside the root's interval. | The sandbox and the runner are different machines. | The runner clamps record times into the root's interval and stamps `ag.meta.trace.clock_clamped`, so the tree renders and the skew is visible. |
+| The extra Daytona daemon calls slow a turn down. | One `deleteFsEntry` per turn plus one `readFsFile` every 2 seconds. | The tool relay already polls the same directory at 300 ms backing off to 1500 ms (`services/runner/src/tools/relay.ts:107-119`), so the added load is a fraction of what is already there. If it still shows up, fold the drain into the relay poll loop rather than running a second timer. |
+| Pull request 6164's rebase drops something it needed from the rejected branch. | It was written on top of it. | Step 1 rebases before anything else, and the two changes it genuinely needed (`iat` and the exception guard) land on `main` first. |
+| A malicious sandbox floods the record file. | The relay directory is sandbox-writable by design. | The per-turn cap bounds it, the runner sets every attribute key itself, and the worst outcome is noise in a trace whose content the same agent already controls. `design.md` has the full table. |


### PR DESCRIPTION
Design only. No code changes.

## What this proposes

The runner builds and exports every span for every agent run. The Pi extension keeps every hook it has today, but instead of building OpenTelemetry spans and shipping them from inside the sandbox, it appends one JSON line per finished unit (a turn, a model call, a tool call) to a file in the relay directory. The runner drains that file, turns each line into a real span under a root span it owns, and exports the tree in one batch when the turn ends.

Three consequences:

- **No Agenta credential enters a sandbox.** The 0600 `.otlp-auth` file, `AGENTA_AGENT_OTLP_AUTH_FILE`, `TRACEPARENT`, and `OTEL_EXPORTER_OTLP_TRACES_ENDPOINT` all leave the sandbox environment, along with the OpenTelemetry SDK in the extension bundle.
- **Hours-long turns export correctly, with no ritual anywhere.** The export credential becomes a getter resolved at export time, backed by the alive watchdog's existing refresh loop (`services/runner/src/sessions/alive.ts:193`). Today it is a string frozen at turn start against a 15 minute token, which is why long turns lose their traces on every placement, sandbox or not.
- **Local and Daytona become one path.** `emitSpans: !plan.isPi || plan.isDaytona` becomes `spanSource: plan.isPi ? "records" : "acp"`. Daytona Pi traces get the observed model, provider, token, and cost detail they do not have today.

## What it replaces

PR #6135 (`fix/otlp-per-turn-credential`), which refreshed a per-turn credential file inside the sandbox and added a scope-bound `trace-ingest` token, a `telemetry_credentials` response field, and an `exportAuthorization` wire field. It was rejected: a 12 hour turn still fails, and the split ownership is the actual defect. `README.md` describes what it did with file and line references. `design.md` lists everything from it that becomes dead, plus the two changes worth salvaging (`iat` on every Secret token, and the `except HTTPException: raise` guard that stops a 401 becoming a 500).

Note for the stack: PR #6164 is based on `fix/otlp-per-turn-credential`, so step 1 of the plan rebases it onto `main` before anything else moves.

## Files

- `docs/design/agent-trace-export/README.md` — the split ownership today with evidence, what #6135 tried, goals and non-goals.
- `docs/design/agent-trace-export/design.md` — the responsibility table, the span record contract, span materialization, credential handling, trust analysis, and five decisions with the options behind each.
- `docs/design/agent-trace-export/plan.md` — seven ordered PRs with files, tests, rollout, and risks.
- `docs/design/agent-trace-export/open-questions.md` — six calls, each with a default so nothing is blocked.

A parallel Codex design for the same problem exists for comparison.
