### PR TITLE
[fix] Restore completion runs with legacy provider records

### DIFF
--- a/sdks/python/agenta/sdk/managers/secrets.py
+++ b/sdks/python/agenta/sdk/managers/secrets.py
@@ -159,7 +159,7 @@ class SecretsManager:
         *, model: str, secrets: list[dict], key: str, from_provider: bool = True
     ):
         for secret in secrets:
-            models = secret.get("data", {}).get("models", [])
+            models = secret.get("data", {}).get("models") or []
             if model in models:
                 if from_provider:
                     return secret.get("data", {}).get("provider", {}).get(key)

--- a/sdks/python/oss/tests/pytest/unit/test_secrets_manager_connection_slug.py
+++ b/sdks/python/oss/tests/pytest/unit/test_secrets_manager_connection_slug.py
@@ -196,6 +196,27 @@ def test_no_slug_with_one_legacy_record_is_unchanged(resolve):
     }
 
 
+def test_null_custom_model_list_does_not_break_standard_resolution(resolve):
+    secrets = [
+        _provider_key(slug="openai", key="sk-openai"),
+        {
+            "kind": "custom_provider",
+            "slug": "legacy-gateway",
+            "data": {
+                "kind": "custom",
+                "provider_slug": "legacy-gateway",
+                "provider": {"extras": {"api_key": "sk-gateway"}},
+                "model_keys": None,
+            },
+        },
+    ]
+
+    assert resolve(secrets, "gpt-4o-mini") == {
+        "model": "gpt-4o-mini",
+        "api_key": "sk-openai",
+    }
+
+
 def test_no_slug_with_two_listless_records_takes_the_first(resolve):
     secrets = [
         _provider_key(slug="openai", key="sk-first"),


### PR DESCRIPTION
## Context
Production completion runs return HTTP 500 when a project contains a custom provider whose saved model list is `null`. The SDK iterates that value while resolving an unrelated standard model, so the request fails before reaching the LLM.

## Changes
The provider lookup now treats a null custom model list as empty. Before, `if model in None` raised `TypeError`; after, that record does not claim the model and normal credential resolution continues.

The regression test combines an OpenAI connection with a legacy custom connection carrying `model_keys: null`, then verifies both runtime resolution paths still select the OpenAI key.

## Tests / notes
- `ruff format --check` and `ruff check` passed.
- Focused connection suite: 30 passed.
- Provider-secret regression set: 114 passed.

## What to QA
- Run an existing completion revision in a project containing a legacy or list-less custom provider. The request completes instead of returning `argument of type NoneType is not iterable`.
- Run an explicitly selected custom-provider model. Its existing model matching and rewriting still work.