### PR TITLE
docs(self-host): document AGENTA_SERVICES_INTERNAL_KEY

### DIFF
--- a/docs/docs/self-host/deploy/01-deploy-remotely.mdx
+++ b/docs/docs/self-host/deploy/01-deploy-remotely.mdx
@@ -99,7 +99,7 @@ For more advanced settings like SSL, authentication, or custom ports, see our [c
 
 ## Step 3: Secure the Deployment
 
-The Compose file publishes PostgreSQL on `0.0.0.0:5432`, and the stack falls back to the credentials `username` / `password` when you do not set your own. On a server with a public IP, that puts your database on the internet with credentials that are in our repository. The two Agenta keys ship as the literal string `replace-me`.
+The Compose file publishes PostgreSQL on `0.0.0.0:5432`, and the stack falls back to the credentials `username` / `password` when you do not set your own. On a server with a public IP, that puts your database on the internet with credentials that are in our repository. The three Agenta keys ship as the literal string `replace-me`.
 
 :::warning Change these before the first start
 PostgreSQL applies `POSTGRES_USER` and `POSTGRES_PASSWORD` when it initializes its data volume. Setting them after the first start does not change an existing database.

--- a/docs/docs/self-host/deploy/01-deploy-remotely.mdx
+++ b/docs/docs/self-host/deploy/01-deploy-remotely.mdx
@@ -118,6 +118,7 @@ POSTGRES_PASSWORD=<a password you generate>
 
 AGENTA_AUTH_KEY=<a random string>
 AGENTA_CRYPT_KEY=<a random string>
+AGENTA_SERVICES_INTERNAL_KEY=<a random string>
 ```
 
 Generate each key with:
@@ -128,6 +129,7 @@ openssl rand -hex 32
 
 - `AGENTA_AUTH_KEY` authenticates the admin API and signs the tokens Agenta issues. A caller who knows it is an admin on your deployment.
 - `AGENTA_CRYPT_KEY` encrypts the secrets Agenta stores, such as the model provider keys you add in the web interface. Any non-empty string works: Agenta derives the encryption key from it with SHA-256. Changing it later makes already-stored secrets undecryptable.
+- `AGENTA_SERVICES_INTERNAL_KEY` proves to the API that a caller is the platform runtime (the Services container), so a run can be issued a credential that reads write-only secret values. Set the same value on the API and the Services container; there is no fallback to `AGENTA_AUTH_KEY`. The API refuses to start while this is unset or still `replace-me`.
 
 The API builds its database URLs from `POSTGRES_USER` and `POSTGRES_PASSWORD`. If you also set `POSTGRES_URI_CORE`, `POSTGRES_URI_TRACING`, or `POSTGRES_URI_SUPERTOKENS` yourself, update the credentials in those URLs too.
 

--- a/docs/docs/self-host/deploy/03-deploy-to-kubernetes.mdx
+++ b/docs/docs/self-host/deploy/03-deploy-to-kubernetes.mdx
@@ -63,11 +63,12 @@ For Enterprise Edition:
 cp hosting/kubernetes/ee/values.ee.example.yaml hosting/kubernetes/ee/.values.ee.yaml
 ```
 
-Open the copy and fill in the values you need — at minimum `agenta.authKey`, `agenta.cryptKey`, `agenta.runnerToken`, and `postgres.password`, plus the public URLs under `agenta.*` if you are not using the default local URLs:
+Open the copy and fill in the values you need — at minimum `agenta.authKey`, `agenta.cryptKey`, `agenta.servicesInternalKey`, `agenta.runnerToken`, and `postgres.password`, plus the public URLs under `agenta.*` if you are not using the default local URLs:
 
 ```bash
 openssl rand -hex 32   # use for agenta.authKey
 openssl rand -hex 32   # use for agenta.cryptKey
+openssl rand -hex 32   # use for agenta.servicesInternalKey
 openssl rand -hex 32   # use for agenta.runnerToken
 openssl rand -hex 16   # use for postgres.password
 ```
@@ -83,6 +84,7 @@ agenta:
   servicesUrl: "https://agenta.example.com/services"
   authKey: "<openssl rand -hex 32>"
   cryptKey: "<openssl rand -hex 32>"
+  servicesInternalKey: "<openssl rand -hex 32>"
   runnerToken: "<openssl rand -hex 32>"
 
 postgres:
@@ -201,6 +203,7 @@ Configuration is done through Helm values. Defaults live in `hosting/kubernetes/
 | `secrets.existingSecret` | Name of an existing Secret to use instead of the chart-managed one | `""` |
 | `agenta.authKey` | Authorization key (**required**) | `""` |
 | `agenta.cryptKey` | Encryption key (**required**) | `""` |
+| `agenta.servicesInternalKey` | Shared secret proving the Services pod is the platform runtime, so a run can read write-only secret values (**required**) | `""` |
 | `agenta.runnerToken` | Shared secret between the agent runner and its caller (**required**) | `""` |
 | `postgres.password` | PostgreSQL password (**required**) | `""` |
 | `supertokens.apiKey` | SuperTokens API key (recommended for production) | `""` |
@@ -617,7 +620,7 @@ kubectl -n agenta describe pod <pod-name>
 ```
 
 Common causes:
-- Missing secrets: ensure `agenta.authKey`, `agenta.cryptKey`, and `postgres.password` are set
+- Missing secrets: ensure `agenta.authKey`, `agenta.cryptKey`, `agenta.servicesInternalKey`, and `postgres.password` are set
 - Image pull errors: verify image names and that `imagePullSecrets` are configured if using a private registry
 
 ### Migration job fails

--- a/docs/docs/self-host/deploy/03-deploy-to-kubernetes.mdx
+++ b/docs/docs/self-host/deploy/03-deploy-to-kubernetes.mdx
@@ -210,7 +210,7 @@ Configuration is done through Helm values. Defaults live in `hosting/kubernetes/
 | `identity.<provider>.{clientId,clientSecret,…}` | OAuth/OIDC provider credentials (Google, GitHub, Okta, Azure AD, …) — injected into pods as `<PROVIDER>_OAUTH_CLIENT_ID/SECRET` env vars | unset |
 | `llm.<provider>` | LLM provider API keys (`openai`, `anthropic`, `gemini`, …) — injected into pods as `<PROVIDER>_API_KEY` env vars | unset |
 
-To use an existing Kubernetes Secret instead of having the chart create one, set `secrets.existingSecret` to the name of your Secret. It must contain `AGENTA_AUTH_KEY`, `AGENTA_CRYPT_KEY`, and `POSTGRES_PASSWORD`.
+To use an existing Kubernetes Secret instead of having the chart create one, set `secrets.existingSecret` to the name of your Secret. It must contain `AGENTA_AUTH_KEY`, `AGENTA_CRYPT_KEY`, `AGENTA_SERVICES_INTERNAL_KEY`, and `POSTGRES_PASSWORD`.
 
 If you enable secret-backed settings such as OAuth, LLM provider keys, SendGrid, Composio, New Relic, or Turnstile, add those keys to the same Secret too. When `secrets.existingSecret` is set, the chart does not create or update the Secret for you.
 

--- a/docs/docs/self-host/deploy/04-deploy-on-railway.mdx
+++ b/docs/docs/self-host/deploy/04-deploy-on-railway.mdx
@@ -51,6 +51,7 @@ For production deployments, generate unique auth and encryption keys:
 ```bash
 export AGENTA_AUTH_KEY="$(openssl rand -hex 32)"
 export AGENTA_CRYPT_KEY="$(openssl rand -hex 32)"
+export AGENTA_SERVICES_INTERNAL_KEY="$(openssl rand -hex 32)"
 ```
 
 Save these keys somewhere safe. You will need them again when upgrading.
@@ -177,6 +178,7 @@ These environment variables control the deployment scripts. All have sensible de
 |---|---|---|
 | `AGENTA_AUTH_KEY` | placeholder | Authentication key (set for production) |
 | `AGENTA_CRYPT_KEY` | placeholder | Encryption key (set for production) |
+| `AGENTA_SERVICES_INTERNAL_KEY` | placeholder | Proves the Services container is the platform runtime, so a run can read write-only secret values (set for production; no fallback to `AGENTA_AUTH_KEY`) |
 
 ### Optional Integrations
 

--- a/docs/docs/self-host/reference/01-configuration.mdx
+++ b/docs/docs/self-host/reference/01-configuration.mdx
@@ -24,7 +24,7 @@ The Helm chart accepts a single Helm-only key, `secrets.existingSecret`, that
 points at a pre-created Kubernetes Secret. When set, the chart will not create
 or update the Secret object; it just wires `envFrom`/`secretKeyRef` references
 to the name you provide. Your Secret must contain the canonical env-var keys
-(`AGENTA_AUTH_KEY`, `AGENTA_CRYPT_KEY`, `POSTGRES_PASSWORD`, and any optional
+(`AGENTA_AUTH_KEY`, `AGENTA_CRYPT_KEY`, `AGENTA_SERVICES_INTERNAL_KEY`, `POSTGRES_PASSWORD`, and any optional
 keys such as `SUPERTOKENS_API_KEY`, `OPENAI_API_KEY`, OAuth client secrets,
 etc.). See [Deploy to Kubernetes Secrets](/self-host/guides/deploy-to-kubernetes#secrets).
 This key has no env-var or `env.py` equivalent.
@@ -41,11 +41,27 @@ This key has no env-var or `env.py` equivalent.
 | `AGENTA_API_INTERNAL_URL` | `agenta.api_internal_url` | `agenta.apiInternalUrl` |
 | `AGENTA_AUTH_KEY` | `agenta.auth_key` | `agenta.authKey` |
 | `AGENTA_CRYPT_KEY` | `agenta.crypt_key` | `agenta.cryptKey` |
+| `AGENTA_SERVICES_INTERNAL_KEY` | `agenta.services_internal_key` | `agenta.servicesInternalKey` |
 | `AGENTA_RUNNER_TOKEN` | n/a (read by the runner and its caller) | `agenta.runnerToken` |
 
-`AGENTA_AUTH_KEY`, `AGENTA_CRYPT_KEY`, and `AGENTA_RUNNER_TOKEN` are required secrets: the examples
-ship them as `replace-me` and you must set a real value for each. See
-[Agent runner](#routing-and-authentication) for the runner token.
+`AGENTA_AUTH_KEY`, `AGENTA_CRYPT_KEY`, `AGENTA_SERVICES_INTERNAL_KEY`, and `AGENTA_RUNNER_TOKEN`
+are required secrets: the examples ship them as `replace-me` and you must set a real value for
+each. See [Agent runner](#routing-and-authentication) for the runner token.
+
+`AGENTA_SERVICES_INTERNAL_KEY` proves to the API that a caller **is** the platform runtime (the
+Services container), as opposed to a browser or an ApiKey holder reaching the same public route.
+Only a caller holding it can be issued a credential that reads write-only secret values (a run
+whose connection stores such a secret otherwise fails with a misleading "provide the provider key
+in this run's environment" error). Set the **same** value on the API and the Services container;
+generate it the same way as the other keys:
+
+```bash
+openssl rand -hex 32
+```
+
+There is no fallback to `AGENTA_AUTH_KEY` — the API refuses to start (`AGENTA_SERVICES_INTERNAL_KEY
+is required and must not use the placeholder. ...`) while this is unset or still `replace-me`. It
+is never sent to the runner or into a sandbox.
 
 ## Agenta access
 

--- a/hosting/docker-compose/ee/README.md
+++ b/hosting/docker-compose/ee/README.md
@@ -22,6 +22,7 @@ Open `.env.ee.gh` and set the required values:
 AGENTA_LICENSE=ee
 AGENTA_AUTH_KEY=<generate with: openssl rand -hex 32>
 AGENTA_CRYPT_KEY=<generate with: openssl rand -hex 32>
+AGENTA_SERVICES_INTERNAL_KEY=<generate with: openssl rand -hex 32>
 ```
 
 See [Environment Variables](#environment-variables) for what else you can configure.
@@ -134,6 +135,7 @@ cp hosting/docker-compose/ee/env.ee.gh.example hosting/docker-compose/ee/.env.ee
 | `AGENTA_LICENSE` | Must be `ee`. |
 | `AGENTA_AUTH_KEY` | Secret for internal service authentication. Generate with `openssl rand -hex 32`. |
 | `AGENTA_CRYPT_KEY` | Encryption key for sensitive data at rest. Generate with `openssl rand -hex 32`. |
+| `AGENTA_SERVICES_INTERNAL_KEY` | Proves the Services container is the platform runtime, so a run can read write-only secret values. Set the same value on the API and the Services container; no fallback to `AGENTA_AUTH_KEY`. Generate with `openssl rand -hex 32`. |
 | `AGENTA_WEB_URL` | Public URL of the web frontend (default: `http://localhost`). |
 | `AGENTA_API_URL` | Public URL of the API (default: `http://localhost/api`). |
 | `AGENTA_SERVICES_URL` | Public URL of the services endpoint (default: `http://localhost/services`). |


### PR DESCRIPTION
## Summary
- v0.114.0 (71a2857a2a) added `AGENTA_SERVICES_INTERNAL_KEY` as a required secret: the API's startup `lifespan()` now calls `validate_platform_runtime_key()` unconditionally and raises if the key is unset or the `replace-me` placeholder, so the API refuses to start without it.
- The example env files (`env.oss.gh.example`, `env.oss.dev.example`, `env.ee.gh.example`, `env.ee.dev.example`), the Helm chart (`secrets.yaml`, `values.schema.json`, `values.oss.example.yaml`), and `hosting/railway/oss/README.md` already document it — but the public self-host docs and the EE Docker Compose README did not, so a self-hoster following only the docs would hit an undocumented startup crash on upgrade.
- Adds the key everywhere `AGENTA_AUTH_KEY`/`AGENTA_CRYPT_KEY` are already documented as required secrets: the configuration reference, the Docker Compose remote-deploy guide, the Kubernetes deploy guide (values snippet, secrets table, troubleshooting section), the Railway deploy guide, and the EE Docker Compose README.

## Test plan
- [x] Docs-only change; verified against the `v0.114.0` source (`71a2857a2a`) that this key has no `AGENTA_AUTH_KEY` fallback and that the API's startup validation is unconditional.
- [ ] Docs build (`docusaurus build`) if CI runs it on this PR.

https://claude.ai/code/session_01LDH8EkbpV3sQDj2kAww5Lh