### PR TITLE
[fix] Use refreshed credentials for trace export

### DIFF
--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -265,7 +265,9 @@ export async function runTurn(
       traceparent: request.context?.propagation?.traceparent,
       baggage: request.context?.propagation?.baggage,
       endpoint: request.telemetry?.exporters?.otlp?.endpoint,
-      authorization: request.telemetry?.exporters?.otlp?.headers?.authorization,
+      // The session keepalive owns this getter and refreshes its value while a long turn runs.
+      // Resolve it only when the trace batch leaves the runner, not when the turn starts.
+      authorization: credential,
       captureContent: request.telemetry?.capture?.content?.enabled,
       // Seed from the request's typed model/MCP credential material (`requestSecretValues` —
       // on a Daytona Secrets run the opaque values left the plaintext env for the secret plan

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -80,8 +80,16 @@ export const INTERRUPTED_BY_USER =
 // Shared, process-wide tracing infrastructure
 // ---------------------------------------------------------------------------
 
-/** Where a trace's spans are shipped: an OTLP endpoint and an Authorization header. */
+type AuthorizationProvider = () => string | undefined;
+
+/** Where a trace's spans are shipped. The credential is read only when the batch is sent. */
 interface ExportTarget {
+  endpoint: string;
+  authorization: AuthorizationProvider;
+}
+
+/** The target material resolved for one concrete export attempt. */
+interface ResolvedExportTarget {
   endpoint: string;
   authorization?: string;
 }
@@ -205,27 +213,59 @@ function redactAttributes(
   }
 }
 
-/** Cache one exporter per distinct endpoint+auth so we do not rebuild per export. */
-const exporterCache = new Map<string, OTLPTraceExporter>();
-
-function targetKey(target: ExportTarget): string {
-  return `${target.endpoint}\n${target.authorization ?? ""}`;
+interface ExporterCacheEntry {
+  authorization?: string;
+  exporter: OTLPTraceExporter;
+  activeExports: number;
+  retired: boolean;
+  shutdown?: Promise<void>;
 }
 
-function getExporter(target: ExportTarget): OTLPTraceExporter {
-  const key = targetKey(target);
-  let exporter = exporterCache.get(key);
-  if (!exporter) {
-    exporter = new OTLPTraceExporter({
+/** Cache the current exporter per endpoint and retire it safely when the credential rotates. */
+const exporterCache = new Map<string, ExporterCacheEntry>();
+/** Only retired exporters with an active request remain here, so rotation cannot grow it unbounded. */
+const retiringExporters = new Set<ExporterCacheEntry>();
+
+function shutdownExporter(entry: ExporterCacheEntry): Promise<void> {
+  entry.shutdown ??= entry.exporter.shutdown();
+  return entry.shutdown;
+}
+
+function retireExporter(entry: ExporterCacheEntry): void {
+  entry.retired = true;
+  if (entry.activeExports === 0) {
+    void shutdownExporter(entry).catch(() => {});
+    return;
+  }
+  retiringExporters.add(entry);
+}
+
+function completeExport(entry: ExporterCacheEntry): void {
+  entry.activeExports -= 1;
+  if (!entry.retired || entry.activeExports !== 0) return;
+  retiringExporters.delete(entry);
+  void shutdownExporter(entry).catch(() => {});
+}
+
+function getExporter(target: ResolvedExportTarget): ExporterCacheEntry {
+  const cached = exporterCache.get(target.endpoint);
+  if (cached && cached.authorization === target.authorization) return cached;
+
+  const entry: ExporterCacheEntry = {
+    authorization: target.authorization,
+    exporter: new OTLPTraceExporter({
       url: target.endpoint,
       headers: target.authorization
         ? { Authorization: target.authorization }
         : {},
       timeoutMillis: 10_000,
-    });
-    exporterCache.set(key, exporter);
-  }
-  return exporter;
+    }),
+    activeExports: 0,
+    retired: false,
+  };
+  if (cached) retireExporter(cached);
+  exporterCache.set(target.endpoint, entry);
+  return entry;
 }
 
 const CLOUD_API_BASE = "https://cloud.agenta.ai/api";
@@ -243,10 +283,9 @@ function defaultTarget(): ExportTarget {
   // reuse (interface.md section 2). The scheme-tagged ephemeral `AGENTA_CREDENTIALS` (a
   // `Secret ...` from `/check`, used verbatim) is the only fallback; absent it, `flush` skips
   // the export rather than sending Agenta an unauthenticated one (see `isAgentaIngest`).
-  const credentials = process.env.AGENTA_CREDENTIALS || "";
   return {
     endpoint: `${base}/otlp/v1/traces`,
-    authorization: credentials || undefined,
+    authorization: () => process.env.AGENTA_CREDENTIALS || undefined,
   };
 }
 
@@ -351,14 +390,35 @@ class TraceBatchProcessor implements SpanProcessor {
         // batch could still land on an unintended endpoint/auth.
         const target =
           (runId ? byRun?.get(runId) : undefined) ?? defaultTarget();
+        let resolvedTarget: ResolvedExportTarget;
+        try {
+          resolvedTarget = {
+            endpoint: target.endpoint,
+            authorization: target.authorization(),
+          };
+        } catch (error) {
+          logExportProblem({
+            traceId,
+            endpoint: target.endpoint,
+            authorization: undefined,
+            spans: group.length,
+            redactors,
+            outcome: "threw",
+            error,
+          });
+          return Promise.resolve();
+        }
         const problem = {
           traceId,
-          endpoint: target.endpoint,
-          authorization: target.authorization,
+          endpoint: resolvedTarget.endpoint,
+          authorization: resolvedTarget.authorization,
           spans: group.length,
           redactors,
         };
-        if (!target.authorization?.trim() && isAgentaIngest(target.endpoint)) {
+        if (
+          !resolvedTarget.authorization?.trim() &&
+          isAgentaIngest(resolvedTarget.endpoint)
+        ) {
           // Agenta's ingest rejects an unauthenticated export, so sending one buys nothing and
           // reports as a 401 that reads like a BAD credential. Say the credential is missing
           // instead, and drop the batch here.
@@ -366,21 +426,35 @@ class TraceBatchProcessor implements SpanProcessor {
           return Promise.resolve();
         }
         return new Promise<void>((resolve) => {
+          let entry: ExporterCacheEntry | undefined;
+          let exportSettled = false;
+          const settleExport = (): void => {
+            if (!exportSettled && entry) {
+              exportSettled = true;
+              completeExport(entry);
+            }
+            resolve();
+          };
           try {
-            getExporter(target).export(orderParentFirst(group), (result) => {
-              if (result.code === ExportResultCode.FAILED)
-                logExportProblem({
-                  ...problem,
-                  outcome: "failed",
-                  error: result.error,
-                });
-              resolve();
+            entry = getExporter(resolvedTarget);
+            entry.activeExports += 1;
+            entry.exporter.export(orderParentFirst(group), (result) => {
+              try {
+                if (result.code === ExportResultCode.FAILED)
+                  logExportProblem({
+                    ...problem,
+                    outcome: "failed",
+                    error: result.error,
+                  });
+              } finally {
+                settleExport();
+              }
             });
           } catch (err) {
             // A synchronous export throw (e.g. misconfigured exporter) must stay best-effort:
             // flush() is awaited without a catch, so a reject here would break the run.
+            settleExport();
             logExportProblem({ ...problem, outcome: "threw", error: err });
-            resolve();
           }
         });
       }),
@@ -396,7 +470,9 @@ class TraceBatchProcessor implements SpanProcessor {
   shutdown(): Promise<void> {
     return this.forceFlush().then(async () => {
       await Promise.all(
-        [...exporterCache.values()].map((exporter) => exporter.shutdown()),
+        [...exporterCache.values(), ...retiringExporters].map((entry) =>
+          shutdownExporter(entry),
+        ),
       );
     });
   }
@@ -776,7 +852,8 @@ export function createAgentaOtel(
       config.traceId = traceId;
       registerRunTarget(traceId, runId, {
         endpoint: config.endpoint ?? defaultTarget().endpoint,
-        authorization: config.authorization ?? defaultTarget().authorization,
+        authorization: () =>
+          config.authorization ?? defaultTarget().authorization(),
       });
       if (config.redactor) registerRunRedactor(traceId, config.redactor);
       agentCtx = trace.setSpan(parent, agentSpan);
@@ -1133,7 +1210,14 @@ function splitModel(model?: string): { provider?: string; id?: string } {
   return { provider: model.slice(0, slash), id: model.slice(slash + 1) };
 }
 
-export interface SandboxAgentOtelInit extends Partial<RunConfig> {
+export interface SandboxAgentOtelInit
+  extends Omit<Partial<RunConfig>, "authorization"> {
+  /**
+   * Authorization for the OTLP exporter. The runner supplies a provider so a long-lived turn
+   * uses the latest session credential when it exports. A string remains accepted for local
+   * callers and focused tests.
+   */
+  authorization?: string | AuthorizationProvider;
   captureContent?: boolean;
   /** Harness id ("pi" / "claude"); becomes gen_ai.agent.name. */
   harness?: string;
@@ -1221,7 +1305,13 @@ export function createSandboxAgentOtel(
   const capture = init.captureContent !== false;
   const emitSpans = init.emitSpans !== false;
   const endpoint = init.endpoint ?? defaultTarget().endpoint;
-  const authorization = init.authorization ?? defaultTarget().authorization;
+  const configuredAuthorization = init.authorization;
+  const authorization: AuthorizationProvider =
+    typeof configuredAuthorization === "function"
+      ? configuredAuthorization
+      : configuredAuthorization !== undefined
+        ? () => configuredAuthorization
+        : defaultTarget().authorization;
   const { provider, id: modelId } = splitModel(init.model);
   const tracer = trace.getTracer("agenta-sandbox-agent-otel", "0.1.0");
   const runId = mintRunId();

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -1306,12 +1306,22 @@ export function createSandboxAgentOtel(
   const emitSpans = init.emitSpans !== false;
   const endpoint = init.endpoint ?? defaultTarget().endpoint;
   const configuredAuthorization = init.authorization;
-  const authorization: AuthorizationProvider =
+  const configuredProvider: AuthorizationProvider | undefined =
     typeof configuredAuthorization === "function"
       ? configuredAuthorization
       : configuredAuthorization !== undefined
         ? () => configuredAuthorization
-        : defaultTarget().authorization;
+        : undefined;
+  // A run whose request carries no authorization header resolves to an empty value, not to
+  // `undefined` — the getter reads a header that may not be there. Treat empty as "unconfigured"
+  // so such a run still exports under the runner's own `AGENTA_CREDENTIALS`, and resolve the
+  // fallback at export time (not at construction) so a credential written after the run started
+  // still counts.
+  const fallbackAuthorization = defaultTarget().authorization;
+  const authorization: AuthorizationProvider = () => {
+    const resolved = configuredProvider?.();
+    return resolved?.trim() ? resolved : fallbackAuthorization();
+  };
   const { provider, id: modelId } = splitModel(init.model);
   const tracer = trace.getTracer("agenta-sandbox-agent-otel", "0.1.0");
   const runId = mintRunId();

--- a/services/runner/tests/unit/otel-trace-target-attribution.test.ts
+++ b/services/runner/tests/unit/otel-trace-target-attribution.test.ts
@@ -246,6 +246,9 @@ describe("otel traceTargets — per-run target attribution across a shared trace
     const endpoint = "https://cloud.agenta.ai/api/otlp/v1/traces";
     let authorization = "Secret initial";
     const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    // A blank resolved credential falls back to the runner's own `AGENTA_CREDENTIALS`, so drop
+    // that too: the skip needs the run credential AND the env fallback to be empty.
+    vi.stubEnv("AGENTA_CREDENTIALS", "");
     const run = createSandboxAgentOtel({
       harness: "claude",
       model: "anthropic/claude-haiku",
@@ -266,6 +269,54 @@ describe("otel traceTargets — per-run target attribution across a shared trace
         args.join(" ").includes("trace export skipped, no credential"),
       ),
     ).toBe(true);
+  });
+
+  it("falls back to the env credential when the run carries no authorization header, and prefers the run's own header when it has one", async () => {
+    // `runCredential` reads the request's OTLP authorization header and trims it, so a run
+    // without that header hands the tracer a provider that resolves to "". That must still
+    // export under `AGENTA_CREDENTIALS`, exactly as a run that configured no credential at all.
+    const endpoint = "https://cloud.agenta.ai/api/otlp/v1/traces";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const headerless = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+      endpoint,
+      authorization: () => "",
+      traceparent: `00-${"a".repeat(32)}-${"7".repeat(16)}-01`,
+    });
+
+    headerless.start({ prompt: "no authorization header on the request" });
+    headerless.finish();
+    await headerless.flush();
+
+    expect(fakeExports.filter((item) => item.url === endpoint)).toEqual([
+      expect.objectContaining({ authorization: "Secret fallback-credential" }),
+    ]);
+    expect(
+      errorSpy.mock.calls.some((args) =>
+        args.join(" ").includes("trace export skipped, no credential"),
+      ),
+    ).toBe(false);
+
+    const withHeader = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+      endpoint,
+      authorization: () => "Secret run-credential",
+      traceparent: `00-${"b".repeat(32)}-${"8".repeat(16)}-01`,
+    });
+
+    withHeader.start({ prompt: "authorization header present" });
+    withHeader.finish();
+    await withHeader.flush();
+
+    expect(
+      fakeExports
+        .filter((item) => item.url === endpoint)
+        .map((item) => item.authorization),
+    ).toEqual(["Secret fallback-credential", "Secret run-credential"]);
   });
 
   it("retires a replaced exporter only after its active export finishes", async () => {

--- a/services/runner/tests/unit/otel-trace-target-attribution.test.ts
+++ b/services/runner/tests/unit/otel-trace-target-attribution.test.ts
@@ -32,12 +32,20 @@ interface FakeExport {
 }
 
 const fakeExports: FakeExport[] = [];
+const fakeShutdowns: Array<string | undefined> = [];
+let holdNextExport = false;
+let releaseHeldExport: (() => void) | undefined;
+let throwNextExporterConstruction = false;
 
 vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => {
   class FakeOTLPTraceExporter {
     url: string;
     authorization?: string;
     constructor(config: { url: string; headers?: Record<string, string> }) {
+      if (throwNextExporterConstruction) {
+        throwNextExporterConstruction = false;
+        throw new Error("exporter construction failed");
+      }
       this.url = config.url;
       this.authorization = config.headers?.Authorization;
     }
@@ -47,9 +55,17 @@ vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => {
         authorization: this.authorization,
         spans,
       });
-      cb({ code: 0 /* ExportResultCode.SUCCESS */ });
+      const finish = () => cb({ code: 0 /* ExportResultCode.SUCCESS */ });
+      if (holdNextExport) {
+        holdNextExport = false;
+        releaseHeldExport = finish;
+        return;
+      }
+      finish();
     }
-    async shutdown(): Promise<void> {}
+    async shutdown(): Promise<void> {
+      fakeShutdowns.push(this.authorization);
+    }
   }
   return { OTLPTraceExporter: FakeOTLPTraceExporter };
 });
@@ -57,9 +73,7 @@ vi.mock("@opentelemetry/exporter-trace-otlp-proto", () => {
 // Imported AFTER the mock so `otel.ts` picks up the fake OTLPTraceExporter.
 const { createSandboxAgentOtel } = await import("../../src/tracing/otel.ts");
 
-/** Batches actually shipped to one endpoint, across every (possibly cached) exporter instance
- * built for it — `getExporter` caches per endpoint+auth, so distinct auths to the same endpoint
- * would be separate instances, but this suite always pairs a distinct auth with a distinct URL. */
+/** Batches actually shipped to one endpoint, across every exporter instance built for it. */
 function exportsTo(endpoint: string): ReadableSpan[] {
   return fakeExports.filter((e) => e.url === endpoint).flatMap((e) => e.spans);
 }
@@ -76,6 +90,10 @@ beforeEach(() => {
 
 afterEach(() => {
   fakeExports.length = 0;
+  fakeShutdowns.length = 0;
+  holdNextExport = false;
+  releaseHeldExport = undefined;
+  throwNextExporterConstruction = false;
   vi.unstubAllEnvs();
   vi.restoreAllMocks();
 });
@@ -199,5 +217,161 @@ describe("otel traceTargets — per-run target attribution across a shared trace
     expect(
       exportsTo("https://cloud.agenta.ai/api/otlp/v1/traces"),
     ).toHaveLength(0);
+  });
+
+  it("resolves a refreshed authorization value when the batch is exported", async () => {
+    const traceparent = `00-${"f".repeat(32)}-${"4".repeat(16)}-01`;
+    const endpoint = "http://collector-rotating.example/v1/traces";
+    let authorization = "Secret initial";
+    const run = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+      endpoint,
+      authorization: () => authorization,
+      traceparent,
+    });
+
+    run.start({ prompt: "long running prompt" });
+    run.finish();
+    authorization = "Secret refreshed";
+    await run.flush();
+
+    const exports = fakeExports.filter((item) => item.url === endpoint);
+    expect(exports).toHaveLength(1);
+    expect(exports[0].authorization).toBe("Secret refreshed");
+  });
+
+  it("uses the resolved authorization for the Agenta missing-credential check", async () => {
+    const endpoint = "https://cloud.agenta.ai/api/otlp/v1/traces";
+    let authorization = "Secret initial";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const run = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+      endpoint,
+      authorization: () => authorization,
+      traceparent: `00-${"c".repeat(32)}-${"6".repeat(16)}-01`,
+    });
+
+    run.start({ prompt: "credential disappears before flush" });
+    run.finish();
+    authorization = "   ";
+    await run.flush();
+
+    expect(fakeExports.filter((item) => item.url === endpoint)).toHaveLength(0);
+    expect(
+      errorSpy.mock.calls.some((args) =>
+        args.join(" ").includes("trace export skipped, no credential"),
+      ),
+    ).toBe(true);
+  });
+
+  it("retires a replaced exporter only after its active export finishes", async () => {
+    const endpoint = "http://collector-cache-rotation.example/v1/traces";
+    let authorization = "Secret first";
+    const makeRun = (traceIdDigit: string) =>
+      createSandboxAgentOtel({
+        harness: "claude",
+        model: "anthropic/claude-haiku",
+        emitSpans: true,
+        endpoint,
+        authorization: () => authorization,
+        traceparent: `00-${traceIdDigit.repeat(32)}-${"5".repeat(16)}-01`,
+      });
+
+    holdNextExport = true;
+    const first = makeRun("a");
+    first.start({ prompt: "first" });
+    first.finish();
+    const firstFlush = first.flush();
+
+    authorization = "Secret second";
+    const second = makeRun("b");
+    second.start({ prompt: "second" });
+    second.finish();
+    await second.flush();
+
+    expect(fakeShutdowns).not.toContain("Secret first");
+    releaseHeldExport?.();
+    await firstFlush;
+    expect(fakeShutdowns).toContain("Secret first");
+    expect(
+      fakeExports
+        .filter((item) => item.url === endpoint)
+        .map((item) => item.authorization),
+    ).toEqual(["Secret first", "Secret second"]);
+  });
+
+  it("keeps the cached exporter live when constructing its replacement throws", async () => {
+    const endpoint = "http://collector-constructor-error.example/v1/traces";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    let authorization = "Secret original";
+    const makeRun = (traceIdDigit: string) =>
+      createSandboxAgentOtel({
+        harness: "claude",
+        model: "anthropic/claude-haiku",
+        emitSpans: true,
+        endpoint,
+        authorization: () => authorization,
+        traceparent: `00-${traceIdDigit.repeat(32)}-${"8".repeat(16)}-01`,
+      });
+
+    const original = makeRun("1");
+    original.start({ prompt: "original" });
+    original.finish();
+    await original.flush();
+
+    authorization = "Secret replacement";
+    throwNextExporterConstruction = true;
+    const failedReplacement = makeRun("2");
+    failedReplacement.start({ prompt: "replacement" });
+    failedReplacement.finish();
+    await expect(failedReplacement.flush()).resolves.toBeUndefined();
+
+    authorization = "Secret original";
+    const reusedOriginal = makeRun("3");
+    reusedOriginal.start({ prompt: "original again" });
+    reusedOriginal.finish();
+    await reusedOriginal.flush();
+
+    expect(fakeShutdowns).not.toContain("Secret original");
+    expect(
+      errorSpy.mock.calls.some((args) =>
+        args.join(" ").includes("exporter construction failed"),
+      ),
+    ).toBe(true);
+    expect(
+      fakeExports
+        .filter((item) => item.url === endpoint)
+        .map((item) => item.authorization),
+    ).toEqual(["Secret original", "Secret original"]);
+  });
+
+  it("keeps flush best-effort when the authorization provider throws", async () => {
+    const endpoint = "http://collector-provider-error.example/v1/traces";
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const run = createSandboxAgentOtel({
+      harness: "claude",
+      model: "anthropic/claude-haiku",
+      emitSpans: true,
+      endpoint,
+      authorization: () => {
+        throw new Error("credential refresh failed");
+      },
+      traceparent: `00-${"9".repeat(32)}-${"7".repeat(16)}-01`,
+    });
+
+    run.start({ prompt: "provider failure" });
+    run.finish();
+
+    await expect(run.flush()).resolves.toBeUndefined();
+    expect(fakeExports.filter((item) => item.url === endpoint)).toHaveLength(0);
+    expect(
+      errorSpy.mock.calls.some((args) =>
+        args.join(" ").includes("credential refresh failed"),
+      ),
+    ).toBe(true);
   });
 });

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -409,6 +409,28 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(calls.workspaceCleanup, 1);
   });
 
+  it("passes the live turn credential provider to the trace exporter", async () => {
+    const { calls, deps } = fakeHarness();
+    let authorization = "Secret initial";
+    const credential = () => authorization;
+
+    const result = await runSandboxAgent(
+      {
+        harness: "claude",
+        messages: [{ role: "user", content: "hello" }],
+      },
+      undefined,
+      undefined,
+      deps,
+      { credential },
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(calls.otelOptions.authorization, credential);
+    authorization = "Secret refreshed";
+    assert.equal(calls.otelOptions.authorization(), "Secret refreshed");
+  });
+
   it("delivers the current legacy inline image before one text block", async () => {
     const { calls, deps } = fakeHarness({ capabilities: { images: true } });
 


### PR DESCRIPTION
## Context
A long runner-exported turn can outlive the Secret credential captured when tracing starts. The session watchdog refreshes that credential, but the trace exporter kept the old string until flush, so a late export could receive 401 and the trace would be lost.

## Changes
The turn now passes its live credential provider into tracing. TraceBatchProcessor resolves it immediately before the missing-credential check, diagnostics, exporter selection, and send.

Before, the cache was keyed by endpoint plus the credential captured at turn start. Now each endpoint keeps one current exporter. A changed credential constructs a replacement first, then retires the old exporter after its last active callback. A failed replacement leaves the previous exporter live.

This changes no external wire field, token lifetime, scope, or Pi span semantics. It is the first prerequisite for the runner-owned Pi export design.

## Tests / notes
- 90 focused runner tests passed, including credential rotation after tracer creation, missing-current-credential handling, safe in-flight retirement, replacement-constructor failure, and run-turn provider wiring.
- pnpm run typecheck passed.
- Independent review completed with no remaining findings.