### PR TITLE
[6157] fix(sdk): Resolve custom providers by stable slug

### DIFF
--- a/sdks/python/agenta/sdk/managers/secrets.py
+++ b/sdks/python/agenta/sdk/managers/secrets.py
@@ -11,6 +11,7 @@ from agenta.sdk.utils.assets import (
 )
 from agenta.sdk.engines.running.errors import (
     ConnectionModelMismatchV0Error,
+    InvalidSecretsV0Error,
     UnknownConnectionV0Error,
 )
 
@@ -104,6 +105,16 @@ class SecretsManager:
     ):
         data = secret.get("data", {})
         safe_url = _safe_api_base(data.get("provider", {}).get("url"))
+        legacy_slug = SecretsManager._stripped(data.get("provider_slug"))
+        provider_slug = SecretsManager._stripped(secret.get("slug")) or legacy_slug
+        model_keys = data.get("model_keys", [])
+        if provider_slug and legacy_slug and provider_slug != legacy_slug:
+            model_keys = [
+                f"{provider_slug}/{key.split('/', 1)[1]}"
+                if key.startswith(f"{legacy_slug}/")
+                else key
+                for key in model_keys
+            ]
         custom_secrets.append(
             {
                 "kind": secret.get("kind", ""),
@@ -112,7 +123,7 @@ class SecretsManager:
                 "slug": SecretsManager._stripped(secret.get("slug"))
                 or SecretsManager._stripped(data.get("provider_slug")),
                 "data": {
-                    "provider_slug": data.get("provider_slug"),
+                    "provider_slug": provider_slug,
                     "provider": {
                         "kind": data.get("kind", ""),
                         "extras": (
@@ -128,7 +139,7 @@ class SecretsManager:
                             else data.get("provider", {}).get("extras", {})
                         ),
                     },
-                    "models": data.get("model_keys", []),
+                    "models": model_keys,
                 },
             }
         )
@@ -330,7 +341,7 @@ class SecretsManager:
         # path already does — a loud InvalidSecrets in the caller — rather than calling out with
         # a mangled model name.
         if model not in (data.get("models") or []):
-            return None
+            raise InvalidSecretsV0Error(expected=data.get("models") or [], got=model)
 
         provider_settings = dict(
             model=SecretsManager._get_compatible_model(
@@ -389,6 +400,14 @@ class SecretsManager:
 
         # STEP 1b: return None in the case provider is None
         if not provider:
+            if "/custom/" in request_provider_model:
+                configured = [
+                    model
+                    for secret in secrets
+                    if secret.get("kind") == "custom_provider"
+                    for model in secret.get("data", {}).get("models", [])
+                ]
+                raise InvalidSecretsV0Error(expected=configured, got=model)
             return None
 
         # STEP 1c: get litellm compatible model

--- a/sdks/python/oss/tests/pytest/unit/test_secrets_manager_connection_slug.py
+++ b/sdks/python/oss/tests/pytest/unit/test_secrets_manager_connection_slug.py
@@ -20,6 +20,7 @@ import pytest
 
 from agenta.sdk.engines.running.errors import (
     ConnectionModelMismatchV0Error,
+    InvalidSecretsV0Error,
     UnknownConnectionV0Error,
 )
 from agenta.sdk.managers.secrets import SecretsManager
@@ -116,13 +117,22 @@ def test_custom_connection_is_addressable_by_its_name_before_slugs_existed(resol
     assert settings["model"] == "openai/gpt-4o-mini"
 
 
-def test_a_custom_connection_rejects_a_model_from_another_namespace(resolve):
-    # What a renamed custom connection leaves behind: the stored model key still names the old
-    # provider_slug, so the litellm rewrite would mangle it. Resolve to nothing (the caller
-    # raises InvalidSecrets) instead of calling out with a bad model name.
+def test_custom_connection_uses_stable_slug_over_display_name(resolve):
     secrets = [_custom_provider(slug="my-gw", provider_slug="renamed-gw")]
 
-    assert resolve(secrets, "my-gw/custom/gpt-4o-mini", "my-gw") is None
+    assert resolve(secrets, "my-gw/custom/gpt-4o-mini", "my-gw")["model"] == (
+        "openai/gpt-4o-mini"
+    )
+
+
+def test_unmatched_custom_model_key_fails_before_provider_call(resolve):
+    secrets = [_custom_provider(slug="my-gw")]
+
+    with pytest.raises(InvalidSecretsV0Error) as excinfo:
+        resolve(secrets, "my-gw/custom/not-configured", "my-gw")
+
+    assert "my-gw/custom/not-configured" in excinfo.value.message
+    assert "my-gw/custom/gpt-4o-mini" in excinfo.value.message
 
 
 def test_unknown_slug_raises_rather_than_falling_back(resolve):


### PR DESCRIPTION
## Summary

- Treat a custom provider connection's stable vault slug as the canonical model-key namespace, remapping legacy display-name-derived keys during resolution.
- Reject unmatched custom model keys locally with the configured keys in the error instead of forwarding the raw key to the provider.
- Fixes Agenta-AI/agenta#6157.

## Testing

### Verified locally

- `cd sdks/python && uv sync --locked`
- `uv run --no-sync pytest -q oss/tests/pytest/unit/test_secrets_manager_connection_slug.py oss/tests/pytest/unit/test_secrets_manager_model_normalization.py oss/tests/pytest/unit/test_secrets_manager_custom_provider_ssrf.py` — 112 passed
- `ruff format agenta/sdk/managers/secrets.py oss/tests/pytest/unit/test_secrets_manager_connection_slug.py`
- `ruff check --fix agenta/sdk/managers/secrets.py oss/tests/pytest/unit/test_secrets_manager_connection_slug.py` — passed

### Added or updated tests

- Updated custom-connection coverage for a stable slug that differs from the display-name-derived provider slug.
- Added coverage proving an unmatched custom model key fails before a provider call and reports the configured key.

### QA follow-up

- Verify one custom OpenAI-compatible provider whose display name differs from its slug through a real completion flow.

## Demo

Focused regression verification for stable-slug resolution and the unmatched-key guard:

![Focused pytest verification: four regression cases passed](https://raw.githubusercontent.com/nightcityblade/agenta/58abda1a7f8f9dd3c510a5e6f1f2b6e16133cfc8/agenta-sdk-provider-slug-demo.png)

## Checklist

- [x] I have included a video or screen recording for UI changes, or marked Demo as N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources

- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
