### PR TITLE
fix(api): reject trigger schedules that fire below a frequency floor

### DIFF
--- a/api/oss/src/core/triggers/service.py
+++ b/api/oss/src/core/triggers/service.py
@@ -1,7 +1,7 @@
 import asyncio
 import hashlib
 import hmac
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import Any, Dict, List, Mapping, Optional, Set, Tuple
 from uuid import UUID
 
@@ -1423,7 +1423,8 @@ class TriggersService:
 
     @staticmethod
     def _validate_schedule(expr: str) -> None:
-        """Reject anything that is not a valid 5-field cron expression (UTC)."""
+        """Reject anything that is not a valid 5-field cron expression (UTC), or
+        that fires more often than ``env.triggers.schedule_min_interval_minutes``."""
         if not isinstance(expr, str) or len(expr.split()) != 5:
             raise TriggerScheduleInvalid(
                 schedule=expr if isinstance(expr, str) else None,
@@ -1434,6 +1435,73 @@ class TriggersService:
                 schedule=expr,
                 reason="cron expression is not parseable",
             )
+
+        floor = env.triggers.schedule_min_interval_minutes
+        gap = TriggersService._smallest_gap_minutes(expr, stop_below=floor)
+        if gap is not None and gap < floor:
+            raise TriggerScheduleInvalid(
+                f"Schedule may run at most once every {floor} minutes, "
+                f"but this one runs every {TriggersService._humanize_gap(gap)}.",
+                schedule=expr,
+                reason=f"fires every {TriggersService._humanize_gap(gap)}, "
+                f"below the {floor}-minute minimum",
+            )
+
+    # A cron's tightest gap always appears within two days of its FIRST fire: a
+    # sub-daily gap needs a multi-valued minute or hour field, and those repeat on
+    # every day the day-fields admit. Anchoring on the first fire rather than on the
+    # scan's base keeps that true for day-restricted expressions such as
+    # "0,1 0 31 1 *", whose only fires sit a month out.
+    _SCHEDULE_SCAN_WINDOW_MINUTES = 2 * 24 * 60
+    # Backstop against a pathological expression. Two days of every-minute fires is
+    # 2880 samples, and the loop exits early the moment it finds a violating gap.
+    _SCHEDULE_SCAN_MAX_SAMPLES = 5000
+
+    @staticmethod
+    def _smallest_gap_minutes(expr: str, *, stop_below: int) -> Optional[float]:
+        """Smallest gap in minutes between two consecutive fires of ``expr``.
+
+        Returns ``None`` when the expression fires at most once inside the scan
+        window, which means it is sparser than the window and clears any floor.
+        Stops as soon as a gap below ``stop_below`` is found, so a runaway
+        expression costs two samples rather than the full window.
+        """
+        try:
+            iterator = croniter(expr, datetime(2024, 1, 1, tzinfo=timezone.utc))
+            previous = iterator.get_next(datetime)
+        except Exception:  # pylint: disable=broad-exception-caught
+            # croniter validated the expression above; a date it cannot resolve
+            # (e.g. "0 0 30 2 *") never fires, so there is no cadence to police.
+            return None
+
+        horizon = previous + timedelta(
+            minutes=TriggersService._SCHEDULE_SCAN_WINDOW_MINUTES
+        )
+        smallest: Optional[float] = None
+
+        for _ in range(TriggersService._SCHEDULE_SCAN_MAX_SAMPLES):
+            try:
+                current = iterator.get_next(datetime)
+            except Exception:  # pylint: disable=broad-exception-caught
+                break
+            if current > horizon:
+                break
+            gap = (current - previous).total_seconds() / 60
+            smallest = gap if smallest is None else min(smallest, gap)
+            if smallest < stop_below:
+                break
+            previous = current
+
+        return smallest
+
+    @staticmethod
+    def _humanize_gap(minutes: float) -> str:
+        """Render a gap for an error message: "1 minute", "5 minutes", "2 hours"."""
+        if minutes >= 60 and minutes % 60 == 0:
+            hours = int(minutes // 60)
+            return f"{hours} hour" if hours == 1 else f"{hours} hours"
+        rounded = int(minutes) if float(minutes).is_integer() else round(minutes, 1)
+        return f"{rounded} minute" if rounded == 1 else f"{rounded} minutes"
 
     @staticmethod
     def _align_to_minute_utc(dt: Optional[datetime]) -> Optional[datetime]:

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -1674,6 +1674,31 @@ class SuperTokensConfig(BaseModel):
 
 
 # ---------------------------------------------------------------------------
+# Triggers
+# ---------------------------------------------------------------------------
+
+
+class TriggersConfig(BaseModel):
+    """Guardrails for trigger schedules."""
+
+    # The smallest gap allowed between two consecutive fires of a schedule's cron
+    # expression. Every fire starts an agent run in its own sandbox, so `* * * * *`
+    # bills 1440 runs a day; and because a run routinely outlives one minute, such a
+    # schedule also overlaps itself. Enforced on create and edit only, so rows stored
+    # before the floor existed keep firing until someone edits them.
+    #
+    # The web mirrors this default as MIN_CRON_INTERVAL_MINUTES so the drawer can
+    # reject a value before submitting. Lowering this below that constant makes the
+    # client stricter than the server until the two are changed together.
+    schedule_min_interval_minutes: int = (
+        _parse_optional_positive_int_env(
+            "AGENTA_TRIGGERS_SCHEDULE_MIN_INTERVAL_MINUTES"
+        )
+        or 15
+    )
+
+
+# ---------------------------------------------------------------------------
 # Auth — derived flags. Kept as a convenience facade reading from
 # identity.* (OIDC) and agenta.access.email_disabled (email).
 # ---------------------------------------------------------------------------
@@ -1760,6 +1785,7 @@ class EnvironSettings(BaseModel):
     store: StoreConfig = StoreConfig()
     stripe: StripeConfig = StripeConfig()
     supertokens: SuperTokensConfig = SuperTokensConfig()
+    triggers: TriggersConfig = TriggersConfig()
 
     model_config = ConfigDict(extra="ignore")
 

--- a/api/oss/tests/pytest/acceptance/triggers/test_triggers_schedules.py
+++ b/api/oss/tests/pytest/acceptance/triggers/test_triggers_schedules.py
@@ -10,6 +10,8 @@ Requires a running API.
 
 from uuid import uuid4
 
+import pytest
+
 
 def _create_workflow(authed_api):
     """Build a workflow + variant + committed revision; return its slug."""
@@ -51,7 +53,7 @@ def _create_workflow(authed_api):
     return slug
 
 
-def _schedule_payload(*, name=None, schedule="*/5 * * * *", workflow_slug=None):
+def _schedule_payload(*, name=None, schedule="*/30 * * * *", workflow_slug=None):
     slug = uuid4().hex[:8]
     data = {
         "event_key": "cron.tick",
@@ -123,6 +125,19 @@ class TestTriggerSchedulesValidation:
         )
         assert response.status_code == 422, response.text
 
+    @pytest.mark.parametrize(
+        "schedule", ["* * * * *", "*/5 * * * *", "0,1 * * * *", "0,1 0 31 1 *"]
+    )
+    def test_schedule_below_frequency_floor_is_rejected(self, authed_api, schedule):
+        """Every fire starts a billed agent run, so the API refuses a cadence
+        tighter than the floor and says so in the response body."""
+        response = authed_api(
+            "POST", "/triggers/schedules/", json=_schedule_payload(schedule=schedule)
+        )
+        assert response.status_code == 422, response.text
+        detail = response.json()["detail"]
+        assert "at most once every" in detail, detail
+
     def test_unresolvable_workflow_reference_is_rejected(self, authed_api):
         payload = _schedule_payload()
         payload["schedule"]["data"]["references"] = {
@@ -150,7 +165,7 @@ class TestTriggerSchedulesLifecycle:
         assert create.status_code == 200, create.text
         sched = create.json()["schedule"]
         schedule_id = sched["id"]
-        assert sched["data"]["schedule"] == "*/5 * * * *"
+        assert sched["data"]["schedule"] == "*/30 * * * *"
         assert sched["flags"]["is_active"] is True
         # The bound reference is stored VERBATIM, not pinned to a resolved
         # revision: a bare artifact slug means "resolve latest at trigger time",

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_schedule_frequency_floor.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_schedule_frequency_floor.py
@@ -1,0 +1,124 @@
+"""Unit tests for the trigger-schedule frequency floor.
+
+Every schedule fire starts an agent run in its own sandbox, so a ``* * * * *``
+schedule bills 1440 runs a day and overlaps itself whenever a run outlives a
+minute. ``TriggersService._validate_schedule`` therefore refuses any cadence
+tighter than ``env.triggers.schedule_min_interval_minutes``.
+
+These pin the gap arithmetic (``_smallest_gap_minutes``), the accept/reject
+boundary, the env override, and the message the API hands back. No DB, no HTTP.
+"""
+
+import pytest
+
+from oss.src.core.triggers.exceptions import TriggerScheduleInvalid
+from oss.src.core.triggers.service import TriggersService
+from oss.src.utils.env import env
+
+
+@pytest.fixture
+def floor(monkeypatch):
+    """Pin the floor to 15 so these tests do not drift with deployment config."""
+    monkeypatch.setattr(env.triggers, "schedule_min_interval_minutes", 15)
+    return 15
+
+
+class TestSmallestGapMinutes:
+    @pytest.mark.parametrize(
+        "expr, expected",
+        [
+            ("* * * * *", 1),
+            ("*/5 * * * *", 5),
+            ("*/15 * * * *", 15),
+            ("0 * * * *", 60),
+            # A list inside one hour: the tight gap is between :00 and :01, not
+            # the 59 minutes that follow it.
+            ("0,1 * * * *", 1),
+            ("0,30 * * * *", 30),
+        ],
+    )
+    def test_finds_the_tightest_gap(self, expr, expected):
+        assert TriggersService._smallest_gap_minutes(expr, stop_below=0) == expected
+
+    def test_day_restricted_expression_is_scanned_from_its_first_fire(self):
+        """The expression 0,1 0 31 1 * only ever fires on 31 January, a month
+        past the scan base. Anchoring the window on the first fire is what
+        catches its one-minute gap; anchoring on the base would see none."""
+        assert TriggersService._smallest_gap_minutes("0,1 0 31 1 *", stop_below=0) == 1
+
+    def test_returns_none_when_sparser_than_the_scan_window(self):
+        # Monthly and weekly fire at most once inside the two-day window, so
+        # there is no gap to measure and nothing that could breach a floor.
+        assert TriggersService._smallest_gap_minutes("0 0 1 * *", stop_below=15) is None
+        assert TriggersService._smallest_gap_minutes("0 9 * * 1", stop_below=15) is None
+
+    def test_expression_that_never_fires_does_not_raise(self):
+        # 30 February. croniter accepts the expression but cannot resolve a date.
+        assert (
+            TriggersService._smallest_gap_minutes("0 0 30 2 *", stop_below=15) is None
+        )
+
+    def test_stops_early_once_below_the_threshold(self):
+        # Correctness of the early exit: it must still report the violating gap.
+        assert TriggersService._smallest_gap_minutes("* * * * *", stop_below=15) == 1
+
+
+class TestValidateScheduleFloor:
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "* * * * *",
+            "*/5 * * * *",
+            "*/14 * * * *",
+            "0,1 * * * *",
+            "0,5,10 * * * *",
+            "0,1 0 31 1 *",
+        ],
+    )
+    def test_rejects_cadences_below_the_floor(self, expr, floor):
+        with pytest.raises(TriggerScheduleInvalid):
+            TriggersService._validate_schedule(expr)
+
+    @pytest.mark.parametrize(
+        "expr",
+        [
+            "*/15 * * * *",  # exactly at the floor
+            "*/30 * * * *",
+            "0 * * * *",
+            "0 9 * * *",
+            "0 9 * * 1",
+            "0 0 1 * *",
+            "0 0 30 2 *",  # never fires; nothing to police
+        ],
+    )
+    def test_accepts_cadences_at_or_above_the_floor(self, expr, floor):
+        TriggersService._validate_schedule(expr)
+
+    def test_message_names_the_floor_and_the_actual_cadence(self, floor):
+        with pytest.raises(TriggerScheduleInvalid) as excinfo:
+            TriggersService._validate_schedule("* * * * *")
+
+        message = excinfo.value.message
+        assert "at most once every 15 minutes" in message
+        assert "every 1 minute" in message
+        assert excinfo.value.schedule == "* * * * *"
+        assert "15-minute minimum" in excinfo.value.reason
+
+    def test_field_shape_is_still_checked_before_the_floor(self, floor):
+        """A malformed expression must fail on its shape, not inside the gap
+        scan, so the reason stays actionable."""
+        with pytest.raises(TriggerScheduleInvalid) as excinfo:
+            TriggersService._validate_schedule("nonsense")
+        assert excinfo.value.reason == "not a 5-field cron expression"
+
+
+class TestFloorIsConfigurable:
+    def test_a_higher_floor_rejects_a_previously_valid_cadence(self, monkeypatch):
+        monkeypatch.setattr(env.triggers, "schedule_min_interval_minutes", 60)
+        with pytest.raises(TriggerScheduleInvalid):
+            TriggersService._validate_schedule("*/30 * * * *")
+        TriggersService._validate_schedule("0 * * * *")
+
+    def test_a_floor_of_one_admits_every_minute(self, monkeypatch):
+        monkeypatch.setattr(env.triggers, "schedule_min_interval_minutes", 1)
+        TriggersService._validate_schedule("* * * * *")

--- a/api/oss/tests/pytest/unit/triggers/test_triggers_schedules_refresh.py
+++ b/api/oss/tests/pytest/unit/triggers/test_triggers_schedules_refresh.py
@@ -62,7 +62,9 @@ def _service(*, schedules=None, seen=False, with_task=True):
 
 class TestValidateSchedule:
     def test_accepts_valid_five_field_cron(self):
-        TriggersService._validate_schedule("*/5 * * * *")
+        # Above the frequency floor; the floor itself is pinned in
+        # test_triggers_schedule_frequency_floor.py.
+        TriggersService._validate_schedule("*/30 * * * *")
 
     @pytest.mark.parametrize("expr", ["* * * *", "* * * * * *", "", "daily"])
     def test_rejects_wrong_field_count(self, expr):

--- a/web/packages/agenta-entities/src/gatewayTrigger/core/cron.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/core/cron.ts
@@ -6,7 +6,11 @@
  * croniter). The web has no cron dependency, so this is a tiny, dependency-free
  * parser/validator used purely for client-side validation, a human-readable
  * description, and a "next runs" preview hint. The backend remains the source of
- * truth; this never blocks a value the backend would accept beyond field bounds.
+ * truth throughout.
+ *
+ * `validateCron` checks field shape only and blocks nothing the backend accepts.
+ * `validateSchedule` adds the cadence floor, which mirrors a backend default that a
+ * deployment can override — see MIN_CRON_INTERVAL_MINUTES for what that implies.
  */
 
 const FIELD_BOUNDS: {min: number; max: number}[] = [
@@ -178,6 +182,73 @@ export function nextCronRuns(expression: string, count = 3, from: Date = new Dat
     }
 
     return runs
+}
+
+const GAP_SAMPLE_COUNT = 64
+
+/**
+ * Smallest gap, in minutes, between two consecutive fires. Returns null when the
+ * expression is invalid or fires at most once inside the sample, which means it is
+ * far sparser than any floor we enforce.
+ *
+ * Sampling from the first fire rather than from "now" is what catches a
+ * day-restricted expression like `0,1 0 31 1 *`, whose only fires sit a month out;
+ * `nextCronRuns` already does that. 64 samples covers every realistic minute/hour
+ * list: a dense expression reveals its gap in the first two fires, and a listy one
+ * (`0,59 * * * *`, whose tight gap is the *second* gap) within a handful.
+ */
+export function smallestCronGapMinutes(expression: string): number | null {
+    const runs = nextCronRuns(expression, GAP_SAMPLE_COUNT)
+    if (runs.length < 2) return null
+
+    let smallest = Infinity
+    for (let i = 1; i < runs.length; i++) {
+        smallest = Math.min(smallest, (runs[i].getTime() - runs[i - 1].getTime()) / 60_000)
+    }
+    return Number.isFinite(smallest) ? smallest : null
+}
+
+/**
+ * The smallest cadence a schedule may run at. Mirrors the backend default
+ * (`AGENTA_TRIGGERS_SCHEDULE_MIN_INTERVAL_MINUTES`, see `TriggersConfig` in
+ * api/oss/src/utils/env.py), which stays the source of truth: this only spares the
+ * user a round-trip for the common case. A deployment that *lowers* the backend
+ * floor has to lower this too, or the drawer will refuse a value the API accepts.
+ */
+export const MIN_CRON_INTERVAL_MINUTES = 15
+
+/** Render a gap for an error message: "1 minute", "5 minutes", "2 hours". */
+function humanizeGap(minutes: number): string {
+    if (minutes >= 60 && minutes % 60 === 0) {
+        const hours = minutes / 60
+        return `${hours} ${hours === 1 ? "hour" : "hours"}`
+    }
+    const rounded = Number.isInteger(minutes) ? minutes : Math.round(minutes * 10) / 10
+    return `${rounded} ${rounded === 1 ? "minute" : "minutes"}`
+}
+
+/**
+ * Full pre-submit check for a schedule's cron: field shape *and* cadence.
+ *
+ * Every fire starts an agent run in its own sandbox, so `* * * * *` bills 1440 runs
+ * a day and overlaps itself whenever a run outlives a minute. Use this wherever a
+ * user sets a schedule; `validateCron` alone only checks field bounds.
+ */
+export function validateSchedule(
+    expression: string,
+    floorMinutes: number = MIN_CRON_INTERVAL_MINUTES,
+): CronValidationResult {
+    const shape = validateCron(expression)
+    if (!shape.valid) return shape
+
+    const gap = smallestCronGapMinutes(expression)
+    if (gap !== null && gap < floorMinutes) {
+        return {
+            valid: false,
+            error: `A schedule may run at most once every ${floorMinutes} minutes. This one runs every ${humanizeGap(gap)}.`,
+        }
+    }
+    return {valid: true}
 }
 
 /** Does `value` satisfy a single cron field (star, step, range, list, plain)? */

--- a/web/packages/agenta-entities/src/gatewayTrigger/index.ts
+++ b/web/packages/agenta-entities/src/gatewayTrigger/index.ts
@@ -71,7 +71,14 @@ export {
     triggerSchedulesResponseSchema,
     triggerSubscriptionsResponseSchema,
 } from "./core"
-export {describeCron, nextCronRuns, validateCron} from "./core/cron"
+export {
+    describeCron,
+    MIN_CRON_INTERVAL_MINUTES,
+    nextCronRuns,
+    smallestCronGapMinutes,
+    validateCron,
+    validateSchedule,
+} from "./core/cron"
 export type {CronValidationResult} from "./core/cron"
 export {
     builderToCron,

--- a/web/packages/agenta-entities/tests/unit/gatewayTriggerCron.test.ts
+++ b/web/packages/agenta-entities/tests/unit/gatewayTriggerCron.test.ts
@@ -9,7 +9,14 @@
 
 import {describe, expect, it} from "vitest"
 
-import {describeCron, nextCronRuns, validateCron} from "../../src/gatewayTrigger/core/cron"
+import {
+    describeCron,
+    MIN_CRON_INTERVAL_MINUTES,
+    nextCronRuns,
+    smallestCronGapMinutes,
+    validateCron,
+    validateSchedule,
+} from "../../src/gatewayTrigger/core/cron"
 
 describe("validateCron", () => {
     it("accepts a well-formed 5-field expression", () => {
@@ -124,5 +131,67 @@ describe("nextCronRuns", () => {
         expect(describeCron("0 9 * * 1-5")).toBe(
             "Monday, Tuesday, Wednesday, Thursday, Friday at 09:00 UTC",
         )
+    })
+})
+
+describe("smallestCronGapMinutes", () => {
+    it("measures a plain step", () => {
+        expect(smallestCronGapMinutes("* * * * *")).toBe(1)
+        expect(smallestCronGapMinutes("*/5 * * * *")).toBe(5)
+        expect(smallestCronGapMinutes("*/15 * * * *")).toBe(15)
+        expect(smallestCronGapMinutes("0 * * * *")).toBe(60)
+    })
+
+    it("finds the tight gap inside a minute list, not the long one after it", () => {
+        // ":00, :01, then :00 next hour" — gaps of 1 and 59; the answer is 1.
+        expect(smallestCronGapMinutes("0,1 * * * *")).toBe(1)
+        // Here the tight gap is the *second* one, so two fires would not be enough.
+        expect(smallestCronGapMinutes("0,59 * * * *")).toBe(1)
+    })
+
+    it("catches a tight gap on a day-restricted expression", () => {
+        // Only ever fires on 31 January; sampling has to reach that far to see it.
+        expect(smallestCronGapMinutes("0,1 0 31 1 *")).toBe(1)
+    })
+
+    it("returns null when there is no second fire to compare against", () => {
+        expect(smallestCronGapMinutes("nope")).toBeNull()
+    })
+})
+
+describe("validateSchedule", () => {
+    it("keeps rejecting what validateCron rejects", () => {
+        expect(validateSchedule("0 9 * *")).toMatchObject({valid: false})
+        expect(validateSchedule("99 * * * *")).toMatchObject({valid: false})
+    })
+
+    it.each(["* * * * *", "*/5 * * * *", "*/14 * * * *", "0,1 * * * *", "0,1 0 31 1 *"])(
+        "rejects %s for running below the floor",
+        (expression) => {
+            const result = validateSchedule(expression)
+            expect(result.valid).toBe(false)
+            expect(result.error).toContain("at most once every 15 minutes")
+        },
+    )
+
+    it.each(["*/15 * * * *", "*/30 * * * *", "0 * * * *", "0 9 * * *", "0 9 * * 1", "0 0 1 * *"])(
+        "accepts %s",
+        (expression) => {
+            expect(validateSchedule(expression)).toEqual({valid: true})
+        },
+    )
+
+    it("names the actual cadence so the user knows what to change", () => {
+        expect(validateSchedule("* * * * *").error).toContain("runs every 1 minute")
+        expect(validateSchedule("*/5 * * * *").error).toContain("runs every 5 minutes")
+    })
+
+    it("honours a caller-supplied floor", () => {
+        expect(validateSchedule("*/30 * * * *", 60).valid).toBe(false)
+        expect(validateSchedule("* * * * *", 1).valid).toBe(true)
+    })
+
+    it("mirrors the backend default", () => {
+        expect(MIN_CRON_INTERVAL_MINUTES).toBe(15)
     })
 })

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/ScheduleBuilderField.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/ScheduleBuilderField.tsx
@@ -6,7 +6,7 @@ import {
     formatNextRun,
     summarizeSchedule,
     timesFormCleanGrid,
-    validateCron,
+    validateSchedule,
     type CronCadence,
     type CronTimeOfDay,
     type ScheduleBuilderState,
@@ -139,7 +139,9 @@ export function ScheduleBuilderField({
         [builder, emit],
     )
 
-    const validation = useMemo(() => validateCron(value), [value])
+    // Cadence, not just field shape: the backend refuses anything tighter than its
+    // frequency floor, so catch it here instead of on submit.
+    const validation = useMemo(() => validateSchedule(value), [value])
     const summary = validation.valid ? summarizeSchedule(builder) : value
     const nextLine = useMemo(
         () => (validation.valid ? formatNextRun(value, builder) : ""),

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/schedule/ScheduleForm.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/schedule/ScheduleForm.tsx
@@ -10,7 +10,7 @@ import {
     triggerApiErrorMessage,
     triggerScheduleDrawerAtom,
     useTriggerSchedule,
-    validateCron,
+    validateSchedule,
     cronToBuilder,
     type TriggerScheduleCreate,
     type TriggerScheduleData,
@@ -132,7 +132,9 @@ export function ScheduleForm({
         // The binding is derived from the stored references, never re-picked on open.
     }, [isEdit, schedule, scheduleFetching, scheduleId])
 
-    const cronValidation = useMemo(() => validateCron(cron), [cron])
+    // Field shape plus cadence: the API rejects anything tighter than its frequency
+    // floor, and Save stays disabled rather than letting the user learn that on submit.
+    const cronValidation = useMemo(() => validateSchedule(cron), [cron])
     const versionChosen = !!activeBinding.workflowId || !!activeBinding.variantId
 
     // Save enables only on draft changes vs the starting point (loaded schedule in edit,
@@ -327,10 +329,14 @@ export function ScheduleForm({
         onSaved,
     ])
 
-    // Create is gated on completeness; edit on having changed something.
+    // A valid cron gates both modes: an edit that loosens nothing but retypes the
+    // expression can still drop below the frequency floor, and Save must go dead
+    // rather than bounce off handleSubmit with a toast. Beyond that, create is gated
+    // on completeness and edit on having changed something.
     const canSubmit =
         !isDeleted &&
-        (isEdit ? isDirty : cronValidation.valid && versionChosen && !!composedMessage.trim())
+        cronValidation.valid &&
+        (isEdit ? isDirty : versionChosen && !!composedMessage.trim())
 
     if (isEdit && scheduleLoading) {
         return <ScheduleFormSkeleton showAgent={!playgroundEntityId} />


### PR DESCRIPTION
## The problem

A trigger schedule accepted any cron expression that parsed, `* * * * *` included. Nothing checked how often it fired.

Every fire starts an agent run in its own Daytona sandbox, so an every-minute schedule bills **1440 runs a day**. It is also wrong on its own terms: an agent run routinely takes longer than a minute, so the schedule launches a new run before the previous one finishes and overlaps itself.

This is not hypothetical. A test schedule named "test every minute" was created on staging on 22 August. It ran roughly $12/day and exhausted the shared Daytona organization's credits the next day, which took down agent runs on every environment sharing that account, including a colleague's PR testing on `preview.demo`.

Here was the entire validation:

```python
def _validate_schedule(expr: str) -> None:
    """Reject anything that is not a valid 5-field cron expression (UTC)."""
    if not isinstance(expr, str) or len(expr.split()) != 5:
        raise TriggerScheduleInvalid(...)
    if not croniter.is_valid(expr):
        raise TriggerScheduleInvalid(...)
```

## The change

A minimum interval between two consecutive fires, defaulting to **15 minutes** and overridable per deployment via `AGENTA_TRIGGERS_SCHEDULE_MIN_INTERVAL_MINUTES`.

| | Before | After |
|---|---|---|
| `POST /triggers/schedules/` with `* * * * *` | 201, schedule fires 1440x/day | 422, `Schedule may run at most once every 15 minutes, but this one runs every 1 minute.` |
| Same value typed in the drawer | Save enabled, request sent | Field shows the error, Save disabled |
| Editing an existing schedule to `*/5 * * * *` | Save enabled, rejected on click with a toast | Save disabled |

**Backend.** `_validate_schedule` is the single gate, and both `create_schedule` and `edit_schedule` already call it first, so both paths are covered by one change. The 422 detail names the floor and the actual cadence so the message is actionable rather than "invalid cron".

**Web.** `validateSchedule` in the shared cron module adds the same cadence check on top of the existing field-shape check, so the drawer rejects the value without a round-trip. The backend stays the source of truth and its message still surfaces through `triggerApiErrorMessage` if the two ever disagree.

**One extra fix found on the way:** `canSubmit` gated edits on `isDirty` alone, never on cron validity. Save looked enabled for an invalid expression in edit mode and only bounced off `handleSubmit` with a toast. It is now gated on a valid cron in both modes.

## Measuring the gap correctly

The interesting part is that comparing two consecutive fires is not enough.

- `0,59 * * * *` fires at `:00`, `:59`, `:00` — the tight gap is the **second** one.
- `0,1 0 31 1 *` only ever fires on 31 January. Scanning from "now" would find nothing at all, so the scan anchors on the expression's **first fire**, not on the clock.

Both sides walk fires from the first one, take the smallest gap, and bail early once a gap falls below the floor, so a runaway expression costs two samples rather than a full window.

## Compatibility

Enforced on write only. Schedules stored before this keep firing until someone edits them, so no existing automation breaks on deploy. The four active schedules on staging are daily and weekly and sit well clear of the floor.

The web mirrors the backend *default* as `MIN_CRON_INTERVAL_MINUTES`. A deployment that **lowers** the backend floor must lower that constant too, or the drawer will refuse a value the API would accept. Exposing the floor over the API would remove the duplication; there is no config endpoint for the web to read today, and adding one felt out of scope here.

## Tests

- `api/oss/tests/pytest/unit/triggers/test_triggers_schedule_frequency_floor.py` — new. Pins the gap arithmetic, the accept/reject boundary (`*/15` accepted, `*/14` rejected), the early exit, the env override, the message text, and that a never-firing expression like `0 0 30 2 *` does not raise.
- `gatewayTriggerCron.test.ts` — the same cases on the web side.
- Two existing tests used cadences that are now below the floor and were updated: the acceptance payload default moved from `*/5` to `*/30`, and a unit test's "a valid cron is accepted" case likewise.
- A new acceptance test asserts the 422 and its body for four sub-floor expressions.

**Local runs:** 172 passed, 4 skipped (`api/oss/tests/pytest/unit/triggers/`, the skips are Postgres DAO tests with no database). 35 passed (`gatewayTriggerCron.test.ts`). `ruff format`/`ruff check` clean, `eslint`/`prettier` clean, `tsc --noEmit` clean on both touched packages.

## Follow-ups, not in this PR

- A cap on active schedules per project, which needs a DAO count and a check on every activation path.
- Per-organization concurrent-run limits, which need shared state and a design.
- Daytona sandboxes are labelled only `code-toolbox-language: python`, the SDK default. Adding stage, project, and trigger id would have made the incident above self-explaining.
