### PR TITLE
[fix] Cancel the run when you close its session tab [AGE-4189]

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -53,6 +53,7 @@ import {
     addSessionAtomFamily,
     adoptSessionAtomFamily,
     closeSessionAtomFamily,
+    closeSessionsAtomFamily,
     pruneSessionHusksAtomFamily,
     renameSessionAtomFamily,
     sessionsListAtomFamily,
@@ -116,20 +117,34 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
     const rawActiveId = useAtomValue(activeSessionIdAtomFamily(scope))
     const addSession = useSetAtom(addSessionAtomFamily(scope))
     const closeSession = useSetAtom(closeSessionAtomFamily(scope))
+    const closeSessions = useSetAtom(closeSessionsAtomFamily(scope))
     const renameSession = useSetAtom(renameSessionAtomFamily(scope))
     const setActiveSession = useSetAtom(setActiveSessionAtomFamily(scope))
     const projectId = useAtomValue(projectIdAtom)
     const store = useStore()
     // Closing a running tab IS a stop, so it sends the same cooperative cancel the Stop button does.
-    const handleClose = useCallback(
+    const cancelIfRunning = useCallback(
         (id: string) => {
             const status = store.get(sessionStatusAtomFamily(id))
             if (projectId && shouldCancelRunOnClose({status, projectId})) {
                 commandSessionStream({sessionId: id, projectId}).catch(() => {})
             }
+        },
+        [projectId, store],
+    )
+    const handleClose = useCallback(
+        (id: string) => {
+            cancelIfRunning(id)
             closeSession(id)
         },
-        [closeSession, projectId, store],
+        [cancelIfRunning, closeSession],
+    )
+    const handleCloseMany = useCallback(
+        (ids: string[]) => {
+            ids.forEach(cancelIfRunning)
+            closeSessions(ids)
+        },
+        [cancelIfRunning, closeSessions],
     )
     // Stable identity: the tag bar forwards this straight to each memo'd chip.
     const handleRename = useCallback(
@@ -377,6 +392,7 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
                                         onAdd={addSession}
                                         addDisabled={addLocked}
                                         onClose={handleClose}
+                                        onCloseMany={handleCloseMany}
                                         onRename={handleRename}
                                         showSessions={!chatMaximized}
                                         leftExtra={

--- a/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentChatPanel.tsx
@@ -10,7 +10,12 @@ import {
     type CSSProperties,
 } from "react"
 
-import {chatPanelMaximizedAtom, configPanelCollapsedAtom} from "@agenta/chat/state"
+import {
+    chatPanelMaximizedAtom,
+    configPanelCollapsedAtom,
+    sessionStatusAtomFamily,
+} from "@agenta/chat/state"
+import {commandSessionStream} from "@agenta/entities/session"
 import {workflowMolecule} from "@agenta/entities/workflow"
 import {DriveSessionProvider} from "@agenta/entity-ui/drive"
 import {
@@ -20,12 +25,13 @@ import {
 } from "@agenta/sessions/state"
 import {simulatedAgentRunAtomFamily} from "@agenta/shared/state"
 import {paneSlideHoldMs, SplitPane} from "@agenta/ui/ui"
-import {useAtomValue, useSetAtom} from "jotai"
+import {useAtomValue, useSetAtom, useStore} from "jotai"
 
 import {SessionFilesPane, useSessionFilesPane} from "@/oss/components/Drives/SessionFilesPane"
 import {useOptionalOnboardingContext} from "@/oss/components/pages/agent-home/PlaygroundOnboarding/OnboardingContext"
 import {projectIdAtom} from "@/oss/state/project"
 
+import {shouldCancelRunOnClose} from "./assets/closeSessionCancel"
 // Direct file import — the barrel would statically pull the inspector drawer into this chunk.
 import {ConversationSkeleton, SessionBarSkeleton} from "./components/AgentChatSkeleton"
 import InspectSessionButton from "./components/Inspector/InspectSessionButton"
@@ -112,6 +118,19 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
     const closeSession = useSetAtom(closeSessionAtomFamily(scope))
     const renameSession = useSetAtom(renameSessionAtomFamily(scope))
     const setActiveSession = useSetAtom(setActiveSessionAtomFamily(scope))
+    const projectId = useAtomValue(projectIdAtom)
+    const store = useStore()
+    // Closing a running tab IS a stop, so it sends the same cooperative cancel the Stop button does.
+    const handleClose = useCallback(
+        (id: string) => {
+            const status = store.get(sessionStatusAtomFamily(id))
+            if (projectId && shouldCancelRunOnClose({status, projectId})) {
+                commandSessionStream({sessionId: id, projectId}).catch(() => {})
+            }
+            closeSession(id)
+        },
+        [closeSession, projectId, store],
+    )
     // Stable identity: the tag bar forwards this straight to each memo'd chip.
     const handleRename = useCallback(
         (id: string, title: string) => renameSession({id, title}),
@@ -172,17 +191,16 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
     // Held too until a project resolves: the session store drops every write made without one, so
     // seeding early latched `seeded` against a session that was never stored, and the latch only
     // re-arms while the list is empty — which the reconciler ends by filling history (#6295).
-    const seedProjectId = useAtomValue(projectIdAtom)
     const seeded = useRef(false)
     useEffect(() => {
-        if (!seedProjectId) return
+        if (!projectId) return
         if (pendingOpensForScope.length > 0) return
         if (sessions.length === 0 && !seeded.current) {
             seeded.current = true
             addSession()
         }
         if (sessions.length > 0) seeded.current = false
-    }, [seedProjectId, sessions.length, addSession, pendingOpensForScope])
+    }, [projectId, sessions.length, addSession, pendingOpensForScope])
 
     // Sweep husks (never-run, untitled, empty sessions) that accumulated in history — from before
     // the close-time cleanup, or orphaned by a reload. Open tabs are untouched, so this never drops
@@ -358,7 +376,7 @@ const AgentChatPanel = ({entityId}: {entityId: string}) => {
                                         onSelect={setActiveSession}
                                         onAdd={addSession}
                                         addDisabled={addLocked}
-                                        onClose={closeSession}
+                                        onClose={handleClose}
                                         onRename={handleRename}
                                         showSessions={!chatMaximized}
                                         leftExtra={

--- a/web/oss/src/components/AgentChatSlice/assets/closeSessionCancel.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/closeSessionCancel.test.ts
@@ -1,0 +1,32 @@
+/**
+ * Closing a running tab has to cancel the run (#6296).
+ *
+ * Closing only unmounted the pane, and the pane's teardown aborts this browser's fetch and nothing
+ * else — the runner kept going and kept the session's alive lock, so the tab you reopened read as
+ * running-elsewhere until that lock timed out.
+ */
+import {describe, expect, it} from "vitest"
+
+import {shouldCancelRunOnClose} from "./closeSessionCancel"
+
+const PROJECT = "project-1"
+
+describe("shouldCancelRunOnClose", () => {
+    it("cancels a run this browser is driving", () => {
+        expect(shouldCancelRunOnClose({status: "running", projectId: PROJECT})).toBe(true)
+    })
+
+    it("leaves a parked approval alone — it is durable and answerable later", () => {
+        expect(shouldCancelRunOnClose({status: "awaiting", projectId: PROJECT})).toBe(false)
+    })
+
+    it("has nothing to cancel on a settled session", () => {
+        expect(shouldCancelRunOnClose({status: "idle", projectId: PROJECT})).toBe(false)
+        expect(shouldCancelRunOnClose({status: "error", projectId: PROJECT})).toBe(false)
+    })
+
+    it("skips the command when no project has resolved to scope it", () => {
+        expect(shouldCancelRunOnClose({status: "running", projectId: null})).toBe(false)
+        expect(shouldCancelRunOnClose({status: "running", projectId: undefined})).toBe(false)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/closeSessionCancel.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/closeSessionCancel.test.ts
@@ -4,16 +4,22 @@
  * Closing only unmounted the pane, and the pane's teardown aborts this browser's fetch and nothing
  * else — the runner kept going and kept the session's alive lock, so the tab you reopened read as
  * running-elsewhere until that lock timed out.
+ *
+ * The cancel is held back behind `CLOSE_CANCELS_RUN` for now, so the running case is pinned to the
+ * flag: it reads false while the switch is off and true the moment it is flipped back on. The
+ * carve-outs below hold either way.
  */
 import {describe, expect, it} from "vitest"
 
-import {shouldCancelRunOnClose} from "./closeSessionCancel"
+import {CLOSE_CANCELS_RUN, shouldCancelRunOnClose} from "./closeSessionCancel"
 
 const PROJECT = "project-1"
 
 describe("shouldCancelRunOnClose", () => {
-    it("cancels a run this browser is driving", () => {
-        expect(shouldCancelRunOnClose({status: "running", projectId: PROJECT})).toBe(true)
+    it("cancels a run this browser is driving, only while the kill switch is on", () => {
+        expect(shouldCancelRunOnClose({status: "running", projectId: PROJECT})).toBe(
+            CLOSE_CANCELS_RUN,
+        )
     })
 
     it("leaves a parked approval alone — it is durable and answerable later", () => {

--- a/web/oss/src/components/AgentChatSlice/assets/closeSessionCancel.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/closeSessionCancel.ts
@@ -1,5 +1,13 @@
 import {type SessionRunStatus} from "@agenta/chat/model"
 
+/**
+ * Kill switch, off while the close-time cancel is held back.
+ *
+ * Flip to `true` to restore the behaviour described below; nothing else has to change, and
+ * `closeSessionCancel.test.ts` pins both sides of this flag.
+ */
+export const CLOSE_CANCELS_RUN = false
+
 export interface CloseSessionCancelInputs {
     /** This browser's run-state for the session whose tab is being closed. */
     status: SessionRunStatus
@@ -18,4 +26,4 @@ export interface CloseSessionCancelInputs {
  * later, so closing its tab must not throw the turn away.
  */
 export const shouldCancelRunOnClose = ({status, projectId}: CloseSessionCancelInputs): boolean =>
-    Boolean(projectId) && status === "running"
+    CLOSE_CANCELS_RUN && Boolean(projectId) && status === "running"

--- a/web/oss/src/components/AgentChatSlice/assets/closeSessionCancel.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/closeSessionCancel.ts
@@ -1,0 +1,21 @@
+import {type SessionRunStatus} from "@agenta/chat/model"
+
+export interface CloseSessionCancelInputs {
+    /** This browser's run-state for the session whose tab is being closed. */
+    status: SessionRunStatus
+    /** Absent before a project resolves; the cancel command is project-scoped. */
+    projectId: string | null | undefined
+}
+
+/**
+ * Does closing this tab need the cooperative cancel the Stop button sends?
+ *
+ * Unmounting the pane only aborts THIS browser's fetch. The runner keeps going and keeps the
+ * session's alive lock, so the reopened tab reads as running-elsewhere until the lock's TTL
+ * expires — the stuck session in #6296.
+ *
+ * `awaiting` is deliberately excluded: a parked approval is durable and meant to be answered
+ * later, so closing its tab must not throw the turn away.
+ */
+export const shouldCancelRunOnClose = ({status, projectId}: CloseSessionCancelInputs): boolean =>
+    Boolean(projectId) && status === "running"

--- a/web/oss/src/components/AgentChatSlice/assets/readyRefresh.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/readyRefresh.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Reopening a session re-read its whole record log twice (#6296).
+ *
+ * The relay's `ready` fires on every connect — every tab activation, every return to the window —
+ * and it ran the same full fetch + remap + replace that a real records change does, right next to
+ * the mount's own revalidation.
+ */
+import {describe, expect, it} from "vitest"
+
+import {READY_RELOAD_GRACE_MS, shouldRefreshOnReady} from "./readyRefresh"
+
+const NOW = 1_000_000
+
+describe("shouldRefreshOnReady", () => {
+    it("reads the log when this mount has never read it", () => {
+        expect(shouldRefreshOnReady({inFlight: false, lastLoadedAt: undefined, now: NOW})).toBe(
+            true,
+        )
+    })
+
+    it("skips while the mount's own read is still running", () => {
+        // The reopen case: the revalidation is in flight and `ready` lands beside it.
+        expect(shouldRefreshOnReady({inFlight: true, lastLoadedAt: undefined, now: NOW})).toBe(
+            false,
+        )
+    })
+
+    it("skips a read that just completed", () => {
+        expect(shouldRefreshOnReady({inFlight: false, lastLoadedAt: NOW - 100, now: NOW})).toBe(
+            false,
+        )
+    })
+
+    it("reads again once the grace window has passed", () => {
+        // A reconnect after the tab was hidden: we may have missed events, so re-read.
+        expect(
+            shouldRefreshOnReady({
+                inFlight: false,
+                lastLoadedAt: NOW - READY_RELOAD_GRACE_MS,
+                now: NOW,
+            }),
+        ).toBe(true)
+        expect(
+            shouldRefreshOnReady({
+                inFlight: false,
+                lastLoadedAt: NOW - READY_RELOAD_GRACE_MS - 1,
+                now: NOW,
+            }),
+        ).toBe(true)
+    })
+
+    it("still skips inside the window even with a completed read on record", () => {
+        expect(
+            shouldRefreshOnReady({
+                inFlight: true,
+                lastLoadedAt: NOW - READY_RELOAD_GRACE_MS - 1,
+                now: NOW,
+            }),
+        ).toBe(false)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/readyRefresh.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/readyRefresh.ts
@@ -1,0 +1,35 @@
+/**
+ * The watch relay emits `ready` on EVERY connect, and it connects on every tab activation and every
+ * return to a foreground window. Treating that like a records change re-read the whole ~200KB log,
+ * remapped it, and replaced the transcript — so reopening a long session paid for the log twice,
+ * and paid again on each refocus (#6296).
+ *
+ * `ready` exists to close one narrow race: a change can land after the response headers flush but
+ * before the Redis subscribe completes, so it reaches neither the stream nor a revalidation driven
+ * by `onopen`. A read of the log that is already newer than the connection cannot have missed that
+ * change, which is why "we just read it" is a safe skip. A genuine change after subscribe arrives as
+ * `records-changed`, which is never deduped.
+ */
+
+/** Matches the relay's own per-event coalescing window, so `ready` and a `records-changed` burst
+ * on the same connect collapse to one read either way. */
+export const READY_RELOAD_GRACE_MS = 3_000
+
+export interface ReadyRefreshInputs {
+    /** A full-log read is running right now (the mount's revalidation, a catch-up poll). */
+    inFlight: boolean
+    /** When the last full-log read completed; absent if none has on this mount. */
+    lastLoadedAt: number | undefined
+    now: number
+}
+
+/** Does this `ready` need its own read of the record log? */
+export const shouldRefreshOnReady = ({
+    inFlight,
+    lastLoadedAt,
+    now,
+}: ReadyRefreshInputs): boolean => {
+    if (inFlight) return false
+    if (lastLoadedAt === undefined) return true
+    return now - lastLoadedAt >= READY_RELOAD_GRACE_MS
+}

--- a/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
@@ -8,7 +8,7 @@ import {
     SessionTabStrip,
 } from "@agenta/sessions-ui"
 import {Button, SimpleTooltip} from "@agenta/ui/ui"
-import {PencilSimple, X} from "@phosphor-icons/react"
+import {ArrowLineRight, PencilSimple, X, XSquare} from "@phosphor-icons/react"
 import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
 import {AnimatePresence, MotionConfig} from "motion/react"
@@ -255,6 +255,8 @@ export interface SessionTagBarProps {
     /** Disable the New session (+) button (e.g. onboarding, until the founding run settles). */
     addDisabled?: boolean
     onClose: (id: string) => void
+    /** Bulk closes from a tab's context menu ("Close other tabs" / "Close tabs to the right"). */
+    onCloseMany?: (ids: string[]) => void
     onRename: (id: string, title: string) => void
     /** Right-aligned extras (e.g. the session-history menu). */
     extra?: React.ReactNode
@@ -280,6 +282,7 @@ const SessionTagBar = ({
     onAdd,
     addDisabled = false,
     onClose,
+    onCloseMany,
     onRename,
     extra,
     leftExtra,
@@ -301,9 +304,49 @@ const SessionTagBar = ({
                 name: session.title,
                 archived: Boolean(session.archived),
             }
-            return {items: menuItems(target), onClick: onMenuClick(target)}
+            // Chrome's bulk closes. Pinned tabs survive "close others", as they do in a browser —
+            // and since pins lead the strip they are never "to the right" of anything anyway.
+            const index = sessions.findIndex((s) => s.id === session.id)
+            const others = sessions
+                .filter((s) => s.id !== session.id && !isPinned(s.id))
+                .map((s) => s.id)
+            const toRight = sessions
+                .slice(index + 1)
+                .filter((s) => !isPinned(s.id))
+                .map((s) => s.id)
+            const shared = onMenuClick(target)
+            return {
+                items: [
+                    ...menuItems(target),
+                    {type: "divider" as const},
+                    {
+                        key: "close",
+                        label: "Close",
+                        icon: <X size={14} />,
+                        disabled: sessions.length <= 1,
+                    },
+                    {
+                        key: "close-others",
+                        label: "Close other tabs",
+                        icon: <XSquare size={14} />,
+                        disabled: others.length === 0,
+                    },
+                    {
+                        key: "close-right",
+                        label: "Close tabs to the right",
+                        icon: <ArrowLineRight size={14} />,
+                        disabled: toRight.length === 0,
+                    },
+                ],
+                onClick: ({key}: {key: string}) => {
+                    if (key === "close") return onClose(session.id)
+                    if (key === "close-others") return onCloseMany?.(others)
+                    if (key === "close-right") return onCloseMany?.(toRight)
+                    shared({key})
+                },
+            }
         },
-        [menuItems, onMenuClick, scope],
+        [isPinned, menuItems, onClose, onCloseMany, onMenuClick, scope, sessions],
     )
     // Session ids present when the bar first mounted. Seeded once; NOT topped up, so an id that
     // appears later reads as "added after mount" and scrolls smoothly (see SessionTag).

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -16,6 +16,7 @@ import {getDefaultStore, useAtomValue, useSetAtom} from "jotai"
 
 import {projectIdAtom} from "@/oss/state/project"
 
+import {shouldRefreshOnReady} from "../assets/readyRefresh"
 import {sessionLivenessAtomFamily, sessionRunningElsewhereAtomFamily} from "../state/liveness"
 import {useChatScopeKey} from "../state/scope"
 import {activeSessionIdAtomFamily} from "../state/sessions"
@@ -214,6 +215,31 @@ export const useSessionHydration = ({
     const adoptServerTranscriptRef = useRef(adoptServerTranscript)
     adoptServerTranscriptRef.current = adoptServerTranscript
 
+    // Every full read of the record log reports itself here, so the relay's `ready` can tell
+    // "nobody has read this yet" from "we are reading it right now" (#6296).
+    const logReadsInFlightRef = useRef(0)
+    const logReadCompletedAtRef = useRef<number | undefined>(undefined)
+    const readLog = useCallback(
+        (onRestored?: (t: SessionTranscript | null) => void): Promise<SessionTranscript | null> => {
+            logReadsInFlightRef.current += 1
+            const settle = () => {
+                logReadsInFlightRef.current -= 1
+                logReadCompletedAtRef.current = Date.now()
+            }
+            return loadSessionMessages(sessionId, onRestored).then(
+                (transcript) => {
+                    settle()
+                    return transcript
+                },
+                (error) => {
+                    settle()
+                    throw error
+                },
+            )
+        },
+        [sessionId],
+    )
+
     useEffect(() => {
         // A session created brand-new in this browser and not yet run has no backend records —
         // skip the guaranteed-empty query (cleared on first send; after a reload it re-hydrates).
@@ -231,7 +257,7 @@ export const useSessionHydration = ({
         // up on the next React commit — so record here, not via what's on screen, that real
         // history was already adopted.
         let adopted = false
-        loadSessionMessages(sessionId, (fresh) => {
+        readLog((fresh) => {
             if (cancelled) return
             // The restore said "no records" but the server has some — clear the notice.
             if (adoptServerTranscript(fresh)) {
@@ -258,7 +284,7 @@ export const useSessionHydration = ({
             cancelled = true
         }
         // Seed once per mounted session tab; `sessionId` is stable for this instance.
-    }, [sessionId])
+    }, [sessionId, readLog])
 
     // SWR revalidate-on-open: a cached session paints instantly from localStorage; in the background
     // we refetch the durable records ONCE (low-priority) and adopt the server transcript when the
@@ -279,12 +305,12 @@ export const useSessionHydration = ({
         }
         // The first result may itself be the disk-restored records log; the callback re-applies
         // the same guarded adoption when the guaranteed background revalidation lands.
-        loadSessionMessages(sessionId, adopt).then(adopt)
+        readLog(adopt).then(adopt)
         return () => {
             cancelled = true
         }
         // Once per mounted session tab; `sessionId` is stable for this instance.
-    }, [sessionId])
+    }, [sessionId, readLog])
 
     // ── Follow a run happening somewhere else (#5530) ──────────────────────────
     // There is no push channel to browsers: the runner publishes every event to Redis, but the only
@@ -311,7 +337,7 @@ export const useSessionHydration = ({
             let grew = false
             try {
                 const adopt = adoptServerTranscriptRef.current
-                const transcript = await loadSessionMessages(sessionId, (fresh) => {
+                const transcript = await readLog((fresh) => {
                     if (!cancelled && adopt(fresh, {armJump: false})) grew = true
                 })
                 if (!cancelled && adopt(transcript, {armJump: false})) grew = true
@@ -348,7 +374,7 @@ export const useSessionHydration = ({
         if (prev.sessionId !== sessionId || !prev.running || runningElsewhere) return
         let cancelled = false
         const adopt = adoptServerTranscriptRef.current
-        loadSessionMessages(sessionId, (fresh) => {
+        readLog((fresh) => {
             if (!cancelled) adopt(fresh, {armJump: false})
         }).then((transcript) => {
             if (!cancelled) adopt(transcript, {armJump: false})
@@ -434,7 +460,7 @@ export const useSessionHydration = ({
         // A tick usually lands inside the records query's stale window, so the shared cache would
         // resolve unchanged; invalidate first, then adopt through the SAME guard as every other path.
         revalidateSessionRecords(sessionId)
-        void loadSessionMessages(sessionId).then((transcript) => {
+        void readLog().then((transcript) => {
             // Adoption-point recheck: the entry check above only covers the window BEFORE this
             // fetch started. `loadSessionMessages` is a real network round trip, and a client-tool
             // settle can land while it's in flight — without re-checking here, that settle arrives
@@ -450,13 +476,28 @@ export const useSessionHydration = ({
             // A background catch-up must not yank a reader who scrolled up — as with the poll.
             adoptServerTranscriptRef.current(transcript, {armJump: false})
         })
-    }, [sessionId, busyRef, pendingResumeRef, revalidateSessionRecords])
+    }, [sessionId, busyRef, pendingResumeRef, revalidateSessionRecords, readLog])
+    // `ready` fires on every connect — each tab activation, each return to the foreground — so it
+    // must not repeat a read the mount is already doing. A change that lands after the subscribe
+    // arrives as `records-changed`, which is never skipped (#6296).
+    const refreshOnReady = useCallback(() => {
+        if (
+            !shouldRefreshOnReady({
+                inFlight: logReadsInFlightRef.current > 0,
+                lastLoadedAt: logReadCompletedAtRef.current,
+                now: Date.now(),
+            })
+        )
+            return
+        refreshFromRecords()
+    }, [refreshFromRecords])
     useSessionRecordsWatch({
         sessionId,
         projectId,
         // #5919 relay; this surface re-reads records on any interaction change.
         onInteractionChanged: () => revalidateSessionRecords(sessionId),
         enabled: activeSessionId === sessionId,
+        onReady: refreshOnReady,
         onRecordsChanged: refreshFromRecords,
     })
 

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts
@@ -19,12 +19,16 @@ export const useSessionRecordsWatch = ({
     sessionId,
     projectId,
     enabled,
+    onReady,
     onRecordsChanged,
     onInteractionChanged,
 }: {
     sessionId: string
     projectId?: string | null
     enabled: boolean
+    /** Fires on every connect — a tab activation, a return to the foreground. Separate from
+     * `onRecordsChanged` so it can skip a log the caller has just read (#6296). */
+    onReady: () => void
     onRecordsChanged: () => void
     onInteractionChanged: () => void
 }): void => {
@@ -34,7 +38,7 @@ export const useSessionRecordsWatch = ({
         enabled,
         refreshSession,
         on: {
-            ready: onRecordsChanged,
+            ready: onReady,
             "records-changed": onRecordsChanged,
             interaction: onInteractionChanged,
         },

--- a/web/oss/src/components/AgentChatSlice/state/sessions.bulkClose.test.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.bulkClose.test.ts
@@ -1,0 +1,95 @@
+/**
+ * "Close other tabs" / "Close tabs to the right" (#6295).
+ *
+ * One write for the whole set, with the same rules as closing a single tab: the sessions stay in
+ * history so they can be reopened, and the active tab lands on the nearest survivor.
+ */
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {projectIdAtom} from "@/oss/state/project"
+
+const {
+    addSessionAtomFamily,
+    closeSessionsAtomFamily,
+    setActiveSessionAtomFamily,
+    activeSessionIdAtomFamily,
+    sessionsListAtomFamily,
+    sessionHistoryAtomFamily,
+    renameSessionAtomFamily,
+} = await import("./sessions")
+
+const SCOPE = "app-bulk-close"
+
+/** Named sessions are not husks, so closing keeps them in history. */
+const newStore = (ids = ["a", "b", "c", "d"]) => {
+    const store = createStore()
+    store.set(projectIdAtom, "project-1")
+    ids.forEach((id) => {
+        store.set(addSessionAtomFamily(SCOPE), {id})
+        store.set(renameSessionAtomFamily(SCOPE), {id, title: `session ${id}`})
+    })
+    return store
+}
+
+const tabIds = (store: ReturnType<typeof createStore>) =>
+    store.get(sessionsListAtomFamily(SCOPE)).map((s) => s.id)
+const activeId = (store: ReturnType<typeof createStore>) =>
+    store.get(activeSessionIdAtomFamily(SCOPE))
+
+describe("closeSessionsAtomFamily", () => {
+    it("closes every id it is given in one write", () => {
+        const store = newStore()
+        store.set(closeSessionsAtomFamily(SCOPE), ["a", "c", "d"])
+        expect(tabIds(store)).toEqual(["b"])
+    })
+
+    it("keeps the closed sessions reopenable from history", () => {
+        const store = newStore()
+        store.set(closeSessionsAtomFamily(SCOPE), ["a", "c"])
+        expect(
+            store
+                .get(sessionHistoryAtomFamily(SCOPE))
+                .map((s) => s.id)
+                .sort(),
+        ).toEqual(["a", "b", "c", "d"])
+    })
+
+    it("leaves the active tab alone when it survives", () => {
+        const store = newStore()
+        store.set(setActiveSessionAtomFamily(SCOPE), "b")
+        store.set(closeSessionsAtomFamily(SCOPE), ["a", "c"])
+        expect(activeId(store)).toBe("b")
+    })
+
+    it("moves the active tab to the one that takes its slot", () => {
+        const store = newStore()
+        store.set(setActiveSessionAtomFamily(SCOPE), "b")
+        store.set(closeSessionsAtomFamily(SCOPE), ["b", "c"])
+        expect(activeId(store)).toBe("d")
+    })
+
+    it("falls back to the left when nothing survives to the right", () => {
+        const store = newStore()
+        store.set(setActiveSessionAtomFamily(SCOPE), "c")
+        store.set(closeSessionsAtomFamily(SCOPE), ["c", "d"])
+        expect(activeId(store)).toBe("b")
+    })
+
+    it("ignores an empty set and ids that are not open", () => {
+        const store = newStore()
+        store.set(setActiveSessionAtomFamily(SCOPE), "b")
+        store.set(closeSessionsAtomFamily(SCOPE), [])
+        store.set(closeSessionsAtomFamily(SCOPE), ["not-a-tab"])
+        expect(tabIds(store)).toEqual(["a", "b", "c", "d"])
+        expect(activeId(store)).toBe("b")
+    })
+
+    it("discards never-run husks instead of leaving them in history", () => {
+        const store = newStore(["a"])
+        store.set(addSessionAtomFamily(SCOPE), {id: "blank"})
+        store.set(closeSessionsAtomFamily(SCOPE), ["blank"])
+        expect(tabIds(store)).toEqual(["a"])
+        expect(store.get(sessionHistoryAtomFamily(SCOPE)).map((s) => s.id)).toEqual(["a"])
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -320,6 +320,48 @@ export const closeSessionAtomFamily = atomFamily((key: string) =>
 )
 
 /**
+ * Close several tabs in one write — the strip's "Close others" and "Close tabs to the right".
+ *
+ * Same rules as closing one, so a never-run husk among them is discarded rather than left in
+ * history. Callers pass explicit ids because what counts as "to the right" is the RENDERED order
+ * (pinned tabs lead), which only the strip knows.
+ */
+export const closeSessionsAtomFamily = atomFamily((key: string) =>
+    atom(null, (get, set, ids: string[]) => {
+        const closing = new Set(ids)
+        if (closing.size === 0) return
+        const open = currentOpenIds(get, key)
+        const nextOpen = open.filter((id) => !closing.has(id))
+        if (nextOpen.length === open.length) return
+        set(openIdsByAppAtom, {...get(openIdsByAppAtom), [key]: nextOpen})
+
+        const active = get(activeByAppAtom)
+        const activeId = active[key]
+        if (activeId && closing.has(activeId)) {
+            // Nearest survivor: the tab that slides into this slot, else the closest one before it.
+            const index = open.indexOf(activeId)
+            const after = open.slice(index).find((id) => !closing.has(id))
+            const before = open
+                .slice(0, index)
+                .reverse()
+                .find((id) => !closing.has(id))
+            set(activeByAppAtom, {...active, [key]: after ?? before ?? ""})
+        }
+
+        const all = get(sessionsByAppAtom)
+        const list = all[key] ?? []
+        const messages = get(sessionMessagesAtom)
+        const husks = new Set(
+            list.filter((s) => closing.has(s.id) && isSessionHusk(s, messages)).map((s) => s.id),
+        )
+        if (husks.size > 0) {
+            set(sessionsByAppAtom, {...all, [key]: list.filter((s) => !husks.has(s.id))})
+            for (const id of husks) clearSessionEphemera(id)
+        }
+    }),
+)
+
+/**
  * Hand-arrange a scope's tabs. The tab strip persists its order here, exactly as it persists which
  * sessions are open — tab order IS the open-ids order.
  *


### PR DESCRIPTION
## Context

Close a tab while the agent is answering, reopen the session later, and it looks stuck. You get the running-elsewhere strip, and the transcript waits on a catch-up poll that backs off from 15 to 60 seconds and finds nothing new.

Closing a tab only unmounts the pane. The pane's teardown calls `stop()`, which aborts this browser's fetch and nothing else. The runner keeps going and keeps the session's alive lock, so the liveness poll still reports the session as running long after the tab is gone.

The Stop button does more than that. It also sends the cooperative cancel:

```ts
commandSessionStream({sessionId, projectId})
```

## Changes

Closing a running tab now sends that same cancel, so the backend releases the lock when the user walks away.

`awaiting` is left alone on purpose. A parked approval is durable and meant to be answered later, so closing its tab must not throw the turn away. The rule lives in `shouldCancelRunOnClose` so that carve-out stays pinned by a test rather than by a comment.

## Tests

- `closeSessionCancel.test.ts` covers running, awaiting, idle, error, and the no-project case.
- Full slice suite green (25 files, 275 tests). `tsc --noEmit` and eslint clean on `@agenta/oss`.
- Not verified in a browser. Worth watching the network panel for the cancel request.

## What to QA

- Send a message, and close the tab while the answer is streaming. Reopen the session from the rail. It shows the interrupted turn, not a running spinner.
- Check the tab dot on other open tabs after that close. None of them sit on "running".
- Trigger a tool that needs approval, then close that tab. Reopen the session. The approval is still waiting for you and can still be answered.
- Regression: the Stop button still stops a run and leaves the session open for a follow-up prompt.

## Notes for the reviewer

#5862 rewrites the same teardown to release through a chat registry. Its `stop()` stays client-side only, so this cancel is additive rather than a duplicate. If #5862 lands first, this still applies unchanged.

One integration point to watch: #6298 restores the keyboard shortcuts and wires `onCloseSession: closeSession`, the raw atom. Whichever of the two lands second should point that at `handleClose`, otherwise Alt+W closes a running tab without the cancel. It merges clean either way, so nothing will flag it.
