### PR TITLE
[fix] scrolling on the Agents page

### DIFF
--- a/web/oss/src/components/pages/agents/AgentsPage.tsx
+++ b/web/oss/src/components/pages/agents/AgentsPage.tsx
@@ -114,12 +114,18 @@ export default function AgentsPage() {
                     </Link>
                 </div>
 
-                <AgentsGrid
-                    rows={rows}
-                    isLoading={isLoading}
-                    actions={cardActions}
-                    onCreate={handleCreate}
-                />
+                {/* /agents is a full-height route, so the layout frame is bounded and
+                    `overflow-hidden`: without a scroller of its own the roster was simply
+                    clipped at the frame's bottom edge. The table this grid replaced scrolled
+                    internally, which is where the page's scrolling used to come from. */}
+                <div className="min-h-0 flex-1 overflow-y-auto">
+                    <AgentsGrid
+                        rows={rows}
+                        isLoading={isLoading}
+                        actions={cardActions}
+                        onCreate={handleCreate}
+                    />
+                </div>
             </PageLayout>
         )
 


### PR DESCRIPTION
## Context

The Agents page could not scroll. Any agent past the first two rows was unreachable: the roster simply stopped at the bottom edge of the window with no scrollbar and no response to the wheel.

`/agents` is registered as a full-height route in `Layout.tsx`, so the shell gives it a bounded frame with `overflow-hidden`. That was correct while the page rendered an `InfiniteVirtualTable`, which scrolled internally. The page later moved to the card roster (`AgentsGrid`), and the grid brought no scroller of its own, so the content had nothing to scroll inside and was clipped instead.

## Changes

The grid now sits in its own bounded scroll container inside `PageLayout`, so the title and the toolbar stay put and only the roster scrolls.

Before:

```tsx
<PageLayout className={clsx(pageContentWidthClass, "grow min-h-0")} title="Agents">
    <div className="flex items-center gap-3">…toolbar…</div>
    <AgentsGrid … />
</PageLayout>
```

After:

```tsx
<PageLayout className={clsx(pageContentWidthClass, "grow min-h-0")} title="Agents">
    <div className="flex items-center gap-3">…toolbar…</div>
    <div className="min-h-0 flex-1 overflow-y-auto">
        <AgentsGrid … />
    </div>
</PageLayout>
```

This is the same pattern the sessions page already uses inside the same full-height frame, and it matches what the page's own rail branch (`NEXT_PUBLIC_AGENT_BROWSE_RAIL=true`) does with `contentClassName="overflow-y-auto …"`. Only the default branch changed.

## Tests / notes

- Local browser verification was not possible: the working tree currently fails to build for unrelated reasons (`pushToTalkLabel` is no longer exported from `@agenta/shared/utils`, and `@agenta/navigation`'s `registry.ts` trips the headless-package lint rule). Neither is touched by this PR.
- The archived agents page is unaffected. It still renders `InfiniteVirtualTableFeatureShell`, which scrolls internally.

## What to QA

- Open Agents in a project with more agents than fit on one screen. Scroll. The roster scrolls and the last row and the dashed "New agent" cell are reachable.
- The page title, the "New agent" button, the search box and the "Archived agents" link stay fixed while the cards scroll under them.
- Scroll to the very top. The avatars overhanging each card's top edge are not clipped by the scroll edge.
- Search for a name so only one or two cards match. The short list does not gain a scrollbar and the layout does not jump.
- Regression: open Archived agents. That table still scrolls and paginates as before.