### PR TITLE
[fix] Unstick the dictation mic and fix the garbled transcript

### DIFF
--- a/web/packages/agenta-chat/src/components/VoiceInputButton.tsx
+++ b/web/packages/agenta-chat/src/components/VoiceInputButton.tsx
@@ -103,22 +103,25 @@ const VoiceInputButton = ({
     // Push the transcript through the editor's dictation session: committed words land as normal
     // text, the provisional tail is styled as unsettled. No document rewrite, so the undo history
     // and anything already typed survive.
+    //
+    // Unguarded: the browser can deliver a last final result in the same commit that ends the
+    // session, and skipping the write there would drop exactly the words `active` exists to save.
+    // Writing once the session is over is already a no-op — `endDictation` clears its ref.
     useEffect(() => {
-        if (!transcribe.recording) return
         inputRef.current?.updateDictation(transcribe.finalText, transcribe.interimText)
-    }, [transcribe.recording, transcribe.finalText, transcribe.interimText, inputRef])
+    }, [transcribe.active, transcribe.finalText, transcribe.interimText, inputRef])
 
     // Settle the editor session once the recogniser actually stops (it emits a last final result
     // on the way out, so ending earlier would drop those words).
-    const wasRecording = useRef(false)
+    const wasActive = useRef(false)
     useEffect(() => {
-        if (wasRecording.current && !transcribe.recording) {
+        if (wasActive.current && !transcribe.active) {
             inputRef.current?.endDictation()
             inputRef.current?.focus()
         }
-        wasRecording.current = transcribe.recording
-        onDictatingChange(transcribe.recording)
-    }, [transcribe.recording, inputRef, onDictatingChange])
+        wasActive.current = transcribe.active
+        onDictatingChange(transcribe.active)
+    }, [transcribe.active, inputRef, onDictatingChange])
 
     // Primary action first: a voice message is the default; dictation is the alternative.
     const modes: {key: VoiceMode; supported: boolean}[] = [
@@ -134,13 +137,14 @@ const VoiceInputButton = ({
     // takeover bar (which covers this button while active).
     const dictating = effective === "transcribe" && transcribe.recording
 
-    // Guarded because `beginDictation` would otherwise orphan the live session's node pair,
-    // stranding its interim text at reduced opacity forever.
+    // The editor session follows whether `start` actually opened one — rendered state lags a press
+    // by a commit, and opening a second session over a running recogniser replays its whole
+    // transcript into the new node. A press while the LAST session is merely closing does open one:
+    // `beginDictation` settles the outgoing nodes rather than orphaning them, and the recogniser
+    // queues the start across that teardown.
     const startDictation = useCallback(() => {
-        if (transcribe.recording) return
-        inputRef.current?.beginDictation()
-        transcribe.start()
-    }, [transcribe.recording, transcribe.start, inputRef])
+        if (transcribe.start()) inputRef.current?.beginDictation()
+    }, [transcribe.start, inputRef])
 
     // Resolved after mount so SSR can't mismatch the glyph.
     const [holdLabel, setHoldLabel] = useState("Ctrl+Alt")

--- a/web/packages/agenta-chat/src/components/VoiceInputButton.tsx
+++ b/web/packages/agenta-chat/src/components/VoiceInputButton.tsx
@@ -11,7 +11,7 @@ import {
     DropdownMenuTrigger,
     SimpleTooltip,
 } from "@agenta/ui/ui"
-import {CaretDown, Microphone, Waveform} from "@phosphor-icons/react"
+import {CaretDown, Microphone, StopCircle, Waveform} from "@phosphor-icons/react"
 import {useAtom} from "jotai"
 import {atomWithStorage} from "jotai/utils"
 
@@ -215,15 +215,15 @@ const VoiceInputButton = ({
                     // A second press while the prompt is open would only queue another request.
                     disabled={disabled || audioPending || audioBlocked}
                     aria-label={dictating ? "Stop voice input" : (title ?? MODE_HINT[effective])}
-                    className={
-                        dictating
-                            ? "animate-pulse text-colorError"
-                            : audioPending
-                              ? "animate-pulse"
-                              : undefined
-                    }
+                    className={highlighted ? "animate-pulse" : undefined}
                 >
-                    {modeIcon(effective, highlighted)}
+                    {/* While dictating the button's job is to stop, so it shows that instead of
+                        the mode it was started from. */}
+                    {dictating ? (
+                        <StopCircle size={16} weight="fill" />
+                    ) : (
+                        modeIcon(effective, highlighted)
+                    )}
                 </Button>
             </SimpleTooltip>
             {available.length > 1 && !dictating && !audioPending ? (

--- a/web/packages/agenta-chat/src/hooks/useVoiceInput.ts
+++ b/web/packages/agenta-chat/src/hooks/useVoiceInput.ts
@@ -7,6 +7,15 @@ import {useCallback, useEffect, useRef, useState} from "react"
  *
  * Committed words and the volatile tail are reported separately, so the editor can render the
  * provisional part distinctly instead of the caller flattening both into one string.
+ *
+ * The recogniser's own lifecycle is far slower and far less obedient than the button that drives
+ * it: `start()` resolves on a later task, `stop()` only reports back once the browser has flushed a
+ * trailing result and closed its speech socket (hundreds of ms, sometimes seconds), and a `start()`
+ * issued inside that teardown throws. So INTENT is the source of truth here — {@link
+ * VoiceInput.recording} flips the instant the person presses the mic, and the session is driven
+ * towards that intent underneath, queueing a start across a teardown and reviving a session the
+ * browser ended on its own. Reading the browser's events as the state instead is what strands the
+ * mic latched-on after a stop, and silently drops a whole utterance spoken into a dead session.
  */
 
 // Minimal shapes for the bits of the Web Speech API we touch (not in the DOM lib types).
@@ -25,6 +34,7 @@ interface SpeechRecognitionLike {
     continuous: boolean
     interimResults: boolean
     lang: string
+    onstart: (() => void) | null
     onresult: ((e: SpeechRecognitionEventLike) => void) | null
     onerror: ((e: {error: string}) => void) | null
     onend: (() => void) | null
@@ -33,6 +43,11 @@ interface SpeechRecognitionLike {
     abort: () => void
 }
 type SpeechRecognitionCtor = new () => SpeechRecognitionLike
+
+/** Gap before retrying a `start()` the browser refused while closing the last session. */
+const RELAUNCH_DELAY_MS = 150
+/** Consecutive failures to get a session open before giving up; reset by every one that starts. */
+const MAX_RELAUNCH_ATTEMPTS = 10
 
 const getRecognitionCtor = (): SpeechRecognitionCtor | undefined => {
     if (typeof window === "undefined") return undefined
@@ -45,13 +60,23 @@ const getRecognitionCtor = (): SpeechRecognitionCtor | undefined => {
 
 export interface VoiceInput {
     supported: boolean
+    /** What the person asked for. Flips synchronously on {@link start}/{@link stop}, so the mic
+     * never reads as still-recording while the browser takes its time closing the session. */
     recording: boolean
+    /**
+     * Whether a recogniser session is still open. Trails {@link recording} through the browser's
+     * teardown, where a last final result can still land — so the editor's dictation session
+     * follows THIS, not `recording`, or those trailing words are dropped.
+     */
+    active: boolean
     /** Words the recogniser has settled on this session. */
     finalText: string
     /** The volatile tail it is still revising — rendered distinctly by the editor. */
     interimText: string
     error: string | null
-    start: () => void
+    /** Opens a session; returns false when one is already open, so the caller can avoid opening a
+     * second editor session over a recogniser that never restarted. */
+    start: () => boolean
     stop: () => void
     reset: () => void
 }
@@ -62,37 +87,54 @@ export function useVoiceInput(): VoiceInput {
     const supported = !!ctorRef.current
 
     const [recording, setRecording] = useState(false)
+    const [active, setActive] = useState(false)
     const [transcript, setTranscript] = useState({finalText: "", interimText: ""})
     const [error, setError] = useState<string | null>(null)
 
     const recRef = useRef<SpeechRecognitionLike | null>(null)
     const finalRef = useRef("")
-    // Chrome auto-ends on silence; we restart until the person actually stops.
-    const stoppingRef = useRef(false)
+    /** The person's intent, read by every callback below. The recogniser's events lag it. */
+    const wantRef = useRef(false)
+    const relaunchTimerRef = useRef<number | undefined>(undefined)
+    const attemptsRef = useRef(0)
+    /** Breaks the launch ⇄ relaunch cycle without re-creating either callback. */
+    const launchRef = useRef<() => void>(() => {})
 
-    const reset = useCallback(() => {
-        finalRef.current = ""
-        setTranscript({finalText: "", interimText: ""})
-        setError(null)
+    const clearRelaunch = useCallback(() => {
+        window.clearTimeout(relaunchTimerRef.current)
+        relaunchTimerRef.current = undefined
     }, [])
 
-    const stop = useCallback(() => {
-        stoppingRef.current = true
-        recRef.current?.stop()
-    }, [])
+    /** Retry on a later task — the only moment the browser accepts a `start()` after a close. */
+    const relaunch = useCallback(() => {
+        if (!wantRef.current) return
+        clearRelaunch()
+        if (attemptsRef.current >= MAX_RELAUNCH_ATTEMPTS) {
+            wantRef.current = false
+            setRecording(false)
+            setActive(false)
+            setError("Voice input stopped unexpectedly")
+            return
+        }
+        attemptsRef.current += 1
+        relaunchTimerRef.current = window.setTimeout(() => launchRef.current(), RELAUNCH_DELAY_MS)
+    }, [clearRelaunch])
 
-    const start = useCallback(() => {
+    const launch = useCallback(() => {
         const Ctor = ctorRef.current
-        if (!Ctor || recRef.current) return
-        setError(null)
-        finalRef.current = ""
-        setTranscript({finalText: "", interimText: ""})
-        stoppingRef.current = false
+        // A session the browser has not finished closing owns the mic. Its `onend` calls back here.
+        if (!Ctor || !wantRef.current || recRef.current) return
 
         const rec = new Ctor()
         rec.continuous = true
         rec.interimResults = true
         rec.lang = (typeof navigator !== "undefined" && navigator.language) || "en-US"
+
+        // The retry budget is for getting STARTED, not for the silence-restarts that follow.
+        rec.onstart = () => {
+            attemptsRef.current = 0
+            setActive(true)
+        }
 
         rec.onresult = (e) => {
             let interim = ""
@@ -107,37 +149,71 @@ export function useVoiceInput(): VoiceInput {
             }
             setTranscript({finalText: finalRef.current, interimText: interim.trim()})
         }
+
         rec.onerror = (e) => {
+            // Ordinary punctuation in a long dictation; `onend` follows and decides what's next.
             if (e.error === "no-speech" || e.error === "aborted") return
+            wantRef.current = false
+            clearRelaunch()
+            setRecording(false)
             setError(e.error === "not-allowed" ? "Microphone access denied" : "Voice input error")
-            stoppingRef.current = true
         }
+
         rec.onend = () => {
-            if (stoppingRef.current) {
-                recRef.current = null
-                setRecording(false)
+            if (recRef.current === rec) recRef.current = null
+            if (!wantRef.current) {
+                setActive(false)
                 return
             }
-            try {
-                rec.start()
-            } catch {
-                recRef.current = null
-                setRecording(false)
-            }
+            // Chrome ends on silence even with `continuous`, and a queued start waits here too.
+            relaunch()
         }
 
         recRef.current = rec
         try {
             rec.start()
-            setRecording(true)
         } catch {
+            // Refused mid-teardown — retry rather than drop dictation with the mic still lit.
             recRef.current = null
+            relaunch()
         }
+    }, [clearRelaunch, relaunch])
+    launchRef.current = launch
+
+    const reset = useCallback(() => {
+        finalRef.current = ""
+        setTranscript({finalText: "", interimText: ""})
+        setError(null)
     }, [])
+
+    const start = useCallback(() => {
+        if (!ctorRef.current || wantRef.current) return false
+        wantRef.current = true
+        attemptsRef.current = 0
+        setError(null)
+        finalRef.current = ""
+        setTranscript({finalText: "", interimText: ""})
+        // Intent, not the recogniser's `onstart` — the control must latch on the press.
+        setRecording(true)
+        setActive(true)
+        launch()
+        return true
+    }, [launch])
+
+    const stop = useCallback(() => {
+        if (!wantRef.current) return
+        wantRef.current = false
+        clearRelaunch()
+        // Unlatch now; `active` holds until `onend` so the trailing final result still lands.
+        setRecording(false)
+        if (recRef.current) recRef.current.stop()
+        else setActive(false)
+    }, [clearRelaunch])
 
     useEffect(
         () => () => {
-            stoppingRef.current = true
+            wantRef.current = false
+            window.clearTimeout(relaunchTimerRef.current)
             recRef.current?.abort()
         },
         [],
@@ -146,6 +222,7 @@ export function useVoiceInput(): VoiceInput {
     return {
         supported,
         recording,
+        active,
         finalText: transcript.finalText,
         interimText: transcript.interimText,
         error,

--- a/web/packages/agenta-chat/tests/unit/hooks/useVoiceInput.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useVoiceInput.test.ts
@@ -1,0 +1,239 @@
+// @vitest-environment jsdom
+import {act, renderHook} from "@testing-library/react"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+import {useVoiceInput} from "../../../src/hooks/useVoiceInput"
+
+/**
+ * Dictation's whole difficulty is that the recogniser answers on its own schedule: `start()`
+ * settles on a later task, `stop()` only reports back once the browser has flushed a trailing
+ * result and closed its speech socket, and a `start()` issued inside that teardown throws. The
+ * cases below are exactly the ones that used to strand the mic latched-on, or swallow an entire
+ * utterance spoken into a session that had already died.
+ */
+
+/** How long this fake takes to close a session — Chrome's is comparable and sometimes worse. */
+const TEARDOWN_MS = 800
+
+class FakeRecognition {
+    static instances: FakeRecognition[] = []
+    /** Chrome refuses a `start()` while a previous session is still closing. */
+    static refuseWhileClosing = true
+
+    state: "idle" | "running" | "closing" = "idle"
+    continuous = false
+    interimResults = false
+    lang = ""
+    onstart: (() => void) | null = null
+    onresult: ((e: {resultIndex: number; results: ArrayLike<any>}) => void) | null = null
+    onerror: ((e: {error: string}) => void) | null = null
+    onend: (() => void) | null = null
+
+    constructor() {
+        FakeRecognition.instances.push(this)
+    }
+
+    start() {
+        if (this.state === "running") throw new Error("InvalidStateError")
+        if (this.state === "closing" && FakeRecognition.refuseWhileClosing) {
+            throw new Error("InvalidStateError")
+        }
+        this.state = "running"
+        this.onstart?.()
+    }
+    stop() {
+        if (this.state !== "running") return
+        this.state = "closing"
+        setTimeout(() => {
+            this.state = "idle"
+            this.onend?.()
+        }, TEARDOWN_MS)
+    }
+    abort() {
+        if (this.state === "idle") return
+        this.state = "idle"
+        this.onend?.()
+    }
+    /** Chrome ends a session after a silent stretch even with `continuous` set. */
+    endOnSilence() {
+        this.state = "idle"
+        this.onend?.()
+    }
+    say(text: string, isFinal: boolean): boolean {
+        if (this.state !== "running") return false
+        this.onresult?.({resultIndex: 0, results: {length: 1, 0: {isFinal, 0: {transcript: text}}}})
+        return true
+    }
+}
+
+const live = () => FakeRecognition.instances.filter((r) => r.state === "running")
+const pristineStart = FakeRecognition.prototype.start
+
+beforeEach(() => {
+    vi.useFakeTimers()
+    FakeRecognition.instances = []
+    FakeRecognition.refuseWhileClosing = true
+    FakeRecognition.prototype.start = pristineStart
+    ;(window as any).SpeechRecognition = FakeRecognition
+    ;(window as any).webkitSpeechRecognition = FakeRecognition
+})
+
+afterEach(() => {
+    vi.useRealTimers()
+})
+
+describe("useVoiceInput", () => {
+    it("transcribes committed words and the volatile tail separately", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        act(() => result.current.start())
+        act(() => void live()[0].say("hello wor", false))
+        expect(result.current.interimText).toBe("hello wor")
+        act(() => void live()[0].say("hello world", true))
+        expect(result.current.finalText).toBe("hello world")
+    })
+
+    it("unlatches the control the moment it is pressed, not when the browser finishes closing", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        act(() => result.current.start())
+        expect(result.current.recording).toBe(true)
+
+        act(() => result.current.stop())
+        // The session is still closing, but the mic must not read as still recording — pressing it
+        // again used to be a no-op for the whole teardown.
+        expect(result.current.recording).toBe(false)
+        expect(result.current.active).toBe(true)
+
+        act(() => vi.advanceTimersByTime(TEARDOWN_MS))
+        expect(result.current.active).toBe(false)
+    })
+
+    it("keeps the editor session open through the teardown so a trailing result still lands", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        act(() => result.current.start())
+        act(() => void live()[0].say("first", true))
+        act(() => result.current.stop())
+
+        // The browser flushes one last result on its way out.
+        act(() => void FakeRecognition.instances[0].onresult?.({
+            resultIndex: 0,
+            results: {length: 1, 0: {isFinal: true, 0: {transcript: "and last"}}},
+        }))
+        expect(result.current.active).toBe(true)
+        expect(result.current.finalText).toBe("first and last")
+    })
+
+    it("revives a session the browser ended on its own after a silence", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        act(() => result.current.start())
+        act(() => FakeRecognition.instances[0].endOnSilence())
+        act(() => vi.runOnlyPendingTimers())
+
+        expect(result.current.recording).toBe(true)
+        expect(live()).toHaveLength(1)
+        act(() => void live()[0].say("still listening", true))
+        expect(result.current.finalText).toBe("still listening")
+    })
+
+    it("queues a restart across the teardown instead of dropping the utterance", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        act(() => result.current.start())
+        act(() => result.current.stop())
+        // Re-pressed well inside the teardown — the window a push-to-talk chord lands in.
+        act(() => result.current.start())
+        expect(result.current.recording).toBe(true)
+
+        act(() => vi.advanceTimersByTime(TEARDOWN_MS))
+        act(() => vi.runOnlyPendingTimers())
+
+        expect(live()).toHaveLength(1)
+        act(() => void live()[0].say("second take", true))
+        expect(result.current.finalText).toBe("second take")
+    })
+
+    it("retries a start the browser refuses rather than dying on the first refusal", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        act(() => result.current.start())
+        act(() => result.current.stop())
+        act(() => result.current.start())
+
+        // Still closing, so the first relaunch attempt is refused too.
+        act(() => vi.advanceTimersByTime(200))
+        expect(live()).toHaveLength(0)
+        expect(result.current.recording).toBe(true)
+        expect(result.current.error).toBeNull()
+
+        act(() => vi.advanceTimersByTime(TEARDOWN_MS))
+        act(() => vi.runOnlyPendingTimers())
+        expect(live()).toHaveLength(1)
+    })
+
+    it("gives up with a message when the recogniser never comes back", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        act(() => result.current.start())
+        act(() => FakeRecognition.instances[0].endOnSilence())
+        // Every subsequent attempt throws: nothing will ever open again.
+        FakeRecognition.prototype.start = function () {
+            throw new Error("InvalidStateError")
+        }
+        act(() => vi.advanceTimersByTime(60_000))
+
+        expect(result.current.recording).toBe(false)
+        expect(result.current.error).toBe("Voice input stopped unexpectedly")
+    })
+
+    it("reports whether a press actually opened a session", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        let opened: boolean | undefined
+        act(() => void (opened = result.current.start()))
+        expect(opened).toBe(true)
+
+        // Rendered state lags a press by a commit, so the caller cannot tell from `recording`
+        // alone — a second press must report that it opened nothing.
+        act(() => void (opened = result.current.start()))
+        expect(opened).toBe(false)
+        expect(FakeRecognition.instances).toHaveLength(1)
+    })
+
+    it("stops for a denied microphone and says so", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        act(() => result.current.start())
+        act(() => FakeRecognition.instances[0].onerror?.({error: "not-allowed"}))
+
+        expect(result.current.recording).toBe(false)
+        expect(result.current.error).toBe("Microphone access denied")
+    })
+
+    it("rides out the errors that punctuate a long dictation", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        act(() => result.current.start())
+        act(() => FakeRecognition.instances[0].onerror?.({error: "no-speech"}))
+        act(() => FakeRecognition.instances[0].endOnSilence())
+        act(() => vi.runOnlyPendingTimers())
+
+        expect(result.current.recording).toBe(true)
+        expect(result.current.error).toBeNull()
+        expect(live()).toHaveLength(1)
+    })
+
+    it("abandons a queued restart when the mic is released again", () => {
+        const {result} = renderHook(() => useVoiceInput())
+        act(() => result.current.start())
+        act(() => result.current.stop())
+        act(() => result.current.start())
+        act(() => result.current.stop())
+
+        act(() => vi.advanceTimersByTime(60_000))
+        expect(result.current.recording).toBe(false)
+        expect(result.current.active).toBe(false)
+        expect(live()).toHaveLength(0)
+    })
+
+    it("reports unsupported where the API is absent, and start is inert", () => {
+        delete (window as any).SpeechRecognition
+        delete (window as any).webkitSpeechRecognition
+        const {result} = renderHook(() => useVoiceInput())
+        expect(result.current.supported).toBe(false)
+        act(() => result.current.start())
+        expect(result.current.recording).toBe(false)
+    })
+})

--- a/web/packages/agenta-chat/tests/unit/hooks/useVoiceInput.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useVoiceInput.test.ts
@@ -15,6 +15,27 @@ import {useVoiceInput} from "../../../src/hooks/useVoiceInput"
 /** How long this fake takes to close a session — Chrome's is comparable and sometimes worse. */
 const TEARDOWN_MS = 800
 
+/** The slice of the Web Speech result shape the hook actually reads. */
+interface FakeAlternative {
+    transcript: string
+}
+interface FakeResult {
+    isFinal: boolean
+    0: FakeAlternative
+}
+interface FakeResultEvent {
+    resultIndex: number
+    results: ArrayLike<FakeResult>
+}
+
+/** The API lives on `window` under two names and is absent in one test, so both are optional. */
+type RecognitionWindow = Window &
+    typeof globalThis & {
+        SpeechRecognition?: typeof FakeRecognition
+        webkitSpeechRecognition?: typeof FakeRecognition
+    }
+const recognitionWindow = () => window as RecognitionWindow
+
 class FakeRecognition {
     static instances: FakeRecognition[] = []
     /** Chrome refuses a `start()` while a previous session is still closing. */
@@ -25,7 +46,7 @@ class FakeRecognition {
     interimResults = false
     lang = ""
     onstart: (() => void) | null = null
-    onresult: ((e: {resultIndex: number; results: ArrayLike<any>}) => void) | null = null
+    onresult: ((e: FakeResultEvent) => void) | null = null
     onerror: ((e: {error: string}) => void) | null = null
     onend: (() => void) | null = null
 
@@ -74,8 +95,8 @@ beforeEach(() => {
     FakeRecognition.instances = []
     FakeRecognition.refuseWhileClosing = true
     FakeRecognition.prototype.start = pristineStart
-    ;(window as any).SpeechRecognition = FakeRecognition
-    ;(window as any).webkitSpeechRecognition = FakeRecognition
+    recognitionWindow().SpeechRecognition = FakeRecognition
+    recognitionWindow().webkitSpeechRecognition = FakeRecognition
 })
 
 afterEach(() => {
@@ -114,10 +135,13 @@ describe("useVoiceInput", () => {
         act(() => result.current.stop())
 
         // The browser flushes one last result on its way out.
-        act(() => void FakeRecognition.instances[0].onresult?.({
-            resultIndex: 0,
-            results: {length: 1, 0: {isFinal: true, 0: {transcript: "and last"}}},
-        }))
+        act(
+            () =>
+                void FakeRecognition.instances[0].onresult?.({
+                    resultIndex: 0,
+                    results: {length: 1, 0: {isFinal: true, 0: {transcript: "and last"}}},
+                }),
+        )
         expect(result.current.active).toBe(true)
         expect(result.current.finalText).toBe("first and last")
     })
@@ -229,8 +253,8 @@ describe("useVoiceInput", () => {
     })
 
     it("reports unsupported where the API is absent, and start is inert", () => {
-        delete (window as any).SpeechRecognition
-        delete (window as any).webkitSpeechRecognition
+        delete recognitionWindow().SpeechRecognition
+        delete recognitionWindow().webkitSpeechRecognition
         const {result} = renderHook(() => useVoiceInput())
         expect(result.current.supported).toBe(false)
         act(() => result.current.start())

--- a/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
@@ -233,7 +233,11 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                         .read(() => $convertToMarkdownString(CHAT_TRANSFORMERS)) ?? "",
                 beginDictation: () => {
                     const editor = editorRef.current
-                    if (editor) dictationRef.current = beginDictation(editor)
+                    if (!editor) return
+                    // Settle any session still open (a re-press while the last one is closing) so
+                    // its words stay put instead of being orphaned at interim opacity.
+                    dictationRef.current?.end()
+                    dictationRef.current = beginDictation(editor)
                 },
                 updateDictation: (finalText: string, interimText: string) =>
                     dictationRef.current?.update(finalText, interimText),

--- a/web/packages/agenta-ui/src/RichChatInput/plugins/dictation.ts
+++ b/web/packages/agenta-ui/src/RichChatInput/plugins/dictation.ts
@@ -23,6 +23,16 @@ import {
  * holds in either theme, and leaves nothing behind once the words are committed. */
 export const INTERIM_STYLE = "opacity: 0.65;"
 
+/**
+ * Visually inert, and load-bearing: Lexical merges adjacent text nodes that share a format and
+ * style, so an unstyled committed node is swallowed by whatever was already typed before it. The
+ * session then can no longer find its own node, re-creates it past the interim tail, and re-appends
+ * the whole transcript on the next result — "Draft" + "hello world" dictated becomes
+ * "Draft  hello hello hello world". A style of its own keeps the node addressable; `end()` drops it
+ * so the words settle into ordinary text and merge like anything else.
+ */
+const COMMITTED_STYLE = "opacity: 1;"
+
 export interface DictationSession {
     /** Push the recogniser's committed text and its provisional tail. */
     update: (finalText: string, interimText: string) => void
@@ -45,20 +55,28 @@ export function beginDictation(editor: LexicalEditor): DictationSession {
         const paragraph = $isParagraphNode(last) ? last : $createParagraphNode()
         if (paragraph !== last) root.append(paragraph)
 
+        // Resolved first, because a replacement committed node has to be placed relative to it.
+        const existingInterim = interimKey ? $getNodeByKey(interimKey) : null
+        const survivingInterim = existingInterim instanceof TextNode ? existingInterim : null
+
         const existingFinal = finalKey ? $getNodeByKey(finalKey) : null
         let finalNode: TextNode
         if (existingFinal instanceof TextNode) {
             finalNode = existingFinal
         } else {
             finalNode = $createTextNode("")
-            paragraph.append(finalNode)
+            finalNode.setStyle(COMMITTED_STYLE)
+            // Lexical collects the node while it holds no text, which is the norm until the first
+            // word settles. A replacement must go back BEFORE the tail — appending it renders the
+            // transcript in reverse ("hello world and" as " andhello world") until the tail empties.
+            if (survivingInterim) survivingInterim.insertBefore(finalNode)
+            else paragraph.append(finalNode)
             finalKey = finalNode.getKey()
         }
 
-        const existingInterim = interimKey ? $getNodeByKey(interimKey) : null
         let interimNode: TextNode
-        if (existingInterim instanceof TextNode) {
-            interimNode = existingInterim
+        if (survivingInterim) {
+            interimNode = survivingInterim
         } else {
             interimNode = $createTextNode("")
             interimNode.setStyle(INTERIM_STYLE)
@@ -84,6 +102,9 @@ export function beginDictation(editor: LexicalEditor): DictationSession {
                     interimNode.setTextContent(
                         interimText && finalText ? ` ${interimText}` : interimText,
                     )
+                    if (finalNode.getStyle() !== COMMITTED_STYLE) {
+                        finalNode.setStyle(COMMITTED_STYLE)
+                    }
                     if (interimNode.getStyle() !== INTERIM_STYLE) {
                         interimNode.setStyle(INTERIM_STYLE)
                     }
@@ -101,8 +122,10 @@ export function beginDictation(editor: LexicalEditor): DictationSession {
                     else interimNode.remove()
                 }
                 const finalNode = finalKey ? $getNodeByKey(finalKey) : null
-                if (finalNode instanceof TextNode && !finalNode.getTextContent().trim()) {
-                    finalNode.remove()
+                if (finalNode instanceof TextNode) {
+                    // Empty means the session caught no words — drop it, separator space and all.
+                    if (finalNode.getTextContent().trim()) finalNode.setStyle("")
+                    else finalNode.remove()
                 }
                 $getRoot().selectEnd()
             })

--- a/web/packages/agenta-ui/tests/unit/dictationSession.test.ts
+++ b/web/packages/agenta-ui/tests/unit/dictationSession.test.ts
@@ -1,0 +1,122 @@
+// @vitest-environment jsdom
+import {createEditor, $getRoot, $createParagraphNode, $createTextNode} from "lexical"
+import {describe, expect, it} from "vitest"
+
+import {INTERIM_STYLE, beginDictation} from "../../src/RichChatInput/plugins/dictation"
+
+/**
+ * Dictation writes through two live text nodes rather than rewriting the document, so the cases
+ * that matter are the ones where those nodes must survive — or be handed over — without taking
+ * anything already in the composer with them.
+ */
+
+const editorWith = (text = "") => {
+    const editor = createEditor({onError: (e) =>
+        // eslint-disable-next-line no-console
+        console.error(e)})
+    editor.update(
+        () => {
+            const paragraph = $createParagraphNode()
+            if (text) paragraph.append($createTextNode(text))
+            $getRoot().append(paragraph)
+        },
+        {discrete: true},
+    )
+    return editor
+}
+
+/** No root element is attached here, so queued updates commit on a microtask — force them out. */
+const flush = (editor: ReturnType<typeof createEditor>) => editor.update(() => {}, {discrete: true})
+
+const textOf = (editor: ReturnType<typeof createEditor>) => {
+    flush(editor)
+    return editor.getEditorState().read(() => $getRoot().getTextContent())
+}
+
+const interimStyled = (editor: ReturnType<typeof createEditor>) => {
+    flush(editor)
+    return editor.getEditorState().read(() =>
+        $getRoot()
+            .getAllTextNodes()
+            .filter((n) => n.getStyle() === INTERIM_STYLE && n.getTextContent())
+            .map((n) => n.getTextContent()),
+    )
+}
+
+describe("dictation session", () => {
+    it("streams committed words and marks the provisional tail", () => {
+        const editor = editorWith()
+        const session = beginDictation(editor)
+        session.update("hello", "wor")
+        expect(textOf(editor)).toBe("hello wor")
+        expect(interimStyled(editor)).toEqual([" wor"])
+    })
+
+    it("keeps the tail behind the committed words when speech starts as interim", () => {
+        const editor = editorWith()
+        const session = beginDictation(editor)
+        // Nothing has settled yet, so the committed node holds no text and Lexical collects it.
+        session.update("", "hel")
+        session.update("", "hello wor")
+        // Its replacement has to go back in front of the tail, or the transcript reads backwards.
+        session.update("hello world", "and")
+        expect(textOf(editor)).toBe("hello world and")
+        session.update("hello world and then", "")
+        session.end()
+        expect(textOf(editor)).toBe("hello world and then")
+    })
+
+    it("streams cleanly into a composer that already has text", () => {
+        const editor = editorWith("Draft")
+        const session = beginDictation(editor)
+        // One result at a time, the way the recogniser delivers them. Every commit used to
+        // re-append the whole transcript here, because Lexical had merged the session's own node
+        // into "Draft" and it could no longer find it.
+        session.update("", "hel")
+        session.update("hello", "")
+        session.update("hello", "wor")
+        session.update("hello world", "")
+        expect(textOf(editor)).toBe("Draft hello world")
+        session.end()
+        expect(textOf(editor)).toBe("Draft hello world")
+    })
+
+    it("leaves what was already typed alone and separates itself from it", () => {
+        const editor = editorWith("Draft so far")
+        beginDictation(editor).update("dictated", "")
+        expect(textOf(editor)).toBe("Draft so far dictated")
+    })
+
+    it("keeps an unsettled tail on end, as plain text", () => {
+        const editor = editorWith()
+        const session = beginDictation(editor)
+        session.update("hello", "world")
+        session.end()
+        expect(textOf(editor)).toBe("hello world")
+        expect(interimStyled(editor)).toEqual([])
+    })
+
+    it("hands over to a session opened on top of it without stranding its words", () => {
+        const editor = editorWith()
+        const first = beginDictation(editor)
+        first.update("first take", "tail")
+
+        // What the editor handle does when the mic is re-pressed while the recogniser is still
+        // closing: settle the outgoing session, then open a new one. Its words must stay put as
+        // ordinary text rather than being orphaned at interim opacity.
+        first.end()
+        const second = beginDictation(editor)
+        second.update("second take", "")
+
+        expect(textOf(editor)).toBe("first take tail second take")
+        expect(interimStyled(editor)).toEqual([])
+    })
+
+    it("leaves nothing behind when a session ends with no speech at all", () => {
+        const editor = editorWith("Draft so far")
+        const session = beginDictation(editor)
+        session.update("", "")
+        session.end()
+        expect(textOf(editor)).toBe("Draft so far")
+    })
+})

--- a/web/packages/agenta-ui/tests/unit/dictationSession.test.ts
+++ b/web/packages/agenta-ui/tests/unit/dictationSession.test.ts
@@ -11,9 +11,12 @@ import {INTERIM_STYLE, beginDictation} from "../../src/RichChatInput/plugins/dic
  */
 
 const editorWith = (text = "") => {
-    const editor = createEditor({onError: (e) =>
-        // eslint-disable-next-line no-console
-        console.error(e)})
+    // Surface a Lexical error as a test failure rather than letting it pass silently.
+    const editor = createEditor({
+        onError: (e) => {
+            throw e
+        },
+    })
     editor.update(
         () => {
             const paragraph = $createParagraphNode()


### PR DESCRIPTION
## Context

Voice-to-text in the agent composer was broken three ways, and all three came from one place: the mic's state was read off the Web Speech API's own events, which lag the person by an entire session teardown. Chrome only reports back once it has flushed a trailing result and closed its speech socket, which takes hundreds of milliseconds and sometimes seconds. A `start()` issued inside that window throws.

- Pressing the mic again after stopping did nothing. The button stayed latched on for the whole teardown, and every further press was a no-op.
- Re-pressing the push-to-talk chord (⌃⌥) landed in that same window, where `start()` returned early in silence. The mic read as recording and the entire held utterance went nowhere.
- A silence auto-restart the browser refused ended dictation with no error at all.

A separate bug made dictation unusable whenever the composer already held text. Lexical merges adjacent text nodes that share a format and style, so the dictation session's committed node was swallowed by whatever had been typed. The session could no longer find its own node, re-created it past the interim tail, and re-appended the whole transcript on every result.

Type `Draft`, then dictate "hello world".

Before:

```
Draft   hello hello hello hello world
```

After:

```
Draft hello world
```

## Changes

`useVoiceInput` now treats intent as the source of truth. `recording` flips on the press, so the control never lags the browser. A start requested mid-teardown is queued and fires when the session actually closes. A refused start retries every 150ms and gives up with a message after ten attempts, rather than dying silently on the first refusal. A new `active` flag holds the editor's dictation session open through the teardown so the trailing final result still lands, and `start()` reports whether it opened a session, so a press cannot stack a second editor session on a running recogniser.

In the editor, the committed dictation node now carries a visually inert style that keeps Lexical from merging it away. When Lexical does collect it (it holds no text until the first word settles), the replacement is inserted ahead of the interim tail instead of appended after it, which otherwise rendered the transcript backwards. `end()` clears the style so the words settle into ordinary text.

The mic also shows a filled stop circle while dictating, since that is what pressing it does.

## Tests / notes

- 12 unit tests for `useVoiceInput` and 7 for the dictation session, each covering one of the reproductions above: a queued restart across a teardown, a refused-start retry, a trailing result arriving during teardown, and streaming into a composer that already has text.
- All three symptoms were reproduced against the running build first, then the fix was confirmed in a dev build by driving the real component tree with a stub that mirrors Chrome's timing. The browser pane blocks the mic, so the recogniser is stubbed rather than spoken into. A pass with a real microphone is worth doing.
- `VoiceInputButton` is shared, so `/m` picks up the same behaviour.

## What to QA

- Open an agent session, press the mic, say a sentence, press it again. It stops on the first press and your words stay in the composer.
- Type a few words first, then dictate. The transcript appends after what you typed, with one space and no repeats.
- Hold ⌃⌥, speak, release, then hold it again straight away. The second hold records and drops nothing.
- Go quiet for ten seconds mid-dictation. The mic keeps listening and picks you up again when you speak.
- Deny mic access in site settings, then press the mic. "Microphone access denied" appears above the composer and the mic returns to idle.
- Regression: the send button and typing stay blocked while dictation is running, and both come back once it settles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
