### PR TITLE
chore: temporary contributor conflict resolution

### DIFF
--- a/.github/.pr-6289-resolution
+++ b/.github/.pr-6289-resolution
@@ -1,0 +1,1 @@
+# temporary conflict-resolution branch


### PR DESCRIPTION
Temporary draft used to regenerate the contributor files from current main while resolving conflicts in #6289. This will be closed and deleted after the original pull request is updated.