### PR TITLE
fix(api): Refuse plus-tag emails for starter credits

### DIFF
--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -36,6 +36,7 @@ from oss.src.core.shared.dtos import Header
 from ee.src.core.starter_credits_bridge.client import StarterCreditsProxyClient
 from ee.src.core.starter_credits_bridge.types import (
     DEVELOPMENT_POLICY_VALUES,
+    PLUS_ALIAS_ALLOWLIST_DOMAINS,
     KeyAliasExistsError,
     MintedKey,
     MintPolicy,
@@ -612,8 +613,17 @@ async def _mint_policy_allows(
     domain = _email_domain(organization_email)
     freemail = policy.is_freemail(domain)
 
+    if "+" in local_part and domain not in PLUS_ALIAS_ALLOWLIST_DOMAINS:
+        log.warning(
+            "[starter_credits_bridge] policy refused mint; skipping seed",
+            rule="plus_local_part",
+            domain=domain,
+        )
+        return False
+
     if (
         not freemail
+        and domain not in PLUS_ALIAS_ALLOWLIST_DOMAINS
         and policy.block_digit_locals
         and any(character.isdigit() for character in local_part)
     ):

--- a/api/ee/src/core/starter_credits_bridge/types.py
+++ b/api/ee/src/core/starter_credits_bridge/types.py
@@ -88,6 +88,10 @@ DEFAULT_FREEMAIL_DOMAINS: tuple[str, ...] = (
     "bol.com.br",
 )
 
+# Plus-tags (`jane+1@gmail.com`) are one inbox and many grant-eligible strings.
+# Internal testers who need a plus tag use this domain.
+PLUS_ALIAS_ALLOWLIST_DOMAINS: tuple[str, ...] = ("agenta.ai",)
+
 
 class MintPolicy(BaseModel):
     """Mint policy: velocity caps, domain classification, eligibility rules, and

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -989,6 +989,28 @@ class TestMintPolicyAllows:
 
         assert await service._mint_policy_allows("john99@acme.test", policy) is True
 
+    @pytest.mark.parametrize(
+        "address",
+        ["person+trial@freemail.test", "person+trial@acme.test"],
+    )
+    async def test_plus_local_part_refuses_before_any_counter(self, address):
+        assert await service._mint_policy_allows(address, _policy()) is False
+        assert self.engine.counts == {}
+
+    async def test_plus_local_part_allows_an_address_without_a_plus(self):
+        assert (
+            await service._mint_policy_allows("person@freemail.test", _policy()) is True
+        )
+
+    @pytest.mark.parametrize(
+        "address",
+        ["person+trial@agenta.ai", "person+1@Agenta.AI"],
+    )
+    async def test_plus_local_part_allows_the_agenta_domain(self, address):
+        policy = _policy(work_domain_daily=10)
+
+        assert await service._mint_policy_allows(address, policy) is True
+
     async def test_global_hourly_cap_blocks(self):
         policy = _policy(global_hourly=2)
 
@@ -1107,6 +1129,20 @@ class TestRefusalLogging:
         assert fields["rule"] == "digit_local_part"
         assert fields["domain"] == "acme.test"
         assert "john99" not in repr((message, fields))
+
+    async def test_a_plus_local_refusal_names_only_the_rule_and_domain(self):
+        assert (
+            await service._mint_policy_allows(
+                "person+private@freemail.test",
+                _policy(),
+            )
+            is False
+        )
+
+        message, fields = self.records[-1]
+        assert fields == {"rule": "plus_local_part", "domain": "freemail.test"}
+        assert "person" not in repr((message, fields))
+        assert "private" not in repr((message, fields))
 
     async def test_a_velocity_refusal_names_the_rule_and_the_domain(self):
         policy = _policy(work_domain_daily=1)


### PR DESCRIPTION
## Context

A person can sign up as `jane+1@gmail.com`, `jane+2@gmail.com`, and so on. Each account gets its own starter-credit grant. Those addresses are one inbox.

## Changes

`_mint_policy_allows` now refuses any local part that contains `+`, except `@agenta.ai` (case-insensitive). The allowlist also skips the work-domain digit rule, so `name+1@agenta.ai` works for internal testers.

Signup still succeeds. No key is minted. A warning logs `rule=plus_local_part` and the domain only.

The check is hardcoded. It is not a PostHog field, so the live payload does not have to change.

Before: `jane+1@gmail.com` gets a grant.

After: `jane+1@gmail.com` does not. `jane@gmail.com` still does. `jane+1@agenta.ai` still does.

## Tests / notes

- 72 starter-credits-bridge unit tests passed, including the new plus-tag cases.
- ruff format + check clean on the touched files.
- Stacked on `credits-starter-seeding` (#6138). Base is that branch, not `release/v0.114.0`.
- Design: #6256.

## How to review

Read the new constant in `types.py`, then the two checks in `_mint_policy_allows`, then `TestMintPolicyAllows` / `TestRefusalLogging`.
