### PR TITLE
fix(frontend): center AuthSideBanner content to fix gap on wide screens

### DIFF
--- a/web/packages/agenta-auth-ui/src/AuthSideBanner.tsx
+++ b/web/packages/agenta-auth-ui/src/AuthSideBanner.tsx
@@ -19,7 +19,7 @@ const FEATURES = [
 const AuthSideBanner = () => {
     return (
         <section className="auth-panel hidden lg:flex flex-1 h-full flex-col justify-center p-24">
-            <div className="flex flex-col gap-[26px] max-w-[520px]">
+            <div className="flex flex-col gap-[26px] max-w-[520px] mx-auto">
                 <a
                     href="https://github.com/Agenta-AI/agenta"
                     target="_blank"


### PR DESCRIPTION
## Summary
On a wide display the sign-in page splits into a fixed-width form on the left and a marketing panel on the right. The panel's content — the GitHub chip, the "Build agents that automate your work" headline, and the three feature rows — sits against the panel's left edge and stops well short of its right edge. Everything past that point stays blank, and the gap grows with the viewport. In the attached screenshot (~1780px wide) roughly half the panel is empty, which makes the page look unfinished.

**Root cause:** flexbox's default cross-axis alignment (`align-items: stretch`) doesn't center a width-capped child, it just anchors it to the start of the cross axis. The fix adds `mx-auto` to the content wrapper so it stays horizontally centered within the panel as the panel grows.

This component lives in the shared `agenta-auth-ui` package (`AuthSideBanner.tsx`), consumed by `AuthShell` across OSS, EE, and mobile, so the fix applies everywhere the banner is rendered.

## Testing
### Verified locally
- Ran the dev stack via `./hosting/docker-compose/run.sh --oss --dev --web-local`
- Verified `/auth` locally on my personal wide screen and at 1780×900 and 1900px+ widths (via Chrome DevTools responsive mode) before and after changes; panel content now stays centered instead of hugging the left edge (see before and after screenshots attached in Demo section)
- Checked dark mode; no regression (diff only touches layout, not color)
- Ran `pnpm format-fix` and `pnpm lint-fix` in `web`

### Added or updated tests
N/A; this is a single-class CSS/layout fix with no behavioral change, so no new test coverage was added.

## Demo
### BEFORE changes
<img width="5014" height="2732" alt="image" src="https://github.com/user-attachments/assets/a25b87be-cde7-445a-9599-acbec6726083" />

### AFTER changes
<img width="5008" height="2664" alt="image" src="https://github.com/user-attachments/assets/ace022f2-9070-4340-986b-74236f87c203" />

## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)

## Issue
Closes #6148 
