### PR TITLE
[fix] Clear the skill drawer's chrome and let its editors fill it

### DIFF
--- a/web/oss/src/styles/globals.css
+++ b/web/oss/src/styles/globals.css
@@ -322,11 +322,6 @@ body {
 .dark .ag-drawer-elevated .ag-drawer-rail {
     background: var(--ag-drawer-rail);
 }
-/* A list that wraps itself in a light "panel" fill (skill Files list) reads as a redundant box on
-   the already-recessed rail in dark — drop the fill so its rows sit directly on the rail. */
-.dark .ag-drawer-elevated .ag-rail-filelist {
-    background: transparent;
-}
 .dark .ag-drawer-elevated .ag-drawer-card {
     background: var(--ag-drawer-card) !important;
     border-color: var(--ag-drawer-card-border) !important;

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -177,6 +177,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
         commitDraft,
         removeItem,
         draftInvalid,
+        draftUnchanged,
     } = useConfigItemDrawer({config, onChange})
 
     // Instructions file editor (a file list — one AGENTS.md today). Draft + Save like the item drawer.
@@ -962,22 +963,37 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
                       const readOnly = disabled || def.isReadOnly(draft)
                       const Form = def.FormView
                       const itemKey = `${shownEditing.kind}-${shownEditing.mode}-${shownEditing.index}`
+                      // Skills state their identity in the form, so the drawer drops the icon,
+                      // badge, subtitle and footer note (rows still show them).
+                      const bareChrome = shownEditing.kind === "skill"
                       return (
                           <ConfigItemDrawer
                               open={!!editing}
                               mode={shownEditing.mode}
-                              icon={def.icon}
+                              icon={bareChrome ? undefined : def.icon}
                               title={def.drawerTitle(draft)}
-                              badge={{text: desc.typeLabel, color: desc.typeColor}}
-                              subtitle={desc.subtitle}
-                              footerNote="Changes apply to this agent configuration"
+                              badge={
+                                  bareChrome
+                                      ? undefined
+                                      : {text: desc.typeLabel, color: desc.typeColor}
+                              }
+                              subtitle={bareChrome ? undefined : desc.subtitle}
+                              footerNote={
+                                  bareChrome
+                                      ? undefined
+                                      : "Changes apply to this agent configuration"
+                              }
                               width={def.drawerWidth}
                               contentFlush={def.formFlush}
                               view={drawerView}
                               onViewChange={setDrawerView}
                               onCancel={closeEditor}
                               onSave={commitDraft}
-                              saveDisabled={draftInvalid || (drawerView === "json" && jsonInvalid)}
+                              saveDisabled={
+                                  draftInvalid ||
+                                  draftUnchanged ||
+                                  (drawerView === "json" && jsonInvalid)
+                              }
                               jsonOnly={def.jsonOnly(draft)}
                               disabled={readOnly}
                               form={

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/CodeEditor.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/CodeEditor.tsx
@@ -12,6 +12,7 @@
 import {useEffect, useRef, useState} from "react"
 
 import {SharedEditor} from "@agenta/ui/shared-editor"
+import {cn} from "@agenta/ui/styles"
 
 /** Languages the shared code editor can highlight; `code` is the generic monospace fallback. */
 export type CodeEditorLanguage = "json" | "yaml" | "code" | "python" | "javascript" | "typescript"
@@ -25,6 +26,9 @@ export interface CodeEditorProps {
     disabled?: boolean
     /** Emit changes immediately instead of after the shared editor's 300 ms debounce. @default false */
     disableDebounce?: boolean
+    /** Fill the height the flex parent gives it, scrolling inside. Parent must be a `min-h-0`
+     * flex column. @default false (content-sized) */
+    grow?: boolean
 }
 
 /** Best-effort highlight language from a file path's extension, for bundled-file editing. */
@@ -57,6 +61,7 @@ export function CodeEditor({
     placeholder,
     disabled,
     disableDebounce = false,
+    grow = false,
 }: CodeEditorProps) {
     const [text, setText] = useState(value ?? "")
     const lastExternal = useRef(value ?? "")
@@ -76,19 +81,37 @@ export function CodeEditor({
         onChange(next)
     }
 
+    const editor = (
+        <SharedEditor
+            // `!min-h-full`: fills the scroll box (beating the component's own `min-h-[70px]`)
+            // while still growing past it, so the border spans the pane AND long files scroll.
+            className={grow ? "!min-h-full" : undefined}
+            editorType="border"
+            initialValue={text}
+            value={text}
+            handleChange={handleChange}
+            disabled={disabled}
+            placeholder={placeholder}
+            editorProps={{codeOnly: true, language}}
+            syncWithInitialValueChanges
+            disableDebounce={disableDebounce}
+        />
+    )
+
     return (
-        <div className="overflow-hidden rounded border border-solid border-[var(--ag-c-EAEFF5)]">
-            <SharedEditor
-                editorType="border"
-                initialValue={text}
-                value={text}
-                handleChange={handleChange}
-                disabled={disabled}
-                placeholder={placeholder}
-                editorProps={{codeOnly: true, language}}
-                syncWithInitialValueChanges
-                disableDebounce={disableDebounce}
-            />
+        // No border here: SharedEditor's own `editorType="border"` already draws one, and a second
+        // ring around it read as a doubled edge.
+        <div className={cn("overflow-hidden rounded", grow && "flex min-h-0 flex-1 flex-col")}>
+            {grow ? (
+                // The scroll lives on this wrapper, NOT on SharedEditor: that component sets
+                // `overflow: hidden` inline, which an `overflow-y-auto` class cannot override.
+                // tabIndex: a scroll region must be keyboard-reachable (axe).
+                <div tabIndex={0} className="min-h-0 flex-1 overflow-y-auto">
+                    {editor}
+                </div>
+            ) : (
+                editor
+            )}
         </div>
     )
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ConfigItemDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/ConfigItemDrawer.tsx
@@ -159,11 +159,14 @@ export function ConfigItemDrawer({
             extra={
                 jsonOnly ? null : (
                     <Segmented
+                        size="sm"
                         value={effectiveView}
                         onChange={(v) => onViewChange(v as ConfigItemView)}
                         options={[
-                            {label: "Form", value: "form"},
-                            {label: "JSON", value: "json"},
+                            // The sm track keeps `text-field-md` (14px); this drops the labels to
+                            // 12px to match the rest of the header.
+                            {label: "Form", value: "form", className: "text-field-sm"},
+                            {label: "JSON", value: "json", className: "text-field-sm"},
                         ]}
                         disabled={disabled}
                         aria-label="Item view"
@@ -172,10 +175,13 @@ export function ConfigItemDrawer({
             }
             footer={
                 <div className="flex items-center justify-between gap-3">
-                    <span className="min-w-0 truncate text-xs text-[var(--ag-zinc-5)]">
-                        {footerNote}
-                    </span>
-                    <div className="flex shrink-0 items-center gap-2">
+                    {footerNote ? (
+                        <span className="min-w-0 truncate text-xs text-[var(--ag-zinc-5)]">
+                            {footerNote}
+                        </span>
+                    ) : null}
+                    {/* ml-auto keeps the actions right-aligned when there is no footer note. */}
+                    <div className="ml-auto flex shrink-0 items-center gap-2">
                         <Button variant="outline" onClick={onCancel}>
                             Cancel
                         </Button>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/JsonObjectEditor.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/JsonObjectEditor.tsx
@@ -50,7 +50,8 @@ export function JsonObjectEditor({
 
     return (
         <div className="flex flex-col gap-1.5">
-            <div className="overflow-hidden rounded border border-solid border-[var(--ag-c-EAEFF5)]">
+            {/* No border here: SharedEditor's own `editorType="border"` already draws one. */}
+            <div className="overflow-hidden rounded">
                 <SharedEditor
                     editorType="border"
                     initialValue={text}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/MarkdownEditor.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/MarkdownEditor.tsx
@@ -21,6 +21,7 @@
 import {
     type CSSProperties,
     type DragEvent,
+    type MouseEvent,
     useCallback,
     useEffect,
     useId,
@@ -76,6 +77,9 @@ export interface MarkdownEditorProps {
     /** Fill the drawer height (fixed, tall) with the toolbar pinned and content scrolling. For an
      * editor that IS the whole drawer body. @default false */
     fill?: boolean
+    /** Fill whatever height the flex parent gives it (no viewport math), toolbar pinned and content
+     * scrolling. The parent chain must be a flex column with `min-h-0`. @default false */
+    grow?: boolean
     /** Cap the editor height (px or CSS length): content-sized up to the cap, then the toolbar pins
      * and the content scrolls inside. For an editor that's one field among others. */
     maxHeight?: number | string
@@ -129,6 +133,7 @@ export function MarkdownEditor({
     hideHeader = false,
     bordered = true,
     fill = false,
+    grow = false,
     maxHeight,
 }: MarkdownEditorProps) {
     // Stable id shared by the provider and the editor so they target one composer. Colons from
@@ -222,7 +227,9 @@ export function MarkdownEditor({
     // Toolbar row pinned above a scroll area this component owns, so it never moves with content.
     // `justify-between` puts formatting on the left and the source/rich toggle hard-right.
     const toolbar = (
-        <div className="flex shrink-0 items-center justify-between gap-1 border-b border-solid border-[var(--ag-c-EAEFF5)] px-3 py-1.5">
+        // border-0 first: preflight is off, so a bare `border-b` still paints the UA's other
+        // three sides — the top one doubling up with the container's own border.
+        <div className="flex shrink-0 items-center justify-between gap-1 border-0 border-b border-solid border-[var(--ag-c-EAEFF5)] px-3 py-1.5">
             <MarkdownToolbar disabled={editorDisabled || markdownView} />
             {viewToggle}
         </div>
@@ -246,11 +253,13 @@ export function MarkdownEditor({
     // Bound the box on this component's own wrapper (self-sized, so it doesn't depend on the parent
     // flex/height chain). `fill` = fixed drawer-body height (≈ header+footer+padding). `maxHeight` =
     // content-sized up to a cap. Either way the toolbar pins and content scrolls inside.
-    const boundStyle: CSSProperties | undefined = fill
-        ? {height: "calc(100vh - 152px)"}
-        : maxHeight != null
-          ? {maxHeight: typeof maxHeight === "number" ? `${maxHeight}px` : maxHeight}
-          : undefined
+    const boundStyle: CSSProperties | undefined = grow
+        ? undefined
+        : fill
+          ? {height: "calc(100vh - 152px)"}
+          : maxHeight != null
+            ? {maxHeight: typeof maxHeight === "number" ? `${maxHeight}px` : maxHeight}
+            : undefined
 
     const editorEl = (
         <SharedEditor
@@ -274,12 +283,40 @@ export function MarkdownEditor({
         />
     )
 
+    // The contenteditable is only as tall as its content, so a click in the empty space below it
+    // would otherwise land on the scroll region and focus nothing. Redirect those to the editor,
+    // caret at the end. Clicks on the text itself fall through untouched.
+    const focusOnBlankClick = (e: MouseEvent<HTMLDivElement>) => {
+        if (editorDisabled) return
+        const target = e.target as HTMLElement
+        if (target.closest('[contenteditable="true"]')) return
+        // Classic (space-taking) scrollbars dispatch mousedown to the scroll box itself; without
+        // this the handler would preventDefault the drag and jerk the caret to the end.
+        const rect = e.currentTarget.getBoundingClientRect()
+        if (
+            e.clientX - rect.left >= e.currentTarget.clientWidth ||
+            e.clientY - rect.top >= e.currentTarget.clientHeight
+        )
+            return
+        const input = e.currentTarget.querySelector<HTMLElement>('[contenteditable="true"]')
+        if (!input) return
+        e.preventDefault()
+        input.focus()
+        const range = document.createRange()
+        range.selectNodeContents(input)
+        range.collapse(false)
+        const selection = window.getSelection()
+        selection?.removeAllRanges()
+        selection?.addRange(range)
+    }
+
     // `md-prose` scopes the document prose styles (Option B) defined in editor-theme.css to these
     // Markdown editors only, so the shared prompt/chat editor theme is untouched.
     const body = showToolbar ? (
         <div
             className={cn(
                 "flex flex-col overflow-hidden",
+                grow && "min-h-0 flex-1",
                 bordered && "rounded-md border border-solid border-[var(--ag-c-BDC7D1)]",
             )}
             style={boundStyle}
@@ -287,12 +324,21 @@ export function MarkdownEditor({
             {toolbar}
             {/* tabIndex: a scroll region must be keyboard-reachable (axe scrollable-region-focusable)
                 — in rendered/read-only view it has no focusable content of its own. */}
-            <div tabIndex={0} className="md-prose min-h-0 flex-1 overflow-y-auto">
+            <div
+                tabIndex={0}
+                className="md-prose min-h-0 flex-1 overflow-y-auto"
+                onMouseDown={focusOnBlankClick}
+            >
                 {editorEl}
             </div>
         </div>
-    ) : boundStyle ? (
-        <div tabIndex={0} className="md-prose overflow-y-auto" style={boundStyle}>
+    ) : boundStyle || grow ? (
+        <div
+            tabIndex={0}
+            className={cn("md-prose overflow-y-auto", grow && "min-h-0 flex-1")}
+            style={boundStyle}
+            onMouseDown={focusOnBlankClick}
+        >
             {editorEl}
         </div>
     ) : (
@@ -306,10 +352,12 @@ export function MarkdownEditor({
             enableTokens={false}
             showToolbar={false}
             disabled={editorDisabled}
+            // `!`: the provider hardcodes a `min-h-[70px]` floor that would block shrinking.
+            className={grow ? "!min-h-0 flex-1" : undefined}
         >
             {dropEnabled ? (
                 <div
-                    className="relative"
+                    className={cn("relative", grow && "flex min-h-0 flex-1 flex-col")}
                     onDragOverCapture={handleDragOver}
                     onDragLeaveCapture={handleDragLeave}
                     onDropCapture={handleDrop}
@@ -328,7 +376,9 @@ export function MarkdownEditor({
             )}
             <MarkdownViewSync enabled={markdownView} />
             <CodeHighlightSync />
-            <CodeBlockLanguageMenu editable={!editorDisabled} />
+            {/* Source view wraps the whole document in one markdown CodeNode — its picker is
+                meaningless there, so the menu is for author-inserted blocks in rich text only. */}
+            {!markdownView && <CodeBlockLanguageMenu editable={!editorDisabled} />}
         </EditorProvider>
     )
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillFormView.tsx
@@ -15,6 +15,7 @@
 import {useEffect, useRef, useState} from "react"
 
 import {message} from "@agenta/ui/app-message"
+import {HeightCollapse} from "@agenta/ui/height-collapse"
 import {cn} from "@agenta/ui/styles"
 import {
     AutosizeTextarea,
@@ -26,7 +27,14 @@ import {
     TooltipProvider,
     TooltipTrigger,
 } from "@agenta/ui/ui"
-import {File as FileIcon, Info, Plus, Trash} from "@phosphor-icons/react"
+import {
+    CaretDown,
+    File as FileIcon,
+    Info,
+    Plus,
+    SlidersHorizontal,
+    Trash,
+} from "@phosphor-icons/react"
 
 import {CodeEditor, codeLanguageFromPath} from "./CodeEditor"
 import {MarkdownEditor} from "./MarkdownEditor"
@@ -77,7 +85,7 @@ function ToggleRow({
                                 <Info size={13} className="shrink-0 text-[var(--ag-zinc-5)]" />
                             </span>
                         </TooltipTrigger>
-                        <TooltipContent>{description}</TooltipContent>
+                        <TooltipContent side="right">{description}</TooltipContent>
                     </Tooltip>
                 </TooltipProvider>
             </div>
@@ -164,6 +172,10 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
         Boolean(String(skill.description ?? "").trim()),
     )
     const [bodyTouched, setBodyTouched] = useState(() => Boolean(String(skill.body ?? "").trim()))
+    // Open when a flag is already off-default, so an existing skill never hides a set toggle.
+    const [advancedOpen, setAdvancedOpen] = useState(
+        () => Boolean(skill.disable_model_invocation) || Boolean(skill.allow_executable_files),
+    )
 
     // The JSON view can put any type here, and a cast alone would let `.trim()` / spread throw.
     const asText = (value: unknown) => (typeof value === "string" ? value : "")
@@ -171,23 +183,29 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
     const name = asText(skill.name)
     const description = asText(skill.description)
     const body = asText(skill.body)
-    const nameError = skillNameError(skill.name, {touched: nameTouched})
+    // An empty value reads as red chrome (label + input border) rather than a "Required." line.
+    // A non-string value is NOT missing — it has its own NOT_TEXT message, which must still show.
+    const missing = (raw: unknown, text: string, touched: boolean) =>
+        !notText(raw) && touched && !text.trim()
+
+    const rawNameError = skillNameError(skill.name, {touched: nameTouched})
+    const nameMissing = missing(skill.name, name, nameTouched)
+    const nameError = nameMissing ? undefined : rawNameError
     const nameSuggestion = nameError && name.trim() ? slugifySkillName(name) : ""
     const showNameSuggestion = Boolean(nameSuggestion) && nameSuggestion !== name
+    const descriptionMissing = missing(skill.description, description, descriptionTouched)
     const descriptionError = notText(skill.description)
         ? NOT_TEXT
-        : descriptionTouched && !description.trim()
-          ? "Required."
-          : [...description].length > SKILL_DESCRIPTION_MAX
-            ? `Max ${SKILL_DESCRIPTION_MAX} characters.`
-            : undefined
+        : [...description].length > SKILL_DESCRIPTION_MAX
+          ? `Max ${SKILL_DESCRIPTION_MAX} characters.`
+          : undefined
+    // Body gets the same treatment: without it an empty SKILL.md disables Create with no cue.
+    const bodyMissing = missing(skill.body, body, bodyTouched)
     const bodyError = notText(skill.body)
         ? NOT_TEXT
-        : bodyTouched && !body.trim()
-          ? "Required."
-          : [...body].length > SKILL_BODY_MAX
-            ? `Max ${SKILL_BODY_MAX} characters.`
-            : undefined
+        : [...body].length > SKILL_BODY_MAX
+          ? `Max ${SKILL_BODY_MAX} characters.`
+          : undefined
 
     const set = (key: string, fieldValue: unknown) => {
         const next = {...skill}
@@ -280,7 +298,16 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
     return (
         <div className="flex h-full gap-3">
             {/* Left: full-height file list (SKILL.md pinned) with the drop zone pinned to the bottom. */}
-            <div className="ag-drawer-rail flex h-full w-44 shrink-0 flex-col gap-2 border-0 border-r border-solid border-[var(--ag-c-EAEFF5)] pr-3">
+            <div
+                className={cn(
+                    // -my/py pair: bleeds the divider through the drawer body's vertical padding so
+                    // it meets the header and footer rules, without moving the rail's content.
+                    // No `ag-drawer-rail`: that class paints a recessed band in dark, which shows
+                    // through around the Files panel. The panel is this rail's surface, as in light.
+                    "-my-4 flex w-44 shrink-0 flex-col gap-2 py-4 pr-3",
+                    "border-0 border-r border-solid border-colorBorderSecondary",
+                )}
+            >
                 <div className="flex shrink-0 items-center justify-between gap-1">
                     <span className="text-xs font-medium">Files</span>
                     {!disabled ? (
@@ -324,21 +351,19 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                 </div>
 
                 {!disabled ? (
-                    <div className="flex shrink-0 flex-col gap-1.5">
+                    <div className="shrink-0">
                         <SkillUploadZone onParsed={applyParsed} disabled={disabled} />
-                        <span className="text-xs leading-snug text-colorTextDescription">
-                            …or paste a SKILL.md anywhere here to fill the fields
-                        </span>
                     </div>
                 ) : null}
             </div>
 
             {/* Right: skill-level fields + the selected file's editor + behaviour toggles. */}
-            <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-y-auto pr-1">
+            <div className="flex min-h-0 min-w-0 flex-1 flex-col gap-3 overflow-hidden">
                 <Field
+                    className="shrink-0"
+                    invalid={nameMissing}
                     label="Name"
-                    required
-                    tooltip="Lowercase letters, digits and single hyphens — this becomes the skill's directory name and its /skill:name handle, so the harness rejects anything else"
+                    tooltip="A short name like weather-report. Lowercase letters, numbers and hyphens only."
                     error={
                         nameError ? (
                             <span>
@@ -371,16 +396,17 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                         }}
                         onBlur={() => setNameTouched(true)}
                         maxLength={SKILL_NAME_MAX}
-                        aria-invalid={nameError ? true : undefined}
+                        aria-invalid={nameMissing || nameError ? true : undefined}
                         placeholder="my-skill"
                         disabled={disabled}
                     />
                 </Field>
 
                 <Field
+                    className="shrink-0"
+                    invalid={descriptionMissing}
                     label="Description"
-                    required
-                    tooltip="The trigger the model matches when deciding to use this skill"
+                    tooltip="Tells the agent when to use this skill."
                     error={descriptionError}
                 >
                     <AutosizeTextarea
@@ -391,7 +417,7 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                         }}
                         onBlur={() => setDescriptionTouched(true)}
                         autoSize={{minRows: 2, maxRows: 4}}
-                        aria-invalid={descriptionError ? true : undefined}
+                        aria-invalid={descriptionMissing || descriptionError ? true : undefined}
                         placeholder="When the agent should reach for this skill"
                         disabled={disabled}
                     />
@@ -399,9 +425,10 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
 
                 {showSkill ? (
                     <Field
+                        className="min-h-0 flex-1"
+                        invalid={bodyMissing}
                         label="SKILL.md"
-                        required
-                        tooltip="The Markdown body the harness reads, written after the composed frontmatter"
+                        tooltip="The instructions the agent follows when it uses this skill."
                         error={bodyError}
                     >
                         <MarkdownEditor
@@ -416,16 +443,14 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                             disabled={disabled}
                             showToolbar
                             defaultView="rendered"
-                            // Viewport-relative, not a fixed 360px: the SKILL.md body is the point of
-                            // this form, so let it use most of the drawer height (scrolls internally
-                            // past that). Full parent-fill for consistency with the instructions
-                            // editor is a larger cross-package layout change (LabeledField in @agenta/ui).
-                            maxHeight="60vh"
+                            // Takes the drawer height left over after the other fields, so the body
+                            // scrolls inside the editor and the drawer itself never does.
+                            grow
                         />
                     </Field>
                 ) : (
-                    <div className="flex flex-col gap-2">
-                        <div className="flex items-center gap-2">
+                    <div className="flex min-h-0 flex-1 flex-col gap-2 overflow-hidden">
+                        <div className="flex shrink-0 items-center gap-2">
                             <Input
                                 value={activeFile?.path ?? ""}
                                 onChange={(e) =>
@@ -456,7 +481,8 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                                         </span>
                                     </TooltipTrigger>
                                     <TooltipContent>
-                                        Mark executable (sandbox policy must also allow it)
+                                        Let this file run as a program. Your sandbox settings must
+                                        allow it too.
                                     </TooltipContent>
                                 </Tooltip>
                             </TooltipProvider>
@@ -470,25 +496,57 @@ export function SkillFormView({value, onChange, disabled}: SkillFormViewProps) {
                             placeholder="File content"
                             disabled={disabled}
                             disableDebounce
+                            grow
                         />
                     </div>
                 )}
 
-                <ToggleRow
-                    label="Hide from prompt"
-                    description="Don't list this skill in the prompt — invoke only via /skill:name (Pi / Claude)"
-                    checked={Boolean(skill.disable_model_invocation)}
-                    onChange={(v) => set("disable_model_invocation", v)}
-                    disabled={disabled}
-                />
+                <div className="flex shrink-0 flex-col">
+                    <button
+                        type="button"
+                        onClick={() => setAdvancedOpen((prev) => !prev)}
+                        // Not disabled in read-only mode: the flags stay readable, just not editable.
+                        aria-expanded={advancedOpen}
+                        // px-0/font-[inherit]: preflight is off, so a bare button keeps the
+                        // UA's 6px inline padding (misaligning it from the fields) and Arial.
+                        className="flex cursor-pointer items-center justify-between border-0 bg-transparent px-0 py-1.5 font-[inherit]"
+                    >
+                        <span className="flex items-center gap-2">
+                            <SlidersHorizontal
+                                size={15}
+                                className="text-[var(--ag-colorTextSecondary)]"
+                            />
+                            <span className="text-xs font-medium text-[var(--ag-colorText)]">
+                                Advanced
+                            </span>
+                        </span>
+                        <CaretDown
+                            size={14}
+                            className={`text-[var(--ag-colorIcon)] transition-transform ${
+                                advancedOpen ? "" : "-rotate-90"
+                            }`}
+                        />
+                    </button>
+                    <HeightCollapse open={advancedOpen}>
+                        <div className="flex flex-col gap-3 pb-2 pt-1">
+                            <ToggleRow
+                                label="Hide from prompt"
+                                description="The agent won't pick this skill on its own. You run it yourself with /skill:name."
+                                checked={Boolean(skill.disable_model_invocation)}
+                                onChange={(v) => set("disable_model_invocation", v)}
+                                disabled={disabled}
+                            />
 
-                <ToggleRow
-                    label="Allow executable files"
-                    description="Permit executable bundled files (the sandbox policy must also allow execution)"
-                    checked={Boolean(skill.allow_executable_files)}
-                    onChange={(v) => set("allow_executable_files", v)}
-                    disabled={disabled}
-                />
+                            <ToggleRow
+                                label="Allow executable files"
+                                description="Let the files in this skill run as programs. Your sandbox settings must allow it too."
+                                checked={Boolean(skill.allow_executable_files)}
+                                onChange={(v) => set("allow_executable_files", v)}
+                                disabled={disabled}
+                            />
+                        </div>
+                    </HeightCollapse>
+                </div>
             </div>
         </div>
     )

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillUploadZone.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SkillUploadZone.tsx
@@ -57,7 +57,8 @@ export function SkillUploadZone({onParsed, disabled}: SkillUploadZoneProps) {
             }}
             className={cn(
                 "flex flex-col items-center justify-center gap-2 rounded border border-dashed px-4 py-5 text-center transition-colors",
-                "border-[var(--ag-zinc-3)]",
+                // Same hairline as the rail divider above, rather than the heavier zinc-3.
+                "border-colorBorderSecondary",
                 over && "border-[var(--ag-c-586673)] bg-[var(--ag-c-F5F7FA)]",
                 disabled && "opacity-60",
             )}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useConfigItemDrawer.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useConfigItemDrawer.ts
@@ -4,6 +4,8 @@
  */
 import {useCallback, useEffect, useMemo, useState} from "react"
 
+import {stableStringify} from "@agenta/entities/workflow/commitDiff"
+
 import type {ConfigItemView} from "../ConfigItemDrawer"
 
 import {cloneItem} from "./agentTemplateUtils"
@@ -25,6 +27,8 @@ export function useConfigItemDrawer({
 }) {
     const [editing, setEditing] = useState<EditingState | null>(null)
     const [draft, setDraft] = useState<Record<string, unknown>>({})
+    // What the drawer opened with, so Save can tell an untouched item from an edited one.
+    const [opened, setOpened] = useState<string>("")
     const [drawerView, setDrawerView] = useState<ConfigItemView>("form")
     // JSON-view parse validity from the open drawer's JsonObjectEditor; blocks Save while the raw
     // JSON is invalid. Reset when the open item changes — each editor is keyed/remounts and starts
@@ -37,6 +41,7 @@ export function useConfigItemDrawer({
     const openCreate = useCallback(
         (kind: ItemKind, seed: Record<string, unknown>, view: ConfigItemView) => {
             setDraft(seed)
+            setOpened(stableStringify(seed))
             setDrawerView(view)
             setEditing({kind, mode: "create", index: -1})
         },
@@ -44,7 +49,9 @@ export function useConfigItemDrawer({
     )
     const openEdit = useCallback(
         (kind: ItemKind, index: number, item: unknown, view: ConfigItemView) => {
-            setDraft(cloneItem(item))
+            const initial = cloneItem(item)
+            setDraft(initial)
+            setOpened(stableStringify(initial))
             setDrawerView(view)
             setEditing({kind, mode: "edit", index})
         },
@@ -82,6 +89,10 @@ export function useConfigItemDrawer({
         [editing, draft],
     )
 
+    // Nothing to commit when the draft still matches what the drawer opened with. Key order is
+    // normalised, so a JSON-view reformat that changes no values still counts as untouched.
+    const draftUnchanged = useMemo(() => stableStringify(draft) === opened, [draft, opened])
+
     return {
         editing,
         draft,
@@ -96,5 +107,6 @@ export function useConfigItemDrawer({
         commitDraft,
         removeItem,
         draftInvalid,
+        draftUnchanged,
     }
 }

--- a/web/packages/agenta-ui/src/Editor/MarkdownToolbar.tsx
+++ b/web/packages/agenta-ui/src/Editor/MarkdownToolbar.tsx
@@ -63,6 +63,7 @@ import {
 } from "../components/ui/dropdown-menu"
 import {Input} from "../components/ui/input"
 import {Popover, PopoverContent, PopoverTrigger} from "../components/ui/popover"
+import {cn} from "../utils/styles"
 
 const BLOCK_TYPES = [
     {key: "paragraph", label: "Normal text"},
@@ -322,12 +323,12 @@ export function MarkdownToolbar({disabled = false}: MarkdownToolbarProps) {
                     {BLOCK_TYPES.map((b) => (
                         <DropdownMenuItem
                             key={b.key}
+                            // text-xs matches the trigger; the item default (14px) overshoots it.
                             // antd `selectable` + `selectedKeys`: the active block is highlighted.
-                            className={
-                                b.key === blockType
-                                    ? "bg-controlItemBgActive text-colorPrimary"
-                                    : undefined
-                            }
+                            className={cn(
+                                "text-xs",
+                                b.key === blockType && "bg-controlItemBgActive text-colorPrimary",
+                            )}
                             onMouseDown={keepEditorSelection}
                             onSelect={() => formatBlock(b.key)}
                         >

--- a/web/packages/agenta-ui/src/components/ui/field.tsx
+++ b/web/packages/agenta-ui/src/components/ui/field.tsx
@@ -60,6 +60,11 @@ export interface FieldProps extends VariantProps<typeof fieldLabelVariants> {
     description?: React.ReactNode
     /** Error / help line under the control, in `colorError`. */
     error?: React.ReactNode
+    /**
+     * Marks the field invalid without a message: reddens the label, pairing with the control's own
+     * `aria-invalid` border. For "this is missing" states where a text error would just be noise.
+     */
+    invalid?: boolean
     /** Layout direction. `vertical` (default) stacks; `horizontal` puts the label beside the control. */
     direction?: "vertical" | "horizontal"
     /**
@@ -86,6 +91,7 @@ function Field({
     tooltipPlacement = "right",
     description,
     error,
+    invalid = false,
     direction = "vertical",
     gap = "xs",
     size,
@@ -105,6 +111,12 @@ function Field({
 
     const isHorizontal = direction === "horizontal"
 
+    const errorLine = error != null && (
+        <span data-slot="field-error" className="text-xs text-error">
+            {error}
+        </span>
+    )
+
     const header = (label != null || description != null) && (
         <div data-slot="field-header" className="flex flex-col gap-0.5">
             {label != null && (
@@ -112,7 +124,11 @@ function Field({
                     <Label
                         htmlFor={controlId}
                         data-slot="field-label"
-                        className={cn(fieldLabelVariants({size}), isHorizontal && "flex-shrink-0")}
+                        className={cn(
+                            fieldLabelVariants({size}),
+                            isHorizontal && "flex-shrink-0",
+                            invalid && "text-error",
+                        )}
                     >
                         <span data-slot="field-label-text">
                             {label}
@@ -152,12 +168,6 @@ function Field({
                 </span>
             )}
         </div>
-    )
-
-    const errorLine = error != null && (
-        <span data-slot="field-error" className="text-xs text-error">
-            {error}
-        </span>
     )
 
     if (isHorizontal) {


### PR DESCRIPTION
## Context

The skill config drawer had accumulated chrome that repeated what the form already said, and two of its editors could not use the space they were given.

The header carried a graduation-cap icon, a gold `skill` badge and an "Inline SKILL.md package" subtitle above a form whose first two fields are Name and Description. The SKILL.md editor was capped at `60vh`, so on a tall drawer it left a band of dead space and made the whole drawer body scroll instead of the editor. Empty required fields printed a "Required." line that pushed every field below it down as you tabbed through.

Several smaller faults turned up while working in there. Preflight is off in this codebase, so the editor toolbar's bare `border-b` still painted the browser's default border on the other three sides, and the top one landed 1px inside the container's own border and read as a doubled edge. `CodeEditor` and `JsonObjectEditor` each wrapped `SharedEditor` in a second bordered box, doubling the ring again. In source view the code-block language picker floated a "Markdown" pill over the text, because source view wraps the whole document in one synthetic markdown `CodeNode` and the picker attaches to every code block. In dark mode the Files panel had its fill deleted by a rule in `globals.css`, leaving the lane invisible against the sheet.

## Changes

**Drawer chrome.** `AgentTemplateControl` passes no icon, badge, subtitle or footer note for the skill item kind. The row descriptors keep all four, so the config-item list is unchanged. `ConfigItemDrawer` renders the footer note only when it has one and pins the actions with `ml-auto`, so Cancel and Save stay right-aligned without it. The behaviour flags moved under an Advanced disclosure built on the same caret-plus-`HeightCollapse` pattern the schedule drawer uses; it opens on mount when either flag is already set.

**Editors fill their pane.** `MarkdownEditor` and `CodeEditor` gained a `grow` mode: instead of viewport math it fills whatever height the flex parent gives it and scrolls inside. The scroll sits on a wrapper, not on `SharedEditor`, which sets `overflow: hidden` inline where a utility class cannot reach it:

```
// does not scroll: inline style wins
<SharedEditor className="flex-1 overflow-y-auto" />

// scrolls
<div className="min-h-0 flex-1 overflow-y-auto">
  <SharedEditor className="!min-h-full" />
</div>
```

The skill form's right pane is now `overflow-hidden`, so the drawer body itself never scrolls. Clicking blank space below the text focuses the editor and puts the caret at the end; clicks past `clientWidth` or `clientHeight` are ignored so classic scrollbars still drag.

**Validation.** A missing value now reads as a red label plus the control's existing red border, rather than a text line that reflows the form. The shared `Field` takes a new `invalid` prop for this. Real messages are untouched: "Max N characters.", the slug rules and "Must be text." all still print. The non-string case is deliberately not treated as missing, so a `"name": 123` typed in the JSON view keeps its explanation.

**Borders and theme.** The toolbar leads with `border-0` before `border-b`. `CodeEditor` and `JsonObjectEditor` dropped their wrapper borders and leave `SharedEditor` to draw the single ring. The language picker is gated out of source view. Dark mode restores the Files panel fill and drops the recessed rail band that showed through around it, so the lane reads the way it does in light mode:

```
             light            dark (before)     dark (after)
sheet        #ffffff          #141414           #141414
rail band    none             #1a1b1e           none
Files panel  #EAEFF5          transparent       #242424
```

Two hardcoded `--ag-*` literals became the semantic `colorBorderSecondary` so the rail divider and the drop zone match in both themes.

## Tests / notes

- `eslint` and `tsc --noEmit` pass on `@agenta/entity-ui` and `@agenta/ui`.
- Verified in the running app against the dark theme, measuring computed styles rather than eyeballing: drawer body at zero overscroll with a 32-line file, the toolbar at `0px` on three sides, the rail divider meeting the header and footer rules exactly, and the form fields and Create button sharing one right edge.
- `ConfigItemDrawer`, `Field`, `MarkdownEditor`, `CodeEditor` and `MarkdownToolbar` are shared. The tool and MCP server drawers pick up the border fixes, the smaller Form/JSON toggle and the footer change; their header chrome is untouched because the bare-chrome path is gated on the skill kind. `Field`'s `invalid` and the editors' `grow` both default off, so no existing caller changes.
- `MarkdownToolbar`'s text-style menu rendered at 14px under a 13px trigger. Fixed per-option, because `size="sm"` on the shared `Segmented` still maps to `text-field-md`, which looks like a bug in that component against its own comment. Left alone here since it would move every small Segmented in the app.

## What to QA

- Open an agent's config, add a skill. The drawer header shows only "New skill" and the Form/JSON toggle, with no icon, badge, subtitle or footer note.
- Paste a long SKILL.md body. The editor fills to the Advanced row and scrolls inside it. The drawer body does not scroll and the Advanced row stays put.
- Click well below the last line of the body. The editor takes focus with the caret at the end.
- Blur Name and Description while empty. Both labels and borders turn red with no "Required." line, and nothing below them shifts. Type past the character limit and the text message still appears.
- Add a bundled file and paste 50 lines. The code editor fills the pane, scrolls, and keeps its line numbers.
- Switch the body to Source. No "Markdown" pill floats over the text. Switch back to Rich text and type ```js in a fenced block; its language picker still appears and reads "JavaScript".
- In dark mode, the Files panel reads as a distinct panel against the drawer, with no lighter band behind or around it.
- Regression: open a tool and an MCP server drawer. Both keep their icon, type badge and subtitle, and their editors show a single border.

## PReview

Before 

<img width="500" alt="image" src="https://github.com/user-attachments/assets/0c9514fb-358e-49fa-b56c-9e18aa873c67" />

After

<img width="500"  alt="image" src="https://github.com/user-attachments/assets/30423b31-86ae-4994-a30b-b65968e9dbf5" />
