### PR TITLE
feat(mobile): mobile app on by default (gate and web-mobile service), opt-out via env

### DIFF
--- a/docs/design/agenta-mobile/README.md
+++ b/docs/design/agenta-mobile/README.md
@@ -158,8 +158,10 @@ image build and `@agenta/mobile` typecheck needed a new job.
 > **STATUS UPDATE (2026-08-22, v0.113.0):** the gate now ships **DEFAULT ON**, and the
 > `web-mobile` compose service starts with every stack (the `with-web-mobile` profile is
 > gone). Both keys became opt-OUTs: only the exact value `false` turns a gate off, and
-> `AGENTA_MOBILE_ENABLED=false` (or `run.sh --no-mobile`) holds the service back. v0.113.0
-> shipped to production without `/m` because no deployment set the keys — that is what the
+> `AGENTA_MOBILE_ENABLED=false` (or `run.sh --no-mobile`) holds the service back and forces
+> the desktop gate off; `--no-web` implies the same opt-out. The Helm chart deploys `web-mobile`
+> and routes `/m` by default; `webMobile.enabled=false` removes both and disables the desktop gate.
+> v0.113.0 shipped to production without `/m` because no deployment set the keys — that is what the
 > flip fixes. The section below records the original default-off design; read it as history.
 
 Ships the mobile device gate (design.md "Gate and routing") behind a runtime flag,

--- a/docs/design/agenta-mobile/README.md
+++ b/docs/design/agenta-mobile/README.md
@@ -65,11 +65,12 @@ What works right now: `cd web && pnpm dev-mobile` → http://localhost:3000/m re
 shell (light+dark from the bridged palette); `pnpm build-mobile` produces a standalone server;
 `pnpm --filter @agenta/mobile lint` enforces the bans + token sync; the dev compose stacks have
 a routable `web-mobile` service (needs a dev-image rebuild to pick up the Dockerfile changes).
-Opt-in in dev too, from the repo root (swap `--oss` for `--ee` to match the loaded env file):
-`bash ./hosting/docker-compose/run.sh --oss --dev --with-mobile`. Originally it rode `with-web`
-and auto-started, but a live dev run showed the second Next dev server pushes an 8GB Docker VM
-into OOM-killing the main web app's first big Turbopack compile — dmesg-confirmed `next-server`
-kills at ~4.5GB RSS. Running both dev servers comfortably wants a 12GB+ VM.
+Since v0.113.0 the dev stack starts it by default, from the repo root (swap `--oss` for `--ee`
+to match the loaded env file): `bash ./hosting/docker-compose/run.sh --oss --dev`. It was opt-in
+(`--with-mobile`) for one release because a live dev run showed the second Next dev server pushes
+an 8GB Docker VM into OOM-killing the main web app's first big Turbopack compile — dmesg-confirmed
+`next-server` kills at ~4.5GB RSS. Running both dev servers comfortably wants a 12GB+ VM, so on a
+small VM pass `--no-mobile`.
 
 ### WP0 residual — COMPLETE (2026-07-25, 9 commits, all dual-reviewed)
 
@@ -154,8 +155,15 @@ image build and `@agenta/mobile` typecheck needed a new job.
 
 ### WP5 device gate — EXECUTED (2026-07-26, 5 commits)
 
+> **STATUS UPDATE (2026-08-22, v0.113.0):** the gate now ships **DEFAULT ON**, and the
+> `web-mobile` compose service starts with every stack (the `with-web-mobile` profile is
+> gone). Both keys became opt-OUTs: only the exact value `false` turns a gate off, and
+> `AGENTA_MOBILE_ENABLED=false` (or `run.sh --no-mobile`) holds the service back. v0.113.0
+> shipped to production without `/m` because no deployment set the keys — that is what the
+> flip fixes. The section below records the original default-off design; read it as history.
+
 Ships the mobile device gate (design.md "Gate and routing") behind a runtime flag,
-`AGENTA_MOBILE_GATE`, **default off**: with the flag off, request behavior is byte-identical to
+`AGENTA_MOBILE_GATE`, **default off** (see the status update above): with the flag off, request behavior is byte-identical to
 today. A second flag, `AGENTA_MOBILE_REVERSE_GATE` (**default on**, mobile app only), turns off
 the reverse direction alone: mobile devices still get sent to `/m`, but nothing is bounced back
 out of `/m`. Set it to `false` to test `/m` from a tablet or a desktop browser — iPadOS Safari
@@ -301,14 +309,15 @@ pnpm dev-mobile   # → http://localhost:3000/m, check light+dark
   ordering:** `17 - check mobile` no longer publishes `latest` — there is no `push_latest` input,
   and `image_tag=latest` is rejected outright. Publication is owned by `43 - Release to GHCR` in
   the private `agenta_cloud` repo, the same as api, web, services and runner; only after that
-  pipeline has published `agenta-web-mobile` once can operators pass `--with-mobile` to
-  `bash ./hosting/docker-compose/run.sh --oss --gh` (or `--ee`). Until then, the `with-web-mobile`
-  compose profile stays opt-in on purpose — `docker compose up`/`pull` would fail the whole stack
-  against a `ghcr.io/agenta-ai/agenta-web-mobile:latest` that doesn't exist yet.
+  pipeline has published `agenta-web-mobile` once can operators start it from
+  `bash ./hosting/docker-compose/run.sh --oss --gh` (or `--ee`). That first publication happened
+  (the image starts at v0.111.0), so the opt-in `with-web-mobile` profile was removed in
+  v0.113.0 and `web-mobile` now starts with every stack; `run.sh --no-mobile` holds it back.
 - **Design-doc staleness:** `docs/designs/sessions/**` predates the streams-merge/turns model;
   don't trust it over the code. The memory file `project_agenta_mobile_discovery` (assistant
   memory) mirrors this handoff.
-- **WP5 device gate flag-flip runbook (not yet run):** once WP2 (mobile auth) and WP4 (product
+- **WP5 device gate flag-flip runbook (SUPERSEDED — the gate is default-on since v0.113.0, so
+  there is nothing to flip):** once WP2 (mobile auth) and WP4 (product
   pages) are live, per deployment: set `AGENTA_MOBILE_GATE=true` in that deployment's env file,
   recreate the `web`/`web-mobile` services, run the T6 Playwright smoke
   (`web/oss/tests/playwright/acceptance/mobile-gate/gate.spec.ts`) against it to confirm 6

--- a/docs/design/agenta-mobile/design.md
+++ b/docs/design/agenta-mobile/design.md
@@ -113,9 +113,11 @@ provider stack before deciding).
   current banner's dismissal-not-persisted annoyance.
 - `NoMobilePageWrapper` is retired when the gate is actually turned **on**, not when its code
   ships. WP5 landed the gate default-off (`AGENTA_MOBILE_GATE`), so retiring the wrapper any
-  earlier would leave a mobile visitor with neither the gate nor the blocker. Retirement (T8)
-  belongs to the deployment window that flips the flag, once WP2 and WP4 can serve what the
-  redirect points at.
+  earlier would leave a mobile visitor with neither the gate nor the blocker. **Since v0.113.0
+  the gate is default-on**, so T8 is now unblocked and is the open follow-up: the only mobile
+  visitors who still reach the wrapper are the ones who chose the desktop view (the
+  `agenta-mobile-optout` cookie) or a deployment that set `AGENTA_MOBILE_GATE=false`, and for
+  the first group the blocker is a dead end.
 
 **URL scheme (mobile app, under basePath `/m`):**
 

--- a/hosting/AGENTS.md
+++ b/hosting/AGENTS.md
@@ -56,8 +56,10 @@ proxy has the same two `location` blocks.
 Three opt-outs, from coarse to fine:
 
 - `run.sh --no-mobile`, or `AGENTA_MOBILE_ENABLED=false` in the shell or in the resolved env
-  file: the service starts with 0 replicas. On a hand-rolled `docker compose up`, the
-  equivalent is `--scale web-mobile=0`. `/m` then answers 502 and nothing else changes.
+  file: the service starts with 0 replicas and the desktop redirect gate is forced off, so
+  phones stay on the desktop UI. `--no-web` / `--web-mode none` implies the same mobile
+  opt-out for backend-only runs. On a hand-rolled `docker compose up`, pass both
+  `--scale web-mobile=0` and `AGENTA_MOBILE_GATE=false`.
 - `AGENTA_MOBILE_GATE=false`: `/m` still runs and is reachable, but no redirect happens in
   either direction.
 - `AGENTA_MOBILE_REVERSE_GATE=false`: phones still go to `/m`, and a desktop browser can open

--- a/hosting/AGENTS.md
+++ b/hosting/AGENTS.md
@@ -46,6 +46,27 @@ subscription logins. Because `run.sh` assembles the same set every time, a routi
 - `--compose-file <name>` appends an extra file (repeatable; bare name resolves in the edition
   dir like `-e`, or pass a path). Appended after the auto-included ones.
 
+### The mobile web app (`/m`) — on by default
+
+Every stack starts the `web-mobile` service, and both device gates are on, so a phone that
+opens the desktop app is redirected to `/m`. The compose files carry no profile for it and
+no env key is needed. Traefik routes ``Path(`/m`) || PathPrefix(`/m/`)`` to it; the nginx
+proxy has the same two `location` blocks.
+
+Three opt-outs, from coarse to fine:
+
+- `run.sh --no-mobile`, or `AGENTA_MOBILE_ENABLED=false` in the shell or in the resolved env
+  file: the service starts with 0 replicas. On a hand-rolled `docker compose up`, the
+  equivalent is `--scale web-mobile=0`. `/m` then answers 502 and nothing else changes.
+- `AGENTA_MOBILE_GATE=false`: `/m` still runs and is reachable, but no redirect happens in
+  either direction.
+- `AGENTA_MOBILE_REVERSE_GATE=false`: phones still go to `/m`, and a desktop browser can open
+  `/m` instead of being bounced back. This is what a preview or review deployment wants.
+
+Only the exact string `false` opts out. The keys are read at request time, so a change plus a
+container recreate is enough — no rebuild. The dev stack pays a second Next dev server for
+`web-mobile` (about 0.5-1GB RAM); use `--no-mobile` on a small VM.
+
 ### Restart one service (surgical)
 
 `run.sh --recreate <service>` and `--rebuild <service>` are the blessed entry point for

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -57,7 +57,7 @@ services:
         # Turbopack's dev middleware sandbox only exposes .env-file vars (not the
         # container's process env), so mirror the gate flag into an env file the
         # app loads. Prod standalone reads process.env at request time — dev-only.
-        command: sh -c 'echo "AGENTA_MOBILE_GATE=$${AGENTA_MOBILE_GATE:-false}" > /app/ee/.env.development.local && pnpm dev-ee'
+        command: sh -c 'echo "AGENTA_MOBILE_GATE=$${AGENTA_MOBILE_GATE:-true}" > /app/ee/.env.development.local && pnpm dev-ee'
         # === STORAGE ============================================== #
         volumes:
             - ../../../web/ee/src:/app/ee/src
@@ -75,7 +75,7 @@ services:
         environment:
             DOCKER_NETWORK_MODE: ${DOCKER_NETWORK_MODE:-bridge}
             WATCHPACK_POLLING: "true"
-            AGENTA_MOBILE_GATE: ${AGENTA_MOBILE_GATE:-false}
+            AGENTA_MOBILE_GATE: ${AGENTA_MOBILE_GATE:-true}
         # === NETWORK ============================================== #
         networks:
             - agenta-network
@@ -89,13 +89,14 @@ services:
 
     web-mobile:
         # === ACTIVATION =========================================== #
-        profiles:
-            - with-web-mobile
+        # No profile: the mobile app (/m) starts with the stack, like api and web.
+        # Opt out with `run.sh --no-mobile`, or with `--scale web-mobile=0` on a
+        # hand-rolled `docker compose up`.
         # === IMAGE ================================================ #
         image: agenta-ee-dev-web:latest
         # === EXECUTION ============================================ #
         # Same dev-sandbox env mirroring as the web service (see comment there).
-        command: sh -c 'printf "AGENTA_MOBILE_GATE=%s\nAGENTA_MOBILE_REVERSE_GATE=%s\n" "$${AGENTA_MOBILE_GATE:-false}" "$${AGENTA_MOBILE_REVERSE_GATE:-true}" > /app/mobile/.env.development.local && pnpm dev-mobile'
+        command: sh -c 'printf "AGENTA_MOBILE_GATE=%s\nAGENTA_MOBILE_REVERSE_GATE=%s\n" "$${AGENTA_MOBILE_GATE:-true}" "$${AGENTA_MOBILE_REVERSE_GATE:-true}" > /app/mobile/.env.development.local && pnpm dev-mobile'
         # === STORAGE ============================================== #
         volumes:
             - ../../../web/packages:/app/packages
@@ -109,7 +110,7 @@ services:
         environment:
             DOCKER_NETWORK_MODE: ${DOCKER_NETWORK_MODE:-bridge}
             WATCHPACK_POLLING: "true"
-            AGENTA_MOBILE_GATE: ${AGENTA_MOBILE_GATE:-false}
+            AGENTA_MOBILE_GATE: ${AGENTA_MOBILE_GATE:-true}
             AGENTA_MOBILE_REVERSE_GATE: ${AGENTA_MOBILE_REVERSE_GATE:-true}
         # === NETWORK ============================================== #
         networks:

--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -27,9 +27,9 @@ services:
 
     web-mobile:
         # === ACTIVATION =========================================== #
-        # Opt-in while the mobile app is pre-GA (run.sh --with-mobile).
-        profiles:
-            - with-web-mobile
+        # No profile: the mobile app (/m) starts with the stack, like api and web.
+        # Opt out with `run.sh --no-mobile`, or with `--scale web-mobile=0` on a
+        # hand-rolled `docker compose up`.
         # === IMAGE ================================================ #
         # The mobile app is edition-agnostic OSS-repo code: one public image
         # serves both editions (no internal-ee variant).

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -19,7 +19,7 @@ services:
         env_file:
             - ${ENV_FILE:-./.env.ee.gh}
         environment:
-            - AGENTA_MOBILE_GATE=${AGENTA_MOBILE_GATE:-false}
+            - AGENTA_MOBILE_GATE=${AGENTA_MOBILE_GATE:-true}
         # === NETWORK ============================================== #
         networks:
             - agenta-ee-gh-network
@@ -33,9 +33,9 @@ services:
 
     web-mobile:
         # === ACTIVATION =========================================== #
-        # Opt-in while the mobile app is pre-GA (run.sh --with-mobile).
-        profiles:
-            - with-web-mobile
+        # No profile: the mobile app (/m) starts with the stack, like api and web.
+        # Opt out with `run.sh --no-mobile`, or with `--scale web-mobile=0` on a
+        # hand-rolled `docker compose up`.
         # === IMAGE ================================================ #
         # The mobile app is edition-agnostic OSS-repo code: one public image
         # serves both editions (no internal-ee variant).
@@ -46,7 +46,7 @@ services:
         env_file:
             - ${ENV_FILE:-./.env.ee.gh}
         environment:
-            - AGENTA_MOBILE_GATE=${AGENTA_MOBILE_GATE:-false}
+            - AGENTA_MOBILE_GATE=${AGENTA_MOBILE_GATE:-true}
             - AGENTA_MOBILE_REVERSE_GATE=${AGENTA_MOBILE_REVERSE_GATE:-true}
         # === NETWORK ============================================== #
         networks:

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -412,8 +412,9 @@ AGENTA_STORE_SIGNING_KEY=dGhpcy1pcy1hLXNpZ25pbmcta2V5LWZvci1tb3VudHM=
 # and the device gate is on. Nothing here has to be set. Every key below is an
 # OPT-OUT.
 #
-# Do not start the web-mobile service at all (run.sh reads this; the equivalent
-# on a hand-rolled `docker compose up` is `--scale web-mobile=0`):
+# Do not start the web-mobile service. run.sh also forces the desktop gate off so
+# phones stay on the desktop UI. For hand-rolled compose, set AGENTA_MOBILE_GATE=false
+# as well as passing `--scale web-mobile=0`:
 # AGENTA_MOBILE_ENABLED=false
 #
 # Device gate. On: a phone on a desktop route goes to /m, and a desktop browser

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -407,10 +407,21 @@ AGENTA_STORE_SIGNING_KEY=dGhpcy1pcy1hLXNpZ25pbmcta2V5LWZvci1tb3VudHM=
 # AGENTA_WORKER_STREAMS / AGENTA_WORKER_QUEUES: worker topology selectors —
 # set inline per-service in compose, not here; see docs/designs/workers-sprawl/specs.md
 
-# Mobile device gate (WP5). Redirects mobile devices to /m and desktop
-# devices out of /m. Default off; flip per deployment once /m has content.
-# AGENTA_MOBILE_GATE=true
-# Reverse direction only (mobile app). Set false to keep sending mobile devices
-# to /m while letting anything reach /m directly — tablets and desktop-UA
-# browsers read as non-mobile, so the bounce blocks deliberate visits.
+# --- Mobile web app (/m) ---
+# The mobile app runs by default: the `web-mobile` service starts with the stack
+# and the device gate is on. Nothing here has to be set. Every key below is an
+# OPT-OUT.
+#
+# Do not start the web-mobile service at all (run.sh reads this; the equivalent
+# on a hand-rolled `docker compose up` is `--scale web-mobile=0`):
+# AGENTA_MOBILE_ENABLED=false
+#
+# Device gate. On: a phone on a desktop route goes to /m, and a desktop browser
+# on /m goes back to the desktop app. Only the exact value `false` turns it off,
+# which leaves /m reachable but never automatic.
+# AGENTA_MOBILE_GATE=false
+#
+# Reverse direction only (mobile app). `false` keeps sending phones to /m while
+# letting anything reach /m directly — tablets and desktop-UA browsers read as
+# non-mobile, so the bounce blocks deliberate visits.
 # AGENTA_MOBILE_REVERSE_GATE=false

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -429,3 +429,22 @@ AGENTA_STORE_SIGNING_KEY=replace-me
 # AGENTA_STORE_DOMAIN=store.example.com
 # AGENTA_WORKER_STREAMS / AGENTA_WORKER_QUEUES: worker topology selectors —
 # set inline per-service in compose, not here; see docs/designs/workers-sprawl/specs.md
+
+# --- Mobile web app (/m) ---
+# The mobile app runs by default: the `web-mobile` service starts with the stack
+# and the device gate is on. Nothing here has to be set. Every key below is an
+# OPT-OUT.
+#
+# Do not start the web-mobile service at all (run.sh reads this; the equivalent
+# on a hand-rolled `docker compose up` is `--scale web-mobile=0`):
+# AGENTA_MOBILE_ENABLED=false
+#
+# Device gate. On: a phone on a desktop route goes to /m, and a desktop browser
+# on /m goes back to the desktop app. Only the exact value `false` turns it off,
+# which leaves /m reachable but never automatic.
+# AGENTA_MOBILE_GATE=false
+#
+# Reverse direction only (mobile app). `false` keeps sending phones to /m while
+# letting anything reach /m directly — tablets and desktop-UA browsers read as
+# non-mobile, so the bounce blocks deliberate visits.
+# AGENTA_MOBILE_REVERSE_GATE=false

--- a/hosting/docker-compose/ee/env.ee.gh.example
+++ b/hosting/docker-compose/ee/env.ee.gh.example
@@ -435,8 +435,9 @@ AGENTA_STORE_SIGNING_KEY=replace-me
 # and the device gate is on. Nothing here has to be set. Every key below is an
 # OPT-OUT.
 #
-# Do not start the web-mobile service at all (run.sh reads this; the equivalent
-# on a hand-rolled `docker compose up` is `--scale web-mobile=0`):
+# Do not start the web-mobile service. run.sh also forces the desktop gate off so
+# phones stay on the desktop UI. For hand-rolled compose, set AGENTA_MOBILE_GATE=false
+# as well as passing `--scale web-mobile=0`:
 # AGENTA_MOBILE_ENABLED=false
 #
 # Device gate. On: a phone on a desktop route goes to /m, and a desktop browser

--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -50,7 +50,7 @@ services:
         # Turbopack's dev middleware sandbox only exposes .env-file vars (not the
         # container's process env), so mirror the gate flag into an env file the
         # app loads. Prod standalone reads process.env at request time — dev-only.
-        command: sh -c 'echo "AGENTA_MOBILE_GATE=$${AGENTA_MOBILE_GATE:-false}" > /app/oss/.env.development.local && pnpm dev-oss'
+        command: sh -c 'echo "AGENTA_MOBILE_GATE=$${AGENTA_MOBILE_GATE:-true}" > /app/oss/.env.development.local && pnpm dev-oss'
         # === STORAGE ============================================== #
         volumes:
             #
@@ -67,7 +67,7 @@ services:
         environment:
             DOCKER_NETWORK_MODE: ${DOCKER_NETWORK_MODE:-bridge}
             WATCHPACK_POLLING: "true"
-            AGENTA_MOBILE_GATE: ${AGENTA_MOBILE_GATE:-false}
+            AGENTA_MOBILE_GATE: ${AGENTA_MOBILE_GATE:-true}
         # === NETWORK ============================================== #
         networks:
             - agenta-network
@@ -81,13 +81,14 @@ services:
 
     web-mobile:
         # === ACTIVATION =========================================== #
-        profiles:
-            - with-web-mobile
+        # No profile: the mobile app (/m) starts with the stack, like api and web.
+        # Opt out with `run.sh --no-mobile`, or with `--scale web-mobile=0` on a
+        # hand-rolled `docker compose up`.
         # === IMAGE ================================================ #
         image: agenta-oss-dev-web:latest
         # === EXECUTION ============================================ #
         # Same dev-sandbox env mirroring as the web service (see comment there).
-        command: sh -c 'printf "AGENTA_MOBILE_GATE=%s\nAGENTA_MOBILE_REVERSE_GATE=%s\n" "$${AGENTA_MOBILE_GATE:-false}" "$${AGENTA_MOBILE_REVERSE_GATE:-true}" > /app/mobile/.env.development.local && pnpm dev-mobile'
+        command: sh -c 'printf "AGENTA_MOBILE_GATE=%s\nAGENTA_MOBILE_REVERSE_GATE=%s\n" "$${AGENTA_MOBILE_GATE:-true}" "$${AGENTA_MOBILE_REVERSE_GATE:-true}" > /app/mobile/.env.development.local && pnpm dev-mobile'
         # === STORAGE ============================================== #
         volumes:
             - ../../../web/packages:/app/packages
@@ -101,7 +102,7 @@ services:
         environment:
             DOCKER_NETWORK_MODE: ${DOCKER_NETWORK_MODE:-bridge}
             WATCHPACK_POLLING: "true"
-            AGENTA_MOBILE_GATE: ${AGENTA_MOBILE_GATE:-false}
+            AGENTA_MOBILE_GATE: ${AGENTA_MOBILE_GATE:-true}
             AGENTA_MOBILE_REVERSE_GATE: ${AGENTA_MOBILE_REVERSE_GATE:-true}
         # === NETWORK ============================================== #
         networks:

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -27,9 +27,9 @@ services:
 
     web-mobile:
         # === ACTIVATION =========================================== #
-        # Opt-in while the mobile app is pre-GA (run.sh --with-mobile).
-        profiles:
-            - with-web-mobile
+        # No profile: the mobile app (/m) starts with the stack, like api and web.
+        # Opt out with `run.sh --no-mobile`, or with `--scale web-mobile=0` on a
+        # hand-rolled `docker compose up`.
         # === IMAGE ================================================ #
         build:
             context: ../../../web

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -29,9 +29,9 @@ services:
 
     web-mobile:
         # === ACTIVATION =========================================== #
-        # Opt-in while the mobile app is pre-GA (run.sh --with-mobile).
-        profiles:
-            - with-web-mobile
+        # No profile: the mobile app (/m) starts with the stack, like api and web.
+        # Opt out with `run.sh --no-mobile`, or with `--scale web-mobile=0` on a
+        # hand-rolled `docker compose up`.
         # === IMAGE ================================================ #
         build:
             context: ../../../web

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -16,7 +16,7 @@ services:
         env_file:
             - ${ENV_FILE:-./.env.oss.gh}
         environment:
-            - AGENTA_MOBILE_GATE=${AGENTA_MOBILE_GATE:-false}
+            - AGENTA_MOBILE_GATE=${AGENTA_MOBILE_GATE:-true}
         # === NETWORK ============================================== #
         networks:
             - agenta-oss-gh-network
@@ -30,9 +30,9 @@ services:
 
     web-mobile:
         # === ACTIVATION =========================================== #
-        # Opt-in while the mobile app is pre-GA (run.sh --with-mobile).
-        profiles:
-            - with-web-mobile
+        # No profile: the mobile app (/m) starts with the stack, like api and web.
+        # Opt out with `run.sh --no-mobile`, or with `--scale web-mobile=0` on a
+        # hand-rolled `docker compose up`.
         # === IMAGE ================================================ #
         # build:
         #     context: ../../../web
@@ -44,7 +44,7 @@ services:
         env_file:
             - ${ENV_FILE:-./.env.oss.gh}
         environment:
-            - AGENTA_MOBILE_GATE=${AGENTA_MOBILE_GATE:-false}
+            - AGENTA_MOBILE_GATE=${AGENTA_MOBILE_GATE:-true}
             - AGENTA_MOBILE_REVERSE_GATE=${AGENTA_MOBILE_REVERSE_GATE:-true}
         # === NETWORK ============================================== #
         networks:

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -409,10 +409,21 @@ AGENTA_STORE_SIGNING_KEY=dGhpcy1pcy1hLXNpZ25pbmcta2V5LWZvci1tb3VudHM=
 # AGENTA_WORKER_STREAMS / AGENTA_WORKER_QUEUES: worker topology selectors —
 # set inline per-service in compose, not here; see docs/designs/workers-sprawl/specs.md
 
-# Mobile device gate (WP5). Redirects mobile devices to /m and desktop
-# devices out of /m. Default off; flip per deployment once /m has content.
-# AGENTA_MOBILE_GATE=true
-# Reverse direction only (mobile app). Set false to keep sending mobile devices
-# to /m while letting anything reach /m directly — tablets and desktop-UA
-# browsers read as non-mobile, so the bounce blocks deliberate visits.
+# --- Mobile web app (/m) ---
+# The mobile app runs by default: the `web-mobile` service starts with the stack
+# and the device gate is on. Nothing here has to be set. Every key below is an
+# OPT-OUT.
+#
+# Do not start the web-mobile service at all (run.sh reads this; the equivalent
+# on a hand-rolled `docker compose up` is `--scale web-mobile=0`):
+# AGENTA_MOBILE_ENABLED=false
+#
+# Device gate. On: a phone on a desktop route goes to /m, and a desktop browser
+# on /m goes back to the desktop app. Only the exact value `false` turns it off,
+# which leaves /m reachable but never automatic.
+# AGENTA_MOBILE_GATE=false
+#
+# Reverse direction only (mobile app). `false` keeps sending phones to /m while
+# letting anything reach /m directly — tablets and desktop-UA browsers read as
+# non-mobile, so the bounce blocks deliberate visits.
 # AGENTA_MOBILE_REVERSE_GATE=false

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -414,8 +414,9 @@ AGENTA_STORE_SIGNING_KEY=dGhpcy1pcy1hLXNpZ25pbmcta2V5LWZvci1tb3VudHM=
 # and the device gate is on. Nothing here has to be set. Every key below is an
 # OPT-OUT.
 #
-# Do not start the web-mobile service at all (run.sh reads this; the equivalent
-# on a hand-rolled `docker compose up` is `--scale web-mobile=0`):
+# Do not start the web-mobile service. run.sh also forces the desktop gate off so
+# phones stay on the desktop UI. For hand-rolled compose, set AGENTA_MOBILE_GATE=false
+# as well as passing `--scale web-mobile=0`:
 # AGENTA_MOBILE_ENABLED=false
 #
 # Device gate. On: a phone on a desktop route goes to /m, and a desktop browser

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -429,3 +429,22 @@ AGENTA_STORE_SIGNING_KEY=replace-me
 # AGENTA_STORE_DOMAIN=store.example.com
 # AGENTA_WORKER_STREAMS / AGENTA_WORKER_QUEUES: worker topology selectors —
 # set inline per-service in compose, not here; see docs/designs/workers-sprawl/specs.md
+
+# --- Mobile web app (/m) ---
+# The mobile app runs by default: the `web-mobile` service starts with the stack
+# and the device gate is on. Nothing here has to be set. Every key below is an
+# OPT-OUT.
+#
+# Do not start the web-mobile service at all (run.sh reads this; the equivalent
+# on a hand-rolled `docker compose up` is `--scale web-mobile=0`):
+# AGENTA_MOBILE_ENABLED=false
+#
+# Device gate. On: a phone on a desktop route goes to /m, and a desktop browser
+# on /m goes back to the desktop app. Only the exact value `false` turns it off,
+# which leaves /m reachable but never automatic.
+# AGENTA_MOBILE_GATE=false
+#
+# Reverse direction only (mobile app). `false` keeps sending phones to /m while
+# letting anything reach /m directly — tablets and desktop-UA browsers read as
+# non-mobile, so the bounce blocks deliberate visits.
+# AGENTA_MOBILE_REVERSE_GATE=false

--- a/hosting/docker-compose/oss/env.oss.gh.example
+++ b/hosting/docker-compose/oss/env.oss.gh.example
@@ -435,8 +435,9 @@ AGENTA_STORE_SIGNING_KEY=replace-me
 # and the device gate is on. Nothing here has to be set. Every key below is an
 # OPT-OUT.
 #
-# Do not start the web-mobile service at all (run.sh reads this; the equivalent
-# on a hand-rolled `docker compose up` is `--scale web-mobile=0`):
+# Do not start the web-mobile service. run.sh also forces the desktop gate off so
+# phones stay on the desktop UI. For hand-rolled compose, set AGENTA_MOBILE_GATE=false
+# as well as passing `--scale web-mobile=0`:
 # AGENTA_MOBILE_ENABLED=false
 #
 # Device gate. On: a phone on a desktop route goes to /m, and a desktop browser

--- a/hosting/docker-compose/oss/nginx/nginx.conf
+++ b/hosting/docker-compose/oss/nginx/nginx.conf
@@ -50,16 +50,16 @@ http {
             proxy_read_timeout 30s;
         }
 
-        # Proxy to the mobile web app, which only runs when the stack was started with
-        # --with-mobile. `location = /m` plus `location /m/` is nginx's spelling of the Traefik
-        # rule the same service carries: segment-exact, so `/models` still falls through to the
-        # catch-all below instead of being swallowed by a bare `/m` prefix.
+        # Proxy to the mobile web app, which starts with every stack. `location = /m` plus
+        # `location /m/` is nginx's spelling of the Traefik rule the same service carries:
+        # segment-exact, so `/models` still falls through to the catch-all below instead of
+        # being swallowed by a bare `/m` prefix.
         #
         # The upstream goes through a variable ON PURPOSE. nginx resolves a literal upstream
-        # host at startup, so without the with-web-mobile profile the whole proxy would fail to
-        # boot on an unresolvable name. Through a variable the lookup happens per request (via
-        # the http-level resolver above), so a stack without the mobile app is unaffected and
-        # /m alone answers 502.
+        # host at startup, so a stack started with `run.sh --no-mobile` (web-mobile scaled to
+        # 0) would fail the whole proxy on an unresolvable name. Through a variable the lookup
+        # happens per request (via the http-level resolver above), so an opted-out stack is
+        # unaffected and /m alone answers 502.
         location = /m {
             set $mobile_upstream http://web-mobile:3000;
             proxy_pass $mobile_upstream;

--- a/hosting/docker-compose/run.sh
+++ b/hosting/docker-compose/run.sh
@@ -21,7 +21,11 @@ NUKE=false  # Default to not nuking volumes
 DOWN=false  # Default to up; --down only stops containers
 WITH_TUNNEL=true  # Composio trigger-event tunnel; disable with --no-tunnel
 LOCAL_OVERRIDES=true  # Auto-include docker-compose.<stage>.*.local.yml; disable with --no-local-overrides
-WITH_MOBILE=false  # Start the mobile web app (/m) via the with-web-mobile profile; enable with --with-mobile
+# The mobile web app (/m) starts with every stack. --no-mobile, or
+# AGENTA_MOBILE_ENABLED=false in the shell or in the resolved env file, drops it (the
+# service is scaled to 0 replicas). Resolved after the env file is known.
+WITH_MOBILE=true
+NO_MOBILE_FLAG=false
 declare -a EXTRA_COMPOSE_FILES=()  # Extra -f files from --compose-file (repeatable)
 declare -a RECREATE_SERVICES=()    # Services to surgically recreate via --recreate (repeatable)
 declare -a REBUILD_SERVICES=()     # Services to surgically rebuild + recreate via --rebuild (repeatable)
@@ -51,8 +55,10 @@ show_usage() {
     echo "  --web-local             Alias for --web-mode local"
     echo "  --web-mode <mode>       Web mode: docker|local|none (default: docker)"
     echo "  --web-url <URL>         Override AGENTA_WEB_URL"
-    echo "  --with-mobile           Also start the mobile web app at /m (all stacks, incl. --dev;"
-    echo "                          the extra dev server costs ~0.5-1GB RAM — keep it off otherwise)"
+    echo "  --no-mobile             Do NOT start the mobile web app at /m. It starts by default on"
+    echo "                          every stack, incl. --dev, where the extra dev server costs"
+    echo "                          ~0.5-1GB RAM. Same as AGENTA_MOBILE_ENABLED=false."
+    echo "  --with-mobile           Deprecated no-op: /m starts by default now."
     echo ""
     echo "Environment:"
     echo "  -e, --env <path>        Use explicit env file (otherwise stage default)"
@@ -257,7 +263,11 @@ while [[ "$#" -gt 0 ]]; do
             WITH_TUNNEL=false
             ;;
         --with-mobile)
+            # Deprecated: /m is on by default. Kept so old commands and scripts still run.
             WITH_MOBILE=true
+            ;;
+        --no-mobile)
+            NO_MOBILE_FLAG=true
             ;;
         --no-local-overrides)
             LOCAL_OVERRIDES=false
@@ -424,6 +434,25 @@ Refusing to start: Docker Compose would silently fall back to its built-in defau
 Pass an existing --env-file (e.g. --env-file .env.$LICENSE.$STAGE.local) or create the file."
 fi
 
+# Resolve the mobile opt-out. Precedence: --no-mobile, then AGENTA_MOBILE_ENABLED in the
+# shell, then the same key in the resolved env file. run.sh does not source the env file
+# (compose reads it directly), so this one key is read out of it explicitly — an operator
+# who writes the opt-out where every other setting lives must get the opt-out.
+if $NO_MOBILE_FLAG; then
+    WITH_MOBILE=false
+elif [[ -n "${AGENTA_MOBILE_ENABLED:-}" ]]; then
+    # Explicit if, not `[[ ]] && ...`: under `set -e` a trailing false test exits the script.
+    if [[ "$AGENTA_MOBILE_ENABLED" == "false" ]]; then
+        WITH_MOBILE=false
+    fi
+elif grep -Eq '^[[:space:]]*AGENTA_MOBILE_ENABLED[[:space:]]*=[[:space:]]*"?false"?[[:space:]]*$' "$ENV_FILE_PATH"; then
+    WITH_MOBILE=false
+fi
+
+if ! $WITH_MOBILE; then
+    echo "Mobile web app (/m) disabled: starting web-mobile with 0 replicas."
+fi
+
 # Export the ENV_FILE to the environment
 export ENV_FILE="$ENV_FILE"
 
@@ -465,8 +494,13 @@ if $WITH_TUNNEL; then
     COMPOSE_CMD+=" --profile with-tunnel"
 fi
 
-if $WITH_MOBILE; then
-    COMPOSE_CMD+=" --profile with-web-mobile"
+# The mobile app has no profile: it is part of the stack. Opting out means starting it
+# with 0 replicas, which is the only compose-native way to hold back one service of a
+# file that everything else in the stack shares. `--scale` is valid on `up` only, so it
+# is kept out of COMPOSE_CMD (which also drives `config`, `build`, `pull`, and `down`).
+UP_EXTRA_ARGS=""
+if ! $WITH_MOBILE; then
+    UP_EXTRA_ARGS=" --scale web-mobile=0"
 fi
 
 # --------------------------------------------------------------------------------------------
@@ -554,7 +588,7 @@ fi
 echo "Stopping existing Docker containers..."
 
 # Include all profiles to ensure clean shutdown
-SHUTDOWN_CMD="$COMPOSE_CMD --profile with-web-mobile --profile with-web --profile with-nginx --profile with-traefik --profile with-tunnel down"
+SHUTDOWN_CMD="$COMPOSE_CMD --profile with-web --profile with-nginx --profile with-traefik --profile with-tunnel down"
 
 if $NUKE; then
     SHUTDOWN_CMD+=" --volumes"
@@ -568,7 +602,7 @@ if $DOWN; then
 fi
 
 echo "Starting Docker containers with domain: $AGENTA_WEB_URL ..."
-AGENTA_WEB_URL="$AGENTA_WEB_URL" $COMPOSE_CMD up -d --remove-orphans || error_exit "Failed to start Docker containers."
+AGENTA_WEB_URL="$AGENTA_WEB_URL" $COMPOSE_CMD up -d --remove-orphans$UP_EXTRA_ARGS || error_exit "Failed to start Docker containers."
 
 echo "✅ Setup complete!"
 

--- a/hosting/docker-compose/run.sh
+++ b/hosting/docker-compose/run.sh
@@ -51,13 +51,13 @@ show_usage() {
     echo "  --no-cache              Build with --no-cache (requires --build)"
     echo ""
     echo "Web:"
-    echo "  --no-web                Alias for --web-mode none"
+    echo "  --no-web                Alias for --web-mode none; disables desktop and mobile web"
     echo "  --web-local             Alias for --web-mode local"
     echo "  --web-mode <mode>       Web mode: docker|local|none (default: docker)"
     echo "  --web-url <URL>         Override AGENTA_WEB_URL"
     echo "  --no-mobile             Do NOT start the mobile web app at /m. It starts by default on"
     echo "                          every stack, incl. --dev, where the extra dev server costs"
-    echo "                          ~0.5-1GB RAM. Same as AGENTA_MOBILE_ENABLED=false."
+    echo "                          ~0.5-1GB RAM. Also disables the desktop redirect gate."
     echo "  --with-mobile           Deprecated no-op: /m starts by default now."
     echo ""
     echo "Environment:"
@@ -434,11 +434,14 @@ Refusing to start: Docker Compose would silently fall back to its built-in defau
 Pass an existing --env-file (e.g. --env-file .env.$LICENSE.$STAGE.local) or create the file."
 fi
 
-# Resolve the mobile opt-out. Precedence: --no-mobile, then AGENTA_MOBILE_ENABLED in the
-# shell, then the same key in the resolved env file. run.sh does not source the env file
-# (compose reads it directly), so this one key is read out of it explicitly — an operator
-# who writes the opt-out where every other setting lives must get the opt-out.
-if $NO_MOBILE_FLAG; then
+# Resolve the mobile opt-out. A backend-only run (--no-web / --web-mode none) disables both
+# web clients. Otherwise precedence is --no-mobile, then AGENTA_MOBILE_ENABLED in the shell,
+# then the same key in the resolved env file. run.sh does not source the env file (compose
+# reads it directly), so this one key is read out of it explicitly — an operator who writes
+# the opt-out where every other setting lives must get the opt-out.
+if [[ "$WEB_MODE" == "none" ]]; then
+    WITH_MOBILE=false
+elif $NO_MOBILE_FLAG; then
     WITH_MOBILE=false
 elif [[ -n "${AGENTA_MOBILE_ENABLED:-}" ]]; then
     # Explicit if, not `[[ ]] && ...`: under `set -e` a trailing false test exits the script.
@@ -451,6 +454,10 @@ fi
 
 if ! $WITH_MOBILE; then
     echo "Mobile web app (/m) disabled: starting web-mobile with 0 replicas."
+    # The desktop middleware defaults its phone gate on. Override compose interpolation when
+    # the target service is absent, so --no-mobile / AGENTA_MOBILE_ENABLED=false can never
+    # redirect phones to a backend that was deliberately scaled to zero.
+    export AGENTA_MOBILE_GATE=false
 fi
 
 # Export the ENV_FILE to the environment

--- a/hosting/kubernetes/ee/values.ee.example.yaml
+++ b/hosting/kubernetes/ee/values.ee.example.yaml
@@ -43,6 +43,11 @@ global:
 #   image:
 #     tag: latest
 #     pullPolicy: IfNotPresent
+# webMobile:
+#   image:
+#     repository: ghcr.io/agenta-ai/agenta-web-mobile
+#     tag: latest
+#     pullPolicy: IfNotPresent
 # services:
 #   image:
 #     tag: latest
@@ -447,6 +452,16 @@ posthog:
 #       memory: 256Mi
 #     limits:
 #       memory: 512Mi
+# webMobile:
+#   enabled: true
+#   replicas: 1
+#   port: 3000
+#   resources:
+#     requests:
+#       cpu: 100m
+#       memory: 256Mi
+#     limits:
+#       memory: 512Mi
 # services:
 #   enabled: true
 #   replicas: 1
@@ -485,8 +500,9 @@ posthog:
 
 # ================================================================== #
 # === ingress ===
-# Path routing: / → web, /api → api (prefix-stripped), /services → services
-# (prefix-stripped).  When running behind Traefik, attach the StripPrefix
+# Path routing: / → web, /m → web-mobile, /api → api (prefix-stripped),
+# /services → services (prefix-stripped). The /m route is fixed because the mobile
+# image is built with basePath /m.  When running behind Traefik, attach the StripPrefix
 # Middleware defined under extraObjects below.
 # ================================================================== #
 # ingress:

--- a/hosting/kubernetes/helm/templates/NOTES.txt
+++ b/hosting/kubernetes/helm/templates/NOTES.txt
@@ -85,6 +85,7 @@ class + annotations and provide an equivalent path-rewrite mechanism.
 Agenta is accessible via Ingress:
 {{- if $ingress.host }}
   Web UI:   http{{ if $ingress.tls }}s{{ end }}://{{ $ingress.host }}/
+  Mobile:   http{{ if $ingress.tls }}s{{ end }}://{{ $ingress.host }}/m
   API:      http{{ if $ingress.tls }}s{{ end }}://{{ $ingress.host }}/api/
   Services: http{{ if $ingress.tls }}s{{ end }}://{{ $ingress.host }}/services/
 {{- else }}
@@ -93,6 +94,7 @@ Agenta is accessible via Ingress:
 
   Then access:
     Web UI:   http://<INGRESS_IP>/
+    Mobile:   http://<INGRESS_IP>/m
     API:      http://<INGRESS_IP>/api/
     Services: http://<INGRESS_IP>/services/
 {{- end }}
@@ -102,6 +104,9 @@ Agenta services are available via ClusterIP. Use port-forward to access them:
 
   # Web UI
   kubectl port-forward svc/{{ include "agenta.fullname" . }}-web {{ include "agenta.web.port" . }}:{{ include "agenta.web.port" . }} -n {{ .Release.Namespace }}
+
+  # Mobile UI
+  kubectl port-forward svc/{{ include "agenta.fullname" . }}-web-mobile {{ include "agenta.webMobile.port" . }}:{{ include "agenta.webMobile.port" . }} -n {{ .Release.Namespace }}
 
   # API
   kubectl port-forward svc/{{ include "agenta.fullname" . }}-api {{ include "agenta.api.port" . }}:{{ include "agenta.api.port" . }} -n {{ .Release.Namespace }}

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -57,6 +57,10 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- $v := (default dict .Values.web).enabled -}}
 {{- if kindIs "invalid" $v }}true{{- else }}{{- $v -}}{{- end }}
 {{- end }}
+{{- define "agenta.webMobile.enabled" -}}
+{{- $v := (default dict .Values.webMobile).enabled -}}
+{{- if kindIs "invalid" $v }}true{{- else }}{{- $v -}}{{- end }}
+{{- end }}
 {{- define "agenta.services.enabled" -}}
 {{- $v := (default dict .Values.services).enabled -}}
 {{- if kindIs "invalid" $v }}true{{- else }}{{- $v -}}{{- end }}
@@ -126,6 +130,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
    ================================================================ */}}
 {{- define "agenta.api.replicas" -}}{{ default 1 (default dict .Values.api).replicas }}{{- end }}
 {{- define "agenta.web.replicas" -}}{{ default 1 (default dict .Values.web).replicas }}{{- end }}
+{{- define "agenta.webMobile.replicas" -}}{{ default 1 (default dict .Values.webMobile).replicas }}{{- end }}
 {{- define "agenta.services.replicas" -}}{{ default 1 (default dict .Values.services).replicas }}{{- end }}
 {{- define "agenta.agentRunner.replicas" -}}{{ default 1 (default dict .Values.agentRunner).replicas }}{{- end }}
 {{- define "agenta.supertokens.replicas" -}}{{ default 1 (default dict (include "agenta.values" . | fromYaml).supertokens).replicas }}{{- end }}
@@ -147,6 +152,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
    ================================================================ */}}
 {{- define "agenta.api.port" -}}{{ default 8000 (default dict .Values.api).port }}{{- end }}
 {{- define "agenta.web.port" -}}{{ default 3000 (default dict .Values.web).port }}{{- end }}
+{{- define "agenta.webMobile.port" -}}{{ default 3000 (default dict .Values.webMobile).port }}{{- end }}
 {{- define "agenta.services.port" -}}{{ default 80 (default dict .Values.services).port }}{{- end }}
 {{- define "agenta.agentRunner.port" -}}{{ default 8765 (default dict .Values.agentRunner).port }}{{- end }}
 {{- define "agenta.supertokens.port" -}}{{ default 3567 (default dict (include "agenta.values" . | fromYaml).supertokens).port }}{{- end }}
@@ -158,6 +164,7 @@ app.kubernetes.io/instance: {{ .Release.Name }}
    ================================================================ */}}
 {{- define "agenta.api.pullPolicy" -}}{{ default "IfNotPresent" (default dict (default dict .Values.api).image).pullPolicy }}{{- end }}
 {{- define "agenta.web.pullPolicy" -}}{{ default "IfNotPresent" (default dict (default dict .Values.web).image).pullPolicy }}{{- end }}
+{{- define "agenta.webMobile.pullPolicy" -}}{{ default "IfNotPresent" (default dict (default dict .Values.webMobile).image).pullPolicy }}{{- end }}
 {{- define "agenta.services.pullPolicy" -}}{{ default "IfNotPresent" (default dict (default dict .Values.services).image).pullPolicy }}{{- end }}
 {{- define "agenta.agentRunner.pullPolicy" -}}{{ default "IfNotPresent" (default dict (default dict .Values.agentRunner).image).pullPolicy }}{{- end }}
 {{- define "agenta.supertokens.pullPolicy" -}}{{ default "IfNotPresent" (default dict (default dict (include "agenta.values" . | fromYaml).supertokens).image).pullPolicy }}{{- end }}
@@ -275,6 +282,16 @@ ghcr.io/agenta-ai/agenta-web
 {{- define "agenta.webImage" -}}
 {{- $img := default dict (default dict .Values.web).image -}}
 {{ include "agenta.webImageRepository" . }}:{{ $img.tag | default .Chart.AppVersion }}
+{{- end }}
+
+{{- define "agenta.webMobileImageRepository" -}}
+{{- $img := default dict (default dict .Values.webMobile).image -}}
+{{- default "ghcr.io/agenta-ai/agenta-web-mobile" $img.repository -}}
+{{- end }}
+
+{{- define "agenta.webMobileImage" -}}
+{{- $img := default dict (default dict .Values.webMobile).image -}}
+{{ include "agenta.webMobileImageRepository" . }}:{{ $img.tag | default .Chart.AppVersion }}
 {{- end }}
 
 {{- define "agenta.servicesImageRepository" -}}
@@ -414,6 +431,8 @@ http://{{ include "agenta.agentRunner.serviceName" . }}:{{ include "agenta.agent
 {{- $svc := default dict $paths.services -}}
 {{- default "Prefix" $svc.pathType -}}
 {{- end }}
+{{- define "agenta.ingress.paths.webMobile.path" -}}/m{{- end }}
+{{- define "agenta.ingress.paths.webMobile.pathType" -}}Prefix{{- end }}
 {{- define "agenta.ingress.paths.web.path" -}}
 {{- $paths := default dict (default dict .Values.ingress).paths -}}
 {{- $w := default dict $paths.web -}}

--- a/hosting/kubernetes/helm/templates/ingress.yaml
+++ b/hosting/kubernetes/helm/templates/ingress.yaml
@@ -3,7 +3,8 @@
 {{- $apiEnabled := eq (include "agenta.api.enabled" .) "true" -}}
 {{- $servicesEnabled := eq (include "agenta.services.enabled" .) "true" -}}
 {{- $webEnabled := eq (include "agenta.web.enabled" .) "true" -}}
-{{- if and (eq (include "agenta.ingress.enabled" .) "true") (or $apiEnabled $servicesEnabled $webEnabled) }}
+{{- $webMobileEnabled := eq (include "agenta.webMobile.enabled" .) "true" -}}
+{{- if and (eq (include "agenta.ingress.enabled" .) "true") (or $apiEnabled $servicesEnabled $webEnabled $webMobileEnabled) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -39,6 +40,15 @@ spec:
             backend:
               service:
                 name: {{ include "agenta.fullname" . }}-services
+                port:
+                  name: http
+          {{- end }}
+          {{- if eq (include "agenta.webMobile.enabled" .) "true" }}
+          - path: {{ include "agenta.ingress.paths.webMobile.path" . }}
+            pathType: {{ include "agenta.ingress.paths.webMobile.pathType" . }}
+            backend:
+              service:
+                name: {{ include "agenta.fullname" . }}-web-mobile
                 port:
                   name: http
           {{- end }}

--- a/hosting/kubernetes/helm/templates/web-mobile-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/web-mobile-deployment.yaml
@@ -1,45 +1,45 @@
 {{- $values := include "agenta.values" . | fromYaml -}}
-{{- $web := default dict $values.web -}}
+{{- $webMobile := default dict $values.webMobile -}}
 {{- $agenta := default dict $values.agenta -}}
-{{- if eq (include "agenta.web.enabled" .) "true" }}
+{{- if eq (include "agenta.webMobile.enabled" .) "true" }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ include "agenta.fullname" . }}-web
+  name: {{ include "agenta.fullname" . }}-web-mobile
   labels:
     {{- include "agenta.labels" . | nindent 4 }}
-    app.kubernetes.io/component: web
+    app.kubernetes.io/component: web-mobile
 spec:
-  replicas: {{ include "agenta.web.replicas" . }}
+  replicas: {{ include "agenta.webMobile.replicas" . }}
   selector:
     matchLabels:
       {{- include "agenta.selectorLabels" . | nindent 6 }}
-      app.kubernetes.io/component: web
+      app.kubernetes.io/component: web-mobile
   template:
     metadata:
       labels:
         {{- include "agenta.selectorLabels" . | nindent 8 }}
-        app.kubernetes.io/component: web
+        app.kubernetes.io/component: web-mobile
     spec:
       {{- include "agenta.imagePullSecrets" . | nindent 6 }}
       serviceAccountName: {{ include "agenta.serviceAccountName" . }}
-      {{- with $web.podSecurityContext }}
+      {{- with $webMobile.podSecurityContext }}
       securityContext:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       containers:
-        - name: web
-          image: {{ include "agenta.webImage" . }}
-          imagePullPolicy: {{ include "agenta.web.pullPolicy" . }}
-          {{- with $web.securityContext }}
+        - name: web-mobile
+          image: {{ include "agenta.webMobileImage" . }}
+          imagePullPolicy: {{ include "agenta.webMobile.pullPolicy" . }}
+          {{- with $webMobile.securityContext }}
           securityContext:
             {{- toYaml . | nindent 12 }}
           {{- end }}
           command: ["/app/entrypoint.sh"]
-          args: ["node", {{ include "agenta.webServerPath" . | quote }}]
+          args: ["node", "mobile/server.js"]
           ports:
             - name: http
-              containerPort: {{ include "agenta.web.port" . }}
+              containerPort: {{ include "agenta.webMobile.port" . }}
               protocol: TCP
           env:
             - name: HOSTNAME
@@ -54,6 +54,8 @@ spec:
               value: {{ $agenta.apiUrl | default "" | quote }}
             - name: AGENTA_MOBILE_GATE
               value: {{ eq (include "agenta.webMobile.enabled" .) "true" | quote }}
+            - name: AGENTA_MOBILE_REVERSE_GATE
+              value: "true"
             - name: AGENTA_AUTH_KEY
               valueFrom:
                 secretKeyRef:
@@ -73,13 +75,13 @@ spec:
                   key: SUPERTOKENS_API_KEY
                   optional: true
             {{- include "agenta.webOptionalEnv" . | nindent 12 }}
-            {{- range $key, $val := $web.env }}
+            {{- range $key, $val := $webMobile.env }}
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
           startupProbe:
             httpGet:
-              path: /
+              path: /m/__env.js
               port: http
             initialDelaySeconds: 5
             periodSeconds: 5
@@ -87,31 +89,31 @@ spec:
             failureThreshold: 30
           livenessProbe:
             httpGet:
-              path: /
+              path: /m/__env.js
               port: http
             periodSeconds: 15
             timeoutSeconds: 5
             failureThreshold: 3
           readinessProbe:
             httpGet:
-              path: /
+              path: /m/__env.js
               port: http
             periodSeconds: 10
             timeoutSeconds: 5
             failureThreshold: 3
-          {{- with $web.resources }}
+          {{- with $webMobile.resources }}
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-      {{- with $web.nodeSelector }}
+      {{- with $webMobile.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $web.tolerations }}
+      {{- with $webMobile.tolerations }}
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
-      {{- with $web.affinity }}
+      {{- with $webMobile.affinity }}
       affinity:
         {{- toYaml . | nindent 8 }}
       {{- end }}

--- a/hosting/kubernetes/helm/templates/web-mobile-service.yaml
+++ b/hosting/kubernetes/helm/templates/web-mobile-service.yaml
@@ -1,0 +1,19 @@
+{{- if eq (include "agenta.webMobile.enabled" .) "true" }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "agenta.fullname" . }}-web-mobile
+  labels:
+    {{- include "agenta.labels" . | nindent 4 }}
+    app.kubernetes.io/component: web-mobile
+spec:
+  type: ClusterIP
+  ports:
+    - port: {{ include "agenta.webMobile.port" . }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "agenta.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/component: web-mobile
+{{- end }}

--- a/hosting/kubernetes/helm/tests/test_web_mobile.py
+++ b/hosting/kubernetes/helm/tests/test_web_mobile.py
@@ -1,0 +1,163 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["PyYAML>=6"]
+# ///
+"""Rendered-chart regression coverage for the default-on mobile web workload.
+
+Run: uv run hosting/kubernetes/helm/tests/test_web_mobile.py
+Requires the `helm` binary on PATH.
+"""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+import yaml
+
+CHART_DIR = Path(__file__).resolve().parents[1]
+BASE_ARGS = [
+    "--set",
+    "agenta.webUrl=https://agenta.example.com",
+    "--set",
+    "agenta.apiUrl=https://agenta.example.com/api",
+    "--set",
+    "agenta.servicesUrl=https://agenta.example.com/services",
+    "--set",
+    "agenta.authKey=test-auth-key",
+    "--set",
+    "agenta.cryptKey=test-crypt-key",
+    "--set",
+    "agenta.runnerToken=test-runner-token",
+    "--set",
+    "postgres.password=test-postgres-password",
+]
+
+
+def render(extra_args: list[str] | None = None) -> list[dict]:
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            "mobile-chart-test",
+            str(CHART_DIR),
+            *BASE_ARGS,
+            *(extra_args or []),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
+def component(docs: list[dict], kind: str, name: str) -> dict:
+    for doc in docs:
+        labels = doc.get("metadata", {}).get("labels", {})
+        if (
+            doc.get("kind") == kind
+            and labels.get("app.kubernetes.io/component") == name
+        ):
+            return doc
+    raise AssertionError(f"no {kind} with component {name!r}")
+
+
+def components(docs: list[dict], name: str) -> list[dict]:
+    return [
+        doc
+        for doc in docs
+        if (
+            doc.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component")
+            == name
+        )
+    ]
+
+
+def container(deployment: dict) -> dict:
+    return deployment["spec"]["template"]["spec"]["containers"][0]
+
+
+def env_value(deployment: dict, name: str) -> str:
+    entry = next(item for item in container(deployment)["env"] if item["name"] == name)
+    return entry["value"]
+
+
+def ingress_paths(docs: list[dict]) -> list[dict]:
+    ingress = next(doc for doc in docs if doc.get("kind") == "Ingress")
+    return ingress["spec"]["rules"][0]["http"]["paths"]
+
+
+def main() -> int:
+    docs = render()
+    mobile_deployment = component(docs, "Deployment", "web-mobile")
+    mobile_container = container(mobile_deployment)
+    mobile_service = component(docs, "Service", "web-mobile")
+    desktop_deployment = component(docs, "Deployment", "web")
+
+    assert mobile_deployment["spec"]["replicas"] == 1
+    assert mobile_container["image"].startswith("ghcr.io/agenta-ai/agenta-web-mobile:")
+    assert mobile_container["command"] == ["/app/entrypoint.sh"]
+    assert mobile_container["args"] == ["node", "mobile/server.js"]
+    assert mobile_service["spec"]["ports"][0]["port"] == 3000
+    assert env_value(desktop_deployment, "AGENTA_MOBILE_GATE") == "true"
+    assert env_value(mobile_deployment, "AGENTA_MOBILE_GATE") == "true"
+    assert env_value(mobile_deployment, "AGENTA_MOBILE_REVERSE_GATE") == "true"
+    for probe in ("startupProbe", "livenessProbe", "readinessProbe"):
+        assert mobile_container[probe]["httpGet"]["path"] == "/m/__env.js"
+
+    mobile_path = next(path for path in ingress_paths(docs) if path["path"] == "/m")
+    assert mobile_path["pathType"] == "Prefix"
+    assert mobile_path["backend"]["service"]["name"].endswith("-web-mobile")
+
+    custom_docs = render(
+        [
+            "--set",
+            "webMobile.replicas=2",
+            "--set",
+            "webMobile.port=3456",
+            "--set",
+            "webMobile.image.repository=registry.example.com/mobile",
+            "--set",
+            "webMobile.image.tag=test",
+        ]
+    )
+    custom_deployment = component(custom_docs, "Deployment", "web-mobile")
+    assert custom_deployment["spec"]["replicas"] == 2
+    assert container(custom_deployment)["image"] == "registry.example.com/mobile:test"
+    assert (
+        component(custom_docs, "Service", "web-mobile")["spec"]["ports"][0]["port"]
+        == 3456
+    )
+
+    ee_docs = render(["--set", "agenta.license=ee"])
+    assert container(component(ee_docs, "Deployment", "web-mobile"))[
+        "image"
+    ].startswith("ghcr.io/agenta-ai/agenta-web-mobile:")
+
+    mobile_only_docs = render(
+        [
+            "--set",
+            "web.enabled=false",
+            "--set",
+            "api.enabled=false",
+            "--set",
+            "services.enabled=false",
+        ]
+    )
+    assert component(mobile_only_docs, "Deployment", "web-mobile")
+    assert [path["path"] for path in ingress_paths(mobile_only_docs)] == ["/m"]
+
+    disabled_docs = render(["--set", "webMobile.enabled=false"])
+    assert not components(disabled_docs, "web-mobile")
+    assert all(path["path"] != "/m" for path in ingress_paths(disabled_docs))
+    assert (
+        env_value(component(disabled_docs, "Deployment", "web"), "AGENTA_MOBILE_GATE")
+        == "false"
+    )
+
+    print("OK: Helm deploys and routes web-mobile by default, with a safe opt-out.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -446,6 +446,7 @@
     "redisDurable":  { "$ref": "#/$defs/bundledRedis" },
     "api":               { "$ref": "#/$defs/component" },
     "web":               { "$ref": "#/$defs/component" },
+    "webMobile":         { "$ref": "#/$defs/component" },
     "services":          { "$ref": "#/$defs/component" },
     "workerStreams":      { "$ref": "#/$defs/component" },
     "workerQueues":       { "$ref": "#/$defs/component" },

--- a/hosting/kubernetes/oss/values.oss.example.yaml
+++ b/hosting/kubernetes/oss/values.oss.example.yaml
@@ -30,6 +30,11 @@ agenta:
 #   image:
 #     tag: latest
 #     pullPolicy: IfNotPresent
+# webMobile:
+#   image:
+#     repository: ghcr.io/agenta-ai/agenta-web-mobile
+#     tag: latest
+#     pullPolicy: IfNotPresent
 # services:
 #   image:
 #     tag: latest
@@ -444,6 +449,16 @@ posthog:
 #       memory: 256Mi
 #     limits:
 #       memory: 512Mi
+# webMobile:
+#   enabled: true
+#   replicas: 1
+#   port: 3000
+#   resources:
+#     requests:
+#       cpu: 100m
+#       memory: 256Mi
+#     limits:
+#       memory: 512Mi
 # services:
 #   enabled: true
 #   replicas: 1
@@ -482,8 +497,9 @@ posthog:
 
 # ================================================================== #
 # === ingress ===
-# Path routing: / → web, /api → api (prefix-stripped), /services → services
-# (prefix-stripped).  When running behind Traefik, attach the StripPrefix
+# Path routing: / → web, /m → web-mobile, /api → api (prefix-stripped),
+# /services → services (prefix-stripped). The /m route is fixed because the mobile
+# image is built with basePath /m.  When running behind Traefik, attach the StripPrefix
 # Middleware defined under extraObjects below.
 # ================================================================== #
 # ingress:

--- a/hosting/railway/oss/README.md
+++ b/hosting/railway/oss/README.md
@@ -210,16 +210,19 @@ export RAILWAY_ENVIRONMENT_NAME="staging"
 
 #### The mobile app (`/m`)
 
-The mobile web app is **opt-in** while it is pre-GA, the same way the compose
-stack keeps it behind the `with-web-mobile` profile (`run.sh --with-mobile`).
-Set the flag before `bootstrap.sh` and it creates a `web-mobile` service; the
-gateway already routes `/m` and `/m/*` to it:
+A from-scratch `bootstrap.sh` run keeps the mobile web app **opt-in**, unlike the
+compose stack, which now starts `web-mobile` by default. Set the flag before
+`bootstrap.sh` and it creates a `web-mobile` service; the gateway already routes
+`/m` and `/m/*` to it. The two gate keys below are optional now: both gates
+default on, so set them only to opt out (`false`).
 
 ```bash
 export AGENTA_RAILWAY_WITH_MOBILE=true
-# Turn the device gate on so phones landing on a desktop route go to /m:
+# The device gate is on by default; this line only makes it explicit. A phone
+# landing on a desktop route goes to /m. Set it to false to turn the gate off.
 export AGENTA_MOBILE_GATE=true
-# Let desktop browsers open /m directly instead of being bounced back:
+# Let desktop browsers open /m directly instead of being bounced back. This one
+# IS a change from the default, and preview environments want it:
 export AGENTA_MOBILE_REVERSE_GATE=false
 ```
 

--- a/hosting/railway/oss/scripts/bootstrap.sh
+++ b/hosting/railway/oss/scripts/bootstrap.sh
@@ -15,10 +15,11 @@ SOURCE_COMPOSE_FILE="${RAILWAY_SOURCE_COMPOSE_FILE:-$(railway_source_compose_fil
 
 WEB_IMAGE="${AGENTA_WEB_IMAGE:-ghcr.io/agenta-ai/agenta-web:latest}"
 WEB_MOBILE_IMAGE="${AGENTA_WEB_MOBILE_IMAGE:-ghcr.io/agenta-ai/agenta-web-mobile:latest}"
-# The mobile app (/m) is opt-in while it is pre-GA, mirroring the compose
-# `with-web-mobile` profile (run.sh --with-mobile). Everything downstream
-# (configure.sh, deploy-from-images.sh) keys off whether the service exists,
-# so this flag is the single switch.
+# The mobile app (/m) stays opt-in for a from-scratch Railway bootstrap, unlike
+# the compose stack, which now starts web-mobile by default. Template clones get
+# the service from template.json either way. Everything downstream (configure.sh,
+# deploy-from-images.sh) keys off whether the service exists, so this flag is the
+# single switch.
 WITH_MOBILE="${AGENTA_RAILWAY_WITH_MOBILE:-false}"
 API_IMAGE="${AGENTA_API_IMAGE:-ghcr.io/agenta-ai/agenta-api:latest}"
 SERVICES_IMAGE="${AGENTA_SERVICES_IMAGE:-ghcr.io/agenta-ai/agenta-services:latest}"

--- a/web/ee/src/middleware.ts
+++ b/web/ee/src/middleware.ts
@@ -1,15 +1,20 @@
-import {GATE_COOKIE_MAX_AGE, decideDesktopGate} from "@agenta/shared/utils/mobileGate"
+import {
+    GATE_COOKIE_MAX_AGE,
+    decideDesktopGate,
+    resolveGateEnabled,
+} from "@agenta/shared/utils/mobileGate"
 import {NextRequest, NextResponse} from "next/server"
 
 /**
  * Mobile device gate, forward direction (agenta-mobile WP5): mobile devices
  * navigating desktop routes are redirected into the /m app.
  *
- * DEFAULT OFF. Activates only when the deployment sets AGENTA_MOBILE_GATE=true.
- * The flag is read inside the handler at request time: on the self-hosted
- * standalone Node server, non-NEXT_PUBLIC process.env is resolved at runtime
- * (the client-only DefinePlugin in next.config.ts does not touch this
- * compiler), so flipping the env + recreating the container is enough — no
+ * DEFAULT ON. Every deployment gates phones into /m without setting anything;
+ * a deployment opts OUT with AGENTA_MOBILE_GATE=false (resolveGateEnabled owns
+ * that rule). The flag is read inside the handler at request time: on the
+ * self-hosted standalone Node server, non-NEXT_PUBLIC process.env is resolved
+ * at runtime (the client-only DefinePlugin in next.config.ts does not touch
+ * this compiler), so flipping the env + recreating the container is enough — no
  * rebuild. Behind Traefik this middleware never sees /m traffic
  * (PathPrefix(`/m`) routes to the mobile app); the matcher still excludes /m
  * for direct-port dev runs.
@@ -24,7 +29,7 @@ export function middleware(request: NextRequest) {
         method: request.method,
         header: (name) => request.headers.get(name),
         cookie: (name) => request.cookies.get(name)?.value,
-        gateEnabled: process.env.AGENTA_MOBILE_GATE === "true",
+        gateEnabled: resolveGateEnabled(process.env.AGENTA_MOBILE_GATE),
     })
 
     if (decision.kind === "redirect") {

--- a/web/mobile/src/proxy.ts
+++ b/web/mobile/src/proxy.ts
@@ -2,18 +2,21 @@ import {NextRequest, NextResponse} from "next/server"
 
 /**
  * Mobile device gate, reverse direction (agenta-mobile WP5): desktop devices
- * navigating /m are redirected to the desktop equivalent. DEFAULT OFF —
- * activates only when the deployment sets AGENTA_MOBILE_GATE=true (read at
- * request time; runtime-flippable on the standalone Node server).
+ * navigating /m are redirected to the desktop equivalent. DEFAULT ON — a
+ * deployment opts OUT with AGENTA_MOBILE_GATE=false (read at request time;
+ * runtime-flippable on the standalone Node server). The reverse direction has
+ * its own opt-out, AGENTA_MOBILE_REVERSE_GATE=false, which keeps the forward
+ * gate but lets a desktop browser open /m.
  *
  * COPY of @agenta/shared/src/utils/mobileGate (reverse-gate subset).
  * web/mobile deliberately has zero workspace deps until WP2 wires @agenta/*
  * into the mobile compose service and Dockerfile (see
  * docs/design/agenta-mobile/README.md "Open items"). When WP2 lands, replace
  * these copies with the @agenta/shared import and delete the twins.
- * Declared adaptations vs the canonical source: none (verbatim functions);
- * this file adds only the NextRequest adapter, basePath handling, and the
- * AGENTA_MOBILE_REVERSE_GATE read (the canonical source takes it as input).
+ * Declared adaptations vs the canonical source: none (verbatim functions,
+ * resolveGateEnabled included); this file adds only the NextRequest adapter,
+ * basePath handling, and the AGENTA_MOBILE_REVERSE_GATE read (the canonical
+ * source takes it as input).
  * Canonical tests: web/packages/agenta-shared/tests/unit/mobileGate.test.ts.
  */
 
@@ -24,6 +27,11 @@ const GATE_COOKIE_MAX_AGE = 60 * 60 * 24 * 180
 
 const MOBILE_UA_RE = /Android|iPhone|iPod|iPad|webOS|BlackBerry|IEMobile|Opera Mini|Mobile/i
 const AUTH_CALLBACK_RE = /^\/auth\/callback(\/|$)/
+
+/** DEFAULT ON: only the exact string "false" turns a gate off. */
+function resolveGateEnabled(raw: string | undefined): boolean {
+    return raw !== "false"
+}
 
 function isMobileDevice(header: (name: string) => string | null): boolean {
     const hint = header("sec-ch-ua-mobile")
@@ -61,7 +69,7 @@ function stripViewParam(pathname: string, search: string): string {
 
 export function proxy(request: NextRequest) {
     try {
-        if (process.env.AGENTA_MOBILE_GATE !== "true") return NextResponse.next()
+        if (!resolveGateEnabled(process.env.AGENTA_MOBILE_GATE)) return NextResponse.next()
 
         const header = (name: string) => request.headers.get(name)
         if (!isDocumentNavigation(request.method, header)) return NextResponse.next()
@@ -93,7 +101,7 @@ export function proxy(request: NextRequest) {
         // Reverse gate off: keep the forward gate, but let anything reach /m (tablets and
         // desktop-UA browsers read as non-mobile). Checked after ?view=mobile so the opt-in
         // cookie is still set if the bounce is re-enabled.
-        if (process.env.AGENTA_MOBILE_REVERSE_GATE === "false") return NextResponse.next()
+        if (!resolveGateEnabled(process.env.AGENTA_MOBILE_REVERSE_GATE)) return NextResponse.next()
         if (isMobileDevice(header)) return NextResponse.next()
 
         return NextResponse.redirect(new URL(mapMobileToDesktop(pathname), request.url), 307)

--- a/web/mobile/tests/unit/proxy.test.ts
+++ b/web/mobile/tests/unit/proxy.test.ts
@@ -23,7 +23,9 @@ let savedReverseFlag: string | undefined
 beforeEach(() => {
     savedFlag = process.env.AGENTA_MOBILE_GATE
     savedReverseFlag = process.env.AGENTA_MOBILE_REVERSE_GATE
-    process.env.AGENTA_MOBILE_GATE = "true"
+    // Both gates default ON, so the suite runs with neither key set — the same
+    // state as a deployment that configures nothing.
+    delete process.env.AGENTA_MOBILE_GATE
     delete process.env.AGENTA_MOBILE_REVERSE_GATE
 })
 
@@ -35,10 +37,41 @@ afterEach(() => {
 })
 
 describe("mobile reverse gate proxy", () => {
+    it("gates by default, with no env key set", () => {
+        const res = proxy(req("/m/", doc(DESKTOP_UA)))
+        expect(res.status).toBe(307)
+        expect(res.headers.get("location")).toBe("http://localhost:3000/w")
+    })
+
+    it("still gates with the flag explicitly on", () => {
+        process.env.AGENTA_MOBILE_GATE = "true"
+        const res = proxy(req("/m/", doc(DESKTOP_UA)))
+        expect(res.headers.get("location")).toBe("http://localhost:3000/w")
+    })
+
     it("passes everything through when the flag is off", () => {
         process.env.AGENTA_MOBILE_GATE = "false"
         const res = proxy(req("/m/", doc(DESKTOP_UA)))
         expect(res.headers.get("location")).toBeNull()
+    })
+
+    it("keeps gating for an empty or unrecognized flag value", () => {
+        // Only the exact string "false" opts out; a typo must not hide the gate.
+        for (const raw of ["", "0", "off", "FALSE"]) {
+            process.env.AGENTA_MOBILE_GATE = raw
+            expect(proxy(req("/m/", doc(DESKTOP_UA))).headers.get("location")).toBe(
+                "http://localhost:3000/w",
+            )
+        }
+    })
+
+    it("keeps the reverse bounce for an unrecognized reverse-gate value", () => {
+        for (const raw of ["", "0", "FALSE"]) {
+            process.env.AGENTA_MOBILE_REVERSE_GATE = raw
+            expect(proxy(req("/m/", doc(DESKTOP_UA))).headers.get("location")).toBe(
+                "http://localhost:3000/w",
+            )
+        }
     })
 
     it("passes desktop UAs when AGENTA_MOBILE_REVERSE_GATE=false", () => {

--- a/web/oss/src/middleware.ts
+++ b/web/oss/src/middleware.ts
@@ -1,15 +1,20 @@
-import {GATE_COOKIE_MAX_AGE, decideDesktopGate} from "@agenta/shared/utils/mobileGate"
+import {
+    GATE_COOKIE_MAX_AGE,
+    decideDesktopGate,
+    resolveGateEnabled,
+} from "@agenta/shared/utils/mobileGate"
 import {NextRequest, NextResponse} from "next/server"
 
 /**
  * Mobile device gate, forward direction (agenta-mobile WP5): mobile devices
  * navigating desktop routes are redirected into the /m app.
  *
- * DEFAULT OFF. Activates only when the deployment sets AGENTA_MOBILE_GATE=true.
- * The flag is read inside the handler at request time: on the self-hosted
- * standalone Node server, non-NEXT_PUBLIC process.env is resolved at runtime
- * (the client-only DefinePlugin in next.config.ts does not touch this
- * compiler), so flipping the env + recreating the container is enough — no
+ * DEFAULT ON. Every deployment gates phones into /m without setting anything;
+ * a deployment opts OUT with AGENTA_MOBILE_GATE=false (resolveGateEnabled owns
+ * that rule). The flag is read inside the handler at request time: on the
+ * self-hosted standalone Node server, non-NEXT_PUBLIC process.env is resolved
+ * at runtime (the client-only DefinePlugin in next.config.ts does not touch
+ * this compiler), so flipping the env + recreating the container is enough — no
  * rebuild. Behind Traefik this middleware never sees /m traffic
  * (PathPrefix(`/m`) routes to the mobile app); the matcher still excludes /m
  * for direct-port dev runs.
@@ -24,7 +29,7 @@ export function middleware(request: NextRequest) {
         method: request.method,
         header: (name) => request.headers.get(name),
         cookie: (name) => request.cookies.get(name)?.value,
-        gateEnabled: process.env.AGENTA_MOBILE_GATE === "true",
+        gateEnabled: resolveGateEnabled(process.env.AGENTA_MOBILE_GATE),
     })
 
     if (decision.kind === "redirect") {

--- a/web/oss/tests/playwright/acceptance/mobile-gate/gate.spec.ts
+++ b/web/oss/tests/playwright/acceptance/mobile-gate/gate.spec.ts
@@ -3,10 +3,12 @@ import {expect, test} from "@playwright/test"
 const IPHONE_UA =
     "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
 
-// Requires a deployment started with AGENTA_MOBILE_GATE=true; the runner env
-// var is the operator's assertion of that. Skipped otherwise.
-const gateEnabled = process.env.AGENTA_MOBILE_GATE === "true"
-test.skip(!gateEnabled, "mobile gate flag off (set AGENTA_MOBILE_GATE=true to run)")
+// The gate ships default-on, and so does the /m service, so this suite runs
+// against any deployment that did not opt out. A deployment that sets
+// AGENTA_MOBILE_GATE=false has no gate to test, and the runner env var is the
+// operator's assertion of that.
+const gateEnabled = process.env.AGENTA_MOBILE_GATE !== "false"
+test.skip(!gateEnabled, "mobile gate opted out (AGENTA_MOBILE_GATE=false)")
 
 test.describe("mobile gate: forward direction", () => {
     test.use({userAgent: IPHONE_UA, storageState: undefined})

--- a/web/packages/agenta-shared/src/utils/mobileGate/index.ts
+++ b/web/packages/agenta-shared/src/utils/mobileGate/index.ts
@@ -40,7 +40,11 @@ export interface GateInput {
     /** Case-insensitive header getter (NextRequest headers already are). */
     header: (name: string) => string | null
     cookie: (name: string) => string | undefined
-    /** AGENTA_MOBILE_GATE, resolved by the adapter at request time. */
+    /**
+     * AGENTA_MOBILE_GATE, resolved by the adapter at request time with
+     * `resolveGateEnabled`. DEFAULT ON: a deployment opts out with
+     * `AGENTA_MOBILE_GATE=false`.
+     */
     gateEnabled: boolean
     /**
      * AGENTA_MOBILE_REVERSE_GATE, mobile-app only. `false` keeps the forward gate (mobile
@@ -48,6 +52,22 @@ export interface GateInput {
      * as non-mobile, so the bounce blocks deliberate visits. Defaults to on.
      */
     reverseGateEnabled?: boolean
+}
+
+/**
+ * Env → flag, for both gates. DEFAULT ON: only the exact string "false" turns a
+ * gate off, so an unset, empty, or misspelled value keeps the mobile app
+ * reachable. Both gates ship on so that no deployment (cloud, self-hosted
+ * compose, Railway, local dev) needs an env key to give phones /m; the keys are
+ * an opt-OUT.
+ *
+ * The adapters read process.env INSIDE the request handler, never at module
+ * scope: on the self-hosted standalone Node server, non-NEXT_PUBLIC env is
+ * resolved at runtime, so flipping the key and recreating the container is
+ * enough — no rebuild.
+ */
+export function resolveGateEnabled(raw: string | undefined | null): boolean {
+    return raw !== "false"
 }
 
 export type GateDecision =
@@ -168,8 +188,9 @@ export function decideDesktopGate(input: GateInput): GateDecision {
         // BEFORE the flag: a provider redirect the MOBILE app started has to reach /m whether or
         // not the device gate is on. The cookie is an explicit intent set by /m moments earlier,
         // not a device heuristic, and the OAuth state lives in /m's same-origin sessionStorage.
-        // The gate defaults OFF, so gating this stranded every mobile SSO sign-in on the desktop
-        // route, where the state it needs does not exist.
+        // A deployment that opts out with AGENTA_MOBILE_GATE=false still runs /m, so gating this
+        // strands every mobile SSO sign-in on the desktop route, where the state it needs does
+        // not exist.
         if (
             !wantsDesktop &&
             isDocumentNavigation(input) &&

--- a/web/packages/agenta-shared/tests/unit/mobileGate.test.ts
+++ b/web/packages/agenta-shared/tests/unit/mobileGate.test.ts
@@ -11,6 +11,7 @@ import {
     isMobileDevice,
     mapDesktopToMobile,
     mapMobileToDesktop,
+    resolveGateEnabled,
     type GateInput,
 } from "../../src/utils/mobileGate"
 
@@ -163,6 +164,27 @@ describe("mapMobileToDesktop", () => {
     })
 })
 
+describe("resolveGateEnabled", () => {
+    // The gate ships ON so that no deployment needs an env key to give phones /m.
+    // Only the exact string "false" opts out.
+    it("is on when the key is unset", () => {
+        expect(resolveGateEnabled(undefined)).toBe(true)
+    })
+    it('is on for "true"', () => {
+        expect(resolveGateEnabled("true")).toBe(true)
+    })
+    it('is off for "false"', () => {
+        expect(resolveGateEnabled("false")).toBe(false)
+    })
+    it("stays on for an empty or unrecognized value", () => {
+        // An empty value comes from a compose `KEY=` line; anything else is a typo.
+        // Neither may silently hide the mobile app.
+        for (const raw of ["", "0", "off", "no", "FALSE", null]) {
+            expect(resolveGateEnabled(raw)).toBe(true)
+        }
+    })
+})
+
 describe("decideDesktopGate", () => {
     it("passes when the flag is off, whatever the device", () => {
         expect(
@@ -236,8 +258,9 @@ describe("decideDesktopGate", () => {
             ),
         ).toEqual({kind: "pass"})
     })
-    // The gate ships DEFAULT OFF, so a mobile SSO sign-in only ever completes if the handback
-    // runs regardless of the flag. It used to sit below the gate-disabled return.
+    // A deployment that opts out with AGENTA_MOBILE_GATE=false still runs /m, so a mobile SSO
+    // sign-in only ever completes if the handback runs regardless of the flag. It used to sit
+    // below the gate-disabled return.
     it("hands a mobile-started callback to /m even when the gate is disabled", () => {
         const i = input({
             pathname: "/auth/callback/google",


### PR DESCRIPTION
## Why

v0.113.0 shipped to production **without `/m`**. The mobile app was opt-in on two
independent switches, and neither was set:

- the device gate ran only when a deployment set `AGENTA_MOBILE_GATE=true`, and
- the `web-mobile` compose service started only behind the `with-web-mobile` profile.

A default that every deployment has to turn on is a default that stays off. This PR flips
both: phones get `/m` everywhere (cloud, staging, OSS self-hosting, local dev) with no env
key, and the keys become opt-OUTs.

## What changed

### Gate defaults (web)

| File | Change |
| --- | --- |
| `web/packages/agenta-shared/src/utils/mobileGate/index.ts` | New exported `resolveGateEnabled(raw)`: a gate is ON unless the value is exactly `"false"`. Doc comments updated; the stale "the gate defaults OFF" reasoning in `decideDesktopGate` rewritten. |
| `web/oss/src/middleware.ts`, `web/ee/src/middleware.ts` | `gateEnabled: resolveGateEnabled(process.env.AGENTA_MOBILE_GATE)` instead of `=== "true"`. Header comment: DEFAULT ON. The two files stay byte-twins apart from their cross-reference line. |
| `web/mobile/src/proxy.ts` | Same rule for both `AGENTA_MOBILE_GATE` and `AGENTA_MOBILE_REVERSE_GATE`, through a local copy of `resolveGateEnabled` (this file is a declared verbatim copy with no workspace deps). The reverse gate keeps its existing default (ON); only the comments changed. |

An unset, empty, or misspelled value keeps the mobile app reachable. A typo cannot silently
hide `/m`.

### Compose and `run.sh` (hosting)

- `web-mobile` loses `profiles: [with-web-mobile]` in all seven files: `oss/` dev, gh,
  gh.local, gh.ssl and `ee/` dev, gh, gh.local. It now starts with the stack, like `api`
  and `web`. Image and route wiring are unchanged: gh files pull
  `ghcr.io/agenta-ai/${AGENTA_WEB_MOBILE_IMAGE_NAME:-agenta-web-mobile}:${AGENTA_WEB_MOBILE_IMAGE_TAG:-latest}`,
  gh.local/gh.ssl build `web/mobile/docker/Dockerfile.gh`, dev runs `pnpm dev-mobile` off the
  shared dev image, and every file carries the Traefik rule ``Path(`/m`) || PathPrefix(`/m/`)``.
- `AGENTA_MOBILE_GATE` defaults to `true` where compose passes it through (`:-false` became
  `:-true`), including the dev `.env.development.local` mirror that Turbopack's dev middleware
  sandbox needs.
- `run.sh`: `/m` starts by default. `--no-mobile` and `AGENTA_MOBILE_ENABLED=false` scale
  `web-mobile` to zero and force `AGENTA_MOBILE_GATE=false`, so phones remain on the desktop UI.
  `--no-web` and `--web-mode none` imply the same mobile opt-out, which preserves the documented
  backend-only dev build without requiring the shared dev web image.
- The nginx `/m` and `/m/` locations already existed; only the comment changed. The
  variable upstream stays, because it is what keeps an opted-out stack from breaking nginx boot.

### Helm and Kubernetes

- `webMobile` is enabled by default and supports the same image, replica, port, resource, and pod
  overrides as the desktop web component. Both OSS and EE use the public
  `ghcr.io/agenta-ai/agenta-web-mobile:<chart-version>` image.
- The chart creates a `web-mobile` Deployment and Service, probes `/m/__env.js`, and routes the
  fixed `/m` prefix to that Service before the desktop `/` catch-all.
- `webMobile.enabled=false` removes the workload and route and sets the desktop Deployment gate to
  `false`, so the chart opt-out cannot leave phones redirecting to a missing backend.

### Opt-out keys

| Key | Effect |
| --- | --- |
| `AGENTA_MOBILE_ENABLED=false` (or `run.sh --no-mobile`) | `web-mobile` starts with 0 replicas and the desktop gate is forced off. Phones remain on the desktop UI. For raw Compose, pass both `--scale web-mobile=0` and `AGENTA_MOBILE_GATE=false`. |
| `AGENTA_MOBILE_GATE=false` | `/m` still runs and is reachable, but no redirect happens in either direction. |
| `AGENTA_MOBILE_REVERSE_GATE=false` | Phones still go to `/m`; a desktop browser can open `/m` instead of being bounced back. What a preview or review deployment wants. |

`run.sh` reads `AGENTA_MOBILE_ENABLED` from the shell **and** from the resolved env file, so
the opt-out works where every other setting lives.

### Docs

`hosting/AGENTS.md` gets a section on the new default and the three opt-outs. All four env
examples (`env.{oss,ee}.{dev,gh}.example`) carry the same block; the redundant
`AGENTA_MOBILE_GATE=true` suggestions are gone. `hosting/railway/oss/README.md` and
`scripts/bootstrap.sh` no longer claim the compose stack keeps `/m` behind a profile.
`docs/design/agenta-mobile/{README,design}.md` get a dated status update over the WP5
default-off record. The Helm examples and install notes now document the default mobile workload,
its public image, `/m` route, resource overrides, and opt-out.

### Tests

- `mobileGate.test.ts`: a `resolveGateEnabled` suite: unset, `"true"`, `"false"`, and
  `""`/`"0"`/`"off"`/`"FALSE"`/`null` (all ON).
- `proxy.test.ts`: the suite now runs with **no** gate key set (the state of a deployment that
  configures nothing) and adds cases for default-on, explicit `"true"`, `"false"`, and
  unrecognized values for both gates.
- `acceptance/mobile-gate/gate.spec.ts` skipped unless the runner asserted
  `AGENTA_MOBILE_GATE=true`. It now runs unless a deployment opted out. Flag this one if it
  fights the acceptance job: the suite needs a stack with `/m`, which every stack now has.
- `hosting/kubernetes/helm/tests/test_web_mobile.py` renders default, EE, custom, mobile-only, and
  disabled configurations. It pins the workload, public image, environment, probes, Service,
  ingress route, overrides, and safe opt-out.

## Verification

**Unit:** `@agenta/shared` 366/366, `@agenta/mobile` 128/128. Typecheck clean for
`@agenta/oss`, `@agenta/ee`, `@agenta/mobile`. `pnpm lint-fix` clean (the 4 remaining mobile
warnings are pre-existing `exhaustive-deps` in files this PR does not touch).

**Helm:** chart lint passes; both OSS and EE example values render. The mobile chart regression
passes alongside the existing runner secret-isolation guard.

**Compose:** `docker compose config` parses all seven files with the matching env file, and
`web-mobile` is present with **no profile** in every one:

```
oss/docker-compose.dev.yml        web-mobile=True profiles=none image=agenta-oss-dev-web:latest        gate=true
oss/docker-compose.gh.yml         web-mobile=True profiles=none image=ghcr.io/agenta-ai/agenta-web-mobile:latest gate=true
oss/docker-compose.gh.local.yml   web-mobile=True profiles=none build=web/mobile/docker/Dockerfile.gh  gate=unset (on)
oss/docker-compose.gh.ssl.yml     web-mobile=True profiles=none build=web/mobile/docker/Dockerfile.gh  gate=unset (on)
ee/docker-compose.dev.yml         web-mobile=True profiles=none image=agenta-ee-dev-web:latest         gate=true
ee/docker-compose.gh.yml          web-mobile=True profiles=none image=ghcr.io/agenta-ai/agenta-web-mobile:latest gate=true
ee/docker-compose.gh.local.yml    web-mobile=True profiles=none build=web/mobile/docker/Dockerfile.gh  gate=unset (on)
```

**`run.sh` opt-out**, with a stubbed `docker` that echoes its arguments:

```
default                           gate=unset  up -d --remove-orphans
--no-mobile                       gate=false  up -d --remove-orphans --scale web-mobile=0
AGENTA_MOBILE_ENABLED=false       gate=false  up -d --remove-orphans --scale web-mobile=0
--no-web --build                  gate=false  build without the with-web profile; up with web-mobile=0
```

**Live**, OSS dev stack on port 8880 (`run.sh --oss --dev`, torn down after), with **no**
`AGENTA_MOBILE_*` key in the env file:

```
GET /w        iPhone UA + sec-ch-ua-mobile: ?1   -> 307  Location: /m/
GET /         iPhone UA                          -> 200 at /m (3 hops: /w, /m/, /m)
GET /m/       iPhone UA                          -> 200
GET /m        desktop UA + sec-ch-ua-mobile: ?0  -> 307  Location: /w      (reverse gate)
container env (from the compose default, not the env file):
              AGENTA_MOBILE_GATE=true / AGENTA_MOBILE_REVERSE_GATE=true
```

With `AGENTA_MOBILE_GATE=false` in the env file and `web` recreated:

```
GET /w        iPhone UA  -> 200, no Location    (no redirect)
GET /         iPhone UA  -> ends at /w, 200     (never /m)
GET /m/       iPhone UA  -> 200                 (the service is unaffected by the gate)
```

Reverse gate against the mobile app on Next 16 (the dev image predates the Next 16 move, so
this ran on the host dev server with no env key set):

```
GET /m                        desktop UA -> 307 /w
GET /m/w/ws1/p/pr1/sessions/abc desktop UA -> 307 /w/ws1/p/pr1/observability?session=abc
GET /m                        iPhone UA  -> 200
GET /m?view=mobile            desktop UA -> 307 /m/ + set-cookie agenta-mobile-optin=1
AGENTA_MOBILE_GATE=false      desktop UA -> 200, no redirect
```

## What each deployment gets

| Deployment | Before | After |
| --- | --- | --- |
| Cloud / staging (agenta_cloud) | `/m` only where the deploy set the keys | gate on from the image, with no key set anywhere; agenta_cloud [#1671](https://github.com/Agenta-AI/agenta_cloud/pull/1671) starts the `web-mobile` service by default alongside it |
| OSS self-hosting (compose gh/ssl/local) | no `web-mobile` container unless `--with-mobile` | `web-mobile` starts; `/m` routed by Traefik or nginx |
| Local dev | opt-in, second dev server off by default | on; `--no-mobile` on a small VM (the second Next dev server costs about 0.5-1GB RAM) |
| Helm / Kubernetes | desktop web only; `/m` reached the desktop Service | `web-mobile` Deployment and Service on by default; ingress routes `/m` to it; `webMobile.enabled=false` also disables the desktop gate |
| Railway | template clones already carry `web-mobile` (#6175) | unchanged. `AGENTA_MOBILE_GATE=true` stays in `template.json` as an explicit, now redundant value; `bootstrap.sh`'s `AGENTA_RAILWAY_WITH_MOBILE` stays opt-in and belongs to the Railway thread |

## Notes

- agenta_cloud PR [#1671](https://github.com/Agenta-AI/agenta_cloud/pull/1671) is the deploy-level
  half and is complementary, not a duplicate: it starts the `web-mobile` service by default in the
  cloud deploy and writes **no** gate keys. The gate defaults live here. Both are needed: this PR
  turns the gate on in the image, #1671 makes sure the service the gate points at is running.
- Follow-up, not in this PR: `NoMobilePageWrapper` (T8 in the mobile design docs) is now
  unblocked. The only mobile visitors who still reach that blocker are the ones who chose
  "View desktop site", and for them it is a dead end.


