### PR TITLE
fix(agents): default to Gemini 3.7 Flash

### DIFF
--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -1562,7 +1562,7 @@ class StarterCreditsBridgeConfig(BaseModel):
 
     model_id: str = (
         os.getenv("AGENTA_STARTER_CREDITS_BRIDGE_MODEL_ID")
-        or "vertex_ai/gemini-3.6-flash"
+        or "vertex_ai/gemini-3.7-flash"
     )
 
     # The mint policy (velocity caps, domain classification, eligibility rules,

--- a/docs/design/starter-credits-bridge/README.md
+++ b/docs/design/starter-credits-bridge/README.md
@@ -67,7 +67,7 @@ deployment does.
 | `PROXY_ADMIN_URL` | yes | The proxy's address on the private network. The minting client dials it, so the master key never crosses the public edge |
 | `MASTER_KEY` | yes | The proxy's admin credential. It mints and blocks keys |
 | `TEAM_ID` | yes | The proxy team every minted key joins. The team's own budget ceiling bounds total exposure, so seeding refuses to run without one |
-| `MODEL_ID` | no | The single model id the minted key allowlists and the seeded connection publishes. Defaults to `vertex_ai/gemini-3.6-flash` |
+| `MODEL_ID` | no | The single model id the minted key allowlists and the seeded connection publishes. Defaults to `vertex_ai/gemini-3.7-flash` |
 | `POLICY_FLAG` | no | The name of the PostHog feature flag whose payload carries the mint policy. Defaults to `starter-credits-bridge-policy` |
 | `ALERT_WEBHOOK` | no | An operator webhook. The service posts `{"text": ...}` to it on refusals and failures |
 

--- a/sdks/python/agenta/sdk/agents/capabilities.py
+++ b/sdks/python/agenta/sdk/agents/capabilities.py
@@ -157,9 +157,10 @@ PROVIDER_DEFAULT_MODELS: Dict[str, List[str]] = {
         "anthropic/claude-sonnet-5",
         "anthropic/claude-haiku-4-5",
     ],
-    # ``gemini-3.6-flash`` postdates the pinned pi-ai catalog, so its facts ride the curated
-    # ``additions`` list in ``data/pi_models.curated.json`` until a regeneration carries it.
+    # New Gemini Flash releases can postdate the pinned pi-ai catalog, so their facts ride the
+    # curated ``additions`` list until a regeneration carries them.
     "gemini": [
+        "gemini/gemini-3.7-flash",
         "gemini/gemini-3.6-flash",
         "gemini/gemini-3.5-flash",
         "gemini/gemini-3.1-pro-preview",

--- a/sdks/python/agenta/sdk/agents/data/pi_models.curated.json
+++ b/sdks/python/agenta/sdk/agents/data/pi_models.curated.json
@@ -3,7 +3,7 @@
   "_curation": {
     "target": "pi_models.generated.json",
     "note": "Human overlay for the generated Pi catalog. Keyed by the entry `id` (the `provider/model` join key). Only `label`, `description`, and `ratings` may appear here; the objective facts (name/pricing/context_window/modalities) always come from the generated file. The SDK loader merges this on top of the generated facts, so a pi-ai regeneration never overwrites these judgments. Ratings: 1-5, higher is better; `cost` is cost-efficiency (5 = cheapest). Sourced from the current lineup (Fable 5 is the Anthropic frontier, above Opus), not a model's memory. Uncurated ids are valid and fall back to `name` in the picker; seed only the models worth a description. The separate `additions` list carries WHOLE entries (facts included, `source`: `curated`) for models released after the pinned pi-ai snapshot, which the generated file cannot carry at all. A generated entry of the same id always wins, so an addition retires itself on the next regeneration; drop it then.",
-    "sources": "@earendil-works/pi-ai@0.80.6; vendor model + pricing pages. gemini/gemini-3.6-flash facts from ai.google.dev/gemini-api/docs/pricing and the vendor model page, checked 2026-08-21. anthropic/claude-opus-5 facts from the Anthropic pricing page, cross-checked against litellm 1.92.0's cost table, checked 2026-08-22."
+    "sources": "@earendil-works/pi-ai@0.80.6; vendor model + pricing pages. gemini/gemini-3.7-flash facts from ai.google.dev/gemini-api/docs/latest-model and docs/pricing, checked 2026-08-24. gemini/gemini-3.6-flash facts from ai.google.dev/gemini-api/docs/pricing and the vendor model page, checked 2026-08-21. anthropic/claude-opus-5 facts from the Anthropic pricing page, cross-checked against litellm 1.92.0's cost table, checked 2026-08-22."
   },
   "overlay": {
     "anthropic/claude-fable-5": {
@@ -36,6 +36,16 @@
     }
   },
   "additions": [
+    {
+      "id": "gemini/gemini-3.7-flash",
+      "provider": "gemini",
+      "source": "curated",
+      "name": "Gemini 3.7 Flash",
+      "pricing": {"input_per_mtok": 0.75, "output_per_mtok": 3.75, "cache_read_per_mtok": 0.075, "currency": "USD"},
+      "context_window": 1048576,
+      "modalities": ["text", "image"],
+      "description": "Google Gemini Flash model for coding and agentic work, with a one-million-token context window."
+    },
     {
       "id": "gemini/gemini-3.6-flash",
       "provider": "gemini",

--- a/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/connections/test_model_catalog.py
@@ -116,6 +116,26 @@ def test_uncurated_pi_entry_is_valid_with_absent_curated_fields():
     assert sample.name is not None  # frontend falls back to name
 
 
+def test_gemini_3_7_flash_is_published_with_its_display_name():
+    entries = model_catalog_entries("pi_core")
+    entry = next(
+        (item for item in entries if item["id"] == "gemini/gemini-3.7-flash"), None
+    )
+    assert entry is not None, "gemini/gemini-3.7-flash missing from the pi catalog"
+    assert entry["name"] == "Gemini 3.7 Flash"
+    assert entry["provider"] == "gemini"
+    assert entry["source"] == "curated"
+    assert entry["context_window"] == 1048576
+    assert entry["pricing"]["input_per_mtok"] == 0.75
+    assert entry["pricing"]["output_per_mtok"] == 3.75
+
+
+def test_gemini_3_7_flash_is_the_first_default_model():
+    assert PROVIDER_DEFAULT_MODELS["gemini"][0] == "gemini/gemini-3.7-flash"
+    defaults = harness_catalog_document()["pi_core"]["capabilities"]["default_models"]
+    assert defaults["gemini"][0] == "gemini/gemini-3.7-flash"
+
+
 def test_gemini_3_6_flash_is_published_with_its_display_name():
     # The model postdates the pinned pi-ai snapshot, so it reaches the catalog through the curated
     # `additions` list. Without an entry the picker can only show the bare id, which is the bug


### PR DESCRIPTION
## Why

Gemini 3.7 Flash is the production-ready successor selected for managed starter credits. The release should seed and recommend it instead of Gemini 3.6 Flash.

## What changed

- publish Gemini 3.7 Flash metadata in the Pi catalog
- make it the first Gemini default while retaining 3.6 as a selectable model
- change the starter-credit bridge fallback to vertex_ai/gemini-3.7-flash
- document the new default

## Validation

- 31 focused model-catalog tests passed
- 72 focused starter-credit bridge tests passed
- Ruff formatting and lint passed
- direct Vertex AI production-project probe returned HTTP 200 for gemini-3.7-flash

## Deployment

The runtime route remains environment-driven through AGENTA_STARTER_CREDITS_BRIDGE_MODEL_ID. Staging will be updated and verified before the identical semantic v0.114.0 image set is promoted.