### PR TITLE
docs(design): runner-owned Pi trace export design and owner review

### DIFF
--- a/docs/design/runner-owned-pi-trace-export/README.md
+++ b/docs/design/runner-owned-pi-trace-export/README.md
@@ -1,0 +1,66 @@
+# Runner-owned Pi trace export
+
+This workspace plans a replacement for the token-lifetime fix in
+[PR #6135](https://github.com/Agenta-AI/agenta/pull/6135).
+
+See [review.md](review.md) for the review and the decisions taken.
+
+The invariant is simple:
+
+- Pi still creates the Pi-native agent, turn, LLM, and tool spans.
+- The runner is the only component that sends spans over the network.
+- Local and Daytona Pi runs use the same file-spool protocol and lifecycle.
+- Credentials and export routing never enter the Pi process or sandbox.
+
+The runner does not reconstruct Pi spans from ACP events. Pi keeps its richer in-process view of
+provider calls, messages, tools, token counts, and cost. It serializes that span tree as a standard
+OTLP protobuf batch and publishes the bytes to a bounded per-turn spool. The runner picks up those
+exact bytes and exports them with a renewable runner-owned credential.
+
+```mermaid
+flowchart LR
+    SDK[SDK and middleware] -->|run request and general credential| Runner
+    Runner -->|turn control file| Pi[Pi extension]
+    Pi -->|native spans as OTLP protobuf| Spool[Ephemeral telemetry spool]
+    Spool -->|same host interface| Runner
+    Runner -->|OTLP POST with current credential| API[Agenta OTLP ingest]
+
+    Local[Local filesystem] -. implements .-> Spool
+    Daytona[Daytona filesystem API] -. implements .-> Spool
+```
+
+This removes the need for a two-hour telemetry token, a token scope field, and a second
+`exportAuthorization` DTO field. A 12-hour session remains safe because the runner renews its own
+credential while the run is active. No fixed export-token lifetime defines how long tracing works.
+
+## Glossary
+
+| Term | Meaning in this plan |
+|---|---|
+| Pi extension | Code loaded inside Pi that observes native Pi lifecycle events and creates spans. |
+| Runner | The trusted runner service that owns session orchestration, platform calls, and external trace export. |
+| Harness | The coding-agent runtime driven by the runner. Pi is one harness. |
+| Turn | One `/run` request and one prompt execution. A warm session can contain many turns. |
+| OTLP batch | A standard `ExportTraceServiceRequest` protobuf body containing spans. |
+| Telemetry spool | An ephemeral directory where Pi atomically publishes an OTLP batch for the runner. |
+| Runtime file host | The runner abstraction that reads and writes runtime files either locally or through Daytona's filesystem API. |
+| Credential lease | A runner-owned object that keeps the caller's platform credential valid and exposes the current value without giving it to Pi. |
+
+## Documents
+
+| File | Purpose |
+|---|---|
+| [context.md](context.md) | Current behavior, problem statement, goals, constraints, and non-goals. |
+| [research.md](research.md) | Verified repository facts and why the existing relay is the right transport precedent. |
+| [architecture.md](architecture.md) | Proposed components, local and Daytona flow, security boundary, and failure behavior. |
+| [interfaces.md](interfaces.md) | Field roles, wire contract, spool protocol, and internal interfaces. |
+| [plan.md](plan.md) | Phased implementation with concrete files and migration steps. |
+| [qa.md](qa.md) | Unit, integration, and live verification matrix. |
+| [status.md](status.md) | Decisions, open questions, progress, and next action. |
+
+## Recommendation
+
+Implement this as a replacement for PR #6135 if that PR has not merged. If it has merged, make the
+runner-owned exporter a follow-up and remove the extra scoped-token contract after the new path is
+proven. Keep the diagnostics from PR #6109 in either case.
+

--- a/docs/design/runner-owned-pi-trace-export/README.md
+++ b/docs/design/runner-owned-pi-trace-export/README.md
@@ -10,7 +10,9 @@ The invariant is simple:
 - Pi still creates the Pi-native agent, turn, LLM, and tool spans.
 - The runner is the only component that sends spans over the network.
 - Local and Daytona Pi runs use the same file-spool protocol and lifecycle.
-- Credentials and export routing never enter the Pi process or sandbox.
+- Export credentials and export routing never enter the Pi process or sandbox. The runner may put
+  sandbox-visible mount credential values in the per-turn control file only so Pi can redact them;
+  those values do not authorize telemetry export.
 
 The runner does not reconstruct Pi spans from ACP events. Pi keeps its richer in-process view of
 provider calls, messages, tools, token counts, and cost. It serializes that span tree as a standard

--- a/docs/design/runner-owned-pi-trace-export/architecture.md
+++ b/docs/design/runner-owned-pi-trace-export/architecture.md
@@ -18,27 +18,28 @@ not a network client of Agenta.
 
 ## Components to add
 
-### RuntimeFileHost
+### TelemetryFileHost
 
-Extract a byte-oriented host interface from the filesystem operations already embedded in tool
-relay:
+Add a byte-oriented host dedicated to telemetry. Do not refactor the tool relay:
 
 ```ts
-interface RuntimeFileHost {
-  list(dir: string): Promise<string[]>;
-  readBytes(path: string): Promise<Uint8Array>;
+interface TelemetryFileHost {
+  list(dir: string, maxEntries: number): Promise<string[]>;
+  statSize(path: string): Promise<number | undefined>;
+  readBytes(path: string, maxBytes: number): Promise<Uint8Array>;
   writeBytes(path: string, contents: Uint8Array | string): Promise<void>;
   rename(from: string, to: string): Promise<void>;
   remove(path: string): Promise<void>;
   mkdir(path: string): Promise<void>;
-  statMtimeMs?(path: string): Promise<number | undefined>;
-  createActivitySource?(dir: string): RuntimeActivitySource | undefined;
 }
 ```
 
-Provide local and Daytona implementations. Keep JSON decoding, tool execution, and tool-specific
-authorization in the tool-relay layer. The shared host is a transport primitive, not a generic
-message bus.
+Provide local and Daytona implementations. The consumer rejects an oversized stat before reading,
+then passes the same byte cap into `readBytes` to close the growth-after-stat race. The local host
+opens without following symlinks, checks the opened file, and allocates at most the cap plus one
+byte. The Daytona host bounds the sandbox command output before base64 decoding and checks the
+decoded length again. A sandbox-controlled file therefore cannot force an unbounded runner
+allocation.
 
 ### Runtime IPC directories
 
@@ -95,7 +96,8 @@ It:
 
 - sweeps stale telemetry files before the control file becomes visible;
 - accepts only the current random channel filename;
-- checks file count and byte limits before reading;
+- bounds directory entries, checks the stat size before reading, and gives the host the same
+  maximum for its growth-safe read;
 - deletes the final file immediately after pickup;
 - retains the bytes in runner memory while export is in flight;
 - forwards the exact protobuf bytes to the runner trace export sink;
@@ -104,50 +106,36 @@ It:
 The channel ID prevents a stale warm-turn file from being attributed to the next turn. It is a
 correlation value, not a secret or an authorization mechanism.
 
-### PlatformCredentialLease
+### Live platform authorization
 
-Refactor the existing session refresh behavior into a per-active-run lease:
-
-```ts
-interface PlatformCredentialLease {
-  current(): string;
-  refreshNow(): Promise<string | null>;
-  dispose(): void;
-}
-```
-
-The lease starts from the fresh credential on the incoming `/run` request. It refreshes before
-expiry, deduplicates concurrent refreshes, and keeps the last valid value if refresh fails. The
-session alive watchdog and trace exporter read the same lease instead of maintaining independent
-copies.
-
-The exporter reads `lease.current()` immediately before each HTTP attempt. On an Agenta HTTP 401,
-it calls `refreshNow()` and retries once. Proactive refresh remains required because an already
-expired credential may be unable to refresh itself.
+The runner already owns a mutable credential getter refreshed by the session alive watchdog.
+PR #6217 makes trace export call that getter immediately before export instead of capturing its
+initial value. The Pi spool uses the same getter. This fixes long turns without adding a second
+lease, a new refresh protocol, or a 401-specific retry path.
 
 For a third-party OTLP endpoint, use the configured static exporter header and do not call Agenta's
 permission exchange. This preserves current collector support.
 
-### RunnerTraceExportSink
+### Raw-byte export path
 
-Centralize external OTLP sending behind one runner-owned sink. It accepts already serialized OTLP
-bytes plus a runner-owned target:
+Keep the existing runner span exporter. Add a thin `exportOtlpBytes` path for already serialized
+Pi batches. It accepts raw bytes plus the same runner-owned target and diagnostics context:
 
 ```ts
-interface OtlpExportRequest {
+interface OtlpBytesExportRequest {
   body: Uint8Array;
-  endpoint: string;
-  authorization: () => string | undefined;
-  refreshAuthorization?: () => Promise<string | null>;
+  target: {
+    endpoint: string;
+    authorization: () => string | undefined;
+  };
   traceId?: string;
   turnId?: string;
-  source: "runner" | "pi-spool";
 }
 ```
 
-Both Pi spool batches and runner-generated batches use this sink for HTTP, timeout, retry,
-diagnostics, and credential lookup. Runner-native spans still avoid the filesystem because they are
-already in the trusted runner process.
+It preserves the existing timeout, retry classification, missing-credential behavior, target
+isolation, and bounded diagnostics. Runner-native spans keep their current exporter and avoid the
+filesystem.
 
 ## Per-turn sequence
 
@@ -160,7 +148,7 @@ sequenceDiagram
     participant API as OTLP ingest
 
     SDK->>Runner: /run with propagation, policy, endpoint, general credential
-    Runner->>Runner: create credential lease and export target
+    Runner->>Runner: retain live authorization getter and export target
     Runner->>Host: start consumer and sweep stale files
     Runner->>Host: atomically publish current.control.json
     Runner->>Pi: prompt
@@ -169,10 +157,10 @@ sequenceDiagram
     Pi->>Host: write temp OTLP protobuf
     Pi->>Host: rename to channelId.otlp.pb
     Runner->>Host: read and delete final file
-    Runner->>Runner: read current credential from lease
+    Runner->>Runner: resolve current authorization
     Runner->>API: POST exact protobuf bytes
     API-->>Runner: 200 or error
-    Runner->>Runner: bounded drain, diagnostics, dispose lease
+    Runner->>Runner: bounded drain, diagnostics, finish turn export
 ```
 
 The sequence is identical for local and Daytona. Only the `RuntimeFileHost` implementation changes.
@@ -184,6 +172,10 @@ Change Pi handling from placement-dependent to harness-dependent:
 ```ts
 emitSpans: !plan.isPi
 ```
+
+The runner and Pi extension are one versioned artifact: the runner bundles and installs its own
+extension into both local and Daytona environments. The cutover is therefore atomic; there is no
+supported new-runner/old-extension pairing to negotiate and no feature flag.
 
 For Pi, `createSandboxAgentOtel` continues to collect streamed output, events, stop reason, and
 fallback error information, but it does not synthesize agent, turn, LLM, or tool spans from ACP.
@@ -218,16 +210,21 @@ the original bytes for forwarding. Do not build a second semantic span validator
 
 | Failure | Behavior |
 |---|---|
-| Control file cannot be published | Log `stage=pi_trace_control`; run Pi without trace export; do not fail the turn. |
-| Pi cannot serialize or publish | Log in Pi; runner drain times out with `stage=pi_trace_spool_missing`; do not fail the turn. |
+| Control file cannot be published | Log `stage=pi_trace_control`; Pi tracing stays disabled; emit one runner fallback span; do not fail the turn. |
+| Pi cannot serialize or publish | Log in Pi; the drain reports `stage=pi_trace_spool_missing`; emit one runner fallback span; do not fail the turn. |
+| Prompt is cancelled or throws | End Pi's lifecycle first so `agent_end` can publish the complete trace it currently holds, then drain. If no valid batch arrives, emit one runner fallback span carrying the run error and resolved usage. |
 | File is too large | Reject and delete it; log bounded metadata; do not send it. |
 | Stale or wrong channel file | Ignore or sweep it; never associate it with the current turn. |
 | Filesystem watch fails | Fall back to bounded polling. |
 | Daytona filesystem call fails transiently | Retry within the existing bounded poll/drain rules. |
-| Credential approaches expiry | Lease refreshes before export. |
-| Agenta returns 401 | Single-flight refresh, one retry, then log failure. |
+| Credential rotates during a turn | The session watchdog refreshes it; export resolves the current getter value. |
+| Agenta returns 401 | Record the failed export through existing bounded diagnostics; this change adds no 401 refresh-and-retry protocol. |
 | OTLP endpoint times out or returns non-success | Log export diagnostics; return the successful agent result. |
 | Runner stops after pickup | Batch is lost in the first release because the queue is not durable. This is explicit and measurable. |
+
+Do not add periodic partial batches. Pi publishes one complete lifecycle batch when `agent_end`
+runs. The fallback callback is idempotent, so teardown cannot create a second fallback. Splitting a
+turn into checkpoints would break ingest-time cumulative usage rollups.
 
 Diagnostics must include stage, placement, source, turn ID, trace ID suffix, batch bytes, pickup
 latency, export latency, HTTP status, and credential age. They must not include the token, protobuf

--- a/docs/design/runner-owned-pi-trace-export/architecture.md
+++ b/docs/design/runner-owned-pi-trace-export/architecture.md
@@ -1,0 +1,235 @@
+# Architecture
+
+## Ownership model
+
+| Responsibility | Owner |
+|---|---|
+| Observe Pi lifecycle events | Pi extension |
+| Build Pi-native spans | Pi extension |
+| Decide trace parent and capture policy for a turn | SDK and runner request |
+| Move span bytes out of the harness | Runtime telemetry spool |
+| Hold export endpoint and credentials | Runner |
+| Renew platform credentials | Runner credential lease |
+| Send OTLP over HTTP | Runner trace export sink |
+| Authorize and ingest spans | Agenta API |
+
+The important boundary is between producing telemetry and exporting telemetry. Pi is a producer,
+not a network client of Agenta.
+
+## Components to add
+
+### RuntimeFileHost
+
+Extract a byte-oriented host interface from the filesystem operations already embedded in tool
+relay:
+
+```ts
+interface RuntimeFileHost {
+  list(dir: string): Promise<string[]>;
+  readBytes(path: string): Promise<Uint8Array>;
+  writeBytes(path: string, contents: Uint8Array | string): Promise<void>;
+  rename(from: string, to: string): Promise<void>;
+  remove(path: string): Promise<void>;
+  mkdir(path: string): Promise<void>;
+  statMtimeMs?(path: string): Promise<number | undefined>;
+  createActivitySource?(dir: string): RuntimeActivitySource | undefined;
+}
+```
+
+Provide local and Daytona implementations. Keep JSON decoding, tool execution, and tool-specific
+authorization in the tool-relay layer. The shared host is a transport primitive, not a generic
+message bus.
+
+### Runtime IPC directories
+
+Give each acquired environment an ephemeral runtime IPC root outside the durable cwd mount:
+
+```text
+<runtimeIpcDir>/
+  tools/
+  telemetry/
+```
+
+The tool subdirectory can be migrated from the current `relayDir` without changing its protocol.
+The telemetry subdirectory is always created for Pi tracing, even when no tools are configured.
+The root is stable for the warm environment; every turn uses a fresh random channel ID.
+
+### PiTurnTraceControl
+
+Before the prompt starts, the runner atomically publishes a small control file at a stable path.
+Pi reads and deletes it during `before_agent_start`.
+
+The file contains only values Pi needs to create correct spans:
+
+- protocol version;
+- random channel ID;
+- turn ID and session ID when present;
+- `traceparent` and `baggage`;
+- content-capture policy;
+- loaded skill names when they can vary by turn.
+
+It does not contain an endpoint, authorization header, project credential, or token expiry.
+
+### PiFileSpanExporter
+
+The Pi extension keeps `createAgentaOtel` and all existing lifecycle hooks. Its batch transport
+changes from HTTP to file publication.
+
+At `agent_end` it:
+
+1. ends the Pi spans through the existing tracer;
+2. gathers the run into one batch through the existing trace batch processor;
+3. serializes the batch as an OTLP `ExportTraceServiceRequest` protobuf;
+4. enforces the configured maximum batch size;
+5. writes `<channelId>.otlp.pb.tmp.<nonce>`;
+6. renames it atomically to `<channelId>.otlp.pb`.
+
+There is no custom span DTO and no JSON or base64 wrapping.
+
+### PiTraceSpoolConsumer
+
+The runner starts one consumer before it publishes the control file and before it sends the prompt.
+The consumer uses the same implementation for both placements and receives a `RuntimeFileHost`.
+
+It:
+
+- sweeps stale telemetry files before the control file becomes visible;
+- accepts only the current random channel filename;
+- checks file count and byte limits before reading;
+- deletes the final file immediately after pickup;
+- retains the bytes in runner memory while export is in flight;
+- forwards the exact protobuf bytes to the runner trace export sink;
+- stops after one accepted batch or a bounded post-prompt drain timeout.
+
+The channel ID prevents a stale warm-turn file from being attributed to the next turn. It is a
+correlation value, not a secret or an authorization mechanism.
+
+### PlatformCredentialLease
+
+Refactor the existing session refresh behavior into a per-active-run lease:
+
+```ts
+interface PlatformCredentialLease {
+  current(): string;
+  refreshNow(): Promise<string | null>;
+  dispose(): void;
+}
+```
+
+The lease starts from the fresh credential on the incoming `/run` request. It refreshes before
+expiry, deduplicates concurrent refreshes, and keeps the last valid value if refresh fails. The
+session alive watchdog and trace exporter read the same lease instead of maintaining independent
+copies.
+
+The exporter reads `lease.current()` immediately before each HTTP attempt. On an Agenta HTTP 401,
+it calls `refreshNow()` and retries once. Proactive refresh remains required because an already
+expired credential may be unable to refresh itself.
+
+For a third-party OTLP endpoint, use the configured static exporter header and do not call Agenta's
+permission exchange. This preserves current collector support.
+
+### RunnerTraceExportSink
+
+Centralize external OTLP sending behind one runner-owned sink. It accepts already serialized OTLP
+bytes plus a runner-owned target:
+
+```ts
+interface OtlpExportRequest {
+  body: Uint8Array;
+  endpoint: string;
+  authorization: () => string | undefined;
+  refreshAuthorization?: () => Promise<string | null>;
+  traceId?: string;
+  turnId?: string;
+  source: "runner" | "pi-spool";
+}
+```
+
+Both Pi spool batches and runner-generated batches use this sink for HTTP, timeout, retry,
+diagnostics, and credential lookup. Runner-native spans still avoid the filesystem because they are
+already in the trusted runner process.
+
+## Per-turn sequence
+
+```mermaid
+sequenceDiagram
+    participant SDK
+    participant Runner
+    participant Host as RuntimeFileHost
+    participant Pi
+    participant API as OTLP ingest
+
+    SDK->>Runner: /run with propagation, policy, endpoint, general credential
+    Runner->>Runner: create credential lease and export target
+    Runner->>Host: start consumer and sweep stale files
+    Runner->>Host: atomically publish current.control.json
+    Runner->>Pi: prompt
+    Pi->>Host: read and delete control file
+    Pi->>Pi: create native spans from Pi events
+    Pi->>Host: write temp OTLP protobuf
+    Pi->>Host: rename to channelId.otlp.pb
+    Runner->>Host: read and delete final file
+    Runner->>Runner: read current credential from lease
+    Runner->>API: POST exact protobuf bytes
+    API-->>Runner: 200 or error
+    Runner->>Runner: bounded drain, diagnostics, dispose lease
+```
+
+The sequence is identical for local and Daytona. Only the `RuntimeFileHost` implementation changes.
+
+## Runner tracer behavior
+
+Change Pi handling from placement-dependent to harness-dependent:
+
+```ts
+emitSpans: !plan.isPi
+```
+
+For Pi, `createSandboxAgentOtel` continues to collect streamed output, events, stop reason, and
+fallback error information, but it does not synthesize agent, turn, LLM, or tool spans from ACP.
+For every other harness, current ACP tracing remains unchanged.
+
+If the runner needs to emit a transport or runner error span, it can send that runner-owned span
+through the same `RunnerTraceExportSink`. It must not replace or duplicate Pi's native span tree.
+
+## Security boundary
+
+The telemetry directory is sandbox-writable. A harness can forge a file, so the runner must treat
+the spool as an untrusted producer.
+
+The runner limits the authority of that producer structurally:
+
+- Pi never sees a platform or exporter credential.
+- Pi never chooses the endpoint. The runner uses the endpoint from the trusted run request.
+- The runner accepts only the current random channel while that turn is active.
+- The runner accepts at most the configured number of files and bytes.
+- The runner sends only an OTLP protobuf body with a fixed content type and method.
+- The runner never turns spool contents into arbitrary headers, URLs, or platform calls.
+- The API still parses the protobuf, authorizes the caller, and applies ingest validation.
+
+This is a bounded trace-ingest capability proxy. It exposes less authority than placing even a
+trace-scoped bearer inside the harness because the bearer cannot be copied or replayed elsewhere.
+
+Parsing and enforcing every span's trace ID in the runner is optional hardening, not a prerequisite
+for removing the credential. If implemented, it must use standard generated OTLP types and preserve
+the original bytes for forwarding. Do not build a second semantic span validator in the runner.
+
+## Failure behavior
+
+| Failure | Behavior |
+|---|---|
+| Control file cannot be published | Log `stage=pi_trace_control`; run Pi without trace export; do not fail the turn. |
+| Pi cannot serialize or publish | Log in Pi; runner drain times out with `stage=pi_trace_spool_missing`; do not fail the turn. |
+| File is too large | Reject and delete it; log bounded metadata; do not send it. |
+| Stale or wrong channel file | Ignore or sweep it; never associate it with the current turn. |
+| Filesystem watch fails | Fall back to bounded polling. |
+| Daytona filesystem call fails transiently | Retry within the existing bounded poll/drain rules. |
+| Credential approaches expiry | Lease refreshes before export. |
+| Agenta returns 401 | Single-flight refresh, one retry, then log failure. |
+| OTLP endpoint times out or returns non-success | Log export diagnostics; return the successful agent result. |
+| Runner stops after pickup | Batch is lost in the first release because the queue is not durable. This is explicit and measurable. |
+
+Diagnostics must include stage, placement, source, turn ID, trace ID suffix, batch bytes, pickup
+latency, export latency, HTTP status, and credential age. They must not include the token, protobuf
+body, prompt, or captured span content.
+

--- a/docs/design/runner-owned-pi-trace-export/context.md
+++ b/docs/design/runner-owned-pi-trace-export/context.md
@@ -1,0 +1,93 @@
+# Context
+
+## Current system
+
+The workflow service receives the user's request. Its auth middleware calls
+`GET /api/access/permissions/check?action=run_service&resource_type=service`. The access router
+checks permission and returns a fresh, short-lived `Secret` credential. The SDK captures that
+credential together with the active trace context and sends them to the runner in the `/run`
+payload.
+
+The current wire shape places the general credential at
+`telemetry.exporters.otlp.headers.authorization`. Despite that location, the runner uses it for
+more than trace export. It authenticates session heartbeats, history reconstruction, turn-ledger
+writes, attachment access, mount signing, and other platform calls.
+
+The runner handles tracing in two ways:
+
+- Claude, Codex, Agenta, and Daytona Pi are traced from the runner's ACP event stream.
+- Local Pi creates its own spans in the Pi extension and exports them directly to Agenta.
+
+Local Pi is special because Pi exposes richer in-process events than ACP. The extension observes
+the actual provider request, model, message, tool execution, token counts, and cost. That data
+produces a better span tree than reconstruction from the ACP stream.
+
+## The failure
+
+The Pi process can stay alive across many warm-session turns. Its extension currently captures
+trace configuration and the export credential when the process starts. The credential expires
+after roughly 15 minutes, so later direct exports receive HTTP 401. Extending a second token to two
+hours changes the failure time but does not remove the lifetime coupling. A 12-hour session can
+still outlive it.
+
+The same process-lifetime capture also affects fields other than authorization. Later turns can
+arrive with a new `traceparent`, baggage, endpoint, or capture policy while the Pi extension still
+holds the first turn's values.
+
+## Required outcome
+
+Pi remains the source of Pi spans. The runner becomes the external exporter for those exact spans.
+The implementation must behave identically for local and Daytona placement.
+
+For every turn:
+
+1. The runner gives Pi only the current trace context and capture policy.
+2. Pi creates its native span tree.
+3. Pi serializes the complete tree as standard OTLP protobuf.
+4. Pi publishes the bytes through one cross-placement spool protocol.
+5. The runner sends those bytes to the configured OTLP endpoint with its current credential.
+
+## Goals
+
+- Preserve Pi-native agent, turn, LLM, and tool spans in both placements.
+- Preserve Pi's exact provider, token, cost, message, and tool data.
+- Make the runner the only external trace exporter.
+- Use one protocol and one state machine for local and Daytona.
+- Keep export credentials and endpoints out of Pi and the sandbox.
+- Refresh the full per-turn tracing context, not only authorization.
+- Support sessions and individual turns that outlive any one short-lived credential.
+- Reuse the existing atomic-file, host-adapter, watch, poll, stale-sweep, and bounded-drain patterns.
+- Keep trace failures best-effort so they never turn a successful agent run into an error.
+
+## Non-goals
+
+- Replacing OTLP with a custom span DTO.
+- Reconstructing Pi spans from ACP events.
+- Building a durable, crash-proof telemetry queue in the first release.
+- Giving the runner permission to choose a different project or destination than the run request.
+- Redesigning the whole access system in the same patch.
+- Making every harness self-instrument. Non-Pi harnesses keep the runner ACP tracer.
+
+## Constraints
+
+- The Daytona sandbox cannot rely on direct network access to Agenta OTLP ingest.
+- The spool directory is writable by the harness and must be treated as untrusted input.
+- Agenta OTLP ingest accepts binary protobuf and enforces a configured maximum batch size.
+- The existing trace processor intentionally sends one run as one batch because ingest computes
+  cumulative usage rollups per batch.
+- A trace-export failure must be observable but must not fail the agent turn.
+- Warm-session state cannot own a fixed per-turn `traceparent` or credential.
+
+## Why this is a general architecture, not a one-off workaround
+
+The design separates three stable responsibilities:
+
+- The harness adapter owns observation. Pi sees the native events and produces spans.
+- A placement-neutral runtime channel moves bytes from the harness to the runner.
+- The runner owns policy, credentials, routing, retry, diagnostics, and network export.
+
+The custom part is only the runtime handoff. The payload is standard OTLP, and the transport reuses
+the same local/Daytona boundary already used by tool relay and Pi usage writeback. A future
+self-instrumenting harness can implement the same producer interface without learning Agenta auth
+or networking.
+

--- a/docs/design/runner-owned-pi-trace-export/context.md
+++ b/docs/design/runner-owned-pi-trace-export/context.md
@@ -50,10 +50,12 @@ For every turn:
 ## Goals
 
 - Preserve Pi-native agent, turn, LLM, and tool spans in both placements.
-- Preserve Pi's exact provider, token, cost, message, and tool data.
+- Preserve Pi's exact provider, token, cost, message, and tool structure after mandatory
+  known-secret redaction inside Pi.
 - Make the runner the only external trace exporter.
 - Use one protocol and one state machine for local and Daytona.
-- Keep export credentials and endpoints out of Pi and the sandbox.
+- Keep export credentials and endpoints out of Pi and the sandbox. Mount credential values may
+  enter the per-turn control only as redaction deny-set data; they carry no export authority.
 - Refresh the full per-turn tracing context, not only authorization.
 - Support sessions and individual turns that outlive any one short-lived credential.
 - Reuse the existing atomic-file, host-adapter, watch, poll, stale-sweep, and bounded-drain patterns.

--- a/docs/design/runner-owned-pi-trace-export/interfaces.md
+++ b/docs/design/runner-owned-pi-trace-export/interfaces.md
@@ -1,0 +1,231 @@
+# Interfaces
+
+## Field classification
+
+| Value | Semantic role | Owner | Changes | Destination |
+|---|---|---|---|---|
+| `traceparent` | Protocol context | Calling trace | Every turn | Pi control file and runner tracer |
+| `baggage` | Protocol context | Calling trace | Every turn | Pi control file and runner tracer |
+| content capture | Policy | Operator or service | May change every turn | Pi control file and runner tracer |
+| OTLP endpoint | Exporter configuration | Operator or SDK | May change every turn | Runner only |
+| general platform authorization | Credential | Access system | Rotates during a turn | Runner credential lease only |
+| channel ID | Transport correlation | Runner | Every turn | Runner and Pi spool filenames |
+| OTLP protobuf body | Telemetry data | Pi tracer | Once per turn | Pi spool to runner export sink |
+| session ID and turn ID | Runtime metadata | Runner request | Per session and turn | Control file and diagnostics |
+
+This classification is the reason `exportAuthorization` is unnecessary. The runner already owns a
+renewable general platform credential. Pi needs telemetry data and protocol context, not a
+credential.
+
+## External `/run` wire
+
+### Required contract for the feature
+
+The runner needs these logical inputs:
+
+```json
+{
+  "context": {
+    "propagation": {
+      "traceparent": "00-...-...-01",
+      "baggage": "..."
+    }
+  },
+  "telemetry": {
+    "capture": {
+      "content": { "enabled": true }
+    },
+    "exporters": {
+      "otlp": {
+        "endpoint": "https://example/api/otlp/v1/traces",
+        "headers": {
+          "authorization": "Secret ..."
+        }
+      }
+    }
+  }
+}
+```
+
+No new field is needed to ship runner-owned export. The existing `headers.authorization` remains
+the compatibility source for the runner's general credential during the first implementation.
+The runner must resolve it once into a `PlatformCredentialLease`; tracing code and session code
+must consume the lease instead of repeatedly reading the telemetry DTO.
+
+Do not add:
+
+- `telemetry_credentials` to middleware state;
+- `TraceContext.export_authorization`;
+- `WireOtlpExporter.exportAuthorization`;
+- an OTLP-only token scope;
+- a fixed export-token TTL.
+
+### Follow-up contract cleanup
+
+The current general credential is semantically misplaced under the OTLP exporter even though many
+runner platform calls use it. Clean that separately after the runner-owned exporter is stable.
+
+Proposed canonical shape:
+
+```json
+{
+  "platform": {
+    "headers": {
+      "authorization": "Secret ..."
+    }
+  },
+  "context": {
+    "propagation": {
+      "traceparent": "00-...-...-01",
+      "baggage": "..."
+    }
+  },
+  "telemetry": {
+    "capture": {
+      "content": { "enabled": true }
+    },
+    "exporters": {
+      "otlp": {
+        "endpoint": "https://example/api/otlp/v1/traces"
+      }
+    }
+  }
+}
+```
+
+`platform.headers.authorization` is a credential under the platform it authenticates.
+`telemetry.exporters.otlp.endpoint` remains exporter configuration. There is no exporter credential
+on the normal Agenta path because the runner derives export authorization from its platform lease.
+
+For a third-party collector that requires its own static header, keep that header under the OTLP
+exporter. Its credential source is static and non-renewable, distinct from the Agenta platform
+lease.
+
+Migration should be explicit:
+
+1. Runner reads `platform.headers.authorization` first and falls back to the legacy OTLP header.
+2. SDK emits both fields during the compatibility window if old runners must remain supported.
+3. Golden wire tests pin both the compatibility phase and final removal.
+4. Remove the legacy general credential from telemetry only after the minimum supported runner
+   version accepts `platform`.
+
+## Pi control file
+
+Stable path supplied once through the Pi process environment:
+
+```text
+AGENTA_AGENT_TELEMETRY_CONTROL_PATH=<runtimeIpcDir>/telemetry/current.control.json
+```
+
+Version 1 body:
+
+```json
+{
+  "version": 1,
+  "channelId": "f3e7d4...",
+  "turnId": "019...",
+  "sessionId": "019...",
+  "propagation": {
+    "traceparent": "00-...-...-01",
+    "baggage": "..."
+  },
+  "capture": {
+    "content": true
+  },
+  "skills": ["_agenta.default"]
+}
+```
+
+Rules:
+
+- Runner writes a temporary sibling and atomically renames it to the stable path.
+- Pi reads and deletes the stable file in `before_agent_start`.
+- Pi rejects unknown versions and malformed channel IDs.
+- Missing optional fields mean the same defaults as today.
+- The file contains no endpoint or credential.
+- The runner keeps its authoritative copy in memory. It never trusts the file on return.
+
+## Pi OTLP spool
+
+Final filename:
+
+```text
+<runtimeIpcDir>/telemetry/<channelId>.otlp.pb
+```
+
+Publication:
+
+```text
+write <channelId>.otlp.pb.tmp.<nonce>
+rename to <channelId>.otlp.pb
+```
+
+Payload:
+
+- raw OTLP `ExportTraceServiceRequest` protobuf bytes;
+- content type fixed by the runner to `application/x-protobuf`;
+- one complete Pi run per file;
+- no JSON envelope, base64 encoding, header map, endpoint, or credential.
+
+Consumer rules:
+
+- Start and finish are scoped to one turn.
+- Accept only the expected final filename.
+- One accepted file per turn in version 1.
+- Mirror the API's configured maximum batch size, with an absolute runner safety ceiling.
+- Delete on pickup and keep bytes in memory for the bounded export attempt.
+- Sweep final and temporary telemetry files before publishing the next control file.
+
+## Internal credential interface
+
+```ts
+interface PlatformCredentialLease {
+  current(): string;
+  refreshNow(): Promise<string | null>;
+  dispose(): void;
+}
+```
+
+Properties:
+
+- created per active `/run`, not stored in a warm `SessionEnvironment`;
+- initialized from the credential on the current request;
+- proactive refresh before expiry with a bounded safety margin;
+- single-flight refresh;
+- last known valid value retained on transient refresh failure;
+- disposed on every run exit;
+- value and raw JWT claims never logged.
+
+The session watchdog should receive this lease. It should not create a second mutable credential.
+
+## Internal export interface
+
+```ts
+interface OtlpExportRequest {
+  body: Uint8Array;
+  endpoint: string;
+  authorization: () => string | undefined;
+  refreshAuthorization?: () => Promise<string | null>;
+  traceId?: string;
+  turnId?: string;
+  source: "runner" | "pi-spool";
+}
+
+interface RunnerTraceExportSink {
+  export(request: OtlpExportRequest): Promise<void>;
+}
+```
+
+`export()` is best-effort and resolves after success, final failure, or timeout. It does not throw
+into agent execution.
+
+## Compatibility rules
+
+- A runner without the new spool path continues current behavior.
+- A new runner enables the spool only when the installed Pi extension advertises protocol version
+  1 or the deployment ships the runner and extension atomically.
+- Do not run direct Pi export and spool export at the same time. The activation flag is exclusive.
+- During rollout, runner logs must identify `source=pi-direct`, `source=pi-spool`, or
+  `source=runner-acp` so duplicate paths are visible.
+- After rollout, Pi uses spool export for local and Daytona. `source=pi-direct` is removed.
+

--- a/docs/design/runner-owned-pi-trace-export/interfaces.md
+++ b/docs/design/runner-owned-pi-trace-export/interfaces.md
@@ -49,8 +49,8 @@ The runner needs these logical inputs:
 
 No new field is needed to ship runner-owned export. The existing `headers.authorization` remains
 the compatibility source for the runner's general credential during the first implementation.
-The runner must resolve it once into a `PlatformCredentialLease`; tracing code and session code
-must consume the lease instead of repeatedly reading the telemetry DTO.
+The runner must resolve it once into its shared current-authorization provider; tracing and
+session code consume that provider instead of repeatedly reading the telemetry DTO.
 
 Do not add:
 
@@ -179,53 +179,41 @@ Consumer rules:
 ## Internal credential interface
 
 ```ts
-interface PlatformCredentialLease {
-  current(): string;
-  refreshNow(): Promise<string | null>;
-  dispose(): void;
-}
+type AuthorizationProvider = () => string | undefined;
 ```
 
 Properties:
 
-- created per active `/run`, not stored in a warm `SessionEnvironment`;
 - initialized from the credential on the current request;
-- proactive refresh before expiry with a bounded safety margin;
-- single-flight refresh;
-- last known valid value retained on transient refresh failure;
-- disposed on every run exit;
+- refreshed by the existing session alive watchdog while a session-owned turn is active;
+- read immediately before every runner or Pi-spool export;
+- kept static for third-party collector authorization;
 - value and raw JWT claims never logged.
 
-The session watchdog should receive this lease. It should not create a second mutable credential.
+Do not create a second trace-specific lease or refresh channel.
 
 ## Internal export interface
 
 ```ts
-interface OtlpExportRequest {
+interface OtlpBytesExportRequest {
   body: Uint8Array;
-  endpoint: string;
-  authorization: () => string | undefined;
-  refreshAuthorization?: () => Promise<string | null>;
-  traceId?: string;
-  turnId?: string;
-  source: "runner" | "pi-spool";
-}
-
-interface RunnerTraceExportSink {
-  export(request: OtlpExportRequest): Promise<void>;
+  target: {
+    endpoint: string;
+    authorization: AuthorizationProvider;
+  };
+  diagnostics: PiSpoolDiagnostics;
 }
 ```
 
-`export()` is best-effort and resolves after success, final failure, or timeout. It does not throw
-into agent execution.
+`exportOtlpBytes()` is best-effort and resolves after success, final failure, or timeout. It
+preserves existing retry and diagnostics behavior and does not throw into agent execution.
 
 ## Compatibility rules
 
 - A runner without the new spool path continues current behavior.
-- A new runner enables the spool only when the installed Pi extension advertises protocol version
-  1 or the deployment ships the runner and extension atomically.
-- Do not run direct Pi export and spool export at the same time. The activation flag is exclusive.
-- During rollout, runner logs must identify `source=pi-direct`, `source=pi-spool`, or
-  `source=runner-acp` so duplicate paths are visible.
-- After rollout, Pi uses spool export for local and Daytona. `source=pi-direct` is removed.
+- The runner bundles and installs its matching Pi extension in both placements, so the runner,
+  extension, and control protocol cut over atomically in one image release.
+- Do not add a feature flag or support a mixed new-runner/old-extension mode.
+- Direct Pi network export and runner spool export never run together.
+- Runner logs identify `source=pi-spool` or `source=runner-acp` so duplicate paths are visible.
 

--- a/docs/design/runner-owned-pi-trace-export/plan.md
+++ b/docs/design/runner-owned-pi-trace-export/plan.md
@@ -1,0 +1,175 @@
+# Implementation plan
+
+Each phase should land green and keep trace failures best-effort. The first two phases establish
+the reusable substrate. The third phase switches Pi. The remaining phases remove temporary
+contracts and prove long-session behavior.
+
+## Immediate prerequisite PRs
+
+1. Runner export-time authorization (own PR): replace the captured authorization value with a provider backed by the credential getter that the alive watchdog already refreshes. Resolve it at flush time, and rebuild the endpoint cache entry when the resolved credential changes without interrupting an export already in flight. Acceptance: a credential rotated after tracing starts is used by export; short and non-session runs preserve current behavior; third-party unauthenticated collectors, diagnostics, and per-run target isolation remain correct.
+2. API Secret-token correctness (own small PR): add issued-at to every Secret JWT and re-raise HTTPException before the verify_secret_token catch-all. Acceptance: issued-at and expiry describe the configured lifetime; intentional, expired, and malformed authentication failures remain 401; unexpected failures remain 500. This adds no telemetry scope, export-only token, or longer TTL.
+
+These prerequisites do not change Pi span production. The Pi-owned span and runner-owned export cutover follows below.
+
+## Approved review changes to the remaining sequence
+
+The decisions in review.md supersede conflicting details in the older phase text below. The implementation order after the two prerequisite PRs is:
+
+1. Pin the public ProtobufTraceSerializer seam and prove parent-first raw-byte round trip in a fixture test. This replaces the serializer spike.
+2. Add a telemetry-only binary file host in a sibling of the relay directory. Do not refactor the tool relay.
+3. Add the per-turn control file and bounded multi-file spool. Include both mount credential pairs, one shared sandbox-visible redaction builder, explicit always-on Pi redaction, a runner size limit below the API 10 MB default, atomic sibling rename, start and teardown sweeps, and an unread-control diagnostic.
+4. Preserve cancellation traces: Pi publishes what it has and the runner emits a minimal error and usage fallback when no batch arrives. Keep one complete batch rather than periodic checkpoints.
+5. Cut local and Daytona Pi over together without a feature flag. Add the spool consumer to the bundle leak gate and reset per-turn Pi usage for warm sessions.
+6. Remove rejected token-scope and export-only DTO surfaces if any remain, then add release-gate trace and trace-long journeys for local Pi, Daytona Pi, and local Claude.
+
+The runner forwards raw standard OTLP protobuf under the current project credential. The accepted trust boundary and idempotent storage behavior are documented in review.md; do not add a custom DTO, a second semantic parser, or a deduplication layer.
+
+## Phase 0: pin the serializer and prove the byte contract
+
+Pin the OpenTelemetry transformer directly at the reviewed version and use its public ProtobufTraceSerializer.serializeRequest API. Add a focused fixture test that serializes a parent-first ReadableSpan batch and proves trace ids, parent ids, attributes, events, status, resources, and raw-byte handling survive. Confirm agent_end drain ordering and keep the consumer symbol out of the extension bundle. There is no serializer discovery spike and no copied protobuf definition.
+
+## Phase 1: add a telemetry-only byte host
+
+Add only the local and Daytona byte operations the telemetry spool needs. Use a telemetry directory beside the existing relay directory, keyed the same way, and create it even when tools are absent. Reads return bytes, writes accept bytes, and publication uses a temporary sibling plus same-directory rename. Add exact local and fake-Daytona binary round-trip tests, size-before-read checks, start and teardown sweeps, and leftover diagnostics. Do not modify or rebuild the tool relay.
+
+## Phase 2: reuse runner export behavior for spooled bytes
+
+PR #6217 already resolves the live platform credential at export time and keeps exporter rotation safe. For spooled batches, retain the existing timeout, missing-credential rule, diagnostics, target attribution, and best-effort failure behavior. Add one thin raw-bytes post path that resolves the same current authorization. Do not create a second lease, a general export-sink rewrite, a 401 retry protocol, or a third-party collector refresh path.
+
+Tests cover current-credential use, missing Agenta credentials, unauthenticated third-party collectors, failed sends, and independent run attribution.
+
+## Phase 3: add the Pi per-turn control and OTLP spool
+
+Files:
+
+- Add a dependency-free control protocol module, for example
+  `services/runner/src/tracing/pi-spool-protocol.ts`, safe to bundle into the Pi extension.
+- Add `services/runner/src/tracing/pi-file-exporter.ts` for Pi-side serialization and atomic
+  publication.
+- Add `services/runner/src/tracing/pi-spool-consumer.ts` for runner-side pickup and forwarding.
+- Update `services/runner/src/extensions/agenta.ts` to read the control file on every
+  `before_agent_start`, mutate all per-turn tracer configuration, and publish on `agent_end`.
+- Update `services/runner/src/tracing/otel.ts` to let Pi use the file batch transport without
+  changing its lifecycle hooks.
+- Update `services/runner/src/engines/sandbox_agent/pi-assets.ts` to supply only the stable control
+  path and spool configuration. Remove the endpoint and auth-file environment variables from Pi.
+- Update `services/runner/src/engines/sandbox_agent/run-turn.ts` to start the spool consumer,
+  publish control, run the prompt, then perform a bounded drain before returning.
+- Update `services/runner/src/engines/sandbox_agent/runtime-contracts.ts` and environment lifecycle
+  types for the new per-turn consumer. Remove `otlpAuthFilePath`.
+
+Runner turn ordering:
+
+1. Start consumer and finish stale sweep.
+2. Atomically publish control file.
+3. Send or resume the Pi prompt.
+4. Stop tool relay after prompt as today.
+5. Resolve Pi usage as today.
+6. Drain the expected telemetry batch with a short bound.
+7. Finish runner event handling and return the agent result.
+8. Stop the consumer in `finally` on every path.
+
+Pi changes:
+
+- `createAgentaOtel` keeps all existing native event hooks.
+- `before_agent_start` replaces `traceparent`, baggage, capture policy, session/turn metadata, and
+  channel state from the current control file.
+- Per-turn usage counters reset at the same boundary. Session-wide totals, if needed elsewhere,
+  remain separate.
+- `agent_end` publishes one complete standard OTLP protobuf batch and then writes usage output.
+
+Tests:
+
+- Control parsing, unknown version, missing file, malformed channel, and read-once deletion.
+- Atomic publication never exposes a temporary or partial file.
+- Exact binary round trip through local and fake-Daytona hosts.
+- Stale previous-turn file is swept and cannot satisfy the next turn.
+- Wrong channel is ignored.
+- Oversized and duplicate files are rejected and removed.
+- Missing batch times out without failing the agent result.
+- Warm turn two uses its own traceparent and capture policy, not turn one's.
+- Pi spans preserve native provider, model, tool, usage, cost, parent IDs, and content-capture rules.
+
+## Phase 4: switch both Pi placements to one path
+
+In `run-turn.ts` change Pi span ownership to:
+
+```ts
+emitSpans: !plan.isPi
+```
+
+Enable the Pi spool in both local and Daytona environment plans. Remove the Daytona statement that
+the extension is usage-only. The resulting behavior is:
+
+| Harness | Placement | Span producer | External exporter |
+|---|---|---|---|
+| Pi | Local | Pi extension | Runner |
+| Pi | Daytona | Pi extension | Runner |
+| Claude, Codex, Agenta | Local or Daytona | Runner ACP tracer | Runner |
+
+Never enable direct Pi export and spool export together. Local and Daytona cut over atomically through the same runner and image release; do not add a feature flag or a second long-lived mode.
+
+Tests:
+
+- One table-driven orchestration suite runs the same Pi spool assertions for local and Daytona
+  hosts.
+- Assert the ACP tracer emits no duplicate Pi agent, LLM, turn, or tool spans in either placement.
+- Assert non-Pi behavior remains unchanged.
+- Assert runner error spans still export without replacing Pi's batch.
+
+## Phase 5: remove the PR #6135 workaround contract
+
+If PR #6135 has not merged, replace its implementation and keep only generally useful diagnostics.
+
+If it has merged, remove:
+
+- export-only token minting and the two-hour TTL;
+- trace-ingest token scope enforcement added solely for this path;
+- `request.state.telemetry_credentials`;
+- `TraceContext.export_authorization`;
+- `WireOtlpExporter.exportAuthorization`;
+- runner `exportAuthorizationOf` compatibility logic;
+- per-turn OTLP auth-file refresh and Pi auth-file reader.
+
+Do not remove a token-scope facility if another merged feature has adopted it. In that case, remove
+only this feature's dependency on it and document the remaining owner.
+
+Update SDK golden requests, DTO repr tests, runner wire-contract tests, API middleware tests, and
+comments that describe local Pi as a direct exporter.
+
+## Phase 6: clean the general credential wire
+
+Treat this as a separate compatibility slice after runner-owned export is stable.
+
+1. Add `platform.headers.authorization` to Python wire models and runner protocol types.
+2. Resolve it into `PlatformCredentialLease` at the server boundary.
+3. Dual-read in the runner and dual-write in the SDK for the supported version window.
+4. Move all runner platform callers to the lease.
+5. Remove the legacy general credential from `telemetry.exporters.otlp.headers` after compatibility
+   is proven.
+
+This phase fixes the strange DTO ownership without coupling that cleanup to the trace outage fix.
+
+## Phase 7: documentation and release gate
+
+- Update Pi and Daytona adapter documentation to say Pi produces spans and the runner exports them.
+- Update runner README security notes to include the bounded telemetry spool.
+- Add the long-session cells from [qa.md](qa.md) to the agent release gate or its runner runtime
+  fixtures.
+- Link issue #6153 and close it only after local and Daytona warm-session traces are visible in the
+  target project.
+
+## Recommended PR stack
+
+Use a linear GitButler stack and set each GitHub PR base to the branch below it:
+
+1. `runner-runtime-file-host`
+2. `runner-credential-lease-export-sink`
+3. `pi-otlp-file-spool`
+4. `pi-spool-local-daytona-cutover`
+5. `remove-pi-export-token-workaround`
+6. `runner-platform-credential-wire` as a follow-up after compatibility review
+
+The first four branches are the functional path. Branch five depends on whether PR #6135 merged.
+Branch six is cleanup and should not delay the cutover.
+

--- a/docs/design/runner-owned-pi-trace-export/plan.md
+++ b/docs/design/runner-owned-pi-trace-export/plan.md
@@ -6,8 +6,8 @@ contracts and prove long-session behavior.
 
 ## Immediate prerequisite PRs
 
-1. Runner export-time authorization (own PR): replace the captured authorization value with a provider backed by the credential getter that the alive watchdog already refreshes. Resolve it at flush time, and rebuild the endpoint cache entry when the resolved credential changes without interrupting an export already in flight. Acceptance: a credential rotated after tracing starts is used by export; short and non-session runs preserve current behavior; third-party unauthenticated collectors, diagnostics, and per-run target isolation remain correct.
-2. API Secret-token correctness (own small PR): add issued-at to every Secret JWT and re-raise HTTPException before the verify_secret_token catch-all. Acceptance: issued-at and expiry describe the configured lifetime; intentional, expired, and malformed authentication failures remain 401; unexpected failures remain 500. This adds no telemetry scope, export-only token, or longer TTL.
+1. Complete: PR #6217 resolves authorization from the alive watchdog's current credential getter at export time. Short and non-session runs, third-party collectors, diagnostics, and per-run target isolation keep their existing behavior.
+2. Complete: PR #6218 adds issued-at to Secret JWTs and preserves intentional authentication failures as 401. It adds no telemetry scope, export-only token, or longer TTL.
 
 These prerequisites do not change Pi span production. The Pi-owned span and runner-owned export cutover follows below.
 
@@ -142,9 +142,9 @@ comments that describe local Pi as a direct exporter.
 Treat this as a separate compatibility slice after runner-owned export is stable.
 
 1. Add `platform.headers.authorization` to Python wire models and runner protocol types.
-2. Resolve it into `PlatformCredentialLease` at the server boundary.
+2. Resolve it into the runner's shared current-authorization provider at the server boundary.
 3. Dual-read in the runner and dual-write in the SDK for the supported version window.
-4. Move all runner platform callers to the lease.
+4. Move all runner platform callers to that provider.
 5. Remove the legacy general credential from `telemetry.exporters.otlp.headers` after compatibility
    is proven.
 

--- a/docs/design/runner-owned-pi-trace-export/qa.md
+++ b/docs/design/runner-owned-pi-trace-export/qa.md
@@ -1,0 +1,150 @@
+# QA plan
+
+The release claim is stronger than "the export returned 200." It is:
+
+> Pi produced the native span tree, the runner exported it, the trace landed under the current
+> turn's trace ID, and the same behavior held for local and Daytona after multiple credential
+> rotations.
+
+## Unit coverage
+
+### Runtime file host
+
+- Local and fake-Daytona implementations pass the same byte contract suite.
+- Binary payloads survive without UTF-8 conversion.
+- Temporary names are not discoverable as final batches.
+- Same-directory rename publishes complete bytes.
+- Missing directories, failed stats, failed watches, and removal failures stay bounded.
+
+### Control protocol
+
+- Version 1 round trip.
+- Unknown version rejected.
+- Channel IDs sanitized and bounded.
+- No endpoint or authorization field accepted or emitted.
+- Missing propagation and baggage preserve standalone-trace defaults.
+- Capture false applies to messages and tool inputs/outputs on the current turn.
+
+### Pi serializer
+
+- The body parses as a standard OTLP `ExportTraceServiceRequest`.
+- Agent, turn, LLM, and tool spans retain parent-child relationships.
+- Provider, request model, response model, usage, cost, events, status, session ID, and skill
+  attributes survive serialization.
+- One turn produces one final batch.
+- Oversized batches fail closed at the spool boundary without failing the run.
+
+### Spool consumer
+
+- Accepts exactly the expected current channel.
+- Ignores stale, temporary, wrong-channel, and duplicate files.
+- Deletes on pickup.
+- Stops cleanly after success, timeout, cancel, pause, and thrown prompt error.
+- A missing batch produces diagnostics and a successful agent result.
+- Local and Daytona hosts execute the same consumer code.
+
+### Credential lease and export sink
+
+- Fake time crosses 15 minutes, two hours, and 12 hours without using an expired credential.
+- Refresh is proactive and single-flight.
+- Export reads the credential immediately before each attempt.
+- One 401 triggers one refresh and one retry.
+- Repeated 401 stops and logs without failing the turn.
+- Third-party collector auth is not sent to `/permissions/check`.
+- Logs contain credential age and status but no secret value or OTLP content.
+
+## Orchestration matrix
+
+Run one table-driven suite for these cells:
+
+| Placement | Session state | Turn | Expected producer | Expected network sender |
+|---|---|---:|---|---|
+| Local | Cold | 1 | Pi | Runner |
+| Local | Warm | 2 | Pi | Runner |
+| Local | Warm after credential rotation | N | Pi | Runner |
+| Daytona | Cold | 1 | Pi | Runner |
+| Daytona | Warm | 2 | Pi | Runner |
+| Daytona | Warm after credential rotation | N | Pi | Runner |
+
+For each cell assert:
+
+- exactly one Pi `invoke_agent` span;
+- no ACP-reconstructed duplicate agent, turn, LLM, or tool span;
+- the span trace ID equals the current turn's propagated trace ID;
+- a tool call has Pi's exact tool call ID, input, output, and status;
+- an LLM call has Pi's provider/model and exact token/cost data;
+- content is absent when capture is false;
+- the HTTP sender runs in the runner test process;
+- Pi receives no endpoint or credential environment variable or control-file field.
+
+## Long-session tests without waiting 12 hours
+
+Use fake clocks and short test TTLs.
+
+### Many-turn warm session
+
+1. Start a Pi environment.
+2. Run turn one with trace A and capture enabled.
+3. Advance past the first credential expiry.
+4. Run turn two with trace B and capture disabled.
+5. Repeat through enough rotations to represent 12 hours.
+
+Assert each batch lands under its own trace, each export uses the lease's current credential, and no
+turn inherits the prior turn's capture policy.
+
+### One very long turn
+
+Hold a fake prompt open while the credential lease crosses multiple expiries. Publish the Pi batch
+only at the end. Assert the export uses the newest credential and succeeds. This covers the case
+that per-turn request refresh alone cannot solve.
+
+## Live local verification
+
+Use the standard local deployment flow with the matching edition and environment file.
+
+1. Run Pi locally with a prompt that makes at least one provider call and one tool call.
+2. Inspect the trace and verify native provider/model, tool data, token counts, and cost.
+3. Continue the same warm session after the normal token TTL.
+4. Verify the later trace lands and has the later `/invoke` trace ID.
+5. Toggle capture policy between turns and verify content follows the current turn.
+6. Confirm runner logs show `source=pi-spool placement=local` and no direct Pi export.
+
+## Live Daytona verification
+
+Repeat the local scenario with Daytona placement.
+
+Additional assertions:
+
+- the Daytona sandbox does not need network access to the Agenta OTLP endpoint;
+- the runner reads the batch through the sandbox filesystem API;
+- trace details match local Pi for the same prompt shape;
+- runner logs show `source=pi-spool placement=daytona`;
+- no ACP-reconstructed duplicate tree appears.
+
+## Failure injection
+
+- Prevent control-file write.
+- Crash Pi before `agent_end`.
+- Publish a truncated protobuf file under a temporary name.
+- Publish an oversized final file.
+- Make Daytona list or read fail transiently.
+- Make the first OTLP request return 401 and the second return 200.
+- Make credential refresh fail.
+- Make OTLP time out.
+- Cancel and pause a turn while the consumer is active.
+
+Every case must leave the agent result semantics unchanged, clean up the consumer, and emit a
+specific bounded diagnostic.
+
+## Regression gate
+
+Before release:
+
+- `pnpm test` in `services/runner`;
+- `pnpm run typecheck` in `services/runner`;
+- targeted Python SDK wire and tracing tests;
+- API auth tests only if removing merged PR #6135 code changes API behavior;
+- the agent release gate against local and Daytona deployments;
+- a persisted trace inspection for both placements, because a green HTTP export alone does not
+  prove span fidelity or parentage.
+

--- a/docs/design/runner-owned-pi-trace-export/qa.md
+++ b/docs/design/runner-owned-pi-trace-export/qa.md
@@ -40,16 +40,16 @@ The release claim is stronger than "the export returned 200." It is:
 - Ignores stale, temporary, wrong-channel, and duplicate files.
 - Deletes on pickup.
 - Stops cleanly after success, timeout, cancel, pause, and thrown prompt error.
-- A missing batch produces diagnostics and a successful agent result.
+- A missing or invalid batch produces exactly one runner-owned fallback error-and-usage span,
+  no partial Pi batch, bounded diagnostics, and unchanged agent-result semantics.
 - Local and Daytona hosts execute the same consumer code.
 
-### Credential lease and export sink
+### Live authorization and export
 
-- Fake time crosses 15 minutes, two hours, and 12 hours without using an expired credential.
-- Refresh is proactive and single-flight.
+- Fake credential rotations cross 15 minutes, two hours, and 12 hours without reusing the
+  captured initial credential.
 - Export reads the credential immediately before each attempt.
-- One 401 triggers one refresh and one retry.
-- Repeated 401 stops and logs without failing the turn.
+- Existing bounded retry classifications stay unchanged; this work adds no 401 refresh protocol.
 - Third-party collector auth is not sent to `/permissions/check`.
 - Logs contain credential age and status but no secret value or OTLP content.
 
@@ -122,6 +122,10 @@ Additional assertions:
 - no ACP-reconstructed duplicate tree appears.
 
 ## Failure injection
+
+For cancellation, prompt failure, missing publication, a truncated final file, and an oversized
+final file, assert exactly one of two outcomes: one valid complete Pi batch, or one idempotent
+runner fallback span. Never accept a periodic or partial Pi batch.
 
 - Prevent control-file write.
 - Crash Pi before `agent_end`.

--- a/docs/design/runner-owned-pi-trace-export/research.md
+++ b/docs/design/runner-owned-pi-trace-export/research.md
@@ -1,0 +1,130 @@
+# Research
+
+Research was performed against `origin/main` at commit
+`53717db55ec9311887be6fe86a67b2007590b6f3` and PR #6135 at
+`f20bede3cb2841234a8d641b273d9b312cb80dce` on 2026-08-22.
+
+## Verified current behavior
+
+### Access exchange and middleware
+
+- `api/oss/src/apis/fastapi/access/router.py`, `AccessRouter.check_permissions`, always returns a
+  freshly signed short-lived `Secret` credential after permission checking.
+- `sdks/python/agenta/sdk/middlewares/routing/auth.py`, `get_credentials`, calls that endpoint for
+  the `run_service` action and caches the result for one minute by default.
+- `sdks/python/agenta/sdk/agents/tracing.py`, `trace_context`, captures the active W3C propagation
+  values, Agenta OTLP endpoint, caller credential, and capture policy.
+- `sdks/python/agenta/sdk/agents/dtos.py`, `TraceContext.telemetry_to_wire`, puts the caller
+  credential under `telemetry.exporters.otlp.headers.authorization`.
+- `services/runner/src/server.ts`, `runCredential`, and
+  `services/runner/src/engines/sandbox_agent/runtime-policy.ts`, `runCredential`, treat that field
+  as the general runner-to-platform credential, not only as exporter authorization.
+
+This explains why replacing the existing field with a trace-only token is unsafe. The field is
+misnamed by location, but its current behavior carries broad runner authority.
+
+### Runner credential refresh
+
+- `services/runner/src/sessions/auth.ts`, `refreshCredential`, reuses
+  `/access/permissions/check` to exchange a still-valid credential for a fresh one.
+- `services/runner/src/sessions/alive.ts`, `startAliveWatchdog`, stores the credential mutably and
+  refreshes it during a long session-owned turn.
+- `services/runner/src/engines/sandbox_agent/run-turn.ts` already accepts a `credential()` closure
+  for runner platform calls during the turn.
+
+The reusable piece is therefore a runner-owned renewable credential lease. Trace export should
+read from that lease at send time. It should not capture one token at process or turn start.
+
+### Pi spans versus ACP reconstruction
+
+- `services/runner/src/tracing/otel.ts`, `createAgentaOtel`, subscribes to Pi's native
+  `before_agent_start`, `agent_start`, `context`, `turn_start`, `before_provider_request`,
+  `message_end`, `tool_execution_start`, `tool_execution_end`, `turn_end`, and `agent_end` events.
+- Those events create the agent, turn, LLM, and tool spans and record the real provider, model,
+  inputs, outputs, token usage, and cost.
+- `createSandboxAgentOtel` reconstructs a similar tree from ACP updates. ACP does not carry all of
+  Pi's per-provider details and exact cost data.
+- `run-turn.ts` currently sets `emitSpans: !plan.isPi || plan.isDaytona`. Local Pi therefore uses
+  Pi-native spans, while Daytona Pi uses ACP reconstruction.
+- `services/runner/src/extensions/agenta.ts` exports directly only when tracing is enabled. Daytona
+  uses the extension for usage writeback but not for direct trace export.
+
+The new design should set runner ACP span emission off for Pi in both placements. It should make
+Pi-native export available in Daytona through the spool instead of direct networking.
+
+### Warm-session tracing state
+
+- `services/runner/src/engines/sandbox_agent/pi-assets.ts`, `buildPiExtensionEnv`, writes
+  `TRACEPARENT`, OTLP endpoint, capture policy, skills, and the auth-file path into the environment
+  created for the Pi process.
+- `services/runner/src/extensions/agenta.ts` reads those values when the extension factory runs and
+  creates one `AgentaOtel` object.
+- A warm environment reuses that Pi process across later `/run` requests.
+
+PR #6135 refreshes authorization before each `agent_start`, but the other tracing values remain
+process-scoped. A proper per-turn contract must refresh propagation and policy together.
+
+## Existing cross-placement transport precedent
+
+`services/runner/src/tools/relay.ts` defines one runner-side relay loop with two host adapters:
+
+- `localRelayHost` uses Node filesystem operations.
+- `sandboxRelayHost` uses Daytona's sandbox filesystem API.
+
+The relay already implements the important transport mechanics:
+
+- atomic publication through write-to-temp and same-directory rename;
+- suffix-based discovery that ignores temporary files;
+- delete-on-pickup;
+- stale-file sweep before a warm turn;
+- local file watching and Daytona watch or poll behavior;
+- polling fallback and bounded stop/drain behavior;
+- a runner-side authorization check because the directory is sandbox-writable.
+
+`services/runner/src/engines/sandbox_agent/usage.ts` independently proves that one logical read can
+work through local filesystem access or Daytona's `readFsFile` API.
+
+The current `RelayHost` is text-specific because the tool protocol is JSON. Daytona's filesystem
+API already returns bytes, and other runner paths write `Buffer` values. The reusable change is to
+factor a binary runtime-file host below the tool relay. Tool relay can decode JSON on top; telemetry
+can preserve protobuf bytes.
+
+## Standard OTLP payload
+
+- The runner pins `@opentelemetry/exporter-trace-otlp-proto` at `0.220.0`.
+- The lockfile includes `@opentelemetry/otlp-transformer` at the same version.
+- The API parses an OTLP `ExportTraceServiceRequest` protobuf in
+  `api/oss/src/apis/fastapi/otlp/opentelemetry/otlp.py`.
+- `api/oss/src/apis/fastapi/otlp/router.py` accepts `application/x-protobuf` and rejects bodies over
+  the configured `AGENTA_OTLP_MAX_BATCH_BYTES` limit.
+
+The first implementation step must prove the supported serializer API for the pinned package and
+pin it as a direct dependency if the extension imports it. The design must not copy generated OTLP
+types or invent a parallel span schema.
+
+## What PR #6135 adds
+
+PR #6135 keeps local Pi as the network exporter and adds:
+
+- an export-only token with a two-hour lifetime;
+- token scope enforcement in API auth middleware;
+- a second `telemetry_credentials` value in routing middleware state;
+- `export_authorization` in the SDK DTO;
+- `exportAuthorization` on the runner wire;
+- a per-turn auth-file rewrite for the Pi extension.
+
+Those changes improve least privilege relative to giving Pi the general credential, but they retain
+a fixed token-lifetime dependency and a local-only direct-export path. The runner-owned design does
+not need the second token or the added wire field because Pi receives no credential at all.
+
+## Related work
+
+- [PR #6109](https://github.com/Agenta-AI/agenta/pull/6109) added trace-export diagnostics. Keep and
+  extend those diagnostics.
+- [Issue #6153](https://github.com/Agenta-AI/agenta/issues/6153) records the warm-session 401
+  incident.
+- `docs/design/agent-workflows/documentation/adapters/pi.md` documents Pi self-instrumentation and
+  exact usage.
+- `docs/design/agent-workflows/documentation/adapters/claude-code.md` documents runner-side ACP
+  reconstruction for a harness that does not self-instrument.
+

--- a/docs/design/runner-owned-pi-trace-export/review.md
+++ b/docs/design/runner-owned-pi-trace-export/review.md
@@ -1,0 +1,342 @@
+# Review
+
+This file reviews the plan in this folder against the code it would change, and records the
+decisions the owner made after that review. Every claim about current behavior cites the file and
+line it came from. Read [README.md](README.md) first for the shape of the design; read this file
+before starting Phase 0.
+
+## Decisions taken by the owner
+
+1. **The credential fix ships first, on its own branch.** The plan already contains it inside
+   Phase 2. It moves out and lands alone, before any spool work, because it fixes long turns for
+   Daytona Pi, Claude, and Codex by itself.
+2. **Redaction moves into Pi, for every placement, with no exceptions.** The extension seeds its
+   deny set from its own process environment and from the mount credentials the runner sends in the
+   per-turn control file. Both mount credential pairs are included. The redaction mode is hardcoded
+   in the extension. One shared builder produces the deny set, so the runner's own redactor and
+   Pi's cannot drift.
+3. **A cancelled turn still produces a trace.** Pi publishes whatever it holds when the turn is
+   cancelled. The runner emits a minimal fallback span carrying the error and the usage totals
+   whenever the drain finds nothing. There are no periodic partial batches.
+
+The rest of this file explains why, lists the trims that shrink the plan, and names what is still
+underspecified.
+
+## Findings
+
+### 1. The credential fix is correct, and it should not wait for the rest
+
+**What the plan says.** Phase 2 refactors session credential handling into a
+`PlatformCredentialLease`, then builds a new `RunnerTraceExportSink` that reads the lease before
+every HTTP attempt (architecture.md:110-150, plan.md:55-90).
+
+**What the code says.** The turn passes the request header to the tracer as a plain string
+(`services/runner/src/engines/sandbox_agent/run-turn.ts:268`). The tracer freezes that string
+(`services/runner/src/tracing/otel.ts:1224`) and registers it as the run's export target
+(`otel.ts:1416`, and again on the error path at `otel.ts:1661`). The exporter cache is keyed on
+endpoint plus credential (`otel.ts:212-231`), so a rotated credential would build a second cache
+entry rather than update the first. A live credential getter already exists
+(`services/runner/src/sessions/alive.ts:249`), refreshed every fifth heartbeat
+(`alive.ts:225-232`), and the turn already holds a credential closure
+(`run-turn.ts:107`).
+
+**Decision.** Land this alone, first. Change `ExportTarget.authorization` to a getter. Resolve it
+inside `TraceBatchProcessor.flush`, immediately before the export, so the credential-less skip and
+the diagnostics both see the current value (`otel.ts:371-390`). Key the exporter cache on endpoint
+alone and rebuild the entry when the resolved value changed. Pass the getter from
+`run-turn.ts:107` instead of the string at `run-turn.ts:268`. Runs with no watchdog pass a closure
+over the request credential, which reproduces today's behavior exactly.
+
+**Severity.** Blocker for sequencing. The change itself is small and compiler enforced.
+
+### 2. Redaction is missing from the plan, and the cutover would remove it from Daytona
+
+**What the plan says.** Nothing. The word does not appear in any file in this folder.
+
+**What the code says.** The runner redacts every string span attribute, every event attribute, and
+the status message at the sink, immediately before export (`otel.ts:184-205`, applied at
+`otel.ts:371-373`). The deny set is seeded from the request's typed credential values plus the
+mount credentials (`run-turn.ts:270-280`, `services/runner/src/redaction.ts:436-470`). The
+in-sandbox extension builds its tracer with no redactor at all
+(`services/runner/src/extensions/agenta.ts:466-475`). Today a Daytona Pi run is traced by the
+runner from the ACP stream (`run-turn.ts:279`), so its spans are redacted. After this plan's Phase
+4, those spans come from the sandbox as opaque bytes and nothing checks them.
+
+**Why the runner cannot fix it after the fact.** Forwarding the exact bytes and redacting them are
+mutually exclusive unless the runner decodes the batch, and no decoder exists in the tree. The
+pinned `@opentelemetry/otlp-transformer` ships a hand written protobuf writer and a response
+deserializer only. There is no request decoder and there are no `.proto` descriptors anywhere in
+`services/runner/node_modules`.
+
+**Decision.** Pi redacts, on every placement. Three parts:
+
+- **The machinery is already in the bundle.** The extension imports `otel.ts`, so the per-trace
+  accumulator (`otel.ts:160-177`), the sink pass (`otel.ts:371-373`), and `redactSpan`
+  (`otel.ts:184-205`) all ship inside `dist/extensions/agenta.js` today. Only the `Redactor` class
+  is missing, because `otel.ts:59` imports it with `import type`, which the bundler erases.
+  Confirmed against the built artifact: it contains the three `redactString` call sites and no
+  other redaction symbol.
+- **Provider keys cost nothing.** `curatedEnvSecretValues` seeds the values of every process
+  environment variable whose name matches the suffix list (`redaction.ts:193-201`, list at
+  `redaction.ts:117-134`). Called inside the sandbox it picks up the provider key the harness reads
+  from its own environment (`services/runner/src/environment/runtime-lifecycle.ts:202`). When
+  Daytona Secrets are active the variable holds a placeholder instead of the key
+  (`services/runner/src/engines/sandbox_agent/daytona-secret-plan.ts:22-60`), so there is nothing
+  to leak and nothing to do.
+- **Mount credentials ride the control file.** They are not in Pi's environment today. On Daytona
+  they are passed as the environment of the single process call that backgrounds geesefs
+  (`services/runner/src/engines/sandbox_agent/mount.ts:669`, built at `mount.ts:236-243`), and
+  deliberately kept out of argv. The sandbox can already read them from the geesefs process,
+  because both run as the same user, so sending them to the extension exposes nothing new. Send
+  them in the per-turn control file as read-once values, never as an environment variable: the
+  Daytona daemon environment is frozen at sandbox creation (`runtime-lifecycle.ts:243-246`), the
+  project already rejected plain environment delivery for this class of value
+  (`services/runner/src/engines/sandbox_agent/pi-assets.ts:468-473`), and a variable in the
+  harness's own environment would land in a span the moment the model runs `env`.
+
+**Both credential pairs, not one.** `agentMountCreds`, the per-harness session and transcript mount
+(`services/runner/src/engines/sandbox_agent/runtime-contracts.ts:294`, set at
+`services/runner/src/engines/sandbox_agent/environment.ts:756`), is absent from the deny set today,
+because `run-turn.ts:277-279` seeds only `env.mountCreds`. Add it on both sides.
+
+**One builder, no drift.** Export a single helper next to `requestSecretValues`
+(`redaction.ts:414-433`) that returns the sandbox-visible subset of the deny set. The control-file
+writer and the runner's own `seedForRun` call at `run-turn.ts:274-280` both use it. The runner's
+deny set stays a superset, because it also holds the run credential and its own environment
+secrets, and neither of those can appear in a Pi span.
+
+**Hardcode the mode.** `redactionMode` reads `AGENTA_REDACTION_MODE` from the process environment
+(`redaction.ts:27-30`). Pass the mode explicitly in the extension so an operator's runner-side
+"off" can never silently disable redaction inside a sandbox.
+
+**Rotation.** On Daytona the re-sign and remount path returns early
+(`services/runner/src/environment/mount-lifecycle.ts:357`), so an environment's mount credentials
+are fixed for its life and the pool retires the environment when the lease expires
+(`services/runner/src/environment/acquire-context.ts:88`). Sending the values every turn is
+therefore correct and also future proof if Daytona ever gains re-signing.
+
+**Cost and risk.** Roughly fifteen to twenty five lines on top of the control file the plan already
+builds, plus about ten kilobytes on an eight hundred kilobyte bundle. False positives are already
+bounded by the library: four characters minimum for whole-value variants, eight plus word-boundary
+matching for decomposed halves, and a junk allowlist (`redaction.ts:243-262`, `:93-110`). Empty
+values are skipped, so an absent session token is a no-op. Cost at flush is a handful of
+`String.includes` passes per attribute, which the runner already pays for every other harness.
+
+**Severity.** Blocker.
+
+### 3. A cancelled or killed turn must still produce a trace
+
+**What the plan says.** The only loss case listed is the runner stopping after pickup
+(architecture.md:230).
+
+**What the code says.** Today an aborted turn still exports, because the spans live in the runner
+and the catch path flushes them (`run-turn.ts:1245`), including the standalone error span
+(`otel.ts:1645-1667`). After Phase 4 sets `emitSpans: !plan.isPi`, an aborted Daytona turn has no
+spans anywhere except inside a sandbox that may already be gone.
+
+**Decision.** Pi publishes what it holds when the prompt is cancelled. The runner emits its minimal
+fallback span, carrying the run error and the usage totals it already resolved, whenever the drain
+finds no batch. No periodic partial batches: the processor deliberately sends one trace as one
+batch because Agenta computes cumulative token and cost rollups per ingest batch
+(`otel.ts:288-295`), and splitting a turn across batches loses the root aggregation. State that
+reason in architecture.md next to the failure table so nobody reintroduces checkpointing.
+
+**Severity.** Should, and it is the main functional regression the cutover would otherwise cause.
+
+## Trims
+
+These shrink the plan without changing its shape.
+
+### 4. Reuse the OTel exporter with a thin bytes post
+
+**What the plan says.** A new `RunnerTraceExportSink` owns HTTP, timeout, retry, diagnostics, and
+credential lookup (interfaces.md:186-205).
+
+**What the code says.** The existing path already has the timeout, the diagnostics, the
+credential-less skip for Agenta's own ingest, and per-run target attribution
+(`otel.ts:216-231`, `otel.ts:355-390`), all covered by existing tests.
+
+**Recommendation.** Keep `OTLPTraceExporter`. Add one thin function that posts pre-serialized bytes
+for the spool case. Severity: should.
+
+### 5. Do not rewrite the tool relay
+
+**What the plan says.** Phase 1 extracts a `RuntimeFileHost` and rebuilds `relay.ts` on top of it
+(plan.md:32-50).
+
+**What the code says.** The sandbox file API is already binary safe: `readFsFile` returns a
+`Uint8Array`, `writeFsFile` takes a body, and `moveFs` is a same-directory rename
+(`services/runner/node_modules/sandbox-agent/dist/index.d.ts:3249-3253`, used at
+`services/runner/src/tools/relay.ts:310-325`). The relay only decodes UTF-8 on top
+(`relay.ts:310-316`).
+
+**Recommendation.** Add the small byte host for telemetry alone. Let the relay adopt it later, or
+never. `relay.ts` is eight hundred and fifty four lines of hard-won behavior and this fix does not
+need to touch it. Severity: should.
+
+### 6. Put the spool beside the relay directory
+
+**What the plan says.** A new runtime IPC root, with the relay migrated under it
+(architecture.md:60-76).
+
+**What the code says.** The relay directory is already ephemeral, off the durable mount, and keyed
+per conversation (`services/runner/src/engines/sandbox_agent/run-plan.ts:645-651`), chosen that way
+because a relay inside the mount routes every tool call through FUSE. Its stale sweep only removes
+relay-suffixed names (`relay.ts:495-502`).
+
+**Recommendation.** Use a sibling directory with the same key. Severity: nice.
+
+### 7. Allow several files per turn
+
+**What the plan says.** One accepted file per turn in version 1 (interfaces.md:160-170).
+
+**What the code says.** The processor flushes per trace id and also fires on its own whenever a
+span with no in-process parent ends (`otel.ts:308-318`), which is exactly a run started without a
+caller traceparent. The error path can flush a second batch (`otel.ts:1661-1665`).
+
+**Recommendation.** Accept a sequence in the filename, with a bounded count, and drain every file
+until the turn ends. Severity: should.
+
+### 8. Serialize parent first
+
+**What the plan says.** "Serializes the batch", with no ordering rule (architecture.md:128-140).
+
+**What the code says.** The export sends `orderParentFirst(group)` (`otel.ts:370`, helper at
+`otel.ts:440-460`) because Agenta stores millisecond timestamps and attaches a span only when its
+parent was already seen.
+
+**Recommendation.** Serialize the ordered array, and assert the tree survives the round trip in the
+Phase 0 fixture test. Severity: should.
+
+### 9. The size limit is ten megabytes, and the runner needs its own cap
+
+**What the plan says.** Mirror the API's configured maximum (interfaces.md:168).
+
+**What the code says.** The API default is ten megabytes (`api/oss/src/utils/env.py:357`), while the
+endpoint docstring still claims four (`api/oss/src/apis/fastapi/otlp/router.py:100`). The runner
+cannot read the API's environment.
+
+**Recommendation.** Add a runner-side maximum with a default below the ingest limit, check the size
+before reading the file, and fix the stale docstring. Severity: should.
+
+### 10. Add the consumer to the bundle leak gate
+
+**What the plan says.** The Pi exporter and the runner consumer live in the same directory
+(plan.md:96-100).
+
+**What the code says.** `services/runner/scripts/build-extension.mjs` fails the build when a
+runner-side symbol reaches the sandbox bundle, and it currently lists three.
+
+**Recommendation.** Add the spool consumer's exported name to that list in the same pull request.
+Severity: nice.
+
+### 11. Keep the per-turn usage reset, and test it
+
+**What the plan says.** One line about resetting per-turn counters (plan.md:141-143).
+
+**What the code says.** The run totals object is created once per extension instance
+(`otel.ts:725`) and never resets, so in a warm session every later turn stamps cumulative totals on
+its agent span and writes cumulative totals to the file the runner reads back as that turn's usage
+(`services/runner/src/engines/sandbox_agent/usage.ts:6-26`).
+
+**Recommendation.** This is a real bug fix, and it changes reported numbers. Give it its own test
+covering turn two of a warm session, and check whether the turn ledger or any cost rollup depends
+on the old behavior. Severity: should.
+
+### 12. Drop the compatibility flag
+
+**What the plan says.** An exclusive feature flag or a capability handshake if the runner and the
+extension can drift (status.md:48-50, interfaces.md:210-222).
+
+**What the code says.** They cannot drift. The runner installs its own bundle from its own build
+output on the local path (`pi-assets.ts:706`, `pi-assets.ts:850`) and uploads that same bundle into
+the sandbox on the Daytona path (`services/runner/src/engines/sandbox_agent/daytona.ts:234`).
+
+**Recommendation.** Delete the flag from the plan. Keep one diagnostic instead: if the control file
+is still present when the turn ends, Pi never read it. Severity: nice.
+
+### 13. Drop the serializer spike
+
+**What the plan says.** Phase 0 must discover which serializer to use (status.md:44-47).
+
+**What the code says.** `ProtobufTraceSerializer.serializeRequest` is a public export of
+`@opentelemetry/otlp-transformer` (`build/src/index.d.ts:6`, contract at `i-serializer.d.ts`). Two
+corrections to research.md: the installed version is 0.219.0, not 0.220.0, and it arrives
+transitively through `exporter-trace-otlp-proto@0.220.0`.
+
+**Recommendation.** Pin it as a direct dependency, record the seam in status.md, and shrink Phase 0
+to a fixture test. Bundle size is not a new risk, since the extension already bundles the OTLP
+exporter and its protobuf dependencies. Severity: nice.
+
+## Trust and blast radius
+
+A prompt-injected sandbox can write any bytes into the spool, so the runner forwards attacker
+controlled protobuf under its own credential. The bounds are worth stating precisely, because they
+are better than they look.
+
+- It cannot cross projects. The ingest takes project, organization, and user from the credential
+  (`api/oss/src/apis/fastapi/otlp/router.py:110-118`, `:253-258`).
+- It cannot smuggle identity in the payload. The parser walks straight to spans and discards
+  resource and scope entirely (`api/oss/src/apis/fastapi/otlp/opentelemetry/otlp.py:129-131`), so no
+  resource attribute is read by anything.
+- It can overwrite spans inside the caller's own project. Storage upserts on the primary key
+  project, trace, and span, and updates every other column on conflict
+  (`api/oss/src/dbs/postgres/tracing/dao.py:104-127`). The sandbox knows the caller's trace id and
+  parent span id from its own traceparent, so it can overwrite the caller's own root span.
+- This is still strictly less authority than today's local Pi, which holds a reusable bearer and can
+  post anywhere the caller can reach.
+
+Record this in architecture.md as the accepted position. If a later change adds a decoder for any
+reason, add two checks in the same pass: the batch's trace id equals the turn's expected trace id,
+and no span id equals the caller's parent span id.
+
+## Idempotency
+
+A retried export is safe and needs no extra machinery. Storage upserts on the span key
+(`dao.py:104-127`), so a resent batch overwrites rather than duplicates. The paid counter only
+counts spans with no parent (`otlp/router.py:217`), and a Pi batch nested under the caller's
+traceparent contains none. Keep the retry bounded anyway, and say this in architecture.md so nobody
+builds a deduplication layer that is not needed.
+
+## Still underspecified
+
+1. **Framing.** One export request per file needs no framing, but that only holds once several
+   files per turn are allowed. Say it, rather than leaving it implied.
+2. **Encoding.** Say raw bytes, no base64 wrapper, and cite that the sandbox read returns a byte
+   array so nothing forces a text round trip.
+3. **Partial writes.** Write to a temporary sibling and rename. Cite the existing proof that the
+   sandbox move is a real rename (`relay.ts:318-322`) instead of restating it as an assumption.
+4. **Cleanup.** Nobody owns deleting the spool directory when the environment is released, and
+   nothing says what happens to a file Pi writes after the consumer stopped. Sweep at teardown and
+   at the start of every turn, and log the leftover rather than deleting it silently.
+5. **An unread control file.** Decide what the runner does when the control file is still present at
+   drain time. That is the one signal that separates "Pi failed" from "Pi never got the turn".
+
+## Carry-overs from the span record design
+
+Three pieces of `docs/design/agent-trace-export/` survive this plan and should be folded into it.
+
+1. **The credential getter, as specified there.** Its Step 2 names the call sites, the exporter
+   cache rule, and the tests, including that a getter returning empty against Agenta's own ingest
+   must still skip the export and log the skip.
+2. **Release gate coverage.** Its Step 6 adds a `trace` journey to the agent release gate that
+   asserts on structure: exactly one agent span, a turn span parented to it, a model span carrying
+   the request model and non-zero total tokens, one tool span per reported tool call with a matching
+   call id, and no secret value in any attribute. Run it on local Pi, Daytona Pi, and local Claude.
+   Add its `trace_long` journey too, which holds one turn open past the credential's life. This
+   folder's qa.md has strong unit coverage but leaves live verification manual.
+3. **The explicit redaction point.** That design names redaction as a first-class requirement. This
+   one did not, which is how the gap in finding 2 stayed invisible.
+
+## Verdict
+
+The design is sound and its core claim holds: Pi should keep producing spans, and the runner should
+be the only component that sends them.
+Two findings had to be resolved before implementation, and the owner resolved both: redaction moves
+into Pi on every placement, and a cancelled turn still produces a trace.
+The credential fix leaves Phase 2 and ships first, alone, because it repairs long turns for three
+harnesses without any of the spool work.
+Two of the plan's open questions are already answered by the code, which removes the serializer
+spike and the compatibility flag outright.
+With the trims applied, the remaining work is smaller than the plan currently describes: a small
+byte host, a control file, a spool consumer, and a cutover.

--- a/docs/design/runner-owned-pi-trace-export/status.md
+++ b/docs/design/runner-owned-pi-trace-export/status.md
@@ -1,0 +1,68 @@
+# Status
+
+**Phase: implementation started.**
+
+Last updated: 2026-08-22.
+
+## Decisions
+
+- Pi remains the source of Pi spans.
+- The runner is the only external exporter.
+- Local and Daytona use one file-spool protocol and one consumer state machine.
+- The payload is raw standard OTLP protobuf, not a custom Agenta DTO.
+- Pi receives per-turn propagation and capture policy, but no endpoint or credential.
+- The runner uses a renewable credential lease, so no two-hour telemetry token sets the session
+  limit.
+- Pi ACP span reconstruction is disabled in both placements after cutover.
+- The existing tool relay supplies transport precedent, but telemetry and tools keep separate
+  protocol directories and authorization rules.
+- General credential wire cleanup is a follow-up compatibility slice, not a prerequisite for the
+  trace fix.
+- Trace export remains best-effort and bounded.
+- No feature flag or parallel long-lived Pi export mode will be added.
+- Work starts with two focused PRs: runner export-time authorization, then API issued-at plus 401 preservation.
+
+## Approved Fable review constraints for the remaining work
+
+- Pi redacts its own spans in every placement. One shared deny-set builder serves Pi and the runner, includes both mount credential pairs, and the extension uses an explicit always-on mode.
+- Cancellation still produces a trace. Pi publishes what it has; when no batch arrives, the runner emits the minimal error and usage fallback span. Do not add periodic partial batches because ingest rollups depend on one complete batch.
+- Keep the existing OTel exporter behavior and add only a thin raw-bytes post for spooled batches.
+- Add a telemetry-only byte host beside the relay directory. Do not rewrite the tool relay.
+- Allow a bounded sequence of raw protobuf files per turn, written by temporary-sibling rename and serialized parent-first.
+- Add a runner-owned size cap below the API 10 MB default, teardown and turn-start sweeps, unread-control diagnostics, and a consumer symbol in the extension bundle leak gate.
+- Pin ProtobufTraceSerializer as a direct dependency and replace the serializer spike with a fixture test.
+- Reset and test per-turn Pi usage for warm sessions.
+- The accepted trust boundary is project-scoped forwarding of sandbox-authored protobuf. No custom DTO, trace parser, deduplication layer, compatibility flag, or feature flag is added.
+- Release-gate coverage must include trace structure, redaction, local Pi, Daytona Pi, local Claude, and a turn held beyond one credential lifetime.
+
+PR #6217 implements the first approved prerequisite. PR #6218 carries the independent Secret-token issued-at and 401 correctness fixes.
+
+## Current evidence
+
+- Main's access router already re-mints renewable short-lived credentials.
+- Main's runner already refreshes credentials during session-owned turns.
+- Main's Pi extension already creates the desired native span tree.
+- Main's relay already supports local and Daytona through host adapters with atomic files, stale
+  sweep, watch/poll fallback, and delete-on-pickup.
+- Main's OTLP ingest accepts the same standard protobuf body the Pi extension can spool.
+- PR #6135 extends the lifetime and refreshes only authorization. It does not remove the lifetime
+  coupling or unify local and Daytona export.
+
+## Open questions
+
+1. Should the first release parse OTLP in the runner for trace-ID hardening, or rely on the bounded
+   current-channel capability plus API parsing? The recommendation is to ship without a second
+   semantic parser unless threat review requires it.
+2. What compatibility window is required before moving the general credential from the legacy
+   telemetry header into `platform.headers.authorization`?
+3. If PR #6135 merges first, has any other feature adopted its token-scope machinery? Remove only
+   code that has no remaining owner.
+
+## Blockers
+
+None. The two prerequisite correctness PRs are open and the serializer seam is decided.
+
+## Next action
+
+Review and land PRs #6217 and #6218. Then pin the reviewed serializer dependency, add the parent-first fixture, and build the telemetry-only byte host.
+


### PR DESCRIPTION
This folder holds the chosen design for exporting Pi traces through the runner: plan, QA plan, and the owner's review with three decisions (the credential getter fix ships first, already merged as #6217/#6218; redaction moves inside Pi for every sandbox kind; an aborted turn writes a fallback span with no partial batches). Implementation is #6223. No product behaviour change. Related: #6223