### PR TITLE
[fix] Keep workflow token totals authoritative

### DIFF
--- a/api/oss/src/core/tracing/utils/trees.py
+++ b/api/oss/src/core/tracing/utils/trees.py
@@ -11,6 +11,7 @@ from oss.src.core.tracing.dtos import (
     OTelSpansTree,
     OTelTraceTree,
     Span,
+    SpanType,
     TraceType,
 )
 
@@ -453,8 +454,25 @@ def cumulate_tokens(
         if span.attributes is None:
             span.attributes = {}
 
+        incremental = (
+            span.attributes.get("ag", {})
+            .get("metrics", {})
+            .get("tokens", {})
+            .get("incremental", {})
+        )
+        has_workflow_total = (
+            span.span_type == SpanType.WORKFLOW
+            and isinstance(incremental, dict)
+            and "total" in incremental
+        )
+        if has_workflow_total:
+            # record_usage stamps the runner's whole-run total on the workflow
+            # root. Its child model spans describe the same usage, not more usage.
+            tokens = _get_incremental(span)
+
         if (
-            tokens.get("prompt", 0.0) != 0.0
+            has_workflow_total
+            or tokens.get("prompt", 0.0) != 0.0
             or tokens.get("completion", 0.0) != 0.0
             or tokens.get("total", 0.0) != 0.0
         ):

--- a/api/oss/tests/pytest/unit/tracing/utils/test_trees.py
+++ b/api/oss/tests/pytest/unit/tracing/utils/test_trees.py
@@ -134,6 +134,8 @@ def test_workflow_root_uses_its_reported_usage_as_cumulative(reported_cost):
         span_id=CHILD_A_UUID,
         parent_id=ROOT_UUID,
         span_name="chat",
+        prompt_tokens=40,
+        completion_tokens=10,
         prompt_cost=0.003,
         completion_cost=0.0012,
         start_offset_s=1,


### PR DESCRIPTION
## Context
Agent workflow spans already report the complete token total for the run. The trace tree fold then added child model tokens again, so observability could show more tokens than the agent actually used.

## Changes
When a workflow span explicitly reports its own incremental total, the fold now treats that value as the authoritative roll-up. Task and model spans keep the existing aggregation behavior, and an explicit zero remains meaningful.

The regression gives the workflow root and its child model span token values and verifies that the cumulative workflow total stays equal to the runner-reported total.

## Tests / notes
- API tracing utility suite: 84 passed.
- Ruff formatting and lint passed for both changed files.
- This is the token counterpart to the cost roll-up correction already merged in #6185.