### PR TITLE
[fix] Keep workflow spans active across streamed generators

### DIFF
--- a/sdks/python/agenta/sdk/decorators/tracing.py
+++ b/sdks/python/agenta/sdk/decorators/tracing.py
@@ -1,6 +1,7 @@
 # /agenta/sdk/decorators/tracing.py
 
 import warnings
+from contextlib import contextmanager
 from functools import wraps
 from inspect import (
     getfullargspec,
@@ -357,6 +358,28 @@ class instrument:  # pylint: disable=invalid-name
             return b"".join(chunks)
         return chunks
 
+    @contextmanager
+    def _stream_span_scope(self, span, captured_ctx):
+        """Activate one stream step in the context that created its span.
+
+        ASGI consumers may request consecutive chunks from different context frames.
+        OpenTelemetry context tokens therefore cannot stay attached across a yielded
+        chunk. Attaching and detaching around each generator step keeps both operations
+        in the same frame and keeps the workflow span current inside stream finalizers.
+        """
+        otel_token = otel_context.attach(captured_ctx)
+        try:
+            with use_span(
+                span,
+                end_on_exit=False,
+                record_exception=True,
+                set_status_on_exception=True,
+            ):
+                yield
+        finally:
+            with suppress():
+                otel_context.detach(otel_token)
+
     def _wrap_returned_gen(self, gen, span, captured_ctx):
         """Keep a batch-path span open across a RETURNED generator's consumption.
 
@@ -374,36 +397,38 @@ class instrument:  # pylint: disable=invalid-name
         """
 
         async def wrapped():
-            otel_token = otel_context.attach(captured_ctx)
+            acc = []
             try:
-                with use_span(
-                    span,
-                    end_on_exit=True,
-                    record_exception=True,
-                    set_status_on_exception=True,
-                ):
-                    acc = []
-                    try:
-                        if isasyncgen(gen):
-                            async for chunk in gen:
-                                acc.append(chunk)
-                                yield chunk
-                        else:
-                            for chunk in gen:
-                                acc.append(chunk)
-                                yield chunk
-                    finally:
-                        self._post_instrument(span, self._join_stream(acc))
+                if isasyncgen(gen):
+                    while True:
+                        with self._stream_span_scope(span, captured_ctx):
+                            try:
+                                chunk = await gen.__anext__()
+                            except StopAsyncIteration:
+                                break
+                        acc.append(chunk)
+                        yield chunk
+                else:
+                    while True:
+                        with self._stream_span_scope(span, captured_ctx):
+                            try:
+                                chunk = next(gen)
+                            except StopIteration:
+                                break
+                        acc.append(chunk)
+                        yield chunk
             finally:
-                # Detach can run in a DIFFERENT context frame than the attach when the
-                # stream is closed abnormally — mid-stream raise, or the ASGI server
-                # calling aclose() from another task (StreamingResponse). OTel raises
-                # "Token created in a different Context" there. Guard it: the leaked
-                # activation dies with the task anyway, and crashing the teardown would
-                # mask the real error. (Thread/task-safety: span currency is per-task
-                # contextvar; this only cleans up THIS task's activation.)
-                with suppress():
-                    otel_context.detach(otel_token)
+                try:
+                    with self._stream_span_scope(span, captured_ctx):
+                        try:
+                            if isasyncgen(gen):
+                                await gen.aclose()
+                            else:
+                                gen.close()
+                        finally:
+                            self._post_instrument(span, self._join_stream(acc))
+                finally:
+                    span.end()
 
         return wrapped()
 

--- a/sdks/python/oss/tests/pytest/integration/observability/test_returned_generator_instrument.py
+++ b/sdks/python/oss/tests/pytest/integration/observability/test_returned_generator_instrument.py
@@ -16,7 +16,10 @@ content in its finally — the same contract a `yield`-based handler gets. Both 
 These tests are RED before the fix, GREEN after. Uses the in-memory exporter (no backend).
 """
 
+import asyncio
+
 import pytest
+from opentelemetry import trace as otel_trace
 
 from agenta.sdk.agents.fold import assistant_text
 from agenta.sdk.decorators.running import workflow
@@ -118,6 +121,40 @@ async def test_returned_agent_event_stream_records_assistant_text(in_memory_trac
 
     root = _roots(in_memory_tracing.finished_spans())[0]
     assert _attr(root, "ag.data.outputs.__default__") == "Hello world"
+
+
+@pytest.mark.asyncio
+async def test_returned_async_gen_reactivates_span_for_each_consumer_context(
+    in_memory_tracing,
+):
+    """Mirror ASGI requesting consecutive stream steps from different contexts."""
+
+    async def _events():
+        try:
+            yield "one"
+            yield "two"
+        finally:
+            otel_trace.get_current_span().set_attribute(
+                "test.stream_finalizer_span_active", True
+            )
+
+    @workflow()
+    async def wf(value: str):
+        return _events()
+
+    response = await wf.invoke(request=_request("a"))
+    stream = response.iterator()
+    items = []
+    while True:
+        try:
+            # A fresh task carries a fresh Context frame, as StreamingResponse may.
+            items.append(await asyncio.create_task(anext(stream)))
+        except StopAsyncIteration:
+            break
+
+    assert items == ["one", "two"]
+    root = _roots(in_memory_tracing.finished_spans())[0]
+    assert _attr(root, "test.stream_finalizer_span_active") is True
 
 
 # --------------------------------------------------------------------------- #


### PR DESCRIPTION
## Context

An SDK workflow that returns an async generator kept one OpenTelemetry context token active while the stream yielded to ASGI. ASGI may request the next item from a different task context, so the SDK logged `Failed to detach context` and finalized the workflow span without the stream's final attributes.

## Changes

The stream wrapper now reactivates the workflow span for each generator step and for finalization. No OpenTelemetry context token remains attached while control is yielded to the caller.

Before, one context scope covered the whole outward stream. After, each `anext`, delegated-generator close, and post-instrumentation step receives its own short-lived scope.

This does not change the workflow or stream API.

## Tests / notes

- Added an integration test that requests each stream item from a fresh asyncio task, matching the ASGI context switch that exposed the bug.
- Focused returned-generator suite: 6 passed.
- Broader tracing and streaming suite: 169 passed.
- A real funded Pi run completed, and the context-detach error no longer appeared in services logs.
- Pi usage publication ordering is a separate runner follow-up and is intentionally not part of this PR.

## How to review

Start with `_stream_span_scope` in `tracing.py`, then read the returned async-generator wrapper. Finish with the ASGI-style regression test and verify that its delegated generator can stamp the workflow root during finalization.
