### PR TITLE
[docs] Reconcile Pi trace export contracts after review

### DIFF
--- a/docs/design/runner-owned-pi-trace-export/architecture.md
+++ b/docs/design/runner-owned-pi-trace-export/architecture.md
@@ -87,6 +87,10 @@ For every completed processor flush it:
 5. renames it atomically to `<channelId>.<sequence>.otlp.pb`;
 6. advances the zero-based sequence only after publication succeeds.
 
+`PiFileSpanExporter` publishes at most four files per turn. It drops a fifth or later completed
+flush, logs `reason=file_limit`, preserves the four published files, and does not advance the
+sequence.
+
 `agent_end` ends the remaining Pi spans and triggers the final flush.
 
 There is no custom span DTO and no JSON or base64 wrapping.
@@ -105,9 +109,10 @@ It:
   maximum for its growth-safe read;
 - deletes the final file immediately after pickup;
 - retains the bytes in runner memory while export is in flight;
-- forwards the exact protobuf bytes to the runner trace export sink;
-- accepts at most four complete batches, deletes each on pickup, and stops at that limit or the
-  bounded post-prompt drain timeout.
+- accepts at most four non-empty batches within the size limit, deletes each on pickup, and stops
+  collecting at that limit or the bounded post-prompt drain timeout;
+- waits until collection closes before it starts any network request;
+- forwards the collected protobuf bodies to the runner trace export sink in parallel.
 
 The channel ID prevents a stale warm-turn file from being attributed to the next turn. It is a
 correlation value, not a secret or an authorization mechanism.
@@ -163,16 +168,22 @@ sequenceDiagram
     Runner->>Pi: prompt
     Pi->>Host: read and delete control file
     Pi->>Pi: create native spans from Pi events
-    Pi->>Host: write temp OTLP protobuf
-    Pi->>Host: rename to channelId.otlp.pb
-    Runner->>Host: read and delete final file
-    Runner->>Runner: resolve current authorization
-    Runner->>API: POST exact protobuf bytes
-    API-->>Runner: 200 or error
-    Runner->>Runner: bounded drain, diagnostics, finish turn export
+    loop Up to four completed processor flushes
+        Pi->>Host: write temporary OTLP protobuf
+        Pi->>Host: rename to channelId.sequence.otlp.pb
+    end
+    Runner->>Host: bounded drain: list, read, and delete final files
+    Runner->>Runner: finish collection before network sends
+    Runner->>Runner: select authorization for the configured target
+    Runner->>API: POST collected protobuf bodies in parallel
+    API-->>Runner: success or error for each body
+    Runner->>Runner: record pickup and export results, then finish
 ```
 
 The sequence is identical for local and Daytona. Only the `RuntimeFileHost` implementation changes.
+For Agenta ingest, target authorization comes from the live platform credential lease. For a
+third-party collector, it comes from the static exporter header. Neither credential crosses to the
+other target.
 
 ## Runner tracer behavior
 

--- a/docs/design/runner-owned-pi-trace-export/architecture.md
+++ b/docs/design/runner-owned-pi-trace-export/architecture.md
@@ -247,3 +247,16 @@ after every batch, so split delivery does not lose root aggregation.
 Diagnostics must include stage, placement, source, turn ID, trace ID suffix, batch bytes, pickup
 latency, export latency, HTTP status, and credential age. They must not include the token, protobuf
 body, prompt, or captured span content.
+
+### HarnessTracePort
+
+Generic turn orchestration depends on one narrow harness tracing port:
+
+- the default adapter keeps runner-created spans for ordinary harnesses;
+- the Pi adapter owns native-span control publication, spool finalization, cancellation, trace ID,
+  and missing-batch fallback;
+- `runTurn` invokes the same `start`, `finish`, and cancellation lifecycle without knowing
+  channel filenames, file hosts, or Pi control fields.
+
+This is a trace-ownership port, not a general harness plugin framework. A future harness that owns
+native spans can add an adapter without adding another harness branch to generic turn orchestration.

--- a/docs/design/runner-owned-pi-trace-export/architecture.md
+++ b/docs/design/runner-owned-pi-trace-export/architecture.md
@@ -2,16 +2,16 @@
 
 ## Ownership model
 
-| Responsibility | Owner |
-|---|---|
-| Observe Pi lifecycle events | Pi extension |
-| Build Pi-native spans | Pi extension |
-| Decide trace parent and capture policy for a turn | SDK and runner request |
-| Move span bytes out of the harness | Runtime telemetry spool |
-| Hold export endpoint and credentials | Runner |
-| Renew platform credentials | Runner credential lease |
-| Send OTLP over HTTP | Runner trace export sink |
-| Authorize and ingest spans | Agenta API |
+| Responsibility                                    | Owner                    |
+| ------------------------------------------------- | ------------------------ |
+| Observe Pi lifecycle events                       | Pi extension             |
+| Build Pi-native spans                             | Pi extension             |
+| Decide trace parent and capture policy for a turn | SDK and runner request   |
+| Move span bytes out of the harness                | Runtime telemetry spool  |
+| Hold export endpoint and credentials              | Runner                   |
+| Renew platform credentials                        | Runner credential lease  |
+| Send OTLP over HTTP                               | Runner trace export sink |
+| Authorize and ingest spans                        | Agenta API               |
 
 The important boundary is between producing telemetry and exporting telemetry. Pi is a producer,
 not a network client of Agenta.
@@ -68,6 +68,8 @@ The file contains only values Pi needs to create correct spans:
 - `traceparent` and `baggage`;
 - content-capture policy;
 - loaded skill names when they can vary by turn.
+- bounded known-secret values already visible in the sandbox, used only to construct Pi's
+  mandatory per-turn redactor.
 
 It does not contain an endpoint, authorization header, project credential, or token expiry.
 
@@ -76,14 +78,16 @@ It does not contain an endpoint, authorization header, project credential, or to
 The Pi extension keeps `createAgentaOtel` and all existing lifecycle hooks. Its batch transport
 changes from HTTP to file publication.
 
-At `agent_end` it:
+For every completed processor flush it:
 
-1. ends the Pi spans through the existing tracer;
-2. gathers the run into one batch through the existing trace batch processor;
-3. serializes the batch as an OTLP `ExportTraceServiceRequest` protobuf;
-4. enforces the configured maximum batch size;
-5. writes `<channelId>.otlp.pb.tmp.<nonce>`;
-6. renames it atomically to `<channelId>.otlp.pb`.
+1. receives a parent-first complete batch from the existing trace batch processor;
+2. serializes that batch as an OTLP `ExportTraceServiceRequest` protobuf;
+3. enforces the configured maximum batch size and four-file turn limit;
+4. writes `<channelId>.<sequence>.otlp.pb.tmp.<nonce>`;
+5. renames it atomically to `<channelId>.<sequence>.otlp.pb`;
+6. advances the zero-based sequence only after publication succeeds.
+
+`agent_end` ends the remaining Pi spans and triggers the final flush.
 
 There is no custom span DTO and no JSON or base64 wrapping.
 
@@ -95,26 +99,32 @@ The consumer uses the same implementation for both placements and receives a `Ru
 It:
 
 - sweeps stale telemetry files before the control file becomes visible;
-- accepts only the current random channel filename;
+- accepts only canonical `<channelId>.<sequence>.otlp.pb` files for the current random channel
+  and sorts unseen sequences numerically;
 - bounds directory entries, checks the stat size before reading, and gives the host the same
   maximum for its growth-safe read;
 - deletes the final file immediately after pickup;
 - retains the bytes in runner memory while export is in flight;
 - forwards the exact protobuf bytes to the runner trace export sink;
-- stops after one accepted batch or a bounded post-prompt drain timeout.
+- accepts at most four complete batches, deletes each on pickup, and stops at that limit or the
+  bounded post-prompt drain timeout.
 
 The channel ID prevents a stale warm-turn file from being attributed to the next turn. It is a
 correlation value, not a secret or an authorization mechanism.
 
 ### Live platform authorization
 
-The runner already owns a mutable credential getter refreshed by the session alive watchdog.
-PR #6217 makes trace export call that getter immediately before export instead of capturing its
-initial value. The Pi spool uses the same getter. This fixes long turns without adding a second
-lease, a new refresh protocol, or a 401-specific retry path.
+PR #6217 makes trace export read a mutable credential getter immediately before sending. One
+reusable platform credential lease now owns that getter: the session alive watchdog holds it for
+session-owned turns, while `runTurn` holds it for standalone turns. Both proactively re-mint the
+credential through the existing permission check, so one 12-hour turn and a 12-hour warm session
+use the same path without adding a trace-specific lease or 401 retry.
 
-For a third-party OTLP endpoint, use the configured static exporter header and do not call Agenta's
-permission exchange. This preserves current collector support.
+Target classification happens before creating the lease. For a third-party OTLP endpoint, the
+configured exporter header remains static and never enters Agenta's permission exchange or session
+API headers. The legacy wire cannot carry separate platform and collector credentials; a
+session-owned external-collector request therefore receives no platform credential until the
+follow-up wire cleanup adds `platform.headers.authorization`.
 
 ### Raw-byte export path
 
@@ -128,8 +138,7 @@ interface OtlpBytesExportRequest {
     endpoint: string;
     authorization: () => string | undefined;
   };
-  traceId?: string;
-  turnId?: string;
+  diagnostics: OtlpBytesExportDiagnostics;
 }
 ```
 
@@ -170,7 +179,7 @@ The sequence is identical for local and Daytona. Only the `RuntimeFileHost` impl
 Change Pi handling from placement-dependent to harness-dependent:
 
 ```ts
-emitSpans: !plan.isPi
+emitSpans: !plan.isPi;
 ```
 
 The runner and Pi extension are one versioned artifact: the runner bundles and installs its own
@@ -202,31 +211,39 @@ The runner limits the authority of that producer structurally:
 This is a bounded trace-ingest capability proxy. It exposes less authority than placing even a
 trace-scoped bearer inside the harness because the bearer cannot be copied or replayed elsewhere.
 
-Parsing and enforcing every span's trace ID in the runner is optional hardening, not a prerequisite
-for removing the credential. If implemented, it must use standard generated OTLP types and preserve
-the original bytes for forwarding. Do not build a second semantic span validator in the runner.
+The first release deliberately does not decode or bind span trace IDs in the runner. Any process
+inside the sandbox that learns the current random channel can publish valid OTLP with arbitrary
+trace IDs and attributes. The runner will forward those bytes under the caller's project-scoped
+credential, so malicious sandbox code can add or replace matching spans inside that caller project.
+It cannot choose another project, endpoint, header, method, or unbounded payload. The API enforces
+project authorization and protobuf validity, but it does not prove that Pi performed redaction or
+that every span belongs to the current turn.
+
+This accepted tradeoff keeps Pi responsible for span semantics and avoids a second protobuf parser.
+If threat review later requires trace binding, use standard generated OTLP types and preserve the
+original bytes for forwarding; do not invent a custom span DTO or semantic validator.
 
 ## Failure behavior
 
-| Failure | Behavior |
-|---|---|
-| Control file cannot be published | Log `stage=pi_trace_control`; Pi tracing stays disabled; emit one runner fallback span; do not fail the turn. |
-| Pi cannot serialize or publish | Log in Pi; the drain reports `stage=pi_trace_spool_missing`; emit one runner fallback span; do not fail the turn. |
-| Prompt is cancelled or throws | End Pi's lifecycle first so `agent_end` can publish the complete trace it currently holds, then drain. If no valid batch arrives, emit one runner fallback span carrying the run error and resolved usage. |
-| File is too large | Reject and delete it; log bounded metadata; do not send it. |
-| Stale or wrong channel file | Ignore or sweep it; never associate it with the current turn. |
-| Filesystem watch fails | Fall back to bounded polling. |
-| Daytona filesystem call fails transiently | Retry within the existing bounded poll/drain rules. |
-| Credential rotates during a turn | The session watchdog refreshes it; export resolves the current getter value. |
-| Agenta returns 401 | Record the failed export through existing bounded diagnostics; this change adds no 401 refresh-and-retry protocol. |
-| OTLP endpoint times out or returns non-success | Log export diagnostics; return the successful agent result. |
-| Runner stops after pickup | Batch is lost in the first release because the queue is not durable. This is explicit and measurable. |
+| Failure                                        | Behavior                                                                                                                                                                                                   |
+| ---------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Control file cannot be published               | Log `stage=pi_trace_control`; Pi tracing stays disabled; emit one runner fallback span; do not fail the turn.                                                                                              |
+| Pi cannot serialize or publish                 | Log in Pi; the drain reports `stage=pi_trace_spool_missing`; emit one runner fallback span; do not fail the turn.                                                                                          |
+| Prompt is cancelled or throws                  | End Pi's lifecycle first so `agent_end` can publish the complete trace it currently holds, then drain. If no valid batch arrives, emit one runner fallback span carrying the run error and resolved usage. |
+| File is too large                              | Reject and delete it; log bounded metadata; do not send it.                                                                                                                                                |
+| Stale or wrong channel file                    | Ignore or sweep it; never associate it with the current turn.                                                                                                                                              |
+| Filesystem watch fails                         | Fall back to bounded polling.                                                                                                                                                                              |
+| Daytona filesystem call fails transiently      | Retry within the existing bounded poll/drain rules.                                                                                                                                                        |
+| Credential rotates during a turn               | The shared platform lease refreshes it for session-owned and standalone turns; export resolves the current getter value.                                                                                   |
+| Agenta returns 401                             | Record the failed export through existing bounded diagnostics; this change adds no 401 refresh-and-retry protocol.                                                                                         |
+| OTLP endpoint times out or returns non-success | Log export diagnostics; return the successful agent result.                                                                                                                                                |
+| Runner stops after pickup                      | Batch is lost in the first release because the queue is not durable. This is explicit and measurable.                                                                                                      |
 
-Do not add periodic partial batches. Pi publishes one complete lifecycle batch when `agent_end`
-runs. The fallback callback is idempotent, so teardown cannot create a second fallback. Splitting a
-turn into checkpoints would break ingest-time cumulative usage rollups.
+Do not add periodic partial snapshots. Pi may publish a bounded sequence of complete processor
+flushes, with `agent_end` producing the final batch. The fallback callback is idempotent and runs
+only when no valid batch was accepted. Ingest recomputes cumulative metrics over the stored trace
+after every batch, so split delivery does not lose root aggregation.
 
 Diagnostics must include stage, placement, source, turn ID, trace ID suffix, batch bytes, pickup
 latency, export latency, HTTP status, and credential age. They must not include the token, protobuf
 body, prompt, or captured span content.
-

--- a/docs/design/runner-owned-pi-trace-export/context.md
+++ b/docs/design/runner-owned-pi-trace-export/context.md
@@ -41,11 +41,15 @@ The implementation must behave identically for local and Daytona placement.
 
 For every turn:
 
-1. The runner gives Pi only the current trace context and capture policy.
+1. The runner gives Pi the current trace context, capture policy, channel ID, turn and session
+   identifiers, loaded skills, and redaction-only values already visible inside the sandbox.
 2. Pi creates its native span tree.
-3. Pi serializes the complete tree as standard OTLP protobuf.
-4. Pi publishes the bytes through one cross-placement spool protocol.
-5. The runner sends those bytes to the configured OTLP endpoint with its current credential.
+3. Each completed processor flush is serialized as a standard OTLP protobuf request.
+4. Pi publishes a bounded sequence of those requests through one cross-placement spool protocol.
+5. The runner sends each request to the configured OTLP endpoint with its current credential.
+
+The control data contains no endpoint or export credential. The channel and runtime metadata
+attribute and transport the batches; the redaction values grant no authority.
 
 ## Goals
 
@@ -75,8 +79,9 @@ For every turn:
 - The Daytona sandbox cannot rely on direct network access to Agenta OTLP ingest.
 - The spool directory is writable by the harness and must be treated as untrusted input.
 - Agenta OTLP ingest accepts binary protobuf and enforces a configured maximum batch size.
-- The existing trace processor intentionally sends one run as one batch because ingest computes
-  cumulative usage rollups per batch.
+- A turn may produce several complete OTLP requests through root-end and explicit flush paths.
+  The consumer bounds that sequence, and ingest recomputes cumulative usage over the stored trace
+  after every batch.
 - A trace-export failure must be observable but must not fail the agent turn.
 - Warm-session state cannot own a fixed per-turn `traceparent` or credential.
 
@@ -92,4 +97,3 @@ The custom part is only the runtime handoff. The payload is standard OTLP, and t
 the same local/Daytona boundary already used by tool relay and Pi usage writeback. A future
 self-instrumenting harness can implement the same producer interface without learning Agenta auth
 or networking.
-

--- a/docs/design/runner-owned-pi-trace-export/context.md
+++ b/docs/design/runner-owned-pi-trace-export/context.md
@@ -46,7 +46,9 @@ For every turn:
 2. Pi creates its native span tree.
 3. Each completed processor flush is serialized as a standard OTLP protobuf request.
 4. Pi publishes a bounded sequence of those requests through one cross-placement spool protocol.
-5. The runner sends each request to the configured OTLP endpoint with its current credential.
+5. For Agenta ingest, the runner sends each request with the current renewable platform
+   credential. For a third-party collector, it sends the configured static exporter header. The
+   runner never sends either credential to the other target.
 
 The control data contains no endpoint or export credential. The channel and runtime metadata
 attribute and transport the batches; the redaction values grant no authority.

--- a/docs/design/runner-owned-pi-trace-export/interfaces.md
+++ b/docs/design/runner-owned-pi-trace-export/interfaces.md
@@ -2,16 +2,17 @@
 
 ## Field classification
 
-| Value                          | Semantic role          | Owner               | Changes               | Destination                       |
-| ------------------------------ | ---------------------- | ------------------- | --------------------- | --------------------------------- |
-| `traceparent`                  | Protocol context       | Calling trace       | Every turn            | Pi control file and runner tracer |
-| `baggage`                      | Protocol context       | Calling trace       | Every turn            | Pi control file and runner tracer |
-| content capture                | Policy                 | Operator or service | May change every turn | Pi control file and runner tracer |
-| OTLP endpoint                  | Exporter configuration | Operator or SDK     | May change every turn | Runner only                       |
-| general platform authorization | Credential             | Access system       | Rotates during a turn | Runner credential lease only      |
-| channel ID                     | Transport correlation  | Runner              | Every turn            | Runner and Pi spool filenames     |
-| OTLP protobuf body             | Telemetry data         | Pi tracer           | Once per turn         | Pi spool to runner export sink    |
-| session ID and turn ID         | Runtime metadata       | Runner request      | Per session and turn  | Control file and diagnostics      |
+| Value                               | Semantic role          | Owner               | Changes               | Destination                       |
+| ----------------------------------- | ---------------------- | ------------------- | --------------------- | --------------------------------- |
+| `traceparent`                       | Protocol context       | Calling trace       | Every turn            | Pi control file and runner tracer |
+| `baggage`                           | Protocol context       | Calling trace       | Every turn            | Pi control file and runner tracer |
+| content capture                     | Policy                 | Operator or service | May change every turn | Pi control file and runner tracer |
+| OTLP endpoint                       | Exporter configuration | Operator or SDK     | May change every turn | Runner only                       |
+| general platform authorization      | Credential             | Access system       | Rotates during a turn | Agenta platform calls only        |
+| third-party collector authorization | Exporter credential    | Operator or SDK     | Static for the run    | That collector's requests only    |
+| channel ID                          | Transport correlation  | Runner              | Every turn            | Runner and Pi spool filenames     |
+| OTLP protobuf body                  | Telemetry data         | Pi tracer           | Every completed flush | Pi spool to runner export sink    |
+| session ID and turn ID              | Runtime metadata       | Runner request      | Per session and turn  | Control file and diagnostics      |
 
 This classification is the reason `exportAuthorization` is unnecessary. The runner already owns a
 renewable general platform credential. Pi needs telemetry data and protocol context, not a
@@ -171,9 +172,13 @@ Payload:
 
 - raw OTLP `ExportTraceServiceRequest` protobuf bytes;
 - content type fixed by the runner to `application/x-protobuf`;
-- one complete OTLP export request per file; a turn may publish several processor flushes;
+- one complete OTLP export request per completed processor flush;
 - zero-based canonical decimal sequence numbers, bounded to four files in version 1;
 - no JSON envelope, base64 encoding, header map, endpoint, or credential.
+
+Pi publishes at most four files per turn. If a fifth or later processor flush completes, Pi drops
+that body, logs `reason=file_limit`, leaves the four published files unchanged, and does not advance
+the sequence.
 
 Consumer rules:
 
@@ -184,6 +189,12 @@ Consumer rules:
 - Delete on pickup and keep bytes in memory for the bounded export attempt.
 - Remember accepted sequence numbers so a repeated listing cannot forward one file twice.
 - Collect all bounded files available in the drain window before starting network sends.
+- Count a non-empty canonical file within the size limit as structurally accepted after pickup. The
+  runner does not decode its protobuf body.
+- Count a batch as exported only after the collector returns success.
+- Trigger the runner fallback only when the turn has zero structurally accepted batches. A
+  canonical malformed protobuf can therefore be picked up, rejected by ingest, and diagnosed
+  without producing a fallback span.
 - Sweep final and temporary telemetry files before publishing the next control file.
 
 ## Internal credential interface

--- a/docs/design/runner-owned-pi-trace-export/interfaces.md
+++ b/docs/design/runner-owned-pi-trace-export/interfaces.md
@@ -2,16 +2,16 @@
 
 ## Field classification
 
-| Value | Semantic role | Owner | Changes | Destination |
-|---|---|---|---|---|
-| `traceparent` | Protocol context | Calling trace | Every turn | Pi control file and runner tracer |
-| `baggage` | Protocol context | Calling trace | Every turn | Pi control file and runner tracer |
-| content capture | Policy | Operator or service | May change every turn | Pi control file and runner tracer |
-| OTLP endpoint | Exporter configuration | Operator or SDK | May change every turn | Runner only |
-| general platform authorization | Credential | Access system | Rotates during a turn | Runner credential lease only |
-| channel ID | Transport correlation | Runner | Every turn | Runner and Pi spool filenames |
-| OTLP protobuf body | Telemetry data | Pi tracer | Once per turn | Pi spool to runner export sink |
-| session ID and turn ID | Runtime metadata | Runner request | Per session and turn | Control file and diagnostics |
+| Value                          | Semantic role          | Owner               | Changes               | Destination                       |
+| ------------------------------ | ---------------------- | ------------------- | --------------------- | --------------------------------- |
+| `traceparent`                  | Protocol context       | Calling trace       | Every turn            | Pi control file and runner tracer |
+| `baggage`                      | Protocol context       | Calling trace       | Every turn            | Pi control file and runner tracer |
+| content capture                | Policy                 | Operator or service | May change every turn | Pi control file and runner tracer |
+| OTLP endpoint                  | Exporter configuration | Operator or SDK     | May change every turn | Runner only                       |
+| general platform authorization | Credential             | Access system       | Rotates during a turn | Runner credential lease only      |
+| channel ID                     | Transport correlation  | Runner              | Every turn            | Runner and Pi spool filenames     |
+| OTLP protobuf body             | Telemetry data         | Pi tracer           | Once per turn         | Pi spool to runner export sink    |
+| session ID and turn ID         | Runtime metadata       | Runner request      | Per session and turn  | Control file and diagnostics      |
 
 This classification is the reason `exportAuthorization` is unnecessary. The runner already owns a
 renewable general platform credential. Pi needs telemetry data and protocol context, not a
@@ -132,7 +132,10 @@ Version 1 body:
   "capture": {
     "content": true
   },
-  "skills": ["_agenta.default"]
+  "skills": ["_agenta.default"],
+  "redaction": {
+    "knownValues": ["<sandbox-visible secret value>"]
+  }
 }
 ```
 
@@ -143,6 +146,10 @@ Rules:
 - Pi rejects unknown versions and malformed channel IDs.
 - Missing optional fields mean the same defaults as today.
 - The file contains no endpoint or credential.
+- `redaction.knownValues` contains only model environment values and both mount credential triples
+  that are already visible to the sandbox. Pi reads them once to build its mandatory per-turn
+  deny-set; they are never interpreted as export authorization.
+- The collection is bounded and malformed or excess values are discarded by the parser.
 - The runner keeps its authoritative copy in memory. It never trusts the file on return.
 
 ## Pi OTLP spool
@@ -150,30 +157,33 @@ Rules:
 Final filename:
 
 ```text
-<runtimeIpcDir>/telemetry/<channelId>.otlp.pb
+<runtimeIpcDir>/telemetry/<channelId>.<sequence>.otlp.pb
 ```
 
 Publication:
 
 ```text
-write <channelId>.otlp.pb.tmp.<nonce>
-rename to <channelId>.otlp.pb
+write <channelId>.<sequence>.otlp.pb.tmp.<nonce>
+rename to <channelId>.<sequence>.otlp.pb
 ```
 
 Payload:
 
 - raw OTLP `ExportTraceServiceRequest` protobuf bytes;
 - content type fixed by the runner to `application/x-protobuf`;
-- one complete Pi run per file;
+- one complete OTLP export request per file; a turn may publish several processor flushes;
+- zero-based canonical decimal sequence numbers, bounded to four files in version 1;
 - no JSON envelope, base64 encoding, header map, endpoint, or credential.
 
 Consumer rules:
 
 - Start and finish are scoped to one turn.
-- Accept only the expected final filename.
-- One accepted file per turn in version 1.
+- Accept only canonical final filenames for the expected channel and sequence.
+- Sort unseen sequences before pickup and accept at most four files per turn.
 - Mirror the API's configured maximum batch size, with an absolute runner safety ceiling.
 - Delete on pickup and keep bytes in memory for the bounded export attempt.
+- Remember accepted sequence numbers so a repeated listing cannot forward one file twice.
+- Collect all bounded files available in the drain window before starting network sends.
 - Sweep final and temporary telemetry files before publishing the next control file.
 
 ## Internal credential interface
@@ -185,9 +195,12 @@ type AuthorizationProvider = () => string | undefined;
 Properties:
 
 - initialized from the credential on the current request;
-- refreshed by the existing session alive watchdog while a session-owned turn is active;
+- refreshed by one reusable platform credential lease while any Agenta turn is active;
+- owned by the alive watchdog for session-owned turns and by `runTurn` for standalone turns;
 - read immediately before every runner or Pi-spool export;
-- kept static for third-party collector authorization;
+- created only after target classification;
+- kept static for third-party collector authorization, which never enters Agenta's permission
+  exchange;
 - value and raw JWT claims never logged.
 
 Do not create a second trace-specific lease or refresh channel.
@@ -201,12 +214,15 @@ interface OtlpBytesExportRequest {
     endpoint: string;
     authorization: AuthorizationProvider;
   };
-  diagnostics: PiSpoolDiagnostics;
+  diagnostics: OtlpBytesExportDiagnostics;
 }
 ```
 
-`exportOtlpBytes()` is best-effort and resolves after success, final failure, or timeout. It
-preserves existing retry and diagnostics behavior and does not throw into agent execution.
+`OtlpBytesExportDiagnostics` owns `traceId`, optional `turnId`, source, placement, byte count,
+and redactors; those identifiers are diagnostic attribution, not separate top-level request
+fields. `exportOtlpBytes()` makes one best-effort request and resolves after success, failure, or
+timeout. It preserves existing classification and diagnostics behavior and does not throw into
+agent execution.
 
 ## Compatibility rules
 
@@ -216,4 +232,3 @@ preserves existing retry and diagnostics behavior and does not throw into agent 
 - Do not add a feature flag or support a mixed new-runner/old-extension mode.
 - Direct Pi network export and runner spool export never run together.
 - Runner logs identify `source=pi-spool` or `source=runner-acp` so duplicate paths are visible.
-

--- a/docs/design/runner-owned-pi-trace-export/plan.md
+++ b/docs/design/runner-owned-pi-trace-export/plan.md
@@ -70,9 +70,10 @@ Runner turn ordering:
 3. Send or resume the Pi prompt.
 4. Stop tool relay after prompt as today.
 5. Resolve Pi usage as today.
-6. Drain the expected bounded telemetry sequence with a short deadline.
-7. Finish runner event handling and return the agent result.
-8. Stop the consumer in `finally` on every path.
+6. Collect and delete up to four expected telemetry files within a short drain window.
+7. After collection closes, export the collected bodies in parallel.
+8. Finish runner event handling and return the agent result.
+9. Stop the consumer in `finally` on every path.
 
 Pi changes:
 
@@ -89,10 +90,15 @@ Tests:
 - Control parsing, unknown version, missing file, malformed channel, and read-once deletion.
 - Atomic publication never exposes a temporary or partial file.
 - Exact binary round trip through local and fake-Daytona hosts.
+- One file per completed processor flush, with a maximum of four; a fifth flush is dropped without
+  overwriting an earlier sequence.
 - Stale previous-turn file is swept and cannot satisfy the next turn.
 - Wrong channel is ignored.
 - Oversized and duplicate files are rejected and removed.
 - Missing batch times out without failing the agent result.
+- A canonical malformed protobuf file is structurally accepted and sent. If ingest rejects it,
+  exported count stays zero, diagnostics record the rejection, and no missing-batch fallback is
+  emitted.
 - Warm turn two uses its own traceparent and capture policy, not turn one's.
 - Pi spans preserve native provider, model, tool, usage, cost, parent IDs, and content-capture rules.
 

--- a/docs/design/runner-owned-pi-trace-export/plan.md
+++ b/docs/design/runner-owned-pi-trace-export/plan.md
@@ -6,7 +6,8 @@ contracts and prove long-session behavior.
 
 ## Immediate prerequisite PRs
 
-1. Complete: PR #6217 resolves authorization from the alive watchdog's current credential getter at export time. Short and non-session runs, third-party collectors, diagnostics, and per-run target isolation keep their existing behavior.
+1. Complete: PR #6217 resolves authorization from a current credential getter at export time.
+   PR #6223 finishes the reusable lease for standalone turns and excludes third-party headers.
 2. Complete: PR #6218 adds issued-at to Secret JWTs and preserves intentional authentication failures as 401. It adds no telemetry scope, export-only token, or longer TTL.
 
 These prerequisites do not change Pi span production. The Pi-owned span and runner-owned export cutover follows below.
@@ -18,7 +19,8 @@ The decisions in review.md supersede conflicting details in the older phase text
 1. Pin the public ProtobufTraceSerializer seam and prove parent-first raw-byte round trip in a fixture test. This replaces the serializer spike.
 2. Add a telemetry-only binary file host in a sibling of the relay directory. Do not refactor the tool relay.
 3. Add the per-turn control file and bounded multi-file spool. Include both mount credential pairs, one shared sandbox-visible redaction builder, explicit always-on Pi redaction, a runner size limit below the API 10 MB default, atomic sibling rename, start and teardown sweeps, and an unread-control diagnostic.
-4. Preserve cancellation traces: Pi publishes what it has and the runner emits a minimal error and usage fallback when no batch arrives. Keep one complete batch rather than periodic checkpoints.
+4. Preserve cancellation traces: Pi publishes complete processor flushes and the runner emits a
+   minimal error and usage fallback only when no valid batch arrives. Do not add periodic snapshots.
 5. Cut local and Daytona Pi over together without a feature flag. Add the spool consumer to the bundle leak gate and reset per-turn Pi usage for warm sessions.
 6. Remove rejected token-scope and export-only DTO surfaces if any remain, then add release-gate trace and trace-long journeys for local Pi, Daytona Pi, and local Claude.
 
@@ -34,9 +36,12 @@ Add only the local and Daytona byte operations the telemetry spool needs. Use a 
 
 ## Phase 2: reuse runner export behavior for spooled bytes
 
-PR #6217 already resolves the live platform credential at export time and keeps exporter rotation safe. For spooled batches, retain the existing timeout, missing-credential rule, diagnostics, target attribution, and best-effort failure behavior. Add one thin raw-bytes post path that resolves the same current authorization. Do not create a second lease, a general export-sink rewrite, a 401 retry protocol, or a third-party collector refresh path.
-
-Tests cover current-credential use, missing Agenta credentials, unauthenticated third-party collectors, failed sends, and independent run attribution.
+PR #6217 resolves the live platform credential at export time. One shared platform lease owns the
+getter: the alive watchdog for session-owned turns and `runTurn` for standalone turns. Classify
+the target first so third-party collector headers stay static and never enter the platform
+permission exchange. For spooled batches, retain the existing timeout, missing-credential rule,
+diagnostics, target attribution, and best-effort failure behavior. Add one thin raw-bytes post path;
+do not add a trace-specific lease, general export-sink rewrite, or 401 retry.
 
 ## Phase 3: add the Pi per-turn control and OTLP spool
 
@@ -65,7 +70,7 @@ Runner turn ordering:
 3. Send or resume the Pi prompt.
 4. Stop tool relay after prompt as today.
 5. Resolve Pi usage as today.
-6. Drain the expected telemetry batch with a short bound.
+6. Drain the expected bounded telemetry sequence with a short deadline.
 7. Finish runner event handling and return the agent result.
 8. Stop the consumer in `finally` on every path.
 
@@ -76,7 +81,8 @@ Pi changes:
   channel state from the current control file.
 - Per-turn usage counters reset at the same boundary. Session-wide totals, if needed elsewhere,
   remain separate.
-- `agent_end` publishes one complete standard OTLP protobuf batch and then writes usage output.
+- Each processor flush publishes one complete standard OTLP protobuf batch under a bounded sequence;
+  `agent_end` publishes the final remaining batch and then writes usage output.
 
 Tests:
 
@@ -95,17 +101,17 @@ Tests:
 In `run-turn.ts` change Pi span ownership to:
 
 ```ts
-emitSpans: !plan.isPi
+emitSpans: !plan.isPi;
 ```
 
 Enable the Pi spool in both local and Daytona environment plans. Remove the Daytona statement that
 the extension is usage-only. The resulting behavior is:
 
-| Harness | Placement | Span producer | External exporter |
-|---|---|---|---|
-| Pi | Local | Pi extension | Runner |
-| Pi | Daytona | Pi extension | Runner |
-| Claude, Codex, Agenta | Local or Daytona | Runner ACP tracer | Runner |
+| Harness               | Placement        | Span producer     | External exporter |
+| --------------------- | ---------------- | ----------------- | ----------------- |
+| Pi                    | Local            | Pi extension      | Runner            |
+| Pi                    | Daytona          | Pi extension      | Runner            |
+| Claude, Codex, Agenta | Local or Daytona | Runner ACP tracer | Runner            |
 
 Never enable direct Pi export and spool export together. Local and Daytona cut over atomically through the same runner and image release; do not add a feature flag or a second long-lived mode.
 
@@ -172,4 +178,3 @@ Use a linear GitButler stack and set each GitHub PR base to the branch below it:
 
 The first four branches are the functional path. Branch five depends on whether PR #6135 merged.
 Branch six is cleanup and should not delay the cutover.
-

--- a/docs/design/runner-owned-pi-trace-export/qa.md
+++ b/docs/design/runner-owned-pi-trace-export/qa.md
@@ -132,13 +132,26 @@ Additional assertions:
 
 ## Failure injection
 
-For cancellation, prompt failure, missing publication, a truncated final file, and an oversized
-final file, assert exactly one of two outcomes: one or more valid complete Pi batches, or one
-idempotent runner fallback span when none was accepted. Never accept a temporary or partial file.
+The consumer treats acceptance and export as separate results. A structurally accepted batch has a
+canonical current-channel filename, a non-empty body, and a size within the configured limit. The
+runner does not parse the protobuf body. Export succeeds only when the configured collector accepts
+the request.
+
+The runner emits one idempotent fallback span only when it picks up zero structurally accepted
+batches. A canonical malformed protobuf still counts as picked up. If ingest rejects it, the runner
+records an export failure and does not emit the missing-batch fallback.
+
+For cancellation, prompt failure, missing publication, malformed publication, and oversized
+publication, assert the pickup, export, fallback, and diagnostic results independently. Never pick
+up a temporary or partial filename.
 
 - Prevent control-file write.
 - Crash Pi before `agent_end`.
-- Publish a truncated protobuf file under a temporary name.
+- Publish a truncated protobuf under a temporary name; assert the consumer ignores it and emits the
+  fallback if no canonical batch arrives.
+- Atomically publish a truncated protobuf under the canonical final name; assert the consumer picks
+  it up, ingest rejects it, exported count remains zero, diagnostics record the rejection, and no
+  fallback is emitted.
 - Publish an oversized final file.
 - Make Daytona list or read fail transiently.
 - Make the OTLP request return 401; assert exactly one request and bounded diagnostics.

--- a/docs/design/runner-owned-pi-trace-export/qa.md
+++ b/docs/design/runner-owned-pi-trace-export/qa.md
@@ -22,6 +22,9 @@ The release claim is stronger than "the export returned 200." It is:
 - Unknown version rejected.
 - Channel IDs sanitized and bounded.
 - No endpoint or authorization field accepted or emitted.
+- Redaction values accept only bounded strings, are read once, and contain no export authorization.
+- Both mount credential triples and model environment values reach the redactor when already
+  sandbox-visible.
 - Missing propagation and baggage preserve standalone-trace defaults.
 - Capture false applies to messages and tool inputs/outputs on the current turn.
 
@@ -31,40 +34,45 @@ The release claim is stronger than "the export returned 200." It is:
 - Agent, turn, LLM, and tool spans retain parent-child relationships.
 - Provider, request model, response model, usage, cost, events, status, session ID, and skill
   attributes survive serialization.
-- One turn produces one final batch.
+- Root-end and explicit flushes produce a zero-based sequence of complete batches, bounded to four
+  files; `agent_end` produces the final remaining batch.
 - Oversized batches fail closed at the spool boundary without failing the run.
 
 ### Spool consumer
 
-- Accepts exactly the expected current channel.
-- Ignores stale, temporary, wrong-channel, and duplicate files.
-- Deletes on pickup.
+- Accepts only canonical files for the expected current channel and sorts sequences numerically.
+- Ignores stale, temporary, wrong-channel, non-canonical, and duplicate sequence files.
+- Accepts at most four files and deletes each on pickup.
+- Collects the bounded sequence before network sends, so a slow first export cannot hide a later
+  published file.
 - Stops cleanly after success, timeout, cancel, pause, and thrown prompt error.
-- A missing or invalid batch produces exactly one runner-owned fallback error-and-usage span,
-  no partial Pi batch, bounded diagnostics, and unchanged agent-result semantics.
+- Zero accepted valid batches produce exactly one runner-owned fallback error-and-usage span,
+  no partial file, bounded diagnostics, and unchanged agent-result semantics.
+- Split batches retain coherent cumulative root usage after ingest recomputes the stored trace.
 - Local and Daytona hosts execute the same consumer code.
 
 ### Live authorization and export
 
-- Fake credential rotations cross 15 minutes, two hours, and 12 hours without reusing the
-  captured initial credential.
+- Session-owned and standalone fake turns cross 15 minutes, two hours, and 12 hours without
+  reusing the captured initial credential.
 - Export reads the credential immediately before each attempt.
-- Existing bounded retry classifications stay unchanged; this work adds no 401 refresh protocol.
-- Third-party collector auth is not sent to `/permissions/check`.
+- A non-success response, including 401, is diagnosed after one request; there is no 401 retry.
+- Third-party collector auth stays static, is not sent to `/permissions/check` or session APIs,
+  and never creates a platform lease.
 - Logs contain credential age and status but no secret value or OTLP content.
 
 ## Orchestration matrix
 
 Run one table-driven suite for these cells:
 
-| Placement | Session state | Turn | Expected producer | Expected network sender |
-|---|---|---:|---|---|
-| Local | Cold | 1 | Pi | Runner |
-| Local | Warm | 2 | Pi | Runner |
-| Local | Warm after credential rotation | N | Pi | Runner |
-| Daytona | Cold | 1 | Pi | Runner |
-| Daytona | Warm | 2 | Pi | Runner |
-| Daytona | Warm after credential rotation | N | Pi | Runner |
+| Placement | Session state                  | Turn | Expected producer | Expected network sender |
+| --------- | ------------------------------ | ---: | ----------------- | ----------------------- |
+| Local     | Cold                           |    1 | Pi                | Runner                  |
+| Local     | Warm                           |    2 | Pi                | Runner                  |
+| Local     | Warm after credential rotation |    N | Pi                | Runner                  |
+| Daytona   | Cold                           |    1 | Pi                | Runner                  |
+| Daytona   | Warm                           |    2 | Pi                | Runner                  |
+| Daytona   | Warm after credential rotation |    N | Pi                | Runner                  |
 
 For each cell assert:
 
@@ -75,7 +83,8 @@ For each cell assert:
 - an LLM call has Pi's provider/model and exact token/cost data;
 - content is absent when capture is false;
 - the HTTP sender runs in the runner test process;
-- Pi receives no endpoint or credential environment variable or control-file field.
+- Pi receives no endpoint or export credential environment variable or control-file field.
+  Redaction-only known values are permitted and must grant no export authority.
 
 ## Long-session tests without waiting 12 hours
 
@@ -124,15 +133,15 @@ Additional assertions:
 ## Failure injection
 
 For cancellation, prompt failure, missing publication, a truncated final file, and an oversized
-final file, assert exactly one of two outcomes: one valid complete Pi batch, or one idempotent
-runner fallback span. Never accept a periodic or partial Pi batch.
+final file, assert exactly one of two outcomes: one or more valid complete Pi batches, or one
+idempotent runner fallback span when none was accepted. Never accept a temporary or partial file.
 
 - Prevent control-file write.
 - Crash Pi before `agent_end`.
 - Publish a truncated protobuf file under a temporary name.
 - Publish an oversized final file.
 - Make Daytona list or read fail transiently.
-- Make the first OTLP request return 401 and the second return 200.
+- Make the OTLP request return 401; assert exactly one request and bounded diagnostics.
 - Make credential refresh fail.
 - Make OTLP time out.
 - Cancel and pause a turn while the consumer is active.
@@ -151,4 +160,3 @@ Before release:
 - the agent release gate against local and Daytona deployments;
 - a persisted trace inspection for both placements, because a green HTTP export alone does not
   prove span fidelity or parentage.
-

--- a/docs/design/runner-owned-pi-trace-export/status.md
+++ b/docs/design/runner-owned-pi-trace-export/status.md
@@ -46,8 +46,12 @@ the shared standalone/session credential lease, and target isolation.
 - The access router re-mints renewable short-lived credentials.
 - The runner shares one proactive platform lease across session-owned and standalone turn paths.
 - Pi creates the native span tree and publishes a bounded sequence of raw protobuf requests.
+- Each completed processor flush publishes one file, up to four per turn. A fifth flush is dropped
+  without overwriting any published sequence.
 - Local and Daytona use the same consumer with atomic files, stale sweep, bounded reads, and
   delete-on-pickup.
+- The consumer finishes bounded pickup before it sends any network request. Pickup acceptance,
+  collector success, and missing-batch fallback remain separate outcomes.
 - OTLP ingest accepts the standard protobuf body and recomputes cumulative metrics over stored
   split batches.
 - Focused credential, session, Pi export, fallback, and orchestration tests are green.

--- a/docs/design/runner-owned-pi-trace-export/status.md
+++ b/docs/design/runner-owned-pi-trace-export/status.md
@@ -1,8 +1,8 @@
 # Status
 
-**Phase: implementation started.**
+**Phase: implementation complete; release-train verification in progress.**
 
-Last updated: 2026-08-22.
+Last updated: 2026-08-23.
 
 ## Decisions
 
@@ -10,8 +10,10 @@ Last updated: 2026-08-22.
 - The runner is the only external exporter.
 - Local and Daytona use one file-spool protocol and one consumer state machine.
 - The payload is raw standard OTLP protobuf, not a custom Agenta DTO.
-- Pi receives per-turn propagation and capture policy, but no endpoint or credential.
-- The runner uses a renewable credential lease, so no two-hour telemetry token sets the session
+- Pi receives per-turn propagation, policy, attribution, and redaction-only values, but no endpoint
+  or export credential.
+- The runner uses one renewable platform credential lease for session and standalone turns, so no
+  two-hour telemetry token sets the session
   limit.
 - Pi ACP span reconstruction is disabled in both placements after cutover.
 - The existing tool relay supplies transport precedent, but telemetry and tools keep separate
@@ -20,12 +22,13 @@ Last updated: 2026-08-22.
   trace fix.
 - Trace export remains best-effort and bounded.
 - No feature flag or parallel long-lived Pi export mode will be added.
-- Work starts with two focused PRs: runner export-time authorization, then API issued-at plus 401 preservation.
+- PRs #6217 and #6218 landed the focused authorization and 401 prerequisites.
 
 ## Approved Fable review constraints for the remaining work
 
 - Pi redacts its own spans in every placement. One shared deny-set builder serves Pi and the runner, includes both mount credential pairs, and the extension uses an explicit always-on mode.
-- Cancellation still produces a trace. Pi publishes what it has; when no batch arrives, the runner emits the minimal error and usage fallback span. Do not add periodic partial batches because ingest rollups depend on one complete batch.
+- Cancellation still produces a trace. Pi publishes complete processor flushes; when no valid batch
+  arrives, the runner emits one minimal error-and-usage fallback span.
 - Keep the existing OTel exporter behavior and add only a thin raw-bytes post for spooled batches.
 - Add a telemetry-only byte host beside the relay directory. Do not rewrite the tool relay.
 - Allow a bounded sequence of raw protobuf files per turn, written by temporary-sibling rename and serialized parent-first.
@@ -35,34 +38,30 @@ Last updated: 2026-08-22.
 - The accepted trust boundary is project-scoped forwarding of sandbox-authored protobuf. No custom DTO, trace parser, deduplication layer, compatibility flag, or feature flag is added.
 - Release-gate coverage must include trace structure, redaction, local Pi, Daytona Pi, local Claude, and a turn held beyond one credential lifetime.
 
-PR #6217 implements the first approved prerequisite. PR #6218 carries the independent Secret-token issued-at and 401 correctness fixes.
+PR #6217 and PR #6218 are merged prerequisites. PR #6223 implements the runner-owned Pi exporter,
+the shared standalone/session credential lease, and target isolation.
 
 ## Current evidence
 
-- Main's access router already re-mints renewable short-lived credentials.
-- Main's runner already refreshes credentials during session-owned turns.
-- Main's Pi extension already creates the desired native span tree.
-- Main's relay already supports local and Daytona through host adapters with atomic files, stale
-  sweep, watch/poll fallback, and delete-on-pickup.
-- Main's OTLP ingest accepts the same standard protobuf body the Pi extension can spool.
-- PR #6135 extends the lifetime and refreshes only authorization. It does not remove the lifetime
-  coupling or unify local and Daytona export.
+- The access router re-mints renewable short-lived credentials.
+- The runner shares one proactive platform lease across session-owned and standalone turn paths.
+- Pi creates the native span tree and publishes a bounded sequence of raw protobuf requests.
+- Local and Daytona use the same consumer with atomic files, stale sweep, bounded reads, and
+  delete-on-pickup.
+- OTLP ingest accepts the standard protobuf body and recomputes cumulative metrics over stored
+  split batches.
+- Focused credential, session, Pi export, fallback, and orchestration tests are green.
 
 ## Open questions
 
-1. Should the first release parse OTLP in the runner for trace-ID hardening, or rely on the bounded
-   current-channel capability plus API parsing? The recommendation is to ship without a second
-   semantic parser unless threat review requires it.
-2. What compatibility window is required before moving the general credential from the legacy
+1. What compatibility window is required before moving the general credential from the legacy
    telemetry header into `platform.headers.authorization`?
-3. If PR #6135 merges first, has any other feature adopted its token-scope machinery? Remove only
-   code that has no remaining owner.
 
 ## Blockers
 
-None. The two prerequisite correctness PRs are open and the serializer seam is decided.
+No implementation blocker. Merge and deployment remain owner-controlled release actions.
 
 ## Next action
 
-Review and land PRs #6217 and #6218. Then pin the reviewed serializer dependency, add the parent-first fixture, and build the telemetry-only byte host.
-
+Finish PR review and CI reconciliation, merge the v0.114 train, then rerun the release gate against
+the combined release SHA before any explicitly approved preview deployment.


### PR DESCRIPTION
## Context

PR #6232 merged while its final review was still exposing contract drift between the design and the implementation. The docs still described one final spool file, session-only credential refresh, and a retrying 401 test even though the reviewed implementation uses bounded complete batches, one shared session and standalone credential lease, and one best-effort export attempt.

## Changes

The design now matches the shipped implementation:

- Pi publishes up to four complete standard OTLP protobuf requests under canonical sequence numbers. The runner collects the bounded sequence before sending and emits its fallback only when no valid batch was accepted.
- Session-owned and standalone turns share the same proactive platform credential lease. Third-party collector authorization remains static and never enters Agenta permission or session API headers.
- The control file may carry bounded redaction-only values already visible inside the sandbox, but still carries no endpoint or export credential.
- The trust boundary now states explicitly that the first release forwards bounded sandbox-authored protobuf without a second semantic parser.
- The raw-byte request shape, cumulative ingest rollup, failure matrix, and 401 QA expectation now use the names and behavior present in code.

Before, a reviewer could read the design and expect one file plus a 401 retry. After this PR, the design describes the bounded multi-batch, no-retry implementation covered by PR #6223.

## Tests / notes

- Formatted all six design files with the repository Prettier installation.
- Ran `git diff --check` on the design directory.
- This PR contains documentation only and is based on the commit merged through #6232.
- The legacy wire still cannot carry separate platform and third-party collector credentials. The design records that limitation for a future `platform.headers.authorization` cleanup.