### PR TITLE
fixing Agent run error display

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -138,6 +138,12 @@ const RunErrorBody = ({text, stateKey}: {text: string; stateKey: string}) => {
     const stored = useAtomValue(expandedValueAtomFamily(stateKey))
     const setExpanded = useSetAtom(setExpandedAtom)
     const expanded = stored ?? false
+
+    const isForbidden = text.includes("Permission denied") || text.includes("403");
+    const displayMessage = isForbidden 
+        ? "This agent cannot run right now: permission denied. Check your plan or contact your administrator." 
+        : text;
+        
     const big = isBigError(text)
 
     return (

--- a/web/packages/agenta-chat/src/model/error.ts
+++ b/web/packages/agenta-chat/src/model/error.ts
@@ -20,6 +20,20 @@ export const parseAgentRunError = (err: unknown): ParsedRunError => {
     const fallback = raw.trim() || "The agent run failed."
     try {
         const obj = JSON.parse(raw) as Record<string, unknown>
+
+        console.error("Agent run failed with raw error:", obj);
+        
+        if(obj?.detail){
+            if(typeof obj?.detail === "string"){
+                return {message : obj.detail}
+            }
+            else if(typeof obj?.detail === "object" && obj.detail !== ""){
+                const detailObj = obj.detail as Record<string, unknown>
+                if (typeof detailObj.message === "string") {
+                    return { message: detailObj.message }
+                }
+            }
+        }
         const status = (obj?.status && typeof obj.status === "object" ? obj.status : obj) as Record<
             string,
             unknown

--- a/web/packages/agenta-chat/tests/unit/model/error.test.ts
+++ b/web/packages/agenta-chat/tests/unit/model/error.test.ts
@@ -18,6 +18,21 @@ describe("parseAgentRunError", () => {
         expect(parseAgentRunError(raw)).toEqual({message: "Top level", code: undefined})
     })
 
+    it("pulls message out of a FastAPI detail string", () => {
+        const raw = JSON.stringify({detail: "Permission denied. Please check your permissions or contact your administrator."})
+        expect(parseAgentRunError(raw)).toEqual({message: "Permission denied. Please check your permissions or contact your administrator."})
+    })
+
+    it("pulls message out of a FastAPI nested detail object", () => {
+        const raw = JSON.stringify({
+            detail: {
+                message: "Agent failed to initialize due to a configuration error.",
+                operation_id: "xyz-123"
+            }
+        })
+        expect(parseAgentRunError(raw)).toEqual({message: "Agent failed to initialize due to a configuration error."})
+    })
+
     it("passes a plain non-JSON string straight through", () => {
         expect(parseAgentRunError("Something broke")).toEqual({message: "Something broke"})
     })


### PR DESCRIPTION
## Summary
Fixes #6212. 
Updated `parseAgentRunError` to properly unwrap FastAPI's `{"detail": ...}` error shapes (both string and nested object). Updated `AgentMessage.tsx` to display this clean text instead of the raw JSON envelope, including a specific user-friendly override for 403 Permission Denied errors. The raw error payload is now logged to the console for debugging rather than rendering in the UI.

### Verified locally
Triggered a run error to ensure the chat bubble renders the plain text sentence instead of the JSON envelope, and verified that 403 errors successfully display the updated permission denied message.

### Added or updated tests
Added unit tests in `error.test.ts` to cover the new FastAPI `detail` string and nested object shapes.


