### PR TITLE
[fix] Say that the approval checkbox auto-approves

### DIFF
--- a/web/oss/src/components/Playground/Components/AlwaysAllowedNotice.tsx
+++ b/web/oss/src/components/Playground/Components/AlwaysAllowedNotice.tsx
@@ -51,10 +51,10 @@ const AlwaysAllowedNotice = ({revisionId}: {revisionId: string}) => {
                         </span>
                         <div className="flex min-w-0 flex-col gap-0.5">
                             <span className="truncate text-xs font-medium leading-5 text-colorText">
-                                Always allowing <span className="font-semibold">{label}</span>
+                                Auto-approving <span className="font-semibold">{label}</span>
                             </span>
                             <span className="text-xs leading-4 text-colorTextSecondary">
-                                Saved to this draft — this tool won&apos;t ask again.
+                                Saved to this draft — it runs without asking from now on.
                             </span>
                         </div>
                     </div>

--- a/web/oss/src/components/Playground/Components/AlwaysAllowedNotice.tsx
+++ b/web/oss/src/components/Playground/Components/AlwaysAllowedNotice.tsx
@@ -24,7 +24,7 @@ const AlwaysAllowedNotice = ({revisionId}: {revisionId: string}) => {
         signal.revisionId === revisionId &&
         signal.origin === "approval-dock",
     )
-    const {revoke} = useAlwaysAllowTool(revisionId)
+    const {revokeMany} = useAlwaysAllowTool(revisionId)
 
     // Latch the last matching signal so content stays rendered through the collapse-out.
     const lastRef = useRef(signal)
@@ -40,6 +40,7 @@ const AlwaysAllowedNotice = ({revisionId}: {revisionId: string}) => {
     }, [active, signal?.at, setSignal])
 
     const label = shown?.label ?? "this tool"
+    const plural = (shown?.toolNames?.length ?? 0) > 1
 
     return (
         <HeightCollapse open={active} durationMs={260} fade slideY={16} inert className="shrink-0">
@@ -54,7 +55,8 @@ const AlwaysAllowedNotice = ({revisionId}: {revisionId: string}) => {
                                 Auto-approving <span className="font-semibold">{label}</span>
                             </span>
                             <span className="text-xs leading-4 text-colorTextSecondary">
-                                Saved to this draft — it runs without asking from now on.
+                                Saved to this draft — {plural ? "they run" : "it runs"} without
+                                asking from now on.
                             </span>
                         </div>
                     </div>
@@ -63,7 +65,7 @@ const AlwaysAllowedNotice = ({revisionId}: {revisionId: string}) => {
                             variant="ghost"
                             className="h-6 gap-1 rounded-md bg-[color-mix(in_srgb,var(--ag-colorPrimary)_12%,transparent)] px-2 text-xs font-medium text-colorPrimary hover:bg-[color-mix(in_srgb,var(--ag-colorPrimary)_22%,transparent)]"
                             onClick={() => {
-                                if (shown?.toolName) revoke(shown.toolName)
+                                if (shown?.toolNames?.length) revokeMany(shown.toolNames)
                                 setSignal(null)
                             }}
                         >

--- a/web/packages/agenta-chat/src/components/ApprovalCard.tsx
+++ b/web/packages/agenta-chat/src/components/ApprovalCard.tsx
@@ -98,7 +98,7 @@ export const ApprovalCard = ({
         if (!responding) setFiredAction(null)
     }, [responding])
 
-    const {infoFor, grant} = useAlwaysAllowTool(entityId)
+    const {infoFor, grantMany} = useAlwaysAllowTool(entityId)
 
     // A commit gate parses its whole delta + manifest, so memoize on the gate id (a gate's payload
     // is immutable) rather than re-parsing on every keystroke and `responding` toggle.
@@ -115,8 +115,15 @@ export const ApprovalCard = ({
 
     if (!current || !preview) return null
 
-    const grantInfo = infoFor(current.toolName)
-    const canAlwaysAllow = Boolean(grantInfo.eligible && !grantInfo.alreadyAllowed)
+    // A batch answers as a whole, so the grant covers every tool it would approve, not just the
+    // first gate's. Ineligible members (a commit op mixed in) simply stay gated.
+    const grantableTools = [
+        ...new Set((batched ? approvals : [current]).map((approval) => approval.toolName)),
+    ].filter((toolName) => {
+        const info = infoFor(toolName)
+        return info.eligible && !info.alreadyAllowed
+    })
+    const canAlwaysAllow = grantableTools.length > 0
     // Touch must NOT change the chrome — the tap target extends invisibly instead.
     const touchCls = touch
         ? "relative after:absolute after:-inset-x-1 after:-inset-y-2 after:content-['']"
@@ -125,7 +132,7 @@ export const ApprovalCard = ({
     const approve = () => {
         if (responding) return
         setFiredAction("approve")
-        if (alwaysAllowArmed && canAlwaysAllow) grant(current.toolName)
+        if (alwaysAllowArmed && canAlwaysAllow) grantMany(grantableTools)
         if (batched) return onApproveAll(approvals.map((a) => a.approvalId))
         onRespond({approvalId: current.approvalId, approved: true})
     }

--- a/web/packages/agenta-chat/src/components/ApprovalCard.tsx
+++ b/web/packages/agenta-chat/src/components/ApprovalCard.tsx
@@ -71,7 +71,6 @@ export const ApprovalCard = ({
     const [alwaysAllowArmed, setAlwaysAllowArmed] = useState(false)
     const alwaysAllowId = useId()
     const alwaysAllowLabelId = `${alwaysAllowId}-label`
-    const alwaysAllowHintId = `${alwaysAllowId}-hint`
     // Which button fired, so the spinner lands on it (the hosts only report "busy").
     const [firedAction, setFiredAction] = useState<"approve" | "deny" | null>(null)
     const [steerOpen, setSteerOpen] = useState(false)
@@ -249,37 +248,22 @@ export const ApprovalCard = ({
             {/* Actions. The whole row collapses while steering: an explicit deny+redirect shouldn't
                 leave Approve competing, so the redirect panel becomes the entire action surface. */}
             <HeightCollapse className="-mt-1" open={!steerOpen} fade inert>
-                <div className="flex flex-col gap-2">
-                    {/* Own row, not inline with the buttons: the grant needs two lines to say
-                        both halves — it approves automatically AND stops asking. */}
+                {/* Wraps rather than squeezes: with Redirect on, the buttons drop to their own line
+                    instead of shoving Approve off a narrow screen. */}
+                <div className="flex flex-wrap items-center gap-2">
                     {canAlwaysAllow ? (
-                        <label className="flex cursor-pointer items-start gap-2 self-start">
+                        <label className="flex shrink-0 cursor-pointer items-center gap-2 whitespace-nowrap text-xs text-colorTextSecondary">
                             <Checkbox
                                 checked={alwaysAllowArmed}
                                 disabled={responding}
                                 onCheckedChange={(checked) => setAlwaysAllowArmed(checked === true)}
                                 aria-labelledby={alwaysAllowLabelId}
-                                aria-describedby={alwaysAllowHintId}
-                                className="mt-px shrink-0"
+                                className="shrink-0"
                             />
-                            <span className="flex flex-col gap-0.5">
-                                <span
-                                    id={alwaysAllowLabelId}
-                                    className="text-xs leading-snug text-colorText"
-                                >
-                                    Auto-approve this tool from now on
-                                </span>
-                                <span
-                                    id={alwaysAllowHintId}
-                                    className="text-[11px] leading-snug text-colorTextSecondary"
-                                >
-                                    This agent runs it without asking, on this run and every future
-                                    one.
-                                </span>
-                            </span>
+                            <span id={alwaysAllowLabelId}>Always auto-approve</span>
                         </label>
                     ) : null}
-                    <div className="flex items-center gap-1.5 self-end">
+                    <div className="ml-auto flex shrink-0 items-center gap-1.5">
                         {steerEnabled ? (
                             <Button
                                 variant="ghost"

--- a/web/packages/agenta-chat/src/components/ApprovalCard.tsx
+++ b/web/packages/agenta-chat/src/components/ApprovalCard.tsx
@@ -8,7 +8,7 @@
  * There is no `body` slot and no mode flag, because a second visual shape is exactly what this
  * card exists to remove.
  */
-import {useEffect, useMemo, useRef, useState} from "react"
+import {useEffect, useId, useMemo, useRef, useState} from "react"
 
 import {HeightCollapse} from "@agenta/ui/height-collapse"
 import {AutosizeTextarea, Button, Checkbox, LoadingButton} from "@agenta/ui/ui"
@@ -67,8 +67,11 @@ export const ApprovalCard = ({
             else next.add(index)
             return next
         })
-    // Armed "don't ask again" intent — applied only when the user approves, never on its own.
+    // Armed auto-approve intent — applied only when the user approves, never on its own.
     const [alwaysAllowArmed, setAlwaysAllowArmed] = useState(false)
+    const alwaysAllowId = useId()
+    const alwaysAllowLabelId = `${alwaysAllowId}-label`
+    const alwaysAllowHintId = `${alwaysAllowId}-hint`
     // Which button fired, so the spinner lands on it (the hosts only report "busy").
     const [firedAction, setFiredAction] = useState<"approve" | "deny" | null>(null)
     const [steerOpen, setSteerOpen] = useState(false)
@@ -246,18 +249,37 @@ export const ApprovalCard = ({
             {/* Actions. The whole row collapses while steering: an explicit deny+redirect shouldn't
                 leave Approve competing, so the redirect panel becomes the entire action surface. */}
             <HeightCollapse className="-mt-1" open={!steerOpen} fade inert>
-                <div className="flex items-center gap-2">
+                <div className="flex flex-col gap-2">
+                    {/* Own row, not inline with the buttons: the grant needs two lines to say
+                        both halves — it approves automatically AND stops asking. */}
                     {canAlwaysAllow ? (
-                        <label className="flex cursor-pointer items-center gap-2 text-xs text-colorTextSecondary">
+                        <label className="flex cursor-pointer items-start gap-2 self-start">
                             <Checkbox
                                 checked={alwaysAllowArmed}
                                 disabled={responding}
                                 onCheckedChange={(checked) => setAlwaysAllowArmed(checked === true)}
+                                aria-labelledby={alwaysAllowLabelId}
+                                aria-describedby={alwaysAllowHintId}
+                                className="mt-px shrink-0"
                             />
-                            Don&apos;t ask again for this
+                            <span className="flex flex-col gap-0.5">
+                                <span
+                                    id={alwaysAllowLabelId}
+                                    className="text-xs leading-snug text-colorText"
+                                >
+                                    Auto-approve this tool from now on
+                                </span>
+                                <span
+                                    id={alwaysAllowHintId}
+                                    className="text-[11px] leading-snug text-colorTextSecondary"
+                                >
+                                    This agent runs it without asking, on this run and every future
+                                    one.
+                                </span>
+                            </span>
                         </label>
                     ) : null}
-                    <div className="ml-auto flex items-center gap-1.5">
+                    <div className="flex items-center gap-1.5 self-end">
                         {steerEnabled ? (
                             <Button
                                 variant="ghost"

--- a/web/packages/agenta-chat/src/hooks/useAlwaysAllowTool.ts
+++ b/web/packages/agenta-chat/src/hooks/useAlwaysAllowTool.ts
@@ -22,6 +22,41 @@ export interface ToolGrantInfo {
 
 const INELIGIBLE: ToolGrantInfo = {eligible: false, alreadyAllowed: false}
 
+interface AppliedPermission {
+    toolName: string
+    /** Landed on a `tools[]` entry rather than a harness allow-rule — decides which section pulses. */
+    viaToolsEntry: boolean
+}
+
+/**
+ * Apply one permission flip per tool onto a SINGLE evolving `parameters`, so a batch lands as one
+ * write. Each `with*` helper returns a whole new object, so applying them against the same base
+ * would keep only the last tool. Ineligible names (platform ops, client tools, MCP) are skipped.
+ */
+export function foldPermissions(
+    parameters: Record<string, unknown> | null,
+    toolNames: string[],
+    allowed: boolean,
+): {next: Record<string, unknown> | null; applied: AppliedPermission[]} {
+    let next = parameters
+    const applied: AppliedPermission[] = []
+    for (const toolName of [...new Set(toolNames)]) {
+        // Route to the field that matches the gate's tool class (see infoFor). `tools[]` first:
+        // its per-tool permission outranks a rule, and a verbatim pattern would match its slug.
+        const tool = findGrantableTool(next, toolName)
+        const pattern = tool ? null : gateRulePattern(toolName)
+        const step = tool
+            ? withToolPermission(next, toolName, allowed ? "allow" : "ask")
+            : pattern
+              ? withHarnessToolAllow(next, pattern, allowed)
+              : null
+        if (!step) continue
+        next = step
+        applied.push({toolName, viaToolsEntry: Boolean(tool)})
+    }
+    return {next, applied}
+}
+
 /**
  * "Always allow this tool" for the approval card.
  *
@@ -72,58 +107,61 @@ export function useAlwaysAllowTool(entityId?: string) {
         [entityId, config],
     )
 
-    // Inverse of grant: put the tool back to gated. Reads the LATEST config (ref), since Undo fires
+    // Inverse of grant: put the tools back to gated. Reads the LATEST config (ref), since Undo fires
     // seconds after the grant and the draft may have moved on.
-    const revoke = useCallback(
-        (toolName: string): boolean => {
-            if (!entityId) return false
-            const cfg = configRef.current
-            // Same routing as `grant` — `tools[]` first, then the harness allow-rule.
-            const tool = findGrantableTool(cfg, toolName)
-            const pattern = tool ? null : gateRulePattern(toolName)
-            const next = tool
-                ? withToolPermission(cfg, toolName, "ask")
-                : pattern
-                  ? withHarnessToolAllow(cfg, pattern, false)
-                  : null
-            if (!next) return false
+    const revokeMany = useCallback(
+        (toolNames: string[]): string[] => {
+            if (!entityId) return []
+            // One folded write: each `with*` returns a whole new `parameters`, so N separate
+            // `setConfiguration` calls in a tick would each build on the same stale base.
+            const {next, applied} = foldPermissions(configRef.current, toolNames, false)
+            if (!applied.length || !next) return []
             setConfiguration(entityId, next)
-            return true
+            return applied.map((entry) => entry.toolName)
         },
         [entityId, setConfiguration],
     )
+    const revoke = useCallback(
+        (toolName: string): boolean => revokeMany([toolName]).length > 0,
+        [revokeMany],
+    )
 
-    const grant = useCallback(
-        (toolName: string): boolean => {
-            if (!entityId) return false
-            // Route to the field that matches the gate's tool class (see infoFor). `tools[]` first:
-            // its per-tool permission outranks a rule, and a verbatim pattern would match its slug.
-            const tool = findGrantableTool(config, toolName)
-            const pattern = tool ? null : gateRulePattern(toolName)
-            const next = tool
-                ? withToolPermission(config, toolName, "allow")
-                : pattern
-                  ? withHarnessToolAllow(config, pattern, true)
-                  : null
-            if (!next) return false
+    const grantMany = useCallback(
+        (toolNames: string[]): string[] => {
+            if (!entityId) return []
+            const {next, applied} = foldPermissions(config, toolNames, true)
+            if (!applied.length || !next) return []
             setConfiguration(entityId, next)
+            const granted = applied.map((entry) => entry.toolName)
             // A harness allow-rule writes `harness.permissions`, which surfaces in the Advanced →
             // Permissions group (and classifies as an "advanced" draft change); gateway/custom-function
             // tools write `tools[]`, surfaced in the Tools section. Pulse the section the change lands in.
+            const sectionKeys = [
+                ...new Set(applied.map((entry) => (entry.viaToolsEntry ? "tools" : "advanced"))),
+            ]
             raiseDraftSignal({
                 revisionId: entityId,
-                sectionKeys: [tool ? "tools" : "advanced"],
+                sectionKeys,
                 origin: "approval-dock",
-                summary: `Always allow ${toolName}`,
+                summary:
+                    granted.length > 1
+                        ? `Always allow ${granted.length} tools`
+                        : `Always allow ${granted[0]}`,
                 // Friendly display (matches the approval card) — a gateway tool's raw name is a slug.
-                label: resolveToolDisplay(toolName).activity.running,
-                toolName,
+                label:
+                    granted.length > 1
+                        ? `${granted.length} tools`
+                        : resolveToolDisplay(granted[0]).activity.running,
+                toolNames: granted,
                 at: Date.now(),
             })
-            return true
+            return granted
         },
         [entityId, config, setConfiguration, raiseDraftSignal],
     )
-
-    return {infoFor, grant, revoke}
+    const grant = useCallback(
+        (toolName: string): boolean => grantMany([toolName]).length > 0,
+        [grantMany],
+    )
+    return {infoFor, grant, grantMany, revoke, revokeMany}
 }

--- a/web/packages/agenta-chat/tests/unit/ApprovalCard.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/ApprovalCard.test.tsx
@@ -10,9 +10,17 @@ import {renderToStaticMarkup} from "react-dom/server"
 import {beforeEach, describe, expect, it, vi} from "vitest"
 
 const grantState = vi.hoisted(() => ({eligible: false, alreadyAllowed: false}))
+// Records what a decision actually granted, so the batch case can assert every tool landed.
+const granted = vi.hoisted(() => ({calls: [] as string[][]}))
 
 vi.mock("../../src/hooks/useAlwaysAllowTool", () => ({
-    useAlwaysAllowTool: () => ({infoFor: () => grantState, grant: () => undefined}),
+    useAlwaysAllowTool: () => ({
+        infoFor: () => grantState,
+        grantMany: (toolNames: string[]) => {
+            granted.calls.push(toolNames)
+            return toolNames
+        },
+    }),
 }))
 
 const {ApprovalCard} = await import("../../src/components/ApprovalCard")
@@ -22,6 +30,7 @@ const {act} = await import("react")
 beforeEach(() => {
     grantState.eligible = false
     grantState.alreadyAllowed = false
+    granted.calls = []
 })
 
 const render = () =>
@@ -88,6 +97,71 @@ describe("the auto-approve row", () => {
             root.unmount()
             host.remove()
         })
+    })
+})
+
+describe("granting a batch", () => {
+    const mount = (approvals: {approvalId: string; toolName: string; input: unknown}[]) => {
+        const host = document.createElement("div")
+        document.body.appendChild(host)
+        const root = createRoot(host)
+        act(() => {
+            root.render(
+                <ApprovalCard
+                    approvals={approvals}
+                    entityId="rev-1"
+                    onRespond={() => undefined}
+                    onApproveAll={() => undefined}
+                />,
+            )
+        })
+        return {host, cleanup: () => act(() => root.unmount())}
+    }
+
+    // "Approve all" answers every gate, so the grant has to cover every tool it just approved. It
+    // used to grant only approvals[0], leaving the rest to stop the next run.
+    it("grants every tool the decision approves, not just the first gate's", () => {
+        grantState.eligible = true
+        const {host, cleanup} = mount([
+            {approvalId: "a1", toolName: "bash", input: {command: "ls"}},
+            {approvalId: "a2", toolName: "Write", input: {path: "/tmp/x"}},
+            {approvalId: "a3", toolName: "bash", input: {command: "pwd"}},
+        ])
+
+        const box = host.querySelector('[role="checkbox"]')!
+        act(() => {
+            box.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+        })
+        const approveAll = [...host.querySelectorAll("button")].find(
+            (node) => node.textContent === "Approve all",
+        )!
+        act(() => {
+            approveAll.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+        })
+
+        expect(granted.calls).toEqual([["bash", "Write"]])
+        cleanup()
+    })
+
+    it("grants nothing on a denial", () => {
+        grantState.eligible = true
+        const {host, cleanup} = mount([
+            {approvalId: "a1", toolName: "bash", input: {command: "ls"}},
+        ])
+
+        const box = host.querySelector('[role="checkbox"]')!
+        act(() => {
+            box.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+        })
+        const deny = [...host.querySelectorAll("button")].find(
+            (node) => node.textContent === "Deny",
+        )!
+        act(() => {
+            deny.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+        })
+
+        expect(granted.calls).toEqual([])
+        cleanup()
     })
 })
 

--- a/web/packages/agenta-chat/tests/unit/ApprovalCard.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/ApprovalCard.test.tsx
@@ -37,17 +37,17 @@ const render = () =>
 describe("the auto-approve row", () => {
     it("appears for a tool whose permission can actually be granted", () => {
         grantState.eligible = true
-        expect(render()).toContain("Auto-approve this tool")
+        expect(render()).toContain("Always auto-approve")
     })
 
     it("stays hidden for an ineligible gate (platform ops like commit_revision)", () => {
-        expect(render()).not.toContain("Auto-approve this tool")
+        expect(render()).not.toContain("Always auto-approve")
     })
 
     it("stays hidden once the tool is already allowed — the row would be a no-op", () => {
         grantState.eligible = true
         grantState.alreadyAllowed = true
-        expect(render()).not.toContain("Auto-approve this tool")
+        expect(render()).not.toContain("Always auto-approve")
     })
 
     // The label forwards a click on the wording to the nested Radix <button>. Pinned because a
@@ -70,7 +70,7 @@ describe("the auto-approve row", () => {
 
         const box = host.querySelector('[role="checkbox"]')!
         const wording = [...host.querySelectorAll("span")].find(
-            (node) => node.textContent === "Auto-approve this tool from now on",
+            (node) => node.textContent === "Always auto-approve",
         )!
         expect(box.getAttribute("data-state")).toBe("unchecked")
 

--- a/web/packages/agenta-chat/tests/unit/ApprovalCard.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/ApprovalCard.test.tsx
@@ -1,5 +1,5 @@
 /**
- * The card's "don't ask again" row, which exists only when the grant would actually do something.
+ * The card's auto-approve row, which exists only when the grant would actually do something.
  *
  * Worth its own test because the rule is invisible from the outside: a `commit_revision` gate never
  * shows the row (platform ops are never grantable), so a card missing it looks like a bug until you
@@ -34,20 +34,60 @@ const render = () =>
         />,
     )
 
-describe("the don't-ask-again row", () => {
+describe("the auto-approve row", () => {
     it("appears for a tool whose permission can actually be granted", () => {
         grantState.eligible = true
-        expect(render()).toContain("ask again")
+        expect(render()).toContain("Auto-approve this tool")
     })
 
     it("stays hidden for an ineligible gate (platform ops like commit_revision)", () => {
-        expect(render()).not.toContain("ask again")
+        expect(render()).not.toContain("Auto-approve this tool")
     })
 
     it("stays hidden once the tool is already allowed — the row would be a no-op", () => {
         grantState.eligible = true
         grantState.alreadyAllowed = true
-        expect(render()).not.toContain("ask again")
+        expect(render()).not.toContain("Auto-approve this tool")
+    })
+
+    // The label forwards a click on the wording to the nested Radix <button>. Pinned because a
+    // hand-rolled onClick here reads like the missing piece and silently double-toggles.
+    it("toggles once when the wording next to the box is clicked", () => {
+        grantState.eligible = true
+        const host = document.createElement("div")
+        document.body.appendChild(host)
+        const root = createRoot(host)
+        act(() => {
+            root.render(
+                <ApprovalCard
+                    approvals={[{approvalId: "a1", toolName: "bash", input: {command: "ls"}}]}
+                    entityId="rev-1"
+                    onRespond={() => undefined}
+                    onApproveAll={() => undefined}
+                />,
+            )
+        })
+
+        const box = host.querySelector('[role="checkbox"]')!
+        const wording = [...host.querySelectorAll("span")].find(
+            (node) => node.textContent === "Auto-approve this tool from now on",
+        )!
+        expect(box.getAttribute("data-state")).toBe("unchecked")
+
+        act(() => {
+            wording.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+        })
+        expect(box.getAttribute("data-state")).toBe("checked")
+
+        act(() => {
+            wording.dispatchEvent(new MouseEvent("click", {bubbles: true}))
+        })
+        expect(box.getAttribute("data-state")).toBe("unchecked")
+
+        act(() => {
+            root.unmount()
+            host.remove()
+        })
     })
 })
 

--- a/web/packages/agenta-chat/tests/unit/hooks/foldPermissions.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/foldPermissions.test.ts
@@ -1,0 +1,54 @@
+/**
+ * `foldPermissions` — the batch half of the approval card's auto-approve grant.
+ *
+ * Worth its own test because the failure is silent: every `with*` helper returns a WHOLE new
+ * `parameters`, so granting N tools by calling the single-tool path N times keeps only the last
+ * one. The fold has to thread each result into the next call, and these tests fail if it stops.
+ */
+import {readHarnessAllowList} from "@agenta/entity-ui/tool-permission"
+import {describe, expect, it} from "vitest"
+
+import {foldPermissions} from "../../../src/hooks/useAlwaysAllowTool"
+
+const harnessConfig = () => ({harness: {permissions: {allow: [], ask: [], deny: []}}})
+
+describe("foldPermissions", () => {
+    it("lands every harness tool in one config, not just the last", () => {
+        const {next, applied} = foldPermissions(harnessConfig(), ["bash", "Write", "Read"], true)
+
+        // The rule list stores the canonical built-in name; `applied` keeps the gate name verbatim.
+        expect(applied.map((entry) => entry.toolName)).toEqual(["bash", "Write", "Read"])
+        expect(readHarnessAllowList(next)).toEqual(["Bash", "Write", "Read"])
+    })
+
+    it("skips a tool that can never be auto-allowed, and keeps the rest", () => {
+        const {next, applied} = foldPermissions(
+            harnessConfig(),
+            ["bash", "commit_revision", "mcp__notion__search", "Write"],
+            true,
+        )
+
+        expect(applied.map((entry) => entry.toolName)).toEqual(["bash", "Write"])
+        expect(readHarnessAllowList(next)).toEqual(["Bash", "Write"])
+    })
+
+    it("collapses a repeated tool to one entry", () => {
+        const {next, applied} = foldPermissions(harnessConfig(), ["bash", "bash"], true)
+
+        expect(applied).toHaveLength(1)
+        expect(readHarnessAllowList(next)).toEqual(["Bash"])
+    })
+
+    it("reverses the whole batch when allowed is false", () => {
+        const {next: granted} = foldPermissions(harnessConfig(), ["bash", "Write"], true)
+        const {next: revoked} = foldPermissions(granted, ["bash", "Write"], false)
+
+        expect(readHarnessAllowList(revoked)).toEqual([])
+    })
+
+    it("applies nothing when no name is grantable", () => {
+        const {applied} = foldPermissions(harnessConfig(), ["commit_revision", "test_run"], true)
+
+        expect(applied).toEqual([])
+    })
+})

--- a/web/packages/agenta-shared/src/state/draftConfigChangeSignal.ts
+++ b/web/packages/agenta-shared/src/state/draftConfigChangeSignal.ts
@@ -26,8 +26,8 @@ export interface DraftConfigChangeSignal {
     summary?: string
     /** Friendly label for the config-pane banner, e.g. "Send email". */
     label?: string
-    /** The tool the change targeted, so the banner's Undo can revert it. */
-    toolName?: string
+    /** The tools the change targeted, so the banner's Undo can revert every one of them. */
+    toolNames?: string[]
     at: number
 }
 


### PR DESCRIPTION
## Context

The grant checkbox on the approval card read "Don't ask again for this". That describes the prompt going away, not what happens instead, so a cautious reader could take it as the tool being skipped rather than run.

Ticking the box and approving writes that tool's permission to `allow` in the agent's draft config. The tool then runs with no prompt, on this run and on every future one. The label never said so.

## Changes

The label now reads "Always auto-approve", and it stays on the same line as Deny and Approve.

```
Before:  [ ] Don't ask again for this
After:   [ ] Always auto-approve
```

The confirmation banner in the config pane follows the same wording. "Always allowing bash / Saved to this draft, this tool won't ask again" becomes "Auto-approving bash / Saved to this draft, it runs without asking from now on".

Two fixes in the same row:

The checkbox had no accessible name. Radix renders it as a `<button role="checkbox">`, and a wrapping `<label>` gives it no name, so a screen reader announced an unlabelled checkbox. It now points at the label text with `aria-labelledby`.

The action row wraps instead of squeezing. With `NEXT_PUBLIC_AGENT_CHAT_STEER` on, the extra Redirect button next to the longer label overflowed a 375px screen and pushed Approve out of view. The buttons now drop to a second line.

## Batched approvals granted only the first tool

"Approve all" answers every pending gate, but the grant wrote only `approvals[0].toolName`. A batch spanning several tools left the rest to stop the next run, with nothing on screen to say so.

The card now collects every grantable tool in the batch and grants them together. Ineligible members are skipped rather than blocking the rest, so a `commit_revision` mixed into a batch stays gated while the shell and file tools beside it are granted.

They have to land as one write. Every `withToolPermission` and `withHarnessToolAllow` call returns a whole new `parameters` object, so calling the single-tool path once per tool would build each flip on the same stale base and keep only the last one. `foldPermissions` threads each result into the next call and returns a single config. The draft-change signal carries the full list, so the config pane's Undo reverts all of them.

## Why some gates still never offer the checkbox

Worth stating, because "auto-approve" invites the question of why it is not offered everywhere. `gateRulePattern` refuses three classes, for two different reasons, and this PR does not change either.

Platform ops (`commit_revision`, `test_run`, schedules, subscriptions) are excluded by design. `runner.permissions.default` stays as authored specifically so these keep gating, and the code describes `commit_revision` and destructive ops as gated by construction. `commit_revision` publishes a revision that triggers then run on their own, so it is the one action that escapes the session you are watching.

MCP tools are excluded for a mechanical reason. `wire_author_permission_rules` drops `mcp__` patterns from the runner plan, so a rule written for one would silently never take effect. MCP is governed per server instead.

Client tools (`request_connection`, `request_input`) are excluded because they exist to ask the user for something. There is nothing to auto-approve.

## Tests

- `vitest` in `@agenta/chat`, 14 tests across the card and the new fold. The card tests cover granting a whole batch and granting nothing on a denial. `foldPermissions` has its own tests for the stale-base trap, for skipping ineligible names, and for reversing a batch.
- One new test pins that a click on the label toggles the box exactly once. A `<button>` is a labelable element, so the label already forwards the click natively; the test guards against someone adding a manual handler that double toggles it.
- Checked in the browser at 375px and at desktop width, single gate and batched, with the Redirect control both off (the default) and on.

## What to QA

- Run an agent until it stops on a tool gate (a shell or file tool, not a commit). The card shows a checkbox reading "Always auto-approve" inline with Deny and Approve, the same shape as before.
- Tick it and press Approve. The config pane shows an "Auto-approving `<tool>`" banner with Undo, and the same tool does not ask again later in the run.
- Press Deny with the box ticked. Nothing is granted, and the tool asks again next time.
- Get two or more gates pending at once for different tools. Tick the box and press "Approve all". Both tools are granted, the banner reads "Auto-approving 2 tools", and neither asks again later in the run.
- Press Undo on that banner. Both tools go back to asking.
- Regression: reach a `commit_revision` gate. The checkbox is absent, as it was before.
- Regression on `/m` at phone width. The row still fits on one line and Approve is fully visible.
