### PR TITLE
[fix] Publish Pi usage before trace completion

### DIFF
--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -731,8 +731,11 @@ export function buildRunPlan(
         telemetryDir,
         toolMcpDir,
         // Usage capture is ephemeral runner output, not durable session data — keep it off the
-        // geesefs mount alongside the relay dir (a mount write would risk ENOTCONN).
-        usageOutPath: isPi ? join(relayDir, ".agenta-usage.json") : undefined,
+        // geesefs mount in Pi's always-created telemetry dir. A plain chat has no tool relay, so
+        // the relay dir may not exist at all.
+        usageOutPath: isPi
+          ? join(telemetryDir, ".agenta-usage.json")
+          : undefined,
         skillDirs,
         skillsCleanup,
         sourcePiAgentDir:

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -1174,6 +1174,14 @@ export async function runTurn(
     }
     logger(`prompt stopReason=${stopReason}`);
 
+    // Pi publishes the usage sidecar immediately before its native trace batch. Draining that
+    // batch first is therefore the cross-filesystem publication barrier for both local and
+    // Daytona runs. Runner-traced harnesses still need usage before trace finalization so the
+    // runner can stamp it on its own span.
+    let traceFinish =
+      plan.isPi && stopReason !== "paused"
+        ? await harnessTrace.finish()
+        : undefined;
     const usage = await resolveRunUsage({
       sandbox: env.sandbox,
       usageOutPath: plan.workspace.usageOutPath,
@@ -1182,8 +1190,9 @@ export async function runTurn(
       streamUsage: run.usage(),
     });
     run.setUsage(usage);
-    const traceFinish =
-      stopReason !== "paused" ? await harnessTrace.finish() : undefined;
+    if (!plan.isPi && stopReason !== "paused") {
+      traceFinish = await harnessTrace.finish();
+    }
     const nativeTraceBatches = traceFinish?.pickedUpBatches;
 
     // A retried turn is empty too. pi-acp streams "Retrying (attempt 1/3, waiting 2s)..." as an

--- a/services/runner/src/extensions/agenta.ts
+++ b/services/runner/src/extensions/agenta.ts
@@ -498,7 +498,8 @@ const factory = (pi: ExtensionAPI): void => {
   otel.register(pi); // lifecycle handlers (spans + usage accumulation)
 
   pi.on("agent_end", async () => {
-    if (otel.config.enabled) await otel.flush();
+    // Publish usage before the native trace batch. The runner treats pickup of that batch as the
+    // barrier that makes this sidecar safe to read, for local and remote sandboxes alike.
     if (usageOut) {
       try {
         writeFileSync(usageOut, JSON.stringify(otel.usage()), "utf-8");
@@ -506,6 +507,7 @@ const factory = (pi: ExtensionAPI): void => {
         log(`usage writeback skipped: ${(err as Error).message}`);
       }
     }
+    if (otel.config.enabled) await otel.flush();
   });
 };
 

--- a/services/runner/tests/unit/extension-tools.test.ts
+++ b/services/runner/tests/unit/extension-tools.test.ts
@@ -520,6 +520,69 @@ describe("readPiTurnTraceControl", () => {
   });
 });
 
+describe("agenta extension usage publication", () => {
+  it("writes usage before waiting for the native trace flush", async () => {
+    clearEnv();
+    const dir = mkdtempSync(join(tmpdir(), "agenta-usage-order-test-"));
+    const controlPath = join(dir, "current.control.json");
+    const usagePath = join(dir, "usage.json");
+    writeFileSync(
+      controlPath,
+      JSON.stringify({
+        version: PI_TRACE_CONTROL_VERSION,
+        channelId: "a".repeat(32),
+        capture: { content: true },
+        skills: [],
+        redaction: { knownValues: [] },
+      }),
+      "utf-8",
+    );
+    process.env[PI_TRACE_CONTROL_ENV] = controlPath;
+    process.env.AGENTA_AGENT_USAGE_CAPTURE_PATH = usagePath;
+
+    const pi = fakePi();
+    factory(pi as any);
+
+    for (const handler of pi.handlers.before_agent_start)
+      await handler({ prompt: "hello" });
+    for (const handler of pi.handlers.agent_start) await handler({});
+    for (const handler of pi.handlers.message_end) {
+      await handler({
+        message: {
+          role: "assistant",
+          content: [{ type: "text", text: "hello" }],
+          usage: {
+            input: 3,
+            output: 2,
+            totalTokens: 5,
+            cost: { total: 0.01 },
+          },
+        },
+      });
+    }
+
+    await pi.handlers.agent_end[0]({
+      messages: [{ role: "assistant", content: "hello" }],
+    });
+    const flush = pi.handlers.agent_end[1]({});
+
+    assert.equal(
+      existsSync(usagePath),
+      true,
+      "the usage sidecar is visible before trace flush yields",
+    );
+    assert.deepEqual(JSON.parse(readFileSync(usagePath, "utf-8")), {
+      input: 3,
+      output: 2,
+      total: 5,
+      cost: 0.01,
+    });
+
+    await flush;
+    rmSync(dir, { recursive: true, force: true });
+  });
+});
+
 describe("agenta extension: Pi dialog gate (approval parking)", () => {
   function builtinEvent(toolName: string, input: unknown) {
     return { type: "tool_call", toolName, toolCallId: "tc-b", input };

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -356,13 +356,15 @@ describe("buildRunPlan", () => {
     assert.equal(result.plan.acpAgent, "pi");
     assert.equal(result.plan.sandboxId, "local");
     assert.equal(result.plan.workspace.cwd, "/tmp/local-cwd");
-    // The relay dir + usage capture are ephemeral runner files kept OFF the (possibly geesefs)
-    // cwd: an ephemeral sibling whose leaf is the cwd basename.
+    // Relay and telemetry are ephemeral runner files kept OFF the (possibly geesefs) cwd.
     assert.ok(!result.plan.workspace.relayDir.startsWith(result.plan.workspace.cwd));
     assert.ok(result.plan.workspace.relayDir.endsWith("/agenta/relay/local-cwd"));
+    assert.ok(
+      result.plan.workspace.telemetryDir.endsWith("/agenta/telemetry/local-cwd"),
+    );
     assert.equal(
       result.plan.workspace.usageOutPath,
-      `${result.plan.workspace.relayDir}/.agenta-usage.json`,
+      `${result.plan.workspace.telemetryDir}/.agenta-usage.json`,
     );
     assert.equal(result.plan.prompt.text, " ship it ");
     assert.equal(result.plan.prompt.agentsMd, "instructions");

--- a/services/runner/tests/unit/sandbox-agent-workspace.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-workspace.test.ts
@@ -104,6 +104,45 @@ describe("prepareWorkspace", () => {
     assert.equal(existsSync(cwd), false);
   });
 
+  it("creates Pi telemetry without creating an unused local tool relay", async () => {
+    const root = tempDir();
+    const cwd = join(root, "cwd");
+    const relayDir = join(root, "relay");
+    const telemetryDir = join(root, "telemetry");
+
+    const workspace = await prepareWorkspace({
+      sandbox: {},
+      plan: {
+        isDaytona: false,
+        acpAgent: "pi",
+        isPi: true,
+        workspace: {
+          cwd,
+          relayDir,
+          telemetryDir,
+          skillDirs: [],
+        },
+        tools: {
+          useToolRelay: false,
+        },
+        prompt: {},
+      },
+    });
+
+    assert.equal(
+      existsSync(telemetryDir),
+      true,
+      "Pi always has a directory for trace and usage publication",
+    );
+    assert.equal(
+      existsSync(relayDir),
+      false,
+      "a chat with no executable tools does not need a relay directory",
+    );
+
+    await workspace.cleanup();
+  });
+
   it("clears a stale .req.json left from a prior turn before the next turn starts", async () => {
     const cwd = tempDir();
     const relayDir = join(cwd, ".agenta-tools");


### PR DESCRIPTION
## Context

Pi produced the correct native token totals, but the workflow root sometimes showed no usage. The runner read Pi's usage sidecar before Pi finished publishing it. Plain chats had a second failure: the sidecar lived in the tool-relay directory, which does not exist when a run has no tools.

## Changes

Pi now writes usage synchronously before flushing its native trace batch. The runner drains that batch first, then reads usage, so trace pickup becomes the publication barrier on both local and Daytona filesystems.

The sidecar now lives in Pi's telemetry directory. That directory already exists for every Pi turn, including chats with no tool relay.

Runner-traced harnesses keep their previous order because the runner must set their usage before finalizing its own span.

## Tests / notes

- Added a deterministic extension test that proves the usage file exists before trace flush yields.
- Added run-plan and workspace coverage for a no-tool Pi chat.
- Focused runner suites: 183 passed.
- Full runner suite: 2,328 passed.
- `pnpm run typecheck` passed.
- Live P2 product-path chat passed on the local sandbox.
- The persisted usage record contained 1,972 input, 108 output, and 2,080 total tokens.
- The workflow root trace contained the same totals and retained Pi's native `invoke_agent`, turn, and chat spans.
- Runner and services logs contained no publication degradation or OpenTelemetry context-detach error.

## How to review

Read `run-plan.ts` first for the sidecar's owner and path. Then read the `agent_end` handler in `agenta.ts` and the Pi-specific ordering in `run-turn.ts`. Finish with the three regression tests that pin publication order, path ownership, and no-tool directory creation.
