### PR TITLE
perf(api): cache Fernet instance in _get_fernet()

### DIFF
--- a/api/oss/src/utils/crypting.py
+++ b/api/oss/src/utils/crypting.py
@@ -7,12 +7,14 @@ derived to a Fernet key via SHA-256 + base64url encoding.
 
 import base64
 import hashlib
+from functools import lru_cache
 
 from cryptography.fernet import Fernet, InvalidToken
 
 from oss.src.utils.env import env
 
 
+@lru_cache(maxsize=1)
 def _get_fernet() -> Fernet:
     crypt_key = env.agenta.crypt_key
     if not crypt_key:


### PR DESCRIPTION
## Description
This PR fixes a performance issue in the vault encryption utility. `_get_fernet()` was recreating the Fernet instance on every `encrypt()`/`decrypt()` call by recomputing SHA-256 and base64-encoding the key material each time. Under load (vault operations, secret reads on every request), this is unnecessary overhead.

## Summary
**What changed?** Added `@lru_cache(maxsize=1)` to `_get_fernet()` in `api/oss/src/utils/crypting.py`.

**Why was this change needed?** Every call to `encrypt()` or `decrypt()` triggered `_get_fernet()`, which re-derived the Fernet key from `AGENTA_CRYPT_KEY` via SHA-256 + base64 on every invocation.

**What problem does it solve?** Eliminates redundant cryptographic key derivation under load. The Fernet instance is now created once and reused for the lifetime of the process.

**How the change addresses the root cause:** `lru_cache(maxsize=1)` caches the single Fernet instance. Since the crypt key is static per deployment, there is no benefit to recreating the instance on every call.

## Testing
### Verified locally
- Ran `ruff check api/oss/src/utils/crypting.py` — passes with no errors
- Ran `ruff format api/oss/src/utils/crypting.py` — no changes needed
- Verified `_get_fernet()` still raises `ValueError` when `AGENTA_CRYPT_KEY` is missing

### Added or updated tests
N/A — This is a performance optimization with no behavior change. Existing vault/encryption tests cover the functional path.

### QA follow-up
N/A — The fix is self-contained and verified by static analysis.

## Demo

BEFORE FIX  : 

<img width="626" height="310" alt="image" src="https://github.com/user-attachments/assets/2cfe47f9-13de-406d-a16f-0bfe6fdcae72" />
 
AFTER FIX 👍 : 

<img width="625" height="379" alt="image" src="https://github.com/user-attachments/assets/70b9f525-b97f-4522-9d3f-ea8ed71757fe" />


## Checklist
- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me