### PR TITLE
[fix] Provision the runtime key in PR previews

### DIFF
--- a/.github/workflows/48-railway-clone-preview-test.yml
+++ b/.github/workflows/48-railway-clone-preview-test.yml
@@ -41,7 +41,7 @@ on:
         description: "Pinned app-image tag to patch to (never 'latest'; must differ from the template's app tag)"
         required: false
         type: string
-        default: "pr-5651-a46168f"
+        default: "pr-6235-927b6dc"
 
 permissions:
   contents: read
@@ -65,7 +65,7 @@ jobs:
       - name: Run consecutive clone cycles with the production scripts
         env:
           CYCLES: ${{ inputs.cycles || '3' }}
-          IMAGE_TAG: ${{ inputs.patch_tag || 'pr-5651-a46168f' }}
+          IMAGE_TAG: ${{ inputs.patch_tag || 'pr-6235-927b6dc' }}
           # One shared call-counter file so per-cycle API call deltas can be
           # computed here (every request in lib-graphql.sh appends a line).
           RW_CALLS_FILE: /tmp/rw-calls-48

--- a/hosting/railway/oss/scripts/preview-clone-create.sh
+++ b/hosting/railway/oss/scripts/preview-clone-create.sh
@@ -250,6 +250,33 @@ apply_ci_auth_key() {
     printf "CI auth key applied to every service that consumes it.\n"
 }
 
+# A write-only vault connection can be resolved only by the trusted platform
+# runtime. Give API and Services one ephemeral shared proof before deploy; do
+# not reuse the admin key and do not expose this proof to any other service.
+# CI may provide a stable value, but disposable previews need no stored secret.
+apply_ci_runtime_key() {
+    local runtime_key="${AGENTA_SERVICES_INTERNAL_KEY:-}"
+    if [ -z "$runtime_key" ]; then
+        command -v openssl >/dev/null 2>&1 || {
+            printf "missing required command: openssl\n" >&2
+            return 1
+        }
+        runtime_key="$(openssl rand -hex 32)" || return 1
+    fi
+
+    local svc svc_id
+    for svc in api services; do
+        svc_id="$(clone_service_id "$svc")"
+        [ -n "$svc_id" ] || return 1
+        rw_graphql \
+            'mutation($in: VariableCollectionUpsertInput!) { variableCollectionUpsert(input: $in) }' \
+            "$(jq -nc --arg p "$PROJECT_ID" --arg e "$CLONE_ENV_ID" --arg s "$svc_id" --arg v "$runtime_key" \
+                '{in: {projectId: $p, environmentId: $e, serviceId: $s, skipDeploys: true, replace: false, variables: {AGENTA_SERVICES_INTERNAL_KEY: $v}}}')" \
+            >/dev/null || return 1
+    done
+    printf "CI runtime key applied to API and Services.\n"
+}
+
 clone_service_id() {
     jq -r --arg n "$1" \
         '.data.environment.serviceInstances.edges[].node | select(.serviceName == $n) | .serviceId' \
@@ -572,6 +599,7 @@ main() {
         fi
         wait_clone_populated || die "environment '$ENV_NAME' never fully materialized"
         apply_ci_auth_key || die "could not apply the CI auth key to the clone"
+        apply_ci_runtime_key || die "could not apply the CI runtime key to the clone"
         t_created=$(( $(now) - t0 ))
 
         # Domain BEFORE app deploys: web/api render

--- a/hosting/railway/oss/scripts/preview-clone-create.sh
+++ b/hosting/railway/oss/scripts/preview-clone-create.sh
@@ -253,16 +253,14 @@ apply_ci_auth_key() {
 # A write-only vault connection can be resolved only by the trusted platform
 # runtime. Give API and Services one ephemeral shared proof before deploy; do
 # not reuse the admin key and do not expose this proof to any other service.
-# CI may provide a stable value, but disposable previews need no stored secret.
+# Disposable previews need no stored secret, so always generate a fresh proof.
 apply_ci_runtime_key() {
-    local runtime_key="${AGENTA_SERVICES_INTERNAL_KEY:-}"
-    if [ -z "$runtime_key" ]; then
-        command -v openssl >/dev/null 2>&1 || {
-            printf "missing required command: openssl\n" >&2
-            return 1
-        }
-        runtime_key="$(openssl rand -hex 32)" || return 1
-    fi
+    command -v openssl >/dev/null 2>&1 || {
+        printf "missing required command: openssl\n" >&2
+        return 1
+    }
+    local runtime_key
+    runtime_key="$(openssl rand -hex 32)" || return 1
 
     local svc svc_id
     for svc in api services; do


### PR DESCRIPTION
## Context

The write-only vault boundary makes the API refuse startup when `AGENTA_SERVICES_INTERNAL_KEY` is missing. Railway PR previews only injected the older admin key, so every PR in the credential stack built successfully and then failed while the API booted.

## Changes

Preview convergence now generates a fresh 32-byte runtime key for every disposable preview and writes the same value only to API and Services before either deploys. It does not accept a caller-supplied value. Web, runner, workers, and sandboxes never receive the key.

Before: the cloned preview kept a missing or placeholder runtime key and the API failed its health check.

After: API and Services start with the same dedicated proof while the existing admin-key flow remains unchanged.

## Tests / notes

- `bash -n hosting/railway/oss/scripts/preview-clone-create.sh`
- `git diff --check`
- The PR's normal Railway preview passed setup, deploy, and readiness with the generated key.
- The separate clone-cycle workflow reaches the new key step successfully but still reports the repository's unrelated disposable `web-mobile` deployment failure.
