### PR TITLE
Reject wrapped or empty session header PUT bodies

### DIFF
--- a/api/oss/src/core/sessions/streams/dtos.py
+++ b/api/oss/src/core/sessions/streams/dtos.py
@@ -3,7 +3,7 @@ from enum import Enum
 from typing import Any, Dict, List, Optional
 from uuid import UUID
 
-from pydantic import BaseModel, Field, field_validator
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
 
 from agenta.sdk.models.workflows import WorkflowServiceRequestData
 
@@ -90,7 +90,14 @@ class SessionStreamHeaderEdit(Header):
     contain a non-whitespace character: storing ``"   "`` clears the visible title
     while the row still holds a value, a state no caller ever means. The LLM-facing
     ``rename_session`` schema already rejects both; this closes the direct-API hole.
+
+    Unknown top-level keys are forbidden (``extra="forbid"``) so a wrapped body such
+    as ``{"header": {"name": "..."}}`` fails validation instead of silently no-op'ing
+    when every recognised field is absent. At least one of ``name`` / ``description``
+    must be present in the request body for the same reason.
     """
+
+    model_config = ConfigDict(extra="forbid")
 
     @field_validator("name")
     @classmethod
@@ -101,6 +108,14 @@ class SessionStreamHeaderEdit(Header):
                 " (send an empty string to clear the title)"
             )
         return value
+
+    @model_validator(mode="after")
+    def _require_at_least_one_header_field(self) -> "SessionStreamHeaderEdit":
+        if not self.model_fields_set.intersection({"name", "description"}):
+            raise ValueError(
+                "no header field to update; send name or description at the top level"
+            )
+        return self
 
 
 class SessionStreamQuery(BaseModel):

--- a/api/oss/tests/pytest/acceptance/sessions/test_stream_header_basics.py
+++ b/api/oss/tests/pytest/acceptance/sessions/test_stream_header_basics.py
@@ -149,3 +149,49 @@ class TestSessionStreamHeaderBasics:
         )
         assert response.status_code == 200
         assert response.json()["stream"]["name"] == ""
+
+    def test_wrapped_header_body_rejected(self, authed_api):
+        # Clients that nest fields under {"header": {...}} used to get 200 with a
+        # silent no-op because every recognised field was absent. Reject that shape.
+        session_id = str(uuid.uuid4())
+        authed_api(
+            "PUT",
+            "/sessions/streams/header",
+            params={"session_id": session_id},
+            json={"name": "Keep Me"},
+        )
+
+        response = authed_api(
+            "PUT",
+            "/sessions/streams/header",
+            params={"session_id": session_id},
+            json={"header": {"name": "Should Not Apply"}},
+        )
+        assert response.status_code == 422
+
+        get_resp = authed_api(
+            "GET", "/sessions/streams/", params={"session_id": session_id}
+        )
+        assert get_resp.json()["stream"]["name"] == "Keep Me"
+
+    def test_empty_header_body_rejected(self, authed_api):
+        session_id = str(uuid.uuid4())
+        authed_api(
+            "PUT",
+            "/sessions/streams/header",
+            params={"session_id": session_id},
+            json={"name": "Keep Me"},
+        )
+
+        response = authed_api(
+            "PUT",
+            "/sessions/streams/header",
+            params={"session_id": session_id},
+            json={},
+        )
+        assert response.status_code == 422
+
+        get_resp = authed_api(
+            "GET", "/sessions/streams/", params={"session_id": session_id}
+        )
+        assert get_resp.json()["stream"]["name"] == "Keep Me"

--- a/api/oss/tests/pytest/unit/sessions/test_stream_header_merge.py
+++ b/api/oss/tests/pytest/unit/sessions/test_stream_header_merge.py
@@ -403,9 +403,24 @@ def test_empty_name_stays_the_explicit_clear():
     assert SessionStreamHeaderEdit(name="").name == ""
 
 
-def test_omitted_and_none_name_still_mean_no_change():
-    assert SessionStreamHeaderEdit().name is None
-    assert SessionStreamHeaderEdit(name=None).name is None
+def test_none_name_still_means_no_change_when_another_field_is_set():
+    # Omitting every header field is rejected (silent no-op / wrapped body guard).
+    # Explicit name=None still means "leave name alone" when description is present.
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError, match="no header field to update"):
+        SessionStreamHeaderEdit()
+
+    edit = SessionStreamHeaderEdit(name=None, description="keep name")
+    assert edit.name is None
+    assert edit.description == "keep name"
+
+
+def test_wrapped_or_unknown_top_level_keys_are_rejected():
+    from pydantic import ValidationError
+
+    with pytest.raises(ValidationError):
+        SessionStreamHeaderEdit.model_validate({"header": {"name": "x"}})
 
 
 def test_a_normal_rename_validates():


### PR DESCRIPTION
Fixes #6214

PUT /sessions/streams/header treated a wrapped body like {"header":{"name":"x"}} as an empty update and returned 200 with no change, because every recognised field was absent.

SessionStreamHeaderEdit now forbids unknown top level keys and requires at least one of name or description. Empty bodies and wrapped shapes return 422. Top level {"name":"..."} still works, including clearing the title with an empty string.

Test plan
1. Unit: SessionStreamHeaderEdit rejects {} and {"header":{"name":"x"}}, accepts {"name":"x"}
2. Acceptance: wrapped body leaves the name unchanged and returns 422
3. Acceptance: empty body returns 422
4. Acceptance: top level rename still returns 200 and persists