### PR TITLE
docs(contributing): Require demo screenshots from the running app

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -16,10 +16,21 @@
 
 ## Demo
 <!-- Required for UI changes. Add screenshots, GIFs, or a short video. -->
-<!-- If this is not a UI change, write N/A. -->
+<!--
+  Screenshots must come from the real app running your branch.
+
+  Run it locally (see AGENTS.md -> "Local dev loop"), open the screen you changed, and capture it there.
+
+  Do NOT paste mock-ups: a standalone HTML page, an isolated component harness,
+  or any UI recreated by hand or by an agent to imitate the screen. A picture
+  that resembles the app but was not produced by the app is not a demo -- it
+  proves nothing about this change and hides real layout, theme, and data bugs.
+
+  If you cannot run the app having issues then contact with the team instead of substituting a mock-up.
+-->
 
 ## Checklist
-- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A
+- [ ] Demo shows the real app running this branch (not a mock-up or recreated UI), or is marked N/A
 - [ ] Relevant tests pass locally
 - [ ] Relevant linting and formatting pass locally
 - [ ] I have signed the CLA, or I will sign it when the bot prompts me

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -26,11 +26,21 @@ Before you request review, make sure your pull request:
 - notes what still needs QA
 - passes the relevant formatting, linting, and test checks locally
 
+### Demo screenshots for UI changes
+
+Screenshots and recordings must come from the real Agenta app running your branch. Start the app locally, open the screen you changed, and capture it there.
+
+Do not submit mock-ups: a standalone HTML page, an isolated component harness, or any UI recreated by hand or by an AI agent to imitate the screen. A picture that resembles the app but was not produced by the app proves nothing about the change, and it hides the layout, theme, and data problems a reviewer needs to see.
+
+If you cannot run the app, say so in the pull request instead of substituting a mock-up.
+
+This applies to AI coding agents as well. If you use one to write the change, it must run the app and capture the real screens.
+
 ## Contribution Rules
 
 We had many inactive issues and pull requests in the past. To keep work moving:
 
-- An issue may only be assigned to one person for up to one week (three days for very simple issues). If the issue remains unsolved after a week, it will be unassigned and made available to others.
+- An assigned issue must show progress within two days. If there is no visible activity, such as a comment with an update, a draft pull request, or a question about the issue, it will be unassigned and made available to others.
 - Any pull request left inactive by the author for over a week may be closed. The author can reopen it later and continue the work.
 
 ## Contributor License Agreement


### PR DESCRIPTION
## Context

UI pull requests keep arriving with screenshots that were never taken from Agenta. Contributors, and more often the AI coding agents they run, build a small standalone page that imitates the screen, capture that, and attach it as the demo. The picture looks plausible and proves nothing: it cannot show a layout break at a real breakpoint, a theme token that resolves wrong, or a row that overflows once real data fills it. Reviewers then approve on the strength of an image the change never produced.

Nothing in the repo said not to do this. The PR template asked for "screenshots, GIFs, or a short video" and left the source open.

## Changes

The Demo section of the PR template now carries an instruction block that both humans and agents read when they fill the template in. It says screenshots must come from the real app running the branch, points at the local dev loop in `AGENTS.md`, and names what does not count: a standalone HTML page, an isolated component harness, or any UI recreated by hand or by an agent. If the contributor cannot run the app, the template tells them to say so rather than substitute a mock-up.

The demo checklist item changed to match, so ticking it is a claim about the source of the image:

Before:
`- [ ] I have included a video or screen recording for UI changes, or marked Demo as N/A`

After:
`- [ ] Demo shows the real app running this branch (not a mock-up or recreated UI), or is marked N/A`

`CONTRIBUTING.md` gets the same rule as a short "Demo screenshots for UI changes" section under Pull Requests, with the reasoning spelled out and an explicit line that it applies to AI coding agents too.

The same file also tightens the issue assignment window. It was one week to solve the issue, three days for simple ones, which meant an assigned issue could sit untouched for a week before anyone could pick it up. It is now two days to show visible progress: a comment with an update, a draft pull request, or a question about the issue. No activity in that window and the issue goes back to the pool.

## Notes

Docs only. No code paths touched.

The template comments are HTML comments, so they stay invisible in the rendered PR body and disappear when the author writes over them.
