### PR TITLE
[docs] Say what to do with the prefilled PR template

### DIFF
--- a/.agents/skills/write-pr-description/SKILL.md
+++ b/.agents/skills/write-pr-description/SKILL.md
@@ -11,6 +11,17 @@ Write PRs that a teammate can understand at a glance. Lead with what was broken 
 
 This is the default quality bar from the first draft. Don't ship a generic version expecting to fix it after feedback.
 
+## 0. The prefilled template
+
+GitHub prefills every PR from `.github/PULL_REQUEST_TEMPLATE.md`, which asks for Summary, Testing, Demo, Checklist, and Contributor Resources. That is not what this repo's PRs look like. Replace the prefilled body with the structure in section 2.
+
+Two parts of the template still apply:
+
+- **Demo.** UI changes need a capture from the real app running your branch. Never substitute a mock-up, a component harness, or a recreated screen. If you cannot run the app, say the demo is outstanding and why, rather than filling the space with something that proves nothing.
+- **Testing.** Keep the substance under a `## Tests` heading. You do not need the template's three subheadings unless the change is large enough that they help.
+
+Drop the Checklist and Contributor Resources. They exist for first-time outside contributors and the team does not fill them in.
+
 ## 1. Title
 
 The title states the actual change in plain words.

--- a/.agents/skills/write-pr-description/SKILL.md
+++ b/.agents/skills/write-pr-description/SKILL.md
@@ -20,7 +20,7 @@ Two parts of the template still apply:
 - **Demo.** UI changes need a capture from the real app running your branch. Never substitute a mock-up, a component harness, or a recreated screen. If you cannot run the app, say the demo is outstanding and why, rather than filling the space with something that proves nothing.
 - **Testing.** Keep the substance under a `## Tests` heading. You do not need the template's three subheadings unless the change is large enough that they help.
 
-Drop the Checklist and Contributor Resources. They exist for first-time outside contributors and the team does not fill them in.
+Drop the Checklist and Contributor Resources if the author is a core maintainer of the repo. They exist for first-time outside contributors and the team does not fill them in.
 
 ## 1. Title
 


### PR DESCRIPTION
## Context

The `write-pr-description` skill and `.github/PULL_REQUEST_TEMPLATE.md` disagree, and neither mentions the other.

GitHub prefills every PR with Summary, Testing, Demo, Checklist and Contributor Resources. The skill teaches Context, Changes, Tests and What to QA. Recent PRs across three authors (#6303, #6307, #6309, #6311) all follow the skill and delete the rest. Not one of them fills in the checklist.

So the convention exists, it is just unwritten. Anyone reading only the template gets it wrong, and anyone reading only the skill wonders what to do with the prefilled text sitting in the box.

## Changes

The skill now opens with a short section on the prefilled template: replace the body with the skill's structure, and drop the Checklist and Contributor Resources, which are there for first-time outside contributors.

Two parts of the template survive, because they carry real requirements the skill did not state:

- The demo rule for UI changes. A capture has to come from the real app running the branch, never a mock-up or a recreated screen. If you cannot run the app, say the demo is outstanding rather than filling the space with something that proves nothing.
- The testing substance, kept under a single `## Tests` heading instead of the template's three subheadings.

I picked this direction over editing the template because the template is what outside contributors see, and its checklist and contributor links are useful to them. The mismatch is only a problem for people who work here every day, and the skill is what they read.

## Tests

Documentation only, no code paths touched.

## Notes for the reviewer

The alternative was to rewrite the template to match the skill. That trades a problem for internal contributors against a worse one for external contributors, so I left it alone. Worth saying out loud in case you would rather go the other way.
