### PR TITLE
[fix] Stop re-reading a session's record log on every connect [AGE-4189]

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/readyRefresh.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/readyRefresh.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Reopening a session re-read its whole record log twice (#6296).
+ *
+ * The relay's `ready` fires on every connect — every tab activation, every return to the window —
+ * and it ran the same full fetch + remap + replace that a real records change does, right next to
+ * the mount's own revalidation.
+ */
+import {describe, expect, it} from "vitest"
+
+import {READY_RELOAD_GRACE_MS, shouldRefreshOnReady} from "./readyRefresh"
+
+const NOW = 1_000_000
+
+describe("shouldRefreshOnReady", () => {
+    it("reads the log when this mount has never read it", () => {
+        expect(shouldRefreshOnReady({inFlight: false, lastLoadedAt: undefined, now: NOW})).toBe(
+            true,
+        )
+    })
+
+    it("skips while the mount's own read is still running", () => {
+        // The reopen case: the revalidation is in flight and `ready` lands beside it.
+        expect(shouldRefreshOnReady({inFlight: true, lastLoadedAt: undefined, now: NOW})).toBe(
+            false,
+        )
+    })
+
+    it("skips a read that just completed", () => {
+        expect(shouldRefreshOnReady({inFlight: false, lastLoadedAt: NOW - 100, now: NOW})).toBe(
+            false,
+        )
+    })
+
+    it("reads again once the grace window has passed", () => {
+        // A reconnect after the tab was hidden: we may have missed events, so re-read.
+        expect(
+            shouldRefreshOnReady({
+                inFlight: false,
+                lastLoadedAt: NOW - READY_RELOAD_GRACE_MS,
+                now: NOW,
+            }),
+        ).toBe(true)
+        expect(
+            shouldRefreshOnReady({
+                inFlight: false,
+                lastLoadedAt: NOW - READY_RELOAD_GRACE_MS - 1,
+                now: NOW,
+            }),
+        ).toBe(true)
+    })
+
+    it("still skips inside the window even with a completed read on record", () => {
+        expect(
+            shouldRefreshOnReady({
+                inFlight: true,
+                lastLoadedAt: NOW - READY_RELOAD_GRACE_MS - 1,
+                now: NOW,
+            }),
+        ).toBe(false)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/readyRefresh.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/readyRefresh.ts
@@ -1,0 +1,35 @@
+/**
+ * The watch relay emits `ready` on EVERY connect, and it connects on every tab activation and every
+ * return to a foreground window. Treating that like a records change re-read the whole ~200KB log,
+ * remapped it, and replaced the transcript — so reopening a long session paid for the log twice,
+ * and paid again on each refocus (#6296).
+ *
+ * `ready` exists to close one narrow race: a change can land after the response headers flush but
+ * before the Redis subscribe completes, so it reaches neither the stream nor a revalidation driven
+ * by `onopen`. A read of the log that is already newer than the connection cannot have missed that
+ * change, which is why "we just read it" is a safe skip. A genuine change after subscribe arrives as
+ * `records-changed`, which is never deduped.
+ */
+
+/** Matches the relay's own per-event coalescing window, so `ready` and a `records-changed` burst
+ * on the same connect collapse to one read either way. */
+export const READY_RELOAD_GRACE_MS = 3_000
+
+export interface ReadyRefreshInputs {
+    /** A full-log read is running right now (the mount's revalidation, a catch-up poll). */
+    inFlight: boolean
+    /** When the last full-log read completed; absent if none has on this mount. */
+    lastLoadedAt: number | undefined
+    now: number
+}
+
+/** Does this `ready` need its own read of the record log? */
+export const shouldRefreshOnReady = ({
+    inFlight,
+    lastLoadedAt,
+    now,
+}: ReadyRefreshInputs): boolean => {
+    if (inFlight) return false
+    if (lastLoadedAt === undefined) return true
+    return now - lastLoadedAt >= READY_RELOAD_GRACE_MS
+}

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -16,6 +16,7 @@ import {getDefaultStore, useAtomValue, useSetAtom} from "jotai"
 
 import {projectIdAtom} from "@/oss/state/project"
 
+import {shouldRefreshOnReady} from "../assets/readyRefresh"
 import {sessionLivenessAtomFamily, sessionRunningElsewhereAtomFamily} from "../state/liveness"
 import {useChatScopeKey} from "../state/scope"
 import {activeSessionIdAtomFamily} from "../state/sessions"
@@ -214,6 +215,31 @@ export const useSessionHydration = ({
     const adoptServerTranscriptRef = useRef(adoptServerTranscript)
     adoptServerTranscriptRef.current = adoptServerTranscript
 
+    // Every full read of the record log reports itself here, so the relay's `ready` can tell
+    // "nobody has read this yet" from "we are reading it right now" (#6296).
+    const logReadsInFlightRef = useRef(0)
+    const logReadCompletedAtRef = useRef<number | undefined>(undefined)
+    const readLog = useCallback(
+        (onRestored?: (t: SessionTranscript | null) => void): Promise<SessionTranscript | null> => {
+            logReadsInFlightRef.current += 1
+            const settle = () => {
+                logReadsInFlightRef.current -= 1
+                logReadCompletedAtRef.current = Date.now()
+            }
+            return loadSessionMessages(sessionId, onRestored).then(
+                (transcript) => {
+                    settle()
+                    return transcript
+                },
+                (error) => {
+                    settle()
+                    throw error
+                },
+            )
+        },
+        [sessionId],
+    )
+
     useEffect(() => {
         // A session created brand-new in this browser and not yet run has no backend records —
         // skip the guaranteed-empty query (cleared on first send; after a reload it re-hydrates).
@@ -231,7 +257,7 @@ export const useSessionHydration = ({
         // up on the next React commit — so record here, not via what's on screen, that real
         // history was already adopted.
         let adopted = false
-        loadSessionMessages(sessionId, (fresh) => {
+        readLog((fresh) => {
             if (cancelled) return
             // The restore said "no records" but the server has some — clear the notice.
             if (adoptServerTranscript(fresh)) {
@@ -258,7 +284,7 @@ export const useSessionHydration = ({
             cancelled = true
         }
         // Seed once per mounted session tab; `sessionId` is stable for this instance.
-    }, [sessionId])
+    }, [sessionId, readLog])
 
     // SWR revalidate-on-open: a cached session paints instantly from localStorage; in the background
     // we refetch the durable records ONCE (low-priority) and adopt the server transcript when the
@@ -279,12 +305,12 @@ export const useSessionHydration = ({
         }
         // The first result may itself be the disk-restored records log; the callback re-applies
         // the same guarded adoption when the guaranteed background revalidation lands.
-        loadSessionMessages(sessionId, adopt).then(adopt)
+        readLog(adopt).then(adopt)
         return () => {
             cancelled = true
         }
         // Once per mounted session tab; `sessionId` is stable for this instance.
-    }, [sessionId])
+    }, [sessionId, readLog])
 
     // ── Follow a run happening somewhere else (#5530) ──────────────────────────
     // There is no push channel to browsers: the runner publishes every event to Redis, but the only
@@ -311,7 +337,7 @@ export const useSessionHydration = ({
             let grew = false
             try {
                 const adopt = adoptServerTranscriptRef.current
-                const transcript = await loadSessionMessages(sessionId, (fresh) => {
+                const transcript = await readLog((fresh) => {
                     if (!cancelled && adopt(fresh, {armJump: false})) grew = true
                 })
                 if (!cancelled && adopt(transcript, {armJump: false})) grew = true
@@ -348,7 +374,7 @@ export const useSessionHydration = ({
         if (prev.sessionId !== sessionId || !prev.running || runningElsewhere) return
         let cancelled = false
         const adopt = adoptServerTranscriptRef.current
-        loadSessionMessages(sessionId, (fresh) => {
+        readLog((fresh) => {
             if (!cancelled) adopt(fresh, {armJump: false})
         }).then((transcript) => {
             if (!cancelled) adopt(transcript, {armJump: false})
@@ -434,7 +460,7 @@ export const useSessionHydration = ({
         // A tick usually lands inside the records query's stale window, so the shared cache would
         // resolve unchanged; invalidate first, then adopt through the SAME guard as every other path.
         revalidateSessionRecords(sessionId)
-        void loadSessionMessages(sessionId).then((transcript) => {
+        void readLog().then((transcript) => {
             // Adoption-point recheck: the entry check above only covers the window BEFORE this
             // fetch started. `loadSessionMessages` is a real network round trip, and a client-tool
             // settle can land while it's in flight — without re-checking here, that settle arrives
@@ -450,13 +476,28 @@ export const useSessionHydration = ({
             // A background catch-up must not yank a reader who scrolled up — as with the poll.
             adoptServerTranscriptRef.current(transcript, {armJump: false})
         })
-    }, [sessionId, busyRef, pendingResumeRef, revalidateSessionRecords])
+    }, [sessionId, busyRef, pendingResumeRef, revalidateSessionRecords, readLog])
+    // `ready` fires on every connect — each tab activation, each return to the foreground — so it
+    // must not repeat a read the mount is already doing. A change that lands after the subscribe
+    // arrives as `records-changed`, which is never skipped (#6296).
+    const refreshOnReady = useCallback(() => {
+        if (
+            !shouldRefreshOnReady({
+                inFlight: logReadsInFlightRef.current > 0,
+                lastLoadedAt: logReadCompletedAtRef.current,
+                now: Date.now(),
+            })
+        )
+            return
+        refreshFromRecords()
+    }, [refreshFromRecords])
     useSessionRecordsWatch({
         sessionId,
         projectId,
         // #5919 relay; this surface re-reads records on any interaction change.
         onInteractionChanged: () => revalidateSessionRecords(sessionId),
         enabled: activeSessionId === sessionId,
+        onReady: refreshOnReady,
         onRecordsChanged: refreshFromRecords,
     })
 

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts
@@ -19,12 +19,16 @@ export const useSessionRecordsWatch = ({
     sessionId,
     projectId,
     enabled,
+    onReady,
     onRecordsChanged,
     onInteractionChanged,
 }: {
     sessionId: string
     projectId?: string | null
     enabled: boolean
+    /** Fires on every connect — a tab activation, a return to the foreground. Separate from
+     * `onRecordsChanged` so it can skip a log the caller has just read (#6296). */
+    onReady: () => void
     onRecordsChanged: () => void
     onInteractionChanged: () => void
 }): void => {
@@ -34,7 +38,7 @@ export const useSessionRecordsWatch = ({
         enabled,
         refreshSession,
         on: {
-            ready: onRecordsChanged,
+            ready: onReady,
             "records-changed": onRecordsChanged,
             interaction: onInteractionChanged,
         },


### PR DESCRIPTION
## Context

Reopening a long session is slow, and it goes slow again every time you come back to the tab. Mahmoud reported that streaming previous records now takes much longer than it used to.

The watch relay emits `ready` on every connect, and it connects on each tab activation and each return to a foreground window. `ready` was wired to the same handler as `records-changed`:

```ts
on: {
    ready: onRecordsChanged,
    "records-changed": onRecordsChanged,
    interaction: onInteractionChanged,
}
```

So each of those invalidated the records query and re-read the whole log. That is a roughly 200KB fetch at `priority: "low"`, a full remap, and a `setMessages` that replaces the transcript and re-renders every row. On reopen it ran next to the mount's own revalidation, so the log was read twice within a second.

## Changes

`ready` now has its own handler. It skips a read the mount is already doing, and one that finished inside the relay's own coalescing window.

The skip is safe because of what `ready` is for. A change can land after the response headers flush but before the Redis subscribe completes, so it reaches neither the stream nor a revalidation driven by `onopen`. `ready` closes that window. A read of the log that is already newer than the connection cannot have missed such a change, so repeating it buys nothing.

A change after the subscribe arrives as `records-changed`, which is never skipped. That is why the two events needed separating instead of sharing one deduped handler.

Every full read now reports itself, so "nobody has read this yet" and "a read is running right now" are distinguishable. The second is the reopen case, where the mount's revalidation is still in flight when `ready` lands.

## Tests

- `readyRefresh.test.ts` covers the first read, a read in flight, a read that just finished, and the grace boundary in both directions.
- Full slice suite green (27 files, 287 tests), including the 10 existing `useSessionHydration` tests. `tsc --noEmit` and eslint clean on `@agenta/oss`.
- Not verified in a browser. This is a timing change, so it wants a look at the network panel on a real session.

## What to QA

- Open a session with a long history, with the network panel recording. Switch to another tab and back. The record log is fetched once on open, not twice, and switching back does not refetch it.
- Leave the browser window, wait a few seconds, come back. Same session, no extra full fetch.
- Leave the window for a few minutes and come back. It does refetch, because the connection dropped and may have missed events.
- Answer an approval from another device, or resume the session on your phone. The open desktop tab still picks up the change within seconds.
- Regression: reopen a session that ran elsewhere while you were away. Its transcript still catches up.

## Notes for the reviewer

This cuts the repeated cost, not the first one. Opening a very large session still fetches the whole log at low priority and renders every row, because transcript virtualization is off by default. That is the next lever and it is a product call, not part of this fix.
