### PR TITLE
[fix] Keep the Templates strip header intact at narrow widths

### DIFF
--- a/web/oss/src/components/TemplateStrip/index.tsx
+++ b/web/oss/src/components/TemplateStrip/index.tsx
@@ -49,9 +49,7 @@ export interface TemplateStripProps {
     className?: string
 }
 
-/** Icon-only header control (arrows + menu): the shared small icon button, so the strip's
- * chrome sizes and disables like every other control. Spreads rest props so antd Dropdown can
- * inject its trigger handlers via cloneElement. */
+/** Icon-only header control (arrows + menu); spreads rest props for antd Dropdown's trigger. */
 const HeaderButton = ({label, className, ...rest}: {label: string} & ButtonProps) => (
     <Button
         type="button"
@@ -227,10 +225,8 @@ const TemplateStrip = ({
                     {STRIP_COPY.label}
                 </span>
                 {isList ? null : (
-                    /* Tabs take the leftover width and scroll inside it: at narrow widths they
-                       would otherwise overflow and squeeze the pager cluster out of shape. The
-                       mask fades the overflow edge (it sits on empty space when nothing clips). */
-                    <div className="flex min-w-0 flex-1 items-center overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-24px),transparent)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
+                    /* Tabs scroll in the leftover width instead of squeezing the pager; mask fades the cut. */
+                    <div className="flex min-w-0 flex-1 items-center overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%_-_24px),transparent)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                         {categories.map((category) => {
                             const active = category === activeCategory
                             return (

--- a/web/oss/src/components/TemplateStrip/index.tsx
+++ b/web/oss/src/components/TemplateStrip/index.tsx
@@ -1,4 +1,4 @@
-import {useMemo, useState, type ButtonHTMLAttributes, type ReactNode} from "react"
+import {useMemo, useState} from "react"
 
 import {
     AGENT_TEMPLATES,
@@ -8,6 +8,7 @@ import {
 } from "@agenta/entities/workflow"
 import {HeightCollapse} from "@agenta/ui"
 import {PANEL_ACTION_CLASS, PanelSection} from "@agenta/ui/components/presentational"
+import {Button, type ButtonProps} from "@agenta/ui/ui"
 import {CaretDown, DotsThree, EyeSlash} from "@phosphor-icons/react"
 import {Dropdown} from "antd"
 import {useAtom} from "jotai"
@@ -48,31 +49,18 @@ export interface TemplateStripProps {
     className?: string
 }
 
-/** 32px square header button (arrows + menu) — plain button so the spec's disabled colors apply.
- * Spreads rest props so antd Dropdown can inject its trigger handlers via cloneElement. */
-const HeaderButton = ({
-    label,
-    disabled,
-    children,
-    className,
-    ...rest
-}: {
-    label: string
-    disabled?: boolean
-    children: ReactNode
-    className?: string
-} & ButtonHTMLAttributes<HTMLButtonElement>) => (
-    <button
+/** Icon-only header control (arrows + menu): the shared small icon button, so the strip's
+ * chrome sizes and disables like every other control. Spreads rest props so antd Dropdown can
+ * inject its trigger handlers via cloneElement. */
+const HeaderButton = ({label, className, ...rest}: {label: string} & ButtonProps) => (
+    <Button
         type="button"
+        variant="outline"
+        size="icon-sm"
         aria-label={label}
-        disabled={disabled}
         {...rest}
-        className={`flex size-8 items-center justify-center rounded-lg border border-solid bg-[var(--ag-colorBgContainer)] p-0 ${
-            disabled ? "" : "cursor-pointer"
-        } ${className ?? ""}`}
-    >
-        {children}
-    </button>
+        className={`flex-none ${className ?? ""}`}
+    />
 )
 
 /**
@@ -230,16 +218,19 @@ const TemplateStrip = ({
     return (
         <div className={className}>
             {/* Header: label + tabs + right cluster (counter, arrows, optional hide menu). */}
-            <div className="flex items-center gap-[14px]">
+            <div className="flex min-w-0 items-center gap-[14px]">
                 <span
-                    className={`font-semibold text-[var(--ag-colorText)] ${
+                    className={`shrink-0 font-semibold text-[var(--ag-colorText)] ${
                         isList ? "text-[13px]" : "text-base"
                     }`}
                 >
                     {STRIP_COPY.label}
                 </span>
                 {isList ? null : (
-                    <div className="flex items-center">
+                    /* Tabs take the leftover width and scroll inside it: at narrow widths they
+                       would otherwise overflow and squeeze the pager cluster out of shape. The
+                       mask fades the overflow edge (it sits on empty space when nothing clips). */
+                    <div className="flex min-w-0 flex-1 items-center overflow-x-auto [mask-image:linear-gradient(to_right,black_calc(100%-24px),transparent)] [scrollbar-width:none] [&::-webkit-scrollbar]:hidden">
                         {categories.map((category) => {
                             const active = category === activeCategory
                             return (
@@ -252,7 +243,7 @@ const TemplateStrip = ({
                                         setGridPage(0)
                                         resetScroll()
                                     }}
-                                    className={`cursor-pointer rounded-t-md border-0 border-b-2 border-solid bg-transparent px-[11px] py-[5px] text-[13px] hover:bg-[var(--ag-colorFillTertiary)] ${
+                                    className={`shrink-0 cursor-pointer whitespace-nowrap rounded-t-md border-0 border-b-2 border-solid bg-transparent px-[11px] py-[5px] text-[13px] hover:bg-[var(--ag-colorFillTertiary)] ${
                                         active
                                             ? "border-b-[var(--ag-colorPrimary)] font-semibold text-[var(--ag-colorText)]"
                                             : "border-b-transparent font-normal text-[var(--ag-colorTextTertiary)]"
@@ -267,21 +258,17 @@ const TemplateStrip = ({
                         })}
                     </div>
                 )}
-                <div className="ml-auto flex items-center gap-[7px]">
+                <div className="ml-auto flex shrink-0 items-center gap-[7px]">
                     {showPager ? (
                         <>
-                            <span className="mr-0.5 text-xs text-[var(--ag-colorTextTertiary)]">
+                            <span className="mr-0.5 whitespace-nowrap text-xs text-[var(--ag-colorTextTertiary)]">
                                 {counterLabel}
                             </span>
                             <HeaderButton
                                 label="Previous templates"
                                 disabled={atStart}
                                 onClick={() => pageBy(-1)}
-                                className={
-                                    atStart
-                                        ? "border-[var(--ag-colorBorderSecondary)] text-[var(--ag-colorTextQuaternary)]"
-                                        : "border-[var(--ag-colorPrimary)] text-[var(--ag-colorPrimary)]"
-                                }
+                                className="border-primary text-primary"
                             >
                                 <ChevronLeft size={14} strokeWidth={2} />
                             </HeaderButton>
@@ -289,11 +276,7 @@ const TemplateStrip = ({
                                 label="Next templates"
                                 disabled={atEnd}
                                 onClick={() => pageBy(1)}
-                                className={
-                                    atEnd
-                                        ? "border-[var(--ag-colorBorderSecondary)] text-[var(--ag-colorTextQuaternary)]"
-                                        : "border-[var(--ag-colorPrimary)] text-[var(--ag-colorPrimary)]"
-                                }
+                                className="border-primary text-primary"
                             >
                                 <ChevronRight size={14} strokeWidth={2} />
                             </HeaderButton>
@@ -318,7 +301,8 @@ const TemplateStrip = ({
                         >
                             <HeaderButton
                                 label="Strip options"
-                                className="border-transparent text-[var(--ag-colorTextTertiary)] hover:bg-[var(--ag-colorFillTertiary)]"
+                                variant="ghost"
+                                className="text-[var(--ag-colorTextTertiary)]"
                             >
                                 <DotsThree size={16} weight="bold" />
                             </HeaderButton>


### PR DESCRIPTION
## Context

Open the agent playground with the config panel expanded, or just narrow the window, and the Templates strip header fell apart. The header was a single flex row with no shrink control, so the category tabs (All 28, Engineering 10, Support 4, and the rest) overflowed their box and pushed into the pager cluster. The "1–2 of 28" counter wrapped onto two lines and the 32px arrow buttons were squeezed into rectangles.

## Changes

The tabs now take the leftover width and scroll inside it instead of overflowing. Each tab keeps its own width (`shrink-0 whitespace-nowrap`), and a mask fades the right edge so a clipped tab reads as "there is more" rather than a cut-off word. When nothing overflows, the fade sits over empty space and is invisible.

Everything else in the row holds its size: the "Templates" label and the counter/arrows cluster are `shrink-0`, and the counter is `whitespace-nowrap`.

The arrow and options buttons were a hand-rolled 32px square `<button>` with their own border, radius, and disabled colors. They are now the shared `Button` from `@agenta/ui/ui` at `size="icon-sm"`, so they size off the `control-sm` scale and get the standard disabled treatment. The enabled arrows keep their primary border and glyph through a `border-primary text-primary` class; the `atStart`/`atEnd` colour branches are gone because the primitive's own `disabled:` styles cover that state. The options button uses `variant="ghost"`.

Note for reviewers: the buttons are 24px now, not 32px, since that is what the design system's small icon button is.

## Tests

- Verified in the running EE app at 900px viewport with the config panel open: the header stays a single 32px row, the arrow buttons measure exactly 32x32 (measured before the shadcn swap), and the counter stays on one line. Measured with `getBoundingClientRect` rather than eyeballing the screenshot.
- `eslint` and `tsc --noEmit` clean for the file.
- The button swap itself was not re-checked in the browser.

## What to QA

- Open any agent in the playground and start a new chat so the Templates strip appears. Narrow the window or expand the config panel. The header stays on one line: no wrapped counter, no squashed arrows, and the tabs fade out at the right edge instead of being cut mid-word.
- Scroll the tab row sideways at a narrow width and pick a category. The card row and the counter update as before.
- Page the strip with the arrows at both widths. Disabled arrows at the start and end of the range look disabled, not just dim.
- Regression: the home page templates grid uses the same header. Check that its label, tabs, counter, and arrows still line up, and that the "..." hide menu on the playground strip still opens.
