### PR TITLE
[fix] Restore missing agent approval after reload

### DIFF
--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts
@@ -11,10 +11,15 @@
  * local `addToolOutput` settle is still waiting for `sendAutomaticallyWhen` to fire — the adopted
  * transcript predates the settle and silently discards it.
  */
+import type {SessionInteractionRowStates} from "@agenta/entities/session"
 import {type UIMessage} from "ai"
 import {describe, expect, it} from "vitest"
 
-import {hasStrandedTail, shouldSkipRecordsRefresh} from "./useSessionHydration"
+import {
+    hasStrandedTail,
+    shouldProtectRenderedInteraction,
+    shouldSkipRecordsRefresh,
+} from "./useSessionHydration"
 
 describe("shouldSkipRecordsRefresh", () => {
     it("does not skip when idle and no settle is pending a resume", () => {
@@ -50,5 +55,57 @@ describe("hasStrandedTail", () => {
 
     it("passes an empty transcript", () => {
         expect(hasStrandedTail([])).toBe(false)
+    })
+})
+
+describe("shouldProtectRenderedInteraction", () => {
+    const pendingRows = new Map([
+        [
+            "approval-1",
+            {
+                token: "approval-1",
+                status: "pending",
+                kind: "user_approval",
+                toolCallId: "call-1",
+            },
+        ],
+    ]) as SessionInteractionRowStates
+    const approval = {
+        id: "a1",
+        role: "assistant",
+        parts: [
+            {
+                type: "tool-commit_revision",
+                toolCallId: "call-1",
+                state: "approval-requested",
+                approval: {id: "approval-1"},
+            },
+        ],
+    } as unknown as UIMessage
+    const staleBeforeApproval = {
+        id: "a1",
+        role: "assistant",
+        parts: [
+            {
+                type: "tool-commit_revision",
+                toolCallId: "call-1",
+                state: "input-available",
+            },
+        ],
+    } as unknown as UIMessage
+
+    it("does not protect a stale cached transcript that has not rendered the pending card", () => {
+        expect(shouldProtectRenderedInteraction([staleBeforeApproval], pendingRows)).toBe(false)
+    })
+
+    it("protects an actionable card already rendered from the pending row", () => {
+        expect(shouldProtectRenderedInteraction([approval], pendingRows)).toBe(true)
+    })
+
+    it("does not protect a stale card after the server row settles", () => {
+        const settledRows = new Map([
+            ["approval-1", {...pendingRows.get("approval-1")!, status: "resolved"}],
+        ]) as SessionInteractionRowStates
+        expect(shouldProtectRenderedInteraction([approval], settledRows)).toBe(false)
     })
 })

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -6,8 +6,10 @@ import {
     fetchSessionRecordsAtom,
     hasWaitingInteraction,
     revalidateSessionRecordsAtom,
+    type SessionInteractionRowStates,
     shouldAdoptServerTranscript,
 } from "@agenta/entities/session"
+import {isHitlPending} from "@agenta/playground"
 import {generateId} from "@agenta/shared/utils"
 import {type UIMessage} from "ai"
 import {getDefaultStore, useAtomValue, useSetAtom} from "jotai"
@@ -61,6 +63,17 @@ export const shouldSkipRecordsRefresh = ({
  * client-side (aborted mid-prepare, a lost seed handoff) leaves behind (#6042). */
 export const hasStrandedTail = (messages: UIMessage[]): boolean =>
     messages.length > 0 && messages[messages.length - 1]?.role === "user"
+
+/**
+ * Protect local interaction state only when the pending server row already has an actionable card
+ * on screen. A pending row by itself is not enough: the browser may have cached the transcript
+ * before the interaction_request record arrived. Treating that stale copy as user-owned state
+ * prevents hydration from ever delivering the missing approval or form.
+ */
+export const shouldProtectRenderedInteraction = (
+    messages: UIMessage[],
+    interactionRows: SessionInteractionRowStates | undefined,
+): boolean => hasWaitingInteraction(interactionRows) && isHitlPending(messages)
 
 /** Same carrier shape `useAgentChatSession`'s error effect uses, so the stamp renders through the
  * existing red error bubble. */
@@ -152,7 +165,10 @@ export const useSessionHydration = ({
                 busy: busyRef.current,
                 // #5942: a card still parked on the user outranks the log — adopting over it
                 // discards whatever they typed into its form.
-                awaitingUser: hasWaitingInteraction(interactionRows),
+                awaitingUser: shouldProtectRenderedInteraction(
+                    messagesRef.current,
+                    interactionRows,
+                ),
             })
             if (!adopt) return false
             // Restored history renders settled (no live fade-in) and pinned to the bottom.


### PR DESCRIPTION
## Context
A builder turn could create a valid pending approval in the backend, but the playground showed only the earlier tool activity after reload. The browser had cached the transcript before the approval record arrived. Hydration then saw the pending server row and protected that stale cache as if an actionable card were already visible.

## Changes
The hydration guard now protects local interaction state only when the server row is still pending and the current transcript actually renders an actionable approval or client-tool form.

Before: a pending row alone could freeze a pre-approval cache forever.

After: stale caches adopt the newer durable transcript, while a visible pending form remains protected from background replacement.

## Tests / notes
- Focused Vitest: 10 passed.
- OSS TypeScript check passed.
- Deterministic local browser QA: created a pending commit, removed its approval from browser storage, reset the record watermark, reloaded, approved the restored card, committed v3, and verified test_run returned LOCAL APPROVAL RESTORED.

## What to QA
- Start an agent configuration change that pauses on approval, reload after the backend interaction is pending, and confirm the approval dock is visible.
- Approve the restored commit. The revision should advance and the run should resume.
- Regression: leave an already visible approval or input form pending while records refresh. The card and any local form state should remain in place.