### PR TITLE
[test] Align SDK stream assertion with runner startup status

### DIFF
--- a/sdks/python/oss/tests/pytest/unit/agents/test_streaming.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_streaming.py
@@ -155,10 +155,20 @@ async def test_cli_stream_terminal_only_on_empty_request() -> None:
     async for record in deliver_subprocess_stream(cmd, {}, cwd=str(agent_dir)):
         records.append(record)
 
-    # An empty request fails before any event, so the stream is exactly one result record.
-    assert len(records) == 1, records
-    assert records[0]["kind"] == "result"
-    assert records[0]["result"]["ok"] is False
+    # Environment acquisition is observable before prompt validation. The empty request then
+    # terminates with the same failed result record as the one-shot path.
+    assert len(records) == 2, records
+    assert records[0] == {
+        "kind": "event",
+        "event": {
+            "type": "data",
+            "name": "agent-status",
+            "data": {"phase": "environment_starting"},
+            "transient": True,
+        },
+    }
+    assert records[1]["kind"] == "result"
+    assert records[1]["result"]["ok"] is False
 
     # AgentStream surfaces that failure as a RuntimeError, just like the one-shot path.
     run = AgentStream(deliver_subprocess_stream(cmd, {}, cwd=str(agent_dir)))


### PR DESCRIPTION
## Why

The broad release validation runs the SDK streaming integration test against an installed runner. The runner intentionally emits a transient `environment_starting` status before validating an empty prompt, but this test still asserted that the terminal failure was the only record. GitHub normally skips this exact seam when runner dependencies are absent, so the stale assertion was hidden.

## What changed

- expect the transient startup-status event first
- keep the failed terminal result and `AgentStream` exception assertions unchanged
- no production code or wire behavior changes

## Validation

- `./.venv/bin/pytest -q oss/tests/pytest/unit/agents/test_streaming.py` — 6 passed
- `ruff format --check oss/tests/pytest/unit/agents/test_streaming.py`
- `ruff check oss/tests/pytest/unit/agents/test_streaming.py`

## Rollback

Revert this one test-only commit. Runtime behavior is unaffected.