### PR TITLE
[fix] Show evaluators in annotation queues

### DIFF
--- a/web/packages/agenta-entities/src/evaluationRun/core/schema.ts
+++ b/web/packages/agenta-entities/src/evaluationRun/core/schema.ts
@@ -25,20 +25,21 @@ export type EvaluationRunStepType = z.infer<typeof evaluationRunStepTypeSchema>
 export const evaluationRunStepOriginSchema = z.enum(["custom", "human", "auto"])
 export type EvaluationRunStepOrigin = z.infer<typeof evaluationRunStepOriginSchema>
 
-const EVALUATION_RUN_MAPPING_KINDS = [
-    "testset",
-    "query",
-    "invocation",
-    "annotation",
-    // legacy / alternate taxonomy still accepted defensively
-    "input",
-    "ground_truth",
-    "application",
-    "evaluator",
-] as const
-// The backend defines mapping kinds as a free-form string and may add values.
+// The backend defines mapping kinds as a free-form string and may add values,
+// so the schema stays permissive and the type only documents the known kinds
+// (the `string & {}` arm keeps editor autocomplete while accepting new values).
 export const evaluationRunMappingKindSchema = z.string()
-export type EvaluationRunMappingKind = (typeof EVALUATION_RUN_MAPPING_KINDS)[number] | (string & {})
+export type EvaluationRunMappingKind =
+    | "testset"
+    | "query"
+    | "invocation"
+    | "annotation"
+    // legacy / alternate taxonomy still accepted defensively
+    | "input"
+    | "ground_truth"
+    | "application"
+    | "evaluator"
+    | (string & {})
 
 // ============================================================================
 // SUB-SCHEMAS

--- a/web/packages/agenta-entities/src/evaluationRun/core/schema.ts
+++ b/web/packages/agenta-entities/src/evaluationRun/core/schema.ts
@@ -25,14 +25,20 @@ export type EvaluationRunStepType = z.infer<typeof evaluationRunStepTypeSchema>
 export const evaluationRunStepOriginSchema = z.enum(["custom", "human", "auto"])
 export type EvaluationRunStepOrigin = z.infer<typeof evaluationRunStepOriginSchema>
 
-export const evaluationRunMappingKindSchema = z.enum([
+const EVALUATION_RUN_MAPPING_KINDS = [
+    "testset",
+    "query",
+    "invocation",
+    "annotation",
+    // legacy / alternate taxonomy still accepted defensively
     "input",
     "ground_truth",
     "application",
     "evaluator",
-    "annotation",
-])
-export type EvaluationRunMappingKind = z.infer<typeof evaluationRunMappingKindSchema>
+] as const
+// The backend defines mapping kinds as a free-form string and may add values.
+export const evaluationRunMappingKindSchema = z.string()
+export type EvaluationRunMappingKind = (typeof EVALUATION_RUN_MAPPING_KINDS)[number] | (string & {})
 
 // ============================================================================
 // SUB-SCHEMAS

--- a/web/packages/agenta-entities/tests/unit/evaluationRunsResponseSchema.test.ts
+++ b/web/packages/agenta-entities/tests/unit/evaluationRunsResponseSchema.test.ts
@@ -1,0 +1,72 @@
+import {describe, expect, it} from "vitest"
+
+import {evaluationRunsResponseSchema} from "../../src/evaluationRun/core/schema"
+
+describe("evaluationRunsResponseSchema mapping-kind tolerance", () => {
+    const run = (mappings: unknown) => ({
+        id: "01a0352d-d47e-7762-add4-ba144b9d0290",
+        name: "QA Queue",
+        status: "running",
+        data: {
+            steps: [
+                {key: "testcases", type: "input", origin: "custom", references: {}},
+                {
+                    key: "evaluator-quality-rating",
+                    type: "annotation",
+                    origin: "human",
+                    references: {
+                        evaluator: {id: "e-1", slug: "quality-rating"},
+                        evaluator_variant: {id: "v-1", slug: "b92017ea5219"},
+                        evaluator_revision: {id: "r-1", slug: "f5ea48c6659f", version: "1"},
+                    },
+                    inputs: [{key: "__all_inputs__"}],
+                },
+            ],
+            repeats: 1,
+            mappings,
+        },
+    })
+
+    it("parses a queue run whose source mapping kind is 'testset'", () => {
+        const result = evaluationRunsResponseSchema.safeParse({
+            count: 1,
+            runs: [
+                run([
+                    {
+                        column: {kind: "testset", name: "data"},
+                        step: {key: "testcases", path: "data"},
+                    },
+                    {
+                        column: {kind: "annotation", name: "approved"},
+                        step: {
+                            key: "evaluator-quality-rating",
+                            path: "attributes.ag.data.outputs.approved",
+                        },
+                    },
+                ]),
+            ],
+        })
+        expect(result.success).toBe(true)
+        if (result.success) {
+            const annotationStep = result.data.runs[0].data?.steps?.find(
+                (step) => step.type === "annotation",
+            )
+            expect(annotationStep?.references?.evaluator?.id).toBe("e-1")
+        }
+    })
+
+    it("accepts new mapping kinds without dropping the run", () => {
+        const result = evaluationRunsResponseSchema.safeParse({
+            count: 1,
+            runs: [
+                run([
+                    {
+                        column: {kind: "future-source-kind", name: "data"},
+                        step: {key: "testcases", path: "data"},
+                    },
+                ]),
+            ],
+        })
+        expect(result.success).toBe(true)
+    })
+})


### PR DESCRIPTION
## Context
After an evaluator was selected for an annotation queue, the annotate view reported that no evaluators were configured. The run API returned the evaluator step correctly, but its source mapping used `kind: "testset"`. The frontend accepted only an older fixed list of mapping kinds, so Zod rejected the entire run response and the evaluator step disappeared.

## Changes
Evaluation run mapping kinds now validate as strings, matching the backend contract where this field is free-form. Known mapping kinds remain documented in the TypeScript type for autocomplete. Step types and origins remain strict.

Before, one unfamiliar mapping kind caused the full `/evaluations/runs/query` response to fall back to zero runs. After this change, the run remains available and the annotation panel can resolve its evaluator step.

A regression test covers a real testcase-backed queue payload with `kind: "testset"` and confirms the evaluator reference survives parsing. It also covers future mapping kinds so the same failure mode does not recur.

## Tests / notes
- `pnpm lint-fix` from `web/`
- `pnpm vitest run` in `web/packages/agenta-entities`: 93 files, 1,396 tests passed
- `pnpm exec tsc --noEmit -p tsconfig.json` in `web/packages/agenta-entities`
- Reproduced against the local EE deployment: the API returned the configured Quality Rating evaluator while the old schema rejected the run payload

## What to QA
- Create a testcase annotation queue with an evaluator, add testcases, and open the annotate view. The configured evaluator fields should appear instead of “No evaluators configured for this queue.”
- Open an existing evaluation run. Its source and metric columns should continue to render.