### PR TITLE
docs: announce Agenta on mobile

### DIFF
--- a/docs/blog/entries/agenta-on-mobile.mdx
+++ b/docs/blog/entries/agenta-on-mobile.mdx
@@ -1,0 +1,59 @@
+---
+title: "Agenta on Mobile"
+slug: agenta-on-mobile
+date: 2026-08-22
+tags: [v0.113.0]
+description: "Use Agenta from your phone to chat with agents, handle tool approvals, return to past sessions, and manage your workspace."
+---
+
+<Summary>
+
+<div style={{display: 'flex', justifyContent: 'center', marginTop: "20px", marginBottom: "20px", flexDirection: 'column', alignItems: 'center'}}>
+  <iframe
+    width="100%"
+    height="500"
+    src="https://customer-8r37tdgzpxskd9f1.cloudflarestream.com/daa9128151b76a751a967c718b327da5/iframe?muted=true&loop=true&autoplay=true"
+    title="Agenta on mobile"
+    frameBorder="0"
+    allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+    allowFullScreen
+  ></iframe>
+</div>
+
+Agenta now works on your phone.
+
+</Summary>
+
+{/* truncate */}
+
+<div style={{display: 'flex', justifyContent: 'center', marginTop: "20px", marginBottom: "20px", flexDirection: 'column', alignItems: 'center'}}>
+  <iframe
+    width="100%"
+    height="500"
+    src="https://customer-8r37tdgzpxskd9f1.cloudflarestream.com/daa9128151b76a751a967c718b327da5/iframe?muted=true&loop=true&autoplay=true"
+    title="Agenta on mobile"
+    frameBorder="0"
+    allow="accelerometer; gyroscope; autoplay; encrypted-media; picture-in-picture;"
+    allowFullScreen
+  ></iframe>
+</div>
+
+Use Agenta from your phone without switching to a desktop.
+
+The mobile app gives you a focused way to work with agents while you are away from your desk. Start a conversation, continue an existing one, watch the agent work, and handle tool approvals directly from the chat.
+
+## Work with agents from your phone
+
+- Browse your agents and start a new session.
+- Continue past conversations with their full history.
+- Watch responses and tool activity arrive live.
+- Approve or deny tool calls without interrupting the run.
+- Stop a running task when you need to.
+
+## Manage your workspace
+
+Switch workspaces and projects from the mobile app. You can also manage agents, projects, team members, tools, triggers, and provider keys.
+
+Observability is available on mobile too. Browse traces and sessions when you need to check what an agent did.
+
+Agenta detects phone browsers and opens the mobile app automatically. Your desktop session stays available when you need the larger workspace.

--- a/docs/src/data/roadmap.ts
+++ b/docs/src/data/roadmap.ts
@@ -33,6 +33,20 @@ export const shippedFeatures: ShippedFeature[] = [
   // Channels: 2DD4BF
   // Mobile: F472B6
   {
+    id: "mobile",
+    title: "Agenta on Mobile",
+    description:
+      "Use Agenta from a phone to chat with agents, handle tool approvals, return to past sessions, and manage your workspace.",
+    changelogPath: "/docs/changelog/agenta-on-mobile",
+    shippedAt: "2026-08-22",
+    labels: [
+      {
+        name: "Mobile",
+        color: "F472B6",
+      },
+    ],
+  },
+  {
     id: "durable-sessions",
     title: "Durable Agent Sessions",
     description:
@@ -156,19 +170,6 @@ export const inProgressFeatures: PlannedFeature[] = [
       {
         name: "Channels",
         color: "2DD4BF",
-      },
-    ],
-  },
-  {
-    id: "mobile",
-    title: "Agenta on Mobile",
-    description:
-      "Use the core agent experience from a phone. Chat with an agent, approve or deny tool calls, and browse past runs on a small screen.",
-    githubUrl: "https://github.com/Agenta-AI/agenta/issues/5511",
-    labels: [
-      {
-        name: "Mobile",
-        color: "F472B6",
       },
     ],
   },

--- a/web/packages/agenta-navigation/src/banners/changelog.json
+++ b/web/packages/agenta-navigation/src/banners/changelog.json
@@ -1,5 +1,11 @@
 [
     {
+        "id": "changelog-2026-08-22-agenta-on-mobile",
+        "title": "Agenta on Mobile",
+        "description": "Chat with agents, follow live runs, and approve tool calls from your phone.",
+        "link": "https://agenta.ai/docs/changelog/agenta-on-mobile"
+    },
+    {
         "id": "changelog-2026-08-12-slash-commands",
         "title": "Slash Commands",
         "description": "Control the model and reference skills or tools without leaving the conversation.",


### PR DESCRIPTION
## What this adds

v0.113.0 introduced a phone-first Agenta experience, but the changelog and roadmap did not record the release.

The changelog entry embeds the supplied mobile demo and describes chat, live tool activity, approvals, workspace management, and observability on a phone. The roadmap moves Agenta on Mobile to shipped, and the sidebar links to the entry.

## Tests

- `DOCUSAURUS_GENERATED_FILES_DIR_NAME=.docusaurus-build pnpm build` in `docs/`
- `pnpm --filter @agenta/navigation lint` in `web/`
- Parsed `web/packages/agenta-navigation/src/banners/changelog.json` with Node