### PR TITLE
[fix] Resolve the invoke URL from the agenta URI, not a stale stored origin

### DIFF
--- a/web/packages/agenta-chat/src/transport/resolveInvocationUrl.ts
+++ b/web/packages/agenta-chat/src/transport/resolveInvocationUrl.ts
@@ -2,41 +2,18 @@
  * Resolve an agent's invoke endpoint from workflow references alone — ONE Fern revision fetch,
  * no molecule hydration. Pairs with `buildAgentResumeRequest` for the lite resume path.
  *
- * The URL rule mirrors `@agenta/entities` `workflow/state/runnableSetup.ts`
- * (`invocationUrlAtomFamily`): prefer the stored `data.url`, else build from the agenta
- * `data.uri` (`agenta:{kind}:{key}:{version}` → `{origin}/services/{key}/{version}`), then
- * append `/invoke`. Kept local because the state atom needs a seeded molecule store.
+ * The URL rule is `@agenta/entities`' `resolveServiceUrl` — the SAME function the playground's
+ * `invocationUrlAtomFamily` calls, not a copy of it. It used to be a copy, and the copy drifted:
+ * both preferred a stored `data.url` whose origin is stamped at creation, so a deployment that
+ * moved its public URL sent every invoke to a host that no longer served it.
  */
-import {retrieveWorkflowRevision} from "@agenta/entities/workflow"
-import {getAgentaApiUrl} from "@agenta/shared/api"
-
-/** `agenta:{kind}:{key}:{version}` → `{origin}/services/{key}/{version}`, or null. */
-const serviceUrlFromUri = (uri: string | null | undefined): string | null => {
-    if (!uri || !uri.startsWith("agenta:")) return null
-    const apiUrl = getAgentaApiUrl()
-    if (!apiUrl) return null
-    const origin = apiUrl.replace(/\/api\/?$/, "")
-    const parts = uri.replace(/^agenta:/, "").split(":")
-    if (parts.length < 3) return null
-    const [, ...rest] = parts
-    return `${origin}/services/${rest.join("/")}`
-}
-
-/** Strip trailing '/' in a single linear scan — NOT `/\/+$/`, whose end-anchored `+` backtracks
- * quadratically on a backend-supplied URL with many '/' (CodeQL polynomial-ReDoS). `47` is '/'. */
-const stripTrailingSlashes = (s: string): string => {
-    let end = s.length
-    while (end > 0 && s.charCodeAt(end - 1) === 47) end--
-    return end === s.length ? s : s.slice(0, end)
-}
+import {resolveServiceUrl, retrieveWorkflowRevision} from "@agenta/entities/workflow"
 
 /** Apply the `data.url|uri → /invoke` rule to a fetched revision. Exported for tests. */
 export const invocationUrlFromRevisionData = (
     data: {url?: string | null; uri?: string | null} | null | undefined,
 ): string | null => {
-    // `!= null` not a truthiness check: an empty `data.url` must NOT fall back to `uri`.
-    const serviceUrl =
-        data?.url != null ? stripTrailingSlashes(data.url) : serviceUrlFromUri(data?.uri)
+    const serviceUrl = resolveServiceUrl(data)
     return serviceUrl ? `${serviceUrl}/invoke` : null
 }
 

--- a/web/packages/agenta-chat/tests/unit/transport/resolveInvocationUrl.test.ts
+++ b/web/packages/agenta-chat/tests/unit/transport/resolveInvocationUrl.test.ts
@@ -4,9 +4,17 @@ import {beforeEach, describe, expect, it, vi} from "vitest"
 // URL rule is tested hermetically (no molecule store, no network).
 let revisionResult: {data?: {url?: string | null; uri?: string | null} | null} | null
 const retrieveWorkflowRevision = vi.fn(async () => revisionResult)
-vi.mock("@agenta/entities/workflow", () => ({
-    retrieveWorkflowRevision: (...args: unknown[]) => retrieveWorkflowRevision(...args),
-}))
+// `resolveServiceUrl` is NOT stubbed — it is the rule under test, imported from entities so the
+// playground and this transport can never drift apart again. Only the network call is a stub.
+vi.mock("@agenta/entities/workflow", async () => {
+    const {resolveServiceUrl} = await vi.importActual<
+        typeof import("@agenta/entities/workflow/state/helpers")
+    >("../../../../agenta-entities/src/workflow/state/helpers")
+    return {
+        resolveServiceUrl,
+        retrieveWorkflowRevision: (...args: unknown[]) => retrieveWorkflowRevision(...args),
+    }
+})
 vi.mock("@agenta/shared/api", () => ({
     getAgentaApiUrl: () => "https://host/api",
 }))
@@ -15,10 +23,29 @@ const {invocationUrlFromRevisionData, resolveInvocationUrl} =
     await import("../../../src/transport/resolveInvocationUrl")
 
 describe("invocationUrlFromRevisionData", () => {
-    it("prefers the stored url, trimming trailing slashes", () => {
+    it("keeps a stored url when no agenta uri claims the revision", () => {
         expect(invocationUrlFromRevisionData({url: "https://host/services/agent/"})).toBe(
             "https://host/services/agent/invoke",
         )
+    })
+
+    // The reported break: a self-hosted stack served agenta on :80, then moved to :8081. Every
+    // revision still carried the :80 origin stamped at creation, and preferring it sent each
+    // invoke to whatever now answers on :80 — surfacing only as `TypeError: Failed to fetch`.
+    it("rebuilds the origin from the agenta uri when the stored url has gone stale", () => {
+        expect(
+            invocationUrlFromRevisionData({
+                url: "http://localhost/services/agent/v0",
+                uri: "agenta:builtin:agent:v0",
+            }),
+        ).toBe("https://host/services/agent/v0/invoke")
+        // Same for a `custom`-kind managed service — the kind segment names the path, not the host.
+        expect(
+            invocationUrlFromRevisionData({
+                url: "http://localhost/services/feedback/v0",
+                uri: "agenta:custom:feedback:v0",
+            }),
+        ).toBe("https://host/services/feedback/v0/invoke")
     })
 
     it("builds from an agenta uri when there is no url (kind segment stripped)", () => {

--- a/web/packages/agenta-entities/src/workflow/index.ts
+++ b/web/packages/agenta-entities/src/workflow/index.ts
@@ -461,6 +461,7 @@ export {
     requestPayloadAtomFamily,
     // Helpers
     resolveBuiltinAppServiceUrl,
+    resolveServiceUrl,
 } from "./state"
 
 // ============================================================================

--- a/web/packages/agenta-entities/src/workflow/state/helpers.ts
+++ b/web/packages/agenta-entities/src/workflow/state/helpers.ts
@@ -188,6 +188,39 @@ export function buildServiceUrlFromUri(uri: string | null | undefined): string |
     return `${origin}/services/${rest.join("/")}`
 }
 
+/** Strip trailing '/' in a single linear scan — NOT `/\/+$/`, whose end-anchored `+` backtracks
+ * quadratically on a backend-supplied URL with many '/' (CodeQL polynomial-ReDoS). `47` is '/'. */
+const stripTrailingSlashes = (s: string): string => {
+    let end = s.length
+    while (end > 0 && s.charCodeAt(end - 1) === 47) end--
+    return end === s.length ? s : s.slice(0, end)
+}
+
+/**
+ * The service URL to call for a workflow revision — the ONE rule every invoke path uses.
+ *
+ * An `agenta:` URI means the service is agenta-MANAGED: it lives at THIS deployment's origin, at
+ * the path the URI itself names. So the URI wins over `data.url`, whose origin is stamped once at
+ * creation and goes stale the moment the deployment's public URL moves — a self-hosted stack off
+ * port 80, a migrated domain. A stale origin is not a degraded URL, it is a different server: the
+ * invoke lands somewhere else entirely and surfaces as a bare `TypeError: Failed to fetch`.
+ *
+ * A revision with NO agenta URI keeps `data.url` verbatim. That one names a service this
+ * deployment does not host, so its origin belongs to whoever set it.
+ *
+ * A url that is PRESENT but empty (or all slashes) stays an explicit "no service" and resolves to
+ * null rather than falling through to the URI — the distinction `data.url != null` has always
+ * drawn, kept here so this rule is a strict fix rather than a semantic change.
+ */
+export function resolveServiceUrl(
+    data: {url?: string | null; uri?: string | null} | null | undefined,
+): string | null {
+    const rawUrl = data?.url
+    const trimmed = rawUrl != null ? stripTrailingSlashes(rawUrl) : null
+    if (rawUrl != null && !trimmed) return null
+    return buildServiceUrlFromUri(data?.uri) ?? trimmed
+}
+
 /**
  * Resolve the correct service URL for a builtin (non-custom) app workflow.
  *

--- a/web/packages/agenta-entities/src/workflow/state/index.ts
+++ b/web/packages/agenta-entities/src/workflow/state/index.ts
@@ -178,6 +178,7 @@ export {
     appOpenApiSchemaAtomFamily,
     // Helpers
     resolveBuiltinAppServiceUrl,
+    resolveServiceUrl,
 } from "./runnableSetup"
 
 // ============================================================================

--- a/web/packages/agenta-entities/src/workflow/state/runnableSetup.ts
+++ b/web/packages/agenta-entities/src/workflow/state/runnableSetup.ts
@@ -48,7 +48,7 @@ import {
     type Workflow,
 } from "../core/schema"
 
-import {buildServiceUrlFromUri, resolveBuiltinAppServiceUrl} from "./helpers"
+import {resolveBuiltinAppServiceUrl, resolveServiceUrl} from "./helpers"
 import {
     workflowAppSchemaAtomFamily,
     workflowBaseEntityAtomFamily,
@@ -59,7 +59,7 @@ import {
 } from "./store"
 
 // Re-export for external consumers
-export {resolveBuiltinAppServiceUrl} from "./helpers"
+export {resolveBuiltinAppServiceUrl, resolveServiceUrl} from "./helpers"
 
 // ============================================================================
 // HELPERS
@@ -238,8 +238,8 @@ export const appOpenApiSchemaAtomFamily = atomFamily((workflowId: string) =>
  * Invocation URL for workflow execution.
  *
  * Calls `POST {serviceUrl}/invoke` directly on the service dispatcher,
- * mirroring how `/inspect` works. The service URL is resolved from
- * `data.url` (stored) or built from `data.uri` via `buildServiceUrlFromUri`.
+ * mirroring how `/inspect` works. The service URL comes from `resolveServiceUrl`
+ * (agenta URI first, so a stale stored origin can't send the call elsewhere).
  *
  * Unified for all workflow types (apps and evaluators).
  */
@@ -248,9 +248,9 @@ export const invocationUrlAtomFamily = atomFamily((workflowId: string) =>
         const entity = get(workflowBaseEntityAtomFamily(workflowId))
         if (!entity?.data) return null
 
-        // Resolve service URL: prefer stored url, fall back to building from URI
-        const serviceUrl =
-            entity.data.url?.replace(/\/+$/, "") ?? buildServiceUrlFromUri(entity.data.uri)
+        // ONE rule, shared with the chat transport's `resolveInvocationUrl`: an agenta URI names a
+        // service at THIS deployment's origin and outranks a `data.url` stamped at creation time.
+        const serviceUrl = resolveServiceUrl(entity.data)
 
         if (serviceUrl) {
             return `${serviceUrl}/invoke`


### PR DESCRIPTION
## Context

Every agent invoke on a local stack went to `http://localhost/services/agent/v0/invoke` and failed with a bare `TypeError: Failed to fetch`. The deployment serves on `:8081`, so the call reached whatever answers on port 80.

`data.url` is stamped on a workflow revision once, at creation, from `AGENTA_SERVICES_URL`. It goes stale the moment a deployment moves its public URL, and it is self-perpetuating: a new revision of an existing app carries the old value forward, so no env change reaches it. Three resolvers disagreed about whether to trust it, and the one that already rebuilt from the `agenta:` URI says why in its own comment: "the URI is preferred because `data.url` may point to a stale/migrated domain".

## Changes

One `resolveServiceUrl` now backs both invoke paths. An `agenta:` URI means the service is agenta-managed and lives at this deployment's origin, so the URI wins over the stored value. A revision with no agenta URI keeps `data.url` verbatim, because that one names a service this deployment does not host.

Before, for a revision created when the deployment served on port 80:

```
http://localhost/services/agent/v0/invoke        (fails)
```

After:

```
http://localhost:8081/services/agent/v0/invoke   (200)
```

`packages/agenta-chat`'s transport carried a copy of this rule, and the copy is what drifted. It now imports the shared function, so the playground and the chat transport cannot disagree again.

A url that is present but empty still resolves to null rather than falling through to the URI. That distinction was deliberate and is preserved, so this is a fix rather than a semantic change.

## Tests

- Added the stale-origin regression to `resolveInvocationUrl.test.ts`, for both a `builtin` and a `custom` kind URI.
- The test's mock no longer stubs `resolveServiceUrl`. It imports the real one, so the two call sites are pinned to the same rule.
- The existing empty-url cases still pass unchanged.
- `@agenta/chat` 10 pass, `@agenta/playground` 40 pass. tsc clean on entities, chat, playground and oss.
- Verified in the browser: invoke returns 200 on the correct port for an agent whose stored `data.url` still names port 80.

## What to QA

- On a deployment that has moved its public URL, open an agent created before the move and send a message. It runs instead of failing with "Failed to fetch".
- Regression: a custom workflow pointing at your own externally hosted service still invokes at that URL, not at the deployment origin.
