### PR TITLE
[fix] Reconnect the playground session keyboard shortcuts

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -13,6 +13,7 @@ import {
 import {chatPanelMaximizedAtom, configPanelCollapsedAtom} from "@agenta/chat/state"
 import {workflowMolecule} from "@agenta/entities/workflow"
 import {DriveSessionProvider} from "@agenta/entity-ui/drive"
+import {workflowRevisionDrawerOpenAtom} from "@agenta/playground-ui/workflow-revision-drawer"
 import {
     pendingSessionOpensAtom,
     removePendingSessionOpensAtom,
@@ -33,6 +34,8 @@ import OpenFilesPaneButton from "./components/OpenFilesPaneButton"
 import RightPanelSplit from "./components/RightPanel/RightPanelSplit"
 import SessionHistoryMenu from "./components/SessionHistoryMenu"
 import ShowConfigPanelButton from "./components/ShowConfigPanelButton"
+import {useSessionActions} from "./hooks/useSessionActions"
+import {useSessionShortcuts} from "./hooks/useSessionShortcuts"
 import {useReconcileServerSessions} from "./state/projectSessions"
 import {
     FILES_PANE_MAX,
@@ -40,7 +43,7 @@ import {
     filesPaneWidthAtom,
     PANES_COEXIST_MIN_WINDOW,
 } from "./state/rightPanel"
-import {useChatScopeKey} from "./state/scope"
+import {isDrawerScopeKey, useChatScopeKey} from "./state/scope"
 import {
     activeSessionIdAtomFamily,
     addSessionAtomFamily,
@@ -51,6 +54,11 @@ import {
     sessionsListAtomFamily,
     setActiveSessionAtomFamily,
 } from "./state/sessions"
+import {
+    focusComposerRequestAtom,
+    renameSessionRequestAtom,
+    sessionSearchRequestAtom,
+} from "./state/uiRequests"
 
 // The frame itself is a thin, synchronous shell (Splitter + Tabs + region slots) so the real
 // structure paints in the first frame. Only the heavy leaves are lazy: the conversation body
@@ -121,6 +129,7 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
     // enrich titles, drop remotely-deleted) — the scope key is the agent's appId (artifact id).
     useReconcileServerSessions(scope)
     const chatMaximized = useAtomValue(chatPanelMaximizedAtom)
+    const setChatMaximized = useSetAtom(chatPanelMaximizedAtom)
     const configPanelCollapsed = useAtomValue(configPanelCollapsedAtom)
     const setConfigPanelCollapsed = useSetAtom(configPanelCollapsedAtom)
     // The rail pane is `size={0}` + `inert` until maximized, so mounting it on boot renders the
@@ -186,6 +195,56 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
 
     // Tolerate a stale active id (its tab was closed) by falling back to the first tab.
     const activeId = sessions.some((s) => s.id === rawActiveId) ? rawActiveId : sessions[0]?.id
+
+    // Keyboard shortcuts. Switch and rename happen inside per-session components, so they travel as
+    // requests on the shared atoms. The drawer mounts a second panel over this one, so exactly one
+    // of the two listens; onboarding hides the bar entirely and allows a single session.
+    const {setArchived} = useSessionActions()
+    const requestComposerFocus = useSetAtom(focusComposerRequestAtom)
+    const requestRename = useSetAtom(renameSessionRequestAtom)
+    const requestSessionSearch = useSetAtom(sessionSearchRequestAtom)
+    const drawerOpen = useAtomValue(workflowRevisionDrawerOpenAtom)
+    useSessionShortcuts({
+        sessions,
+        activeId,
+        enabled: !chromeHidden && isDrawerScopeKey(scope) === drawerOpen,
+        onJump: useCallback(
+            (id: string) => {
+                setActiveSession(id)
+                requestComposerFocus({scope, sessionId: id, nonce: Date.now()})
+            },
+            [scope, setActiveSession, requestComposerFocus],
+        ),
+        onRename: useCallback(
+            (id: string) => requestRename({scope, sessionId: id, nonce: Date.now()}),
+            [scope, requestRename],
+        ),
+        onArchive: useCallback(
+            (id: string) => {
+                const session = sessions.find((s) => s.id === id)
+                if (session) void setArchived({sessionId: id, appId: scope, name: session.title})
+            },
+            [sessions, scope, setArchived],
+        ),
+        onNewSession: useCallback(() => {
+            if (!addLocked) addSession()
+        }, [addLocked, addSession]),
+        onCloseSession: closeSession,
+        // Toggles: the list opens with the caret already in the search box, and the same key puts
+        // it away.
+        onSearch: useCallback(() => {
+            if (chatMaximized) {
+                setChatMaximized(false)
+                return
+            }
+            setChatMaximized(true)
+            requestSessionSearch({scope, nonce: Date.now()})
+        }, [chatMaximized, scope, setChatMaximized, requestSessionSearch]),
+        onToggleConfigPanel: useCallback(
+            () => setConfigPanelCollapsed(!configPanelCollapsed),
+            [configPanelCollapsed, setConfigPanelCollapsed],
+        ),
+    })
 
     // Docked Files pane — a full-height sibling of the WHOLE chat column (session bar included),
     // like the config pane on the other side: its divider runs to the top and the session bar

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -56,6 +56,7 @@ import {useComposerDraft} from "./hooks/useComposerDraft"
 import {useFirstRunSeed} from "./hooks/useFirstRunSeed"
 import {useOnboardingChat} from "./hooks/useOnboardingChat"
 import {useScrollIntent} from "./hooks/useScrollIntent"
+import {isAltChord, isOverlayOpen} from "./hooks/useSessionShortcuts"
 import {useTranscriptScroll} from "./hooks/useTranscriptScroll"
 import {useTurnInspector} from "./hooks/useTurnInspector"
 import {useVirtuosoTranscript} from "./hooks/useVirtuosoTranscript"
@@ -66,6 +67,7 @@ import {
     bumpSessionActivityAtomFamily,
     firstUserText,
 } from "./state/sessions"
+import {focusComposerRequestAtom, matchesSessionRequest} from "./state/uiRequests"
 
 /**
  * One agent conversation for a single session tab. A `useChat` whose transport is fed by the
@@ -410,6 +412,47 @@ const AgentConversation = ({
         submit({text: pendingRun.text})
         setPendingRun(null)
     }, [pendingRun, activeSessionId, sessionId, submit, setPendingRun])
+
+    // Run-level shortcuts. They live here, not in the panel's session hook, because only this
+    // conversation knows whether a run is in flight and what it is waiting on. Bubble phase, so an
+    // open picker or dialog that stops propagation still gets Escape first.
+    useEffect(() => {
+        if (activeSessionId !== sessionId) return
+        const onKey = (e: KeyboardEvent) => {
+            if (isOverlayOpen()) return
+            // An IME user presses Escape to cancel composition, not to stop the run.
+            if (e.key === "Escape" && !e.isComposing && busyRef.current) {
+                e.preventDefault()
+                handleStop()
+                return
+            }
+            // Approve answers ONE gate, never the dock's "Approve all": a mis-press should not
+            // grant a tool the user never read.
+            if (isAltChord(e) && e.code === "KeyG" && pendingApprovals.length > 0) {
+                e.preventDefault()
+                handleApprovalResponse({id: pendingApprovals[0].approvalId, approved: true})
+            }
+        }
+        document.addEventListener("keydown", onKey)
+        return () => document.removeEventListener("keydown", onKey)
+    }, [activeSessionId, sessionId, busyRef, handleStop, pendingApprovals, handleApprovalResponse])
+
+    // A keyboard switch (Alt+1…9 / Alt+Z / Alt+X) lands the caret here. antd mounts a never-visited
+    // pane only on activation, so this effect runs on that mount and a first-visit switch focuses
+    // too. The frame claims the nonce, not the effect body: StrictMode replays the mount, and
+    // claiming it up front would leave the replay with nothing to do.
+    const focusRequest = useAtomValue(focusComposerRequestAtom)
+    const consumedFocusNonceRef = useRef<number | null>(null)
+    useEffect(() => {
+        if (!matchesSessionRequest(focusRequest, scopeKey, sessionId)) return
+        const {nonce} = focusRequest
+        if (consumedFocusNonceRef.current === nonce) return
+        requestAnimationFrame(() => {
+            if (consumedFocusNonceRef.current === nonce) return
+            consumedFocusNonceRef.current = nonce
+            richInputRef.current?.focus()
+        })
+    }, [focusRequest, scopeKey, sessionId])
 
     // Exactly one scroll engine owns the transcript: Virtuoso when it's enabled in the playground
     // settings, the SC-1..4 DOM engine otherwise (each bails on the other's flag). Both act on the

--- a/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
@@ -37,7 +37,7 @@ import {
     sessionHistoryAtomFamily,
     unarchiveSessionAtomFamily,
 } from "../state/sessions"
-import {sessionSearchRequestAtom} from "../state/uiRequests"
+import {renameSessionRequestAtom, sessionSearchRequestAtom} from "../state/uiRequests"
 
 import SessionTabLabel, {type SessionTabLabelHandle} from "./SessionTabLabel"
 import {SessionStatusDot} from "./SessionTagBar"
@@ -319,6 +319,12 @@ const SessionRail = ({activeId, addDisabled = false, className}: SessionRailProp
         searchRef.current?.focus()
         searchRef.current?.select()
     }, [searchRequest, scope])
+    // A filtered-out active session has no row, so its rename consumer never mounts. Clear the
+    // filter when Alt+R names a session this rail is meant to answer.
+    const renameRequest = useAtomValue(renameSessionRequestAtom)
+    useEffect(() => {
+        if (renameRequest?.scope === scope) setQuery("")
+    }, [renameRequest, scope])
     const [showArchived, setShowArchived] = useState(false)
     const q = query.trim().toLowerCase()
     // `openSession`/`deleteSession`/`archiveSession`/`unarchiveSession` are already stable id-taking

--- a/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
@@ -1,4 +1,4 @@
-import {memo, useCallback, useRef, useState} from "react"
+import {memo, useCallback, useEffect, useRef, useState} from "react"
 
 import {sessionMessagesAtom} from "@agenta/chat/state"
 import {useSessionPins} from "@agenta/sessions/state"
@@ -20,6 +20,7 @@ import {useAtomValue, useSetAtom} from "jotai"
 import {AnimatePresence, MotionConfig, motion} from "motion/react"
 
 import {ROW_VARIANTS, SESSION_SPRING} from "../assets/sessionMotion"
+import {useInlineRenameRequest} from "../hooks/useInlineRenameRequest"
 import {useChatScopeKey} from "../state/scope"
 import {
     type AgentChatSession,
@@ -36,6 +37,7 @@ import {
     sessionHistoryAtomFamily,
     unarchiveSessionAtomFamily,
 } from "../state/sessions"
+import {sessionSearchRequestAtom} from "../state/uiRequests"
 
 import SessionTabLabel, {type SessionTabLabelHandle} from "./SessionTabLabel"
 import {SessionStatusDot} from "./SessionTagBar"
@@ -88,6 +90,7 @@ const SessionRailRow = memo(function SessionRailRow({
     archived = false,
 }: SessionRailRowProps) {
     const labelRef = useRef<SessionTabLabelHandle>(null)
+    useInlineRenameRequest(session.id, labelRef, "rail")
     // Hide the action cluster while the inline rename input owns the row, so it gets full width.
     const [renaming, setRenaming] = useState(false)
     // The rename/delete cluster is hover-only. Mount it on hover/focus instead of rendering it
@@ -308,6 +311,14 @@ const SessionRail = ({activeId, addDisabled = false, className}: SessionRailProp
     // so pinning here reorders those surfaces too (and vice versa).
     const {isPinned, toggle: togglePin} = useSessionPins()
     const [query, setQuery] = useState("")
+    // Alt+F focuses the box. Scope-matched: the drawer's rail must not answer the playground's.
+    const searchRef = useRef<HTMLInputElement>(null)
+    const searchRequest = useAtomValue(sessionSearchRequestAtom)
+    useEffect(() => {
+        if (searchRequest?.scope !== scope) return
+        searchRef.current?.focus()
+        searchRef.current?.select()
+    }, [searchRequest, scope])
     const [showArchived, setShowArchived] = useState(false)
     const q = query.trim().toLowerCase()
     // `openSession`/`deleteSession`/`archiveSession`/`unarchiveSession` are already stable id-taking
@@ -377,6 +388,7 @@ const SessionRail = ({activeId, addDisabled = false, className}: SessionRailProp
                 <div className="shrink-0 px-2 pt-2">
                     <SearchInput
                         allowClear
+                        ref={searchRef}
                         value={query}
                         onChange={(e) => setQuery(e.target.value)}
                         placeholder="Search sessions"

--- a/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
@@ -14,6 +14,7 @@ import {useAtomValue, useSetAtom} from "jotai"
 import {AnimatePresence, MotionConfig} from "motion/react"
 
 import {SESSION_SPRING, TAG_VARIANTS} from "../assets/sessionMotion"
+import {useInlineRenameRequest} from "../hooks/useInlineRenameRequest"
 import {useSessionActions, type SessionMenuItem} from "../hooks/useSessionActions"
 import {type SessionDotStatus, sessionDotStatusAtomFamily} from "../state/liveness"
 import {useChatScopeKey} from "../state/scope"
@@ -127,6 +128,7 @@ const SessionTag = memo(function SessionTag({
     const label = session.title || text || `Chat ${index + 1}`
     const tabRef = useRef<HTMLDivElement>(null)
     const labelRef = useRef<SessionTabLabelHandle>(null)
+    useInlineRenameRequest(session.id, labelRef, "strip")
     // Hide the hover actions while the inline rename input owns the row. The chip itself owns the
     // hover/focus state that decides whether they're mounted at all (see SessionTab).
     const [renaming, setRenaming] = useState(false)


### PR DESCRIPTION
## Context

Every keyboard shortcut in the agent playground stopped working. Pressing `⌥1`, `⌥Z`, `⌥C`, `⌥R` or any of the others does nothing at all, and `Escape` no longer stops a running response.

The carve merge that shipped with v0.113.0 dropped every call site while leaving the modules behind. `useSessionShortcuts.ts`, `useInlineRenameRequest.ts` and `uiRequests.ts` are all still in `main` with zero callers. `AgentChatPanel` no longer calls the hook, `AgentConversation` lost its consumers, and `SessionRail` stopped answering the search request.

CI never caught it because the tests exercise the hooks directly rather than the wiring. All 21 of them pass against code nothing calls.

## Changes

Reconnects the four consumers. No new behaviour, no new keys.

`AgentChatPanel` calls `useSessionShortcuts` again and supplies the handlers, so `⌥1`-`⌥9`, `⌥Z`, `⌥X`, `⌥C`, `⌥W`, `⌥R`, `⌥A`, `⌥F` and `⌥B` fire. The single-owner rule comes back with it: when the revision drawer is open its panel owns the keyboard, otherwise the playground's does.

`AgentConversation` consumes the composer-focus request, so the caret lands in the destination session after a switch. It also regains `Escape` to stop a run and `⌥G` to approve a pending tool call. Both live here because only this component knows whether a run is in flight. `⌥G` answers one gate, never the dock's "Approve all".

`SessionRail` focuses its search box on the scoped `⌥F` request. `SessionRail` and `SessionTagBar` answer the inline-rename request again, so `⌥R` opens the same editor a double-click opens.

One small fix along the way: `setConfigPanelCollapsed` no longer accepts an updater function after the atom moved to `@agenta/chat/state`, so `⌥B` reads the current value instead.

## Tests

- `pnpm lint-fix` clean, `types:check` clean, and the 21 existing shortcut tests pass.
- Verified in a running playground rather than only in tests, since the bug was that the wiring was missing and the tests cannot see it.

## What to QA

Open an agent playground with a couple of sessions.

- `⌥C` opens a new session. `⌥W` closes the active one, and refuses on the last remaining session.
- `⌥X` and `⌥Z` step forward and back through the tabs and wrap at both ends. The caret lands in the destination composer each time.
- `⌥2` jumps to the second tab. Try one you have never opened; it should still land focused, because that pane mounts lazily.
- `⌥R` opens the inline rename on the active chip. Enter commits, Escape reverts. `⌥A` archives and the next tab takes over.
- `⌥F` opens the session list with the caret in the search box, and again puts it away. `⌥B` toggles the config panel.
- Send a message, then press `Escape` mid-stream. The run stops. Press `Escape` with nothing running and nothing happens.
- Trigger a tool that needs approval and press `⌥G`. One gate is approved. If the turn asked for several, the rest still wait.
- Regression: open the rename confirm from a chip's right-click menu and press `⌥2` while it is up. Nothing should happen.
- Regression: open the workflow revision drawer over the playground. The shortcuts drive the drawer's sessions, not the ones behind it.

## Notes for the reviewer

`feat/keyboard-shortcut-registry` restores three of these four call sites on top of a new shortcut catalog, and its own commit message records that the composer-focus consumer was still missing. This PR is the standalone fix so it can ship to production without waiting for the catalog. If the registry lands first, expect a conflict in `AgentChatPanel`, `SessionRail` and `SessionTagBar`, and keep the registry's version plus the `AgentConversation` consumers from here.

Shortcut hints are not restored here. `menuItems` lost its `shortcuts` option in the refactor, and the registry branch owns hint rendering.
