### PR TITLE
[fix] Gate the instructions drawer's Save on a real edit

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -182,10 +182,14 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
     // Instructions file editor (a file list — one AGENTS.md today). Draft + Save like the item drawer.
     const [editingInstruction, setEditingInstruction] = useState<{filename: string} | null>(null)
     const [instructionDraft, setInstructionDraft] = useState("")
+    // The content we opened with — Save is gated on a real diff against it, like the section drawers.
+    const [instructionOriginal, setInstructionOriginal] = useState("")
     const openInstruction = useCallback((filename: string, content: string) => {
         setInstructionDraft(content)
+        setInstructionOriginal(content)
         setEditingInstruction({filename})
     }, [])
+    const instructionDirty = instructionDraft !== instructionOriginal
 
     // Section drawers (Model & harness, Advanced) use a SCOPED draft: edits are buffered locally and
     // relayed to the entity only on Save (Cancel discards; Save is gated on a real diff vs. the value
@@ -1017,6 +1021,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
                         setEditingInstruction(null)
                     }}
                     disabled={disabled}
+                    dirty={instructionDirty}
                 />
             )}
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/InstructionsDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/InstructionsDrawer.tsx
@@ -4,7 +4,7 @@
  * The right-hand editor drawer for a single instructions markdown file (e.g. AGENTS.md), opened
  * from a file row in the Instructions section. A header `Edit | Preview` toggle switches between the
  * editing view (the shared `MarkdownEditor` with a formatting toolbar) and a read-only rendered
- * Preview that can Expand to fill the drawer. A right rail carries suggested-action scaffolds.
+ * Preview. A right rail carries suggested-action scaffolds.
  *
  * Like the tools/skills drawer, editing happens on a draft the host owns: the drawer reports changes
  * via `onChange`, commits via `onSave`, and discards via `onCancel` / the close button, so an
@@ -15,15 +15,8 @@
 import {useCallback, useState} from "react"
 
 import {EnhancedDrawer} from "@agenta/ui/drawer"
-import {
-    Button,
-    Segmented,
-    Tooltip,
-    TooltipContent,
-    TooltipProvider,
-    TooltipTrigger,
-} from "@agenta/ui/ui"
-import {ArrowsIn, ArrowsOut, FileText, Lightbulb} from "@phosphor-icons/react"
+import {Button, Segmented} from "@agenta/ui/ui"
+import {Lightbulb} from "@phosphor-icons/react"
 
 import {MarkdownEditor} from "./MarkdownEditor"
 
@@ -40,6 +33,8 @@ export interface InstructionsDrawerProps {
     /** Commit the draft to the config. */
     onSave: () => void
     disabled?: boolean
+    /** Whether the draft differs from the content the drawer opened with — Save is gated on it. */
+    dirty?: boolean
 }
 
 type DrawerMode = "edit" | "preview"
@@ -72,21 +67,16 @@ export function InstructionsDrawer({
     onCancel,
     onSave,
     disabled = false,
+    dirty = false,
 }: InstructionsDrawerProps) {
     const [mode, setMode] = useState<DrawerMode>("edit")
-    const [expanded, setExpanded] = useState(false)
 
     const appendSnippet = useCallback(
         (snippet: string) => onChange(`${value}${snippet}`),
         [value, onChange],
     )
 
-    const changeMode = useCallback((next: DrawerMode) => {
-        setMode(next)
-        if (next === "edit") setExpanded(false)
-    }, [])
-
-    const railHidden = mode === "preview" && expanded
+    const changeMode = useCallback((next: DrawerMode) => setMode(next), [])
 
     return (
         <EnhancedDrawer
@@ -98,14 +88,11 @@ export function InstructionsDrawer({
             // Explicit Cancel/Save only — an outside click must not silently drop the draft.
             closeOnLayoutClick={false}
             destroyOnClose
-            title={
-                <div className="flex min-w-0 items-center gap-2">
-                    <FileText size={16} />
-                    <span className="truncate font-mono text-sm font-medium">{filename}</span>
-                </div>
-            }
+            title={<span className="truncate font-mono text-sm font-medium">{filename}</span>}
             extra={
                 <Segmented
+                    size="sm"
+                    className="[&_[data-slot=segmented-item]]:text-field-sm"
                     value={mode}
                     onChange={(v) => changeMode(v as DrawerMode)}
                     options={[
@@ -116,16 +103,13 @@ export function InstructionsDrawer({
                 />
             }
             footer={
-                <div className="flex items-center justify-between gap-3">
-                    <span className="text-xs text-[var(--ag-zinc-5)]">Draft — applies on save</span>
-                    <div className="flex shrink-0 items-center gap-2">
-                        <Button variant="outline" onClick={onCancel}>
-                            Cancel
-                        </Button>
-                        <Button variant="default" onClick={onSave} disabled={disabled}>
-                            Save
-                        </Button>
-                    </div>
+                <div className="flex items-center justify-end gap-2">
+                    <Button variant="outline" onClick={onCancel}>
+                        Cancel
+                    </Button>
+                    <Button variant="default" onClick={onSave} disabled={disabled || !dirty}>
+                        Save
+                    </Button>
                 </div>
             }
             styles={{body: {padding: 16, overflow: "hidden"}}}
@@ -147,29 +131,6 @@ export function InstructionsDrawer({
                         />
                     ) : (
                         <div className="relative flex-1">
-                            <TooltipProvider>
-                                <Tooltip>
-                                    <TooltipTrigger asChild>
-                                        <button
-                                            type="button"
-                                            aria-label={
-                                                expanded ? "Collapse preview" : "Expand preview"
-                                            }
-                                            onClick={() => setExpanded((e) => !e)}
-                                            className="absolute right-2 top-2 z-10 flex h-7 w-7 cursor-pointer items-center justify-center rounded border border-solid border-[var(--ag-c-EAEFF5)] bg-[var(--ag-c-FFFFFF)] text-[var(--ag-c-586673)] hover:border-[var(--ag-zinc-5)]"
-                                        >
-                                            {expanded ? (
-                                                <ArrowsIn size={14} />
-                                            ) : (
-                                                <ArrowsOut size={14} />
-                                            )}
-                                        </button>
-                                    </TooltipTrigger>
-                                    <TooltipContent>
-                                        {expanded ? "Collapse" : "Expand"}
-                                    </TooltipContent>
-                                </Tooltip>
-                            </TooltipProvider>
                             <MarkdownEditor
                                 value={value}
                                 onChange={onChange}
@@ -183,47 +144,42 @@ export function InstructionsDrawer({
                     )}
                 </div>
 
-                {!railHidden ? (
-                    <div className="flex w-[240px] shrink-0 flex-col gap-6">
-                        {filename === "AGENTS.md" ? (
-                            <div className="rounded-md bg-[var(--ag-rgba-051729-04,rgba(5,23,41,0.04))] p-3">
-                                <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-[var(--ag-c-586673)]">
-                                    <Lightbulb size={14} />
-                                    Writing a good AGENTS.md
-                                </div>
-                                <ul className="m-0 flex list-disc flex-col gap-1 pl-4 text-xs leading-snug text-[var(--ag-zinc-5)]">
-                                    <li>
-                                        Open with the agent&apos;s role and goal in one or two
-                                        lines.
-                                    </li>
-                                    <li>
-                                        Keep short, labelled sections (Role, Tools, Guardrails).
-                                    </li>
-                                    <li>Be concrete about the output format and hard limits.</li>
-                                    <li>Prefer imperative instructions over long prose.</li>
-                                </ul>
+                <div className="flex w-[240px] shrink-0 flex-col gap-3">
+                    {filename === "AGENTS.md" ? (
+                        <div className="rounded-md bg-[var(--ag-rgba-051729-04,rgba(5,23,41,0.04))] p-3">
+                            <div className="mb-1.5 flex items-center gap-1.5 text-xs font-medium text-[var(--ag-c-586673)]">
+                                <Lightbulb size={14} />
+                                Writing a good AGENTS.md
                             </div>
-                        ) : null}
-                        <div>
-                            <div className="mb-2 text-xs uppercase tracking-wide text-[var(--ag-zinc-5)]">
-                                Suggested
-                            </div>
-                            <div className="flex flex-wrap gap-1.5">
-                                {SUGGESTIONS.map((s) => (
-                                    <button
-                                        key={s.label}
-                                        type="button"
-                                        disabled={disabled || mode === "preview"}
-                                        onClick={() => appendSnippet(s.snippet)}
-                                        className="cursor-pointer rounded-full border border-solid border-[var(--ag-c-EAEFF5)] bg-transparent px-2.5 py-1 text-xs text-[var(--ag-c-586673)] transition-colors hover:border-[var(--ag-zinc-5)] disabled:cursor-not-allowed disabled:opacity-50"
-                                    >
-                                        + {s.label}
-                                    </button>
-                                ))}
-                            </div>
+                            <ul className="m-0 flex list-disc flex-col gap-1 pl-4 text-xs leading-snug text-[var(--ag-zinc-5)]">
+                                <li>
+                                    Open with the agent&apos;s role and goal in one or two lines.
+                                </li>
+                                <li>Keep short, labelled sections (Role, Tools, Guardrails).</li>
+                                <li>Be concrete about the output format and hard limits.</li>
+                                <li>Prefer imperative instructions over long prose.</li>
+                            </ul>
+                        </div>
+                    ) : null}
+                    <div>
+                        <div className="mb-2 text-xs tracking-wide text-[var(--ag-zinc-5)]">
+                            Suggested
+                        </div>
+                        <div className="flex flex-wrap gap-1.5">
+                            {SUGGESTIONS.map((s) => (
+                                <button
+                                    key={s.label}
+                                    type="button"
+                                    disabled={disabled || mode === "preview"}
+                                    onClick={() => appendSnippet(s.snippet)}
+                                    className="cursor-pointer rounded-control border border-solid border-[var(--ag-c-EAEFF5)] bg-transparent px-2.5 py-1 text-xs text-[var(--ag-c-586673)] transition-colors hover:border-[var(--ag-zinc-5)] disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    + {s.label}
+                                </button>
+                            ))}
                         </div>
                     </div>
-                ) : null}
+                </div>
             </div>
         </EnhancedDrawer>
     )

--- a/web/storybook/stories/entity-ui/InstructionsDrawer.stories.tsx
+++ b/web/storybook/stories/entity-ui/InstructionsDrawer.stories.tsx
@@ -69,6 +69,7 @@ const DrawerDemo = ({filename = "AGENTS.md", disabled = false}) => {
                 onCancel={() => setOpen(false)}
                 onSave={() => setOpen(false)}
                 disabled={disabled}
+                dirty={value !== SAMPLE}
             />
         </div>
     )


### PR DESCRIPTION
## Context

The Instructions drawer (the AGENTS.md editor in the agent config) had two problems.

Its Save button was enabled from the moment the drawer opened. Open a file, change nothing, hit Save, and the drawer wrote the untouched content back to the config as if you had edited it. The section drawers beside it already gate Save on a real diff. This one did not.

The drawer also carried chrome that told the reader nothing: a file icon next to a filename that was already there, a "Draft — applies on save" footer note restating what Cancel and Save make obvious, and an Expand toggle on the preview pane that hid the guidance rail.

## Changes

`InstructionsDrawer` takes a new `dirty` prop and gates Save on `disabled || !dirty`. This is deliberately separate from `disabled`, which the drawer also passes to the markdown editor and the suggestion chips. Folding the diff check into `disabled` would have made the editor read-only whenever the content was unchanged.

`AgentTemplateControl` records the content the drawer opened with and derives the flag from it, matching how the section drawers compute `sectionDirty`:

```
const [instructionOriginal, setInstructionOriginal] = useState("")
// set alongside the draft in openInstruction
const instructionDirty = instructionDraft !== instructionOriginal
```

Removing the Expand toggle also removed the `expanded` state it drove and the `railHidden` branch that state fed, so the guidance rail now always renders in preview mode. The `Tooltip` and `ArrowsIn`/`ArrowsOut` imports went with it.

The rest is visual: the segmented control drops to `size="sm"` with `text-field-sm` labels, the suggestion chips go from `rounded-full` to `rounded-control`, the "SUGGESTED" label loses its `uppercase` and reads "Suggested", and the rail's internal gap tightens from `gap-6` to `gap-3`.

## Tests

- `pnpm lint-fix` in `web` passes.
- The Storybook story wires `dirty={value !== SAMPLE}` so the Save gate is exercised there.
- Worth a look in review: the drawer's `disabled` prop is a read-only flag from the playground, and it still greys the editor, the chips, and Save. That behavior is unchanged and intentional.

## What to QA

- Open an agent's AGENTS.md from the Instructions section. Save is greyed out.
- Type a character. Save enables. Delete it so the content matches what you opened with. Save greys out again.
- Click a suggestion chip (Output format, Tone & style, Guardrails). The snippet appends and Save enables.
- Edit, Save, then reopen the same file. Save starts greyed again against the newly saved content.
- Switch to Preview. The "Writing a good AGENTS.md" rail stays visible (it used to be hidden behind the removed Expand toggle).
- Regression: open the drawer on a read-only revision. The editor, the chips, and Save are all still greyed.
