### PR TITLE
[fix] Recognize this deployment's own OTLP ingest in bridge mode

### DIFF
--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -339,12 +339,40 @@ export function resolveOtlpTraceEndpoint(endpoint?: string): string {
  * public URL while the runner's own hop is internal. The full normalized ingest URL must match,
  * because a third-party collector may share the Agenta host behind a different proxy path.
  */
+/**
+ * Host names that all denote THIS deployment's own API host.
+ *
+ * A service running in bridge mode cannot reach the host through `localhost` — that name resolves
+ * to its own container — so the SDK rewrites a configured `localhost`/`0.0.0.0` API URL to
+ * `host.docker.internal` before using it (`agenta/sdk/utils/helpers.py`, `parse_url`). The endpoint
+ * that then arrives on a run request names a DIFFERENT alias than the base configured here, and
+ * comparing them verbatim says "this is somebody else's collector" about the deployment's own
+ * ingest. The credential is withheld on that basis and every session call the runner makes comes
+ * back 401 — with nothing in the message pointing at a hostname.
+ *
+ * Folding the aliases together does not widen who gets the credential: the endpoint must still
+ * equal one of the operator-configured API bases, port and path included. Only the spelling of the
+ * local host is treated as interchangeable, which is the same equivalence the SDK's rewrite asserts.
+ */
+const LOCAL_HOST_ALIASES = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "[::1]",
+  "::1",
+  "host.docker.internal",
+]);
+
 export function isAgentaIngest(endpoint: string): boolean {
   const normalize = (value: string): string | undefined => {
     try {
       const url = new URL(value);
       const path = url.pathname.replace(/\/+$/, "") || "/";
-      return `${url.origin}${path}`;
+      const host = LOCAL_HOST_ALIASES.has(url.hostname)
+        ? "__local__"
+        : url.hostname;
+      const port = url.port ? `:${url.port}` : "";
+      return `${url.protocol}//${host}${port}${path}`;
     } catch {
       return undefined;
     }

--- a/services/runner/tests/unit/agenta-ingest-host-alias.test.ts
+++ b/services/runner/tests/unit/agenta-ingest-host-alias.test.ts
@@ -1,0 +1,89 @@
+/**
+ * `isAgentaIngest` decides whether a run's OTLP endpoint is this deployment's own ingest, and that
+ * answer gates whether the runner may use the caller's credential for its session calls. Getting it
+ * wrong is silent: the credential is withheld, and every `/sessions/*` call comes back 401 with
+ * nothing naming a hostname.
+ *
+ * The case that broke: a service in bridge mode cannot reach the host as `localhost`, so the SDK
+ * rewrites the configured API URL to `host.docker.internal` before putting it on the run request
+ * (`agenta/sdk/utils/helpers.py`, `parse_url`). Compared verbatim against `AGENTA_API_URL`, the
+ * deployment failed to recognize its own ingest.
+ */
+import { afterEach, beforeEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import { isAgentaIngest } from "../../src/tracing/otel.ts";
+
+const ENV_KEYS = ["AGENTA_API_URL", "AGENTA_API_INTERNAL_URL"] as const;
+const saved: Record<string, string | undefined> = {};
+
+beforeEach(() => {
+  for (const key of ENV_KEYS) saved[key] = process.env[key];
+});
+
+afterEach(() => {
+  for (const key of ENV_KEYS) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("isAgentaIngest", () => {
+  it("accepts the bridge-mode rewrite of its own configured host", () => {
+    process.env.AGENTA_API_URL = "http://localhost:8081/api";
+    delete process.env.AGENTA_API_INTERNAL_URL;
+
+    // What the SDK actually sends from a bridge-mode container.
+    assert.equal(
+      isAgentaIngest("http://host.docker.internal:8081/api/otlp/v1/traces"),
+      true,
+    );
+    // ...and the unrewritten spelling still matches.
+    assert.equal(
+      isAgentaIngest("http://localhost:8081/api/otlp/v1/traces"),
+      true,
+    );
+    assert.equal(
+      isAgentaIngest("http://127.0.0.1:8081/api/otlp/v1/traces"),
+      true,
+    );
+  });
+
+  it("still matches the internal service name exactly", () => {
+    process.env.AGENTA_API_INTERNAL_URL = "http://api:8000";
+    delete process.env.AGENTA_API_URL;
+
+    assert.equal(isAgentaIngest("http://api:8000/otlp/v1/traces"), true);
+  });
+
+  it("keeps the port significant — an alias is not a wildcard", () => {
+    process.env.AGENTA_API_URL = "http://localhost:8081/api";
+    delete process.env.AGENTA_API_INTERNAL_URL;
+
+    // The reported deployment moved off :80; a run still naming it is NOT this ingest.
+    assert.equal(
+      isAgentaIngest("http://host.docker.internal/api/otlp/v1/traces"),
+      false,
+    );
+    assert.equal(
+      isAgentaIngest("http://localhost:9999/api/otlp/v1/traces"),
+      false,
+    );
+  });
+
+  it("refuses a foreign collector, which is the whole point of the gate", () => {
+    process.env.AGENTA_API_URL = "http://localhost:8081/api";
+    delete process.env.AGENTA_API_INTERNAL_URL;
+
+    assert.equal(
+      isAgentaIngest("https://collector.example.com/v1/traces"),
+      false,
+    );
+    // Same host alias, different path — not the deployment's ingest endpoint.
+    assert.equal(
+      isAgentaIngest("http://host.docker.internal:8081/api/other"),
+      false,
+    );
+    assert.equal(isAgentaIngest("not-a-url"), false);
+  });
+});


### PR DESCRIPTION
## Context

Agent runs failed in chat with "record log is unreadable; cannot rebuild the conversation". Behind it, every runner call back to the API returned 401:

```
[sessions/alive]         heartbeat HTTP 401
[sessions/persist]       DROPPED idx=0 type=message after 6 retries: HTTP 401
[sessions/records-query] query FAILED: HTTP 401
```

No records were written at all, so a session had nothing to rebuild from.

The runner may use the caller's credential for platform calls only when the run's OTLP endpoint is this deployment's own ingest. That check compared the endpoint verbatim against the configured API bases. A service running in bridge mode cannot reach the host as `localhost`, so the SDK rewrites the API URL to `host.docker.internal` before putting it on the run request (`agenta/sdk/utils/helpers.py`, `parse_url`). The runner never learned about that rewrite, so it read its own deployment's ingest as a foreign collector and withheld the credential by design.

```
arrives on the run request:  http://host.docker.internal:8081/api/otlp/v1/traces
runner would accept:         http://localhost:8081/api/otlp/v1/traces
                             http://api:8000/otlp/v1/traces
```

Nothing in the 401 named a hostname, which is what made this expensive to find.

## Changes

`isAgentaIngest` folds the loopback aliases (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`, `host.docker.internal`) before comparing.

This does not widen who receives the credential. The endpoint must still equal one of the operator-configured API bases, port and path included. Only the spelling of the local host is treated as interchangeable, which is the same equivalence the SDK's rewrite already asserts.

## Tests

- New unit test covering the bridge-mode rewrite, the unrewritten spelling, the internal service name, and the two negatives that matter: a wrong port is still not this ingest, and a foreign collector is still refused.
- The runner unit suite matches its pre-change baseline exactly (same 5 files and 14 tests fail before and after, all from fixtures unrelated to this change), plus the 4 new tests.
- Verified on a live stack: after the change the same run logs `heartbeat OK`, `ingest OK` and `append OK`, and records persist.

## What to QA

- Send a message to any agent on a local docker stack. It runs, and the chat does not show "record log is unreadable".
- Reload the session afterwards. The transcript rebuilds, which means records were actually written.
- Regression: a run configured to export to an external OTLP collector still sends to that collector, and the platform credential is not attached to it.
