### PR TITLE
[ci] Serve the docs from Cloudflare Workers with per-PR previews

### DIFF
--- a/.github/workflows/18-docs-preview.yml
+++ b/.github/workflows/18-docs-preview.yml
@@ -1,0 +1,209 @@
+name: "18 - docs preview"
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/18-docs-preview.yml'
+  workflow_dispatch:
+    inputs:
+      pr_number:
+        description: "PR number to comment the preview URL on"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: docs-preview-${{ github.event.pull_request.number || inputs.pr_number || github.ref_name }}
+  cancel-in-progress: true
+
+env:
+  WRANGLER_VERSION: "4.113.0"
+
+jobs:
+  deploy:
+    name: Build and deploy preview
+    runs-on: ubuntu-latest
+    # Fork PRs get no secrets: skip when the head repo is not this repo.
+    # Dependabot PRs run without repository secrets (GitHub policy), so the
+    # deploy could never succeed there; skip them cleanly instead of failing.
+    if: >-
+      github.event_name == 'workflow_dispatch' ||
+      (github.event.pull_request.head.repo.full_name == github.repository &&
+       !github.event.pull_request.draft &&
+       github.actor != 'dependabot[bot]')
+    env:
+      PR_NUMBER: ${{ github.event.pull_request.number || inputs.pr_number }}
+      RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+    steps:
+      # A workflow_dispatch run only carries a PR number. Without this, checkout
+      # would build whatever ref the dispatch came from (main, usually) and
+      # publish it under that PR's alias, and the comment would name the wrong
+      # commit. Resolve the PR's real head first, and refuse a fork head: the
+      # job holds deploy secrets, so it must never build code from outside this
+      # repository.
+      - name: Resolve the pull request head
+        id: head
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT_NAME: ${{ github.event_name }}
+          EVENT_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          if [ "$EVENT_NAME" = "workflow_dispatch" ]; then
+            pr=$(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}")
+            repo=$(jq -r '.head.repo.full_name' <<< "$pr")
+            if [ "$repo" != "${{ github.repository }}" ]; then
+              echo "::error::PR #${PR_NUMBER} comes from $repo. Fork heads are not built here."
+              exit 1
+            fi
+            sha=$(jq -r '.head.sha' <<< "$pr")
+          else
+            sha="$EVENT_SHA"
+          fi
+          echo "sha=$sha" >> "$GITHUB_OUTPUT"
+
+      # Posted before the build so the PR shows the preview is on its way. Every
+      # later comment step reuses the `docs-preview` header, so GitHub shows one
+      # comment that updates in place instead of a new one per push.
+      - name: Comment build started
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docs-preview
+          number: ${{ env.PR_NUMBER }}
+          message: |
+            ### 📘 Docs preview
+
+            |  |  |
+            | --- | --- |
+            | **Status** | 🔄 Building... |
+            | **Inspect** | [Actions run](${{ env.RUN_URL }}) |
+            | **Commit** | `${{ steps.head.outputs.sha }}` |
+
+      - uses: actions/checkout@v6
+        with:
+          ref: ${{ steps.head.outputs.sha }}
+          # Nothing here pushes; do not leave a token in .git/config.
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: docs/package.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          cache-dependency-path: docs/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd docs && pnpm install --frozen-lockfile
+
+      - name: Build site
+        env:
+          # Preview deploys are public workers.dev URLs: keep them out of search
+          # indexes (noindex <meta> + disallow-all robots.txt) so they never rank
+          # as duplicate content against the real docs. The production build
+          # (workflow 19) deliberately does NOT set this.
+          DOCS_NOINDEX: "true"
+          # 1,100+ pages with image processing; the default heap is not enough.
+          NODE_OPTIONS: "--max-old-space-size=4096"
+          # POSTHOG_API_KEY is deliberately unset: previews send no analytics.
+        run: cd docs && pnpm run build:worker
+
+      - name: Deploy preview version
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd docs
+          alias="pr-${PR_NUMBER}"
+          pnpm dlx "wrangler@${WRANGLER_VERSION}" versions upload \
+            --preview-alias "$alias" 2>&1 | tee /tmp/wrangler.log
+          url=$(grep -oiE 'Version Preview Alias URL: https://[a-z0-9.-]+\.workers\.dev' /tmp/wrangler.log | sed 's/.*: //' | head -1)
+          if [ -z "$url" ]; then
+            echo "::error::Could not extract preview alias URL from wrangler output"
+            exit 1
+          fi
+          # The docs live under /docs on the worker, matching the public URL.
+          echo "url=${url}/docs" >> "$GITHUB_OUTPUT"
+
+      - name: Verify preview serves the docs
+        run: |
+          for _ in 1 2 3 4 5; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              --connect-timeout 10 --max-time 30 "${{ steps.deploy.outputs.url }}")
+            [ "$code" = "200" ] && exit 0
+            sleep 5
+          done
+          echo "::error::Preview URL did not return 200 (last code: $code)"
+          exit 1
+
+      # Deep links to the pages this PR touches, so a reviewer lands on the
+      # changed page instead of the docs home. Best effort: the step prints
+      # nothing when it cannot map a file to a route, and never fails the job.
+      - name: Collect changed pages
+        id: pages
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          cd docs
+          # Read into an array so a path with a space or a glob character stays
+          # one argument.
+          files=()
+          while IFS= read -r line; do
+            files+=("$line")
+          done < <(gh api "repos/${{ github.repository }}/pulls/${PR_NUMBER}/files" \
+            --paginate --jq '.[] | select(.status != "removed") | .filename' \
+            | grep -E '^docs/(docs|versioned_docs|blog)/.*\.mdx?$' || true)
+          {
+            echo "list<<PAGES_EOF"
+            if [ ${#files[@]} -gt 0 ]; then
+              node scripts/changed-pages.mjs "${{ steps.deploy.outputs.url }}" "${files[@]}" || true
+            fi
+            echo "PAGES_EOF"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Comment preview URL
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docs-preview
+          number: ${{ env.PR_NUMBER }}
+          message: |
+            ### 📘 Docs preview
+
+            |  |  |
+            | --- | --- |
+            | **Status** | ✅ Ready |
+            | **Preview** | ${{ steps.deploy.outputs.url }} |
+            | **Inspect** | [Actions run](${{ env.RUN_URL }}) |
+            | **Commit** | `${{ steps.head.outputs.sha }}` |
+
+            ${{ steps.pages.outputs.list }}
+
+            This comment updates in place on every push.
+
+      - name: Comment failure
+        if: failure()
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          header: docs-preview
+          number: ${{ env.PR_NUMBER }}
+          message: |
+            ### 📘 Docs preview
+
+            |  |  |
+            | --- | --- |
+            | **Status** | ❌ Failed |
+            | **Inspect** | [Actions run](${{ env.RUN_URL }}) |
+            | **Commit** | `${{ steps.head.outputs.sha }}` |
+
+            The docs build or deploy failed. The Docusaurus build treats broken links
+            and anchors as errors, so a bad link in this PR will stop it here.

--- a/.github/workflows/19-docs-production.yml
+++ b/.github/workflows/19-docs-production.yml
@@ -1,0 +1,91 @@
+name: "19 - docs production"
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'docs/**'
+      - '.github/workflows/19-docs-production.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-production
+  cancel-in-progress: false
+
+env:
+  WRANGLER_VERSION: "4.113.0"
+
+jobs:
+  deploy:
+    name: Build and deploy production
+    runs-on: ubuntu-latest
+    # Only deploy from this repo (skip forks/mirrors that lack the secrets).
+    if: github.repository == 'Agenta-AI/agenta'
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          # Nothing here pushes; do not leave a token in .git/config.
+          persist-credentials: false
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          package_json_file: docs/package.json
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: 'pnpm'
+          cache-dependency-path: docs/pnpm-lock.yaml
+
+      - name: Install dependencies
+        run: cd docs && pnpm install --frozen-lockfile
+
+      - name: Build site
+        env:
+          # PostHog project key: ingest-only and public by design, but kept as a
+          # secret so it is set in one place. Unset, the docs config falls back
+          # to a dummy key and sends nothing.
+          POSTHOG_API_KEY: ${{ secrets.POSTHOG_API_KEY }}
+          # 1,100+ pages with image processing; the default heap is not enough.
+          NODE_OPTIONS: "--max-old-space-size=4096"
+        run: |
+          # docusaurus.config.ts falls back to a dummy key when this is empty,
+          # so without this guard a green deploy could quietly ship the docs
+          # with analytics switched off.
+          if [ -z "${POSTHOG_API_KEY}" ]; then
+            echo "::error::POSTHOG_API_KEY is not set. Add it as a repository secret before deploying the docs."
+            exit 1
+          fi
+          cd docs && pnpm run build:worker
+
+      - name: Deploy production
+        id: deploy
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          cd docs
+          pnpm dlx "wrangler@${WRANGLER_VERSION}" deploy \
+            --config wrangler.production.jsonc 2>&1 | tee /tmp/wrangler.log
+          url=$(grep -oiE 'https://[a-z0-9.-]+\.workers\.dev' /tmp/wrangler.log | head -1)
+          if [ -z "$url" ]; then
+            echo "::error::Could not extract deployed URL from wrangler output"
+            exit 1
+          fi
+          echo "url=${url}/docs" >> "$GITHUB_OUTPUT"
+
+      - name: Verify production serves the docs
+        run: |
+          for _ in 1 2 3 4 5; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' \
+              --connect-timeout 10 --max-time 30 "${{ steps.deploy.outputs.url }}")
+            [ "$code" = "200" ] && exit 0
+            sleep 5
+          done
+          echo "::error::Production URL did not return 200 (last code: $code)"
+          exit 1

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -18,3 +18,6 @@
 npm-debug.log*
 yarn-debug.log*
 yarn-error.log*
+
+# Worker build output (Cloudflare Workers Static Assets)
+/dist

--- a/docs/README.md
+++ b/docs/README.md
@@ -36,6 +36,53 @@ To set up the documentation locally, follow these steps:
    ```
    Visit `localhost:3000` to explore the production build.
 
+## Deployment
+
+The docs build to Cloudflare Workers Static Assets. Two workers serve the site:
+
+| Worker | Config | What it serves |
+| --- | --- | --- |
+| `agenta-docs` | `wrangler.production.jsonc` | the production build, on its own `workers.dev` URL |
+| `agenta-docs-preview` | `wrangler.jsonc` | one version per pull request |
+
+**`https://agenta.ai/docs` does not point at these workers yet.** That hostname
+still goes through the older `new-docs-router` worker, which proxies to Vercel.
+Deploying `agenta-docs` changes no live traffic. The cutover is a separate,
+deliberate step: remove the `agenta.ai/docs*` route from `new-docs-router` and
+add `agenta.ai/docs` and `agenta.ai/docs/*` to `agenta-docs`. The exact patterns
+are commented in `wrangler.production.jsonc`. Rolling back means dropping those
+two routes and restoring the old one, which takes about a minute.
+
+Two GitHub Actions workflows drive them:
+
+- `.github/workflows/18-docs-preview.yml` builds every pull request that touches
+  `docs/**`, uploads it as a new version of the preview worker under the alias
+  `pr-<number>`, and posts the preview URL as a comment on the pull request. Pull
+  requests from forks are skipped, because they cannot read the deploy secrets.
+- `.github/workflows/19-docs-production.yml` builds and deploys on every merge to
+  `main` that touches `docs/**`.
+
+Both run `pnpm run build:worker`, which writes the site into `dist/docs` rather than
+`build`. The nested directory makes the file tree match the public `/docs/` URL
+prefix, so Cloudflare serves the site with no rewrite rule. `scripts/stage-worker-assets.mjs`
+then copies `worker-assets/_headers` and `worker-assets/_redirects` to `dist/`, where
+Cloudflare reads them.
+
+To build and serve the exact production artifact locally:
+
+```bash
+pnpm run build:worker
+npx wrangler dev --config wrangler.jsonc   # http://localhost:8787/docs
+```
+
+`scripts/check-parity.mjs` requests every URL in the live sitemap against another
+host, which is how a preview or a new production deploy is checked before traffic
+moves to it:
+
+```bash
+node scripts/check-parity.mjs https://pr-1234-agenta-docs-preview.<subdomain>.workers.dev
+```
+
 ## Changelog Guidelines
 
 When working on the changelog page, following specific formatting rules are important to ensure the page's layout remains intact. Failure to follow these guidelines may result in broken UI elements.

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -17,6 +17,10 @@ const config: Config = {
   baseUrl: "/docs/",
   organizationName: "Agenta-AI",
   projectName: "agenta",
+  // Preview deploys go to a public *.workers.dev URL. DOCS_NOINDEX=true (set by
+  // .github/workflows/18-docs-preview.yml) keeps them out of search indexes so
+  // they never rank as duplicates of the real docs. Production leaves it unset.
+  noIndex: process.env.DOCS_NOINDEX === "true",
   onBrokenLinks: "throw",
   onBrokenMarkdownLinks: "throw",
   onBrokenAnchors: "throw",

--- a/docs/package.json
+++ b/docs/package.json
@@ -8,6 +8,7 @@
     "start": "docusaurus start --port 5000 --host 0.0.0.0 --config docusaurus.config.dev.ts",
     "start:prod": "docusaurus start --port 5000 --host 0.0.0.0",
     "build": "docusaurus build",
+    "build:worker": "docusaurus build --out-dir dist/docs && node scripts/stage-worker-assets.mjs",
     "build:dev": "docusaurus build --config docusaurus.config.dev.ts",
     "swizzle": "docusaurus swizzle",
     "deploy": "docusaurus deploy",

--- a/docs/scripts/changed-pages.mjs
+++ b/docs/scripts/changed-pages.mjs
@@ -1,0 +1,90 @@
+// Prints markdown links to the docs pages a pull request changed, so the
+// preview comment can deep-link straight into the pages under review.
+//
+// Usage: node scripts/changed-pages.mjs <preview-url> <changed-file>...
+//   the preview URL may be the bare host or the host plus /docs
+//   changed files are repo-relative paths, e.g. docs/docs/guides/foo.mdx
+//
+// The source-file to URL mapping is NOT guessed from the path: numeric prefixes
+// (06-foo.mdx), `slug:` frontmatter, underscore-excluded partials and versioned
+// docs all break naive derivation. Instead it reads the metadata Docusaurus
+// writes for every page during the build (.docusaurus/**/site-*.json), which
+// carries the real `source` and `permalink`. So this must run AFTER the build.
+//
+// Best effort by design: it prints nothing at all rather than a wrong link.
+
+import { readdir, readFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const MAX_LINKS = 10;
+
+const docsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const [rawOrigin, ...changed] = process.argv.slice(2);
+
+if (!rawOrigin || changed.length === 0) process.exit(0);
+
+// Permalinks already carry the /docs prefix in a production build, so accept
+// either the bare host or the host plus /docs and normalise to the host.
+const origin = rawOrigin.replace(/\/+$/, "").replace(/\/docs$/, "");
+
+const collectMetadata = async (dir) => {
+  const found = [];
+  let entries;
+  try {
+    entries = await readdir(dir, { withFileTypes: true });
+  } catch {
+    return found;
+  }
+  for (const entry of entries) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      found.push(...(await collectMetadata(full)));
+    } else if (entry.name.startsWith("site-") && entry.name.endsWith(".json")) {
+      found.push(full);
+    }
+  }
+  return found;
+};
+
+const bySource = new Map();
+for (const file of await collectMetadata(path.join(docsRoot, ".docusaurus"))) {
+  try {
+    const data = JSON.parse(await readFile(file, "utf8"));
+    if (typeof data.source === "string" && typeof data.permalink === "string") {
+      bySource.set(data.source, data);
+    }
+  } catch {
+    // A metadata file we cannot parse is not worth failing the comment over.
+  }
+}
+
+if (bySource.size === 0) process.exit(0);
+
+const links = [];
+for (const file of changed) {
+  // Repo-relative docs/docs/foo.mdx is @site/docs/foo.mdx to Docusaurus.
+  const relative = file.startsWith("docs/") ? file.slice("docs/".length) : file;
+  const entry = bySource.get(`@site/${relative}`);
+  if (!entry) continue;
+
+  // permalink already carries the baseUrl in a production build, but not when
+  // the metadata came from the localhost dev config. Normalise either shape.
+  const permalink = entry.permalink.startsWith("/docs/")
+    ? entry.permalink
+    : `/docs${entry.permalink}`;
+  // Escape the backslash first (in the same pass), otherwise a title ending in
+  // one would escape the escape and break out of the link text.
+  const title = (entry.title || permalink).replace(/([\\[\]])/g, "\\$1");
+  links.push(`- [${title}](${origin}${permalink})`);
+}
+
+if (links.length === 0) process.exit(0);
+
+console.log("**Pages changed in this pull request**");
+console.log("");
+for (const link of links.slice(0, MAX_LINKS)) console.log(link);
+if (links.length > MAX_LINKS) {
+  console.log(`- ...and ${links.length - MAX_LINKS} more`);
+}

--- a/docs/scripts/check-parity.mjs
+++ b/docs/scripts/check-parity.mjs
@@ -1,0 +1,242 @@
+// Checks that a candidate docs deployment serves every URL the live docs serve.
+//
+// Usage:
+//   node scripts/check-parity.mjs <target> [options]
+//
+//   node scripts/check-parity.mjs https://pr-1234-agenta-docs-preview.example.workers.dev
+//   node scripts/check-parity.mjs https://agenta.ai --sitemap https://agenta.ai/docs/sitemap.xml
+//
+// Options:
+//   --sitemap <url>      sitemap to read the URL list from
+//                        (default https://agenta.ai/docs/sitemap.xml)
+//   --concurrency <n>    parallel requests (default 12)
+//   --limit <n>          only check the first n URLs (for a quick smoke run)
+//   --timeout <seconds>  per-request deadline (default 30)
+//
+// Only the ORIGIN of the target is used. Sitemap paths already carry the /docs
+// prefix, so a target written as https://host/docs would otherwise produce
+// /docs/docs/... and check the wrong URLs.
+//
+// After the sitemap sweep it also checks the shape of the deployment: a page
+// that cannot exist must 404, and the cache policy from worker-assets/_headers
+// must be in force on both HTML and hashed assets.
+//
+// Every URL in the sitemap is re-pointed at the target origin and requested.
+// Redirects are followed by hand so the report shows the hops: this is how the
+// trailing-slash behaviour and the "path segment containing a dot" cases get
+// verified, not just the final status code. Exits non-zero if anything ends on
+// a status other than 200.
+
+import process from "node:process";
+
+const args = process.argv.slice(2);
+const target = args[0];
+const option = (name, fallback) => {
+  const at = args.indexOf(`--${name}`);
+  return at === -1 ? fallback : args[at + 1];
+};
+
+if (!target || target.startsWith("--")) {
+  console.error("usage: node scripts/check-parity.mjs <target-origin> [--sitemap url] [--concurrency n] [--limit n]");
+  process.exit(2);
+}
+
+// A bad number must stop the run, not silently spawn zero workers or check
+// zero URLs: this script is the gate in front of a traffic cutover.
+const integerOption = (name, fallback, { min }) => {
+  const raw = option(name, fallback);
+  const value = Number(raw);
+  if (!Number.isInteger(value) || value < min) {
+    console.error(`--${name} must be an integer of at least ${min}, got "${raw}"`);
+    process.exit(2);
+  }
+  return value;
+};
+
+const sitemapUrl = option("sitemap", "https://agenta.ai/docs/sitemap.xml");
+const concurrency = integerOption("concurrency", "12", { min: 1 });
+const limit = integerOption("limit", "0", { min: 0 });
+const timeoutMs = integerOption("timeout", "30", { min: 1 }) * 1000;
+const MAX_HOPS = 3;
+
+let targetOrigin;
+try {
+  targetOrigin = new URL(target).origin;
+} catch {
+  console.error(`target must be an absolute URL, got "${target}"`);
+  process.exit(2);
+}
+
+const sitemapResponse = await fetch(sitemapUrl, { signal: AbortSignal.timeout(timeoutMs) });
+if (!sitemapResponse.ok) {
+  console.error(`could not read ${sitemapUrl}: HTTP ${sitemapResponse.status}`);
+  process.exit(2);
+}
+const sitemap = await sitemapResponse.text();
+const sourceUrls = [...sitemap.matchAll(/<loc>(.*?)<\/loc>/g)].map((m) => m[1].trim());
+if (sourceUrls.length === 0) {
+  console.error(`${sitemapUrl} listed no <loc> URLs, so there is nothing to check`);
+  process.exit(2);
+}
+const urls = (limit > 0 ? sourceUrls.slice(0, limit) : sourceUrls).map((raw) => {
+  const source = new URL(raw);
+  return { source: raw, url: `${targetOrigin}${source.pathname}${source.search}` };
+});
+
+console.log(`checking ${urls.length} URLs from ${sitemapUrl} against ${targetOrigin}`);
+
+// A 200 is only worth counting if it came back from the page that was asked
+// for. Without these two checks a deployment that redirected every docs URL to
+// its home page, or to the live site, would sail through this gate while
+// serving none of the documentation.
+const dropTrailingSlash = (pathname) =>
+  pathname.length > 1 ? pathname.replace(/\/$/, "") : pathname;
+
+const visit = async (url) => {
+  const requested = new URL(url);
+  const hops = [];
+  let current = url;
+  for (let hop = 0; hop <= MAX_HOPS; hop += 1) {
+    const response = await fetch(current, {
+      redirect: "manual",
+      // node fetch has no deadline of its own, so one stalled request would
+      // hang the whole run.
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    if (response.status >= 300 && response.status < 400) {
+      const location = response.headers.get("location");
+      if (!location) return { status: response.status, hops };
+      hops.push(`${response.status} -> ${location}`);
+      const next = new URL(location, current);
+      if (next.origin !== targetOrigin) {
+        return { status: `redirect left ${targetOrigin}`, hops };
+      }
+      current = next.toString();
+      continue;
+    }
+    if (response.status === 200) {
+      // The only redirect we expect is the trailing-slash normalisation that
+      // Cloudflare's `drop-trailing-slash` mode performs.
+      const landed = new URL(current);
+      if (dropTrailingSlash(landed.pathname) !== dropTrailingSlash(requested.pathname)) {
+        return { status: `redirect changed the path to ${landed.pathname}`, hops };
+      }
+    }
+    return { status: response.status, hops };
+  }
+  return { status: `more than ${MAX_HOPS} redirects`, hops };
+};
+
+const failures = [];
+const redirected = [];
+let done = 0;
+
+const queue = [...urls];
+const worker = async () => {
+  for (;;) {
+    const next = queue.shift();
+    if (!next) return;
+    try {
+      const { status, hops } = await visit(next.url);
+      if (status !== 200) failures.push({ ...next, status, hops });
+      else if (hops.length > 0) redirected.push({ ...next, hops });
+    } catch (error) {
+      failures.push({ ...next, status: "network error", hops: [String(error)] });
+    }
+    done += 1;
+    if (done % 100 === 0) console.log(`  ${done}/${urls.length}`);
+  }
+};
+
+await Promise.all(Array.from({ length: Math.max(1, concurrency) }, worker));
+
+if (redirected.length > 0) {
+  console.log(`\n${redirected.length} URL(s) reached 200 after a redirect:`);
+  for (const item of redirected.slice(0, 25)) {
+    console.log(`  ${item.url}\n    ${item.hops.join("\n    ")}`);
+  }
+  if (redirected.length > 25) console.log(`  ...and ${redirected.length - 25} more`);
+}
+
+if (failures.length > 0) {
+  console.log(`\n${failures.length} URL(s) did NOT return 200:`);
+  for (const item of failures) {
+    console.log(`  [${item.status}] ${item.url}`);
+    for (const hop of item.hops) console.log(`    ${hop}`);
+  }
+  console.log(`\nparity FAILED: ${failures.length}/${urls.length}`);
+  process.exit(1);
+}
+
+console.log(`\nparity OK: ${urls.length}/${urls.length} returned 200`);
+
+// Every URL returning 200 is necessary but not sufficient. A deployment that
+// answered every request with the home page would also score 950 out of 950,
+// and one that lost the _headers file would serve the whole site with the
+// wrong cache policy. Check both before reporting success.
+console.log("\nchecking deployment shape");
+const shapeFailures = [];
+
+const head = async (path) =>
+  fetch(`${targetOrigin}${path}`, {
+    redirect: "follow",
+    signal: AbortSignal.timeout(timeoutMs),
+  });
+
+// A page that cannot exist must 404, not fall back to something that works.
+const missingPath = "/docs/this-page-does-not-exist-parity-probe";
+try {
+  const response = await head(missingPath);
+  if (response.status !== 404) {
+    shapeFailures.push(`${missingPath} returned ${response.status}, expected 404`);
+  } else {
+    console.log(`  missing page 404s`);
+  }
+} catch (error) {
+  shapeFailures.push(`${missingPath} failed: ${error}`);
+}
+
+// HTML gets a short time to live so docs edits appear quickly. Hashed build
+// assets get the immutable one-year policy. Both come from worker-assets/_headers.
+const cacheChecks = [
+  { what: "html", path: "/docs", expect: /max-age=60\b/ },
+  { what: "hashed asset", path: null, expect: /immutable/ },
+];
+
+try {
+  const home = await head("/docs");
+  const html = await home.text();
+  const asset = html.match(/\/docs\/assets\/js\/[A-Za-z0-9._-]+\.js/);
+  cacheChecks[1].path = asset ? asset[0] : null;
+} catch (error) {
+  shapeFailures.push(`could not read /docs to find a hashed asset: ${error}`);
+}
+
+for (const check of cacheChecks) {
+  if (!check.path) {
+    shapeFailures.push(`could not find a ${check.what} to check the cache policy on`);
+    continue;
+  }
+  try {
+    const response = await head(check.path);
+    const cacheControl = response.headers.get("cache-control") || "";
+    if (!check.expect.test(cacheControl)) {
+      shapeFailures.push(
+        `${check.what} ${check.path} sent "cache-control: ${cacheControl}", expected ${check.expect}`,
+      );
+    } else {
+      console.log(`  ${check.what} cache policy: ${cacheControl}`);
+    }
+  } catch (error) {
+    shapeFailures.push(`${check.path} failed: ${error}`);
+  }
+}
+
+if (shapeFailures.length > 0) {
+  console.log(`\n${shapeFailures.length} deployment shape problem(s):`);
+  for (const problem of shapeFailures) console.log(`  ${problem}`);
+  console.log("\nparity FAILED on deployment shape");
+  process.exit(1);
+}
+
+console.log("\nall checks passed");

--- a/docs/scripts/stage-worker-assets.mjs
+++ b/docs/scripts/stage-worker-assets.mjs
@@ -1,0 +1,55 @@
+// Stages the Cloudflare Workers Static Assets metadata files next to the built
+// docs, and is run by `pnpm run build:worker` right after `docusaurus build`.
+//
+// The docs build is written to dist/docs so that the file tree matches the
+// public /docs/ URL prefix (Cloudflare serves a subdirectory by mirroring the
+// path, which is what replaces the old Vercel `/docs/:path*` rewrite). But
+// `_headers` and `_redirects` are only read at the ROOT of the assets
+// directory, so they cannot live inside the build output: they are kept in
+// docs/worker-assets/ and copied to dist/ here.
+//
+// With DOCS_NOINDEX=true (set for CI preview deploys) it also writes a
+// disallow-all robots.txt at the preview host root, so a public *.workers.dev
+// preview can never be indexed as duplicate content.
+
+import { copyFile, mkdir, stat, writeFile } from "node:fs/promises";
+import path from "node:path";
+import process from "node:process";
+import { fileURLToPath } from "node:url";
+
+const docsRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), "..");
+const distDir = path.join(docsRoot, "dist");
+const siteDir = path.join(distDir, "docs");
+const sourceDir = path.join(docsRoot, "worker-assets");
+
+const exists = async (target) => {
+  try {
+    await stat(target);
+    return true;
+  } catch {
+    return false;
+  }
+};
+
+if (!(await exists(siteDir))) {
+  console.error(
+    `stage-worker-assets: ${path.relative(docsRoot, siteDir)} is missing. ` +
+      "Run `docusaurus build --out-dir dist/docs` first.",
+  );
+  process.exit(1);
+}
+
+await mkdir(distDir, { recursive: true });
+
+for (const name of ["_headers", "_redirects"]) {
+  await copyFile(path.join(sourceDir, name), path.join(distDir, name));
+  console.log(`stage-worker-assets: staged dist/${name}`);
+}
+
+if (process.env.DOCS_NOINDEX === "true") {
+  await writeFile(
+    path.join(distDir, "robots.txt"),
+    "# Preview deploy — never index this host.\nUser-agent: *\nDisallow: /\n",
+  );
+  console.log("stage-worker-assets: wrote dist/robots.txt (noindex preview)");
+}

--- a/docs/worker-assets/_headers
+++ b/docs/worker-assets/_headers
@@ -1,0 +1,46 @@
+# Cloudflare Workers Static Assets edge response headers for the docs site.
+# https://developers.cloudflare.com/workers/static-assets/headers/
+#
+# Paths here are PUBLIC URL paths, and the docs build is staged into dist/docs
+# so that the asset tree matches the /docs/ URL prefix. This file itself lives
+# at the assets root (dist/_headers); Cloudflare ignores it anywhere else, which
+# is why scripts/stage-worker-assets.mjs copies it up out of the build.
+#
+# A request that matches several rules INHERITS all of their headers, and a
+# header set by more than one matching rule is joined with a comma. Since every
+# path below also matches the `/*` rule at the bottom, each block first clears
+# the inherited `Cache-Control` (`! Cache-Control`) before setting its own —
+# otherwise assets would ship a malformed, dual-`max-age` header.
+
+# Content-hashed JS, CSS and images emitted by the Docusaurus build.
+/docs/assets/*
+  ! Cache-Control
+  Cache-Control: public, max-age=31536000, immutable
+
+# Copied verbatim from static/ — stable filenames, so revalidate weekly.
+/docs/img/*
+  ! Cache-Control
+  Cache-Control: public, max-age=604800, stale-while-revalidate=86400
+
+/docs/images/*
+  ! Cache-Control
+  Cache-Control: public, max-age=604800, stale-while-revalidate=86400
+
+/docs/examples/*
+  ! Cache-Control
+  Cache-Control: public, max-age=604800, stale-while-revalidate=86400
+
+# Both workers answer on a public *.workers.dev URL. The production build is
+# deliberately built WITHOUT DOCS_NOINDEX, because it is the real docs, so
+# without this rule a crawler could index agenta-docs.<subdomain>.workers.dev as
+# a duplicate of agenta.ai/docs. The rule is scoped to the workers.dev host, so
+# it never applies to agenta.ai.
+https://:worker.:subdomain.workers.dev/*
+  X-Robots-Tag: noindex
+
+# HTML pages and everything else — short TTL, stale-while-revalidate so readers
+# get a fast page and still see docs edits within the minute.
+/*
+  Cache-Control: public, max-age=60, stale-while-revalidate=3600
+  X-Content-Type-Options: nosniff
+  Referrer-Policy: strict-origin-when-cross-origin

--- a/docs/worker-assets/_redirects
+++ b/docs/worker-assets/_redirects
@@ -1,0 +1,8 @@
+# Cloudflare Workers Static Assets redirects for the docs site.
+# https://developers.cloudflare.com/workers/static-assets/redirects/
+#
+# The docs are staged under dist/docs, so the bare root of the assets directory
+# holds no page. In production the Worker only ever sees /docs* (that is its
+# route), so this rule exists for the preview and local `wrangler dev` hosts,
+# where opening the root should land on the docs home page.
+/ /docs 302

--- a/docs/wrangler.jsonc
+++ b/docs/wrangler.jsonc
@@ -1,0 +1,28 @@
+{
+  // Cloudflare Workers Static Assets config for the PREVIEW docs worker.
+  //
+  // The docs are a pure static Docusaurus build, so there is no Worker script:
+  // this config just tells one Worker to serve ./dist as plain assets.
+  // `pnpm run build:worker` writes the site into dist/docs so the file tree
+  // matches the public /docs/ URL prefix, which is what replaces the Vercel
+  // `/docs/:path*` rewrite we used to need.
+  //
+  // One worker serves every pull request: CI runs
+  // `wrangler versions upload --preview-alias pr-<n>` from
+  // .github/workflows/18-docs-preview.yml, so each PR gets a stable URL
+  // (https://pr-<n>-agenta-docs-preview.<subdomain>.workers.dev/docs) without
+  // touching this worker's own deployment, and nothing needs cleaning up.
+  "name": "agenta-docs-preview",
+  "compatibility_date": "2026-08-01",
+  // Required for `versions upload --preview-alias` to hand out a URL.
+  "preview_urls": true,
+  "assets": {
+    "directory": "./dist",
+    // Docusaurus emits foo/index.html and links to /docs/foo with no trailing
+    // slash, so drop-trailing-slash is the mode that serves those links
+    // directly. /docs/foo/ redirects to /docs/foo.
+    "html_handling": "drop-trailing-slash",
+    // Unknown paths render the generated Docusaurus 404 page.
+    "not_found_handling": "404-page"
+  }
+}

--- a/docs/wrangler.production.jsonc
+++ b/docs/wrangler.production.jsonc
@@ -1,0 +1,31 @@
+{
+  // Cloudflare Workers Static Assets config for the PRODUCTION docs worker.
+  // Same asset behaviour as wrangler.jsonc (the preview worker); the split
+  // exists so a preview upload can never touch production.
+  //
+  // Deployed by .github/workflows/19-docs-production.yml on every merge to main
+  // that touches docs/**.
+  //
+  // No `routes` block yet. The docs are still served through the older
+  // `new-docs-router` worker, which proxies agenta.ai/docs/* to Vercel. Cutover
+  // is a deliberate one-time swap: remove the agenta.ai/docs* route from
+  // new-docs-router and add these two routes here.
+  //
+  //   "routes": [
+  //     { "pattern": "agenta.ai/docs", "zone_name": "agenta.ai" },
+  //     { "pattern": "agenta.ai/docs/*", "zone_name": "agenta.ai" }
+  //   ]
+  //
+  // new-docs-router keeps the docs.agenta.ai -> agenta.ai/docs redirect and the
+  // combined /sitemap_index.xml; only its Vercel proxy rule goes away.
+  "name": "agenta-docs",
+  "compatibility_date": "2026-08-01",
+  // Production takes no per-version preview aliases; those live on the preview
+  // worker.
+  "preview_urls": false,
+  "assets": {
+    "directory": "./dist",
+    "html_handling": "drop-trailing-slash",
+    "not_found_handling": "404-page"
+  }
+}


### PR DESCRIPTION
## Context

The docs site is the last thing we host on Vercel. Vercel's GitHub integration builds it, and the whole setup lives in a dashboard, so the only trace of it in this repo is a four-line `docs/vercel.json`. Nobody can review the deploy, reproduce it, or change it from a pull request.

Docs pull requests also get no preview that a reviewer can open. You approve a wording change by reading the diff and hoping the page still builds.

The marketing site moved to Cloudflare Workers in July and that setup works well. This puts the docs on the same one.

## Changes

Two new workers, both plain static-asset workers with no worker code:

| Worker | Config | What it serves |
| --- | --- | --- |
| `agenta-docs` | `docs/wrangler.production.jsonc` | production |
| `agenta-docs-preview` | `docs/wrangler.jsonc` | one version per pull request |

Two workflows drive them, cloned from the marketing site's `15`/`16`: `18-docs-preview.yml` builds every pull request that touches `docs/**` and uploads it as a preview version, and `19-docs-production.yml` builds and deploys on merge to `main`.

The one real change to the site itself is where the build lands. Docusaurus writes the site to the root of `build/` while every link is prefixed `/docs/`, which is exactly what the Vercel rewrite existed to paper over:

```
"rewrites": [{ "source": "/docs/:path*", "destination": "/:path*" }]
```

`pnpm run build:worker` writes to `dist/docs` instead, so the file tree matches the URL tree and Cloudflare serves `/docs/anything` with no rule at all. `scripts/stage-worker-assets.mjs` then copies `_headers` and `_redirects` up to `dist/`, where Cloudflare reads them.

The preview comment updates in place on every push and deep-links the pages the branch touched:

```
### 📘 Docs preview

|  |  |
| --- | --- |
| Status | ✅ Ready |
| Preview | https://pr-1234-agenta-docs-preview.<subdomain>.workers.dev/docs |
| Inspect | Actions run |
| Commit | abc1234 |

**Pages changed in this pull request**
- [Quick start](.../docs/getting-started/quick-start)
```

The links are not guessed from file paths. Numeric prefixes, `slug:` frontmatter and versioned docs all break that. `scripts/changed-pages.mjs` reads the metadata Docusaurus writes during the build, which carries the real source path and permalink, and prints nothing at all rather than a wrong link.

Preview builds set `DOCS_NOINDEX=true`, which turns on Docusaurus `noIndex` and writes a disallow-all `robots.txt`, so a public `workers.dev` preview can never rank against the real docs.

**Nothing routes to the new production worker yet.** `agenta.ai/docs/*` still goes through the existing `new-docs-router` worker and on to Vercel. Merging this deploys `agenta-docs` to its `workers.dev` URL and changes no live traffic. Cutover is a separate step (below).

## Tests

Verified against a real preview deploy of this branch, `agenta-docs-preview`:

- `scripts/check-parity.mjs` requested all **950 URLs** from the live docs sitemap against the preview. All 950 returned 200. The only two redirects are the two version roots, `/docs/` and `/docs/1.0/`, which now 307 to the no-slash form.
- Cloudflare's asset router can treat a path segment containing a dot as a file name and skip the `index.html` lookup, which would have broken `/docs/1.0` and `/docs/self-host/upgrades/v0.100.3-migration`. Both return 200.
- The custom 404 page renders even though the site sits one level down in `dist/docs`.
- Cache headers land as intended and are not comma-joined: `max-age=31536000, immutable` on `/docs/assets/*`, one week on images, 60 s with `stale-while-revalidate` on HTML.
- Client-side redirect pages still bounce, for example `/docs/changelog/main`.
- `<meta name="robots" content="noindex, nofollow">` is present on the preview and `/robots.txt` disallows everything.
- `wrangler versions upload --preview-alias pr-0` produced the alias URL the workflow greps for. The first upload of the full 378 MB build took 35 seconds; the second took 6, because wrangler only sends changed files.
- Build wall time is 1 minute 33 seconds locally.
- Rendered both the home page and a deep page in a browser. Layout, images, sidebar and search all fine.

## Before merging

`POSTHOG_API_KEY` currently lives in the Vercel project settings. It needs to exist as a GitHub repo secret of the same name, or docs analytics goes quiet when we cut over. PostHog project keys are ingest-only and public by design, so this is about not losing the value, not about secrecy.

## Cutover, after this merges

1. Run `node docs/scripts/check-parity.mjs https://agenta-docs.<subdomain>.workers.dev` against the deployed production worker.
2. In one sitting, remove the `agenta.ai/docs*` route from `new-docs-router` and add `agenta.ai/docs` and `agenta.ai/docs/*` to `agenta-docs`. Two workers cannot hold the same route, so this is a single swap. The commented-out `routes` block in `wrangler.production.jsonc` has the exact patterns.
3. Re-run the parity check against `https://agenta.ai`, and confirm `docs.agenta.ai` still redirects and `/sitemap_index.xml` still lists both sitemaps. `new-docs-router` keeps owning both; only its Vercel proxy rule goes away.
4. Rolling back takes under two minutes: drop the two routes and restore the old one. The Vercel proxy code is untouched.
5. After a couple of quiet weeks, delete `docs/vercel.json` and the Vercel project.

## Not in this pull request

Fork pull requests get no preview, because they cannot read the deploy secrets. Two of the last sixty docs pull requests came from forks. The safe pattern (build without secrets, upload an artifact, deploy from a `workflow_run` job) is a follow-up if we decide we want it.
