### PR TITLE
[6274] feat(frontend): Autofocus auth inputs

### DIFF
--- a/web/packages/agenta-auth-ui/src/EmailFirstForm.tsx
+++ b/web/packages/agenta-auth-ui/src/EmailFirstForm.tsx
@@ -54,6 +54,7 @@ export const EmailFirstForm = ({
             <div className="relative">
                 <input
                     type="email"
+                    autoFocus
                     autoComplete="email"
                     aria-label="Email address"
                     placeholder="Enter your email address"

--- a/web/packages/agenta-auth-ui/src/EmailPasswordForm.tsx
+++ b/web/packages/agenta-auth-ui/src/EmailPasswordForm.tsx
@@ -111,6 +111,7 @@ export const EmailPasswordForm = ({
         <form className="flex w-full flex-col gap-4" onSubmit={submit} noValidate>
             <input
                 type="email"
+                autoFocus={!lockEmail}
                 autoComplete="email"
                 aria-label="Email address"
                 placeholder="Enter valid email address"
@@ -125,6 +126,7 @@ export const EmailPasswordForm = ({
             />
             <input
                 type="password"
+                autoFocus={lockEmail}
                 autoComplete="current-password"
                 aria-label="Password"
                 placeholder="Enter your password"

--- a/web/packages/agenta-auth-ui/src/PasswordlessRequestForm.tsx
+++ b/web/packages/agenta-auth-ui/src/PasswordlessRequestForm.tsx
@@ -65,6 +65,7 @@ export const PasswordlessRequestForm = ({
             {message.type === "error" && <ShowErrorMessage info={message} />}
             <input
                 type="email"
+                autoFocus={!lockEmail}
                 autoComplete="email"
                 aria-label="Email address"
                 placeholder="Enter valid email address"


### PR DESCRIPTION
## Summary

- Focus the email field when the email-first and passwordless forms appear.
- In the email/password form, focus the first editable field: email for an unlocked address and password for a locked address.
- Keep the existing OTP autofocus behavior unchanged.

Fixes Agenta-AI/agenta#6274

## Testing

### Verified locally

- `pnpm exec turbo run lint --filter=@agenta/auth-ui -- --fix`
- `pnpm turbo run build --filter=@agenta/auth-ui`
- `pnpm turbo run lint --filter=@agenta/auth-ui`
- `pnpm --filter @agenta/auth-ui check`
- Prettier check on all three changed files
- Playwright browser check: keyboard input reached the email field without a click

All commands passed with Node.js 24.18.0.

### Added or updated tests

N/A — `@agenta/auth-ui` does not currently have a component-test harness; this uses React's native `autoFocus` behavior.

### QA follow-up

- Verify focus on the email-first, locked-email password, unlocked email/password, and passwordless screens in supported browsers.
- Confirm the existing OTP first-cell focus remains unchanged.

## Demo

The demo bundles the real `EmailFirstForm` source and `auth.css`. Playwright loaded the page and typed with `page.keyboard` without clicking; the active element was verified as the email input.

![Email field focused immediately after the auth screen loads](https://raw.githubusercontent.com/nightcityblade/agenta/demo-issue-6274/agenta-auth-autofocus.png)

## Checklist

- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources

- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
