### PR TITLE
[test] Align v0.114 release acceptance gates

### DIFF
--- a/.github/workflows/14-check-pr-preview.yml
+++ b/.github/workflows/14-check-pr-preview.yml
@@ -4,18 +4,18 @@ on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     paths:
-      - 'api/**'
-      - 'web/**'
-      - 'services/**'
-      - 'sdks/python/**'
-      - 'hosting/railway/**'
-      - '.github/workflows/14-check-pr-preview.yml'
-      - '.github/workflows/40-railway.yml'
-      - '.github/workflows/41-railway-setup.yml'
-      - '.github/workflows/42-railway-build.yml'
-      - '.github/workflows/43-railway-deploy.yml'
-      - '.github/workflows/44-railway-tests.yml'
-      - '.github/workflows/45-railway-cleanup.yml'
+      - "api/**"
+      - "web/**"
+      - "services/**"
+      - "sdks/python/**"
+      - "hosting/railway/**"
+      - ".github/workflows/14-check-pr-preview.yml"
+      - ".github/workflows/40-railway.yml"
+      - ".github/workflows/41-railway-setup.yml"
+      - ".github/workflows/42-railway-build.yml"
+      - ".github/workflows/43-railway-deploy.yml"
+      - ".github/workflows/44-railway-tests.yml"
+      - ".github/workflows/45-railway-cleanup.yml"
   workflow_dispatch:
     inputs:
       pr_number:
@@ -68,5 +68,7 @@ jobs:
       agenta_web_url: ${{ needs.deploy.outputs.preview_url }}
       layers: all
       packages: all
+      mobile_gate_enabled: true
+      # Railway previews keep /m directly reachable for desktop reviewers.
+      mobile_reverse_gate_enabled: false
     secrets: inherit
-

--- a/.github/workflows/44-railway-tests.yml
+++ b/.github/workflows/44-railway-tests.yml
@@ -72,6 +72,16 @@ on:
         required: false
         type: string
         default: ""
+      mobile_gate_enabled:
+        description: "Whether the tested deployment redirects mobile clients to /m"
+        required: false
+        type: boolean
+        default: true
+      mobile_reverse_gate_enabled:
+        description: "Whether the tested /m service redirects desktop clients back"
+        required: false
+        type: boolean
+        default: true
     secrets:
       AGENTA_TEST_OSS_AUTH_KEY:
         required: true
@@ -152,6 +162,16 @@ on:
         description: "Plan (hobby, pro, business, enterprise)"
         required: false
         type: string
+      mobile_gate_enabled:
+        description: "Test the mobile-to-/m redirect"
+        required: false
+        type: boolean
+        default: true
+      mobile_reverse_gate_enabled:
+        description: "Test the /m-to-desktop redirect"
+        required: false
+        type: boolean
+        default: true
 
 permissions:
   contents: read
@@ -626,6 +646,8 @@ jobs:
       AGENTA_TEST_OSS_OWNER_PASSWORD: ${{ secrets.AGENTA_TEST_OSS_OWNER_PASSWORD }}
       AGENTA_TEST_LLM_PROVIDER: mock
       AGENTA_TEST_EPHEMERAL_PROJECT: "true"
+      AGENTA_MOBILE_GATE: ${{ inputs.mobile_gate_enabled }}
+      AGENTA_MOBILE_REVERSE_GATE: ${{ inputs.mobile_reverse_gate_enabled }}
       TESTMAIL_API_KEY: ${{ secrets.TESTMAIL_API_KEY }}
       TESTMAIL_NAMESPACE: ${{ secrets.TESTMAIL_NAMESPACE }}
     steps:

--- a/services/runner/tests/unit/daytona-transcript-recovery.test.ts
+++ b/services/runner/tests/unit/daytona-transcript-recovery.test.ts
@@ -102,20 +102,21 @@ describe("a Pi transcript inside a remote sandbox", () => {
     );
 
     assert.equal(result.ok, false);
-    // The recovered provider error is classified before it reaches the user. A generic "the
-    // agent produced no output" cannot satisfy this, which is the point.
-    assert.ok(
-      result.error?.toLowerCase().includes("too many requests"),
-      `expected the classified transcript failure, got: ${result.error}`,
+    // The combined contract classifies the transcript's raw provider refusal before exposing it.
+    // Only a recovery that read RATE_LIMIT_ERROR can produce this stable user-facing message; a
+    // generic "the agent produced no output" cannot satisfy it.
+    assert.equal(
+      result.error,
+      "Too many requests right now. Try again in a moment.",
     );
     // The playground renders the event stream, not the result envelope: the error has to be IN
     // the stream, and ahead of the terminal `done`, or the turn still renders as a silent blank.
     const order = events.map((e) => e.type);
     const errorEvent = events.find((event) => event.type === "error");
     assert.ok(errorEvent, `no error event in stream: ${order}`);
-    assert.ok(
-      errorEvent.message.toLowerCase().includes("too many requests"),
-      `expected classified rate-limit error in stream, got: ${errorEvent.message}`,
+    assert.equal(
+      errorEvent.message,
+      "Too many requests right now. Try again in a moment.",
     );
     assert.equal(errorEvent.code, "rate_limited");
     assert.ok(

--- a/services/runner/tests/unit/otel-bytes-export.test.ts
+++ b/services/runner/tests/unit/otel-bytes-export.test.ts
@@ -113,6 +113,7 @@ describe("raw OTLP byte export", () => {
   });
 
   it("keeps credential-provider and fetch throws best effort", async () => {
+    const credential = "Bearer trace-export-secret";
     const fetchMock = vi.fn(async () => {
       throw new Error("connection refused");
     });
@@ -129,12 +130,12 @@ describe("raw OTLP byte export", () => {
     expect(fetchMock).not.toHaveBeenCalled();
 
     await expect(
-      exportOtlpBytes(request(THIRD_PARTY_ENDPOINT, () => "Bearer current")),
+      exportOtlpBytes(request(THIRD_PARTY_ENDPOINT, () => credential)),
     ).resolves.toMatchObject({ outcome: "failed" });
     expect(fetchMock).toHaveBeenCalledOnce();
     const lines = log.mock.calls.flat().join(" ");
     expect(lines).toContain("credential store unavailable");
     expect(lines).toContain("connection refused");
-    expect(lines).not.toContain("current");
+    expect(lines).not.toContain("trace-export-secret");
   });
 });

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -2330,7 +2330,14 @@ describe("runSandboxAgent orchestration", () => {
 
   it("preserves a failed Pi turn's agent error when no native trace batch arrives", async () => {
     const cwd = mkdtempSync(join(tmpdir(), "pi-failed-trace-"));
-    const fixture = fakeHarness({ cwd, promptError: new Error("boom") });
+    const fixture = fakeHarness({
+      cwd,
+      promptError: new Error(
+        '429: {"message":"Budget has been exceeded! Key=organization-id (sk-...suffix) Current cost: 5.1, Max budget: 5.0","type":"budget_exceeded","code":"429"}',
+      ),
+    });
+    const message =
+      "Your free Agenta credits are used up. Add your own provider key to keep going.";
 
     try {
       const result = await runSandboxAgent(
@@ -2343,10 +2350,14 @@ describe("runSandboxAgent orchestration", () => {
         fixture.deps,
       );
 
-      assert.deepEqual(result, { ok: false, error: "boom" });
+      assert.deepEqual(result, { ok: false, error: message });
       assert.deepEqual(fixture.calls.recordedErrors, [
-        { message: "boom", provider: undefined },
+        { message, provider: undefined },
       ]);
+      assert.deepEqual(
+        fixture.events.find((event) => event.type === "error"),
+        { type: "error", message, code: "starter_credits_exhausted" },
+      );
       assert.match(
         fixture.logs.join("\n"),
         /stage=pi_trace_missing_batch diagnostic=true/,

--- a/web/oss/tests/playwright/acceptance/mobile-gate/gate.spec.ts
+++ b/web/oss/tests/playwright/acceptance/mobile-gate/gate.spec.ts
@@ -3,15 +3,16 @@ import {expect, test} from "@playwright/test"
 const IPHONE_UA =
     "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1"
 
-// The gate ships default-on, and so does the /m service, so this suite runs
-// against any deployment that did not opt out. A deployment that sets
-// AGENTA_MOBILE_GATE=false has no gate to test, and the runner env var is the
-// operator's assertion of that.
 const gateEnabled = process.env.AGENTA_MOBILE_GATE !== "false"
-test.skip(!gateEnabled, "mobile gate opted out (AGENTA_MOBILE_GATE=false)")
+const reverseGateEnabled = process.env.AGENTA_MOBILE_REVERSE_GATE !== "false"
 
 test.describe("mobile gate: forward direction", () => {
-    test.use({userAgent: IPHONE_UA, storageState: undefined})
+    test.skip(!gateEnabled, "mobile gate opted out (AGENTA_MOBILE_GATE=false)")
+    test.use({
+        userAgent: IPHONE_UA,
+        extraHTTPHeaders: {"sec-ch-ua-mobile": "?1"},
+        storageState: undefined,
+    })
 
     test("mobile UA on a desktop route lands in /m", async ({page}) => {
         await page.goto("/w")
@@ -24,10 +25,9 @@ test.describe("mobile gate: forward direction", () => {
         await expect(page).toHaveURL(/\/m\/w\/ws1\/p\/pr1\/sessions\/abc$/)
     })
 
-    test("auth stays on desktop (documented exception)", async ({page}) => {
+    test("auth maps to the mobile sign-in", async ({page}) => {
         await page.goto("/auth")
-        await expect(page).toHaveURL(/\/auth/)
-        expect(page.url()).not.toContain("/m/")
+        await expect(page).toHaveURL(/\/m\/auth$/)
     })
 
     test("?view=desktop sets the opt-out and pins the desktop site", async ({page, context}) => {
@@ -41,6 +41,10 @@ test.describe("mobile gate: forward direction", () => {
 })
 
 test.describe("mobile gate: reverse direction", () => {
+    test.skip(
+        !reverseGateEnabled,
+        "reverse mobile gate opted out (AGENTA_MOBILE_REVERSE_GATE=false)",
+    )
     test.use({storageState: undefined})
 
     test("desktop UA on /m is sent to the desktop app", async ({page}) => {

--- a/web/oss/tests/playwright/acceptance/settings/model-hub.ts
+++ b/web/oss/tests/playwright/acceptance/settings/model-hub.ts
@@ -10,8 +10,8 @@ import {
     TestSpeedType,
 } from "@agenta/web-tests/playwright/config/testTags"
 import {test} from "@agenta/web-tests/tests/fixtures/base.fixture"
-import {expect, pollLocatorState} from "@agenta/web-tests/utils"
-import type {Locator} from "@playwright/test"
+import {expect} from "@agenta/web-tests/utils"
+import type {Locator, Page} from "@playwright/test"
 
 import {expectAuthenticatedSession} from "../utils/auth"
 import {createScenarios} from "../utils/scenarios"
@@ -30,23 +30,23 @@ import {buildAcceptanceTags} from "../utils/tags"
  * NOTE: Authentication is globally handled in Playwright config/globalSetup.
  * Info: Adding secret at the bigening of the all tests and then removing the secret in the end of all the tests
  */
-// Product copy for the custom-providers section. The section header is plural; the
-// button that opens its create form is "Add endpoint". Note that the provider-KIND
-// label in the type dropdown is still the singular "OpenAI-compatible endpoint" — a
-// different string in a different place, deliberately left as-is below.
-const CUSTOM_PROVIDERS_SECTION_HEADER = "OpenAI-compatible endpoints"
-const CUSTOM_PROVIDER_ADD_BUTTON_LABEL = "Add endpoint"
+const PROVIDER_ADD_BUTTON_LABEL = "Add provider"
 
 /**
  * A data row in one of the provider tables.
  *
- * These tables are virtualised: the semantic `<table>` carries only the `<thead>`, and
- * each body row is rendered outside it as a `[data-row-key]` node with no `row`/`cell`
- * role. Matching on `getByRole("row")`/`getByRole("cell")` therefore only ever sees the
- * header. `[data-row-key]` is how the rest of this suite addresses virtualised rows.
+ * Anchor on the exact Name cell so provider text in another column cannot select the
+ * wrong connection, then use its clickable table-row ancestor.
  */
 const providerRow = (section: Locator, name: string) =>
-    section.locator("[data-row-key]").filter({hasText: name}).first()
+    section.getByRole("cell", {name, exact: true}).locator("xpath=ancestor::tr[1]").first()
+
+const providersSection = (page: Page) =>
+    page
+        .getByRole("button", {name: PROVIDER_ADD_BUTTON_LABEL})
+        .first()
+        .locator("xpath=ancestor::section[1]")
+        .first()
 
 const scenarios = createScenarios(test)
 
@@ -84,12 +84,8 @@ const modelHubTests = () => {
             await testProviderHelpers.ensureTestProvider()
         })
 
-        await scenarios.then('the "Custom providers" table lists the "mock" provider', async () => {
-            const customProvidersSection = page
-                .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
-                .locator("xpath=ancestor::section[1]")
-                .first()
-            const mockRow = providerRow(customProvidersSection, "mock")
+        await scenarios.then('the providers table lists the "mock" connection', async () => {
+            const mockRow = providerRow(providersSection(page), "mock")
 
             await expect(mockRow).toBeVisible({timeout: 15000})
             await expect(mockRow).toContainText("mock")
@@ -97,126 +93,44 @@ const modelHubTests = () => {
     })
 
     test(
-        "should configure a standard provider key and verify it is listed",
+        "should test a stored provider connection and keep it listed",
         {tag: tagsLight},
-        async ({page, testProviderHelpers}, testInfo) => {
-            // Captured before configuring so the "then" step can assert the count went
-            // down. Counting rows instead does not work: the table is virtualised, so the
-            // DOM holds only the rows currently in view.
-            let configureNowCountBefore = 0
-
+        async ({page, testProviderHelpers}) => {
             await scenarios.given("the user is authenticated", async () => {
                 await expectAuthenticatedSession(page)
             })
 
-            await scenarios.given("the user is on the Settings models page", async () => {
+            await scenarios.given("a stored mock provider is listed in Settings", async () => {
                 await testProviderHelpers.ensureTestProvider()
             })
 
             await scenarios.when(
-                "the user configures a key for the first unconfigured standard provider",
+                "the user tests the connection without re-entering its write-only key",
                 async () => {
-                    const standardProvidersSection = page
-                        .getByText("Standard providers", {exact: true})
-                        .locator("xpath=ancestor::section[1]")
-                        .first()
+                    const mockRow = providerRow(providersSection(page), "mock")
+                    await expect(mockRow).toBeVisible({timeout: 15000})
+                    await mockRow.click()
 
-                    const configureNowButton = standardProvidersSection
-                        .getByRole("button", {name: "Configure now"})
-                        .first()
-
-                    const hasConfigureNow = await pollLocatorState(() =>
-                        configureNowButton.isVisible({timeout: 5000}),
-                    )
-
-                    testInfo.skip(
-                        !hasConfigureNow,
-                        "All standard providers are already configured — skipping standard provider key test",
-                    )
-
-                    configureNowCountBefore = await standardProvidersSection
-                        .getByRole("button", {name: "Configure now"})
-                        .count()
-
-                    await configureNowButton.click()
-
-                    // Matched by role: this modal renders through `EnhancedModal`, a facade
-                    // over the @agenta/ui (Radix) `Dialog`, so there is no `.ant-modal`.
-                    const modal = page.getByRole("dialog").last()
-                    await expect(modal).toBeVisible({timeout: 15000})
-                    await modal.getByPlaceholder("Enter API key").fill("sk-test-e2e-cleanup")
-                    await modal.getByRole("button", {name: "Confirm"}).click()
-                    await expect(modal).not.toBeVisible({timeout: 15000})
-                },
-            )
-
-            await scenarios.then(
-                "the Status column no longer shows Configure now for that row",
-                async () => {
-                    const standardProvidersSection = page
-                        .getByText("Standard providers", {exact: true})
-                        .locator("xpath=ancestor::section[1]")
-                        .first()
-
-                    const configureNowButtons = standardProvidersSection.getByRole("button", {
-                        name: "Configure now",
+                    const drawer = page.getByRole("dialog").last()
+                    await expect(drawer).toBeVisible({timeout: 15000})
+                    await expect(drawer.getByText(/Key configured/)).toBeVisible({
+                        timeout: 15000,
                     })
 
-                    // One more provider is configured than before, so one fewer row offers
-                    // "Configure now". Comparing against a row count does not work here —
-                    // the table is virtualised, so the number of rows in the DOM depends on
-                    // the viewport rather than on how many providers exist.
-                    await expect
-                        .poll(() => configureNowButtons.count(), {timeout: 15000})
-                        .toBeLessThan(configureNowCountBefore)
-                },
-            )
-
-            await scenarios.when(
-                "the user deletes the configured standard provider key",
-                async () => {
-                    const standardProvidersSection = page
-                        .getByText("Standard providers", {exact: true})
-                        .locator("xpath=ancestor::section[1]")
-                        .first()
-
-                    // Deleting is no longer a visible danger button — it is an entry in the
-                    // row's actions menu. That menu only renders for rows that already have
-                    // a key, so "the first row with an actions button" IS a configured row.
-                    const configuredRow = standardProvidersSection
-                        .locator("[data-row-key]")
-                        .filter({has: page.locator("button")})
-                        .first()
-                    await expect(configuredRow).toBeVisible({timeout: 15000})
-                    await configuredRow.locator("button").last().click()
-
-                    // Scope by name: the sidebar navigation also uses role="menuitem".
-                    const removeKeyItem = page.getByRole("menuitem", {name: "Remove key"})
-                    await expect(removeKeyItem).toBeVisible({timeout: 10000})
-                    await removeKeyItem.click()
-
-                    // Matched by role: this confirmation renders through `EnhancedModal`
-                    // (Radix `Dialog`), so there is no `.ant-modal`.
-                    const deleteModal = page.getByRole("dialog").last()
-                    await expect(deleteModal).toBeVisible({timeout: 15000})
-                    await deleteModal.getByRole("button", {name: "Delete"}).click()
-                    await expect(deleteModal).not.toBeVisible({timeout: 15000})
+                    await drawer.getByRole("button", {name: "Test"}).click()
+                    const done = drawer.getByRole("button", {name: "Done"})
+                    await expect(done).toBeEnabled({timeout: 30000})
+                    await done.click()
+                    await expect(drawer).not.toBeVisible({timeout: 15000})
                 },
             )
 
             await scenarios.then(
-                'the Status column shows "Configure now" again for that provider',
+                "the stored connection remains in the providers table",
                 async () => {
-                    const standardProvidersSection = page
-                        .getByText("Standard providers", {exact: true})
-                        .locator("xpath=ancestor::section[1]")
-                        .first()
-
-                    await expect(
-                        standardProvidersSection
-                            .getByRole("button", {name: "Configure now"})
-                            .first(),
-                    ).toBeVisible({timeout: 15000})
+                    await expect(providerRow(providersSection(page), "mock")).toBeVisible({
+                        timeout: 15000,
+                    })
                 },
             )
         },
@@ -241,16 +155,13 @@ const modelHubTests = () => {
             await scenarios.when(
                 "the user creates a new custom provider via the drawer",
                 async () => {
-                    const customProvidersSection = page
-                        .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
-                        .locator("xpath=ancestor::section[1]")
-                        .first()
+                    const customProvidersSection = providersSection(page)
 
                     // The button that opens the create form. It is rendered twice inside
                     // the section (header + empty-state row), hence `.first()`.
                     const createButton = customProvidersSection
                         .getByRole("button", {
-                            name: CUSTOM_PROVIDER_ADD_BUTTON_LABEL,
+                            name: PROVIDER_ADD_BUTTON_LABEL,
                             exact: true,
                         })
                         .first()
@@ -309,10 +220,7 @@ const modelHubTests = () => {
             await scenarios.then(
                 "the new custom provider row appears in the Custom providers table",
                 async () => {
-                    const customProvidersSection = page
-                        .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
-                        .locator("xpath=ancestor::section[1]")
-                        .first()
+                    const customProvidersSection = providersSection(page)
 
                     const newRow = providerRow(customProvidersSection, providerName)
 
@@ -321,10 +229,7 @@ const modelHubTests = () => {
             )
 
             await scenarios.when("the user deletes the newly created custom provider", async () => {
-                const customProvidersSection = page
-                    .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
-                    .locator("xpath=ancestor::section[1]")
-                    .first()
+                const customProvidersSection = providersSection(page)
 
                 const newRow = providerRow(customProvidersSection, providerName)
 
@@ -345,10 +250,7 @@ const modelHubTests = () => {
             })
 
             await scenarios.then("the deleted provider row is no longer visible", async () => {
-                const customProvidersSection = page
-                    .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
-                    .locator("xpath=ancestor::section[1]")
-                    .first()
+                const customProvidersSection = providersSection(page)
 
                 const deletedRow = providerRow(customProvidersSection, providerName)
 

--- a/web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts
+++ b/web/tests/tests/fixtures/base.fixture/providerHelpers/index.ts
@@ -15,11 +15,10 @@ import type {
     TestProviderProfileInfo,
 } from "./types"
 
-// Header of the custom-providers ("OpenAI-compatible endpoints") section, and the
-// label of the button that opens its create form. Both are product copy; keep them
-// here so a rename is a one-line fix rather than a hunt through the helpers.
-const CUSTOM_PROVIDERS_SECTION_HEADER = "OpenAI-compatible endpoints"
-const CUSTOM_PROVIDER_ADD_BUTTON_LABEL = "Add endpoint"
+// Settings now presents one table of provider connections. Keep the page and action
+// copy here so future wording changes stay local to this fixture.
+const PROVIDERS_PAGE_HEADING = "AI providers"
+const PROVIDER_ADD_BUTTON_LABEL = "Add provider"
 
 const MOCK_PROVIDER_NAME = "mock"
 const MOCK_PROVIDER_KIND = "custom"
@@ -30,6 +29,10 @@ const MOCK_API_BASE_URL = "https://mockgpt.wiremockapi.cloud/v1"
 interface VaultSecretRecord {
     id: string
     kind: string
+    value_status?: {
+        configured?: boolean
+        preview?: string | null
+    }
     header?: {
         name?: string
     }
@@ -134,7 +137,7 @@ function readTestProjectMetadata(): TestProjectMetadata | null {
 }
 
 async function waitForModelsPageReady(page: Page): Promise<void> {
-    const customProvidersSection = getCustomProvidersSection(page)
+    const providersSection = getProvidersSection(page)
 
     await page.waitForLoadState("networkidle", {timeout: 10000}).catch(() => {})
 
@@ -144,23 +147,16 @@ async function waitForModelsPageReady(page: Page): Promise<void> {
                 const pathname = new URL(page.url()).pathname
                 const hasScopedSettingsPath = /\/w\/[^/]+\/p\/[^/]+\/settings$/.test(pathname)
                 const headingVisible = await pollLocatorState(() =>
-                    page.getByRole("heading", {name: "LLMs"}).isVisible(),
+                    page.getByRole("heading", {name: PROVIDERS_PAGE_HEADING}).isVisible(),
                 )
-                const sectionVisible = await pollLocatorState(() =>
-                    customProvidersSection.isVisible(),
-                )
+                const sectionVisible = await pollLocatorState(() => providersSection.isVisible())
                 const hasVisibleSpinner = await pollLocatorState(() =>
-                    customProvidersSection.locator(".ant-spin-spinning").isVisible(),
+                    providersSection.locator(".ant-spin-spinning").isVisible(),
                 )
-                // `.first()` matters: the section renders this button twice (once in the
-                // header, once in the empty-state row). Without it the locator is strict-mode
-                // ambiguous and `isEnabled()` throws — pollLocatorState lets that throw
-                // through instead of swallowing it, so a future selector regression fails
-                // loudly instead of timing out with a "never reached a stable ready state"
-                // message that names no real cause.
+                // The empty state renders a second Add provider button.
                 const createButtonEnabled = await pollLocatorState(() =>
-                    customProvidersSection
-                        .getByRole("button", {name: CUSTOM_PROVIDER_ADD_BUTTON_LABEL})
+                    providersSection
+                        .getByRole("button", {name: PROVIDER_ADD_BUTTON_LABEL})
                         .first()
                         .isEnabled(),
                 )
@@ -196,31 +192,29 @@ async function navigateToModels(page: Page, uiHelpers: UIHelpers): Promise<void>
     await page.goto(`${projectBasePath}/settings?tab=llms`, {waitUntil: "domcontentloaded"})
 
     await uiHelpers.expectPath("/settings")
-    await expect(page.getByRole("heading", {name: "LLMs"})).toBeVisible({
+    await expect(page.getByRole("heading", {name: PROVIDERS_PAGE_HEADING})).toBeVisible({
         timeout: 15000,
     })
-    await expect(getCustomProvidersSection(page)).toBeVisible({timeout: 15000})
+    await expect(getProvidersSection(page)).toBeVisible({timeout: 15000})
     await waitForModelsPageReady(page)
 }
 
-function getCustomProvidersSection(page: Page): Locator {
-    // Anchored on the section's own header text. This used to key off the
-    // "OpenAI-compatible endpoint" trigger button, but that button is now labelled
-    // "Add endpoint", so the old anchor matched nothing and the section could never
-    // be found. The header reads "OpenAI-compatible endpoints" (plural).
+function getProvidersSection(page: Page): Locator {
+    // The unified connections table has no section heading of its own. Its primary
+    // action is the stable accessible anchor, including while the table is empty.
     return page
-        .getByText(CUSTOM_PROVIDERS_SECTION_HEADER, {exact: true})
+        .getByRole("button", {name: PROVIDER_ADD_BUTTON_LABEL})
+        .first()
         .locator("xpath=ancestor::section[1]")
         .first()
 }
 
 async function getCustomProviderRow(page: Page, providerName: string): Promise<Locator | null> {
-    const customProvidersSection = getCustomProvidersSection(page)
-    const table = customProvidersSection.getByRole("table").first()
-
-    const row = table
-        .getByRole("row")
-        .filter({has: page.getByRole("cell", {name: providerName, exact: true})})
+    // Start from the exact Name cell; its table row is the clickable control.
+    const section = getProvidersSection(page)
+    const row = section
+        .getByRole("cell", {name: providerName, exact: true})
+        .locator("xpath=ancestor::tr[1]")
         .first()
 
     return (await row.count()) > 0 ? row : null
@@ -262,7 +256,8 @@ function assertMockProviderSecret(secret: VaultSecretRecord): void {
     expect(secret.header?.name).toBe(MOCK_PROVIDER_NAME)
     expect(secret.data?.kind).toBe(MOCK_PROVIDER_KIND)
     expect(secret.data?.provider?.url).toBe(MOCK_API_BASE_URL)
-    expect(secret.data?.provider?.extras?.api_key).toBe(MOCK_API_KEY)
+    expect(secret.value_status?.configured).toBe(true)
+    expect(secret.data?.provider?.extras?.api_key).toBeUndefined()
     expect(secret.data?.models?.some((model) => model.slug === MOCK_MODEL_NAME)).toBe(true)
 }
 
@@ -313,16 +308,12 @@ async function createMockProvider(page: Page, uiHelpers: UIHelpers): Promise<voi
     await page.reload({waitUntil: "domcontentloaded"})
     await waitForModelsPageReady(page)
 
-    const providerNameCell = getCustomProvidersSection(page).getByRole("cell", {
-        name: MOCK_PROVIDER_NAME,
-        exact: true,
-    })
-
-    const providerVisible = await pollLocatorState(() =>
-        providerNameCell.isVisible({timeout: 5000}),
-    )
-    if (providerVisible) {
-        await expect(providerNameCell).toBeVisible({timeout: 15000})
+    const providerRow = await getCustomProviderRow(page, MOCK_PROVIDER_NAME)
+    const providerVisible =
+        providerRow !== null &&
+        (await pollLocatorState(() => providerRow.isVisible({timeout: 5000})))
+    if (providerRow && providerVisible) {
+        await expect(providerRow).toBeVisible({timeout: 15000})
     }
 }
 


### PR DESCRIPTION
## Context
The Railway acceptance suite still encoded older provider and mobile contracts. Healthy preview pages therefore failed on obsolete labels, a desktop mobile hint, and reverse-gate assertions that ran even when the preview disabled that direction. Two runner regressions also needed stronger assertions: trace-export diagnostics must never leak the credential, and a missing Pi trace batch must not replace the real classified run error.

## Changes
The provider fixture now follows the current AI providers UI and verifies that a stored write-only key can be tested without reading or re-entering it. Mobile requests send the mobile client hint, and forward and reverse gate suites follow separate explicit workflow inputs.

The runner tests use an unambiguous secret sentinel, pin the classified Daytona rate-limit event, and verify that starter-credit error codes survive missing-native-trace fallback.

This PR changes tests and CI workflow inputs only. It does not change application or runner production code.

## Tests / notes
- Runner: 90 tests passed across the three changed files; typecheck passed.
- Frontend: all 25 lint tasks passed; OSS and EE typecheck passed.
- Both workflow YAML files parsed successfully.
- The same provider and mobile acceptance paths previously passed against the local EE stack.