### PR TITLE
[fix] Give the runner both canonical Agenta API URLs

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -488,10 +488,9 @@ services:
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
             PI_CODING_AGENT_DIR: /pi-agent
-            # The API as reached FROM this container — by its compose service name, over the
-            # network (the same `http://api:8000` the workers use), NOT the public
-            # `http://localhost/api` (which doesn't resolve inside a container). Used by the
-            # OTLP tracing-export fallback AND the session heartbeat/record-persist calls.
+            # Keep both canonical API bases. The public URL identifies caller-provided OTLP
+            # credentials as Agenta-owned; the internal URL is the route the runner actually uses.
+            AGENTA_API_URL: ${AGENTA_API_URL:-}
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS: ${AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS:-local}

--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -323,6 +323,7 @@ services:
             # a random id would orphan them for the owner TTL. A fixed default is safe because
             # compose runs a single runner. Override only if you scale to multiple runners.
             AGENTA_RUNNER_REPLICA_ID: ${AGENTA_RUNNER_REPLICA_ID:-local-runner-1}
+            AGENTA_API_URL: ${AGENTA_API_URL:-}
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -325,6 +325,7 @@ services:
             # a random id would orphan them for the owner TTL. A fixed default is safe because
             # compose runs a single runner. Override only if you scale to multiple runners.
             AGENTA_RUNNER_REPLICA_ID: ${AGENTA_RUNNER_REPLICA_ID:-local-runner-1}
+            AGENTA_API_URL: ${AGENTA_API_URL:-}
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}

--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -452,10 +452,9 @@ services:
             # default of `127.0.0.1` (same-host only) is unreachable cross-container.
             AGENTA_RUNNER_HOST: ${AGENTA_RUNNER_HOST:-0.0.0.0}
             PI_CODING_AGENT_DIR: /pi-agent
-            # API as reached FROM this container: the compose service name over the network
-            # (http://api:8000, as the workers use), NOT the public http://localhost/api
-            # which does not resolve inside a container. Used by the OTLP tracing-export
-            # fallback AND the session heartbeat/record-persist calls.
+            # Keep both canonical API bases. The public URL identifies caller-provided OTLP
+            # credentials as Agenta-owned; the internal URL is the route the runner actually uses.
+            AGENTA_API_URL: ${AGENTA_API_URL:-}
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -319,6 +319,7 @@ services:
             # a random id would orphan them for the owner TTL. A fixed default is safe because
             # compose runs a single runner. Override only if you scale to multiple runners.
             AGENTA_RUNNER_REPLICA_ID: ${AGENTA_RUNNER_REPLICA_ID:-local-runner-1}
+            AGENTA_API_URL: ${AGENTA_API_URL:-}
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -342,6 +342,7 @@ services:
             # a random id would orphan them for the owner TTL. A fixed default is safe because
             # compose runs a single runner. Override only if you scale to multiple runners.
             AGENTA_RUNNER_REPLICA_ID: ${AGENTA_RUNNER_REPLICA_ID:-local-runner-1}
+            AGENTA_API_URL: ${AGENTA_API_URL:-}
             # API as reached FROM this container: the compose service name over the network
             # (http://api:8000, as the workers use), NOT the public http://localhost/api
             # which does not resolve inside a container. Used by the OTLP tracing-export

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -343,6 +343,7 @@ services:
             # a random id would orphan them for the owner TTL. A fixed default is safe because
             # compose runs a single runner. Override only if you scale to multiple runners.
             AGENTA_RUNNER_REPLICA_ID: ${AGENTA_RUNNER_REPLICA_ID:-local-runner-1}
+            AGENTA_API_URL: ${AGENTA_API_URL:-}
             AGENTA_API_INTERNAL_URL: ${AGENTA_API_INTERNAL_URL:-http://api:8000}
             AGENTA_API_KEY: ${AGENTA_API_KEY:-}
             AGENTA_RUNNER_TOKEN: ${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}

--- a/hosting/railway/oss/template/template.json
+++ b/hosting/railway/oss/template/template.json
@@ -268,6 +268,8 @@
       "variables": {
         "AGENTA_RUNNER_HOST": "0.0.0.0",
         "AGENTA_RUNNER_PORT": "8765",
+        "AGENTA_API_URL": "https://${{gateway.RAILWAY_PUBLIC_DOMAIN}}/api",
+        "AGENTA_API_INTERNAL_URL": "http://api.railway.internal:8000/api",
         "AGENTA_RUNNER_TOKEN": {
           "secret": "AGENTA_RUNNER_TOKEN"
         },
@@ -286,7 +288,6 @@
         }
       },
       "optionalVariables": [
-        "AGENTA_API_URL",
         "AGENTA_API_KEY",
         "AGENTA_RUNNER_DAYTONA_API_KEY",
         "AGENTA_RUNNER_DAYTONA_API_URL",


### PR DESCRIPTION
## Context

Runner-owned session persistence and Pi trace export reuse the invoke caller credential only when the OTLP endpoint is recognized as Agenta ingest. Local Compose and Railway gave the runner only an internal API route, while the SDK sent the public OTLP URL. The security guard therefore classified the credential as third-party exporter auth and withheld it from platform calls. Fresh session writes returned 401 and the run failed as an unreadable record log.

## Changes

- Pass both `AGENTA_API_URL` and `AGENTA_API_INTERNAL_URL` to every OSS and EE Compose runner.
- Give Railway runners the public gateway URL and the private API route by default.
- Keep the existing trust rule unchanged: only an exact configured Agenta ingest URL can reuse the credential for platform calls.

Before: the runner knew only the internal route, so a public Agenta OTLP endpoint was not recognized.

After: the public URL establishes endpoint identity; the internal URL remains the actual runner-to-API route. No new secret, token, scope, or fallback is added.

## Validation

- `git diff --check`
- JSON parsing for the Railway template
- Parsed all seven Compose runner definitions and asserted both URL variables are present
- Recreated only the local runner from this branch; health check passed and both variables were present
- Real `/services/agent/v0/invoke` release-gate P2 chat with a fresh starter-credit account: PASS (`PONG`)
- Runner evidence: platform credential present, user/agent/done records ingested, native Pi OTLP protobuf exported by the runner with HTTP 200

## Rollback

Revert this PR. It changes deployment configuration only; no schema or persisted data changes.