### PR TITLE
[fix] Switch organizations, not workspaces, in the mobile switcher [AGE-4181]

### DIFF
--- a/web/mobile/src/features/context/workspaceGroups.ts
+++ b/web/mobile/src/features/context/workspaceGroups.ts
@@ -25,3 +25,36 @@ export const groupByWorkspace = (projects: MobileProject[]): WorkspaceGroup[] =>
     }
     return [...byWorkspace.values()]
 }
+
+export interface OrganizationGroup {
+    organizationId: string
+    organizationName: string
+    /** Workspace to enter when this org is picked — the first one the server listed. */
+    workspaceId: string
+    /** Every project in the org, across all its workspaces, in server order. */
+    projects: MobileProject[]
+}
+
+/**
+ * Group the flat project list by ORGANIZATION — what the switcher offers, matching the desktop
+ * rail. Grouping by workspace instead rendered one indistinguishable "Default" row per org,
+ * because every org's default workspace carries that same name.
+ */
+export const groupByOrganization = (projects: MobileProject[]): OrganizationGroup[] => {
+    const byOrganization = new Map<string, OrganizationGroup>()
+    for (const project of projects) {
+        // A project with no workspace cannot be routed to (`/w/:id/p/:id`), so it is dropped.
+        if (!project.workspace_id) continue
+        // An org-less row still belongs to somebody: key it by workspace rather than drop it.
+        const key = project.organization_id ?? `workspace:${project.workspace_id}`
+        const group = byOrganization.get(key) ?? {
+            organizationId: key,
+            organizationName: project.organization_name ?? project.workspace_name ?? "Organization",
+            workspaceId: project.workspace_id,
+            projects: [],
+        }
+        group.projects.push(project)
+        byOrganization.set(key, group)
+    }
+    return [...byOrganization.values()]
+}

--- a/web/mobile/src/features/context/workspaceGroups.ts
+++ b/web/mobile/src/features/context/workspaceGroups.ts
@@ -3,10 +3,7 @@ import type {MobileProject} from "@/lib/context"
 /** A project row that can be routed to: `/w/:workspace_id/p/:project_id` needs both halves. */
 export type RoutableProject = MobileProject & {workspace_id: string}
 
-/**
- * The one place a project is judged routable. A row without a workspace would render as a tap
- * that goes nowhere, so it never reaches a group.
- */
+/** A row without a workspace would be a tap that goes nowhere, so it never reaches a group. */
 const routableProjects = (projects: MobileProject[]): RoutableProject[] =>
     projects.filter((project): project is RoutableProject => Boolean(project.workspace_id))
 
@@ -49,14 +46,7 @@ export interface OrganizationGroup {
     projects: RoutableProject[]
 }
 
-/**
- * Group the flat project list by ORGANIZATION — what the switcher offers, matching the desktop
- * rail. Grouping by workspace instead rendered one indistinguishable "Default" row per org,
- * because every org's default workspace carries that same name.
- *
- * Every group-level field is resolved from the WHOLE group rather than from whichever row arrived
- * first, so a row with a missing or blank name cannot pin the group to a fallback label.
- */
+/** Group by organization, resolving each field across the whole group, never off the first row. */
 export const groupByOrganization = (projects: MobileProject[]): OrganizationGroup[] =>
     [
         ...bucketBy(
@@ -66,7 +56,7 @@ export const groupByOrganization = (projects: MobileProject[]): OrganizationGrou
         ),
     ].map(([key, rows]) => ({
         key,
-        // Every row in a bucket agrees on this by construction — it IS the bucket key.
+        // Every row in a bucket agrees on this: it IS the bucket key.
         organizationId: rows[0].organization_id ?? null,
         organizationName:
             firstNonBlank(rows.map((row) => row.organization_name)) ??

--- a/web/mobile/src/features/context/workspaceGroups.ts
+++ b/web/mobile/src/features/context/workspaceGroups.ts
@@ -1,60 +1,77 @@
 import type {MobileProject} from "@/lib/context"
 
+/** A project row that can be routed to: `/w/:workspace_id/p/:project_id` needs both halves. */
+export type RoutableProject = MobileProject & {workspace_id: string}
+
+/**
+ * The one place a project is judged routable. A row without a workspace would render as a tap
+ * that goes nowhere, so it never reaches a group.
+ */
+const routableProjects = (projects: MobileProject[]): RoutableProject[] =>
+    projects.filter((project): project is RoutableProject => Boolean(project.workspace_id))
+
+/** First value that is a real, non-blank string. `""` is a missing name, not a name. */
+const firstNonBlank = (values: (string | null | undefined)[]): string | undefined =>
+    values.find((value): value is string => typeof value === "string" && value.trim() !== "")
+
+/** Bucket rows by key, keeping the server's key order and its row order within each bucket. */
+const bucketBy = <T>(rows: T[], keyOf: (row: T) => string): Map<string, T[]> => {
+    const buckets = new Map<string, T[]>()
+    for (const row of rows) {
+        const key = keyOf(row)
+        const bucket = buckets.get(key)
+        if (bucket) bucket.push(row)
+        else buckets.set(key, [row])
+    }
+    return buckets
+}
+
+/** Routing identity only. Display names live on `OrganizationGroup`, which is what the UI reads. */
 export interface WorkspaceGroup {
     workspaceId: string
-    workspaceName: string
-    /** The owning organization's name — what the switcher displays, matching the desktop. */
-    organizationName?: string
-    projects: MobileProject[]
+    projects: RoutableProject[]
 }
 
 /** Group the flat project list by workspace, preserving the server's order within each. */
-export const groupByWorkspace = (projects: MobileProject[]): WorkspaceGroup[] => {
-    const byWorkspace = new Map<string, WorkspaceGroup>()
-    for (const project of projects) {
-        // A project with no workspace cannot be routed to (`/w/:id/p/:id`), so it is dropped.
-        if (!project.workspace_id) continue
-        const group = byWorkspace.get(project.workspace_id) ?? {
-            workspaceId: project.workspace_id,
-            workspaceName: project.workspace_name ?? "Workspace",
-            organizationName: project.organization_name ?? undefined,
-            projects: [],
-        }
-        group.projects.push(project)
-        byWorkspace.set(project.workspace_id, group)
-    }
-    return [...byWorkspace.values()]
-}
+export const groupByWorkspace = (projects: MobileProject[]): WorkspaceGroup[] =>
+    [...bucketBy(routableProjects(projects), (project) => project.workspace_id)].map(
+        ([workspaceId, rows]) => ({workspaceId, projects: rows}),
+    )
 
 export interface OrganizationGroup {
-    organizationId: string
+    /** Stable list key: the org id, or the workspace standing in for a row that carries none. */
+    key: string
+    organizationId: string | null
     organizationName: string
-    /** Workspace to enter when this org is picked — the first one the server listed. */
+    /** Workspace the org row enters — its first project's, so the two cannot disagree. */
     workspaceId: string
     /** Every project in the org, across all its workspaces, in server order. */
-    projects: MobileProject[]
+    projects: RoutableProject[]
 }
 
 /**
  * Group the flat project list by ORGANIZATION — what the switcher offers, matching the desktop
  * rail. Grouping by workspace instead rendered one indistinguishable "Default" row per org,
  * because every org's default workspace carries that same name.
+ *
+ * Every group-level field is resolved from the WHOLE group rather than from whichever row arrived
+ * first, so a row with a missing or blank name cannot pin the group to a fallback label.
  */
-export const groupByOrganization = (projects: MobileProject[]): OrganizationGroup[] => {
-    const byOrganization = new Map<string, OrganizationGroup>()
-    for (const project of projects) {
-        // A project with no workspace cannot be routed to (`/w/:id/p/:id`), so it is dropped.
-        if (!project.workspace_id) continue
-        // An org-less row still belongs to somebody: key it by workspace rather than drop it.
-        const key = project.organization_id ?? `workspace:${project.workspace_id}`
-        const group = byOrganization.get(key) ?? {
-            organizationId: key,
-            organizationName: project.organization_name ?? project.workspace_name ?? "Organization",
-            workspaceId: project.workspace_id,
-            projects: [],
-        }
-        group.projects.push(project)
-        byOrganization.set(key, group)
-    }
-    return [...byOrganization.values()]
-}
+export const groupByOrganization = (projects: MobileProject[]): OrganizationGroup[] =>
+    [
+        ...bucketBy(
+            routableProjects(projects),
+            // An org-less row still belongs to somebody: key it by workspace rather than drop it.
+            (project) => project.organization_id ?? `workspace:${project.workspace_id}`,
+        ),
+    ].map(([key, rows]) => ({
+        key,
+        // Every row in a bucket agrees on this by construction — it IS the bucket key.
+        organizationId: rows[0].organization_id ?? null,
+        organizationName:
+            firstNonBlank(rows.map((row) => row.organization_name)) ??
+            firstNonBlank(rows.map((row) => row.workspace_name)) ??
+            "Organization",
+        workspaceId: rows[0].workspace_id,
+        projects: rows,
+    }))

--- a/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
+++ b/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
@@ -67,26 +67,26 @@ export const DrawerProjectSwitcher = ({
                 key: project.project_id,
                 name: project.project_name ?? "Project",
                 isActive: project.project_id === projectId,
-                onSelect: () => goTo(project.workspace_id ?? workspaceId, project.project_id),
+                onSelect: () => goTo(project.workspace_id, project.project_id),
             })),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [currentGroup?.projects, projectId, workspaceId],
+        [currentGroup?.projects, projectId],
     )
 
     const organizations = useMemo<SwitcherEntry[]>(
         () =>
             groups.map((group) => ({
-                key: group.organizationId,
+                key: group.key,
                 name: group.organizationName,
-                isActive: group.organizationId === currentGroup?.organizationId,
+                isActive: group.key === currentGroup?.key,
                 // Entering an org lands on its first project; the project panel then narrows.
                 onSelect: () => {
                     const first = group.projects[0]
-                    if (first) goTo(first.workspace_id ?? group.workspaceId, first.project_id)
+                    if (first) goTo(group.workspaceId, first.project_id)
                 },
             })),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [groups, currentGroup?.organizationId],
+        [groups, currentGroup?.key],
     )
 
     const [createOpen, setCreateOpen] = useState(false)

--- a/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
+++ b/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
@@ -13,16 +13,16 @@ import {useRouter} from "next/router"
 import {fetchProjects, writeLastContext} from "@/lib/context"
 
 import {useLogout} from "../auth/useLogout"
-import {groupByWorkspace} from "../context/workspaceGroups"
+import {groupByOrganization} from "../context/workspaceGroups"
 
 /**
  * The drawer's header switcher — the same designed component as the desktop rail, bound to
- * mobile's workspace/project data.
+ * mobile's project data.
  *
- * The trigger names the ORGANIZATION, as the desktop does. Labelling it by workspace read
- * "Default" on every account whose projects sit in the one default workspace, which is all of
- * them; the org is the name a person recognises. The second panel still moves between
- * workspaces, which is the routable unit here (`/w/:id/p/:id`).
+ * Both panels speak ORGANIZATIONS, as the desktop does. Listing workspaces instead rendered one
+ * indistinguishable "Default" row per org — every org's default workspace carries that name — so
+ * a multi-org account had no way to tell the rows apart. The workspace stays in the URL
+ * (`/w/:id/p/:id`); each project row routes with its OWN workspace id.
  */
 export const DrawerProjectSwitcher = ({
     workspaceId,
@@ -39,11 +39,19 @@ export const DrawerProjectSwitcher = ({
         staleTime: 30_000,
     })
     const groups = useMemo(
-        () => (query.data?.kind === "ok" ? groupByWorkspace(query.data.projects) : []),
+        () => (query.data?.kind === "ok" ? groupByOrganization(query.data.projects) : []),
         [query.data],
     )
 
-    const currentGroup = groups.find((group) => group.workspaceId === workspaceId)
+    // Resolve by the project in the URL: an org can hold several workspaces, and the workspace
+    // alone would not name the org on a route the switcher did not build.
+    const currentGroup =
+        groups.find((group) =>
+            group.projects.some(
+                (project) =>
+                    project.project_id === projectId && project.workspace_id === workspaceId,
+            ),
+        ) ?? groups.find((group) => group.projects.some((p) => p.workspace_id === workspaceId))
     const currentProject = currentGroup?.projects.find(
         (project) => project.project_id === projectId,
     )
@@ -59,27 +67,26 @@ export const DrawerProjectSwitcher = ({
                 key: project.project_id,
                 name: project.project_name ?? "Project",
                 isActive: project.project_id === projectId,
-                onSelect: () => goTo(workspaceId, project.project_id),
+                onSelect: () => goTo(project.workspace_id ?? workspaceId, project.project_id),
             })),
         // eslint-disable-next-line react-hooks/exhaustive-deps
         [currentGroup?.projects, projectId, workspaceId],
     )
 
-    const workspaces = useMemo<SwitcherEntry[]>(
+    const organizations = useMemo<SwitcherEntry[]>(
         () =>
             groups.map((group) => ({
-                key: group.workspaceId,
-                name: group.workspaceName,
-                isActive: group.workspaceId === workspaceId,
-                // Entering a workspace lands on its first project; the drawer's project panel
-                // then narrows within it.
+                key: group.organizationId,
+                name: group.organizationName,
+                isActive: group.organizationId === currentGroup?.organizationId,
+                // Entering an org lands on its first project; the project panel then narrows.
                 onSelect: () => {
                     const first = group.projects[0]
-                    if (first) goTo(group.workspaceId, first.project_id)
+                    if (first) goTo(first.workspace_id ?? group.workspaceId, first.project_id)
                 },
             })),
         // eslint-disable-next-line react-hooks/exhaustive-deps
-        [groups, workspaceId],
+        [groups, currentGroup?.organizationId],
     )
 
     const [createOpen, setCreateOpen] = useState(false)
@@ -123,8 +130,8 @@ export const DrawerProjectSwitcher = ({
                 projectLabel={currentProject?.project_name ?? "Select project"}
                 orgLabel={currentGroup?.organizationName ?? "Organization"}
                 projects={projects}
-                orgs={workspaces}
-                orgNoun="workspace"
+                orgs={organizations}
+                orgNoun="organization"
                 theme={theme}
                 onCreateProject={() => setCreateOpen(true)}
                 onLogout={() => void logout()}

--- a/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
+++ b/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
@@ -16,13 +16,8 @@ import {useLogout} from "../auth/useLogout"
 import {groupByOrganization} from "../context/workspaceGroups"
 
 /**
- * The drawer's header switcher — the same designed component as the desktop rail, bound to
- * mobile's project data.
- *
- * Both panels speak ORGANIZATIONS, as the desktop does. Listing workspaces instead rendered one
- * indistinguishable "Default" row per org — every org's default workspace carries that name — so
- * a multi-org account had no way to tell the rows apart. The workspace stays in the URL
- * (`/w/:id/p/:id`); each project row routes with its OWN workspace id.
+ * The drawer's header switcher: the desktop rail's component, bound to mobile's project data.
+ * Both panels speak organizations, because every org's workspace is named "Default".
  */
 export const DrawerProjectSwitcher = ({
     workspaceId,
@@ -43,8 +38,7 @@ export const DrawerProjectSwitcher = ({
         [query.data],
     )
 
-    // Resolve by the project in the URL: an org can hold several workspaces, and the workspace
-    // alone would not name the org on a route the switcher did not build.
+    // Matched on the project, not the workspace: one org can hold several workspaces.
     const currentGroup =
         groups.find((group) =>
             group.projects.some(

--- a/web/mobile/src/lib/context.ts
+++ b/web/mobile/src/lib/context.ts
@@ -1,3 +1,4 @@
+import {filterOutDemoProjects} from "@agenta/entities/project"
 import {safeParseWithLogging} from "@agenta/entities/shared"
 import {getProjectsClient} from "@agenta/sdk/resources"
 import {z} from "zod"
@@ -106,7 +107,9 @@ async function fetchProjectsOnce(): Promise<ProjectsResult> {
         const data = await getProjectsClient().getProjects()
         const projects = safeParseWithLogging(z.array(projectRowSchema), data, "[fetchProjects]")
         if (!projects) return {kind: "error"}
-        return {kind: "ok", projects}
+        // Hide demo projects, exactly as the desktop's projectsAtom does. Without this a mobile
+        // sign-in could resolve into a demo org the desktop never offers, with no way back out.
+        return {kind: "ok", projects: filterOutDemoProjects(projects)}
     } catch (error) {
         const status = (error as {statusCode?: number} | null)?.statusCode
         if (status === 401 || status === 403) return {kind: "unauthenticated"}

--- a/web/mobile/tests/unit/contextTarget.test.ts
+++ b/web/mobile/tests/unit/contextTarget.test.ts
@@ -16,7 +16,6 @@ const project = (projectId: string, workspaceId: string) =>
 
 const group = (workspaceId: string, projectIds: string[]): WorkspaceGroup => ({
     workspaceId,
-    workspaceName: workspaceId,
     projects: projectIds.map((id) => project(id, workspaceId)),
 })
 

--- a/web/mobile/tests/unit/workspaceGroups.test.ts
+++ b/web/mobile/tests/unit/workspaceGroups.test.ts
@@ -29,11 +29,8 @@ describe("groupByWorkspace", () => {
         expect(groupByWorkspace([project("orphan", null), project("p1", "w1")])).toHaveLength(1)
     })
 
-    it("falls back to a generic name when the workspace is unnamed", () => {
-        const [group] = groupByWorkspace([
-            {project_id: "p1", project_name: "p1", workspace_id: "w1"} as MobileProject,
-        ])
-        expect(group.workspaceName).toBe("Workspace")
+    it("drops a project whose workspace is an empty string", () => {
+        expect(groupByWorkspace([project("p1", "")])).toHaveLength(0)
     })
 })
 
@@ -84,6 +81,34 @@ describe("groupByOrganization", () => {
     it("keeps an org-less project, keyed by its workspace", () => {
         const groups = groupByOrganization([orgProject("p1", null, null, "w1")])
         expect(groups).toHaveLength(1)
+        expect(groups[0].key).toBe("workspace:w1")
+        expect(groups[0].organizationId).toBeNull()
         expect(groups[0].organizationName).toBe("Default")
+    })
+
+    it("takes the org name from a later row when the first one has none", () => {
+        // Resolution reads the WHOLE group: a nameless first row must not pin the label to a
+        // fallback for the rest of the org's rows.
+        const groups = groupByOrganization([
+            orgProject("p1", "o1", null, "ws-a"),
+            orgProject("p2", "o1", "Acme Robotics", "ws-b"),
+        ])
+
+        expect(groups[0].organizationName).toBe("Acme Robotics")
+    })
+
+    it("treats a blank name as missing, not as a name", () => {
+        const groups = groupByOrganization([
+            orgProject("p1", "o1", "   ", "ws-a"),
+            orgProject("p2", "o1", "Acme Robotics", "ws-b"),
+        ])
+
+        expect(groups[0].organizationName).toBe("Acme Robotics")
+    })
+
+    it("carries the org id when the rows have one", () => {
+        const [group] = groupByOrganization([orgProject("p1", "o1", "Acme", "ws-a")])
+        expect(group.key).toBe("o1")
+        expect(group.organizationId).toBe("o1")
     })
 })

--- a/web/mobile/tests/unit/workspaceGroups.test.ts
+++ b/web/mobile/tests/unit/workspaceGroups.test.ts
@@ -51,8 +51,7 @@ const orgProject = (
 
 describe("groupByOrganization", () => {
     it("names each group after its ORGANIZATION, not its workspace", () => {
-        // The bug this guards: every org's default workspace is called "Default", so grouping by
-        // workspace rendered N indistinguishable rows and switching orgs became a coin flip.
+        // Guards #6228: every org's workspace is "Default", so workspace rows were identical.
         const groups = groupByOrganization([
             orgProject("p1", "o1", "Acme Robotics"),
             orgProject("p2", "o2", "Contoso"),
@@ -87,8 +86,6 @@ describe("groupByOrganization", () => {
     })
 
     it("takes the org name from a later row when the first one has none", () => {
-        // Resolution reads the WHOLE group: a nameless first row must not pin the label to a
-        // fallback for the rest of the org's rows.
         const groups = groupByOrganization([
             orgProject("p1", "o1", null, "ws-a"),
             orgProject("p2", "o1", "Acme Robotics", "ws-b"),

--- a/web/mobile/tests/unit/workspaceGroups.test.ts
+++ b/web/mobile/tests/unit/workspaceGroups.test.ts
@@ -1,6 +1,6 @@
 import {describe, expect, it} from "vitest"
 
-import {groupByWorkspace} from "../../src/features/context/workspaceGroups"
+import {groupByOrganization, groupByWorkspace} from "../../src/features/context/workspaceGroups"
 import type {MobileProject} from "../../src/lib/context"
 
 const project = (projectId: string, workspaceId: string | null, name = "Workspace") =>
@@ -34,5 +34,56 @@ describe("groupByWorkspace", () => {
             {project_id: "p1", project_name: "p1", workspace_id: "w1"} as MobileProject,
         ])
         expect(group.workspaceName).toBe("Workspace")
+    })
+})
+
+const orgProject = (
+    projectId: string,
+    organizationId: string | null,
+    organizationName: string | null,
+    workspaceId: string | null = `ws-${organizationId}`,
+) =>
+    ({
+        project_id: projectId,
+        project_name: projectId,
+        workspace_id: workspaceId,
+        workspace_name: "Default",
+        organization_id: organizationId,
+        organization_name: organizationName,
+    }) as MobileProject
+
+describe("groupByOrganization", () => {
+    it("names each group after its ORGANIZATION, not its workspace", () => {
+        // The bug this guards: every org's default workspace is called "Default", so grouping by
+        // workspace rendered N indistinguishable rows and switching orgs became a coin flip.
+        const groups = groupByOrganization([
+            orgProject("p1", "o1", "Acme Robotics"),
+            orgProject("p2", "o2", "Contoso"),
+        ])
+
+        expect(groups.map((g) => g.organizationName)).toEqual(["Acme Robotics", "Contoso"])
+    })
+
+    it("collects every workspace's projects under one org, keeping server order", () => {
+        const groups = groupByOrganization([
+            orgProject("p1", "o1", "Acme", "ws-a"),
+            orgProject("p2", "o2", "Contoso", "ws-c"),
+            orgProject("p3", "o1", "Acme", "ws-b"),
+        ])
+
+        expect(groups).toHaveLength(2)
+        expect(groups[0].projects.map((p) => p.project_id)).toEqual(["p1", "p3"])
+        // The org row enters its FIRST workspace; each project row carries its own.
+        expect(groups[0].workspaceId).toBe("ws-a")
+    })
+
+    it("drops a project with no workspace — it cannot be routed to", () => {
+        expect(groupByOrganization([orgProject("orphan", "o1", "Acme", null)])).toHaveLength(0)
+    })
+
+    it("keeps an org-less project, keyed by its workspace", () => {
+        const groups = groupByOrganization([orgProject("p1", null, null, "w1")])
+        expect(groups).toHaveLength(1)
+        expect(groups[0].organizationName).toBe("Default")
     })
 })

--- a/web/oss/src/state/project/selectors/project.ts
+++ b/web/oss/src/state/project/selectors/project.ts
@@ -1,4 +1,4 @@
-import {fetchAllProjects} from "@agenta/entities/project"
+import {fetchAllProjects, filterOutDemoProjects} from "@agenta/entities/project"
 import {ProjectsResponse} from "@agenta/entities/project"
 import {catalogPersister} from "@agenta/shared/api/persist"
 import {logAtom, projectIdAtom} from "@agenta/shared/state"
@@ -124,15 +124,9 @@ logAtom(projectsQueryAtom, "projectsQueryAtom", logProjects)
 
 const EmptyProjects: ProjectsResponse[] = []
 
-/**
- * Filters demo projects out of the list. Falls back to the full list when
- * every project is a demo one, so the user is not left with an empty UI.
- * Exported for unit-test access (projectsDemoFilter.test.ts).
- */
-export const filterOutDemoProjects = (projects: ProjectsResponse[]): ProjectsResponse[] => {
-    const nonDemoProjects = projects.filter((project) => !project.is_demo)
-    return nonDemoProjects.length ? nonDemoProjects : projects
-}
+// Lives in @agenta/entities/project so /m applies the SAME filter; re-exported for the local
+// unit test (projectsDemoFilter.test.ts) and existing importers.
+export {filterOutDemoProjects}
 
 export const projectsAtom = atom((get) => {
     const res = get(projectsQueryAtom)

--- a/web/packages/agenta-entities/src/project/demo.ts
+++ b/web/packages/agenta-entities/src/project/demo.ts
@@ -1,0 +1,12 @@
+/**
+ * Drop demo projects from a project list, falling back to the full list when every project is a
+ * demo one — hiding them there would leave an empty, dead-end UI.
+ *
+ * Shared because BOTH shells have to agree: the desktop hides demo projects (`projectsAtom`) while
+ * `/m` used to show them, so a mobile sign-in could resolve into a demo org the desktop never
+ * offers. Generic over the row so `/m`'s zod-inferred project type keeps its own shape.
+ */
+export const filterOutDemoProjects = <T extends {is_demo?: boolean | null}>(projects: T[]): T[] => {
+    const nonDemoProjects = projects.filter((project) => !project.is_demo)
+    return nonDemoProjects.length ? nonDemoProjects : projects
+}

--- a/web/packages/agenta-entities/src/project/index.ts
+++ b/web/packages/agenta-entities/src/project/index.ts
@@ -1,2 +1,3 @@
 export * from "./types"
 export * from "./api"
+export * from "./demo"


### PR DESCRIPTION
## Context

Signing in from a phone appeared not to work, and the reporter could not switch organization or project once inside `/m`. Switching the browser to desktop mode was the workaround.

Sign-in itself is fine. I verified sign-up, sign-in, sign-out, re-sign-in and the OIDC callback handback on `/m` against a local EE stack, and they all work. The real problem is that a multi-org account lands in one organization on mobile and has no usable way out, which is what "signing in does not work" felt like. Two separate causes:

**The switcher listed workspaces, not organizations.** Every organization's default workspace is named `Default`, so `DrawerProjectSwitcher` rendered one identical `Default` row per org. The trigger already named the organization. Only the list did not, so the rows were indistinguishable and picking one was a coin flip.

**`/m` never hid demo projects.** The desktop hides them everywhere (`projectsAtom`) and prefers a non-demo project after login (`postLoginRedirect.ts`). `/m` applied neither, so a demo organization sat in the switcher next to the real ones and could win `selectContextTarget`'s post-sign-in resolution, dropping the user into a project the desktop never offers.

## Changes

The mobile switcher now groups by organization instead of workspace. `groupByOrganization` in `workspaceGroups.ts` keys on `organization_id`, labels each row with the organization name, and collects every one of that org's projects across all its workspaces. The panel says "Switch organization" like the desktop rail.

The workspace still lives in the URL, so each project row now routes with its **own** `workspace_id` rather than the currently active one. That makes an organization with several workspaces switch correctly too. `groupByWorkspace` stays untouched, because context resolution is workspace-keyed to match `/w/:workspace_id/p/:project_id`.

Before, in a two-org account:

```
Workspaces
  D  Default
  D  Default
```

After:

```
Organizations
  Q   qa-mobile-1   ✓
  AR  Acme Robotics
```

For the demo projects, `filterOutDemoProjects` moved out of `oss/src/state/project/selectors/project.ts` into `@agenta/entities/project`, so both shells share one implementation instead of growing a second copy. It is generic over the row type so `/m`'s zod-inferred `MobileProject` keeps its own shape. `/m` applies it at the fetch boundary in `lib/context.ts`, which covers the context resolver, the switcher and post-sign-in landing in one place. OSS keeps a re-export, so nothing there changes behavior.

## Tests

- `pnpm --filter @agenta/mobile test`: 128 pass, including 4 new cases for `groupByOrganization` (org naming, multi-workspace collection, unroutable rows, org-less fallback).
- `tsc` clean on `@agenta/mobile` and `@agenta/oss`; lint clean on every touched file.
- OSS `projectsDemoFilter.test.ts` still passes against the relocated function.
- Browser-verified on a local EE stack with an iPhone user agent and `sec-ch-ua-mobile: ?1`, using a two-org account: sign-up, sign-in, sign-out, re-sign-in, organization switch in both directions, project switch, and reload continuity. The demo path was proven by flipping `project_members.is_demo` in Postgres and back.
- The desktop switcher was re-checked in the same browser for regressions from the extraction. Organizations and projects list as before.

## What to QA

Needs an account in two or more organizations. Open the site on a phone, or force the gate with an iPhone user agent plus `sec-ch-ua-mobile: ?1`.

- Sign in on `/m`. Open the drawer, tap the switcher at the bottom, then "Switch organization". The list shows organization names with distinct avatars, not repeated `Default` rows.
- Pick the other organization. The URL changes to that org's workspace and project, and the trigger's second line shows the new organization name.
- Reopen the panel. The checkmark sits on the organization you just entered.
- In an organization with more than one project, pick a different project from the first panel. It routes to that project and stays inside the same organization.
- If you have access to a demo organization: it should no longer appear in the mobile switcher, and signing in should not land you in it. This already matched the desktop before this PR.
- Regression: on desktop, open the rail switcher. Organizations and projects list exactly as before, and demo projects stay hidden.

Fixes #6228
