### PR TITLE
feat(runner): export Pi traces through the runner

### DIFF
--- a/api/oss/src/apis/fastapi/otlp/router.py
+++ b/api/oss/src/apis/fastapi/otlp/router.py
@@ -97,7 +97,7 @@ class OTLPRouter:
 
         Binary protobuf only (`Content-Type: application/x-protobuf`).
         JSON OTLP is not accepted. Requests larger than the configured
-        batch limit (default 4 MB, see `OTLP_MAX_BATCH_BYTES`) return
+        batch limit (default 10 MB, see `AGENTA_OTLP_MAX_BATCH_BYTES`) return
         `413 Request Entity Too Large`.
 
         ## Response

--- a/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
+++ b/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
@@ -134,6 +134,45 @@ pnpm exec vitest run --project unit \
   tests/unit/session-keepalive-approval.test.ts
 ```
 
+### 5. Review-fix invariants
+
+Use these checks for the follow-up commit that addresses the first review round:
+
+- Call `finish()` twice and then call `teardown()`. The runner must perform one pickup,
+  one HTTP request, and return the same counts to every caller.
+- Read `pickedUpBatches` as the number of valid protobuf files accepted by the runner.
+  Read `exportedBatches` as the subset accepted by the collector. A 401 can reduce the
+  second count, but it must not create a missing-Pi fallback.
+- Confirm the control-file deny set includes `modelConnection.environment` values that
+  already enter the Pi process. It must still exclude the runner OTLP authorization.
+- For Agenta ingest, resolve a blank request authorization through the same live
+  `AGENTA_CREDENTIALS` fallback used by ordinary runner spans. Do not apply that
+  fallback to a third-party collector.
+- During finalization, drain the current channel before the bounded sweep. A valid late
+  batch must reach the export callback instead of being deleted as residue.
+- Treat a missing Daytona telemetry directory as an empty list. Reject a missing,
+  truncated, or zero-byte Daytona read before building an HTTP request.
+- Increment the Pi file sequence only after the atomic rename succeeds. Reject
+  non-canonical sequence spellings such as `02`; cleanup may remove them, but the
+  consumer must never forward them.
+- Keep parent-first ordering inside `serializeTraceBatch` for Pi. Apply the separate
+  ordering pass only to the ordinary HTTP exporter.
+
+Run the focused review-fix suite:
+
+```bash
+cd services/runner
+pnpm exec vitest run --project unit \
+  tests/unit/pi-file-exporter.test.ts \
+  tests/unit/pi-spool-consumer.test.ts \
+  tests/unit/pi-trace-turn-export.test.ts \
+  tests/unit/telemetry-file-host.test.ts \
+  tests/unit/sandbox-agent-orchestration.test.ts \
+  tests/unit/session-keepalive-approval.test.ts \
+  tests/unit/otel-trace-serialization.test.ts \
+  tests/unit/otel-trace-target-attribution.test.ts
+```
+
 ## Full validation
 
 Run from `services/runner`:
@@ -144,7 +183,7 @@ pnpm run test:unit
 pnpm run build:extension
 ```
 
-The implementation run passed 138 unit files: 2,276 tests passed and 7 existing
+The implementation run passed 138 unit files: 2,282 tests passed and 7 existing
 tests remained marked as expected failures. Typecheck and the extension build
 also passed.
 

--- a/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
+++ b/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
@@ -183,9 +183,9 @@ pnpm run test:unit
 pnpm run build:extension
 ```
 
-The implementation run passed 138 unit files: 2,282 tests passed and 7 existing
-tests remained marked as expected failures. Typecheck and the extension build
-also passed.
+The focused review-fix suite passed 152 tests. The full implementation run passed
+138 unit files: 2,282 tests passed and 7 existing tests remained marked as
+expected failures. Typecheck and the extension build also passed.
 
 ## Live acceptance
 
@@ -197,15 +197,21 @@ once with `pi_core` and `sandbox=daytona`. For each run:
    suffix, the expected placement, `outcome=exported`, and `status=200`.
 3. Fetch `/api/tracing/traces/{trace_id}` with a key for the same project.
 4. Confirm the stored trace contains Pi-native span names such as `pi`, `chat`,
-   and `turn 0`.
+   `invoke_agent`, and `turn 0`, with parent IDs forming one connected tree.
 
-The implementation run persisted both paths:
+The final local run persisted the native tree at:
 
-- Local: `89ce156bd188780fb61b8f7853ffc350`.
-- Daytona: `d7cc51df721601b355e02af617b2f583`.
+- `b88610d6d07d49db6a41bc3ab505096e`
 
-The shared OpenAI test secret did not produce a successful model response in
-that run. This does not invalidate the export evidence because both Pi native
-batches were exported and fetched back from storage. Repeat the model-response
-portion with a working project credential before treating the broader Pi run as
-a release-gate pass.
+The final Daytona run persisted native trees at:
+
+- `6f7ab273e8e0a22ff8c04d1e5c67ff5f`
+- `ee9acd9a22bb1f3f9b73b9029f2ac92c`
+
+A funded OpenAI run also completed at
+`f9728271e297986eb805b8bcd67f2388`. Its root, `invoke_agent`, turn, and chat
+spans each carry the same `$0.0023065` cumulative total, while only the actual
+model-bearing spans carry it incrementally. This proves the runner export and
+the stored cost roll-up agree without double-counting.
+
+The release gate passed P2 and P2b on the local sandbox and P3 on Daytona. The

--- a/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
+++ b/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
@@ -129,7 +129,9 @@ Read:
 Trace finalization must cover normal completion, cancellation, an approval
 pause, approval resume, and parked-environment eviction. A resumed approval must
 keep the original Pi trace ID. The runner may emit its fallback span only when
-Pi produced no valid batch, and the fallback callback must be idempotent.
+Pi produced no structurally accepted batch, and the fallback callback must be
+idempotent. A canonical non-empty file within the size limit is structurally
+accepted even when ingest later rejects its protobuf body.
 
 Run:
 
@@ -154,16 +156,18 @@ Use these checks for the follow-up commit that addresses the first review round:
 
 - Call `finish()` twice and then call `teardown()`. The runner must perform one pickup,
   one HTTP request, and return the same counts to every caller.
-- Read `pickedUpBatches` as the number of non-empty, size-bounded files accepted for
-  export. Read `exportedBatches` as the subset accepted by the collector. A 401 can reduce
-  the second count, but it must not create a missing-Pi fallback.
+- Read `pickedUpBatches` as the number of canonical, non-empty, size-bounded files picked
+  up for export. The runner does not decode their protobuf bodies. Read
+  `exportedBatches` as the subset accepted by the collector. A canonical malformed body
+  can therefore produce one picked-up batch, zero exported batches, and no missing-Pi
+  fallback.
 - Confirm the control-file deny set includes `modelConnection.environment` values that
   already enter the Pi process. It must still exclude the runner OTLP authorization.
 - For Agenta ingest, resolve a blank request authorization through the same live
   `AGENTA_CREDENTIALS` fallback used by ordinary runner spans. Do not apply that
   fallback to a third-party collector.
-- During finalization, drain the current channel before the bounded sweep. A valid late
-  batch must reach the export callback instead of being deleted as residue.
+- During finalization, drain the current channel before the bounded sweep. A structurally
+  accepted late batch must reach the export callback instead of being deleted as residue.
 - Treat a missing Daytona telemetry directory as an empty list. Reject a missing,
   truncated, or zero-byte Daytona read before building an HTTP request.
 - Increment the Pi file sequence only after the atomic rename succeeds. Reject

--- a/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
+++ b/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
@@ -140,9 +140,9 @@ Use these checks for the follow-up commit that addresses the first review round:
 
 - Call `finish()` twice and then call `teardown()`. The runner must perform one pickup,
   one HTTP request, and return the same counts to every caller.
-- Read `pickedUpBatches` as the number of valid protobuf files accepted by the runner.
-  Read `exportedBatches` as the subset accepted by the collector. A 401 can reduce the
-  second count, but it must not create a missing-Pi fallback.
+- Read `pickedUpBatches` as the number of non-empty, size-bounded files accepted for
+  export. Read `exportedBatches` as the subset accepted by the collector. A 401 can reduce
+  the second count, but it must not create a missing-Pi fallback.
 - Confirm the control-file deny set includes `modelConnection.environment` values that
   already enter the Pi process. It must still exclude the runner OTLP authorization.
 - For Agenta ingest, resolve a blank request authorization through the same live

--- a/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
+++ b/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
@@ -1,0 +1,172 @@
+# Reviewer protocol: runner-owned Pi trace export
+
+Use this protocol to review the implementation PR. The PR targets
+`release/v0.114.0` and depends on:
+
+- #6217 for refreshed platform credentials at the runner export boundary.
+- #6218 for preserving Secret token timing and authentication errors.
+
+Review those contracts before judging the credential behavior in this PR.
+
+## Intended result
+
+Pi still creates its native span tree. Pi does not send the spans over the
+network. At the end of a turn, Pi serializes a standard OTLP protobuf request
+and atomically publishes the bytes to a private telemetry directory. The runner
+picks up those bytes and sends them through its normal OTLP endpoint and
+credential boundary.
+
+Local and Daytona use the same protocol and runner consumer. Only the file host
+adapter changes:
+
+- Local uses bounded file-descriptor reads on the shared filesystem.
+- Daytona bounds the read inside the sandbox and also caps the sandbox process
+  response before decoding it in the runner.
+
+## Scope boundaries
+
+The PR intentionally does not add:
+
+- a longer-lived Pi credential;
+- an endpoint or authorization header in the Pi control file;
+- a custom trace DTO or a second trace schema;
+- an exporter-specific 401 retry protocol;
+- a feature flag;
+- a separate Daytona export path.
+
+If any of those appear in the diff, treat the change as a scope regression.
+
+## Review order
+
+### 1. Standard byte format
+
+Read these files first:
+
+- `src/tracing/otel.ts`
+- `src/tracing/pi-file-exporter.ts`
+- `src/tracing/pi-spool-protocol.ts`
+- `src/extensions/agenta.ts`
+
+Verify that Pi serializes an OTLP `ExportTraceServiceRequest` and writes the
+exact protobuf bytes. The extension must instantiate the atomic file transport. Its bundle must not
+contain the runner-only `exportOtlpBytes` helper or spool consumer; it may share the tracer
+and standard OTLP serializer with runner tracing.
+
+Run:
+
+```bash
+cd services/runner
+pnpm run build:extension
+pnpm exec vitest run --project unit \
+  tests/unit/otel-trace-serialization.test.ts \
+  tests/unit/pi-file-exporter.test.ts \
+  tests/unit/pi-spool-protocol.test.ts \
+  tests/unit/extension-tools.test.ts
+```
+
+### 2. Process boundary and secrets
+
+Read:
+
+- `src/engines/sandbox_agent/run-turn.ts`
+- `src/engines/sandbox_agent/pi-assets.ts`
+- `src/redaction.ts`
+
+Verify these invariants:
+
+- The Pi control file contains capture policy, propagation, skills, known
+  redaction values, and a random channel ID.
+- It contains no OTLP endpoint and no authorization value.
+- Runner and mount credentials are included in known-value redaction.
+- The control file is published atomically and consumed once per turn.
+- A warm Pi session resets its tracer and usage state before the next turn.
+
+### 3. Local and Daytona adapters
+
+Read:
+
+- `src/engines/sandbox_agent/workspace.ts`
+- `src/tracing/telemetry-file-host.ts`
+- `src/tracing/pi-spool-consumer.ts`
+
+Verify that both placements create the same telemetry directory shape and feed
+the same consumer. Confirm the limits remain bounded: four batches per turn,
+8 MiB per batch, bounded directory listings, and bounded reads. Pickup deletes
+the file before network export so a later poll cannot forward it twice.
+
+Run:
+
+```bash
+cd services/runner
+pnpm exec vitest run --project unit \
+  tests/unit/telemetry-file-host.test.ts \
+  tests/unit/pi-spool-consumer.test.ts \
+  tests/unit/sandbox-agent-workspace.test.ts
+```
+
+### 4. Runner-owned authorization and lifecycle
+
+Read:
+
+- `src/engines/sandbox_agent/runtime-policy.ts`
+- `src/tracing/pi-trace-turn-export.ts`
+- `src/tracing/otlp-bytes-export.ts`
+- `src/engines/sandbox_agent/environment.ts`
+- `src/engines/sandbox_agent/run-turn.ts`
+
+Verify that Agenta ingest reads the current platform authorization immediately
+before export. A third-party collector must keep its configured exporter
+authorization and must never receive the platform token.
+
+Trace finalization must cover normal completion, cancellation, an approval
+pause, approval resume, and parked-environment eviction. A resumed approval must
+keep the original Pi trace ID. The runner may emit its fallback span only when
+Pi produced no valid batch, and the fallback callback must be idempotent.
+
+Run:
+
+```bash
+cd services/runner
+pnpm exec vitest run --project unit \
+  tests/unit/otel-bytes-export.test.ts \
+  tests/unit/pi-trace-turn-export.test.ts \
+  tests/unit/sandbox-agent-orchestration.test.ts \
+  tests/unit/session-keepalive-approval.test.ts
+```
+
+## Full validation
+
+Run from `services/runner`:
+
+```bash
+pnpm run typecheck
+pnpm run test:unit
+pnpm run build:extension
+```
+
+The implementation run passed 138 unit files: 2,276 tests passed and 7 existing
+tests remained marked as expected failures. Typecheck and the extension build
+also passed.
+
+## Live acceptance
+
+Drive `/services/agent/v0/invoke` once with `pi_core` and `sandbox=local`, then
+once with `pi_core` and `sandbox=daytona`. For each run:
+
+1. Capture the `messageMetadata.traceId` from the SSE stream.
+2. Find one `stage=pi_trace_spool_export` runner log with the matching trace
+   suffix, the expected placement, `outcome=exported`, and `status=200`.
+3. Fetch `/api/tracing/traces/{trace_id}` with a key for the same project.
+4. Confirm the stored trace contains Pi-native span names such as `pi`, `chat`,
+   and `turn 0`.
+
+The implementation run persisted both paths:
+
+- Local: `89ce156bd188780fb61b8f7853ffc350`.
+- Daytona: `d7cc51df721601b355e02af617b2f583`.
+
+The shared OpenAI test secret did not produce a successful model response in
+that run. This does not invalidate the export evidence because both Pi native
+batches were exported and fetched back from storage. Repeat the model-response
+portion with a working project credential before treating the broader Pi run as
+a release-gate pass.

--- a/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
+++ b/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md
@@ -1,7 +1,7 @@
 # Reviewer protocol: runner-owned Pi trace export
 
 Use this protocol to review the implementation PR. The PR targets
-`release/v0.114.0` and depends on:
+`release/v0.114.0`. Its merged prerequisites are:
 
 - #6217 for refreshed platform credentials at the runner export boundary.
 - #6218 for preserving Secret token timing and authentication errors.
@@ -70,6 +70,7 @@ Read:
 
 - `src/engines/sandbox_agent/run-turn.ts`
 - `src/engines/sandbox_agent/pi-assets.ts`
+- `src/engines/sandbox_agent/harness-trace-port.ts`
 - `src/redaction.ts`
 
 Verify these invariants:
@@ -77,9 +78,14 @@ Verify these invariants:
 - The Pi control file contains capture policy, propagation, skills, known
   redaction values, and a random channel ID.
 - It contains no OTLP endpoint and no authorization value.
-- Runner and mount credentials are included in known-value redaction.
+- Model environment values and mount credentials already visible inside the sandbox are included
+  in known-value redaction. The runner OTLP authorization is excluded.
 - The control file is published atomically and consumed once per turn.
 - A warm Pi session resets its tracer and usage state before the next turn.
+- Generic `runTurn` calls only the harness tracing port lifecycle. It must not know about
+  channel filenames, telemetry hosts, or Pi control payloads.
+- The default adapter keeps runner-created spans for ordinary harnesses. The Pi adapter owns
+  native-span spool setup, finalization, cancellation, and fallback.
 
 ### 3. Local and Daytona adapters
 
@@ -114,9 +120,11 @@ Read:
 - `src/engines/sandbox_agent/environment.ts`
 - `src/engines/sandbox_agent/run-turn.ts`
 
-Verify that Agenta ingest reads the current platform authorization immediately
-before export. A third-party collector must keep its configured exporter
-authorization and must never receive the platform token.
+- `src/engines/sandbox_agent/harness-trace-port.ts`
+- `src/sessions/auth.ts`
+  Verify that Agenta ingest reads the current platform authorization immediately
+  before export. A third-party collector must keep its configured exporter
+  authorization and must never receive the platform token.
 
 Trace finalization must cover normal completion, cancellation, an approval
 pause, approval resume, and parked-environment eviction. A resumed approval must
@@ -125,13 +133,19 @@ Pi produced no valid batch, and the fallback callback must be idempotent.
 
 Run:
 
+Session-owned and standalone turns must use the same proactive platform credential lease. A
+failed refresh keeps the last usable value. A third-party collector header must never create a
+platform lease or enter permission and session API calls.
+
 ```bash
 cd services/runner
 pnpm exec vitest run --project unit \
   tests/unit/otel-bytes-export.test.ts \
   tests/unit/pi-trace-turn-export.test.ts \
   tests/unit/sandbox-agent-orchestration.test.ts \
-  tests/unit/session-keepalive-approval.test.ts
+  tests/unit/session-keepalive-approval.test.ts \
+  tests/unit/credential-refresh.test.ts \
+  tests/unit/server.test.ts
 ```
 
 ### 5. Review-fix invariants
@@ -183,11 +197,15 @@ pnpm run test:unit
 pnpm run build:extension
 ```
 
-The focused review-fix suite passed 152 tests. The full implementation run passed
-138 unit files: 2,282 tests passed and 7 existing tests remained marked as
-expected failures. Typecheck and the extension build also passed.
+The final full implementation run passed 139 unit files and all 2,300 tests. Typecheck and the
+extension build also passed. The focused credential, session, trace, orchestration, and server
+suite passed 137 tests.
 
-## Live acceptance
+## Pre-merge live acceptance
+
+The live evidence below was captured before the final port extraction. That extraction is
+behavior-preserving and covered by the full unit suite, but the release claim remains provisional
+until the same gate is rerun against the combined post-merge release SHA.
 
 Drive `/services/agent/v0/invoke` once with `pi_core` and `sandbox=local`, then
 once with `pi_core` and `sandbox=daytona`. For each run:
@@ -214,4 +232,24 @@ spans each carry the same `$0.0023065` cumulative total, while only the actual
 model-bearing spans carry it incrementally. This proves the runner export and
 the stored cost roll-up agree without double-counting.
 
-The release gate passed P2 and P2b on the local sandbox and P3 on Daytona. The
+The release gate passed P2 and P2b on the local sandbox and P3 on Daytona. The post-merge gate
+must repeat those cells before preview deployment.
+
+## Rollback protocol
+
+No database migration or persisted custom trace format is involved. Raw spool files are standard
+OTLP protobuf and are swept on turn teardown.
+
+Before merge, undo layers in reverse dependency order:
+
+1. Revert `1f78090822` to remove only the harness tracing port extraction.
+2. Revert `da83e2b80b` to remove the shared standalone credential lease and third-party-header
+   isolation.
+3. Revert the remaining #6223 commits to restore ACP/runner tracing for Pi.
+
+After merge, prefer reverting the #6223 merge commit as one unit. The runner and its bundled Pi
+extension cut over atomically; do not deploy a new runner with an old extension or the reverse.
+#6217 and #6218 are independent correctness fixes and do not need to be rolled back with #6223.
+
+After any rollback or redeploy, rerun P2, P2b, and P3. Confirm that non-Pi runner traces still
+export and that no stale Pi spool file is attributed to the next turn.

--- a/services/runner/package.json
+++ b/services/runner/package.json
@@ -32,6 +32,7 @@
     "@opentelemetry/api": "1.9.1",
     "@opentelemetry/core": "2.8.0",
     "@opentelemetry/exporter-trace-otlp-proto": "0.220.0",
+    "@opentelemetry/otlp-transformer": "0.220.0",
     "@opentelemetry/resources": "2.0.1",
     "@opentelemetry/sdk-trace-base": "2.0.1",
     "@opentelemetry/sdk-trace-node": "2.0.1",

--- a/services/runner/pnpm-lock.yaml
+++ b/services/runner/pnpm-lock.yaml
@@ -51,6 +51,9 @@ importers:
       '@opentelemetry/exporter-trace-otlp-proto':
         specifier: 0.220.0
         version: 0.220.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/otlp-transformer':
+        specifier: 0.220.0
+        version: 0.220.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources':
         specifier: 2.0.1
         version: 2.0.1(@opentelemetry/api@1.9.1)

--- a/services/runner/scripts/build-extension.mjs
+++ b/services/runner/scripts/build-extension.mjs
@@ -27,6 +27,8 @@ const FORBIDDEN_SERVER_SYMBOLS = [
   "daytonaRelayActivitySource",
   "startToolRelay",
   "deleteFsEntry",
+  "createPiTraceSpoolConsumer",
+  "exportOtlpBytes",
 ];
 
 async function assertBundleSafe(outfile) {

--- a/services/runner/src/engines/sandbox_agent/environment-setup.ts
+++ b/services/runner/src/engines/sandbox_agent/environment-setup.ts
@@ -26,7 +26,6 @@ import {
   configurePiSkillSnapshot,
   prepareLocalPiAssets,
   resolvePiSkillSnapshot,
-  writeOtlpAuthFile,
 } from "./pi-assets.ts";
 import {
   buildPiModelConfigPlan,
@@ -178,7 +177,7 @@ export async function prepareEnvironmentSetup(
   // provider cannot leak.
   // "none" asserts NO credential (connections/models.py), so it clears too — otherwise the
   // daemon would inherit the declared provider's keys (e.g. OPENAI_API_KEY) from the sidecar.
-  // RuntimeLifecycle BUILDS the daemon world: both env maps plus the 0600 OTLP bearer file.
+  // RuntimeLifecycle BUILDS the daemon world: both environment maps and runner-owned paths.
   // That was never planning, which is why it moved out of this file (lifecycle migration,
   // step 5). See `environment/runtime-lifecycle.ts` for the ordering rule inside it.
   const runtimeEnvironment = buildRuntimeEnvironment({
@@ -193,7 +192,6 @@ export async function prepareEnvironmentSetup(
   const env = runtimeEnvironment.env;
   const piExtEnv = runtimeEnvironment.piExtEnv;
   const piSessionDir = runtimeEnvironment.piSessionDir;
-  const otlpAuthFilePath = runtimeEnvironment.otlpAuthFilePath;
   const strictModel = modelResolutionStrict();
   logger(
     `tools=${plan.tools.toolSpecs.length} executableTools=${plan.tools.executableToolSpecs.length} ` +
@@ -386,7 +384,6 @@ export async function prepareEnvironmentSetup(
     executableToolGateRef,
     mcpAbort,
     runAgentDir,
-    otlpAuthFilePath,
     codexSqliteHome,
     mountCreds,
     agentMountCreds,

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -387,6 +387,24 @@ export async function acquireEnvironment(
       session: environment.session,
       alreadyRequested: !!environment.sessionDestroyRequested,
     });
+    // Pi may have retained the original prompt's telemetry channel across an approval park.
+    // The harness is now quiescent and `agent_end` has had a chance to publish its partial trace;
+    // drain it before the filesystem disappears. `finish` includes bounded teardown/sweeping.
+    const piTraceExport = environment.piTraceExport;
+    if (piTraceExport) {
+      let validBatches = 0;
+      try {
+        validBatches = (await piTraceExport.finish()).validBatches;
+      } catch {}
+      if (validBatches === 0) {
+        await piTraceExport
+          .emitMissingBatchFallback(
+            "Pi session ended before publishing a valid trace batch",
+          )
+          .catch(() => {});
+      }
+    }
+    environment.piTraceExport = undefined;
     // SandboxLifecycle owns park-versus-delete. It returns `parked` because the mount teardown
     // below is gated on it: a parked Daytona sandbox keeps its agent mount.
     const { parked } = await teardownSandbox({
@@ -438,7 +456,6 @@ export async function acquireEnvironment(
     // Codex auth.json backstop that deliberately does NOT exist — lives with the unit.
     removeRuntimeFiles({
       runAgentDir: environment.runAgentDir,
-      otlpAuthFilePath: environment.otlpAuthFilePath,
       codexSqliteHome: environment.codexSqliteHome,
     });
     // Remove the per-run skills temp root the materializer created (success or error).

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -392,11 +392,11 @@ export async function acquireEnvironment(
     // drain it before the filesystem disappears. `finish` includes bounded teardown/sweeping.
     const piTraceExport = environment.piTraceExport;
     if (piTraceExport) {
-      let validBatches = 0;
+      let pickedUpBatches = 0;
       try {
-        validBatches = (await piTraceExport.finish()).validBatches;
+        pickedUpBatches = (await piTraceExport.finish()).pickedUpBatches;
       } catch {}
-      if (validBatches === 0) {
+      if (pickedUpBatches === 0) {
         await piTraceExport
           .emitMissingBatchFallback(
             "Pi session ended before publishing a valid trace batch",

--- a/services/runner/src/engines/sandbox_agent/harness-trace-port.ts
+++ b/services/runner/src/engines/sandbox_agent/harness-trace-port.ts
@@ -1,0 +1,202 @@
+import { randomBytes } from "node:crypto";
+
+import type { AgentRunRequest } from "../../protocol.ts";
+import { sandboxVisibleSecretValues, type Redactor } from "../../redaction.ts";
+import type { createSandboxAgentOtel } from "../../tracing/otel.ts";
+import { createPiTraceTurnExport } from "../../tracing/pi-trace-turn-export.ts";
+import {
+  PI_TRACE_CONTROL_VERSION,
+  type PiTurnTraceControl,
+} from "../../tracing/pi-spool-protocol.ts";
+import {
+  localTelemetryFileHost,
+  sandboxTelemetryFileHost,
+} from "../../tracing/telemetry-file-host.ts";
+import type { SessionEnvironment } from "./runtime-contracts.ts";
+import type { RunOtlpTarget } from "./runtime-policy.ts";
+
+type TraceRun = ReturnType<typeof createSandboxAgentOtel>;
+
+export interface HarnessTraceFinish {
+  pickedUpBatches: number;
+}
+
+export interface HarnessTracePort {
+  /** False when the harness publishes its own native spans through this port. */
+  runnerEmitsSpans: boolean;
+  start(run: TraceRun, redactor: Redactor): Promise<void>;
+  traceId(run: TraceRun): string | undefined;
+  cancelBeforeDrain(): Promise<void>;
+  finish(): Promise<HarnessTraceFinish | undefined>;
+  emitMissingBatchFallback(run?: TraceRun, message?: string): Promise<void>;
+}
+
+function runnerTracePort(): HarnessTracePort {
+  return {
+    runnerEmitsSpans: true,
+    start: async () => {},
+    traceId: (run) => run.traceId(),
+    cancelBeforeDrain: async () => {},
+    finish: async () => undefined,
+    emitMissingBatchFallback: async () => {},
+  };
+}
+
+function piTracePort(options: {
+  env: SessionEnvironment;
+  request: () => AgentRunRequest;
+  target: RunOtlpTarget;
+  resume: boolean;
+}): HarnessTracePort {
+  const { env, target } = options;
+  const { plan, logger } = env;
+  let fallbackEmitted = false;
+
+  const cancelBeforeDrain = async (): Promise<void> => {
+    if (env.sessionDestroyRequested) return;
+    env.mcpAbort.abort();
+    env.sessionDestroyRequested = true;
+    try {
+      await env.sandbox.destroySession?.(env.session.id);
+    } catch (error) {
+      logger(
+        "stage=pi_trace_cancel failed=true error=" +
+          (error instanceof Error ? error.message : String(error)),
+      );
+    }
+  };
+
+  const finish = async (): Promise<HarnessTraceFinish> => {
+    const traceExport = env.piTraceExport;
+    if (!traceExport) return { pickedUpBatches: 0 };
+    traceExport.updatePlatformAuthorization(target.authorization);
+    try {
+      return {
+        pickedUpBatches: (await traceExport.finish()).pickedUpBatches,
+      };
+    } catch (error) {
+      logger(
+        "stage=pi_trace_spool_finish failed=true error=" +
+          (error instanceof Error ? error.message : String(error)),
+      );
+      return { pickedUpBatches: 0 };
+    }
+  };
+
+  return {
+    runnerEmitsSpans: false,
+    start: async (run, redactor) => {
+      const request = options.request();
+      const exportContext = {
+        endpoint: target.endpoint,
+        authorization: target.authorization,
+        authorizationSource: target.authorizationSource,
+        redactor,
+        traceId: run.traceId(),
+        placement: plan.isDaytona ? ("daytona" as const) : ("local" as const),
+        turnId: request.turnId?.trim() || undefined,
+        onMissingBatch: async (message: string) => {
+          run.recordError(message, request.modelConnection?.provider);
+          await run.flush();
+          logger("stage=pi_trace_missing_batch diagnostic=true");
+        },
+      };
+
+      if (options.resume) {
+        // This is still the original Pi prompt. Keep its channel and target. Only the platform
+        // credential may rotate; an external collector keeps the original exporter header.
+        env.piTraceExport?.updatePlatformAuthorization(target.authorization);
+        return;
+      }
+
+      await env.piTraceExport?.teardown().catch(() => {});
+      const host = plan.isDaytona
+        ? sandboxTelemetryFileHost(env.sandbox)
+        : localTelemetryFileHost();
+
+      // The usage path is stable across warm turns. Remove the preceding turn value before Pi
+      // starts, so a missing write can never be mistaken for current usage.
+      if (plan.workspace.usageOutPath) {
+        await host.remove(plan.workspace.usageOutPath).catch(() => {});
+      }
+
+      const channelId = randomBytes(16).toString("hex");
+      const traceExport = createPiTraceTurnExport({
+        host,
+        dir: plan.workspace.telemetryDir,
+        channelId,
+        context: exportContext,
+        log: logger,
+      });
+      env.piTraceExport = traceExport;
+
+      const control: PiTurnTraceControl = {
+        version: PI_TRACE_CONTROL_VERSION,
+        channelId,
+        turnId: request.turnId?.trim() || undefined,
+        sessionId: env.sessionId || undefined,
+        propagation: {
+          traceparent: request.context?.propagation?.traceparent,
+          baggage: request.context?.propagation?.baggage,
+        },
+        capture: {
+          content: request.telemetry?.capture?.content?.enabled !== false,
+        },
+        skills: plan.workspace.skillDirs.map((skill) => skill.name),
+        // Only values visible inside the sandbox cross this boundary. In particular, the runner
+        // OTLP authorization never enters the control file.
+        redaction: {
+          knownValues: [
+            ...new Set(
+              [
+                ...Object.values(request.modelConnection?.environment ?? {}),
+                ...sandboxVisibleSecretValues(env),
+              ].filter((value): value is string => !!value),
+            ),
+          ],
+        },
+      };
+      if (!(await traceExport.publishControl(control))) {
+        logger("stage=pi_trace_control tracing_disabled=true");
+      }
+    },
+    traceId: (run) => env.piTraceExport?.traceId() ?? run.traceId(),
+    cancelBeforeDrain,
+    finish,
+    emitMissingBatchFallback: async (
+      run,
+      message = "Pi did not publish a valid trace batch before the turn ended",
+    ) => {
+      const traceExport = env.piTraceExport;
+      if (traceExport) {
+        try {
+          await traceExport.emitMissingBatchFallback(message);
+        } catch (error) {
+          logger(
+            "stage=pi_trace_fallback failed=true error=" +
+              (error instanceof Error ? error.message : String(error)),
+          );
+        }
+        return;
+      }
+      if (fallbackEmitted) return;
+      fallbackEmitted = true;
+      run?.recordError(message, options.request().modelConnection?.provider);
+      await run?.flush();
+      logger("stage=pi_trace_missing_batch diagnostic=true");
+    },
+  };
+}
+
+/**
+ * One narrow port for harness trace ownership. Most harnesses use runner-created spans; Pi owns
+ * native span semantics and supplies the same lifecycle operations through its adapter.
+ */
+export function createHarnessTracePort(options: {
+  env: SessionEnvironment;
+  request: () => AgentRunRequest;
+  target: RunOtlpTarget;
+  resume: boolean;
+}): HarnessTracePort {
+  return options.env.plan.isPi ? piTracePort(options) : runnerTracePort();
+}

--- a/services/runner/src/engines/sandbox_agent/mount.ts
+++ b/services/runner/src/engines/sandbox_agent/mount.ts
@@ -7,8 +7,9 @@
  * prefix-scoped credentials (`POST /sessions/mounts/sign`), then geesefs-mounts with those.
  *
  * This module covers the LOCAL sandbox: the daemon runs on this host, so the cwd is a host
- * directory and geesefs mounts on-host — the signed credentials never enter agent-reachable
- * space. The remote (Daytona/E2B) path mounts INSIDE the sandbox and is layered on top of this.
+ * directory and geesefs mounts on-host. The signed credentials stay out of the agent process env
+ * and argv, but a same-user local process can inspect the mount process, so Pi redaction still
+ * treats them as visible. The remote (Daytona/E2B) path mounts inside the sandbox.
  *
  * Uses scoped STS credentials instead of a bucket-wide master key.
  */

--- a/services/runner/src/engines/sandbox_agent/pi-assets.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-assets.ts
@@ -16,6 +16,7 @@ import { tmpdir } from "node:os";
 import { dirname, join } from "node:path";
 
 import type { AgentRunRequest, ResolvedToolSpec } from "../../protocol.ts";
+import { PI_TRACE_CONTROL_ENV } from "../../tracing/pi-spool-protocol.ts";
 import {
   encodePiModelProviderOverride,
   PI_MODEL_PROVIDER_OVERRIDE_ENV,
@@ -463,41 +464,21 @@ export async function uploadPiToolSpecsToSandbox(
 }
 
 /**
- * Env the Agenta Pi extension reads. Tool env contains only public metadata plus the
- * relay directory; private specs/auth stay in the runner.
- *
- * The OTLP bearer is deliberately NOT placed in `OTEL_EXPORTER_OTLP_HEADERS` (or any other
- * plain env var): that env is inherited by the harness process, so a prompt-injected sandbox
- * could read/echo the caller's reusable Authorization bearer and impersonate the caller. It
- * rides a runner-written 0600 read-once file whose PATH is the only thing env carries
- * (`opts.otlpAuthFilePath` -> `AGENTA_AGENT_OTLP_AUTH_FILE`, see `writeOtlpAuthFile`).
+ * Env the Agenta Pi extension reads. Per-turn trace context, capture policy, and redaction values
+ * ride the stable read-once control file; the endpoint and authorization stay in the runner.
  */
 export function buildPiExtensionEnv(
   request: AgentRunRequest,
-  tracing: boolean,
   opts: {
     relayDir?: string;
     usageOutPath?: string;
-    otlpAuthFilePath?: string;
-    skills?: string[];
+    telemetryControlPath?: string;
     builtinGatingActive?: boolean;
   } = {},
 ): Record<string, string> {
   const env: Record<string, string> = {};
-  const propagation = tracing ? request.context?.propagation : undefined;
-  const telemetry = tracing ? request.telemetry : undefined;
-  const otlp = telemetry?.exporters?.otlp;
-  if (propagation?.traceparent) env.TRACEPARENT = propagation.traceparent;
-  if (otlp?.endpoint) env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT = otlp.endpoint;
-  if (otlp?.headers?.authorization && opts.otlpAuthFilePath)
-    env.AGENTA_AGENT_OTLP_AUTH_FILE = opts.otlpAuthFilePath;
-  if (telemetry?.capture?.content?.enabled === false)
-    env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED = "false";
-  // The skills that materialized for this run (author + forced `_agenta.*`), so Pi's own agent
-  // span records which skills loaded (F-029). Only set under tracing (the extension's only span
-  // consumer); a JSON array string the extension parses.
-  if (telemetry && opts.skills && opts.skills.length > 0)
-    env.AGENTA_AGENT_SKILLS_LOADED = JSON.stringify(opts.skills);
+  if (opts.telemetryControlPath)
+    env[PI_TRACE_CONTROL_ENV] = opts.telemetryControlPath;
 
   // Point Pi's built-in provider at the resolved custom base URL via the Agenta extension
   // (`model-provider-override.ts`). Skipped when the managed OpenAI-compatible custom path
@@ -538,25 +519,6 @@ export function buildPiExtensionEnv(
   if (opts.usageOutPath)
     env.AGENTA_AGENT_USAGE_CAPTURE_PATH = opts.usageOutPath;
   return env;
-}
-
-/**
- * Write the OTLP bearer to a 0600 file at `path`: the runner still holds this value
- * in memory for its own out-of-band use (session/mount calls), but the harness process only
- * ever gets a path, never the value, via env. Best-effort: a write failure just means the
- * extension traces without export auth (falls back to its own env fallback, if any).
- */
-export function writeOtlpAuthFile(
-  path: string,
-  authorization: string,
-  log: Log = () => {},
-): void {
-  try {
-    mkdirSync(dirname(path), { recursive: true });
-    writeFileSync(path, authorization, { encoding: "utf-8", mode: 0o600 });
-  } catch (err) {
-    log(`otlp auth file write skipped: ${(err as Error).message}`);
-  }
 }
 
 /**

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -137,6 +137,8 @@ export interface RunPlanCredentials {
 export interface RunPlanWorkspace {
   cwd: string;
   relayDir: string;
+  /** Ephemeral Pi telemetry IPC, sibling to relay and keyed to the same conversation cwd. */
+  telemetryDir: string;
   /**
    * Where the in-sandbox stdio MCP shim assets (bundle + public-specs file) are uploaded on
    * the Daytona non-Pi executable-tools path (`uploadToolMcpAssets`). An ephemeral in-VM
@@ -649,6 +651,10 @@ export function buildRunPlan(
     ? "/home/sandbox/agenta/relay"
     : join(tmpdir(), "agenta", "relay");
   const relayDir = join(relayBase, basename(cwd));
+  const telemetryBase = isDaytona
+    ? "/home/sandbox/agenta/telemetry"
+    : join(tmpdir(), "agenta", "telemetry");
+  const telemetryDir = join(telemetryBase, basename(cwd));
   // The in-sandbox stdio MCP shim assets live in an ephemeral SIBLING of the relay dir, keyed
   // the same way (stable across turns of one conversation). Never inside the relay dir — the
   // relay loop sweeps/watches it — and never on the geesefs mount (see `toolMcpDir` docs).
@@ -683,6 +689,13 @@ export function buildRunPlan(
     `relay dir '${relayDir}' must be a distinct ephemeral dir, not the durable cwd`,
   );
   assert(
+    !!telemetryDir &&
+      telemetryDir !== cwd &&
+      telemetryDir !== relayDir &&
+      !telemetryDir.startsWith(`${relayDir}/`),
+    `telemetry dir '${telemetryDir}' must be an ephemeral sibling of the relay dir`,
+  );
+  assert(
     !!toolMcpDir &&
       toolMcpDir !== cwd &&
       toolMcpDir !== relayDir &&
@@ -715,6 +728,7 @@ export function buildRunPlan(
       workspace: {
         cwd,
         relayDir,
+        telemetryDir,
         toolMcpDir,
         // Usage capture is ephemeral runner output, not durable session data — keep it off the
         // geesefs mount alongside the relay dir (a mount write would risk ENOTCONN).

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -1,3 +1,5 @@
+import { randomBytes } from "node:crypto";
+
 import {
   effectivePermission,
   permissionsFromRequest,
@@ -10,7 +12,7 @@ import {
   type EmitEvent,
   type ToolCallbackContext,
 } from "../../protocol.ts";
-import { seedForRun } from "../../redaction.ts";
+import { sandboxVisibleSecretValues, seedForRun } from "../../redaction.ts";
 import {
   ApprovalResponder,
   ApprovedExecutionGrants,
@@ -38,6 +40,15 @@ import {
   INTERRUPTED_BY_USER,
   TOOL_NOT_EXECUTED_PAUSED,
 } from "../../tracing/otel.ts";
+import { createPiTraceTurnExport } from "../../tracing/pi-trace-turn-export.ts";
+import {
+  PI_TRACE_CONTROL_VERSION,
+  type PiTurnTraceControl,
+} from "../../tracing/pi-spool-protocol.ts";
+import {
+  localTelemetryFileHost,
+  sandboxTelemetryFileHost,
+} from "../../tracing/telemetry-file-host.ts";
 import {
   attachPermissionResponder,
   buildGateDescriptor,
@@ -77,6 +88,7 @@ import {
   type SessionEnvironment,
 } from "./runtime-contracts.ts";
 import {
+  resolveRunOtlpTarget,
   runCredential,
   serverPermissionsFromRequest,
   shouldSuppressPausedToolCallUpdate,
@@ -105,6 +117,7 @@ export async function runTurn(
 ): Promise<AgentRunResult> {
   const { plan, logger, deps } = env;
   const credential = opts.credential ?? (() => runCredential(request));
+  const otlpTarget = resolveRunOtlpTarget(request, credential);
   const sessionId = env.sessionId;
   const toolRunContext = env.sessionId
     ? { ...request.runContext, session: { id: env.sessionId } }
@@ -144,6 +157,36 @@ export async function runTurn(
   // stop this turn's relay on EVERY exit path (a cleared sink must never orphan it).
   let otel: ReturnType<typeof createSandboxAgentOtel> | undefined;
   let activeTurn: CurrentTurn | undefined;
+  const cancelPiHarnessBeforeTraceDrain = async (): Promise<void> => {
+    if (!plan.isPi || env.sessionDestroyRequested) return;
+    env.mcpAbort.abort();
+    env.sessionDestroyRequested = true;
+    try {
+      await env.sandbox.destroySession?.(env.session.id);
+    } catch (error) {
+      logger(
+        "stage=pi_trace_cancel failed=true error=" +
+          (error instanceof Error ? error.message : String(error)),
+      );
+    }
+  };
+  const finishPiTrace = async (): Promise<number> => {
+    if (!plan.isPi) return 0;
+    const traceExport = env.piTraceExport;
+    if (!traceExport) return 0;
+    traceExport.updatePlatformAuthorization(credential);
+    try {
+      return (await traceExport.finish()).validBatches;
+    } catch (error) {
+      logger(
+        "stage=pi_trace_spool_finish failed=true error=" +
+          (error instanceof Error ? error.message : String(error)),
+      );
+      return 0;
+    } finally {
+      if (env.piTraceExport === traceExport) env.piTraceExport = undefined;
+    }
+  };
   // Assigned once the turn's interaction plumbing exists; called from the `finally` so EVERY exit
   // path (done, paused, cancelled, error) settles the durable rows this turn's in-band answers
   // consumed. Without it, a resume the harness does not re-gate leaves them `pending` forever.
@@ -258,27 +301,24 @@ export async function runTurn(
         ? buildTurnText(request, logger)
         : plan.prompt.turnText;
 
+    const runRedactor = seedForRun(request, sandboxVisibleSecretValues(env));
     const run = (deps.createOtel ?? createSandboxAgentOtel)({
       harness: plan.harness,
       model: env.model,
       skills: plan.workspace.skillDirs.map((s) => s.name),
       traceparent: request.context?.propagation?.traceparent,
       baggage: request.context?.propagation?.baggage,
-      endpoint: request.telemetry?.exporters?.otlp?.endpoint,
+      endpoint: otlpTarget.endpoint,
       // The session keepalive owns this getter and refreshes its value while a long turn runs.
       // Resolve it only when the trace batch leaves the runner, not when the turn starts.
-      authorization: credential,
+      authorization: otlpTarget.authorization,
       captureContent: request.telemetry?.capture?.content?.enabled,
       // Seed from the request's typed model/MCP credential material (`requestSecretValues` —
       // on a Daytona Secrets run the opaque values left the plaintext env for the secret plan
       // but still transit runner memory) plus the mount's STS pair — none of which lives in the
       // sidecar's process env.
-      redactor: seedForRun(request, [
-        env.mountCreds?.accessKey,
-        env.mountCreds?.secretKey,
-        env.mountCreds?.sessionToken,
-      ]),
-      emitSpans: !plan.isPi || plan.isDaytona,
+      redactor: runRedactor,
+      emitSpans: !plan.isPi,
       // Every emitted event is a progress signal for the idle/TTFB deadlines (message/thought
       // deltas, tool calls and results, usage, ...) — the one seam every harness's output flows
       // through. Per-tool-call timers are driven separately from `handleUpdate` below.
@@ -294,6 +334,77 @@ export async function runTurn(
         { role: "user", content: promptText },
       ],
     });
+
+    if (plan.isPi) {
+      const exportContext = {
+        endpoint: otlpTarget.endpoint,
+        authorization: otlpTarget.authorization,
+        authorizationSource: otlpTarget.authorizationSource,
+        redactor: runRedactor,
+        traceId: run.traceId(),
+        placement: plan.isDaytona ? ("daytona" as const) : ("local" as const),
+        turnId: request.turnId?.trim() || undefined,
+        onMissingBatch: async (message: string) => {
+          run.recordError(message, request.modelConnection?.provider);
+          await run.flush();
+        },
+      };
+      if (opts.resume) {
+        // This is still the original Pi prompt. Keep its channel and target. Only the platform
+        // credential may rotate; an external collector keeps the original exporter header.
+        env.piTraceExport?.updatePlatformAuthorization(credential);
+      } else {
+        await env.piTraceExport?.teardown().catch(() => {});
+        const host = plan.isDaytona
+          ? sandboxTelemetryFileHost(env.sandbox)
+          : localTelemetryFileHost();
+        // The usage path is stable across warm turns. Remove the preceding turn value before
+        // Pi starts, so a missing write can never be mistaken for current usage.
+        if (plan.workspace.usageOutPath) {
+          await host.remove(plan.workspace.usageOutPath).catch(() => {});
+        }
+        const channelId = randomBytes(16).toString("hex");
+        const traceExport = createPiTraceTurnExport({
+          host,
+          dir: plan.workspace.telemetryDir,
+          channelId,
+          context: exportContext,
+          log: logger,
+        });
+        env.piTraceExport = traceExport;
+        const control: PiTurnTraceControl = {
+          version: PI_TRACE_CONTROL_VERSION,
+          channelId,
+          turnId: request.turnId?.trim() || undefined,
+          sessionId: sessionId || undefined,
+          propagation: {
+            traceparent: request.context?.propagation?.traceparent,
+            baggage: request.context?.propagation?.baggage,
+          },
+          capture: {
+            content: request.telemetry?.capture?.content?.enabled !== false,
+          },
+          skills: plan.workspace.skillDirs.map((skill) => skill.name),
+          // Only values visible inside the sandbox cross this boundary. In particular, the
+          // runner OTLP authorization never enters the control file.
+          redaction: {
+            knownValues: [
+              ...new Set(
+                sandboxVisibleSecretValues(env).filter(
+                  (value): value is string => !!value,
+                ),
+              ),
+            ],
+          },
+        };
+        if (!(await traceExport.publishControl(control))) {
+          logger("stage=pi_trace_control tracing_disabled=true");
+        }
+      }
+    }
+    const resultTraceId = plan.isPi
+      ? (env.piTraceExport?.traceId() ?? run.traceId())
+      : run.traceId();
 
     let promptBlocks: AcpPromptBlock[] = [{ type: "text", text: turnText }];
     if (!opts.resume) {
@@ -384,7 +495,7 @@ export async function runTurn(
           agentSessionId: env.session?.agentSessionId,
           sandboxId: env.sandbox?.sandboxId,
           references: workflowRefs,
-          traceId: run.traceId() ?? request.runContext?.trace?.trace_id,
+          traceId: resultTraceId ?? request.runContext?.trace?.trace_id,
           spanId: request.runContext?.trace?.span_id,
           startTime: turnStartedAt,
         },
@@ -1018,9 +1129,7 @@ export async function runTurn(
         pause.pause();
       }
     } else {
-      promptPromise = Promise.resolve(
-        env.session.prompt(promptBlocks),
-      );
+      promptPromise = Promise.resolve(env.session.prompt(promptBlocks));
       promptPromise.catch(() => {});
     }
     // A user Stop aborts `signal`, which severs the harness fetch (rejecting the prompt). We want a
@@ -1132,6 +1241,12 @@ export async function runTurn(
       }
     }
     await turn.toolRelay?.stop();
+    if (stopReason === "cancelled") {
+      // `agent_end` publishes Pi's partial native trace. Ask the adapter to finish that lifecycle
+      // before draining; the outer environment teardown would otherwise cancel Pi only after the
+      // spool had already timed out and then sweep the late batch.
+      await cancelPiHarnessBeforeTraceDrain();
+    }
     logger(`prompt stopReason=${stopReason}`);
 
     const usage = await resolveRunUsage({
@@ -1142,6 +1257,8 @@ export async function runTurn(
       streamUsage: run.usage(),
     });
     run.setUsage(usage);
+    const piValidTraceBatches =
+      plan.isPi && stopReason !== "paused" ? await finishPiTrace() : undefined;
 
     const swallowedPiError =
       plan.isPi &&
@@ -1162,6 +1279,12 @@ export async function runTurn(
       );
       run.recordError(swallowedError, request.modelConnection?.provider);
       run.emitEvent({ type: "error", message: swallowedError });
+    }
+    if (piValidTraceBatches === 0 && !swallowedError) {
+      run.recordError(
+        "Pi did not publish a valid trace batch before the turn ended",
+        request.modelConnection?.provider,
+      );
     }
 
     // Before `finish()`, which emits the terminal `done` the API reconciles gates against.
@@ -1225,7 +1348,7 @@ export async function runTurn(
       },
       sessionId,
       model: env.model ?? request.model,
-      traceId: run.traceId(),
+      traceId: resultTraceId,
     } as AgentRunResult;
   } catch (err) {
     const error = conciseError(
@@ -1234,7 +1357,13 @@ export async function runTurn(
       request.modelConnection?.provider,
       { authFault: () => describeCodexSubscriptionAuthFault(plan) },
     );
-    otel?.recordError(error, request.modelConnection?.provider);
+    await cancelPiHarnessBeforeTraceDrain();
+    const piValidTraceBatches = plan.isPi ? await finishPiTrace() : 0;
+    // A valid native Pi batch already carries the harness failure. Otherwise preserve the
+    // runner-owned error and usage fallback under the caller trace context.
+    if (!plan.isPi || piValidTraceBatches === 0) {
+      otel?.recordError(error, request.modelConnection?.provider);
+    }
     otel?.emitEvent({ type: "error", message: error });
     // An aborted turn may have left a partial turn in the native transcript.
     invalidateContinuity(sessionId, plan.harness, deps);

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -174,18 +174,31 @@ export async function runTurn(
     if (!plan.isPi) return 0;
     const traceExport = env.piTraceExport;
     if (!traceExport) return 0;
-    traceExport.updatePlatformAuthorization(credential);
+    traceExport.updatePlatformAuthorization(otlpTarget.authorization);
     try {
-      return (await traceExport.finish()).validBatches;
+      return (await traceExport.finish()).pickedUpBatches;
     } catch (error) {
       logger(
         "stage=pi_trace_spool_finish failed=true error=" +
           (error instanceof Error ? error.message : String(error)),
       );
       return 0;
-    } finally {
-      if (env.piTraceExport === traceExport) env.piTraceExport = undefined;
     }
+  };
+  const emitPiMissingBatchFallback = async (message: string): Promise<void> => {
+    const traceExport = env.piTraceExport;
+    if (traceExport) {
+      try {
+        await traceExport.emitMissingBatchFallback(message);
+      } catch (error) {
+        logger(
+          "stage=pi_trace_fallback failed=true error=" +
+            (error instanceof Error ? error.message : String(error)),
+        );
+      }
+      return;
+    }
+    otel?.recordError(message, request.modelConnection?.provider);
   };
   // Assigned once the turn's interaction plumbing exists; called from the `finally` so EVERY exit
   // path (done, paused, cancelled, error) settles the durable rows this turn's in-band answers
@@ -352,7 +365,7 @@ export async function runTurn(
       if (opts.resume) {
         // This is still the original Pi prompt. Keep its channel and target. Only the platform
         // credential may rotate; an external collector keeps the original exporter header.
-        env.piTraceExport?.updatePlatformAuthorization(credential);
+        env.piTraceExport?.updatePlatformAuthorization(otlpTarget.authorization);
       } else {
         await env.piTraceExport?.teardown().catch(() => {});
         const host = plan.isDaytona
@@ -390,7 +403,10 @@ export async function runTurn(
           redaction: {
             knownValues: [
               ...new Set(
-                sandboxVisibleSecretValues(env).filter(
+                [
+                  ...Object.values(request.modelConnection?.environment ?? {}),
+                  ...sandboxVisibleSecretValues(env),
+                ].filter(
                   (value): value is string => !!value,
                 ),
               ),
@@ -1257,7 +1273,7 @@ export async function runTurn(
       streamUsage: run.usage(),
     });
     run.setUsage(usage);
-    const piValidTraceBatches =
+    const piPickedUpTraceBatches =
       plan.isPi && stopReason !== "paused" ? await finishPiTrace() : undefined;
 
     const swallowedPiError =
@@ -1280,10 +1296,9 @@ export async function runTurn(
       run.recordError(swallowedError, request.modelConnection?.provider);
       run.emitEvent({ type: "error", message: swallowedError });
     }
-    if (piValidTraceBatches === 0 && !swallowedError) {
-      run.recordError(
+    if (piPickedUpTraceBatches === 0 && !swallowedError) {
+      await emitPiMissingBatchFallback(
         "Pi did not publish a valid trace batch before the turn ended",
-        request.modelConnection?.provider,
       );
     }
 
@@ -1358,11 +1373,13 @@ export async function runTurn(
       { authFault: () => describeCodexSubscriptionAuthFault(plan) },
     );
     await cancelPiHarnessBeforeTraceDrain();
-    const piValidTraceBatches = plan.isPi ? await finishPiTrace() : 0;
+    const piPickedUpTraceBatches = plan.isPi ? await finishPiTrace() : 0;
     // A valid native Pi batch already carries the harness failure. Otherwise preserve the
     // runner-owned error and usage fallback under the caller trace context.
-    if (!plan.isPi || piValidTraceBatches === 0) {
+    if (!plan.isPi) {
       otel?.recordError(error, request.modelConnection?.provider);
+    } else if (piPickedUpTraceBatches === 0) {
+      await emitPiMissingBatchFallback(error);
     }
     otel?.emitEvent({ type: "error", message: error });
     // An aborted turn may have left a partial turn in the native transcript.

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -185,7 +185,14 @@ export async function runTurn(
       return 0;
     }
   };
-  const emitPiMissingBatchFallback = async (message: string): Promise<void> => {
+  const emitPiMissingBatchFallback = async (
+    message: string,
+    options: { runFailed?: boolean } = {},
+  ): Promise<void> => {
+    if (options.runFailed) {
+      otel?.recordError(message, request.modelConnection?.provider);
+      await otel?.flush();
+    }
     const traceExport = env.piTraceExport;
     if (traceExport) {
       try {
@@ -198,7 +205,7 @@ export async function runTurn(
       }
       return;
     }
-    otel?.recordError(message, request.modelConnection?.provider);
+    logger("stage=pi_trace_missing_batch diagnostic=true");
   };
   // Assigned once the turn's interaction plumbing exists; called from the `finally` so EVERY exit
   // path (done, paused, cancelled, error) settles the durable rows this turn's in-band answers
@@ -357,15 +364,16 @@ export async function runTurn(
         traceId: run.traceId(),
         placement: plan.isDaytona ? ("daytona" as const) : ("local" as const),
         turnId: request.turnId?.trim() || undefined,
-        onMissingBatch: async (message: string) => {
-          run.recordError(message, request.modelConnection?.provider);
-          await run.flush();
+        onMissingBatch: async () => {
+          logger("stage=pi_trace_missing_batch diagnostic=true");
         },
       };
       if (opts.resume) {
         // This is still the original Pi prompt. Keep its channel and target. Only the platform
         // credential may rotate; an external collector keeps the original exporter header.
-        env.piTraceExport?.updatePlatformAuthorization(otlpTarget.authorization);
+        env.piTraceExport?.updatePlatformAuthorization(
+          otlpTarget.authorization,
+        );
       } else {
         await env.piTraceExport?.teardown().catch(() => {});
         const host = plan.isDaytona
@@ -406,9 +414,7 @@ export async function runTurn(
                 [
                   ...Object.values(request.modelConnection?.environment ?? {}),
                   ...sandboxVisibleSecretValues(env),
-                ].filter(
-                  (value): value is string => !!value,
-                ),
+                ].filter((value): value is string => !!value),
               ),
             ],
           },
@@ -1379,7 +1385,7 @@ export async function runTurn(
     if (!plan.isPi) {
       otel?.recordError(error, request.modelConnection?.provider);
     } else if (piPickedUpTraceBatches === 0) {
-      await emitPiMissingBatchFallback(error);
+      await emitPiMissingBatchFallback(error, { runFailed: true });
     }
     otel?.emitEvent({ type: "error", message: error });
     // An aborted turn may have left a partial turn in the native transcript.

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -185,14 +185,8 @@ export async function runTurn(
       return 0;
     }
   };
-  const emitPiMissingBatchFallback = async (
-    message: string,
-    options: { runFailed?: boolean } = {},
-  ): Promise<void> => {
-    if (options.runFailed) {
-      otel?.recordError(message, request.modelConnection?.provider);
-      await otel?.flush();
-    }
+  let piMissingBatchFallbackEmitted = false;
+  const emitPiMissingBatchFallback = async (message: string): Promise<void> => {
     const traceExport = env.piTraceExport;
     if (traceExport) {
       try {
@@ -205,6 +199,10 @@ export async function runTurn(
       }
       return;
     }
+    if (piMissingBatchFallbackEmitted) return;
+    piMissingBatchFallbackEmitted = true;
+    otel?.recordError(message, request.modelConnection?.provider);
+    await otel?.flush();
     logger("stage=pi_trace_missing_batch diagnostic=true");
   };
   // Assigned once the turn's interaction plumbing exists; called from the `finally` so EVERY exit
@@ -364,7 +362,9 @@ export async function runTurn(
         traceId: run.traceId(),
         placement: plan.isDaytona ? ("daytona" as const) : ("local" as const),
         turnId: request.turnId?.trim() || undefined,
-        onMissingBatch: async () => {
+        onMissingBatch: async (message: string) => {
+          run.recordError(message, request.modelConnection?.provider);
+          await run.flush();
           logger("stage=pi_trace_missing_batch diagnostic=true");
         },
       };
@@ -1385,7 +1385,7 @@ export async function runTurn(
     if (!plan.isPi) {
       otel?.recordError(error, request.modelConnection?.provider);
     } else if (piPickedUpTraceBatches === 0) {
-      await emitPiMissingBatchFallback(error, { runFailed: true });
+      await emitPiMissingBatchFallback(error);
     }
     otel?.emitEvent({ type: "error", message: error });
     // An aborted turn may have left a partial turn in the native transcript.

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -1,5 +1,6 @@
 import { randomBytes } from "node:crypto";
 
+import { apiBase } from "../../apiBase.ts";
 import {
   effectivePermission,
   permissionsFromRequest,
@@ -13,6 +14,7 @@ import {
   type ToolCallbackContext,
 } from "../../protocol.ts";
 import { sandboxVisibleSecretValues, seedForRun } from "../../redaction.ts";
+import { startPlatformCredentialLease } from "../../sessions/auth.ts";
 import {
   ApprovalResponder,
   ApprovedExecutionGrants,
@@ -116,7 +118,17 @@ export async function runTurn(
   opts: RunTurnOptions = {},
 ): Promise<AgentRunResult> {
   const { plan, logger, deps } = env;
-  const credential = opts.credential ?? (() => runCredential(request));
+  const initialCredential = opts.credential ?? (() => runCredential(request));
+  const initialOtlpTarget = resolveRunOtlpTarget(request, initialCredential);
+  // Session-owned turns receive the watchdog's lease through opts.credential. A standalone
+  // Agenta run owns the same reusable lease here so even a single 12-hour turn exports with a
+  // current credential. External collector headers stay static and never enter this exchange.
+  const platformCredentialLease =
+    !opts.credential && initialOtlpTarget.authorizationSource === "platform"
+      ? startPlatformCredentialLease(apiBase(), runCredential(request))
+      : undefined;
+  const credential =
+    opts.credential ?? platformCredentialLease?.credential ?? initialCredential;
   const otlpTarget = resolveRunOtlpTarget(request, credential);
   const sessionId = env.sessionId;
   const toolRunContext = env.sessionId
@@ -1399,6 +1411,7 @@ export async function runTurn(
     await otel?.flush().catch(() => {});
     return { ok: false, error };
   } finally {
+    platformCredentialLease?.release();
     // Backstop for the exits that reach neither branch above (cancel, abort). Idempotent via the
     // resolved-token set, so the ordered calls make this a no-op on the paths that took them, and
     // never throws — a row whose gate is gone is unanswerable however the turn ended.

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -1,5 +1,3 @@
-import { randomBytes } from "node:crypto";
-
 import { apiBase } from "../../apiBase.ts";
 import {
   effectivePermission,
@@ -42,15 +40,6 @@ import {
   INTERRUPTED_BY_USER,
   TOOL_NOT_EXECUTED_PAUSED,
 } from "../../tracing/otel.ts";
-import { createPiTraceTurnExport } from "../../tracing/pi-trace-turn-export.ts";
-import {
-  PI_TRACE_CONTROL_VERSION,
-  type PiTurnTraceControl,
-} from "../../tracing/pi-spool-protocol.ts";
-import {
-  localTelemetryFileHost,
-  sandboxTelemetryFileHost,
-} from "../../tracing/telemetry-file-host.ts";
 import {
   attachPermissionResponder,
   buildGateDescriptor,
@@ -61,6 +50,7 @@ import {
 } from "./client-tools.ts";
 import { buildExecutableToolGate } from "./executable-tools.ts";
 import { invalidateContinuity } from "./environment.ts";
+import { createHarnessTracePort } from "./harness-trace-port.ts";
 import {
   attachmentCapabilityGate,
   buildPromptBlocks,
@@ -169,54 +159,12 @@ export async function runTurn(
   // stop this turn's relay on EVERY exit path (a cleared sink must never orphan it).
   let otel: ReturnType<typeof createSandboxAgentOtel> | undefined;
   let activeTurn: CurrentTurn | undefined;
-  const cancelPiHarnessBeforeTraceDrain = async (): Promise<void> => {
-    if (!plan.isPi || env.sessionDestroyRequested) return;
-    env.mcpAbort.abort();
-    env.sessionDestroyRequested = true;
-    try {
-      await env.sandbox.destroySession?.(env.session.id);
-    } catch (error) {
-      logger(
-        "stage=pi_trace_cancel failed=true error=" +
-          (error instanceof Error ? error.message : String(error)),
-      );
-    }
-  };
-  const finishPiTrace = async (): Promise<number> => {
-    if (!plan.isPi) return 0;
-    const traceExport = env.piTraceExport;
-    if (!traceExport) return 0;
-    traceExport.updatePlatformAuthorization(otlpTarget.authorization);
-    try {
-      return (await traceExport.finish()).pickedUpBatches;
-    } catch (error) {
-      logger(
-        "stage=pi_trace_spool_finish failed=true error=" +
-          (error instanceof Error ? error.message : String(error)),
-      );
-      return 0;
-    }
-  };
-  let piMissingBatchFallbackEmitted = false;
-  const emitPiMissingBatchFallback = async (message: string): Promise<void> => {
-    const traceExport = env.piTraceExport;
-    if (traceExport) {
-      try {
-        await traceExport.emitMissingBatchFallback(message);
-      } catch (error) {
-        logger(
-          "stage=pi_trace_fallback failed=true error=" +
-            (error instanceof Error ? error.message : String(error)),
-        );
-      }
-      return;
-    }
-    if (piMissingBatchFallbackEmitted) return;
-    piMissingBatchFallbackEmitted = true;
-    otel?.recordError(message, request.modelConnection?.provider);
-    await otel?.flush();
-    logger("stage=pi_trace_missing_batch diagnostic=true");
-  };
+  const harnessTrace = createHarnessTracePort({
+    env,
+    request: () => request,
+    target: otlpTarget,
+    resume: !!opts.resume,
+  });
   // Assigned once the turn's interaction plumbing exists; called from the `finally` so EVERY exit
   // path (done, paused, cancelled, error) settles the durable rows this turn's in-band answers
   // consumed. Without it, a resume the harness does not re-gate leaves them `pending` forever.
@@ -348,7 +296,7 @@ export async function runTurn(
       // but still transit runner memory) plus the mount's STS pair — none of which lives in the
       // sidecar's process env.
       redactor: runRedactor,
-      emitSpans: !plan.isPi,
+      emitSpans: harnessTrace.runnerEmitsSpans,
       // Every emitted event is a progress signal for the idle/TTFB deadlines (message/thought
       // deltas, tool calls and results, usage, ...) — the one seam every harness's output flows
       // through. Per-tool-call timers are driven separately from `handleUpdate` below.
@@ -364,81 +312,8 @@ export async function runTurn(
         { role: "user", content: promptText },
       ],
     });
-
-    if (plan.isPi) {
-      const exportContext = {
-        endpoint: otlpTarget.endpoint,
-        authorization: otlpTarget.authorization,
-        authorizationSource: otlpTarget.authorizationSource,
-        redactor: runRedactor,
-        traceId: run.traceId(),
-        placement: plan.isDaytona ? ("daytona" as const) : ("local" as const),
-        turnId: request.turnId?.trim() || undefined,
-        onMissingBatch: async (message: string) => {
-          run.recordError(message, request.modelConnection?.provider);
-          await run.flush();
-          logger("stage=pi_trace_missing_batch diagnostic=true");
-        },
-      };
-      if (opts.resume) {
-        // This is still the original Pi prompt. Keep its channel and target. Only the platform
-        // credential may rotate; an external collector keeps the original exporter header.
-        env.piTraceExport?.updatePlatformAuthorization(
-          otlpTarget.authorization,
-        );
-      } else {
-        await env.piTraceExport?.teardown().catch(() => {});
-        const host = plan.isDaytona
-          ? sandboxTelemetryFileHost(env.sandbox)
-          : localTelemetryFileHost();
-        // The usage path is stable across warm turns. Remove the preceding turn value before
-        // Pi starts, so a missing write can never be mistaken for current usage.
-        if (plan.workspace.usageOutPath) {
-          await host.remove(plan.workspace.usageOutPath).catch(() => {});
-        }
-        const channelId = randomBytes(16).toString("hex");
-        const traceExport = createPiTraceTurnExport({
-          host,
-          dir: plan.workspace.telemetryDir,
-          channelId,
-          context: exportContext,
-          log: logger,
-        });
-        env.piTraceExport = traceExport;
-        const control: PiTurnTraceControl = {
-          version: PI_TRACE_CONTROL_VERSION,
-          channelId,
-          turnId: request.turnId?.trim() || undefined,
-          sessionId: sessionId || undefined,
-          propagation: {
-            traceparent: request.context?.propagation?.traceparent,
-            baggage: request.context?.propagation?.baggage,
-          },
-          capture: {
-            content: request.telemetry?.capture?.content?.enabled !== false,
-          },
-          skills: plan.workspace.skillDirs.map((skill) => skill.name),
-          // Only values visible inside the sandbox cross this boundary. In particular, the
-          // runner OTLP authorization never enters the control file.
-          redaction: {
-            knownValues: [
-              ...new Set(
-                [
-                  ...Object.values(request.modelConnection?.environment ?? {}),
-                  ...sandboxVisibleSecretValues(env),
-                ].filter((value): value is string => !!value),
-              ),
-            ],
-          },
-        };
-        if (!(await traceExport.publishControl(control))) {
-          logger("stage=pi_trace_control tracing_disabled=true");
-        }
-      }
-    }
-    const resultTraceId = plan.isPi
-      ? (env.piTraceExport?.traceId() ?? run.traceId())
-      : run.traceId();
+    await harnessTrace.start(run, runRedactor);
+    const resultTraceId = harnessTrace.traceId(run);
 
     let promptBlocks: AcpPromptBlock[] = [{ type: "text", text: turnText }];
     if (!opts.resume) {
@@ -1279,7 +1154,7 @@ export async function runTurn(
       // `agent_end` publishes Pi's partial native trace. Ask the adapter to finish that lifecycle
       // before draining; the outer environment teardown would otherwise cancel Pi only after the
       // spool had already timed out and then sweep the late batch.
-      await cancelPiHarnessBeforeTraceDrain();
+      await harnessTrace.cancelBeforeDrain();
     }
     logger(`prompt stopReason=${stopReason}`);
 
@@ -1291,8 +1166,9 @@ export async function runTurn(
       streamUsage: run.usage(),
     });
     run.setUsage(usage);
-    const piPickedUpTraceBatches =
-      plan.isPi && stopReason !== "paused" ? await finishPiTrace() : undefined;
+    const traceFinish =
+      stopReason !== "paused" ? await harnessTrace.finish() : undefined;
+    const nativeTraceBatches = traceFinish?.pickedUpBatches;
 
     const swallowedPiError =
       plan.isPi &&
@@ -1314,10 +1190,8 @@ export async function runTurn(
       run.recordError(swallowedError, request.modelConnection?.provider);
       run.emitEvent({ type: "error", message: swallowedError });
     }
-    if (piPickedUpTraceBatches === 0 && !swallowedError) {
-      await emitPiMissingBatchFallback(
-        "Pi did not publish a valid trace batch before the turn ended",
-      );
+    if (nativeTraceBatches === 0 && !swallowedError) {
+      await harnessTrace.emitMissingBatchFallback(run);
     }
 
     // Before `finish()`, which emits the terminal `done` the API reconciles gates against.
@@ -1390,14 +1264,15 @@ export async function runTurn(
       request.modelConnection?.provider,
       { authFault: () => describeCodexSubscriptionAuthFault(plan) },
     );
-    await cancelPiHarnessBeforeTraceDrain();
-    const piPickedUpTraceBatches = plan.isPi ? await finishPiTrace() : 0;
+    await harnessTrace.cancelBeforeDrain();
+    const traceFinish = await harnessTrace.finish();
+    const nativeTraceBatches = traceFinish?.pickedUpBatches;
     // A valid native Pi batch already carries the harness failure. Otherwise preserve the
     // runner-owned error and usage fallback under the caller trace context.
-    if (!plan.isPi) {
+    if (harnessTrace.runnerEmitsSpans) {
       otel?.recordError(error, request.modelConnection?.provider);
-    } else if (piPickedUpTraceBatches === 0) {
-      await emitPiMissingBatchFallback(error);
+    } else if (nativeTraceBatches === 0) {
+      await harnessTrace.emitMissingBatchFallback(otel, error);
     }
     otel?.emitEvent({ type: "error", message: error });
     // An aborted turn may have left a partial turn in the native transcript.

--- a/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
@@ -13,6 +13,7 @@ import {
   startToolRelay,
 } from "../../tools/relay.ts";
 import { createSandboxAgentOtel } from "../../tracing/otel.ts";
+import type { PiTraceTurnExport } from "../../tracing/pi-trace-turn-export.ts";
 import { createAcpFetch } from "./acp-fetch.ts";
 import { type ParkedApprovalGateType } from "./acp-interactions.ts";
 import { signAgentMountCredentials } from "./agent-mount.ts";
@@ -282,7 +283,6 @@ export interface SessionEnvironment {
   executableToolGateRef: { current?: ExecutableToolGate };
   mcpAbort: AbortController;
   runAgentDir: string | undefined;
-  otlpAuthFilePath: string | undefined;
   /**
    * The local off-mount directory this run pointed CODEX_SQLITE_HOME at (Codex's SQLite state,
    * which cannot live on the geesefs cwd mount). Removed best-effort by `destroy`; the state is
@@ -324,6 +324,8 @@ export interface SessionEnvironment {
   runtimeRemount: Promise<boolean> | undefined;
   closeToolMcp: (() => Promise<void>) | undefined;
   currentTurn?: CurrentTurn;
+  /** Pi's native span spool for the original prompt; survives approval park/resume. */
+  piTraceExport?: PiTraceTurnExport;
   /**
    * The unique ACP tool-call ids the LAST completed turn emitted (reset at each turn start).
    * The keep-alive dispatch folds them into the expected next-history fingerprint at park time,

--- a/services/runner/src/engines/sandbox_agent/runtime-policy.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-policy.ts
@@ -1,8 +1,10 @@
-import {
-  type AgentRunRequest,
-  type ToolPermission,
-} from "../../protocol.ts";
+import { type AgentRunRequest, type ToolPermission } from "../../protocol.ts";
 import { claimSessionOwnership, REPLICA_ID } from "../../sessions/alive.ts";
+import {
+  isAgentaIngest,
+  resolveOtlpTraceEndpoint,
+  type AuthorizationProvider,
+} from "../../tracing/otel.ts";
 import { PendingApprovalPauseController } from "./pause.ts";
 
 type Log = (message: string) => void;
@@ -14,6 +16,39 @@ export function runCredential(request: AgentRunRequest): string {
     string
   >;
   return (headers["authorization"] ?? headers["Authorization"] ?? "").trim();
+}
+
+export interface RunOtlpTarget {
+  endpoint: string;
+  authorization: AuthorizationProvider;
+  authorizationSource: "platform" | "exporter";
+}
+
+/**
+ * Bind one run to its trusted OTLP destination and the credential that belongs to it.
+ * Agenta ingest follows the renewable platform credential; an external collector keeps the
+ * exporter header from the original request and never receives a refreshed platform token.
+ */
+export function resolveRunOtlpTarget(
+  request: AgentRunRequest,
+  platformAuthorization: AuthorizationProvider,
+): RunOtlpTarget {
+  const endpoint = resolveOtlpTraceEndpoint(
+    request.telemetry?.exporters?.otlp?.endpoint,
+  );
+  if (isAgentaIngest(endpoint)) {
+    return {
+      endpoint,
+      authorization: platformAuthorization,
+      authorizationSource: "platform",
+    };
+  }
+  const exporterAuthorization = runCredential(request) || undefined;
+  return {
+    endpoint,
+    authorization: () => exporterAuthorization,
+    authorizationSource: "exporter",
+  };
 }
 
 export function serverPermissionsFromRequest(

--- a/services/runner/src/engines/sandbox_agent/runtime-policy.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-policy.ts
@@ -2,6 +2,7 @@ import { type AgentRunRequest, type ToolPermission } from "../../protocol.ts";
 import { claimSessionOwnership, REPLICA_ID } from "../../sessions/alive.ts";
 import {
   isAgentaIngest,
+  platformAuthorizationProvider,
   resolveOtlpTraceEndpoint,
   type AuthorizationProvider,
 } from "../../tracing/otel.ts";
@@ -39,7 +40,7 @@ export function resolveRunOtlpTarget(
   if (isAgentaIngest(endpoint)) {
     return {
       endpoint,
-      authorization: platformAuthorization,
+      authorization: platformAuthorizationProvider(platformAuthorization),
       authorizationSource: "platform",
     };
   }

--- a/services/runner/src/engines/sandbox_agent/runtime-policy.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-policy.ts
@@ -19,6 +19,18 @@ export function runCredential(request: AgentRunRequest): string {
   return (headers["authorization"] ?? headers["Authorization"] ?? "").trim();
 }
 
+/**
+ * The legacy wire has one authorization header for two possible owners. Treat it as an Agenta
+ * platform credential only when the configured destination is Agenta ingest; for an external
+ * collector it belongs exclusively to that collector and must never enter platform calls.
+ */
+export function platformCredentialForRequest(request: AgentRunRequest): string {
+  const endpoint = resolveOtlpTraceEndpoint(
+    request.telemetry?.exporters?.otlp?.endpoint,
+  );
+  return isAgentaIngest(endpoint) ? runCredential(request) : "";
+}
+
 export interface RunOtlpTarget {
   endpoint: string;
   authorization: AuthorizationProvider;

--- a/services/runner/src/engines/sandbox_agent/workspace.ts
+++ b/services/runner/src/engines/sandbox_agent/workspace.ts
@@ -26,7 +26,7 @@ export interface PrepareWorkspaceInput {
   plan: Pick<RunPlan, "isDaytona" | "isPi" | "acpAgent"> & {
     workspace: Pick<
       RunPlanWorkspace,
-      "cwd" | "relayDir" | "harnessFiles" | "skillDirs"
+      "cwd" | "relayDir" | "telemetryDir" | "harnessFiles" | "skillDirs"
     >;
     tools: Pick<RunPlanTools, "useToolRelay">;
     prompt: Pick<RunPlanPrompt, "agentsMd">;
@@ -85,6 +85,13 @@ export async function prepareWorkspace({
           log(`tool relay dir mkdir skipped: ${err.message}`);
         });
     }
+    if (plan.isPi) {
+      await sandbox
+        .mkdirFs({ path: plan.workspace.telemetryDir })
+        .catch((err: Error) => {
+          log(`telemetry dir mkdir skipped: ${err.message}`);
+        });
+    }
     if (plan.prompt.agentsMd) {
       await sandbox.writeFsFile(
         { path: `${plan.workspace.cwd}/${instructionsFile}` },
@@ -122,6 +129,8 @@ export async function prepareWorkspace({
   // runner has no /dev/fuse), acquisition deliberately falls back to an ephemeral cwd. Ensure
   // that fallback exists before writing CLAUDE.md/AGENTS.md or any harness files into it.
   mkdirSync(plan.workspace.cwd, { recursive: true });
+
+  if (plan.isPi) mkdirSync(plan.workspace.telemetryDir, { recursive: true });
 
   if (plan.tools.useToolRelay) {
     // Clear stale .req.json from a prior turn: relayDir is keyed on the durable cwd and

--- a/services/runner/src/environment/acquire-context-impl.ts
+++ b/services/runner/src/environment/acquire-context-impl.ts
@@ -186,9 +186,6 @@ export function createAcquireContext(
     setRunAgentDir(dir) {
       environment.runAgentDir = dir;
     },
-    setOtlpAuthFilePath(path) {
-      environment.otlpAuthFilePath = path;
-    },
     setCodexSqliteHome(dir) {
       environment.codexSqliteHome = dir;
     },

--- a/services/runner/src/environment/acquire-context.ts
+++ b/services/runner/src/environment/acquire-context.ts
@@ -323,7 +323,6 @@ export interface AcquireContext {
    */
   setRunAgentDir(dir: string | undefined): void;
 
-  setOtlpAuthFilePath(path: string | undefined): void;
   setCodexSqliteHome(dir: string | undefined): void;
   setCloseToolMcp(close: (() => Promise<void>) | undefined): void;
 
@@ -377,9 +376,8 @@ export interface AcquireContextHandle {
  * | 6 | `durableCwdSafeToDelete` | mount + teardown    | beginCwdMount / markCwdDetachConfirmed / recordCwdUnmountResult |
  * | 7 | `runtimeRemount`         | runtime             | setRuntimeRemount            |
  * | 8 | `runAgentDir`            | mount (GUIDANCE)    | setRunAgentDir               |
- * | 9 | `otlpAuthFilePath`       | runtime             | setOtlpAuthFilePath          |
- * |10 | `codexSqliteHome`        | runtime             | setCodexSqliteHome           |
- * |11 | `closeToolMcp`           | runtime             | setCloseToolMcp              |
+ * | 9 | `codexSqliteHome`        | runtime             | setCodexSqliteHome           |
+ * |10 | `closeToolMcp`           | runtime             | setCloseToolMcp              |
  *
  * Corrections against revision 1, all from the review:
  *   - #3 is LOCAL ONLY. Daytona records an expiry with no path (#5's second committer).

--- a/services/runner/src/environment/runtime-lifecycle.ts
+++ b/services/runner/src/environment/runtime-lifecycle.ts
@@ -1,9 +1,8 @@
 /**
  * `RuntimeLifecycle` — the agent daemon and the runner-owned files that live beside it.
  *
- * LIFECYCLE MIGRATION, STEP 5 (S7b). This unit owns the four handles nothing else owns:
- * the loopback tool-MCP server, the OTLP bearer file, the Codex SQLite home, and the per-run
- * agent directory. It also owns the two teardown steps that must run FIRST.
+ * LIFECYCLE MIGRATION, STEP 5 (S7b). This unit owns the three handles nothing else owns:
+ * the loopback tool-MCP server, the Codex SQLite home, and the per-run agent directory. It also owns the two teardown steps that must run FIRST.
  *
  * ============================================================================================
  * WHY THIS UNIT IS SMALL, AND WHY THAT IS THE HONEST ANSWER
@@ -40,11 +39,11 @@ import {
   configurePiSessionWorkspace,
   configurePiSkillSnapshot,
   resolvePiToolSpecsDelivery,
-  writeOtlpAuthFile,
   writePiToolSpecsFileLocal,
 } from "../engines/sandbox_agent/pi-assets.ts";
 import { applyClaudeConnectionEnv } from "../engines/sandbox_agent/runtime-policy.ts";
 import type { AgentRunRequest } from "../protocol.ts";
+import { PI_TRACE_CONTROL_FILE } from "../tracing/pi-spool-protocol.ts";
 import type { RunPlan } from "../engines/sandbox_agent/run-plan.ts";
 import type { Log } from "./timing.ts";
 
@@ -88,11 +87,6 @@ export interface RuntimeFilesInput {
    */
   runAgentDir: string | undefined;
   /**
-   * The OTLP bearer file. The Pi extension deletes it on read; this is the backstop for a
-   * harness that never started or crashed before reading it, so the bearer never lingers.
-   */
-  otlpAuthFilePath: string | undefined;
-  /**
    * The local off-mount Codex SQLite home. Disposable: native resume rides the `sessions/`
    * rollout files on CODEX_HOME, not the SQLite, so losing it costs nothing.
    */
@@ -115,7 +109,6 @@ export function removeRuntimeFiles(input: RuntimeFilesInput): void {
   // never to throw. Each removal is independent, so one failure must not skip the next.
   for (const [path, recursive] of [
     [input.runAgentDir, true],
-    [input.otlpAuthFilePath, false],
     [input.codexSqliteHome, true],
   ] as const) {
     if (!path) continue;
@@ -164,21 +157,17 @@ export interface RuntimeEnvironment {
   piExtEnv: Record<string, string>;
   /** Where Pi writes native transcripts, or undefined for a non-Pi run. */
   piSessionDir: string | undefined;
-  /** The 0600 file holding the OTLP bearer, or undefined when there is none to write. */
-  otlpAuthFilePath: string | undefined;
 }
 
 /**
- * Build the daemon and extension environments, and write the OTLP bearer file.
+ * Build the daemon and extension environments.
  *
  * ONE ORDERING RULE INSIDE: `Object.assign(env, piExtEnv)` comes LAST. The local daemon inherits
  * the extension env that way, while Daytona receives the same values through its own `envVars`.
  * Assigning earlier would drop every key the Pi and Codex configuration adds after it.
  *
- * THE OTLP BEARER RIDES A FILE, NEVER AN ENV VAR. The daemon environment is inherited by the
- * harness process, so a prompt-injected sandbox could read and echo a plain env var holding the
- * caller's reusable bearer. Only the PATH goes into the env; the extension reads the file once
- * and deletes it, and `removeRuntimeFiles` above is the backstop for a harness that never ran.
+ * The stable telemetry-control PATH enters Pi's env; per-turn context rides that read-once file.
+ * The OTLP endpoint and authorization remain runner-owned and never enter the daemon env.
  */
 export function buildRuntimeEnvironment(
   input: BuildRuntimeEnvironmentInput,
@@ -204,31 +193,17 @@ export function buildRuntimeEnvironment(
   const piSessionDir = configurePiSessionWorkspace(input.plan, env);
   configurePiSkillSnapshot(input.piSkillSnapshot as never, env);
 
-  // Pi self-instruments locally: the trace context and public tool metadata reach Pi through the
-  // Agenta extension. Tool execution always relays back to this runner, which keeps private
-  // specs, scoped env, callback endpoints, and callback auth in runner memory.
-  const otlpAuthFilePath =
-    p.isPi && !p.isDaytona ? `${p.workspace.relayDir}.otlp-auth` : undefined;
-  const otlpAuthorization =
-    r.telemetry?.exporters?.otlp?.headers?.authorization;
-  if (otlpAuthFilePath && otlpAuthorization) {
-    writeOtlpAuthFile(otlpAuthFilePath, otlpAuthorization, input.log);
-  }
-
   const piExtEnv: Record<string, string> = p.isPi
-    ? buildPiExtensionEnv(input.request, !p.isDaytona, {
+    ? buildPiExtensionEnv(input.request, {
         relayDir: p.workspace.relayDir,
         usageOutPath: p.workspace.usageOutPath,
-        otlpAuthFilePath,
+        telemetryControlPath: `${p.workspace.telemetryDir}/${PI_TRACE_CONTROL_FILE}`,
         builtinGatingActive: p.tools.builtinGatingActive,
-        // The materialized skill names (author plus forced `_agenta.*`) so Pi's own agent span
-        // records which skills loaded.
-        skills: p.workspace.skillDirs.map((skill) => skill.name),
       })
     : {};
   // The tool specs `buildPiExtensionEnv` just pointed the extension at ride a FILE (they are far
   // too large for an env string — see `piToolSpecsFilePath`). A local run writes it here, beside
-  // the OTLP bearer file; a Daytona run cannot, because the runner's filesystem is not the
+  // the relay dir. A Daytona run cannot write there because the runner's filesystem is not the
   // sandbox's, so `prepareDaytonaPiAssets` uploads the same bytes to the same path instead.
   if (p.isPi && !p.isDaytona) {
     const toolSpecs = resolvePiToolSpecsDelivery(
@@ -249,5 +224,5 @@ export function buildRuntimeEnvironment(
   // values through `envVars`. Assigning earlier would drop every key added above.
   Object.assign(env, piExtEnv);
 
-  return { env, piExtEnv, piSessionDir, otlpAuthFilePath };
+  return { env, piExtEnv, piSessionDir };
 }

--- a/services/runner/src/extensions/agenta.ts
+++ b/services/runner/src/extensions/agenta.ts
@@ -4,32 +4,23 @@
  *
  * This is how we keep WP-1/WP-2/WP-7 behavior on the sandbox-agent path: instead of a synthetic,
  * coarse tracer in the runner, we propagate the caller's trace context INTO Pi and let
- * Pi emit its real span tree (turn / chat / tool, with token usage) under that parent —
+ * Pi record its real span tree (turn / chat / tool, with token usage) under that parent —
  * and we deliver tools the Pi-native way (`registerTool`), each routing back to Agenta's
  * /tools/call, rather than over MCP. Pi is highly customizable; this leans on that.
  *
- * Everything is read from the environment (injected at the daemon's birth). Tool env is
+ * Stable paths are read from the environment (injected at the daemon's birth). Per-turn
+ * telemetry data is delivered through a read-once control file. Tool env is
  * intentionally public-only; execution relays back to the runner where private specs/auth
  * remain in memory:
- *   TRACEPARENT                       W3C traceparent of the caller's /invoke span
- *   OTEL_EXPORTER_OTLP_TRACES_ENDPOINT  OTLP traces URL (e.g. https://host/api/otlp/v1/traces)
- *   AGENTA_AGENT_OTLP_AUTH_FILE       path to a runner-written, 0600, read-once file holding
- *                                     the OTLP Authorization bearer (never a plain env
- *                                     var — read once here, then deleted, see readOtlpAuthFile)
- *   AGENTA_AGENT_CONTENT_CAPTURE_ENABLED "false" to drop prompt/completion/tool I/O from spans
- *   AGENTA_AGENT_TOOLS_PUBLIC_SPECS_FILE  path to a runner-written JSON file holding
- *                                     [{ name, description, inputSchema }] — a FILE because a
- *                                     large tool set exceeds the per-string execve limit and the
- *                                     harness spawn then fails with E2BIG (see loadPublicToolSpecs)
- *   AGENTA_AGENT_TOOLS_PUBLIC_SPECS   the same JSON inline; the pre-file fallback, one release only
- *   AGENTA_AGENT_TOOLS_RELAY_DIR      relay tool calls through the runner via files here
- *   AGENTA_AGENT_SKILLS_LOADED        JSON [skillName] of skills that loaded this run (F-029)
+ *   AGENTA_AGENT_TELEMETRY_CONTROL_PATH path to the runner-written, read-once turn control
+ *   Pi publishes raw OTLP batch siblings beside the control file
  *
  * Bundled self-contained (esbuild) so its OpenTelemetry deps resolve wherever Pi loads
  * it (local, the docker sidecar, a Daytona snapshot). Default export is the Pi
  * ExtensionFactory.
  */
 import { readFileSync, unlinkSync, writeFileSync } from "node:fs";
+import { dirname } from "node:path";
 
 import {
   isToolCallEventType,
@@ -40,7 +31,16 @@ import {
 } from "@earendil-works/pi-coding-agent";
 
 import { createAgentaOtel } from "../tracing/otel.ts";
+import { Redactor, curatedEnvSecretValues } from "../redaction.ts";
+import { createPiFileSpanExporter } from "../tracing/pi-file-exporter.ts";
+import {
+  PI_TRACE_CONTROL_ENV,
+  PI_TRACE_MAX_CONTROL_BYTES,
+  parsePiTurnTraceControl,
+  type PiTurnTraceControl,
+} from "../tracing/pi-spool-protocol.ts";
 import type { ResolvedToolSpec } from "../protocol.ts";
+import { runResolvedTool } from "../tools/dispatch.ts";
 import { EMPTY_OBJECT_SCHEMA } from "../tools/callback.ts";
 import {
   approvalUnavailableText,
@@ -62,24 +62,37 @@ import {
   PI_MODEL_PROVIDER_OVERRIDE_ENV,
 } from "./model-provider-override.ts";
 
-/** Read the OTLP bearer from its runner-written file once, then best-effort delete it. */
-export function readOtlpAuthFile(path?: string): string | undefined {
+/** Read and delete one runner-authored turn control. Invalid bytes never poison a warm turn. */
+export function readPiTurnTraceControl(
+  path?: string,
+): PiTurnTraceControl | undefined {
   if (!path) return undefined;
-  let value: string;
+  let bytes: Buffer;
   try {
-    value = readFileSync(path, "utf-8").trim();
+    bytes = readFileSync(path);
   } catch {
     return undefined;
   }
-  // Delete is best-effort and must not drop a bearer we already read (runner cleanup also removes it).
+  // Delete immediately after the successful read, before parsing, so malformed bytes cannot be
+  // inherited by the next warm turn.
   try {
     unlinkSync(path);
   } catch {
     /* ignore */
   }
-  return value || undefined;
+  if (bytes.byteLength > PI_TRACE_MAX_CONTROL_BYTES) {
+    log(`trace control ignored: ${bytes.byteLength} bytes exceeds limit`);
+    return undefined;
+  }
+  try {
+    return parsePiTurnTraceControl(JSON.parse(bytes.toString("utf-8")));
+  } catch (error) {
+    log(
+      `trace control ignored: ${error instanceof Error ? error.message : String(error)}`,
+    );
+    return undefined;
+  }
 }
-import { runResolvedTool } from "../tools/dispatch.ts";
 
 function log(message: string): void {
   process.stderr.write(`[agenta-pi-ext] ${message}\n`);
@@ -269,19 +282,6 @@ function promptGuidelines(spec: ResolvedToolSpec): string[] {
   return guidelines;
 }
 
-/** Parse the JSON array of loaded skill names from AGENTA_AGENT_SKILLS_LOADED; [] on absent/malformed. */
-function parseSkillsLoaded(raw: string | undefined): string[] {
-  if (!raw) return [];
-  try {
-    const parsed = JSON.parse(raw);
-    return Array.isArray(parsed)
-      ? parsed.filter((s): s is string => typeof s === "string")
-      : [];
-  } catch {
-    return [];
-  }
-}
-
 /**
  * Load the run's public tool specs, preferring the runner-written FILE.
  *
@@ -295,7 +295,8 @@ function parseSkillsLoaded(raw: string | undefined): string[] {
  * caller then registers nothing, which is the same outcome as before, but the reason is on stderr.
  */
 function loadPublicToolSpecs():
-  { specs: ResolvedToolSpec[]; route: string } | undefined {
+  | { specs: ResolvedToolSpec[]; route: string }
+  | undefined {
   const path = process.env[PUBLIC_SPECS_FILE_ENV];
   const raw = process.env[LEGACY_PUBLIC_SPECS_ENV];
   let json: string;
@@ -419,9 +420,8 @@ const factory = (pi: ExtensionAPI): void => {
       : decodePiModelProviderOverride(modelProviderOverrideRaw);
   // Fully inert unless Agenta wired this run (so it is safe to install globally in a
   // shared Pi agent dir — a normal `pi` session with no Agenta env does nothing).
-  const hasTracing = !!(
-    process.env.TRACEPARENT || process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT
-  );
+  const traceControlPath = process.env[PI_TRACE_CONTROL_ENV];
+  const hasTracing = !!traceControlPath;
   const relayDir = process.env.AGENTA_AGENT_TOOLS_RELAY_DIR;
   const hasTools = !!(
     (process.env[PUBLIC_SPECS_FILE_ENV] ||
@@ -456,27 +456,49 @@ const factory = (pi: ExtensionAPI): void => {
   if (hasTools) registerTools(pi);
   if (hasBuiltinActivation) registerBuiltinActivation(pi);
   if (hasBuiltinGating) registerBuiltinGating(pi);
-  // Tracing exports the span tree (when the OTLP target is reachable, i.e. local runs).
-  // Usage accumulation is needed both for that export AND for the writeback the runner
-  // uses on Daytona (where the in-sandbox process can't reach Agenta's OTLP, so the
-  // runner traces from the event stream and only needs the token totals). So set up the
-  // otel state whenever either applies; only flush (export) when tracing is on.
+  // Pi records the native span tree and publishes raw OTLP bytes into its telemetry spool.
+  // The runner owns the network export for both local and Daytona runs. Usage is also written
+  // separately for the runner's response accounting.
   if (!hasTracing && !usageOut) return;
 
-  const otel = createAgentaOtel({
-    traceparent: process.env.TRACEPARENT,
-    endpoint: process.env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-    authorization: readOtlpAuthFile(process.env.AGENTA_AGENT_OTLP_AUTH_FILE),
-    captureContent:
-      process.env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED !== "false",
-    // The skills that loaded for this run (author + forced `_agenta.*`), stamped on the agent
-    // span so a trace shows which skills surfaced (F-029). A JSON array string from the runner.
-    skills: parseSkillsLoaded(process.env.AGENTA_AGENT_SKILLS_LOADED),
+  const otel = createAgentaOtel({ enabled: false, captureContent: true });
+  pi.on("before_agent_start", async () => {
+    // Clear every turn-owned value first. A missing or malformed control must never reuse the
+    // prior warm turn's traceparent, policy, redactor, channel, or usage.
+    otel.beginTurn({ enabled: false, captureContent: true });
+    if (usageOut) {
+      try {
+        unlinkSync(usageOut);
+      } catch {
+        // absent is the normal case; this only prevents stale warm-turn usage
+      }
+    }
+    const control = readPiTurnTraceControl(traceControlPath);
+    if (!control || !traceControlPath) return;
+    const redactor = new Redactor({ mode: "known" }).withKnownSecrets([
+      ...curatedEnvSecretValues(),
+      ...control.redaction.knownValues,
+    ]);
+    otel.beginTurn({
+      enabled: true,
+      traceparent: control.propagation?.traceparent,
+      baggage: control.propagation?.baggage,
+      captureContent: control.capture.content,
+      sessionId: control.sessionId,
+      turnId: control.turnId,
+      skills: control.skills,
+      redactor,
+      serializedBatchTransport: createPiFileSpanExporter({
+        directory: dirname(traceControlPath),
+        channelId: control.channelId,
+        log,
+      }),
+    });
   });
   otel.register(pi); // lifecycle handlers (spans + usage accumulation)
 
   pi.on("agent_end", async () => {
-    if (hasTracing) await otel.flush(); // invoke_agent has a remote parent → flush by id
+    if (otel.config.enabled) await otel.flush();
     if (usageOut) {
       try {
         writeFileSync(usageOut, JSON.stringify(otel.usage()), "utf-8");

--- a/services/runner/src/redaction.ts
+++ b/services/runner/src/redaction.ts
@@ -13,7 +13,7 @@
 
 const PLACEHOLDER_BARE = "[ag:redacted]";
 
-type RedactionMode = "off" | "known" | "pattern" | "full";
+export type RedactionMode = "off" | "known" | "pattern" | "full";
 const LIVE_MODES: ReadonlySet<string> = new Set(["off", "known"]);
 const INERT_MODES: ReadonlySet<string> = new Set(["pattern", "full"]);
 
@@ -230,9 +230,15 @@ export class Redactor {
   // high-entropy enough to substring-match safely.
   private bounded = new Set<string>();
   private sortedValues: string[] = []; // longest-first, recomputed on seed
+  private readonly mode?: RedactionMode;
 
-  constructor(options?: { allowlist?: Iterable<string> }) {
+  constructor(options?: {
+    allowlist?: Iterable<string>;
+    /** Explicit sink policy. Pi passes `known` so sandbox redaction cannot be disabled by env. */
+    mode?: RedactionMode;
+  }) {
     this.allowlist = new Set(DEFAULT_REDACTION_ALLOWLIST);
+    this.mode = options?.mode;
     for (const item of options?.allowlist ?? []) {
       this.allowlist.add(item.toLowerCase());
     }
@@ -279,7 +285,11 @@ export class Redactor {
   }
 
   private knownValuePass(value: string, sink: string): string {
-    if (redactionMode() === "off" || this.sortedValues.length === 0 || !value) {
+    if (
+      (this.mode ?? redactionMode()) === "off" ||
+      this.sortedValues.length === 0 ||
+      !value
+    ) {
       return this.shapePass(value, sink);
     }
     let out = value;
@@ -425,6 +435,33 @@ export function requestSecretValues(
       ),
     ),
   ];
+}
+
+/**
+ * Mount credentials visible to a sandbox process and therefore eligible to appear in Pi spans.
+ * Keep this one projection shared by the runner redactor and the per-turn Pi control writer.
+ */
+export interface SandboxVisibleSecretSource {
+  mountCreds?: {
+    accessKey?: string | null;
+    secretKey?: string | null;
+    sessionToken?: string | null;
+  } | null;
+  agentMountCreds?: {
+    accessKey?: string | null;
+    secretKey?: string | null;
+    sessionToken?: string | null;
+  } | null;
+}
+
+export function sandboxVisibleSecretValues(
+  source: SandboxVisibleSecretSource,
+): Array<string | null | undefined> {
+  return [source.mountCreds, source.agentMountCreds].flatMap((credential) => [
+    credential?.accessKey,
+    credential?.secretKey,
+    credential?.sessionToken,
+  ]);
 }
 
 /**

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -58,6 +58,7 @@ import {
   type KeepaliveConfig,
   type KeepaliveProviderName,
 } from "./engines/sandbox_agent/session-identity.ts";
+import { platformCredentialForRequest } from "./engines/sandbox_agent/runtime-policy.ts";
 import { SessionPool } from "./engines/sandbox_agent/session-pool.ts";
 import { runnerInfo } from "./version.ts";
 import { subscriptionStatusResponse } from "./subscription-status.ts";
@@ -180,16 +181,6 @@ function isSessionOwned(request: AgentRunRequest): boolean {
  */
 function resolveTurnId(request: AgentRunRequest): string {
   return request.turnId?.trim() || randomUUID();
-}
-
-/**
- * The invoke caller's Agenta credential, used to authenticate session coordination calls AS
- * the caller. It rides the telemetry exporter headers (where the run's Agenta secret already
- * lives, kept verbatim). Empty string if absent.
- */
-function runCredential(request: AgentRunRequest): string {
-  const headers = request.telemetry?.exporters?.otlp?.headers ?? {};
-  return (headers.authorization ?? headers.Authorization ?? "").trim();
 }
 
 function apiBaseFromRequest(request: AgentRunRequest): string | undefined {
@@ -419,7 +410,7 @@ async function runAndStreamWithApiBaseResolved(
   // Diagnostic: surface whether the session-owned persist/alive path is entered and
   // whether the invoke credential arrived. Empty cred => heartbeat/persist would 401.
   process.stderr.write(
-    `[sessions] stream sessionOwned=${sessionOwned} sessionId=${sessionId ?? "-"} turnId=${turnId ?? "-"} cred=${runCredential(request) ? "present" : "MISSING"}\n`,
+    `[sessions] stream sessionOwned=${sessionOwned} sessionId=${sessionId ?? "-"} turnId=${turnId ?? "-"} cred=${platformCredentialForRequest(request) ? "present" : "MISSING"}\n`,
   );
 
   // Session-owned runs survive client disconnect — the runner owns the run. Non-session
@@ -492,7 +483,7 @@ async function runAndStreamWithApiBaseResolved(
     const watchdog = await startAliveWatchdog(
       sessionId,
       turnId,
-      runCredential(request),
+      platformCredentialForRequest(request),
       () => controller.abort(),
       {
         name: proposeSessionName(request),

--- a/services/runner/src/sessions/alive.ts
+++ b/services/runner/src/sessions/alive.ts
@@ -31,7 +31,7 @@ const REFRESH_INTERVAL_MS = HEARTBEAT_INTERVAL_SECONDS * 1000;
 export const REPLICA_ID =
   process.env.AGENTA_RUNNER_REPLICA_ID?.trim() || randomUUID();
 
-import { refreshCredential } from "./auth.ts";
+import { startPlatformCredentialLease } from "./auth.ts";
 import type { TypedReference } from "./interactions.ts";
 
 /**
@@ -45,12 +45,6 @@ export interface SessionProposal {
   /** The run's workflow references, so the stream row is openable without a turn append. */
   references?: TypedReference[];
 }
-
-/** Refresh the run credential every Nth heartbeat (well inside the ~15-min token TTL). */
-const REFRESH_EVERY_N_HEARTBEATS = Math.max(
-  1,
-  Math.floor((5 * 60) / HEARTBEAT_INTERVAL_SECONDS),
-);
 
 function log(msg: string): void {
   process.stderr.write(`[sessions/alive] ${msg}\n`);
@@ -193,10 +187,12 @@ export async function startAliveWatchdog(
   credential: () => string;
   streamId: () => string | undefined;
 }> {
-  // The run credential is an ephemeral Secret (~15-min TTL). Hold it mutably and refresh it
-  // every Nth heartbeat (re-/check mints a fresh-expiry token) so a long turn never 401s.
-  let credential = authorization;
-  let beats = 0;
+  // Session coordination and standalone turns share this lease. The watchdog owns it here so
+  // heartbeat, persistence, and trace export all observe the same current credential.
+  const credentialLease = startPlatformCredentialLease(
+    apiBase(),
+    authorization,
+  );
   let interruptedFired = false;
   let streamId: string | undefined;
 
@@ -216,7 +212,7 @@ export async function startAliveWatchdog(
   const first = await sendHeartbeat(
     sessionId,
     turnId,
-    credential,
+    credentialLease.credential(),
     true,
     proposal,
   );
@@ -224,13 +220,14 @@ export async function startAliveWatchdog(
 
   const interval = setInterval(() => {
     void (async () => {
-      beats += 1;
-      if (beats % REFRESH_EVERY_N_HEARTBEATS === 0) {
-        const fresh = await refreshCredential(apiBase(), credential);
-        if (fresh) credential = fresh;
-      }
       handleBeat(
-        await sendHeartbeat(sessionId, turnId, credential, true, proposal),
+        await sendHeartbeat(
+          sessionId,
+          turnId,
+          credentialLease.credential(),
+          true,
+          proposal,
+        ),
       );
     })();
   }, REFRESH_INTERVAL_MS);
@@ -243,10 +240,17 @@ export async function startAliveWatchdog(
   return {
     async release() {
       clearInterval(interval);
+      credentialLease.release();
       // Mark the stream row ended (best-effort; the orphan sweep catches a miss).
-      await sendHeartbeat(sessionId, turnId, credential, false, proposal);
+      await sendHeartbeat(
+        sessionId,
+        turnId,
+        credentialLease.credential(),
+        false,
+        proposal,
+      );
     },
-    credential: () => credential,
+    credential: credentialLease.credential,
     streamId: () => streamId,
   };
 }

--- a/services/runner/src/sessions/auth.ts
+++ b/services/runner/src/sessions/auth.ts
@@ -29,7 +29,70 @@ export async function refreshCredential(
     const body = (await res.json()) as { credentials?: string };
     return body.credentials ?? null;
   } catch (err) {
-    log(`refresh failed: ${String(err instanceof Error ? err.message : err).slice(0, 120)}`);
+    log(
+      `refresh failed: ${String(err instanceof Error ? err.message : err).slice(0, 120)}`,
+    );
     return null;
   }
+}
+
+export const DEFAULT_PLATFORM_CREDENTIAL_REFRESH_INTERVAL_MS = 5 * 60 * 1000;
+
+export interface PlatformCredentialLease {
+  credential: () => string;
+  release: () => void;
+}
+
+/**
+ * Keep one Agenta platform credential fresh for the lifetime of a runner-owned operation.
+ *
+ * The lease is deliberately target-agnostic: callers create it only after classifying the
+ * destination as Agenta ingest. External collector credentials must never enter this exchange.
+ * Refresh is proactive, bounded to one in-flight request, and fail-open: a failed refresh keeps
+ * the last credential so tracing or session cleanup never changes agent-result semantics.
+ */
+export function startPlatformCredentialLease(
+  baseUrl: string,
+  authorization: string,
+  options: {
+    intervalMs?: number;
+    refresh?: typeof refreshCredential;
+  } = {},
+): PlatformCredentialLease {
+  let credential = authorization;
+  let released = false;
+  let refreshInFlight = false;
+  const refresh = options.refresh ?? refreshCredential;
+  const intervalMs =
+    options.intervalMs ?? DEFAULT_PLATFORM_CREDENTIAL_REFRESH_INTERVAL_MS;
+
+  if (!credential) {
+    return { credential: () => credential, release: () => {} };
+  }
+
+  const interval = setInterval(() => {
+    if (released || refreshInFlight) return;
+    refreshInFlight = true;
+    void refresh(baseUrl, credential)
+      .then((fresh) => {
+        if (!released && fresh) credential = fresh;
+      })
+      .catch((err) => {
+        log(
+          `refresh failed: ${String(err instanceof Error ? err.message : err).slice(0, 120)}`,
+        );
+      })
+      .finally(() => {
+        refreshInFlight = false;
+      });
+  }, intervalMs);
+  interval.unref?.();
+
+  return {
+    credential: () => credential,
+    release: () => {
+      released = true;
+      clearInterval(interval);
+    },
+  };
 }

--- a/services/runner/src/tracing/export-diagnostics.ts
+++ b/services/runner/src/tracing/export-diagnostics.ts
@@ -153,7 +153,11 @@ export function logExportProblem(problem: {
   traceId: string;
   endpoint: string;
   authorization?: string;
-  spans: number;
+  spans?: number;
+  source?: "pi-spool" | "runner";
+  placement?: "local" | "daytona";
+  turnId?: string;
+  bytes?: number;
   error?: unknown;
   redactors?: Iterable<Redactor>;
 }): void {
@@ -175,6 +179,10 @@ export function logExportProblem(problem: {
     OUTCOME_MESSAGES[problem.outcome],
     JSON.stringify({
       traceId: problem.traceId,
+      source: problem.source,
+      placement: problem.placement,
+      turnId: problem.turnId,
+      bytes: problem.bytes,
       endpoint: endpointHost(problem.endpoint),
       status,
       statusClass,

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -1,6 +1,6 @@
 /**
- * agenta-otel — a Pi extension that turns Pi's `pi.on(...)` lifecycle events into
- * OpenTelemetry spans and exports them (OTLP/HTTP protobuf) to Agenta.
+ * agenta-otel turns Pi lifecycle events into OpenTelemetry spans. Runner tracing may
+ * export through HTTP; Pi injects a serialized-byte transport so the runner owns export.
  *
  * This is the service build of the WP-1 POC extension
  * (docs/design/agent-workflows/scratch/wp-1-pi-tracing/poc/agenta-otel.ts). It keeps the
@@ -16,10 +16,9 @@
  *      remote span, so the whole agent run joins the same trace as the `/invoke`
  *      request — the agent's work becomes part of the response trace, the way
  *      completion/chat nest their LLM spans under the workflow span.
- *   3. Per-trace export target. The OTLP endpoint and `Authorization` header come
- *      from the run config (the caller's host + credentials), falling back to env.
- *      Each trace is exported with its own target, so a shared process can serve
- *      more than one project.
+ *   3. Per-run export destination. Runner tracing can supply an HTTP endpoint and
+ *      authorization provider. Pi supplies only a serialized-byte transport, so no
+ *      endpoint or export credential crosses into the Pi process.
  *
  * Span tree (per user prompt), unchanged from the POC:
  *   invoke_agent            (openinference.span.kind = AGENT)
@@ -27,7 +26,7 @@
  *       chat <model>        (LLM)   — the provider request for that turn
  *       execute_tool <name> (TOOL)  — each tool the turn ran
  *
- * Config (read lazily from the environment for the fallback target):
+ * Runner HTTP fallback config (read lazily from the environment):
  *   AGENTA_API_INTERNAL_URL, AGENTA_API_URL  — fallback exporter endpoint
  *   AGENTA_CREDENTIALS                       — per-run caller credential (no static API key)
  *   OTEL_SERVICE_NAME            — resource service.name (default "pi-agent")
@@ -46,6 +45,7 @@ import {
 } from "@opentelemetry/api";
 import { ExportResultCode } from "@opentelemetry/core";
 import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
+import { ProtobufTraceSerializer } from "@opentelemetry/otlp-transformer";
 import { resourceFromAttributes } from "@opentelemetry/resources";
 import type {
   ReadableSpan,
@@ -80,13 +80,34 @@ export const INTERRUPTED_BY_USER =
 // Shared, process-wide tracing infrastructure
 // ---------------------------------------------------------------------------
 
-type AuthorizationProvider = () => string | undefined;
+export type AuthorizationProvider = () => string | undefined;
+
+/** One complete OTLP request body produced from a parent-first trace batch. */
+export interface SerializedTraceBatch {
+  body: Uint8Array;
+  traceId: string;
+  spanCount: number;
+}
+
+/** Bundle-safe destination for Pi-produced OTLP bytes, such as its atomic file publisher. */
+export interface SerializedTraceBatchTransport {
+  export(batch: SerializedTraceBatch): void | Promise<void>;
+}
 
 /** Where a trace's spans are shipped. The credential is read only when the batch is sent. */
-interface ExportTarget {
+interface HttpExportTarget {
+  kind: "http";
   endpoint: string;
   authorization: AuthorizationProvider;
 }
+
+/** A non-network target used inside Pi to publish a standard serialized OTLP request. */
+interface SerializedExportTarget {
+  kind: "serialized";
+  transport: SerializedTraceBatchTransport;
+}
+
+type ExportTarget = HttpExportTarget | SerializedExportTarget;
 
 /** The target material resolved for one concrete export attempt. */
 interface ResolvedExportTarget {
@@ -271,22 +292,28 @@ function getExporter(target: ResolvedExportTarget): ExporterCacheEntry {
 const CLOUD_API_BASE = "https://cloud.agenta.ai/api";
 
 /** Fallback target from env, used when a trace was started without an explicit one. */
-function defaultTarget(): ExportTarget {
+function defaultTarget(): HttpExportTarget {
   // Internal direct hop first, then the public `.../api` base, then cloud.
   const base =
     (
       process.env.AGENTA_API_INTERNAL_URL ?? process.env.AGENTA_API_URL
     )?.replace(/\/+$/, "") || CLOUD_API_BASE;
   // The per-run caller credential rides the request (each explicit trace target carries its own
-  // authorization; local Pi's OTLP bearer is written to a 0600 file). The runner holds no static
+  // authorization; Pi's runner-owned exporter receives it only at send time). The runner holds no static
   // platform key: it must not carry an `AGENTA_API_KEY` a local harness could read from /proc and
   // reuse (interface.md section 2). The scheme-tagged ephemeral `AGENTA_CREDENTIALS` (a
   // `Secret ...` from `/check`, used verbatim) is the only fallback; absent it, `flush` skips
   // the export rather than sending Agenta an unauthenticated one (see `isAgentaIngest`).
   return {
+    kind: "http",
     endpoint: `${base}/otlp/v1/traces`,
     authorization: () => process.env.AGENTA_CREDENTIALS || undefined,
   };
+}
+
+/** Resolve the trace endpoint exactly as the runner's ordinary span exporter does. */
+export function resolveOtlpTraceEndpoint(endpoint?: string): string {
+  return endpoint?.trim() || defaultTarget().endpoint;
 }
 
 /**
@@ -299,7 +326,7 @@ function defaultTarget(): ExportTarget {
  * public URL while the runner's own hop is internal. The full normalized ingest URL must match,
  * because a third-party collector may share the Agenta host behind a different proxy path.
  */
-function isAgentaIngest(endpoint: string): boolean {
+export function isAgentaIngest(endpoint: string): boolean {
   const normalize = (value: string): string | undefined => {
     try {
       const url = new URL(value);
@@ -390,6 +417,36 @@ class TraceBatchProcessor implements SpanProcessor {
         // batch could still land on an unintended endpoint/auth.
         const target =
           (runId ? byRun?.get(runId) : undefined) ?? defaultTarget();
+        const ordered = orderParentFirst(group);
+        if (target.kind === "serialized") {
+          try {
+            const body = serializeTraceBatch(group);
+            if (!body)
+              throw new Error("OTLP trace serialization returned no body");
+            return Promise.resolve(
+              target.transport.export({
+                body,
+                traceId,
+                spanCount: group.length,
+              }),
+            ).catch((error) => {
+              logSerializedTransportProblem(
+                traceId,
+                group.length,
+                error,
+                redactors,
+              );
+            });
+          } catch (error) {
+            logSerializedTransportProblem(
+              traceId,
+              group.length,
+              error,
+              redactors,
+            );
+            return Promise.resolve();
+          }
+        }
         let resolvedTarget: ResolvedExportTarget;
         try {
           resolvedTarget = {
@@ -438,7 +495,7 @@ class TraceBatchProcessor implements SpanProcessor {
           try {
             entry = getExporter(resolvedTarget);
             entry.activeExports += 1;
-            entry.exporter.export(orderParentFirst(group), (result) => {
+            entry.exporter.export(ordered, (result) => {
               try {
                 if (result.code === ExportResultCode.FAILED)
                   logExportProblem({
@@ -548,6 +605,28 @@ function orderParentFirst(spans: ReadableSpan[]): ReadableSpan[] {
   return ordered;
 }
 
+/** Serialize one complete trace batch in the exact parent-first order Agenta ingest expects. */
+export function serializeTraceBatch(
+  spans: ReadableSpan[],
+): Uint8Array | undefined {
+  return ProtobufTraceSerializer.serializeRequest(orderParentFirst(spans));
+}
+
+function logSerializedTransportProblem(
+  traceId: string,
+  spanCount: number,
+  error: unknown,
+  redactors?: Iterable<Redactor>,
+): void {
+  let message = error instanceof Error ? error.message : String(error);
+  for (const redactor of redactors ?? [])
+    message = redactor.redactString(message, "stderr") ?? message;
+  console.error(
+    "otel: serialized trace transport threw",
+    JSON.stringify({ traceId, spans: spanCount, error: message.slice(0, 200) }),
+  );
+}
+
 /** Build a parent Context from a W3C traceparent string, or undefined if absent/invalid. */
 function parentContext(traceparent?: string): Context | undefined {
   if (!traceparent) return undefined;
@@ -573,14 +652,20 @@ function parentContext(traceparent?: string): Context | undefined {
 
 /** One run's tracing config. Mutated by the runner after the session is created. */
 export interface RunConfig {
+  /** False when this warm Pi turn did not receive a valid runner control file. */
+  enabled?: boolean;
   /** OTLP traces endpoint for this run's trace (falls back to env). */
   endpoint?: string;
   /** Authorization header value for the OTLP export (falls back to env ApiKey). */
   authorization?: string;
+  /** Optional bundle-safe Pi transport that receives raw OTLP bytes instead of sending HTTP. */
+  serializedBatchTransport?: SerializedTraceBatchTransport;
   /** W3C traceparent from the caller; nests invoke_agent under that span. */
   traceparent?: string;
   /** W3C baggage from the caller (carried for future use). */
   baggage?: string;
+  /** Durable turn id stamped as runner metadata when supplied. */
+  turnId?: string;
   /** Drop prompt/completion/tool I/O from spans when false. */
   captureContent: boolean;
   /** Pi session id, set after createAgentSession so spans carry session.id. */
@@ -755,6 +840,8 @@ export interface AgentaOtel {
   register: (pi: ExtensionAPI) => void;
   /** Mutable config; set sessionId/provider/requestModel after the session exists. */
   config: RunConfig;
+  /** Replace all per-turn Pi state and reset usage before a warm prompt begins. */
+  beginTurn: (next: Partial<RunConfig>) => void;
   /** Flush this run's trace to Agenta. Await before the process/response ends. */
   flush: () => Promise<void>;
   /** Run totals (tokens + cost) summed across turns, for roll-up onto the parent. */
@@ -772,11 +859,15 @@ export function createAgentaOtel(
   ensureProvider();
 
   const config: RunConfig = {
+    enabled: init.enabled,
     endpoint: init.endpoint,
     authorization: init.authorization,
+    serializedBatchTransport: init.serializedBatchTransport,
     traceparent: init.traceparent,
+    baggage: init.baggage,
     captureContent: init.captureContent !== false,
     sessionId: init.sessionId,
+    turnId: init.turnId,
     provider: init.provider,
     requestModel: init.requestModel,
     skills: init.skills,
@@ -811,12 +902,34 @@ export function createAgentaOtel(
     if (u.cost?.total != null) runUsage.cost += u.cost.total;
   }
 
+  function beginTurn(next: Partial<RunConfig>): void {
+    config.enabled = next.enabled;
+    config.endpoint = next.endpoint;
+    config.authorization = next.authorization;
+    config.serializedBatchTransport = next.serializedBatchTransport;
+    config.traceparent = next.traceparent;
+    config.baggage = next.baggage;
+    config.captureContent = next.captureContent !== false;
+    config.sessionId = next.sessionId;
+    config.turnId = next.turnId;
+    config.provider = next.provider;
+    config.requestModel = next.requestModel;
+    config.skills = next.skills;
+    config.redactor = next.redactor;
+    config.traceId = undefined;
+    runUsage.input = 0;
+    runUsage.output = 0;
+    runUsage.total = 0;
+    runUsage.cost = 0;
+  }
+
   const register = (pi: ExtensionAPI): void => {
     pi.on("before_agent_start", async (event: any) => {
       pendingPrompt = event?.prompt;
     });
 
     pi.on("agent_start", async () => {
+      if (config.enabled === false) return;
       // Nest under the caller's workflow span when a traceparent was supplied,
       // so the whole run joins the /invoke trace; otherwise start a fresh root.
       // Tag the run id onto the start context BEFORE creating the root span, so onStart
@@ -833,7 +946,7 @@ export function createAgentaOtel(
       // `ag.meta.*` namespace, so a local-Pi trace shows the surfaced skills (not just the author
       // config echoed elsewhere) AND Agenta's OTel ingest keeps them in a first-class `ag.*` bucket
       // rather than relocating an unrecognized `ag.agent.*` key to `ag.unsupported.*`. The set is
-      // passed from the runner via AGENTA_AGENT_SKILLS_LOADED.
+      // passed from the runner through the per-turn trace control.
       if (config.skills && config.skills.length > 0) {
         agentSpan.setAttribute("ag.meta.skills.loaded", config.skills);
         agentSpan.setAttribute("ag.meta.skills.count", config.skills.length);
@@ -842,6 +955,8 @@ export function createAgentaOtel(
         agentSpan.setAttribute("session.id", config.sessionId);
         agentSpan.setAttribute("gen_ai.conversation.id", config.sessionId);
       }
+      if (config.turnId)
+        agentSpan.setAttribute("ag.meta.turn.id", config.turnId);
       setInputs(
         agentSpan,
         { prompt: pendingPrompt ?? "" },
@@ -850,11 +965,21 @@ export function createAgentaOtel(
 
       const traceId = agentSpan.spanContext().traceId;
       config.traceId = traceId;
-      registerRunTarget(traceId, runId, {
-        endpoint: config.endpoint ?? defaultTarget().endpoint,
-        authorization: () =>
-          config.authorization ?? defaultTarget().authorization(),
-      });
+      registerRunTarget(
+        traceId,
+        runId,
+        config.serializedBatchTransport
+          ? {
+              kind: "serialized",
+              transport: config.serializedBatchTransport,
+            }
+          : {
+              kind: "http",
+              endpoint: config.endpoint ?? defaultTarget().endpoint,
+              authorization: () =>
+                config.authorization ?? defaultTarget().authorization(),
+            },
+      );
       if (config.redactor) registerRunRedactor(traceId, config.redactor);
       agentCtx = trace.setSpan(parent, agentSpan);
     });
@@ -865,6 +990,7 @@ export function createAgentaOtel(
     });
 
     pi.on("turn_start", async (event: any) => {
+      if (config.enabled === false) return;
       const parent = agentCtx ?? context.active();
       const name =
         event?.turnIndex != null ? `turn ${event.turnIndex}` : "turn";
@@ -880,6 +1006,7 @@ export function createAgentaOtel(
     });
 
     pi.on("before_provider_request", async (_event: any, ctx: any) => {
+      if (config.enabled === false) return;
       const parent = currentTurn?.ctx ?? agentCtx ?? context.active();
       const modelId = config.requestModel ?? ctx?.model?.id;
       const providerName = config.provider ?? ctx?.model?.provider;
@@ -903,14 +1030,16 @@ export function createAgentaOtel(
 
     pi.on("message_end", async (event: any) => {
       const msg = event?.message;
-      if (!msg || msg.role !== "assistant" || !llmSpan) return;
-      applyAssistant(llmSpan, msg, config.captureContent);
+      if (!msg || msg.role !== "assistant") return;
       accumulateUsage(msg);
+      if (!llmSpan) return;
+      applyAssistant(llmSpan, msg, config.captureContent);
       llmSpan.end();
       llmSpan = undefined;
     });
 
     pi.on("tool_execution_start", async (event: any) => {
+      if (config.enabled === false) return;
       const parent = currentTurn?.ctx ?? agentCtx ?? context.active();
       const name = event?.toolName
         ? `execute_tool ${event.toolName}`
@@ -958,6 +1087,18 @@ export function createAgentaOtel(
 
     pi.on("agent_end", async (event: any) => {
       if (!agentSpan) return;
+      // Cancellation may skip message_end, tool_execution_end, and turn_end. Close every child
+      // before the agent root so the one native batch contains all partial work Pi still holds.
+      if (llmSpan) {
+        llmSpan.end();
+        llmSpan = undefined;
+      }
+      for (const span of toolSpans.values()) span.end();
+      toolSpans.clear();
+      if (currentTurn) {
+        currentTurn.span.end();
+        currentTurn = undefined;
+      }
       setOutput(
         agentSpan,
         lastAssistantText(event?.messages),
@@ -987,6 +1128,7 @@ export function createAgentaOtel(
   return {
     register,
     config,
+    beginTurn,
     flush: () => flushTrace(config.traceId, config.redactor, runId),
     usage: () => ({ ...runUsage }),
   };
@@ -1210,8 +1352,10 @@ function splitModel(model?: string): { provider?: string; id?: string } {
   return { provider: model.slice(0, slash), id: model.slice(slash + 1) };
 }
 
-export interface SandboxAgentOtelInit
-  extends Omit<Partial<RunConfig>, "authorization"> {
+export interface SandboxAgentOtelInit extends Omit<
+  Partial<RunConfig>,
+  "authorization" | "serializedBatchTransport"
+> {
   /**
    * Authorization for the OTLP exporter. The runner supplies a provider so a long-lived turn
    * uses the latest session credential when it exports. A string remains accepted for local
@@ -1513,7 +1657,11 @@ export function createSandboxAgentOtel(
     setInputs(agentSpan, { prompt: input.prompt ?? "" }, capture);
 
     runTraceId = agentSpan.spanContext().traceId;
-    registerRunTarget(runTraceId, runId, { endpoint, authorization });
+    registerRunTarget(runTraceId, runId, {
+      kind: "http",
+      endpoint,
+      authorization,
+    });
     if (init.redactor) registerRunRedactor(runTraceId, init.redactor);
     agentCtx = trace.setSpan(parent, agentSpan);
 
@@ -1718,8 +1866,8 @@ export function createSandboxAgentOtel(
    * Two cases:
    *  - This tracer owns the agent span (emitSpans=true: Claude / gateway / Daytona) — stamp it
    *    directly, before finish() ends it.
-   *  - The harness self-instruments (emitSpans=false: local Pi emits its own spans in another
-   *    process, which never carry the error and are already flushed) — emit a standalone error
+   *  - The harness self-instruments (emitSpans=false: Pi emits its own spans in another process)
+   *    and no valid native batch was received — emit a standalone error
    *    span as a child of the caller's traceparent, so the error still reaches the /invoke trace.
    * Idempotent and best-effort: a second call or a tracing failure must never break the run.
    */
@@ -1753,12 +1901,17 @@ export function createSandboxAgentOtel(
       errSpan.setAttribute("openinference.span.kind", "AGENT");
       errSpan.setAttribute("gen_ai.operation.name", "invoke_agent");
       errSpan.setAttribute("gen_ai.agent.name", init.harness ?? "agent");
+      stampUsage(errSpan, usage);
       stamp(errSpan);
       // The standalone span shares the caller's trace id; make sure the run reports it so the
       // engine flushes this trace (a self-instrumenting run otherwise only tracked it from the
       // traceparent, which is the same id — but set it defensively if it was never resolved).
       runTraceId = runTraceId ?? errSpan.spanContext().traceId;
-      registerRunTarget(runTraceId, runId, { endpoint, authorization });
+      registerRunTarget(runTraceId, runId, {
+        kind: "http",
+        endpoint,
+        authorization,
+      });
       // Register BEFORE end(): a root span with no in-process parent flushes synchronously
       // on end(), so the redactor/target must already be in their accumulators or this batch
       // escapes raw / falls back to the wrong target.

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -311,6 +311,19 @@ function defaultTarget(): HttpExportTarget {
   };
 }
 
+/** Add the runner's live platform credential as the fallback for a blank request credential. */
+export function platformAuthorizationProvider(
+  configured?: string | AuthorizationProvider,
+): AuthorizationProvider {
+  const configuredProvider =
+    typeof configured === "function" ? configured : () => configured;
+  const fallbackAuthorization = defaultTarget().authorization;
+  return () => {
+    const resolved = configuredProvider();
+    return resolved?.trim() ? resolved : fallbackAuthorization();
+  };
+}
+
 /** Resolve the trace endpoint exactly as the runner's ordinary span exporter does. */
 export function resolveOtlpTraceEndpoint(endpoint?: string): string {
   return endpoint?.trim() || defaultTarget().endpoint;
@@ -417,7 +430,6 @@ class TraceBatchProcessor implements SpanProcessor {
         // batch could still land on an unintended endpoint/auth.
         const target =
           (runId ? byRun?.get(runId) : undefined) ?? defaultTarget();
-        const ordered = orderParentFirst(group);
         if (target.kind === "serialized") {
           try {
             const body = serializeTraceBatch(group);
@@ -447,6 +459,7 @@ class TraceBatchProcessor implements SpanProcessor {
             return Promise.resolve();
           }
         }
+        const ordered = orderParentFirst(group);
         let resolvedTarget: ResolvedExportTarget;
         try {
           resolvedTarget = {
@@ -1449,23 +1462,9 @@ export function createSandboxAgentOtel(
   const capture = init.captureContent !== false;
   const emitSpans = init.emitSpans !== false;
   const endpoint = init.endpoint ?? defaultTarget().endpoint;
-  const configuredAuthorization = init.authorization;
-  const configuredProvider: AuthorizationProvider | undefined =
-    typeof configuredAuthorization === "function"
-      ? configuredAuthorization
-      : configuredAuthorization !== undefined
-        ? () => configuredAuthorization
-        : undefined;
   // A run whose request carries no authorization header resolves to an empty value, not to
-  // `undefined` — the getter reads a header that may not be there. Treat empty as "unconfigured"
-  // so such a run still exports under the runner's own `AGENTA_CREDENTIALS`, and resolve the
-  // fallback at export time (not at construction) so a credential written after the run started
-  // still counts.
-  const fallbackAuthorization = defaultTarget().authorization;
-  const authorization: AuthorizationProvider = () => {
-    const resolved = configuredProvider?.();
-    return resolved?.trim() ? resolved : fallbackAuthorization();
-  };
+  // undefined. The shared provider keeps runner and Pi export behavior identical.
+  const authorization = platformAuthorizationProvider(init.authorization);
   const { provider, id: modelId } = splitModel(init.model);
   const tracer = trace.getTracer("agenta-sandbox-agent-otel", "0.1.0");
   const runId = mintRunId();

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -1475,6 +1475,7 @@ export function createSandboxAgentOtel(
   let turnCtx: Context | undefined;
   let llmSpan: Span | undefined;
   let runTraceId: string | undefined;
+  let standaloneErrorRecorded = false;
   let accumulated = "";
   let reasoningAccumulated = "";
   let usage: AgentUsage | undefined;
@@ -1868,7 +1869,8 @@ export function createSandboxAgentOtel(
    *  - The harness self-instruments (emitSpans=false: Pi emits its own spans in another process)
    *    and no valid native batch was received — emit a standalone error
    *    span as a child of the caller's traceparent, so the error still reaches the /invoke trace.
-   * Idempotent and best-effort: a second call or a tracing failure must never break the run.
+   * The standalone fallback is idempotent and best-effort: a second call or a tracing failure
+   * must never break the run.
    */
   function recordError(message: string, errorProvider?: string): void {
     const text = message || "agent run failed";
@@ -1888,10 +1890,12 @@ export function createSandboxAgentOtel(
         stamp(agentSpan);
         return;
       }
-      // No owned span (harness self-instruments). Emit a standalone error span under the
-      // caller's traceparent so the failure is visible in the /invoke trace. Tag the run id
-      // onto the start context first, same as the emitSpans=true root, so onStart attributes
-      // this span to THIS run (concurrent runs sharing the trace id may have different targets).
+      // No owned span (harness self-instruments). Emit one standalone error span under the
+      // caller's traceparent so the failure is visible in the /invoke trace.
+      if (standaloneErrorRecorded) return;
+      standaloneErrorRecorded = true;
+      // Tag the run id onto the start context first, same as the emitSpans=true root, so onStart
+      // attributes this span to THIS run (concurrent runs may have different targets).
       const parent = withRunId(
         parentContext(init.traceparent) ?? context.active(),
         runId,

--- a/services/runner/src/tracing/otlp-bytes-export.ts
+++ b/services/runner/src/tracing/otlp-bytes-export.ts
@@ -1,0 +1,129 @@
+/**
+ * Runner-only HTTP transport for an already-serialized OTLP trace request.
+ *
+ * Pi can produce the standard protobuf bytes inside its extension bundle, then hand them to
+ * the runner through a transport seam. Keeping this POST helper outside `otel.ts` prevents
+ * runner networking code from being pulled into that extension bundle.
+ */
+import type { Redactor } from "../redaction.ts";
+import { logExportProblem } from "./export-diagnostics.ts";
+import { isAgentaIngest, type AuthorizationProvider } from "./otel.ts";
+
+const OTLP_BYTES_EXPORT_TIMEOUT_MS = 10_000;
+
+export interface OtlpBytesExportTarget {
+  endpoint: string;
+  /** Read immediately before the request. Platform credentials may rotate between turns. */
+  authorization: AuthorizationProvider;
+}
+
+export interface OtlpBytesExportDiagnostics {
+  traceId: string;
+  spanCount?: number;
+  source?: "pi-spool" | "runner";
+  placement?: "local" | "daytona";
+  turnId?: string;
+  batchBytes?: number;
+  redactors?: Iterable<Redactor>;
+}
+
+export interface OtlpBytesExportOutcome {
+  outcome: "exported" | "failed" | "skipped";
+  status?: number;
+  durationMs: number;
+}
+
+export interface OtlpBytesExportRequest {
+  body: Uint8Array;
+  target: OtlpBytesExportTarget;
+  diagnostics: OtlpBytesExportDiagnostics;
+}
+
+/**
+ * POST one protobuf OTLP request with the credential owned by the export target.
+ *
+ * Export remains best effort: a missing Agenta credential, an HTTP rejection, or a thrown
+ * transport error is diagnosed and resolves normally. Third-party collectors may intentionally
+ * be unauthenticated, so only Agenta's own ingest is skipped when the credential is absent.
+ */
+export async function exportOtlpBytes(
+  request: OtlpBytesExportRequest,
+): Promise<OtlpBytesExportOutcome> {
+  const { body, target, diagnostics } = request;
+  const startedAt = Date.now();
+  let authorization: string | undefined;
+
+  try {
+    authorization = target.authorization();
+  } catch (error) {
+    logExportProblem({
+      outcome: "threw",
+      traceId: diagnostics.traceId,
+      endpoint: target.endpoint,
+      authorization,
+      spans: diagnostics.spanCount,
+      source: diagnostics.source,
+      placement: diagnostics.placement,
+      turnId: diagnostics.turnId,
+      bytes: diagnostics.batchBytes,
+      error,
+      redactors: diagnostics.redactors,
+    });
+    return { outcome: "failed", durationMs: Date.now() - startedAt };
+  }
+
+  const problem = {
+    traceId: diagnostics.traceId,
+    endpoint: target.endpoint,
+    authorization,
+    spans: diagnostics.spanCount,
+    source: diagnostics.source,
+    placement: diagnostics.placement,
+    turnId: diagnostics.turnId,
+    bytes: diagnostics.batchBytes,
+    redactors: diagnostics.redactors,
+  };
+
+  if (!authorization?.trim() && isAgentaIngest(target.endpoint)) {
+    logExportProblem({ outcome: "skipped", ...problem });
+    return { outcome: "skipped", durationMs: Date.now() - startedAt };
+  }
+
+  try {
+    const response = await fetch(target.endpoint, {
+      method: "POST",
+      headers: {
+        "content-type": "application/x-protobuf",
+        ...(authorization ? { Authorization: authorization } : {}),
+      },
+      // Preserve the exact view when `body` is a slice of a larger ArrayBuffer.
+      body: Buffer.from(body.buffer, body.byteOffset, body.byteLength),
+      signal: AbortSignal.timeout(OTLP_BYTES_EXPORT_TIMEOUT_MS),
+      redirect: "manual",
+    });
+
+    if (response.ok) {
+      return {
+        outcome: "exported",
+        status: response.status,
+        durationMs: Date.now() - startedAt,
+      };
+    }
+
+    const error = Object.assign(
+      new Error(`OTLP export returned HTTP ${response.status}`),
+      {
+        code: response.status,
+      },
+    );
+    logExportProblem({ outcome: "failed", ...problem, error });
+    return {
+      outcome: "failed",
+      status: response.status,
+      durationMs: Date.now() - startedAt,
+    };
+  } catch (error) {
+    logExportProblem({ outcome: "threw", ...problem, error });
+    return { outcome: "failed", durationMs: Date.now() - startedAt };
+  }
+}

--- a/services/runner/src/tracing/pi-file-exporter.ts
+++ b/services/runner/src/tracing/pi-file-exporter.ts
@@ -1,0 +1,80 @@
+import { randomBytes } from "node:crypto";
+import { mkdirSync, renameSync, rmSync, writeFileSync } from "node:fs";
+import { join } from "node:path";
+
+import type {
+  SerializedTraceBatch,
+  SerializedTraceBatchTransport,
+} from "./otel.ts";
+import {
+  PI_TRACE_MAX_BATCH_BYTES,
+  PI_TRACE_MAX_FILES,
+  piTraceFileName,
+} from "./pi-spool-protocol.ts";
+
+export interface PiFileSpanExporterOptions {
+  directory: string;
+  channelId: string;
+  maxBatchBytes?: number;
+  maxFiles?: number;
+  log?: (message: string) => void;
+}
+
+/** Pi-side transport: publish exact OTLP protobuf bytes through an atomic sibling rename. */
+export function createPiFileSpanExporter(
+  options: PiFileSpanExporterOptions,
+): SerializedTraceBatchTransport {
+  const log = options.log ?? (() => {});
+  const maxBatchBytes = Math.min(
+    PI_TRACE_MAX_BATCH_BYTES,
+    Math.max(1, options.maxBatchBytes ?? PI_TRACE_MAX_BATCH_BYTES),
+  );
+  const maxFiles = Math.min(
+    PI_TRACE_MAX_FILES,
+    Math.max(1, options.maxFiles ?? PI_TRACE_MAX_FILES),
+  );
+  let sequence = 0;
+
+  return {
+    async export(batch: SerializedTraceBatch): Promise<void> {
+      if (sequence >= maxFiles) {
+        log(
+          `stage=pi_trace_publish skipped=true reason=file_limit limit=${maxFiles}`,
+        );
+        return;
+      }
+      if (batch.body.byteLength > maxBatchBytes) {
+        log(
+          `stage=pi_trace_publish skipped=true reason=oversized bytes=${batch.body.byteLength} limit=${maxBatchBytes}`,
+        );
+        return;
+      }
+
+      const finalPath = join(
+        options.directory,
+        piTraceFileName(options.channelId, sequence),
+      );
+      const temporaryPath = `${finalPath}.tmp.${randomBytes(8).toString("hex")}`;
+      sequence += 1;
+      try {
+        mkdirSync(options.directory, { recursive: true });
+        writeFileSync(temporaryPath, batch.body, { mode: 0o600 });
+        renameSync(temporaryPath, finalPath);
+        log(
+          `stage=pi_trace_publish sequence=${sequence - 1} bytes=${batch.body.byteLength} spans=${batch.spanCount}`,
+        );
+      } catch (error) {
+        try {
+          rmSync(temporaryPath, { force: true });
+        } catch {
+          // best-effort temporary-file cleanup
+        }
+        log(
+          `stage=pi_trace_publish failed=true sequence=${sequence - 1} error=${
+            error instanceof Error ? error.message : String(error)
+          }`,
+        );
+      }
+    },
+  };
+}

--- a/services/runner/src/tracing/pi-file-exporter.ts
+++ b/services/runner/src/tracing/pi-file-exporter.ts
@@ -55,11 +55,11 @@ export function createPiFileSpanExporter(
         piTraceFileName(options.channelId, sequence),
       );
       const temporaryPath = `${finalPath}.tmp.${randomBytes(8).toString("hex")}`;
-      sequence += 1;
       try {
         mkdirSync(options.directory, { recursive: true });
         writeFileSync(temporaryPath, batch.body, { mode: 0o600 });
         renameSync(temporaryPath, finalPath);
+        sequence += 1;
         log(
           `stage=pi_trace_publish sequence=${sequence - 1} bytes=${batch.body.byteLength} spans=${batch.spanCount}`,
         );
@@ -70,7 +70,7 @@ export function createPiFileSpanExporter(
           // best-effort temporary-file cleanup
         }
         log(
-          `stage=pi_trace_publish failed=true sequence=${sequence - 1} error=${
+          `stage=pi_trace_publish failed=true sequence=${sequence} error=${
             error instanceof Error ? error.message : String(error)
           }`,
         );

--- a/services/runner/src/tracing/pi-spool-consumer.ts
+++ b/services/runner/src/tracing/pi-spool-consumer.ts
@@ -28,8 +28,10 @@ export interface PiTraceSpoolBatch {
 
 export interface PiTraceSpoolDrainResult {
   pickedUp: number;
-  forwarded: number;
+  accepted: number;
+  exported: number;
   oversized: number;
+  empty: number;
   unreadControl: boolean;
   limitReached: boolean;
 }
@@ -42,14 +44,16 @@ export interface PiTraceSpoolConsumer {
   /** Pick up and forward every bounded current-channel batch available by the deadline. */
   drain: () => Promise<PiTraceSpoolDrainResult>;
   /** Remove telemetry-owned residue and report what was found. Never rejects. */
-  teardown: () => Promise<void>;
+  teardown: () => Promise<PiTraceSpoolDrainResult>;
 }
 
 export interface PiTraceSpoolConsumerOptions {
   host: TelemetryFileHost;
   dir: string;
   channelId: string;
-  onBatch: (batch: PiTraceSpoolBatch) => Promise<void> | void;
+  onBatch: (
+    batch: PiTraceSpoolBatch,
+  ) => Promise<boolean | void> | boolean | void;
   maxBatchBytes?: number;
   maxFiles?: number;
   drainTimeoutMs?: number;
@@ -165,7 +169,11 @@ function currentChannelSequence(
   const raw = name.slice(prefix.length, -PI_TRACE_FILE_SUFFIX.length);
   if (!/^\d+$/.test(raw)) return undefined;
   const sequence = Number(raw);
-  return Number.isSafeInteger(sequence) && sequence >= 0 ? sequence : undefined;
+  return Number.isSafeInteger(sequence) &&
+    sequence >= 0 &&
+    raw === String(sequence)
+    ? sequence
+    : undefined;
 }
 
 function boundedInteger(
@@ -228,8 +236,10 @@ export function createPiTraceSpoolConsumer(
     await ready;
     const result: PiTraceSpoolDrainResult = {
       pickedUp: 0,
-      forwarded: 0,
+      accepted: 0,
+      exported: 0,
       oversized: 0,
+      empty: 0,
       unreadControl: false,
       limitReached: false,
     };
@@ -270,13 +280,6 @@ export function createPiTraceSpoolConsumer(
             break;
           }
           const path = join(options.dir, candidate.name);
-          if (seenSequences.has(candidate.sequence)) {
-            await options.host.remove(path).catch(() => {});
-            log(
-              `stage=pi_trace_spool_pickup sequence=${candidate.sequence} duplicate=true`,
-            );
-            continue;
-          }
           const size = await options.host.statSize(path);
           if (size === undefined) {
             log(
@@ -315,6 +318,16 @@ export function createPiTraceSpoolConsumer(
             continue;
           }
 
+          if (bytes.byteLength === 0) {
+            result.empty += 1;
+            await options.host.remove(path).catch(() => {});
+            log(
+              `stage=pi_trace_spool_pickup sequence=${candidate.sequence} empty=true`,
+            );
+            continue;
+          }
+          result.accepted += 1;
+
           // Delete-on-pickup prevents a later poll from forwarding the same batch. Collect every
           // bounded file before starting network I/O, so one slow collector cannot hide a later
           // file that Pi publishes within the pickup window.
@@ -342,8 +355,7 @@ export function createPiTraceSpoolConsumer(
     await Promise.all(
       pickedUpBatches.map(async (batch) => {
         try {
-          await options.onBatch(batch);
-          result.forwarded += 1;
+          if ((await options.onBatch(batch)) !== false) result.exported += 1;
         } catch (err) {
           log(
             `stage=pi_trace_spool_export sequence=${batch.sequence} failed=true error=${conciseError(err)}`,
@@ -370,7 +382,7 @@ export function createPiTraceSpoolConsumer(
     },
     drain,
     teardown: async () => {
-      await ready;
+      const result = await drain();
       await sweepPiTraceSpoolFiles({
         host: options.host,
         dir: options.dir,
@@ -382,6 +394,7 @@ export function createPiTraceSpoolConsumer(
           `stage=pi_trace_spool_teardown failed=true error=${conciseError(err)}`,
         );
       });
+      return result;
     },
   };
 }

--- a/services/runner/src/tracing/pi-spool-consumer.ts
+++ b/services/runner/src/tracing/pi-spool-consumer.ts
@@ -1,0 +1,387 @@
+import { join } from "node:path";
+
+import {
+  PI_TRACE_CONTROL_FILE,
+  PI_TRACE_FILE_SUFFIX,
+  PI_TRACE_MAX_BATCH_BYTES,
+  PI_TRACE_MAX_FILES,
+  isPiTraceChannelId,
+  isPiTraceSpoolFileName,
+} from "./pi-spool-protocol.ts";
+import {
+  publishTelemetryFileAtomic,
+  type TelemetryFileHost,
+} from "./telemetry-file-host.ts";
+
+export const PI_TRACE_DRAIN_TIMEOUT_MS = 750;
+export const PI_TRACE_DRAIN_POLL_MS = 50;
+export const PI_TRACE_SWEEP_MAX_FILES = 64;
+const PI_TRACE_LIST_ATTEMPTS = 3;
+const PI_TRACE_LIST_RETRY_MS = 25;
+
+export interface PiTraceSpoolBatch {
+  channelId: string;
+  sequence: number;
+  path: string;
+  bytes: Uint8Array;
+}
+
+export interface PiTraceSpoolDrainResult {
+  pickedUp: number;
+  forwarded: number;
+  oversized: number;
+  unreadControl: boolean;
+  limitReached: boolean;
+}
+
+export interface PiTraceSpoolConsumer {
+  /** Directory creation and the start-of-turn stale sweep. Never rejects. */
+  ready: Promise<void>;
+  /** Atomically publish the read-once control file. False means tracing was skipped. */
+  publishControl: (contents: Uint8Array | string) => Promise<boolean>;
+  /** Pick up and forward every bounded current-channel batch available by the deadline. */
+  drain: () => Promise<PiTraceSpoolDrainResult>;
+  /** Remove telemetry-owned residue and report what was found. Never rejects. */
+  teardown: () => Promise<void>;
+}
+
+export interface PiTraceSpoolConsumerOptions {
+  host: TelemetryFileHost;
+  dir: string;
+  channelId: string;
+  onBatch: (batch: PiTraceSpoolBatch) => Promise<void> | void;
+  maxBatchBytes?: number;
+  maxFiles?: number;
+  drainTimeoutMs?: number;
+  pollMs?: number;
+  log?: (message: string) => void;
+  /** Test seam for deterministic bounded drains. */
+  now?: () => number;
+  /** Test seam for deterministic bounded drains and list retries. */
+  sleep?: (ms: number) => Promise<void>;
+}
+
+interface SweepOptions {
+  host: TelemetryFileHost;
+  dir: string;
+  phase: "start" | "teardown";
+  log: (message: string) => void;
+  sleep: (ms: number) => Promise<void>;
+  maxFiles?: number;
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+function conciseError(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
+function isOwnedTelemetryFile(name: string): boolean {
+  return (
+    isPiTraceSpoolFileName(name) ||
+    name.startsWith(`${PI_TRACE_CONTROL_FILE}.tmp.`)
+  );
+}
+
+async function listWithRetries(
+  host: TelemetryFileHost,
+  dir: string,
+  sleep: (ms: number) => Promise<void>,
+  log: (message: string) => void,
+  stage: string,
+  maxEntries: number,
+): Promise<string[] | undefined> {
+  for (let attempt = 1; attempt <= PI_TRACE_LIST_ATTEMPTS; attempt += 1) {
+    try {
+      return await host.list(dir, maxEntries);
+    } catch (err) {
+      if (attempt === PI_TRACE_LIST_ATTEMPTS) {
+        log(
+          `stage=${stage} list_failed=true attempts=${attempt} error=${conciseError(err)}`,
+        );
+        return undefined;
+      }
+      await sleep(PI_TRACE_LIST_RETRY_MS);
+    }
+  }
+  return undefined;
+}
+
+/** Bounded cleanup of files owned by the telemetry protocol. */
+export async function sweepPiTraceSpoolFiles({
+  host,
+  dir,
+  phase,
+  log,
+  sleep,
+  maxFiles = PI_TRACE_SWEEP_MAX_FILES,
+}: SweepOptions): Promise<void> {
+  const names = await listWithRetries(
+    host,
+    dir,
+    sleep,
+    log,
+    "pi_trace_spool_sweep",
+    maxFiles + 1,
+  );
+  if (!names) return;
+
+  const owned = names.filter(isOwnedTelemetryFile);
+  if (phase === "teardown" && names.includes(PI_TRACE_CONTROL_FILE)) {
+    log("stage=pi_trace_control unread=true phase=teardown");
+  }
+  let removed = 0;
+  let removeFailed = 0;
+  for (const name of owned.slice(0, Math.max(0, maxFiles))) {
+    try {
+      await host.remove(join(dir, name));
+      removed += 1;
+    } catch (err) {
+      removeFailed += 1;
+      log(
+        `stage=pi_trace_spool_sweep phase=${phase} remove_failed=true file=${name} error=${conciseError(err)}`,
+      );
+    }
+  }
+
+  if (owned.length > 0) {
+    const leftovers = owned.length - removed;
+    log(
+      `stage=pi_trace_spool_sweep phase=${phase} found=${owned.length} removed=${removed} leftovers=${leftovers} remove_failed=${removeFailed}`,
+    );
+  }
+}
+
+function currentChannelSequence(
+  name: string,
+  channelId: string,
+): number | undefined {
+  const prefix = `${channelId}.`;
+  if (!name.startsWith(prefix) || !name.endsWith(PI_TRACE_FILE_SUFFIX)) {
+    return undefined;
+  }
+  const raw = name.slice(prefix.length, -PI_TRACE_FILE_SUFFIX.length);
+  if (!/^\d+$/.test(raw)) return undefined;
+  const sequence = Number(raw);
+  return Number.isSafeInteger(sequence) && sequence >= 0 ? sequence : undefined;
+}
+
+function boundedInteger(
+  value: number | undefined,
+  fallback: number,
+  cap: number,
+): number {
+  if (!Number.isFinite(value)) return fallback;
+  return Math.min(cap, Math.max(1, Math.floor(value!)));
+}
+
+/** Runner-side pickup for raw OTLP protobuf batches authored by Pi. */
+export function createPiTraceSpoolConsumer(
+  options: PiTraceSpoolConsumerOptions,
+): PiTraceSpoolConsumer {
+  if (!isPiTraceChannelId(options.channelId)) {
+    throw new Error("Pi trace spool channelId is invalid");
+  }
+
+  const log = options.log ?? (() => {});
+  const sleep = options.sleep ?? defaultSleep;
+  const now = options.now ?? Date.now;
+  const maxBatchBytes = boundedInteger(
+    options.maxBatchBytes,
+    PI_TRACE_MAX_BATCH_BYTES,
+    PI_TRACE_MAX_BATCH_BYTES,
+  );
+  const maxFiles = boundedInteger(
+    options.maxFiles,
+    PI_TRACE_MAX_FILES,
+    PI_TRACE_MAX_FILES,
+  );
+  const drainTimeoutMs = Math.max(
+    0,
+    Math.floor(options.drainTimeoutMs ?? PI_TRACE_DRAIN_TIMEOUT_MS),
+  );
+  const pollMs = Math.max(
+    1,
+    Math.floor(options.pollMs ?? PI_TRACE_DRAIN_POLL_MS),
+  );
+  const seenSequences = new Set<number>();
+  const controlPath = join(options.dir, PI_TRACE_CONTROL_FILE);
+
+  const ready = (async () => {
+    try {
+      await options.host.mkdir(options.dir);
+      await sweepPiTraceSpoolFiles({
+        host: options.host,
+        dir: options.dir,
+        phase: "start",
+        log,
+        sleep,
+      });
+    } catch (err) {
+      log(`stage=pi_trace_spool_start failed=true error=${conciseError(err)}`);
+    }
+  })();
+
+  const drain = async (): Promise<PiTraceSpoolDrainResult> => {
+    await ready;
+    const result: PiTraceSpoolDrainResult = {
+      pickedUp: 0,
+      forwarded: 0,
+      oversized: 0,
+      unreadControl: false,
+      limitReached: false,
+    };
+    const deadline = now() + drainTimeoutMs;
+    const maxPolls = Math.max(1, Math.ceil(drainTimeoutMs / pollMs) + 1);
+    const pickedUpBatches: PiTraceSpoolBatch[] = [];
+
+    for (let poll = 0; poll < maxPolls; poll += 1) {
+      const names = await listWithRetries(
+        options.host,
+        options.dir,
+        sleep,
+        log,
+        "pi_trace_spool_drain",
+        PI_TRACE_SWEEP_MAX_FILES + 1,
+      );
+      if (names) {
+        if (names.includes(PI_TRACE_CONTROL_FILE) && !result.unreadControl) {
+          result.unreadControl = true;
+          log("stage=pi_trace_control unread=true");
+        }
+
+        const candidates = names
+          .map((name) => ({
+            name,
+            sequence: currentChannelSequence(name, options.channelId),
+          }))
+          .filter(
+            (candidate): candidate is { name: string; sequence: number } =>
+              candidate.sequence !== undefined &&
+              !seenSequences.has(candidate.sequence),
+          )
+          .sort((a, b) => a.sequence - b.sequence);
+
+        for (const candidate of candidates) {
+          if (result.pickedUp >= maxFiles) {
+            result.limitReached = true;
+            break;
+          }
+          const path = join(options.dir, candidate.name);
+          if (seenSequences.has(candidate.sequence)) {
+            await options.host.remove(path).catch(() => {});
+            log(
+              `stage=pi_trace_spool_pickup sequence=${candidate.sequence} duplicate=true`,
+            );
+            continue;
+          }
+          const size = await options.host.statSize(path);
+          if (size === undefined) {
+            log(
+              `stage=pi_trace_spool_pickup sequence=${candidate.sequence} stat_failed=true`,
+            );
+            continue;
+          }
+          if (size > maxBatchBytes) {
+            seenSequences.add(candidate.sequence);
+            result.pickedUp += 1;
+            result.oversized += 1;
+            await options.host.remove(path).catch(() => {});
+            log(
+              `stage=pi_trace_spool_pickup sequence=${candidate.sequence} oversized=true size=${size} limit=${maxBatchBytes}`,
+            );
+            continue;
+          }
+
+          let bytes: Uint8Array;
+          try {
+            bytes = await options.host.readBytes(path, maxBatchBytes);
+          } catch (err) {
+            log(
+              `stage=pi_trace_spool_pickup sequence=${candidate.sequence} read_failed=true error=${conciseError(err)}`,
+            );
+            continue;
+          }
+          seenSequences.add(candidate.sequence);
+          result.pickedUp += 1;
+          if (bytes.byteLength > maxBatchBytes) {
+            result.oversized += 1;
+            await options.host.remove(path).catch(() => {});
+            log(
+              `stage=pi_trace_spool_pickup sequence=${candidate.sequence} oversized_after_read=true size=${bytes.byteLength} limit=${maxBatchBytes}`,
+            );
+            continue;
+          }
+
+          // Delete-on-pickup prevents a later poll from forwarding the same batch. Collect every
+          // bounded file before starting network I/O, so one slow collector cannot hide a later
+          // file that Pi publishes within the pickup window.
+          await options.host.remove(path).catch((err) => {
+            log(
+              `stage=pi_trace_spool_pickup sequence=${candidate.sequence} remove_failed=true error=${conciseError(err)}`,
+            );
+          });
+          pickedUpBatches.push({
+            channelId: options.channelId,
+            sequence: candidate.sequence,
+            path,
+            bytes,
+          });
+        }
+      }
+
+      if (result.pickedUp >= maxFiles) {
+        result.limitReached = true;
+        break;
+      }
+      if (now() >= deadline || poll + 1 >= maxPolls) break;
+      await sleep(Math.min(pollMs, Math.max(0, deadline - now())));
+    }
+    await Promise.all(
+      pickedUpBatches.map(async (batch) => {
+        try {
+          await options.onBatch(batch);
+          result.forwarded += 1;
+        } catch (err) {
+          log(
+            `stage=pi_trace_spool_export sequence=${batch.sequence} failed=true error=${conciseError(err)}`,
+          );
+        }
+      }),
+    );
+    return result;
+  };
+
+  return {
+    ready,
+    publishControl: async (contents) => {
+      await ready;
+      try {
+        await publishTelemetryFileAtomic(options.host, controlPath, contents);
+        return true;
+      } catch (err) {
+        log(
+          `stage=pi_trace_control publish_failed=true error=${conciseError(err)}`,
+        );
+        return false;
+      }
+    },
+    drain,
+    teardown: async () => {
+      await ready;
+      await sweepPiTraceSpoolFiles({
+        host: options.host,
+        dir: options.dir,
+        phase: "teardown",
+        log,
+        sleep,
+      }).catch((err) => {
+        log(
+          `stage=pi_trace_spool_teardown failed=true error=${conciseError(err)}`,
+        );
+      });
+    },
+  };
+}

--- a/services/runner/src/tracing/pi-spool-protocol.ts
+++ b/services/runner/src/tracing/pi-spool-protocol.ts
@@ -1,0 +1,99 @@
+/** Bundle-safe protocol shared by the Pi extension and the runner-side spool consumer. */
+
+export const PI_TRACE_CONTROL_VERSION = 1 as const;
+export const PI_TRACE_CONTROL_FILE = "current.control.json";
+export const PI_TRACE_CONTROL_ENV = "AGENTA_AGENT_TELEMETRY_CONTROL_PATH";
+export const PI_TRACE_MAX_CONTROL_BYTES = 256 * 1024;
+export const PI_TRACE_MAX_BATCH_BYTES = 8 * 1024 * 1024;
+export const PI_TRACE_MAX_FILES = 4;
+export const PI_TRACE_FILE_SUFFIX = ".otlp.pb";
+
+const CHANNEL_ID_RE = /^[0-9a-f]{32}$/;
+
+export interface PiTurnTraceControl {
+  version: typeof PI_TRACE_CONTROL_VERSION;
+  channelId: string;
+  turnId?: string;
+  sessionId?: string;
+  propagation?: {
+    traceparent?: string;
+    baggage?: string;
+  };
+  capture: {
+    content: boolean;
+  };
+  skills: string[];
+  redaction: {
+    knownValues: string[];
+  };
+}
+
+export function isPiTraceChannelId(value: unknown): value is string {
+  return typeof value === "string" && CHANNEL_ID_RE.test(value);
+}
+
+export function piTraceFileName(channelId: string, sequence: number): string {
+  return `${channelId}.${sequence}${PI_TRACE_FILE_SUFFIX}`;
+}
+
+export function isPiTraceSpoolFileName(name: string): boolean {
+  if (name === PI_TRACE_CONTROL_FILE) return true;
+  if (name.includes(`${PI_TRACE_FILE_SUFFIX}.tmp.`)) return true;
+  const match = /^([0-9a-f]{32})\.(\d+)\.otlp\.pb$/.exec(name);
+  return !!match;
+}
+
+function optionalString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+/** Parse the sandbox-writable control file without accepting unbounded collections. */
+export function parsePiTurnTraceControl(value: unknown): PiTurnTraceControl {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    throw new Error("Pi trace control must be an object");
+  }
+  const raw = value as Record<string, unknown>;
+  if (raw.version !== PI_TRACE_CONTROL_VERSION) {
+    throw new Error("Unsupported Pi trace control version");
+  }
+  if (!isPiTraceChannelId(raw.channelId)) {
+    throw new Error("Pi trace control channelId is invalid");
+  }
+  const propagation =
+    raw.propagation && typeof raw.propagation === "object"
+      ? (raw.propagation as Record<string, unknown>)
+      : undefined;
+  const capture =
+    raw.capture && typeof raw.capture === "object"
+      ? (raw.capture as Record<string, unknown>)
+      : undefined;
+  const skills = Array.isArray(raw.skills)
+    ? raw.skills
+        .filter((item): item is string => typeof item === "string")
+        .slice(0, 256)
+    : [];
+  const redaction =
+    raw.redaction && typeof raw.redaction === "object"
+      ? (raw.redaction as Record<string, unknown>)
+      : undefined;
+  const knownValues = Array.isArray(redaction?.knownValues)
+    ? redaction.knownValues
+        .filter((item): item is string => typeof item === "string")
+        .slice(0, 256)
+    : [];
+  return {
+    version: PI_TRACE_CONTROL_VERSION,
+    channelId: raw.channelId,
+    turnId: optionalString(raw.turnId),
+    sessionId: optionalString(raw.sessionId),
+    propagation: propagation
+      ? {
+          traceparent: optionalString(propagation.traceparent),
+          baggage: optionalString(propagation.baggage),
+        }
+      : undefined,
+    capture: { content: capture?.content !== false },
+    skills,
+    redaction: { knownValues },
+  };
+}

--- a/services/runner/src/tracing/pi-trace-turn-export.ts
+++ b/services/runner/src/tracing/pi-trace-turn-export.ts
@@ -1,0 +1,119 @@
+import type { Redactor } from "../redaction.ts";
+import type { AuthorizationProvider } from "./otel.ts";
+import { exportOtlpBytes } from "./otlp-bytes-export.ts";
+import {
+  createPiTraceSpoolConsumer,
+  type PiTraceSpoolConsumer,
+} from "./pi-spool-consumer.ts";
+import type { PiTurnTraceControl } from "./pi-spool-protocol.ts";
+import type { TelemetryFileHost } from "./telemetry-file-host.ts";
+
+interface ExportContext {
+  endpoint: string;
+  authorization: AuthorizationProvider;
+  authorizationSource: "platform" | "exporter";
+  redactor: Redactor;
+  traceId?: string;
+  placement: "local" | "daytona";
+  turnId?: string;
+  onMissingBatch?: (message: string) => void | Promise<void>;
+}
+
+export interface PiTraceTurnExport {
+  publishControl(control: PiTurnTraceControl): Promise<boolean>;
+  updatePlatformAuthorization(authorization: AuthorizationProvider): void;
+  traceId(): string | undefined;
+  emitMissingBatchFallback(message: string): Promise<void>;
+  finish(): Promise<{ validBatches: number }>;
+  teardown(): Promise<void>;
+}
+
+export function createPiTraceTurnExport(options: {
+  host: TelemetryFileHost;
+  dir: string;
+  channelId: string;
+  context: ExportContext;
+  log?: (message: string) => void;
+}): PiTraceTurnExport {
+  const context = options.context;
+  let authorization = context.authorization;
+  let closed = false;
+  let fallbackEmitted = false;
+  let consumer: PiTraceSpoolConsumer;
+  const createdAtMs = Date.now();
+
+  consumer = createPiTraceSpoolConsumer({
+    host: options.host,
+    dir: options.dir,
+    channelId: options.channelId,
+    log: options.log,
+    onBatch: async ({ bytes }) => {
+      const pickupLatencyMs = Date.now() - createdAtMs;
+      const outcome = await exportOtlpBytes({
+        body: bytes,
+        target: {
+          endpoint: context.endpoint,
+          authorization,
+        },
+        diagnostics: {
+          traceId: context.traceId ?? "unknown",
+          source: "pi-spool",
+          placement: context.placement,
+          turnId: context.turnId,
+          batchBytes: bytes.byteLength,
+          redactors: [context.redactor],
+        },
+      });
+      options.log?.(
+        "stage=pi_trace_spool_export source=pi-spool placement=" +
+          context.placement +
+          " turn=" +
+          (context.turnId || "<none>") +
+          " trace=" +
+          (context.traceId || "unknown").slice(-8) +
+          " bytes=" +
+          bytes.byteLength +
+          " pickup_ms=" +
+          pickupLatencyMs +
+          " export_ms=" +
+          outcome.durationMs +
+          " outcome=" +
+          outcome.outcome +
+          " status=" +
+          (outcome.status || "<none>"),
+      );
+    },
+  });
+
+  const teardown = async (): Promise<void> => {
+    if (closed) return;
+    closed = true;
+    await consumer.teardown();
+  };
+
+  return {
+    publishControl: async (control) => {
+      if (closed) return false;
+      return consumer.publishControl(JSON.stringify(control));
+    },
+    updatePlatformAuthorization: (next) => {
+      if (context.authorizationSource === "platform") authorization = next;
+    },
+    traceId: () => context.traceId,
+    emitMissingBatchFallback: async (message) => {
+      if (fallbackEmitted) return;
+      fallbackEmitted = true;
+      await context.onMissingBatch?.(message);
+    },
+    finish: async () => {
+      if (closed) return { validBatches: 0 };
+      try {
+        const result = await consumer.drain();
+        return { validBatches: result.forwarded };
+      } finally {
+        await teardown();
+      }
+    },
+    teardown,
+  };
+}

--- a/services/runner/src/tracing/pi-trace-turn-export.ts
+++ b/services/runner/src/tracing/pi-trace-turn-export.ts
@@ -19,12 +19,17 @@ interface ExportContext {
   onMissingBatch?: (message: string) => void | Promise<void>;
 }
 
+export interface PiTraceTurnExportResult {
+  pickedUpBatches: number;
+  exportedBatches: number;
+}
+
 export interface PiTraceTurnExport {
   publishControl(control: PiTurnTraceControl): Promise<boolean>;
   updatePlatformAuthorization(authorization: AuthorizationProvider): void;
   traceId(): string | undefined;
   emitMissingBatchFallback(message: string): Promise<void>;
-  finish(): Promise<{ validBatches: number }>;
+  finish(): Promise<PiTraceTurnExportResult>;
   teardown(): Promise<void>;
 }
 
@@ -39,6 +44,7 @@ export function createPiTraceTurnExport(options: {
   let authorization = context.authorization;
   let closed = false;
   let fallbackEmitted = false;
+  let finalization: Promise<PiTraceTurnExportResult> | undefined;
   let consumer: PiTraceSpoolConsumer;
   const createdAtMs = Date.now();
 
@@ -82,13 +88,23 @@ export function createPiTraceTurnExport(options: {
           " status=" +
           (outcome.status || "<none>"),
       );
+      return outcome.outcome === "exported";
     },
   });
 
+  const finalize = (): Promise<PiTraceTurnExportResult> => {
+    if (!finalization) {
+      closed = true;
+      finalization = consumer.teardown().then((result) => ({
+        pickedUpBatches: result.accepted,
+        exportedBatches: result.exported,
+      }));
+    }
+    return finalization;
+  };
+
   const teardown = async (): Promise<void> => {
-    if (closed) return;
-    closed = true;
-    await consumer.teardown();
+    await finalize();
   };
 
   return {
@@ -105,15 +121,7 @@ export function createPiTraceTurnExport(options: {
       fallbackEmitted = true;
       await context.onMissingBatch?.(message);
     },
-    finish: async () => {
-      if (closed) return { validBatches: 0 };
-      try {
-        const result = await consumer.drain();
-        return { validBatches: result.forwarded };
-      } finally {
-        await teardown();
-      }
-    },
+    finish: finalize,
     teardown,
   };
 }

--- a/services/runner/src/tracing/telemetry-file-host.ts
+++ b/services/runner/src/tracing/telemetry-file-host.ts
@@ -115,7 +115,7 @@ export function sandboxTelemetryFileHost(
         command: "sh",
         args: [
           "-c",
-          'test -d "$1" && LC_ALL=C ls -1A -- "$1" | head -n "$2"',
+          'if [ ! -d "$1" ]; then exit 0; fi; LC_ALL=C ls -1A -- "$1" | head -n "$2"',
           "agenta-telemetry-list",
           dir,
           String(limit),
@@ -146,16 +146,15 @@ export function sandboxTelemetryFileHost(
     readBytes: async (path, maxBytes) => {
       const rawLimit = Math.max(1, Math.floor(maxBytes)) + 1;
       const encodedLimit = 4 * Math.ceil(rawLimit / 3) + 1024;
-      // sandbox-agent v0.4.2 readFsFile materializes the full remote file before returning.
-      // Limit the bytes inside the sandbox, then cap the process response as a second bound.
+      // The consumer checks stat size before this call. Cap the encoded process response too,
+      // so a file that grows between stat and read fails closed.
       const result = await sandbox.runProcess({
         command: "sh",
         args: [
           "-c",
-          'test -f "$1" && head -c "$2" -- "$1" | base64 | tr -d "\n"',
+          'if [ ! -f "$1" ]; then exit 44; fi; base64 "$1"',
           "agenta-telemetry-read",
           path,
-          String(rawLimit),
         ],
         maxOutputBytes: encodedLimit,
         timeoutMs: 10_000,
@@ -169,6 +168,9 @@ export function sandboxTelemetryFileHost(
         throw new Error("Telemetry file read exceeded its bound");
       }
       const bytes = Buffer.from(result.stdout, "base64");
+      if (bytes.byteLength === 0) {
+        throw new Error("Telemetry file read returned no bytes");
+      }
       if (bytes.byteLength > rawLimit) {
         throw new Error("Telemetry file read exceeded its bound");
       }

--- a/services/runner/src/tracing/telemetry-file-host.ts
+++ b/services/runner/src/tracing/telemetry-file-host.ts
@@ -115,7 +115,7 @@ export function sandboxTelemetryFileHost(
         command: "sh",
         args: [
           "-c",
-          'if [ ! -d "$1" ]; then exit 0; fi; LC_ALL=C ls -1A -- "$1" | head -n "$2"',
+          'if [ ! -d "$1" ]; then exit 44; fi; LC_ALL=C ls -1A -- "$1" | head -n "$2"',
           "agenta-telemetry-list",
           dir,
           String(limit),
@@ -123,6 +123,7 @@ export function sandboxTelemetryFileHost(
         maxOutputBytes: (limit + 1) * 512,
         timeoutMs: 10_000,
       });
+      if (result.exitCode === 44) return [];
       if (
         result.exitCode !== 0 ||
         result.stdoutTruncated ||
@@ -152,13 +153,18 @@ export function sandboxTelemetryFileHost(
         command: "sh",
         args: [
           "-c",
-          'if [ ! -f "$1" ]; then exit 44; fi; base64 "$1"',
+          'if [ ! -f "$1" ]; then exit 44; fi; base64 "$1" | tr -d \'\\n\'',
           "agenta-telemetry-read",
           path,
         ],
         maxOutputBytes: encodedLimit,
         timeoutMs: 10_000,
       });
+      if (result.exitCode === 44) {
+        throw Object.assign(new Error("Telemetry file is missing"), {
+          code: "ENOENT",
+        });
+      }
       if (
         result.exitCode !== 0 ||
         result.stdoutTruncated ||

--- a/services/runner/src/tracing/telemetry-file-host.ts
+++ b/services/runner/src/tracing/telemetry-file-host.ts
@@ -1,0 +1,208 @@
+import {
+  closeSync,
+  mkdirSync,
+  constants,
+  fstatSync,
+  openSync,
+  opendirSync,
+  readSync,
+  renameSync,
+  statSync,
+  unlinkSync,
+  writeFileSync,
+} from "node:fs";
+import { randomBytes } from "node:crypto";
+import { dirname } from "node:path";
+
+import type { SandboxAgent } from "sandbox-agent";
+
+/** Binary filesystem operations used only by the Pi telemetry spool. */
+export interface TelemetryFileHost {
+  mkdir: (path: string) => Promise<void>;
+  list: (dir: string, maxEntries: number) => Promise<string[]>;
+  statSize: (path: string) => Promise<number | undefined>;
+  readBytes: (path: string, maxBytes: number) => Promise<Uint8Array>;
+  writeBytes: (path: string, contents: Uint8Array | string) => Promise<void>;
+  rename: (from: string, to: string) => Promise<void>;
+  remove: (path: string) => Promise<void>;
+}
+
+/** Telemetry host for a Pi process sharing the runner's local filesystem. */
+export function localTelemetryFileHost(): TelemetryFileHost {
+  return {
+    mkdir: async (path) => {
+      mkdirSync(path, { recursive: true });
+    },
+    list: async (dir, maxEntries) => {
+      let handle: ReturnType<typeof opendirSync> | undefined;
+      try {
+        handle = opendirSync(dir);
+        const names: string[] = [];
+        while (names.length < Math.max(0, maxEntries)) {
+          const entry = handle.readSync();
+          if (!entry) break;
+          names.push(entry.name);
+        }
+        return names;
+      } catch (err) {
+        if ((err as NodeJS.ErrnoException).code === "ENOENT") return [];
+        throw err;
+      } finally {
+        handle?.closeSync();
+      }
+    },
+    statSize: async (path) => {
+      try {
+        return statSync(path).size;
+      } catch {
+        return undefined;
+      }
+    },
+    readBytes: async (path, maxBytes) => {
+      const fd = openSync(
+        path,
+        constants.O_RDONLY | (constants.O_NOFOLLOW ?? 0),
+      );
+      try {
+        const initial = fstatSync(fd);
+        if (!initial.isFile() || initial.size > maxBytes) {
+          throw new Error("Telemetry file exceeds read limit");
+        }
+        const buffer = Buffer.allocUnsafe(
+          Math.min(maxBytes + 1, Math.max(1, initial.size + 1)),
+        );
+        const length = readSync(fd, buffer, 0, buffer.byteLength, 0);
+        return buffer.subarray(0, length);
+      } finally {
+        closeSync(fd);
+      }
+    },
+    writeBytes: async (path, contents) => {
+      mkdirSync(dirname(path), { recursive: true });
+      writeFileSync(path, contents, { mode: 0o600 });
+    },
+    rename: async (from, to) => {
+      renameSync(from, to);
+    },
+    remove: async (path) => {
+      unlinkSync(path);
+    },
+  };
+}
+
+type TelemetrySandbox = Pick<
+  SandboxAgent,
+  | "mkdirFs"
+  | "statFs"
+  | "runProcess"
+  | "writeFsFile"
+  | "moveFs"
+  | "deleteFsEntry"
+>;
+
+/** Telemetry host for a Pi process running inside a Daytona sandbox. */
+export function sandboxTelemetryFileHost(
+  sandbox: TelemetrySandbox,
+): TelemetryFileHost {
+  return {
+    mkdir: async (path) => {
+      await sandbox.mkdirFs({ path });
+    },
+    list: async (dir, maxEntries) => {
+      const limit = Math.max(0, Math.floor(maxEntries));
+      if (limit === 0) return [];
+      const result = await sandbox.runProcess({
+        command: "sh",
+        args: [
+          "-c",
+          'test -d "$1" && LC_ALL=C ls -1A -- "$1" | head -n "$2"',
+          "agenta-telemetry-list",
+          dir,
+          String(limit),
+        ],
+        maxOutputBytes: (limit + 1) * 512,
+        timeoutMs: 10_000,
+      });
+      if (
+        result.exitCode !== 0 ||
+        result.stdoutTruncated ||
+        result.stderrTruncated ||
+        result.timedOut
+      ) {
+        throw new Error("Telemetry directory listing exceeded its bound");
+      }
+      return result.stdout.split("\n").filter(Boolean);
+    },
+    statSize: async (path) => {
+      try {
+        const stat = await sandbox.statFs({ path });
+        return Number.isFinite(stat.size) && stat.size >= 0
+          ? stat.size
+          : undefined;
+      } catch {
+        return undefined;
+      }
+    },
+    readBytes: async (path, maxBytes) => {
+      const rawLimit = Math.max(1, Math.floor(maxBytes)) + 1;
+      const encodedLimit = 4 * Math.ceil(rawLimit / 3) + 1024;
+      // sandbox-agent v0.4.2 readFsFile materializes the full remote file before returning.
+      // Limit the bytes inside the sandbox, then cap the process response as a second bound.
+      const result = await sandbox.runProcess({
+        command: "sh",
+        args: [
+          "-c",
+          'test -f "$1" && head -c "$2" -- "$1" | base64 | tr -d "\n"',
+          "agenta-telemetry-read",
+          path,
+          String(rawLimit),
+        ],
+        maxOutputBytes: encodedLimit,
+        timeoutMs: 10_000,
+      });
+      if (
+        result.exitCode !== 0 ||
+        result.stdoutTruncated ||
+        result.stderrTruncated ||
+        result.timedOut
+      ) {
+        throw new Error("Telemetry file read exceeded its bound");
+      }
+      const bytes = Buffer.from(result.stdout, "base64");
+      if (bytes.byteLength > rawLimit) {
+        throw new Error("Telemetry file read exceeded its bound");
+      }
+      return bytes;
+    },
+    writeBytes: async (path, contents) => {
+      const body =
+        typeof contents === "string"
+          ? contents
+          : Uint8Array.from(contents).buffer;
+      await sandbox.writeFsFile({ path }, body);
+    },
+    rename: async (from, to) => {
+      // sandbox-agent v0.4.2 maps this same-directory move to rename(2).
+      await sandbox.moveFs({ from, to, overwrite: true });
+    },
+    remove: async (path) => {
+      await sandbox.deleteFsEntry({ path });
+    },
+  };
+}
+
+/** Write a complete sibling and expose it only through an atomic rename. */
+export async function publishTelemetryFileAtomic(
+  host: TelemetryFileHost,
+  finalPath: string,
+  contents: Uint8Array | string,
+): Promise<void> {
+  const tempPath = `${finalPath}.tmp.${randomBytes(8).toString("hex")}`;
+  try {
+    await host.writeBytes(tempPath, contents);
+    await host.rename(tempPath, finalPath);
+  } catch (err) {
+    await host.remove(tempPath).catch(() => {});
+    throw err;
+  }
+}

--- a/services/runner/tests/unit/acquire-context.test.ts
+++ b/services/runner/tests/unit/acquire-context.test.ts
@@ -41,7 +41,6 @@ function makeContext() {
     runAgentDir: undefined,
     durableCwdSafeToDelete: false,
     runtimeRemount: undefined,
-    otlpAuthFilePath: undefined,
     codexSqliteHome: undefined,
     closeToolMcp: undefined,
     installedMountExpiries: {} as Record<string, number | undefined>,
@@ -88,13 +87,10 @@ describe("FINDING 1: the environment is a read-only projection, not a readonly r
     const { context } = makeContext();
     // Structural proof: assigning through the view cannot compile, and at runtime the getter-only
     // property refuses the write. Both directions matter; a silent no-op would be worse.
-    assert.throws(
-      () => {
-        "use strict";
-        (context.env as unknown as Record<string, unknown>).mountedCwd = "/hack";
-      },
-      /only a getter|Cannot set/,
-    );
+    assert.throws(() => {
+      "use strict";
+      (context.env as unknown as Record<string, unknown>).mountedCwd = "/hack";
+    }, /only a getter|Cannot set/);
   });
 
   it("reads through, so a committed change is visible at once", () => {
@@ -253,7 +249,11 @@ describe("FINDING 5 and INVARIANT 2: credentials and the re-sign path", () => {
     context.recordResignedCredential("cwd", fresh);
     context.beginCwdMount();
 
-    assert.strictEqual(environment.mountCreds, fresh, "the new credential is committed");
+    assert.strictEqual(
+      environment.mountCreds,
+      fresh,
+      "the new credential is committed",
+    );
     assert.equal(
       context.env.mountedCwd,
       "/run/cwd",
@@ -274,7 +274,8 @@ describe("the plan mutation is narrow, and the budgets are per acquire", () => {
     const { context, plan } = makeContext();
     context.appendAgentMountGuidance("DURABLE STORAGE");
     assert.equal(
-      (plan as { prompt: { appendSystemPrompt?: string } }).prompt.appendSystemPrompt,
+      (plan as { prompt: { appendSystemPrompt?: string } }).prompt
+        .appendSystemPrompt,
       "DURABLE STORAGE",
     );
     assert.equal(

--- a/services/runner/tests/unit/credential-refresh.test.ts
+++ b/services/runner/tests/unit/credential-refresh.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { afterEach, describe, it, vi } from "vitest";
+
+import { startPlatformCredentialLease } from "../../src/sessions/auth.ts";
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("platform credential lease", () => {
+  it("refreshes proactively and exposes the latest credential", async () => {
+    vi.useFakeTimers();
+    const calls: Array<{ baseUrl: string; authorization: string }> = [];
+    const lease = startPlatformCredentialLease(
+      "https://api.agenta.test/api",
+      "Secret initial",
+      {
+        intervalMs: 1_000,
+        refresh: async (baseUrl, authorization) => {
+          calls.push({ baseUrl, authorization });
+          return "Secret refreshed";
+        },
+      },
+    );
+
+    assert.equal(lease.credential(), "Secret initial");
+    await vi.advanceTimersByTimeAsync(1_000);
+    assert.deepEqual(calls, [
+      {
+        baseUrl: "https://api.agenta.test/api",
+        authorization: "Secret initial",
+      },
+    ]);
+    assert.equal(lease.credential(), "Secret refreshed");
+
+    lease.release();
+    await vi.advanceTimersByTimeAsync(5_000);
+    assert.equal(calls.length, 1);
+  });
+
+  it("keeps the last credential when refresh fails", async () => {
+    vi.useFakeTimers();
+    const lease = startPlatformCredentialLease(
+      "https://api.agenta.test/api",
+      "Secret initial",
+      {
+        intervalMs: 1_000,
+        refresh: async () => null,
+      },
+    );
+
+    await vi.advanceTimersByTimeAsync(1_000);
+    assert.equal(lease.credential(), "Secret initial");
+    lease.release();
+  });
+
+  it("does not start a permission exchange without a platform credential", async () => {
+    vi.useFakeTimers();
+    const refresh = vi.fn(async () => "unexpected");
+    const lease = startPlatformCredentialLease(
+      "https://api.agenta.test/api",
+      "",
+      { intervalMs: 1_000, refresh },
+    );
+
+    await vi.advanceTimersByTimeAsync(5_000);
+    assert.equal(refresh.mock.calls.length, 0);
+    lease.release();
+  });
+});

--- a/services/runner/tests/unit/environment-units.test.ts
+++ b/services/runner/tests/unit/environment-units.test.ts
@@ -20,7 +20,10 @@ import {
 import * as workspaceManager from "../../src/environment/workspace-manager.ts";
 
 const SRC = (rel: string) =>
-  readFileSync(fileURLToPath(new URL(`../../src/${rel}`, import.meta.url)), "utf-8");
+  readFileSync(
+    fileURLToPath(new URL(`../../src/${rel}`, import.meta.url)),
+    "utf-8",
+  );
 
 /**
  * Every file that may emit an acquire stage. The split moves stages OUT of `environment.ts` and
@@ -119,7 +122,8 @@ describe("timing: the stage names are a public interface", () => {
     // one place that documents the public set.
     const source = ALL_STAGE_SOURCE();
     const emitted = new Set<string>();
-    for (const m of source.matchAll(/timingLog\(\s*"([a-z_]+)"/g)) emitted.add(m[1]);
+    for (const m of source.matchAll(/timingLog\(\s*"([a-z_]+)"/g))
+      emitted.add(m[1]);
     for (const stage of emitted) {
       assert.ok(
         (ACQUIRE_STAGES as readonly string[]).includes(stage),
@@ -184,7 +188,11 @@ describe("workspace manager: the public surface", () => {
     );
     // Step 6: materialize now returns a ManagedWorkspace — the writer's handle PLUS the
     // inventory of what it wrote — so it is no longer reference-equal to the raw result.
-    assert.equal(result.cleanup, fake.cleanup, "the writer's handle is carried through");
+    assert.equal(
+      result.cleanup,
+      fake.cleanup,
+      "the writer's handle is carried through",
+    );
     assert.equal(result.inventory.instructionsFile, "CLAUDE.md");
     assert.equal(seen.length, 1);
     const input = seen[0] as Record<string, unknown>;
@@ -264,7 +272,8 @@ describe("a skipped durable mount is LOUD at both surfaces", () => {
   // `acquireEnvironment`, which no unit test can drive without a live provider. What must not
   // regress is that the skip has a branch at all. It used to have none, and the timing line was
   // the only trace it left.
-  const environment = () => CODE_ONLY(SRC("engines/sandbox_agent/environment.ts"));
+  const environment = () =>
+    CODE_ONLY(SRC("engines/sandbox_agent/environment.ts"));
 
   it("names WHY the mount was refused, because the two causes have different fixes", () => {
     const source = environment();
@@ -306,7 +315,9 @@ describe("a skipped durable mount is LOUD at both surfaces", () => {
   });
 
   it("advertises the resolved path and never the variable name", () => {
-    const guidance = CODE_ONLY(SRC("engines/sandbox_agent/agent-mount-guidance.ts"));
+    const guidance = CODE_ONLY(
+      SRC("engines/sandbox_agent/agent-mount-guidance.ts"),
+    );
     assert.doesNotMatch(
       guidance,
       /also.{0,20}AGENTA_AGENT_MOUNT_DIR/,
@@ -399,7 +410,9 @@ describe("mount unit: the seam (lifecycle migration, step 5 / S7b)", () => {
     // the skills temp root leaked; and a `destroy()` between the two points raised a
     // ReferenceError instead of tearing down.
     const source = CODE_ONLY(SRC("engines/sandbox_agent/environment.ts"));
-    const ctxAt = source.indexOf("const { context: ctx } = createAcquireContext");
+    const ctxAt = source.indexOf(
+      "const { context: ctx } = createAcquireContext",
+    );
     const destroyAt = source.indexOf("environment.destroy = async (opts");
     assert.ok(ctxAt > 0 && destroyAt > 0, "both sites still exist");
     assert.ok(
@@ -432,7 +445,10 @@ describe("mount unit: the seam (lifecycle migration, step 5 / S7b)", () => {
       "reSignAndRemountLocalCwd()",
       "remountLocalCwdAfterRuntimeEnotconn",
     ]) {
-      assert.ok(source.includes(call), `the composer lost its '${call}' call site`);
+      assert.ok(
+        source.includes(call),
+        `the composer lost its '${call}' call site`,
+      );
     }
   });
 
@@ -471,7 +487,9 @@ describe("harness-session unit: the seam", () => {
     // The comparison proves the adapter accepted the id, not that it replayed the turns. The
     // caveat is in the type's doc comment so a reader cannot mistake one for the other.
     const source = SRC("environment/harness-session-lifecycle.ts");
-    assert.ok(source.includes("It does NOT prove the adapter replayed the turns"));
+    assert.ok(
+      source.includes("It does NOT prove the adapter replayed the turns"),
+    );
   });
 
   it("the composer delegates both stages", () => {
@@ -515,12 +533,11 @@ describe("runtime unit: the seam", () => {
 });
 
 describe("environment-setup is a planner again", () => {
-  it("no longer builds the daemon environment or writes the OTLP bearer", () => {
-    // The purification. These were never planning: they build two env maps and write a file.
+  it("no longer builds the daemon environment", () => {
+    // The purification: these operations build runtime env maps and are not planning.
     const source = CODE_ONLY(SRC("engines/sandbox_agent/environment-setup.ts"));
     for (const marker of [
       "buildDaemonEnv)(",
-      "writeOtlpAuthFile(",
       "buildPiExtensionEnv(",
       "configureDaytonaCodexEnv(",
     ]) {

--- a/services/runner/tests/unit/environment-units.test.ts
+++ b/services/runner/tests/unit/environment-units.test.ts
@@ -538,6 +538,7 @@ describe("environment-setup is a planner again", () => {
     const source = CODE_ONLY(SRC("engines/sandbox_agent/environment-setup.ts"));
     for (const marker of [
       "buildDaemonEnv)(",
+      "writeOtlpAuthFile(",
       "buildPiExtensionEnv(",
       "configureDaytonaCodexEnv(",
     ]) {

--- a/services/runner/tests/unit/extension-tools.test.ts
+++ b/services/runner/tests/unit/extension-tools.test.ts
@@ -23,9 +23,13 @@ import { tmpdir } from "node:os";
 import { join } from "node:path";
 
 import factory, {
-  readOtlpAuthFile,
+  readPiTurnTraceControl,
   replaceActiveBuiltinTools,
 } from "../../src/extensions/agenta.ts";
+import {
+  PI_TRACE_CONTROL_ENV,
+  PI_TRACE_CONTROL_VERSION,
+} from "../../src/tracing/pi-spool-protocol.ts";
 import { PI_MODEL_PROVIDER_OVERRIDE_ENV } from "../../src/extensions/model-provider-override.ts";
 import { refusedAtGateText } from "../../src/tools/denial-text.ts";
 import { PUBLIC_SPECS_FILE_ENV } from "../../src/tools/tool-mcp-env.ts";
@@ -34,11 +38,8 @@ const TOOL_ENV = [
   "AGENTA_AGENT_TOOLS_PUBLIC_SPECS",
   PUBLIC_SPECS_FILE_ENV,
   "AGENTA_AGENT_TOOLS_RELAY_DIR",
-  "TRACEPARENT",
-  "OTEL_EXPORTER_OTLP_TRACES_ENDPOINT",
-  "AGENTA_AGENT_OTLP_AUTH_FILE",
+  PI_TRACE_CONTROL_ENV,
   "AGENTA_AGENT_USAGE_CAPTURE_PATH",
-  "AGENTA_AGENT_CONTENT_CAPTURE_ENABLED",
   "AGENTA_AGENT_BUILTIN_ACTIVATION",
   "AGENTA_AGENT_BUILTIN_GATING",
   PI_MODEL_PROVIDER_OVERRIDE_ENV,
@@ -487,22 +488,35 @@ describe("agenta extension tool specs delivery", () => {
   });
 });
 
-describe("readOtlpAuthFile", () => {
-  it("reads the bearer once, then deletes the file so it cannot be re-read", () => {
-    const dir = mkdtempSync(join(tmpdir(), "agenta-otlp-auth-test-"));
-    const path = join(dir, "otlp-auth");
-    writeFileSync(path, "Bearer trace-token", "utf-8");
+describe("readPiTurnTraceControl", () => {
+  it("reads one bounded turn control, then deletes it", () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-trace-control-test-"));
+    const path = join(dir, "current.control.json");
+    const control = {
+      version: PI_TRACE_CONTROL_VERSION,
+      channelId: "a".repeat(32),
+      capture: { content: true },
+      skills: ["weather"],
+      redaction: { knownValues: ["mount-secret"] },
+    };
+    writeFileSync(path, JSON.stringify(control), "utf-8");
 
-    const value = readOtlpAuthFile(path);
-
-    assert.equal(value, "Bearer trace-token");
+    assert.deepEqual(readPiTurnTraceControl(path), {
+      ...control,
+      turnId: undefined,
+      sessionId: undefined,
+      propagation: undefined,
+    });
     assert.equal(existsSync(path), false);
     rmSync(dir, { recursive: true, force: true });
   });
 
   it("returns undefined for a missing path without throwing", () => {
-    assert.equal(readOtlpAuthFile(undefined), undefined);
-    assert.equal(readOtlpAuthFile("/nonexistent/agenta-otlp-auth"), undefined);
+    assert.equal(readPiTurnTraceControl(undefined), undefined);
+    assert.equal(
+      readPiTurnTraceControl("/nonexistent/agenta-trace-control"),
+      undefined,
+    );
   });
 });
 

--- a/services/runner/tests/unit/otel-bytes-export.test.ts
+++ b/services/runner/tests/unit/otel-bytes-export.test.ts
@@ -1,0 +1,140 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { exportOtlpBytes } from "../../src/tracing/otlp-bytes-export.ts";
+
+const AGENTA_ENDPOINT = "https://cloud.agenta.ai/api/otlp/v1/traces";
+const THIRD_PARTY_ENDPOINT = "https://collector.example/v1/traces";
+const TRACE_ID = "a".repeat(32);
+
+function request(
+  endpoint: string,
+  authorization: () => string | undefined,
+  body = new Uint8Array([1, 2, 3]),
+) {
+  return {
+    body,
+    target: { endpoint, authorization },
+    diagnostics: { traceId: TRACE_ID, spanCount: 3 },
+  };
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+  vi.unstubAllEnvs();
+});
+
+describe("raw OTLP byte export", () => {
+  it("posts the exact protobuf view with the live credential and a 10 second timeout", async () => {
+    let credential = "Secret stale";
+    const fetchMock = vi.fn(
+      async (_input: Parameters<typeof fetch>[0], _init?: RequestInit) =>
+        new Response(null, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+    const timeoutSignal = new AbortController().signal;
+    const timeout = vi
+      .spyOn(AbortSignal, "timeout")
+      .mockReturnValue(timeoutSignal);
+    const storage = new Uint8Array([9, 1, 2, 3, 8]);
+    const body = storage.subarray(1, 4);
+    const exportRequest = request(AGENTA_ENDPOINT, () => credential, body);
+
+    credential = "Secret refreshed";
+    await exportOtlpBytes(exportRequest);
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const [url, init] = fetchMock.mock.calls[0]!;
+    expect(init).toBeDefined();
+    expect(url).toBe(AGENTA_ENDPOINT);
+    expect(init).toMatchObject({
+      method: "POST",
+      redirect: "manual",
+      signal: timeoutSignal,
+    });
+    expect(new Headers(init!.headers).get("content-type")).toBe(
+      "application/x-protobuf",
+    );
+    expect(new Headers(init!.headers).get("authorization")).toBe(
+      "Secret refreshed",
+    );
+    expect(Buffer.from(init!.body as Buffer)).toEqual(Buffer.from([1, 2, 3]));
+    expect(timeout).toHaveBeenCalledWith(10_000);
+  });
+
+  it("sends an unauthenticated batch to a third-party collector", async () => {
+    const fetchMock = vi.fn(
+      async (_input: Parameters<typeof fetch>[0], _init?: RequestInit) =>
+        new Response(null, { status: 200 }),
+    );
+    vi.stubGlobal("fetch", fetchMock);
+
+    await exportOtlpBytes(request(THIRD_PARTY_ENDPOINT, () => undefined));
+
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const headers = new Headers(fetchMock.mock.calls[0]?.[1]?.headers);
+    expect(headers.has("authorization")).toBe(false);
+  });
+
+  it("skips Agenta ingest without a credential and diagnoses the resolved value", async () => {
+    const fetchMock = vi.fn();
+    vi.stubGlobal("fetch", fetchMock);
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      exportOtlpBytes(request(AGENTA_ENDPOINT, () => "   ")),
+    ).resolves.toMatchObject({ outcome: "skipped" });
+
+    expect(fetchMock).not.toHaveBeenCalled();
+    const line = log.mock.calls.flat().join(" ");
+    expect(line).toContain("trace export skipped, no credential");
+    expect(line).toContain('"scheme":"none"');
+    expect(line).toContain('"spans":3');
+  });
+
+  it("reports a rejecting endpoint with existing export diagnostics and resolves", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response('{"message":"denied"}', { status: 401 })),
+    );
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      exportOtlpBytes(request(AGENTA_ENDPOINT, () => "ApiKey live-token")),
+    ).resolves.toMatchObject({ outcome: "failed", status: 401 });
+
+    const line = log.mock.calls.flat().join(" ");
+    expect(line).toContain("trace export failed");
+    expect(line).toContain('"status":401');
+    expect(line).toContain('"endpoint":"cloud.agenta.ai"');
+    expect(line).toContain('"scheme":"ApiKey"');
+    expect(line).not.toContain("denied");
+    expect(line).not.toContain("live-token");
+  });
+
+  it("keeps credential-provider and fetch throws best effort", async () => {
+    const fetchMock = vi.fn(async () => {
+      throw new Error("connection refused");
+    });
+    vi.stubGlobal("fetch", fetchMock);
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      exportOtlpBytes(
+        request(THIRD_PARTY_ENDPOINT, () => {
+          throw new Error("credential store unavailable");
+        }),
+      ),
+    ).resolves.toMatchObject({ outcome: "failed" });
+    expect(fetchMock).not.toHaveBeenCalled();
+
+    await expect(
+      exportOtlpBytes(request(THIRD_PARTY_ENDPOINT, () => "Bearer current")),
+    ).resolves.toMatchObject({ outcome: "failed" });
+    expect(fetchMock).toHaveBeenCalledOnce();
+    const lines = log.mock.calls.flat().join(" ");
+    expect(lines).toContain("credential store unavailable");
+    expect(lines).toContain("connection refused");
+    expect(lines).not.toContain("current");
+  });
+});

--- a/services/runner/tests/unit/otel-skills-error.test.ts
+++ b/services/runner/tests/unit/otel-skills-error.test.ts
@@ -210,7 +210,7 @@ describe("otel skills + error tracing", () => {
     expect(agentSpan?.status?.code).toBe(2);
   });
 
-  it("emits a standalone error span when the harness self-instruments (F-030, local Pi)", () => {
+  it("emits one usage-bearing fallback span when a self-instrumenting harness reports no batch", () => {
     const spans = spyTracer();
     const otel = createSandboxAgentOtel({
       harness: "pi",
@@ -220,22 +220,26 @@ describe("otel skills + error tracing", () => {
       traceparent: `00-${"a".repeat(32)}-${"b".repeat(16)}-01`,
     });
     otel.start({ prompt: "hi" });
+    otel.setUsage({ input: 10, output: 5, total: 15, cost: 0.001 });
     // No invoke_agent span exists yet (span-less mode).
     expect(spans.find((s) => s.name === "invoke_agent")).toBeUndefined();
 
-    otel.recordError(
-      "pi_core: model authentication failed — add the project's Anthropic key.",
-      "anthropic",
-    );
+    const message =
+      "pi_core: model authentication failed — add the project's Anthropic key.";
+    otel.recordError(message, "anthropic");
+    otel.recordError(message, "anthropic");
 
-    const errSpan = spans.find((s) => s.name === "agent_error");
-    expect(errSpan).toBeTruthy();
-    expect(errSpan?.attributes["ag.exception.message"]).toContain(
+    const errorSpans = spans.filter((span) => span.name === "agent_error");
+    expect(errorSpans).toHaveLength(1);
+    const errSpan = errorSpans[0];
+    expect(errSpan.attributes["ag.exception.message"]).toContain(
       "model authentication failed",
     );
-    expect(errSpan?.attributes["ag.exception.provider"]).toBe("anthropic");
-    expect(errSpan?.exceptions.length).toBe(1);
-    expect(errSpan?.ended).toBe(true);
+    expect(errSpan.attributes["ag.exception.provider"]).toBe("anthropic");
+    expect(errSpan.attributes["gen_ai.usage.total_tokens"]).toBe(15);
+    expect(errSpan.attributes["gen_ai.usage.cost"]).toBe(0.001);
+    expect(errSpan.exceptions).toHaveLength(1);
+    expect(errSpan.ended).toBe(true);
   });
 
   it("falls back to the init model provider when recordError omits one", () => {

--- a/services/runner/tests/unit/otel-trace-serialization.test.ts
+++ b/services/runner/tests/unit/otel-trace-serialization.test.ts
@@ -1,0 +1,220 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { TraceFlags } from "@opentelemetry/api";
+import { ProtobufTraceSerializer } from "@opentelemetry/otlp-transformer";
+import type { ReadableSpan } from "@opentelemetry/sdk-trace-base";
+
+import {
+  createAgentaOtel,
+  serializeTraceBatch,
+  type SerializedTraceBatch,
+} from "../../src/tracing/otel.ts";
+
+const TRACE_ID = "1".repeat(32);
+
+function readableSpan(
+  name: string,
+  spanId: string,
+  parentSpanId?: string,
+): ReadableSpan {
+  return {
+    name,
+    spanContext: () => ({
+      traceId: TRACE_ID,
+      spanId,
+      traceFlags: TraceFlags.SAMPLED,
+    }),
+    parentSpanContext: parentSpanId
+      ? {
+          traceId: TRACE_ID,
+          spanId: parentSpanId,
+          traceFlags: TraceFlags.SAMPLED,
+        }
+      : undefined,
+  } as unknown as ReadableSpan;
+}
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+describe("Pi OTLP serialization", () => {
+  it("parent-orders the trace before calling the public protobuf serializer", () => {
+    const root = readableSpan("root", "a".repeat(16));
+    const child = readableSpan("child", "b".repeat(16), "a".repeat(16));
+    const grandchild = readableSpan(
+      "grandchild",
+      "c".repeat(16),
+      "b".repeat(16),
+    );
+    const expected = new Uint8Array([10, 20, 30]);
+    const serialize = vi
+      .spyOn(ProtobufTraceSerializer, "serializeRequest")
+      .mockReturnValue(expected);
+
+    const actual = serializeTraceBatch([grandchild, child, root]);
+
+    expect(actual).toBe(expected);
+    expect(
+      serialize.mock.calls[0]?.[0].map((span: ReadableSpan) => span.name),
+    ).toEqual(["root", "child", "grandchild"]);
+  });
+
+  it("lets Pi publish one standard byte batch without using runner network code", async () => {
+    const exported: SerializedTraceBatch[] = [];
+    const otel = createAgentaOtel({
+      captureContent: true,
+      traceparent: `00-${TRACE_ID}-${"2".repeat(16)}-01`,
+      serializedBatchTransport: {
+        export: async (batch) => {
+          exported.push(batch);
+        },
+      },
+    });
+    const handlers: Record<string, (...args: any[]) => Promise<void>> = {};
+    otel.register({
+      on: (name: string, handler: (...args: any[]) => Promise<void>) => {
+        handlers[name] = handler;
+      },
+    } as any);
+
+    await handlers["before_agent_start"]?.({ prompt: "hello" });
+    await handlers["agent_start"]?.({});
+    await handlers["turn_start"]?.({ turnIndex: 0 });
+    await handlers["before_provider_request"]?.(
+      {},
+      { model: { id: "gpt-5", provider: "openai" } },
+    );
+    await handlers["message_end"]?.({
+      message: {
+        role: "assistant",
+        content: [{ type: "text", text: "done" }],
+        usage: { input: 2, output: 1, totalTokens: 3 },
+      },
+    });
+    await handlers["turn_end"]?.({});
+    await handlers["agent_end"]?.({
+      messages: [
+        {
+          role: "assistant",
+          content: [{ type: "text", text: "done" }],
+        },
+      ],
+    });
+    await expect(otel.flush()).resolves.toBeUndefined();
+
+    expect(exported).toHaveLength(1);
+    expect(exported[0]).toMatchObject({
+      traceId: TRACE_ID,
+      spanCount: 3,
+    });
+    expect(exported[0]?.body).toBeInstanceOf(Uint8Array);
+    expect(exported[0]?.body.byteLength).toBeGreaterThan(0);
+  });
+
+  it("keeps a rejected Pi byte transport best effort", async () => {
+    const log = vi.spyOn(console, "error").mockImplementation(() => {});
+    const otel = createAgentaOtel({
+      traceparent: `00-${TRACE_ID}-${"3".repeat(16)}-01`,
+      serializedBatchTransport: {
+        export: async () => {
+          throw new Error("spool unavailable");
+        },
+      },
+    });
+    const handlers: Record<string, (...args: any[]) => Promise<void>> = {};
+    otel.register({
+      on: (name: string, handler: (...args: any[]) => Promise<void>) => {
+        handlers[name] = handler;
+      },
+    } as any);
+
+    await handlers["before_agent_start"]?.({ prompt: "hello" });
+    await handlers["agent_start"]?.({});
+    await handlers["agent_end"]?.({ messages: [] });
+
+    await expect(otel.flush()).resolves.toBeUndefined();
+    expect(log.mock.calls.flat().join(" ")).toContain(
+      "serialized trace transport threw",
+    );
+  });
+
+  it("closes partial child spans before publishing a cancelled Pi agent", async () => {
+    const exported: SerializedTraceBatch[] = [];
+    const otel = createAgentaOtel({
+      traceparent: "00-" + TRACE_ID + "-" + "4".repeat(16) + "-01",
+      serializedBatchTransport: {
+        export: async (batch) => {
+          exported.push(batch);
+        },
+      },
+    });
+    const handlers: Record<string, (...args: any[]) => Promise<void>> = {};
+    otel.register({
+      on: (name: string, handler: (...args: any[]) => Promise<void>) => {
+        handlers[name] = handler;
+      },
+    } as any);
+
+    await handlers["before_agent_start"]?.({ prompt: "cancel me" });
+    await handlers["agent_start"]?.({});
+    await handlers["turn_start"]?.({ turnIndex: 0 });
+    await handlers["before_provider_request"]?.(
+      {},
+      { model: { id: "gpt-5", provider: "openai" } },
+    );
+    await handlers["tool_execution_start"]?.({
+      toolName: "bash",
+      toolCallId: "tool-1",
+      args: { command: "sleep 10" },
+    });
+    await handlers["agent_end"]?.({ messages: [] });
+    await otel.flush();
+
+    expect(exported).toHaveLength(1);
+    expect(exported[0]?.spanCount).toBe(4);
+  });
+
+  it("resets warm-turn tracing policy and usage before handling the next prompt", async () => {
+    const exported: SerializedTraceBatch[] = [];
+    const otel = createAgentaOtel({ enabled: false, captureContent: true });
+    const handlers: Record<string, (...args: any[]) => Promise<void>> = {};
+    otel.register({
+      on: (name: string, handler: (...args: any[]) => Promise<void>) => {
+        handlers[name] = handler;
+      },
+    } as any);
+
+    otel.beginTurn({
+      enabled: true,
+      captureContent: true,
+      serializedBatchTransport: {
+        export: async (batch) => {
+          exported.push(batch);
+        },
+      },
+    });
+    await handlers["before_agent_start"]?.({ prompt: "first" });
+    await handlers["agent_start"]?.({});
+    await handlers["message_end"]?.({
+      message: { role: "assistant", usage: { input: 2, output: 1 } },
+    });
+    await handlers["agent_end"]?.({ messages: [] });
+    await otel.flush();
+    expect(exported).toHaveLength(1);
+    expect(otel.usage()).toMatchObject({ input: 2, output: 1, total: 3 });
+
+    // A missing control disables only tracing. Usage writeback still reflects this turn and
+    // cannot inherit the first turn totals or transport.
+    otel.beginTurn({ enabled: false, captureContent: true });
+    await handlers["before_agent_start"]?.({ prompt: "second" });
+    await handlers["message_end"]?.({
+      message: { role: "assistant", usage: { input: 5, output: 4 } },
+    });
+    await handlers["agent_end"]?.({ messages: [] });
+    await otel.flush();
+
+    expect(exported).toHaveLength(1);
+    expect(otel.usage()).toMatchObject({ input: 5, output: 4, total: 9 });
+    expect(otel.config.serializedBatchTransport).toBeUndefined();
+  });
+});

--- a/services/runner/tests/unit/pi-file-exporter.test.ts
+++ b/services/runner/tests/unit/pi-file-exporter.test.ts
@@ -1,10 +1,12 @@
 import {
   existsSync,
+  mkdirSync,
   mkdtempSync,
   readFileSync,
   readdirSync,
   rmSync,
   statSync,
+  writeFileSync,
 } from "node:fs";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
@@ -38,6 +40,41 @@ describe("createPiFileSpanExporter", () => {
     expect([...readFileSync(path)]).toEqual([0, 255, 7]);
     expect(statSync(path).mode & 0o777).toBe(0o600);
     expect(readdirSync(directory)).toEqual([piTraceFileName(channelId, 0)]);
+  });
+
+  it("reuses the same sequence after a failed publication", async () => {
+    const root = mkdtempSync(join(tmpdir(), "agenta-pi-traces-retry-"));
+    dirs.push(root);
+    const directory = join(root, "telemetry");
+    writeFileSync(directory, "blocks mkdir");
+    const logs: string[] = [];
+    const channelId = "e".repeat(32);
+    const exporter = createPiFileSpanExporter({
+      directory,
+      channelId,
+      maxFiles: 1,
+      log: (message) => logs.push(message),
+    });
+
+    await exporter.export({
+      body: Uint8Array.from([1]),
+      traceId: "f".repeat(32),
+      spanCount: 1,
+    });
+    rmSync(directory, { force: true });
+    mkdirSync(directory);
+    await exporter.export({
+      body: Uint8Array.from([2]),
+      traceId: "f".repeat(32),
+      spanCount: 1,
+    });
+
+    expect(readdirSync(directory)).toEqual([piTraceFileName(channelId, 0)]);
+    expect([
+      ...readFileSync(join(directory, piTraceFileName(channelId, 0))),
+    ]).toEqual([2]);
+    expect(logs.filter((line) => line.includes("sequence=0"))).toHaveLength(2);
+    expect(logs.some((line) => line.includes("reason=file_limit"))).toBe(false);
   });
 
   it("drops oversized and over-limit batches without exposing partial files", async () => {

--- a/services/runner/tests/unit/pi-file-exporter.test.ts
+++ b/services/runner/tests/unit/pi-file-exporter.test.ts
@@ -1,0 +1,77 @@
+import {
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  readdirSync,
+  rmSync,
+  statSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import { createPiFileSpanExporter } from "../../src/tracing/pi-file-exporter.ts";
+import { piTraceFileName } from "../../src/tracing/pi-spool-protocol.ts";
+
+const dirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of dirs.splice(0))
+    rmSync(dir, { recursive: true, force: true });
+});
+
+describe("createPiFileSpanExporter", () => {
+  it("publishes exact bytes under a bounded numeric sequence with no temp residue", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "agenta-pi-traces-"));
+    dirs.push(directory);
+    const channelId = "a".repeat(32);
+    const exporter = createPiFileSpanExporter({ directory, channelId });
+
+    await exporter.export({
+      body: Uint8Array.from([0, 255, 7]),
+      traceId: "b".repeat(32),
+      spanCount: 3,
+    });
+
+    const path = join(directory, piTraceFileName(channelId, 0));
+    expect(existsSync(path)).toBe(true);
+    expect([...readFileSync(path)]).toEqual([0, 255, 7]);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect(readdirSync(directory)).toEqual([piTraceFileName(channelId, 0)]);
+  });
+
+  it("drops oversized and over-limit batches without exposing partial files", async () => {
+    const directory = mkdtempSync(join(tmpdir(), "agenta-pi-traces-"));
+    dirs.push(directory);
+    const logs: string[] = [];
+    const exporter = createPiFileSpanExporter({
+      directory,
+      channelId: "c".repeat(32),
+      maxBatchBytes: 2,
+      maxFiles: 1,
+      log: (message) => logs.push(message),
+    });
+
+    await exporter.export({
+      body: Uint8Array.from([1, 2, 3]),
+      traceId: "d".repeat(32),
+      spanCount: 1,
+    });
+    await exporter.export({
+      body: Uint8Array.from([4]),
+      traceId: "d".repeat(32),
+      spanCount: 1,
+    });
+    await exporter.export({
+      body: Uint8Array.from([5]),
+      traceId: "d".repeat(32),
+      spanCount: 1,
+    });
+
+    expect(readdirSync(directory)).toEqual([
+      piTraceFileName("c".repeat(32), 0),
+    ]);
+    expect(logs.some((line) => line.includes("reason=oversized"))).toBe(true);
+    expect(logs.some((line) => line.includes("reason=file_limit"))).toBe(true);
+  });
+});

--- a/services/runner/tests/unit/pi-spool-consumer.test.ts
+++ b/services/runner/tests/unit/pi-spool-consumer.test.ts
@@ -1,0 +1,359 @@
+import { basename, dirname, join } from "node:path";
+import { describe, expect, it } from "vitest";
+
+import {
+  PI_TRACE_CONTROL_FILE,
+  piTraceFileName,
+} from "../../src/tracing/pi-spool-protocol.ts";
+import {
+  createPiTraceSpoolConsumer,
+  sweepPiTraceSpoolFiles,
+  type PiTraceSpoolBatch,
+} from "../../src/tracing/pi-spool-consumer.ts";
+import type { TelemetryFileHost } from "../../src/tracing/telemetry-file-host.ts";
+
+const DIR = "/runtime/telemetry/conversation";
+const CHANNEL = "0123456789abcdef0123456789abcdef";
+const OTHER_CHANNEL = "fedcba9876543210fedcba9876543210";
+
+function bytes(...values: number[]): Uint8Array {
+  return Uint8Array.from(values);
+}
+
+function memoryHost() {
+  const files = new Map<string, Uint8Array>();
+  const statSizes = new Map<string, number>();
+  const operations: string[] = [];
+  let listFailures = 0;
+
+  const host: TelemetryFileHost = {
+    mkdir: async (path) => {
+      operations.push(`mkdir:${path}`);
+    },
+    list: async (dir) => {
+      operations.push(`list:${dir}`);
+      if (listFailures > 0) {
+        listFailures -= 1;
+        throw new Error("transient list failure");
+      }
+      return [...files.keys()]
+        .filter((path) => dirname(path) === dir)
+        .map((path) => basename(path));
+    },
+    statSize: async (path) => {
+      operations.push(`stat:${path}`);
+      return statSizes.get(path) ?? files.get(path)?.byteLength;
+    },
+    readBytes: async (path) => {
+      operations.push(`read:${path}`);
+      const value = files.get(path);
+      if (!value) throw new Error("missing");
+      return value;
+    },
+    writeBytes: async (path, contents) => {
+      operations.push(`write:${path}`);
+      files.set(
+        path,
+        typeof contents === "string"
+          ? new TextEncoder().encode(contents)
+          : Uint8Array.from(contents),
+      );
+    },
+    rename: async (from, to) => {
+      operations.push(`rename:${from}:${to}`);
+      const value = files.get(from);
+      if (!value) throw new Error("missing temp");
+      files.set(to, value);
+      files.delete(from);
+    },
+    remove: async (path) => {
+      operations.push(`remove:${path}`);
+      if (!files.delete(path)) throw new Error("missing");
+    },
+  };
+
+  return {
+    host,
+    files,
+    statSizes,
+    operations,
+    failLists(count: number) {
+      listFailures = count;
+    },
+  };
+}
+
+function spoolPath(channel: string, sequence: number): string {
+  return join(DIR, piTraceFileName(channel, sequence));
+}
+
+describe("createPiTraceSpoolConsumer", () => {
+  it("retries and completes the start sweep before atomic control publication", async () => {
+    const memory = memoryHost();
+    const logs: string[] = [];
+    const sleeps: number[] = [];
+    memory.files.set(spoolPath(OTHER_CHANNEL, 0), bytes(1));
+    memory.files.set(join(DIR, `${PI_TRACE_CONTROL_FILE}.tmp.old`), bytes(2));
+    memory.files.set(join(DIR, "unrelated.txt"), bytes(3));
+    memory.failLists(2);
+    const consumer = createPiTraceSpoolConsumer({
+      host: memory.host,
+      dir: DIR,
+      channelId: CHANNEL,
+      onBatch: async () => {},
+      log: (message) => logs.push(message),
+      sleep: async (ms) => {
+        sleeps.push(ms);
+      },
+    });
+
+    await consumer.ready;
+    expect(sleeps).toEqual([25, 25]);
+    expect(memory.files.has(spoolPath(OTHER_CHANNEL, 0))).toBe(false);
+    expect(
+      memory.files.has(join(DIR, `${PI_TRACE_CONTROL_FILE}.tmp.old`)),
+    ).toBe(false);
+    expect(memory.files.has(join(DIR, "unrelated.txt"))).toBe(true);
+    expect(
+      logs.some(
+        (line) => line.includes("phase=start") && line.includes("found=2"),
+      ),
+    ).toBe(true);
+
+    expect(await consumer.publishControl("control")).toBe(true);
+    const writeIndex = memory.operations.findIndex((op) =>
+      op.startsWith("write:"),
+    );
+    const renameIndex = memory.operations.findIndex((op) =>
+      op.startsWith("rename:"),
+    );
+    expect(writeIndex).toBeGreaterThan(-1);
+    expect(renameIndex).toBeGreaterThan(writeIndex);
+    expect(memory.files.has(join(DIR, PI_TRACE_CONTROL_FILE))).toBe(true);
+    expect(
+      [...memory.files.keys()].some((path) =>
+        path.includes("current.control.json.tmp."),
+      ),
+    ).toBe(false);
+  });
+
+  it("drains current-channel files before exporting the bounded batch in parallel", async () => {
+    const memory = memoryHost();
+    const calls: Array<{ sequence: number; bytes: number[] }> = [];
+    let active = 0;
+    let maxActive = 0;
+    const logs: string[] = [];
+    const consumer = createPiTraceSpoolConsumer({
+      host: memory.host,
+      dir: DIR,
+      channelId: CHANNEL,
+      drainTimeoutMs: 0,
+      onBatch: async (batch) => {
+        expect(memory.files.has(batch.path)).toBe(false);
+        active += 1;
+        maxActive = Math.max(maxActive, active);
+        calls.push({ sequence: batch.sequence, bytes: [...batch.bytes] });
+        await Promise.resolve();
+        active -= 1;
+        if (batch.sequence === 2) throw new Error("export unavailable");
+      },
+      log: (message) => logs.push(message),
+    });
+    await consumer.ready;
+    memory.files.set(spoolPath(CHANNEL, 10), bytes(10));
+    memory.files.set(spoolPath(CHANNEL, 2), bytes(2));
+    memory.files.set(join(DIR, `${CHANNEL}.02.otlp.pb`), bytes(22));
+    memory.files.set(spoolPath(CHANNEL, 1), bytes(1));
+    memory.files.set(spoolPath(OTHER_CHANNEL, 0), bytes(99));
+    memory.files.set(`${spoolPath(CHANNEL, 3)}.tmp.partial`, bytes(3));
+
+    const result = await consumer.drain();
+
+    expect(calls).toEqual([
+      { sequence: 1, bytes: [1] },
+      { sequence: 2, bytes: [2] },
+      { sequence: 10, bytes: [10] },
+    ]);
+    expect(maxActive).toBe(3);
+    expect(result).toMatchObject({ pickedUp: 3, forwarded: 2, oversized: 0 });
+    expect(
+      logs.some((line) =>
+        line.includes("stage=pi_trace_spool_export sequence=2"),
+      ),
+    ).toBe(true);
+    for (const sequence of [1, 2, 10]) {
+      const path = spoolPath(CHANNEL, sequence);
+      const stat = memory.operations.indexOf(`stat:${path}`);
+      const read = memory.operations.indexOf(`read:${path}`);
+      const remove = memory.operations.indexOf(`remove:${path}`);
+      expect(stat).toBeLessThan(read);
+      expect(read).toBeLessThan(remove);
+    }
+    expect(memory.files.has(spoolPath(OTHER_CHANNEL, 0))).toBe(true);
+    expect(memory.files.has(`${spoolPath(CHANNEL, 3)}.tmp.partial`)).toBe(true);
+    expect(memory.files.has(join(DIR, `${CHANNEL}.02.otlp.pb`))).toBe(false);
+    expect(
+      logs.some(
+        (line) =>
+          line.includes("sequence=2") && line.includes("duplicate=true"),
+      ),
+    ).toBe(true);
+  });
+
+  it("rejects an oversized stat without reading and rechecks the bytes after reading", async () => {
+    const memory = memoryHost();
+    const forwarded: PiTraceSpoolBatch[] = [];
+    const consumer = createPiTraceSpoolConsumer({
+      host: memory.host,
+      dir: DIR,
+      channelId: CHANNEL,
+      maxBatchBytes: 4,
+      drainTimeoutMs: 0,
+      onBatch: async (batch) => {
+        forwarded.push(batch);
+      },
+    });
+    await consumer.ready;
+    const statOversized = spoolPath(CHANNEL, 0);
+    const grewAfterStat = spoolPath(CHANNEL, 1);
+    memory.files.set(statOversized, bytes(1));
+    memory.statSizes.set(statOversized, 5);
+    memory.files.set(grewAfterStat, bytes(1, 2, 3, 4, 5));
+    memory.statSizes.set(grewAfterStat, 3);
+
+    const result = await consumer.drain();
+
+    expect(result).toMatchObject({ pickedUp: 2, forwarded: 0, oversized: 2 });
+    expect(memory.operations).not.toContain(`read:${statOversized}`);
+    expect(memory.operations).toContain(`read:${grewAfterStat}`);
+    expect(forwarded).toEqual([]);
+    expect(memory.files.has(statOversized)).toBe(false);
+    expect(memory.files.has(grewAfterStat)).toBe(false);
+  });
+
+  it("bounds accepted files and leaves later files for teardown", async () => {
+    const memory = memoryHost();
+    const sequences: number[] = [];
+    const consumer = createPiTraceSpoolConsumer({
+      host: memory.host,
+      dir: DIR,
+      channelId: CHANNEL,
+      maxFiles: 2,
+      drainTimeoutMs: 0,
+      onBatch: async (batch) => {
+        sequences.push(batch.sequence);
+      },
+    });
+    await consumer.ready;
+    for (let sequence = 0; sequence < 4; sequence += 1) {
+      memory.files.set(spoolPath(CHANNEL, sequence), bytes(sequence));
+    }
+
+    const result = await consumer.drain();
+
+    expect(sequences).toEqual([0, 1]);
+    expect(result).toMatchObject({
+      pickedUp: 2,
+      forwarded: 2,
+      limitReached: true,
+    });
+    expect(memory.files.has(spoolPath(CHANNEL, 2))).toBe(true);
+    expect(memory.files.has(spoolPath(CHANNEL, 3))).toBe(true);
+  });
+
+  it("waits within the bounded drain for a late file and reports unread control", async () => {
+    const memory = memoryHost();
+    const logs: string[] = [];
+    const sequences: number[] = [];
+    let clock = 0;
+    let published = false;
+    const consumer = createPiTraceSpoolConsumer({
+      host: memory.host,
+      dir: DIR,
+      channelId: CHANNEL,
+      drainTimeoutMs: 100,
+      pollMs: 25,
+      now: () => clock,
+      sleep: async (ms) => {
+        clock += ms;
+        if (!published) {
+          published = true;
+          memory.files.set(spoolPath(CHANNEL, 0), bytes(7));
+        }
+      },
+      onBatch: async (batch) => {
+        sequences.push(batch.sequence);
+      },
+      log: (message) => logs.push(message),
+    });
+    await consumer.ready;
+    memory.files.set(join(DIR, PI_TRACE_CONTROL_FILE), bytes(1));
+
+    const result = await consumer.drain();
+
+    expect(sequences).toEqual([0]);
+    expect(result.unreadControl).toBe(true);
+    expect(clock).toBe(100);
+    expect(
+      logs.filter((line) => line === "stage=pi_trace_control unread=true"),
+    ).toHaveLength(1);
+  });
+
+  it("teardown sweeps late telemetry residue, preserves unrelated files, and logs leftovers", async () => {
+    const memory = memoryHost();
+    const logs: string[] = [];
+    const consumer = createPiTraceSpoolConsumer({
+      host: memory.host,
+      dir: DIR,
+      channelId: CHANNEL,
+      onBatch: async () => {},
+      log: (message) => logs.push(message),
+    });
+    await consumer.ready;
+    memory.files.set(spoolPath(CHANNEL, 0), bytes(1));
+    memory.files.set(join(DIR, PI_TRACE_CONTROL_FILE), bytes(2));
+    memory.files.set(join(DIR, "keep.me"), bytes(3));
+
+    await consumer.teardown();
+
+    expect(memory.files.has(spoolPath(CHANNEL, 0))).toBe(false);
+    expect(memory.files.has(join(DIR, PI_TRACE_CONTROL_FILE))).toBe(false);
+    expect(memory.files.has(join(DIR, "keep.me"))).toBe(true);
+    expect(
+      logs.some(
+        (line) =>
+          line.includes("phase=teardown") &&
+          line.includes("found=2") &&
+          line.includes("leftovers=0"),
+      ),
+    ).toBe(true);
+    expect(logs).toContain("stage=pi_trace_control unread=true phase=teardown");
+  });
+
+  it("bounds stale cleanup and reports telemetry files left behind", async () => {
+    const memory = memoryHost();
+    const logs: string[] = [];
+    for (let sequence = 0; sequence < 3; sequence += 1) {
+      memory.files.set(spoolPath(CHANNEL, sequence), bytes(sequence));
+    }
+
+    await sweepPiTraceSpoolFiles({
+      host: memory.host,
+      dir: DIR,
+      phase: "teardown",
+      log: (message) => logs.push(message),
+      sleep: async () => {},
+      maxFiles: 1,
+    });
+
+    expect(
+      [...memory.files.keys()].filter((path) => path.endsWith(".otlp.pb")),
+    ).toHaveLength(2);
+    expect(
+      logs.some(
+        (line) =>
+          line.includes("phase=teardown") && line.includes("leftovers=2"),
+      ),
+    ).toBe(true);
+  });
+});

--- a/services/runner/tests/unit/pi-spool-consumer.test.ts
+++ b/services/runner/tests/unit/pi-spool-consumer.test.ts
@@ -175,7 +175,12 @@ describe("createPiTraceSpoolConsumer", () => {
       { sequence: 10, bytes: [10] },
     ]);
     expect(maxActive).toBe(3);
-    expect(result).toMatchObject({ pickedUp: 3, forwarded: 2, oversized: 0 });
+    expect(result).toMatchObject({
+      pickedUp: 3,
+      accepted: 3,
+      exported: 2,
+      oversized: 0,
+    });
     expect(
       logs.some((line) =>
         line.includes("stage=pi_trace_spool_export sequence=2"),
@@ -191,13 +196,11 @@ describe("createPiTraceSpoolConsumer", () => {
     }
     expect(memory.files.has(spoolPath(OTHER_CHANNEL, 0))).toBe(true);
     expect(memory.files.has(`${spoolPath(CHANNEL, 3)}.tmp.partial`)).toBe(true);
-    expect(memory.files.has(join(DIR, `${CHANNEL}.02.otlp.pb`))).toBe(false);
-    expect(
-      logs.some(
-        (line) =>
-          line.includes("sequence=2") && line.includes("duplicate=true"),
-      ),
-    ).toBe(true);
+    const nonCanonical = join(DIR, `${CHANNEL}.02.otlp.pb`);
+    expect(memory.files.has(nonCanonical)).toBe(true);
+    expect(logs.some((line) => line.includes("duplicate=true"))).toBe(false);
+    await consumer.teardown();
+    expect(memory.files.has(nonCanonical)).toBe(false);
   });
 
   it("rejects an oversized stat without reading and rechecks the bytes after reading", async () => {
@@ -223,12 +226,43 @@ describe("createPiTraceSpoolConsumer", () => {
 
     const result = await consumer.drain();
 
-    expect(result).toMatchObject({ pickedUp: 2, forwarded: 0, oversized: 2 });
+    expect(result).toMatchObject({
+      pickedUp: 2,
+      accepted: 0,
+      exported: 0,
+      oversized: 2,
+    });
     expect(memory.operations).not.toContain(`read:${statOversized}`);
     expect(memory.operations).toContain(`read:${grewAfterStat}`);
     expect(forwarded).toEqual([]);
     expect(memory.files.has(statOversized)).toBe(false);
     expect(memory.files.has(grewAfterStat)).toBe(false);
+  });
+
+  it("rejects an empty file before export", async () => {
+    const memory = memoryHost();
+    const forwarded: PiTraceSpoolBatch[] = [];
+    const consumer = createPiTraceSpoolConsumer({
+      host: memory.host,
+      dir: DIR,
+      channelId: CHANNEL,
+      drainTimeoutMs: 0,
+      onBatch: async (batch) => {
+        forwarded.push(batch);
+      },
+    });
+    await consumer.ready;
+    memory.files.set(spoolPath(CHANNEL, 0), bytes());
+
+    const result = await consumer.teardown();
+
+    expect(result).toMatchObject({
+      pickedUp: 1,
+      accepted: 0,
+      exported: 0,
+      empty: 1,
+    });
+    expect(forwarded).toEqual([]);
   });
 
   it("bounds accepted files and leaves later files for teardown", async () => {
@@ -254,7 +288,8 @@ describe("createPiTraceSpoolConsumer", () => {
     expect(sequences).toEqual([0, 1]);
     expect(result).toMatchObject({
       pickedUp: 2,
-      forwarded: 2,
+      accepted: 2,
+      exported: 2,
       limitReached: true,
     });
     expect(memory.files.has(spoolPath(CHANNEL, 2))).toBe(true);
@@ -302,11 +337,15 @@ describe("createPiTraceSpoolConsumer", () => {
   it("teardown sweeps late telemetry residue, preserves unrelated files, and logs leftovers", async () => {
     const memory = memoryHost();
     const logs: string[] = [];
+    const sequences: number[] = [];
     const consumer = createPiTraceSpoolConsumer({
       host: memory.host,
       dir: DIR,
       channelId: CHANNEL,
-      onBatch: async () => {},
+      drainTimeoutMs: 0,
+      onBatch: async (batch) => {
+        sequences.push(batch.sequence);
+      },
       log: (message) => logs.push(message),
     });
     await consumer.ready;
@@ -314,7 +353,9 @@ describe("createPiTraceSpoolConsumer", () => {
     memory.files.set(join(DIR, PI_TRACE_CONTROL_FILE), bytes(2));
     memory.files.set(join(DIR, "keep.me"), bytes(3));
 
-    await consumer.teardown();
+    const result = await consumer.teardown();
+    expect(result).toMatchObject({ accepted: 1, exported: 1 });
+    expect(sequences).toEqual([0]);
 
     expect(memory.files.has(spoolPath(CHANNEL, 0))).toBe(false);
     expect(memory.files.has(join(DIR, PI_TRACE_CONTROL_FILE))).toBe(false);
@@ -323,7 +364,7 @@ describe("createPiTraceSpoolConsumer", () => {
       logs.some(
         (line) =>
           line.includes("phase=teardown") &&
-          line.includes("found=2") &&
+          line.includes("found=1") &&
           line.includes("leftovers=0"),
       ),
     ).toBe(true);

--- a/services/runner/tests/unit/pi-spool-protocol.test.ts
+++ b/services/runner/tests/unit/pi-spool-protocol.test.ts
@@ -1,0 +1,58 @@
+import assert from "node:assert/strict";
+import { describe, it } from "vitest";
+
+import {
+  isPiTraceSpoolFileName,
+  parsePiTurnTraceControl,
+  piTraceFileName,
+} from "../../src/tracing/pi-spool-protocol.ts";
+
+const CHANNEL = "0123456789abcdef0123456789abcdef";
+
+describe("Pi trace spool protocol", () => {
+  it("parses the bounded per-turn control contract", () => {
+    assert.deepEqual(
+      parsePiTurnTraceControl({
+        version: 1,
+        channelId: CHANNEL,
+        turnId: "turn-1",
+        sessionId: "session-1",
+        propagation: { traceparent: "00-a-b-01", baggage: "tenant=x" },
+        capture: { content: false },
+        skills: ["one", 2, "two"],
+        redaction: { knownValues: ["secret-value", null] },
+      }),
+      {
+        version: 1,
+        channelId: CHANNEL,
+        turnId: "turn-1",
+        sessionId: "session-1",
+        propagation: { traceparent: "00-a-b-01", baggage: "tenant=x" },
+        capture: { content: false },
+        skills: ["one", "two"],
+        redaction: { knownValues: ["secret-value"] },
+      },
+    );
+  });
+
+  it("rejects unknown versions and malformed channel ids", () => {
+    assert.throws(
+      () => parsePiTurnTraceControl({ version: 2, channelId: CHANNEL }),
+      /Unsupported Pi trace control version/,
+    );
+    assert.throws(
+      () => parsePiTurnTraceControl({ version: 1, channelId: "../escape" }),
+      /channelId is invalid/,
+    );
+  });
+
+  it("recognizes only owned control, final, and temporary files", () => {
+    const final = piTraceFileName(CHANNEL, 3);
+    assert.equal(final, `${CHANNEL}.3.otlp.pb`);
+    assert.equal(isPiTraceSpoolFileName("current.control.json"), true);
+    assert.equal(isPiTraceSpoolFileName(final), true);
+    assert.equal(isPiTraceSpoolFileName(`${final}.tmp.nonce`), true);
+    assert.equal(isPiTraceSpoolFileName("unrelated.txt"), false);
+    assert.equal(isPiTraceSpoolFileName("../escape.0.otlp.pb"), false);
+  });
+});

--- a/services/runner/tests/unit/pi-trace-turn-export.test.ts
+++ b/services/runner/tests/unit/pi-trace-turn-export.test.ts
@@ -1,0 +1,183 @@
+import { basename, dirname, join } from "node:path";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { Redactor } from "../../src/redaction.ts";
+import { createPiTraceTurnExport } from "../../src/tracing/pi-trace-turn-export.ts";
+import {
+  PI_TRACE_CONTROL_FILE,
+  PI_TRACE_CONTROL_VERSION,
+  piTraceFileName,
+} from "../../src/tracing/pi-spool-protocol.ts";
+import type { TelemetryFileHost } from "../../src/tracing/telemetry-file-host.ts";
+
+const DIR = "/telemetry/session";
+const CHANNEL = "1".repeat(32);
+
+function memoryHost() {
+  const files = new Map<string, Uint8Array>();
+  const host: TelemetryFileHost = {
+    mkdir: async () => {},
+    list: async (dir) =>
+      [...files.keys()]
+        .filter((path) => dirname(path) === dir)
+        .map((path) => basename(path)),
+    statSize: async (path) => files.get(path)?.byteLength,
+    readBytes: async (path) => {
+      const value = files.get(path);
+      if (!value) throw new Error("missing");
+      return value;
+    },
+    writeBytes: async (path, contents) => {
+      files.set(
+        path,
+        typeof contents === "string"
+          ? new TextEncoder().encode(contents)
+          : Uint8Array.from(contents),
+      );
+    },
+    rename: async (from, to) => {
+      const value = files.get(from);
+      if (!value) throw new Error("missing");
+      files.set(to, value);
+      files.delete(from);
+    },
+    remove: async (path) => {
+      if (!files.delete(path)) throw new Error("missing");
+    },
+  };
+  return { files, host };
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+  vi.restoreAllMocks();
+});
+
+describe("createPiTraceTurnExport", () => {
+  it("keeps the bytes standard and resolves the live runner credential at pickup", async () => {
+    const memory = memoryHost();
+    const requests: Array<{ body: number[]; authorization?: string }> = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        requests.push({
+          body: [...(init?.body as Buffer)],
+          authorization: (init?.headers as Record<string, string>)
+            ?.Authorization,
+        });
+        return new Response(null, { status: 200 });
+      }),
+    );
+    let credential = "ApiKey old";
+    const turn = createPiTraceTurnExport({
+      host: memory.host,
+      dir: DIR,
+      channelId: CHANNEL,
+      context: {
+        endpoint: "https://cloud.agenta.ai/api/otlp/v1/traces",
+        authorization: () => credential,
+        authorizationSource: "platform",
+        placement: "local",
+        redactor: new Redactor({ mode: "known" }),
+        traceId: "a".repeat(32),
+      },
+    });
+
+    expect(
+      await turn.publishControl({
+        version: PI_TRACE_CONTROL_VERSION,
+        channelId: CHANNEL,
+        capture: { content: true },
+        skills: [],
+        redaction: { knownValues: [] },
+      }),
+    ).toBe(true);
+    await memory.host.remove(join(DIR, PI_TRACE_CONTROL_FILE));
+    memory.files.set(
+      join(DIR, piTraceFileName(CHANNEL, 0)),
+      Uint8Array.from([10, 0, 255]),
+    );
+    credential = "ApiKey rotated";
+
+    await expect(turn.finish()).resolves.toEqual({ validBatches: 1 });
+    expect(requests).toEqual([
+      { body: [10, 0, 255], authorization: "ApiKey rotated" },
+    ]);
+    expect(memory.files.size).toBe(0);
+  });
+
+  it("keeps an external collector credential static and reports bounded spool diagnostics", async () => {
+    const memory = memoryHost();
+    const authorizations: Array<string | undefined> = [];
+    const logs: string[] = [];
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        authorizations.push(
+          (init?.headers as Record<string, string>)?.Authorization,
+        );
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const turn = createPiTraceTurnExport({
+      host: memory.host,
+      dir: DIR,
+      channelId: CHANNEL,
+      context: {
+        endpoint: "https://collector.example.test/v1/traces",
+        authorization: () => "Bearer collector",
+        authorizationSource: "exporter",
+        placement: "daytona",
+        turnId: "turn-1",
+        redactor: new Redactor({ mode: "known" }),
+        traceId: "b".repeat(32),
+      },
+      log: (message) => logs.push(message),
+    });
+    await turn.publishControl({
+      version: PI_TRACE_CONTROL_VERSION,
+      channelId: CHANNEL,
+      capture: { content: true },
+      skills: [],
+      redaction: { knownValues: [] },
+    });
+    await memory.host.remove(join(DIR, PI_TRACE_CONTROL_FILE));
+    memory.files.set(
+      join(DIR, piTraceFileName(CHANNEL, 0)),
+      Uint8Array.from([1, 2, 3]),
+    );
+
+    turn.updatePlatformAuthorization(() => "Secret platform");
+    await turn.finish();
+
+    expect(authorizations).toEqual(["Bearer collector"]);
+    expect(logs.join("\n")).toContain("source=pi-spool placement=daytona");
+    expect(logs.join("\n")).toContain("bytes=3");
+  });
+
+  it("exposes the original trace id and emits a missing-batch fallback once", async () => {
+    const fallback: string[] = [];
+    const turn = createPiTraceTurnExport({
+      host: memoryHost().host,
+      dir: DIR,
+      channelId: CHANNEL,
+      context: {
+        endpoint: "https://cloud.agenta.ai/api/otlp/v1/traces",
+        authorization: () => "Secret current",
+        authorizationSource: "platform",
+        placement: "local",
+        redactor: new Redactor({ mode: "known" }),
+        traceId: "c".repeat(32),
+        onMissingBatch: async (message) => {
+          fallback.push(message);
+        },
+      },
+    });
+
+    expect(turn.traceId()).toBe("c".repeat(32));
+    await turn.emitMissingBatchFallback("missing");
+    await turn.emitMissingBatchFallback("duplicate");
+    expect(fallback).toEqual(["missing"]);
+    await turn.teardown();
+  });
+});

--- a/services/runner/tests/unit/pi-trace-turn-export.test.ts
+++ b/services/runner/tests/unit/pi-trace-turn-export.test.ts
@@ -165,11 +165,13 @@ describe("createPiTraceTurnExport", () => {
     expect(logs.join("\n")).toContain("bytes=3");
   });
 
-  it("counts a valid pickup separately from a rejected HTTP export", async () => {
+  it("counts a canonical malformed body as picked up when ingest rejects it", async () => {
     const memory = memoryHost();
+    const logs: string[] = [];
+    const fallback: string[] = [];
     vi.stubGlobal(
       "fetch",
-      vi.fn(async () => new Response(null, { status: 401 })),
+      vi.fn(async () => new Response(null, { status: 400 })),
     );
     const turn = createPiTraceTurnExport({
       host: memory.host,
@@ -181,7 +183,11 @@ describe("createPiTraceTurnExport", () => {
         authorizationSource: "platform",
         placement: "local",
         redactor: new Redactor({ mode: "known" }),
+        onMissingBatch: async (message) => {
+          fallback.push(message);
+        },
       },
+      log: (message) => logs.push(message),
     });
     await turn.publishControl({
       version: PI_TRACE_CONTROL_VERSION,
@@ -193,13 +199,20 @@ describe("createPiTraceTurnExport", () => {
     await memory.host.remove(join(DIR, PI_TRACE_CONTROL_FILE));
     memory.files.set(
       join(DIR, piTraceFileName(CHANNEL, 0)),
-      Uint8Array.from([1]),
+      // A length-delimited protobuf field with no length byte is intentionally malformed.
+      Uint8Array.from([0x0a]),
     );
 
-    await expect(turn.finish()).resolves.toEqual({
+    const result = await turn.finish();
+    expect(result).toEqual({
       pickedUpBatches: 1,
       exportedBatches: 0,
     });
+    if (result.pickedUpBatches === 0) {
+      await turn.emitMissingBatchFallback("missing");
+    }
+    expect(fallback).toEqual([]);
+    expect(logs.join("\n")).toContain("outcome=failed status=400");
   });
 
   it("exposes the original trace id and emits a missing-batch fallback once", async () => {

--- a/services/runner/tests/unit/pi-trace-turn-export.test.ts
+++ b/services/runner/tests/unit/pi-trace-turn-export.test.ts
@@ -99,7 +99,17 @@ describe("createPiTraceTurnExport", () => {
     );
     credential = "ApiKey rotated";
 
-    await expect(turn.finish()).resolves.toEqual({ validBatches: 1 });
+    const firstFinish = turn.finish();
+    const secondFinish = turn.finish();
+    await expect(firstFinish).resolves.toEqual({
+      pickedUpBatches: 1,
+      exportedBatches: 1,
+    });
+    await expect(secondFinish).resolves.toEqual({
+      pickedUpBatches: 1,
+      exportedBatches: 1,
+    });
+    await turn.teardown();
     expect(requests).toEqual([
       { body: [10, 0, 255], authorization: "ApiKey rotated" },
     ]);
@@ -153,6 +163,43 @@ describe("createPiTraceTurnExport", () => {
     expect(authorizations).toEqual(["Bearer collector"]);
     expect(logs.join("\n")).toContain("source=pi-spool placement=daytona");
     expect(logs.join("\n")).toContain("bytes=3");
+  });
+
+  it("counts a valid pickup separately from a rejected HTTP export", async () => {
+    const memory = memoryHost();
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async () => new Response(null, { status: 401 })),
+    );
+    const turn = createPiTraceTurnExport({
+      host: memory.host,
+      dir: DIR,
+      channelId: CHANNEL,
+      context: {
+        endpoint: "https://cloud.agenta.ai/api/otlp/v1/traces",
+        authorization: () => "Secret current",
+        authorizationSource: "platform",
+        placement: "local",
+        redactor: new Redactor({ mode: "known" }),
+      },
+    });
+    await turn.publishControl({
+      version: PI_TRACE_CONTROL_VERSION,
+      channelId: CHANNEL,
+      capture: { content: true },
+      skills: [],
+      redaction: { knownValues: [] },
+    });
+    await memory.host.remove(join(DIR, PI_TRACE_CONTROL_FILE));
+    memory.files.set(
+      join(DIR, piTraceFileName(CHANNEL, 0)),
+      Uint8Array.from([1]),
+    );
+
+    await expect(turn.finish()).resolves.toEqual({
+      pickedUpBatches: 1,
+      exportedBatches: 0,
+    });
   });
 
   it("exposes the original trace id and emits a missing-batch fallback once", async () => {

--- a/services/runner/tests/unit/redaction-sinks.test.ts
+++ b/services/runner/tests/unit/redaction-sinks.test.ts
@@ -14,7 +14,11 @@ import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-proto";
 import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
 import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
 
-import { seedForRun } from "../../src/redaction.ts";
+import {
+  Redactor,
+  sandboxVisibleSecretValues,
+  seedForRun,
+} from "../../src/redaction.ts";
 import { buildPersistingEmitter } from "../../src/sessions/persist.ts";
 import { createSandboxAgentOtel } from "../../src/tracing/otel.ts";
 
@@ -24,6 +28,12 @@ const PER_RUN_KEY = "sk-per-run-fake-key-DO-NOT-USE-a1b2c3d4e5f6";
 const MCP_HEADER_KEY = "Bearer mcp-per-run-fake-DO-NOT-USE-f6e5d4";
 /** The invoke caller's credential, which rides the OTLP auth header. */
 const RUN_CREDENTIAL = "ApiKey ag-run-cred-9f8e7d6c5b4a";
+const MOUNT_ACCESS_KEY = "mount-access-key-a1b2c3d4";
+const MOUNT_SECRET_KEY = "mount-secret-placeholder-placeholder";
+const MOUNT_SESSION_TOKEN = "mount-session-token-i9j0k1l2";
+const AGENT_MOUNT_ACCESS_KEY = "agent-mount-access-key-m3n4o5p6";
+const AGENT_MOUNT_SECRET_KEY = "agent-mount-secret-key-q7r8s9t0";
+const AGENT_MOUNT_SESSION_TOKEN = "agent-mount-session-token-u1v2w3x4";
 
 /** A request carrying this run's resolved typed credentials + run credential. */
 const runRequest = {
@@ -77,6 +87,7 @@ beforeEach(() => {
 
 afterEach(() => {
   vi.restoreAllMocks();
+  vi.unstubAllEnvs();
 });
 
 /** The shared base prototype real exporters inherit `export` from (see otel-flush-export.test). */
@@ -139,6 +150,47 @@ describe("seedForRun (WP1.1 — the deny-set source)", () => {
     expect(
       redactor.redactString(`header was ${MCP_HEADER_KEY}`, "test"),
     ).not.toContain(MCP_HEADER_KEY);
+  });
+});
+
+describe("sandbox-visible redaction inputs", () => {
+  it("returns all three credentials from both mount sets", () => {
+    const values = sandboxVisibleSecretValues({
+      mountCreds: {
+        accessKey: MOUNT_ACCESS_KEY,
+        secretKey: MOUNT_SECRET_KEY,
+        sessionToken: MOUNT_SESSION_TOKEN,
+      },
+      agentMountCreds: {
+        accessKey: AGENT_MOUNT_ACCESS_KEY,
+        secretKey: AGENT_MOUNT_SECRET_KEY,
+        sessionToken: AGENT_MOUNT_SESSION_TOKEN,
+      },
+    });
+
+    expect(values).toEqual([
+      MOUNT_ACCESS_KEY,
+      MOUNT_SECRET_KEY,
+      MOUNT_SESSION_TOKEN,
+      AGENT_MOUNT_ACCESS_KEY,
+      AGENT_MOUNT_SECRET_KEY,
+      AGENT_MOUNT_SESSION_TOKEN,
+    ]);
+  });
+
+  it("forces known-value redaction even when the process-wide mode is off", () => {
+    vi.stubEnv("AGENTA_REDACTION_MODE", "off");
+    const inherited = new Redactor().withKnownSecrets([MOUNT_SECRET_KEY]);
+    const alwaysOn = new Redactor({ mode: "known" }).withKnownSecrets([
+      MOUNT_SECRET_KEY,
+    ]);
+
+    expect(
+      inherited.redactString(`credential=${MOUNT_SECRET_KEY}`, "test"),
+    ).toContain(MOUNT_SECRET_KEY);
+    expect(
+      alwaysOn.redactString(`credential=${MOUNT_SECRET_KEY}`, "test"),
+    ).not.toContain(MOUNT_SECRET_KEY);
   });
 });
 
@@ -322,7 +374,9 @@ describe("exported span sink (WP1.5)", () => {
     const agentSpan = exported.find((s) => s.name === "invoke_agent");
     expect(agentSpan).toBeTruthy();
 
-    const eventAttrs = JSON.stringify(agentSpan!.events.map((e) => e.attributes));
+    const eventAttrs = JSON.stringify(
+      agentSpan!.events.map((e) => e.attributes),
+    );
     expect(eventAttrs).not.toContain(PER_RUN_KEY);
     expect(eventAttrs).toContain("[ag:redacted");
 
@@ -375,7 +429,11 @@ describe("exported span sink (WP1.5)", () => {
 
     expect(exported.length).toBeGreaterThanOrEqual(2);
     const allText = JSON.stringify(
-      exported.map((s) => ({ attrs: s.attributes, events: s.events, status: s.status })),
+      exported.map((s) => ({
+        attrs: s.attributes,
+        events: s.events,
+        status: s.status,
+      })),
     );
     expect(allText).not.toContain(SECRET_A);
     expect(allText).not.toContain(SECRET_B);

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -31,6 +31,7 @@ import {
 } from "../../src/tracing/pi-spool-protocol.ts";
 import { PendingApprovalPauseController } from "../../src/engines/sandbox_agent/pause.ts";
 import {
+  platformCredentialForRequest,
   resolveRunOtlpTarget,
   shouldSuppressPausedToolCallUpdate,
 } from "../../src/engines/sandbox_agent/runtime-policy.ts";
@@ -439,6 +440,84 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(typeof calls.otelOptions.authorization, "function");
     authorization = "Secret refreshed";
     assert.equal(calls.otelOptions.authorization(), "Secret refreshed");
+  });
+
+  it("refreshes a standalone Agenta credential while a long turn is active", async () => {
+    vi.useFakeTimers();
+    try {
+      vi.stubEnv("AGENTA_API_URL", "https://api.agenta.test/api");
+      vi.stubEnv("AGENTA_RUNNER_RUN_TTFB_TIMEOUT_MS", "900000");
+      vi.stubEnv("AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS", "900000");
+      vi.stubEnv("AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS", "900000");
+      resetRunnerConfigCache();
+      const refreshRequests: Array<{ url: string; authorization: string }> = [];
+      vi.stubGlobal(
+        "fetch",
+        async (url: string | URL | Request, init?: RequestInit) => {
+          const renderedUrl = String(url);
+          refreshRequests.push({
+            url: renderedUrl,
+            authorization: String(
+              (init?.headers as Record<string, string> | undefined)
+                ?.authorization ?? "",
+            ),
+          });
+          return new Response(
+            JSON.stringify({ credentials: "Secret refreshed" }),
+            { status: 200 },
+          );
+        },
+      );
+      const request: AgentRunRequest = {
+        harness: "claude",
+        messages: [{ role: "user", content: "hello" }],
+        telemetry: {
+          exporters: {
+            otlp: {
+              endpoint: "https://api.agenta.test/api/otlp/v1/traces",
+              headers: { authorization: "Secret initial" },
+            },
+          },
+        },
+      };
+      const { calls, deps } = fakeHarness({
+        afterPromptEvents: async () => {
+          await vi.advanceTimersByTimeAsync(5 * 60 * 1_000);
+        },
+      });
+
+      const result = await runSandboxAgent(request, undefined, undefined, deps);
+
+      assert.equal(result.ok, true, JSON.stringify(result));
+      assert.equal(platformCredentialForRequest(request), "Secret initial");
+      assert.equal(calls.otelOptions.authorization(), "Secret refreshed");
+      assert.deepEqual(refreshRequests, [
+        {
+          url: "https://api.agenta.test/api/access/permissions/check?action=run_service&resource_type=service",
+          authorization: "Secret initial",
+        },
+      ]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("never treats a third-party collector header as a platform credential", () => {
+    assert.equal(
+      platformCredentialForRequest({
+        harness: "claude",
+        messages: [{ role: "user", content: "hello" }],
+        telemetry: {
+          exporters: {
+            otlp: {
+              endpoint: "https://collector.example.test/v1/traces",
+              headers: { authorization: "Bearer collector-secret" },
+            },
+          },
+        },
+      }),
+      "",
+    );
   });
 
   it("keeps platform rotation away from third-party collector credentials", () => {
@@ -2234,7 +2313,8 @@ describe("runSandboxAgent orchestration", () => {
       assert.equal(result.ok, true);
       assert.deepEqual(fixture.calls.recordedErrors, [
         {
-          message: "Pi did not publish a valid trace batch before the turn ended",
+          message:
+            "Pi did not publish a valid trace batch before the turn ended",
           provider: undefined,
         },
       ]);

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -2216,6 +2216,60 @@ describe("runSandboxAgent orchestration", () => {
     }
   });
 
+  it("keeps a successful Pi turn successful when no native trace batch arrives", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-missing-trace-"));
+    const fixture = fakeHarness({ cwd });
+
+    try {
+      const result = await runSandboxAgent(
+        {
+          harness: "pi_core",
+          messages: [{ role: "user", content: "hello" }],
+        },
+        undefined,
+        undefined,
+        fixture.deps,
+      );
+
+      assert.equal(result.ok, true);
+      assert.deepEqual(fixture.calls.recordedErrors, []);
+      assert.match(
+        fixture.logs.join("\n"),
+        /stage=pi_trace_missing_batch diagnostic=true/,
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
+  it("preserves a failed Pi turn's agent error when no native trace batch arrives", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-failed-trace-"));
+    const fixture = fakeHarness({ cwd, promptError: new Error("boom") });
+
+    try {
+      const result = await runSandboxAgent(
+        {
+          harness: "pi_core",
+          messages: [{ role: "user", content: "fail" }],
+        },
+        undefined,
+        undefined,
+        fixture.deps,
+      );
+
+      assert.deepEqual(result, { ok: false, error: "boom" });
+      assert.deepEqual(fixture.calls.recordedErrors, [
+        { message: "boom", provider: undefined },
+      ]);
+      assert.match(
+        fixture.logs.join("\n"),
+        /stage=pi_trace_missing_batch diagnostic=true/,
+      );
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("clears inherited provider env on a managed run and applies ANTHROPIC_BASE_URL for claude", async () => {
     const { calls, deps } = fakeHarness();
 

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -13,6 +13,7 @@ import {
   lstatSync,
   mkdirSync,
   mkdtempSync,
+  readFileSync,
   readlinkSync,
   rmSync,
   writeFileSync,
@@ -24,8 +25,15 @@ import {
   createSandboxAgentOtel,
   TOOL_NOT_EXECUTED_PAUSED,
 } from "../../src/tracing/otel.ts";
+import {
+  PI_TRACE_CONTROL_FILE,
+  piTraceFileName,
+} from "../../src/tracing/pi-spool-protocol.ts";
 import { PendingApprovalPauseController } from "../../src/engines/sandbox_agent/pause.ts";
-import { shouldSuppressPausedToolCallUpdate } from "../../src/engines/sandbox_agent/runtime-policy.ts";
+import {
+  resolveRunOtlpTarget,
+  shouldSuppressPausedToolCallUpdate,
+} from "../../src/engines/sandbox_agent/runtime-policy.ts";
 import { mountStorage } from "../../src/engines/sandbox_agent/mount.ts";
 import { buildPiGateEnvelope } from "../../src/engines/sandbox_agent/pi-gate-envelope.ts";
 import { appendPlatformGuidance } from "../../src/engines/sandbox_agent/system-prompt-appendix.ts";
@@ -82,6 +90,7 @@ interface FakeOptions {
   // stand in for a wedged harness that a run-limits deadline (which aborts `startOptions.signal`)
   // must be able to unstick.
   abortSignalCancelsHungPrompt?: boolean;
+  afterDestroySession?: () => Promise<void> | void;
 }
 
 function fakeHarness(options: FakeOptions = {}) {
@@ -190,6 +199,7 @@ function fakeHarness(options: FakeOptions = {}) {
       calls.sessionDestroyed += 1;
       void id;
       if (options.destroySessionError) throw options.destroySessionError;
+      await options.afterDestroySession?.();
       // Managed cancel: resolve any in-flight prompt with a cancelled stop reason (the runner
       // races this against the park signal, so the turn ends either way). Mirrors the package.
       resolveHungPrompt?.({ stopReason: "cancelled" });
@@ -431,6 +441,47 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(calls.otelOptions.authorization(), "Secret refreshed");
   });
 
+  it("keeps platform rotation away from third-party collector credentials", () => {
+    vi.stubEnv("AGENTA_API_URL", "https://api.agenta.test/api");
+    let live = "Secret initial";
+    const platform = resolveRunOtlpTarget(
+      {
+        harness: "claude",
+        messages: [{ role: "user", content: "hello" }],
+        telemetry: {
+          exporters: {
+            otlp: {
+              endpoint: "https://api.agenta.test/api/otlp/v1/traces",
+              headers: { authorization: "Secret initial" },
+            },
+          },
+        },
+      },
+      () => live,
+    );
+    const collector = resolveRunOtlpTarget(
+      {
+        harness: "claude",
+        messages: [{ role: "user", content: "hello" }],
+        telemetry: {
+          exporters: {
+            otlp: {
+              endpoint: "https://collector.example.test/v1/traces",
+              headers: { authorization: "Bearer collector-secret" },
+            },
+          },
+        },
+      },
+      () => live,
+    );
+
+    live = "Secret refreshed";
+    assert.equal(platform.authorizationSource, "platform");
+    assert.equal(platform.authorization(), "Secret refreshed");
+    assert.equal(collector.authorizationSource, "exporter");
+    assert.equal(collector.authorization(), "Bearer collector-secret");
+  });
+
   it("delivers the current legacy inline image before one text block", async () => {
     const { calls, deps } = fakeHarness({ capabilities: { images: true } });
 
@@ -480,10 +531,9 @@ describe("runSandboxAgent orchestration", () => {
     );
 
     assert.equal(result.ok, true);
-    assert.deepEqual(
-      calls.promptBlocks,
-      [{ type: "image", data: "AQID", mimeType: "image/png" }],
-    );
+    assert.deepEqual(calls.promptBlocks, [
+      { type: "image", data: "AQID", mimeType: "image/png" },
+    ]);
     assert.ok(calls.promptBlocks.length > 0);
     assert.deepEqual(
       logs.filter((message) => message.includes("legacy inline image")),
@@ -993,15 +1043,15 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "codex",
-      customTools: [
-        {
-          name: "commit_revision",
-          kind: "callback",
-          callRef: "tools.agenta.commit_revision",
-          permission: "ask",
-          readOnly: false,
-        },
-      ] as never,
+        customTools: [
+          {
+            name: "commit_revision",
+            kind: "callback",
+            callRef: "tools.agenta.commit_revision",
+            permission: "ask",
+            readOnly: false,
+          },
+        ] as never,
         agentsMd: "Be terse.",
         messages: [{ role: "user", content: "hello" }],
       } as AgentRunRequest,
@@ -1034,15 +1084,15 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "codex",
-      customTools: [
-        {
-          name: "commit_revision",
-          kind: "callback",
-          callRef: "tools.agenta.commit_revision",
-          permission: "ask",
-          readOnly: false,
-        },
-      ] as never,
+        customTools: [
+          {
+            name: "commit_revision",
+            kind: "callback",
+            callRef: "tools.agenta.commit_revision",
+            permission: "ask",
+            readOnly: false,
+          },
+        ] as never,
         messages: [{ role: "user", content: "hello" }],
       } as AgentRunRequest,
       undefined,
@@ -1085,15 +1135,15 @@ describe("runSandboxAgent orchestration", () => {
     const result = await runSandboxAgent(
       {
         harness: "pi_core",
-      customTools: [
-        {
-          name: "commit_revision",
-          kind: "callback",
-          callRef: "tools.agenta.commit_revision",
-          permission: "ask",
-          readOnly: false,
-        },
-      ] as never,
+        customTools: [
+          {
+            name: "commit_revision",
+            kind: "callback",
+            callRef: "tools.agenta.commit_revision",
+            permission: "ask",
+            readOnly: false,
+          },
+        ] as never,
         agentsMd: "Be terse.",
         runContext: { workflow: { artifact: { id: "artifact-1" } } },
         telemetry: {
@@ -1109,8 +1159,14 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(result.ok, true);
     const file: string = calls.workspacePlan.prompt.agentsMd;
     // The append prompt DID get it, which is what makes the file's silence meaningful.
-    assert.match(calls.workspacePlan.prompt.appendSystemPrompt, /agent-files\//);
-    assert.ok(file.includes("parameters.agent.skills"), "the skill sentence still lands");
+    assert.match(
+      calls.workspacePlan.prompt.appendSystemPrompt,
+      /agent-files\//,
+    );
+    assert.ok(
+      file.includes("parameters.agent.skills"),
+      "the skill sentence still lands",
+    );
     assert.ok(
       !file.includes("agent-files/"),
       "the mount paragraph must not appear in the file as well",
@@ -1769,7 +1825,9 @@ describe("runSandboxAgent orchestration", () => {
     // The relay carries execution only (no permissions argument). The request sent no
     // runContext, but the runner augments its dispatch copy with the live session id so
     // $ctx.session.id bindings resolve (RunContext.session is runner-filled).
-    assert.deepEqual(calls.toolRelayArgs?.[4], { session: { id: "session-1" } });
+    assert.deepEqual(calls.toolRelayArgs?.[4], {
+      session: { id: "session-1" },
+    });
     // Trailing arg is the relay callbacks object (client-tool + park handlers).
     assert.deepEqual(
       Object.keys((calls.toolRelayArgs?.[5] ?? {}) as object).sort(),
@@ -1818,8 +1876,7 @@ describe("runSandboxAgent orchestration", () => {
       piGuard(request.customTools?.[0], relayRequest),
       {
         allow: false,
-        reason:
-          declinedByUserText("server_tool"),
+        reason: declinedByUserText("server_tool"),
       },
       "Pi ask without a grant fails closed",
     );
@@ -2065,6 +2122,66 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(calls.startOptions.signal.aborted, true);
   });
 
+  it("cancels Pi before draining so agent_end's native batch is exported", async () => {
+    const cwd = mkdtempSync(join(tmpdir(), "pi-cancel-trace-"));
+    let callsRef: ReturnType<typeof fakeHarness>["calls"] | undefined;
+    const exported: number[][] = [];
+    const fixture = fakeHarness({
+      cwd,
+      hangPrompt: true,
+      abortSignalCancelsHungPrompt: true,
+      afterDestroySession: async () => {
+        const telemetryDir = callsRef?.workspacePlan?.workspace.telemetryDir;
+        assert.equal(typeof telemetryDir, "string");
+        const control = JSON.parse(
+          readFileSync(join(telemetryDir, PI_TRACE_CONTROL_FILE), "utf8"),
+        ) as { channelId: string };
+        writeFileSync(
+          join(telemetryDir, piTraceFileName(control.channelId, 0)),
+          Buffer.from([10, 0, 255]),
+        );
+      },
+    });
+    callsRef = fixture.calls;
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (_url: string, init?: RequestInit) => {
+        exported.push([...(init?.body as Buffer)]);
+        return new Response(null, { status: 200 });
+      }),
+    );
+    const controller = new AbortController();
+
+    try {
+      const running = runSandboxAgent(
+        {
+          harness: "pi_core",
+          messages: [{ role: "user", content: "keep working" }],
+          telemetry: {
+            exporters: {
+              otlp: { headers: { authorization: "Secret current" } },
+            },
+          },
+        },
+        undefined,
+        controller.signal,
+        fixture.deps,
+      );
+      await flushPromises();
+      controller.abort();
+      const result = await running;
+
+      assert.equal(result.ok, true);
+      if (!result.ok) return;
+      assert.equal(result.stopReason, "cancelled");
+      assert.deepEqual(exported, [[10, 0, 255]], fixture.logs.join("\n"));
+      assert.equal(fixture.calls.sessionDestroyed, 1);
+      assert.deepEqual(fixture.calls.recordedErrors, []);
+    } finally {
+      rmSync(cwd, { recursive: true, force: true });
+    }
+  });
+
   it("clears inherited provider env on a managed run and applies ANTHROPIC_BASE_URL for claude", async () => {
     const { calls, deps } = fakeHarness();
 
@@ -2147,9 +2264,10 @@ describe("runSandboxAgent orchestration", () => {
 
     assert.equal(result.ok, true);
     const env = calls.providerArgs[1] as Record<string, string>;
-    // The harness-readable env carries a file path, never the bearer itself.
+    // The harness sees only a stable telemetry-control path; endpoint and bearer stay here.
     assert.equal(env.OTEL_EXPORTER_OTLP_HEADERS, undefined);
-    assert.equal(typeof env.AGENTA_AGENT_OTLP_AUTH_FILE, "string");
+    assert.equal(env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, undefined);
+    assert.equal(typeof env.AGENTA_AGENT_TELEMETRY_CONTROL_PATH, "string");
     assert.equal(JSON.stringify(env).includes("reusable-caller-token"), false);
   });
 

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -2232,7 +2232,13 @@ describe("runSandboxAgent orchestration", () => {
       );
 
       assert.equal(result.ok, true);
-      assert.deepEqual(fixture.calls.recordedErrors, []);
+      assert.deepEqual(fixture.calls.recordedErrors, [
+        {
+          message: "Pi did not publish a valid trace batch before the turn ended",
+          provider: undefined,
+        },
+      ]);
+      assert.equal(fixture.calls.runFlushed, 2);
       assert.match(
         fixture.logs.join("\n"),
         /stage=pi_trace_missing_batch diagnostic=true/,

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -436,7 +436,7 @@ describe("runSandboxAgent orchestration", () => {
     );
 
     assert.equal(result.ok, true);
-    assert.equal(calls.otelOptions.authorization, credential);
+    assert.equal(typeof calls.otelOptions.authorization, "function");
     authorization = "Secret refreshed";
     assert.equal(calls.otelOptions.authorization(), "Secret refreshed");
   });
@@ -480,6 +480,22 @@ describe("runSandboxAgent orchestration", () => {
     assert.equal(platform.authorization(), "Secret refreshed");
     assert.equal(collector.authorizationSource, "exporter");
     assert.equal(collector.authorization(), "Bearer collector-secret");
+
+    vi.stubEnv("AGENTA_CREDENTIALS", "Secret runner-fallback");
+    const headerless = resolveRunOtlpTarget(
+      {
+        harness: "pi_core",
+        messages: [{ role: "user", content: "hello" }],
+        telemetry: {
+          exporters: {
+            otlp: { endpoint: "https://api.agenta.test/api/otlp/v1/traces" },
+          },
+        },
+      },
+      () => "",
+    );
+    assert.equal(headerless.authorizationSource, "platform");
+    assert.equal(headerless.authorization(), "Secret runner-fallback");
   });
 
   it("delivers the current legacy inline image before one text block", async () => {
@@ -2135,7 +2151,18 @@ describe("runSandboxAgent orchestration", () => {
         assert.equal(typeof telemetryDir, "string");
         const control = JSON.parse(
           readFileSync(join(telemetryDir, PI_TRACE_CONTROL_FILE), "utf8"),
-        ) as { channelId: string };
+        ) as {
+          channelId: string;
+          redaction: { knownValues: string[] };
+        };
+        assert.equal(
+          control.redaction.knownValues.includes("model-env-visible-to-pi"),
+          true,
+        );
+        assert.equal(
+          control.redaction.knownValues.includes("Secret current"),
+          false,
+        );
         writeFileSync(
           join(telemetryDir, piTraceFileName(control.channelId, 0)),
           Buffer.from([10, 0, 255]),
@@ -2157,6 +2184,13 @@ describe("runSandboxAgent orchestration", () => {
         {
           harness: "pi_core",
           messages: [{ role: "user", content: "keep working" }],
+          modelConnection: {
+            provider: "openai",
+            deployment: "custom",
+            credentialMode: "none",
+            environment: { GATEWAY_AUTH: "model-env-visible-to-pi" },
+            credentials: [],
+          },
           telemetry: {
             exporters: {
               otlp: { headers: { authorization: "Secret current" } },

--- a/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-pi-assets.test.ts
@@ -37,7 +37,6 @@ import {
   resolvePiToolSpecsDelivery,
   uploadDirToSandbox,
   uploadPiToolSpecsToSandbox,
-  writeOtlpAuthFile,
   writePiModelsConfigLocal,
   writePiToolSpecsFileLocal,
   writeSystemPromptLocal,
@@ -123,7 +122,7 @@ describe("buildPiExtensionEnv", () => {
       },
     } as AgentRunRequest;
 
-    const env = buildPiExtensionEnv(request, false);
+    const env = buildPiExtensionEnv(request);
 
     assert.deepEqual(JSON.parse(env[PI_MODEL_PROVIDER_OVERRIDE_ENV]), {
       provider: "anthropic",
@@ -150,23 +149,18 @@ describe("buildPiExtensionEnv", () => {
       () =>
         buildPiExtensionEnv(
           request("bad/provider", "https://proxy.example.test"),
-          false,
         ),
       /invalid provider/,
     );
     assert.throws(
       () =>
-        buildPiExtensionEnv(
-          request("anthropic", "http://proxy.example.test"),
-          false,
-        ),
+        buildPiExtensionEnv(request("anthropic", "http://proxy.example.test")),
       /must be an HTTPS URL/,
     );
     assert.throws(
       () =>
         buildPiExtensionEnv(
           request("anthropic", "https://user:pass@proxy.example.test"),
-          false,
         ),
       /without credentials/,
     );
@@ -219,24 +213,23 @@ describe("buildPiExtensionEnv", () => {
     } as AgentRunRequest;
 
     const relayDir = join(tempDir("agenta-pi-specs-"), "relay");
-    const env = buildPiExtensionEnv(request, true, {
+    const env = buildPiExtensionEnv(request, {
       relayDir,
       usageOutPath: "/tmp/usage.json",
-      otlpAuthFilePath: "/tmp/otlp-auth",
+      telemetryControlPath: "/tmp/telemetry/current.control.json",
     });
     writePiToolSpecsFileLocal(
       resolvePiToolSpecsDelivery(request.customTools ?? [], relayDir)!,
     );
 
-    assert.equal(env.TRACEPARENT, request.context?.propagation?.traceparent);
     assert.equal(
-      env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT,
-      request.telemetry?.exporters?.otlp?.endpoint,
+      env.AGENTA_AGENT_TELEMETRY_CONTROL_PATH,
+      "/tmp/telemetry/current.control.json",
     );
-    // the bearer rides a file path, never a plain env var the harness can read/echo.
-    assert.equal(env.AGENTA_AGENT_OTLP_AUTH_FILE, "/tmp/otlp-auth");
+    assert.equal(env.TRACEPARENT, undefined);
+    assert.equal(env.OTEL_EXPORTER_OTLP_TRACES_ENDPOINT, undefined);
     assert.equal(env.OTEL_EXPORTER_OTLP_HEADERS, undefined);
-    assert.equal(env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED, "false");
+    assert.equal(env.AGENTA_AGENT_CONTENT_CAPTURE_ENABLED, undefined);
     assert.equal(env.AGENTA_AGENT_TOOLS_RELAY_DIR, relayDir);
     assert.equal(env.AGENTA_AGENT_USAGE_CAPTURE_PATH, "/tmp/usage.json");
 
@@ -271,19 +264,16 @@ describe("buildPiExtensionEnv", () => {
   });
 
   it("omits trace and tool env when tracing and relay are disabled", () => {
-    const env = buildPiExtensionEnv(
-      {
-        context: {
-          propagation: {
-            traceparent:
-              "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
-          },
+    const env = buildPiExtensionEnv({
+      context: {
+        propagation: {
+          traceparent:
+            "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
         },
-        telemetry: { capture: { content: { enabled: true } } },
-        customTools: [{ name: "safe_tool", kind: "callback" }],
-      } as AgentRunRequest,
-      false,
-    );
+      },
+      telemetry: { capture: { content: { enabled: true } } },
+      customTools: [{ name: "safe_tool", kind: "callback" }],
+    } as AgentRunRequest);
 
     assert.equal(env.TRACEPARENT, undefined);
     assert.equal(env[PUBLIC_SPECS_FILE_ENV], undefined);
@@ -292,7 +282,7 @@ describe("buildPiExtensionEnv", () => {
   });
 
   it("sets builtin gating env WITHOUT a relay dir (the gate rides the ACP dialog plane)", () => {
-    const env = buildPiExtensionEnv({} as AgentRunRequest, false, {
+    const env = buildPiExtensionEnv({} as AgentRunRequest, {
       relayDir: "/tmp/relay",
       builtinGatingActive: true,
     });
@@ -303,10 +293,10 @@ describe("buildPiExtensionEnv", () => {
   });
 
   it("always sets the builtin activation env and never a grant list", () => {
-    const gating = buildPiExtensionEnv({} as AgentRunRequest, false, {
+    const gating = buildPiExtensionEnv({} as AgentRunRequest, {
       builtinGatingActive: true,
     });
-    const noGating = buildPiExtensionEnv({} as AgentRunRequest, false, {});
+    const noGating = buildPiExtensionEnv({} as AgentRunRequest, {});
 
     assert.equal(gating.AGENTA_AGENT_BUILTIN_ACTIVATION, "1");
     assert.equal(noGating.AGENTA_AGENT_BUILTIN_ACTIVATION, "1");
@@ -329,7 +319,6 @@ describe("buildPiExtensionEnv", () => {
     ];
     const env = buildPiExtensionEnv(
       { customTools } as unknown as AgentRunRequest,
-      false,
       { relayDir: "/tmp/relay" },
     );
 
@@ -342,50 +331,6 @@ describe("buildPiExtensionEnv", () => {
       required: ["integration"],
       properties: { integration: { type: "string" } },
     });
-  });
-
-  it("carries the loaded skill names under tracing (F-029)", () => {
-    const request = {
-      context: {
-        propagation: {
-          traceparent:
-            "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
-        },
-      },
-      telemetry: { capture: { content: { enabled: true } } },
-    } as AgentRunRequest;
-
-    const env = buildPiExtensionEnv(request, true, {
-      skills: ["weather-oracle", "_agenta.agenta-getting-started"],
-    });
-
-    assert.deepEqual(JSON.parse(env.AGENTA_AGENT_SKILLS_LOADED ?? "[]"), [
-      "weather-oracle",
-      "_agenta.agenta-getting-started",
-    ]);
-  });
-
-  it("omits the loaded skills env when there are none or tracing is off", () => {
-    const request = {
-      context: {
-        propagation: {
-          traceparent:
-            "00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-bbbbbbbbbbbbbbbb-01",
-        },
-      },
-      telemetry: { capture: { content: { enabled: true } } },
-    } as AgentRunRequest;
-
-    assert.equal(
-      buildPiExtensionEnv(request, true, { skills: [] })
-        .AGENTA_AGENT_SKILLS_LOADED,
-      undefined,
-    );
-    assert.equal(
-      buildPiExtensionEnv(request, false, { skills: ["x"] })
-        .AGENTA_AGENT_SKILLS_LOADED,
-      undefined,
-    );
   });
 
   describe("hop-1 response-watch kill switch forwarding", () => {
@@ -402,7 +347,7 @@ describe("buildPiExtensionEnv", () => {
 
     it("forwards the flag verbatim into the sandbox env when the operator set it", () => {
       process.env[FLAG] = "false";
-      const env = buildPiExtensionEnv(relayRequest, false, {
+      const env = buildPiExtensionEnv(relayRequest, {
         relayDir: "/tmp/relay",
       });
       assert.equal(env[FLAG], "false");
@@ -410,7 +355,7 @@ describe("buildPiExtensionEnv", () => {
 
     it("omits the flag when the operator did not set it (writer defaults to true)", () => {
       delete process.env[FLAG];
-      const env = buildPiExtensionEnv(relayRequest, false, {
+      const env = buildPiExtensionEnv(relayRequest, {
         relayDir: "/tmp/relay",
       });
       assert.equal(env[FLAG], undefined);
@@ -418,21 +363,18 @@ describe("buildPiExtensionEnv", () => {
   });
 
   it("never leaks the bearer into env when no auth file path is given", () => {
-    const env = buildPiExtensionEnv(
-      {
-        telemetry: {
-          exporters: {
-            otlp: {
-              endpoint: "https://otlp.example.test/v1/traces",
-              headers: { authorization: "Bearer trace-token" },
-            },
+    const env = buildPiExtensionEnv({
+      telemetry: {
+        exporters: {
+          otlp: {
+            endpoint: "https://otlp.example.test/v1/traces",
+            headers: { authorization: "Bearer trace-token" },
           },
         },
-      } as AgentRunRequest,
-      true,
-    );
+      },
+    } as AgentRunRequest);
 
-    assert.equal(env.AGENTA_AGENT_OTLP_AUTH_FILE, undefined);
+    assert.equal(env.AGENTA_AGENT_TELEMETRY_CONTROL_PATH, undefined);
     assert.equal(env.OTEL_EXPORTER_OTLP_HEADERS, undefined);
     assert.equal(JSON.stringify(env).includes("trace-token"), false);
   });
@@ -473,7 +415,7 @@ describe("Pi tool specs delivery", () => {
     const customTools = fatToolSpecs();
     const request = { customTools } as unknown as AgentRunRequest;
 
-    const env = buildPiExtensionEnv(request, false, { relayDir });
+    const env = buildPiExtensionEnv(request, { relayDir });
     const delivery = resolvePiToolSpecsDelivery(customTools as never, relayDir);
     assert.ok(delivery);
     writePiToolSpecsFileLocal(delivery);
@@ -560,13 +502,9 @@ describe("Pi tool specs delivery", () => {
     ]);
     // The env the sandbox was created with names exactly this path.
     assert.equal(
-      buildPiExtensionEnv(
-        { customTools } as unknown as AgentRunRequest,
-        false,
-        {
-          relayDir: "/home/sandbox/agenta/relay/session-1",
-        },
-      )[PUBLIC_SPECS_FILE_ENV],
+      buildPiExtensionEnv({ customTools } as unknown as AgentRunRequest, {
+        relayDir: "/home/sandbox/agenta/relay/session-1",
+      })[PUBLIC_SPECS_FILE_ENV],
       writes[0].path,
     );
   });
@@ -588,18 +526,6 @@ describe("Pi tool specs delivery", () => {
       uploadPiToolSpecsToSandbox(sandbox, delivery),
       (err: Error) => err.message === PI_TOOL_SPECS_UNAVAILABLE_MESSAGE,
     );
-  });
-});
-
-describe("writeOtlpAuthFile", () => {
-  it("writes the bearer to a 0600 file, not env", () => {
-    const dir = tempDir("agenta-pi-otlp-auth-test-");
-    const path = join(dir, "nested", "otlp-auth");
-
-    writeOtlpAuthFile(path, "Bearer trace-token");
-
-    assert.equal(readFileSync(path, "utf-8"), "Bearer trace-token");
-    assert.equal(statSync(path).mode & 0o777, 0o600);
   });
 });
 

--- a/services/runner/tests/unit/sandbox-agent-workspace.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-workspace.test.ts
@@ -47,6 +47,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd,
           relayDir: join(cwd, ".agenta-tools"),
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [],
         },
         tools: {
@@ -79,6 +80,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd,
           relayDir: join(cwd, ".agenta-tools"),
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [],
         },
         tools: {
@@ -119,6 +121,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd,
           relayDir,
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [],
         },
         tools: {
@@ -135,14 +138,22 @@ describe("prepareWorkspace", () => {
       false,
       "the stale request file from the prior turn must not survive into the next turn",
     );
-    assert.equal(existsSync(relayDir), true, "the relay dir itself is recreated");
+    assert.equal(
+      existsSync(relayDir),
+      true,
+      "the relay dir itself is recreated",
+    );
 
     await workspace.cleanup();
   });
 
   it("clears the Daytona relay dir via runProcess before recreating it", async () => {
-    const calls: Array<{ op: string; path?: string; command?: string; args?: string[] }> =
-      [];
+    const calls: Array<{
+      op: string;
+      path?: string;
+      command?: string;
+      args?: string[];
+    }> = [];
     const sandbox = {
       mkdirFs: async ({ path }: { path: string }) =>
         calls.push({ op: "mkdir", path }),
@@ -161,6 +172,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd: "/home/sandbox/agenta-fixed",
           relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [],
         },
         tools: {
@@ -174,7 +186,9 @@ describe("prepareWorkspace", () => {
 
     const runIndex = calls.findIndex((c) => c.op === "run");
     const mkdirRelayIndex = calls.findIndex(
-      (c) => c.op === "mkdir" && c.path === "/home/sandbox/agenta-fixed/.agenta-tools",
+      (c) =>
+        c.op === "mkdir" &&
+        c.path === "/home/sandbox/agenta-fixed/.agenta-tools",
     );
     assert.ok(runIndex !== -1, "the relay dir is cleared via runProcess");
     assert.equal(
@@ -207,6 +221,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd,
           relayDir: join(cwd, ".agenta-tools"),
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [],
         },
         tools: {
@@ -253,6 +268,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd,
           relayDir: join(cwd, ".agenta-tools"),
+          telemetryDir: "/tmp/agenta-telemetry-test",
           harnessFiles: [{ path: ".claude/settings.json", content }],
           skillDirs: [],
         },
@@ -285,6 +301,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd,
           relayDir: join(cwd, ".agenta-tools"),
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [],
         },
         tools: {
@@ -318,6 +335,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd: "/home/sandbox/agenta-fixed",
           relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [],
         },
         tools: {
@@ -333,6 +351,7 @@ describe("prepareWorkspace", () => {
     assert.deepEqual(calls, [
       { op: "mkdir", path: "/home/sandbox/agenta-fixed" },
       { op: "mkdir", path: "/home/sandbox/agenta-fixed/.agenta-tools" },
+      { op: "mkdir", path: "/tmp/agenta-telemetry-test" },
       {
         op: "write",
         path: "/home/sandbox/agenta-fixed/AGENTS.md",
@@ -360,6 +379,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd: "/home/sandbox/agenta-fixed",
           relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [],
         },
         tools: {
@@ -411,6 +431,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd: "/home/sandbox/agenta-fixed",
           relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          telemetryDir: "/tmp/agenta-telemetry-test",
           harnessFiles: [{ path: ".claude/settings.json", content }],
           skillDirs: [],
         },
@@ -458,6 +479,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd: "/home/sandbox/agenta-fixed",
           relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [],
         },
         tools: {
@@ -490,6 +512,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd,
           relayDir: join(cwd, ".agenta-tools"),
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [{ name: "release-notes", dir: skillDir }],
         },
         tools: {
@@ -529,6 +552,7 @@ describe("prepareWorkspace", () => {
         workspace: {
           cwd: "/home/sandbox/agenta-fixed",
           relayDir: "/home/sandbox/agenta-fixed/.agenta-tools",
+          telemetryDir: "/tmp/agenta-telemetry-test",
           skillDirs: [{ name: "release-notes", dir: skillDir }],
         },
         tools: {

--- a/services/runner/tests/unit/server.test.ts
+++ b/services/runner/tests/unit/server.test.ts
@@ -652,6 +652,74 @@ describe("createAgentServer", () => {
     }
   });
 
+  it("never sends a third-party collector credential to session APIs", async () => {
+    let engineCredential: string | undefined;
+    const s = await listen(async (_request, _emit, _signal, options) => {
+      engineCredential = options?.credential?.();
+      return { ok: true, output: "done", events: [] };
+    });
+    const realFetch = globalThis.fetch.bind(globalThis);
+    const platformCalls: Array<{ url: string; authorization: string }> = [];
+    const fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockImplementation(async (input, init) => {
+        const url = String(input);
+        if (url === `${s.url}/run`) return realFetch(input, init);
+        const headers = (init?.headers ?? {}) as Record<string, string>;
+        platformCalls.push({
+          url,
+          authorization: headers.authorization ?? "",
+        });
+        if (url.endsWith("/sessions/streams/heartbeat")) {
+          return Response.json({
+            stream: { id: "stream-1" },
+            is_current_turn: true,
+          });
+        }
+        return Response.json({});
+      });
+
+    try {
+      const res = await fetchSpy(`${s.url}/run`, {
+        method: "POST",
+        headers: { accept: "application/x-ndjson", ...AUTH },
+        body: JSON.stringify({
+          harness: "pi_core",
+          sessionId: "session-third-party",
+          telemetry: {
+            exporters: {
+              otlp: {
+                endpoint: "https://collector.example.test/v1/traces",
+                headers: {
+                  authorization: "Bearer collector-secret",
+                },
+              },
+            },
+          },
+          messages: [{ role: "user", content: "hello" }],
+        }),
+      });
+      await res.text();
+
+      assert.equal(engineCredential, "");
+      assert.equal(
+        platformCalls.some((call) =>
+          call.url.endsWith("/sessions/streams/heartbeat"),
+        ),
+        true,
+      );
+      assert.equal(
+        platformCalls.some(
+          (call) => call.authorization === "Bearer collector-secret",
+        ),
+        false,
+      );
+    } finally {
+      fetchSpy.mockRestore();
+      await s.close();
+    }
+  });
+
   it("persists a legacy image-only tail without attachment references", async () => {
     let runCalls = 0;
     const s = await listen(async () => {

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -1844,7 +1844,7 @@ describe("runTurn: real approval park + respondPermission resume", () => {
       updatePlatformAuthorization() {},
       traceId: () => "11111111111111111111111111111111",
       emitMissingBatchFallback: async () => {},
-      finish: async () => ({ validBatches: 1 }),
+      finish: async () => ({ pickedUpBatches: 1, exportedBatches: 1 }),
       teardown: async () => {},
     };
 
@@ -1890,7 +1890,7 @@ describe("runTurn: real approval park + respondPermission resume", () => {
       },
       finish: async () => {
         journal.push("finish");
-        return { validBatches: 0 };
+        return { pickedUpBatches: 0, exportedBatches: 0 };
       },
       teardown: async () => {},
     };

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -1824,6 +1824,82 @@ describe("runTurn: real approval park + respondPermission resume", () => {
     assert.equal(r.stopReason, "cancelled");
   });
 
+  it("returns the original Pi trace id when an approval resume has a new runner trace", async () => {
+    const { deps } = pausableHarness();
+    const request: AgentRunRequest = {
+      harness: "pi_core",
+      messages: [{ role: "user", content: "approve" }],
+      context: {
+        propagation: {
+          traceparent:
+            "00-22222222222222222222222222222222-3333333333333333-01",
+        },
+      },
+    };
+    const acquired = await acquireEnvironment(request, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+    acquired.env.piTraceExport = {
+      publishControl: async () => true,
+      updatePlatformAuthorization() {},
+      traceId: () => "11111111111111111111111111111111",
+      emitMissingBatchFallback: async () => {},
+      finish: async () => ({ validBatches: 1 }),
+      teardown: async () => {},
+    };
+
+    const result = await runTurn(acquired.env, request, undefined, undefined, {
+      approvalParkMode: true,
+      resume: {
+        decisions: [
+          {
+            permissionId: "perm-pi",
+            reply: "once",
+            toolCallId: "tool-pi",
+            toolName: "edit",
+            args: {},
+            interactionToken: "tool-pi",
+            promptPromise: Promise.resolve({ stopReason: "complete" }),
+          },
+        ],
+        carriedForward: [],
+      },
+    });
+
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+    assert.equal(result.traceId, "11111111111111111111111111111111");
+  });
+
+  it("emits the missing-batch fallback when a parked Pi environment is evicted", async () => {
+    const { deps } = pausableHarness();
+    const request: AgentRunRequest = {
+      harness: "pi_core",
+      messages: [{ role: "user", content: "approve" }],
+    };
+    const acquired = await acquireEnvironment(request, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+    const journal: string[] = [];
+    acquired.env.piTraceExport = {
+      publishControl: async () => true,
+      updatePlatformAuthorization() {},
+      traceId: () => "11111111111111111111111111111111",
+      emitMissingBatchFallback: async () => {
+        journal.push("fallback");
+      },
+      finish: async () => {
+        journal.push("finish");
+        return { validBatches: 0 };
+      },
+      teardown: async () => {},
+    };
+
+    await acquired.env.destroy({ reason: "capacity-eviction" });
+
+    assert.deepEqual(journal, ["finish", "fallback"]);
+  });
+
   it("parks a Claude ACP gate (session alive), then answers it live and streams the continuation", async () => {
     const { calls, deps, captured } = pausableHarness();
     const acquired = await acquireEnvironment(engineReq, deps);

--- a/services/runner/tests/unit/telemetry-file-host.test.ts
+++ b/services/runner/tests/unit/telemetry-file-host.test.ts
@@ -201,6 +201,62 @@ describe("sandboxTelemetryFileHost", () => {
     expect(processCalls.every((call) => call.timeoutMs === 10_000)).toBe(true);
   });
 
+  it("treats a missing Daytona telemetry directory as empty", async () => {
+    const calls: any[] = [];
+    const host = sandboxTelemetryFileHost({
+      mkdirFs: async () => ({ path: "/telemetry" }),
+      statFs: async () => {
+        throw new Error("missing");
+      },
+      runProcess: async (value: any) => {
+        calls.push(value);
+        return {
+          durationMs: 1,
+          exitCode: 0,
+          stderr: "",
+          stderrTruncated: false,
+          stdout: "",
+          stdoutTruncated: false,
+          timedOut: false,
+        };
+      },
+      writeFsFile: async () => ({ path: "/telemetry/file" }),
+      moveFs: async () => ({}),
+      deleteFsEntry: async () => ({}),
+    } as never);
+
+    await expect(host.list("/telemetry/missing", 10)).resolves.toEqual([]);
+    expect(calls[0].args[1]).toContain("if [ ! -d");
+  });
+
+  it("rejects an empty Daytona file instead of exporting an empty OTLP body", async () => {
+    const host = sandboxTelemetryFileHost({
+      mkdirFs: async () => ({ path: "/telemetry" }),
+      statFs: async () => ({
+        entryType: "file",
+        modified: null,
+        path: "/telemetry/batch.otlp.pb",
+        size: 1,
+      }),
+      runProcess: async () => ({
+        durationMs: 1,
+        exitCode: 0,
+        stderr: "",
+        stderrTruncated: false,
+        stdout: "",
+        stdoutTruncated: false,
+        timedOut: false,
+      }),
+      writeFsFile: async () => ({ path: "/telemetry/file" }),
+      moveFs: async () => ({}),
+      deleteFsEntry: async () => ({}),
+    } as never);
+
+    await expect(host.readBytes("/telemetry/batch.otlp.pb", 4)).rejects.toThrow(
+      "Telemetry file read returned no bytes",
+    );
+  });
+
   it("rejects a truncated Daytona process response", async () => {
     const host = sandboxTelemetryFileHost({
       mkdirFs: async () => ({ path: "/telemetry" }),

--- a/services/runner/tests/unit/telemetry-file-host.test.ts
+++ b/services/runner/tests/unit/telemetry-file-host.test.ts
@@ -1,0 +1,262 @@
+import {
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { afterEach, describe, expect, it } from "vitest";
+
+import {
+  localTelemetryFileHost,
+  publishTelemetryFileAtomic,
+  sandboxTelemetryFileHost,
+  type TelemetryFileHost,
+} from "../../src/tracing/telemetry-file-host.ts";
+
+const temporaryDirs: string[] = [];
+
+afterEach(() => {
+  for (const dir of temporaryDirs.splice(0)) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+describe("localTelemetryFileHost", () => {
+  it("round-trips arbitrary bytes and reports size without a text conversion", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-telemetry-host-"));
+    temporaryDirs.push(dir);
+    const path = join(dir, "batch.otlp.pb");
+    const bytes = Uint8Array.from([0, 255, 254, 128, 10, 0, 42]);
+    const host = localTelemetryFileHost();
+
+    await host.writeBytes(path, bytes);
+
+    expect(await host.list(dir, 10)).toEqual(["batch.otlp.pb"]);
+    expect(await host.statSize(path)).toBe(bytes.byteLength);
+    expect(statSync(path).mode & 0o777).toBe(0o600);
+    expect([...(await host.readBytes(path, 10))]).toEqual([...bytes]);
+    await host.remove(path);
+    expect(await host.list(dir, 10)).toEqual([]);
+  });
+
+  it("rejects a local file before allocating beyond the read bound", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-telemetry-bound-"));
+    temporaryDirs.push(dir);
+    const path = join(dir, "batch.otlp.pb");
+    writeFileSync(path, Uint8Array.from([1, 2, 3, 4]));
+
+    await expect(localTelemetryFileHost().readBytes(path, 3)).rejects.toThrow(
+      "Telemetry file exceeds read limit",
+    );
+  });
+
+  it("atomically publishes through a temporary sibling", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-telemetry-atomic-"));
+    temporaryDirs.push(dir);
+    const finalPath = join(dir, "current.control.json");
+    const real = localTelemetryFileHost();
+    const operations: string[] = [];
+    const host: TelemetryFileHost = {
+      ...real,
+      writeBytes: async (path, contents) => {
+        operations.push(`write:${path}`);
+        expect(path.startsWith(`${finalPath}.tmp.`)).toBe(true);
+        await real.writeBytes(path, contents);
+      },
+      rename: async (from, to) => {
+        operations.push(`rename:${from}:${to}`);
+        expect(readFileSync(from, "utf8")).toBe("control");
+        expect(() => readFileSync(to)).toThrow();
+        await real.rename(from, to);
+      },
+    };
+
+    await publishTelemetryFileAtomic(host, finalPath, "control");
+
+    expect(operations.map((entry) => entry.split(":", 1)[0])).toEqual([
+      "write",
+      "rename",
+    ]);
+    expect(readFileSync(finalPath, "utf8")).toBe("control");
+    expect(
+      (await real.list(dir, 10)).filter((name) => name.includes(".tmp.")),
+    ).toEqual([]);
+  });
+
+  it("removes a temporary sibling when publication fails", async () => {
+    const dir = mkdtempSync(join(tmpdir(), "agenta-telemetry-failure-"));
+    temporaryDirs.push(dir);
+    const finalPath = join(dir, "current.control.json");
+    const real = localTelemetryFileHost();
+    const host: TelemetryFileHost = {
+      ...real,
+      rename: async () => {
+        throw new Error("rename failed");
+      },
+    };
+
+    await expect(
+      publishTelemetryFileAtomic(host, finalPath, "control"),
+    ).rejects.toThrow("rename failed");
+    expect(await real.list(dir, 10)).toEqual([]);
+  });
+});
+
+describe("sandboxTelemetryFileHost", () => {
+  it("uses bounded Daytona reads and maps publication to overwrite rename", async () => {
+    const calls: Array<{ method: string; value: unknown }> = [];
+    const stored = Uint8Array.from([0, 255, 1, 128]);
+    const sandbox = {
+      mkdirFs: async (value: unknown) => {
+        calls.push({ method: "mkdirFs", value });
+        return { path: "/telemetry" };
+      },
+      listFsEntries: async (value: unknown) => {
+        calls.push({ method: "listFsEntries", value });
+        return [
+          {
+            entryType: "file",
+            modified: null,
+            name: "batch.otlp.pb",
+            path: "/telemetry/batch.otlp.pb",
+            size: stored.byteLength,
+          },
+        ];
+      },
+      runProcess: async (value: any) => {
+        calls.push({ method: "runProcess", value });
+        const isList = value.args?.[2] === "agenta-telemetry-list";
+        return {
+          durationMs: 1,
+          exitCode: 0,
+          stderr: "",
+          stderrTruncated: false,
+          stdout: isList
+            ? "batch.otlp.pb\n"
+            : Buffer.from(stored).toString("base64"),
+          stdoutTruncated: false,
+          timedOut: false,
+        };
+      },
+      statFs: async (value: unknown) => {
+        calls.push({ method: "statFs", value });
+        return {
+          entryType: "file",
+          modified: null,
+          path: "/telemetry/batch.otlp.pb",
+          size: stored.byteLength,
+        };
+      },
+      readFsFile: async (value: unknown) => {
+        calls.push({ method: "readFsFile", value });
+        return stored;
+      },
+      writeFsFile: async (query: unknown, body: unknown) => {
+        calls.push({ method: "writeFsFile", value: { query, body } });
+        return { path: "/telemetry/batch.otlp.pb" };
+      },
+      moveFs: async (value: unknown) => {
+        calls.push({ method: "moveFs", value });
+        return value;
+      },
+      deleteFsEntry: async (value: unknown) => {
+        calls.push({ method: "deleteFsEntry", value });
+        return { path: "/telemetry/batch.otlp.pb" };
+      },
+    };
+    const host = sandboxTelemetryFileHost(sandbox as never);
+
+    await host.mkdir("/telemetry");
+    expect(await host.list("/telemetry", 10)).toEqual(["batch.otlp.pb"]);
+    expect(await host.statSize("/telemetry/batch.otlp.pb")).toBe(4);
+    expect([...(await host.readBytes("/telemetry/batch.otlp.pb", 10))]).toEqual(
+      [0, 255, 1, 128],
+    );
+    await host.writeBytes("/telemetry/temp", stored);
+    await host.rename("/telemetry/temp", "/telemetry/batch.otlp.pb");
+    await host.remove("/telemetry/batch.otlp.pb");
+
+    const write = calls.find((call) => call.method === "writeFsFile")
+      ?.value as {
+      query: unknown;
+      body: ArrayBuffer;
+    };
+    expect(write.query).toEqual({ path: "/telemetry/temp" });
+    expect([...new Uint8Array(write.body)]).toEqual([...stored]);
+    expect(calls.find((call) => call.method === "moveFs")?.value).toEqual({
+      from: "/telemetry/temp",
+      to: "/telemetry/batch.otlp.pb",
+      overwrite: true,
+    });
+    const processCalls = calls
+      .filter((call) => call.method === "runProcess")
+      .map(
+        (call) => call.value as { maxOutputBytes: number; timeoutMs: number },
+      );
+    expect(processCalls).toHaveLength(2);
+    expect(processCalls.every((call) => call.maxOutputBytes > 0)).toBe(true);
+    expect(processCalls.every((call) => call.timeoutMs === 10_000)).toBe(true);
+  });
+
+  it("rejects a truncated Daytona process response", async () => {
+    const host = sandboxTelemetryFileHost({
+      mkdirFs: async () => ({ path: "/telemetry" }),
+      statFs: async () => ({
+        entryType: "file",
+        modified: null,
+        path: "/telemetry/batch.otlp.pb",
+        size: 4,
+      }),
+      runProcess: async () => ({
+        durationMs: 1,
+        exitCode: 0,
+        stderr: "",
+        stderrTruncated: false,
+        stdout: "AA==",
+        stdoutTruncated: true,
+        timedOut: false,
+      }),
+      writeFsFile: async () => ({ path: "/telemetry/file" }),
+      moveFs: async ({ from, to }: { from: string; to: string }) => ({
+        from,
+        to,
+      }),
+      deleteFsEntry: async () => ({ path: "/telemetry/file" }),
+    } as never);
+
+    await expect(host.readBytes("/telemetry/batch.otlp.pb", 4)).rejects.toThrow(
+      "Telemetry file read exceeded its bound",
+    );
+  });
+
+  it("returns undefined when the remote stat cannot be obtained", async () => {
+    const host = sandboxTelemetryFileHost({
+      mkdirFs: async () => ({ path: "/telemetry" }),
+      listFsEntries: async () => [],
+      statFs: async () => {
+        throw new Error("gone");
+      },
+      runProcess: async () => ({
+        durationMs: 1,
+        exitCode: 0,
+        stderr: "",
+        stderrTruncated: false,
+        stdout: "",
+        stdoutTruncated: false,
+        timedOut: false,
+      }),
+      readFsFile: async () => new Uint8Array(),
+      writeFsFile: async () => ({ path: "/telemetry/file" }),
+      moveFs: async ({ from, to }: { from: string; to: string }) => ({
+        from,
+        to,
+      }),
+      deleteFsEntry: async () => ({ path: "/telemetry/file" }),
+    } as never);
+
+    expect(await host.statSize("/telemetry/missing")).toBeUndefined();
+  });
+});

--- a/services/runner/tests/unit/telemetry-file-host.test.ts
+++ b/services/runner/tests/unit/telemetry-file-host.test.ts
@@ -212,7 +212,7 @@ describe("sandboxTelemetryFileHost", () => {
         calls.push(value);
         return {
           durationMs: 1,
-          exitCode: 0,
+          exitCode: 44,
           stderr: "",
           stderrTruncated: false,
           stdout: "",
@@ -227,6 +227,35 @@ describe("sandboxTelemetryFileHost", () => {
 
     await expect(host.list("/telemetry/missing", 10)).resolves.toEqual([]);
     expect(calls[0].args[1]).toContain("if [ ! -d");
+    expect(calls[0].args[1]).toContain("exit 44");
+  });
+
+  it("reports a missing Daytona telemetry file as ENOENT", async () => {
+    const host = sandboxTelemetryFileHost({
+      mkdirFs: async () => ({ path: "/telemetry" }),
+      statFs: async () => {
+        throw new Error("missing");
+      },
+      runProcess: async () => ({
+        durationMs: 1,
+        exitCode: 44,
+        stderr: "",
+        stderrTruncated: false,
+        stdout: "",
+        stdoutTruncated: false,
+        timedOut: false,
+      }),
+      writeFsFile: async () => ({ path: "/telemetry/file" }),
+      moveFs: async () => ({}),
+      deleteFsEntry: async () => ({}),
+    } as never);
+
+    await expect(
+      host.readBytes("/telemetry/missing.otlp.pb", 4),
+    ).rejects.toMatchObject({
+      code: "ENOENT",
+      message: "Telemetry file is missing",
+    });
   });
 
   it("rejects an empty Daytona file instead of exporting an empty OTLP body", async () => {
@@ -255,6 +284,39 @@ describe("sandboxTelemetryFileHost", () => {
     await expect(host.readBytes("/telemetry/batch.otlp.pb", 4)).rejects.toThrow(
       "Telemetry file read returned no bytes",
     );
+  });
+
+  it("suppresses base64 wrapping before applying the Daytona output bound", async () => {
+    const calls: any[] = [];
+    const host = sandboxTelemetryFileHost({
+      mkdirFs: async () => ({ path: "/telemetry" }),
+      statFs: async () => ({
+        entryType: "file",
+        modified: null,
+        path: "/telemetry/batch.otlp.pb",
+        size: 1,
+      }),
+      runProcess: async (value: any) => {
+        calls.push(value);
+        return {
+          durationMs: 1,
+          exitCode: 0,
+          stderr: "",
+          stderrTruncated: false,
+          stdout: "AQ==",
+          stdoutTruncated: false,
+          timedOut: false,
+        };
+      },
+      writeFsFile: async () => ({ path: "/telemetry/file" }),
+      moveFs: async () => ({}),
+      deleteFsEntry: async () => ({}),
+    } as never);
+
+    await expect(
+      host.readBytes("/telemetry/batch.otlp.pb", 4),
+    ).resolves.toEqual(Buffer.from([1]));
+    expect(calls[0].args[1]).toContain("tr -d");
   });
 
   it("rejects a truncated Daytona process response", async () => {


### PR DESCRIPTION
## Context

Pi currently builds and sends its own trace spans from inside the harness process. That freezes export authorization when the sandbox starts. A warm session or one long standalone turn can outlive that credential, so extending the token lifetime only delays the same failure.

This change keeps Pi native spans but moves network export to the runner, which owns the live platform credential and OTLP boundary.

## Changes

- Pi serializes each completed processor flush as standard OTLP protobuf and atomically publishes up to four bounded batches per turn. A fifth flush is dropped without overwriting the earlier files.
- The runner consumes the same spool protocol for local and Daytona, collects the bounded sequence before network sends, then sends the bodies through the configured OTLP target in parallel.
- Generic `runTurn` uses a narrow `HarnessTracePort`. The default adapter keeps runner-created spans for ordinary harnesses; the Pi adapter owns native-span setup, finalization, cancellation, and fallback.
- Session-owned and standalone Agenta turns share one proactive platform credential lease. A failed refresh keeps the last usable value.
- Third-party collector authorization remains static and never enters the Agenta permission exchange or session API headers.
- The Pi control file carries propagation, capture policy, attribution, skills, and bounded redaction-only values already visible inside the sandbox. It carries no endpoint or export authorization.
- Completion, cancellation, approval pause and resume, and parked-session eviction finalize and drain Pi telemetry. The runner fallback is emitted only when Pi produced no canonical, non-empty, size-bounded batch. Collector acceptance is tracked separately.
- The spool is bounded to four files per turn and 8 MiB per file, with bounded directory listings and reads on both file-host adapters.

This PR intentionally adds no custom trace DTO, longer-lived Pi token, exporter-specific 401 retry, feature flag, or separate Daytona export path.

Merged prerequisites: #6217 and #6218.

## Validation

- Full runner suite: 139 unit files and all 2,300 tests passed.
- Focused credential, session, trace, orchestration, and server suite: 137 tests passed.
- Canonical malformed-body regression: pickup count is one, export count is zero after HTTP 400, and no missing-batch fallback is emitted.
- `pnpm run typecheck`
- `pnpm run build:extension`
- API OTLP router: Ruff format and lint passed.
- Pre-final-refactor release gate: P2 local sandbox, P2b provider set, and P3 Daytona passed.
- Native Pi traces persisted through runner export in local and Daytona.
- A funded Pi run produced a non-zero trace cost of `$0.0023065`; cumulative roll-up did not double-count it.

The live release-gate evidence predates the final behavior-preserving port extraction. The complete unit suite covers that refactor, but P2, P2b, and P3 must be rerun against the combined post-merge release SHA before preview deployment.

## Reviewer guide

Use the [reviewer protocol](https://github.com/Agenta-AI/agenta/blob/feat/pi-runner-owned-trace-export/docs/design/runner-owned-pi-trace-export/reviewer-protocol.md) for intended invariants, review order, focused commands, live evidence, and rollback order.