### PR TITLE
[docs] Require stories for new features and an /m smoke on shared-package changes

### DIFF
--- a/.agents/skills/write-pr-description/SKILL.md
+++ b/.agents/skills/write-pr-description/SKILL.md
@@ -11,6 +11,17 @@ Write PRs that a teammate can understand at a glance. Lead with what was broken 
 
 This is the default quality bar from the first draft. Don't ship a generic version expecting to fix it after feedback.
 
+## 0. The prefilled template
+
+GitHub prefills every PR from `.github/PULL_REQUEST_TEMPLATE.md`, which asks for Summary, Testing, Demo, Checklist, and Contributor Resources. That is not what this repo's PRs look like. Replace the prefilled body with the structure in section 2.
+
+Two parts of the template still apply:
+
+- **Demo.** UI changes need a capture from the real app running your branch. Never substitute a mock-up, a component harness, or a recreated screen. If you cannot run the app, say the demo is outstanding and why, rather than filling the space with something that proves nothing.
+- **Testing.** Keep the substance under a `## Tests` heading. You do not need the template's three subheadings unless the change is large enough that they help.
+
+Drop the Checklist and Contributor Resources. They exist for first-time outside contributors and the team does not fill them in.
+
 ## 1. Title
 
 The title states the actual change in plain words.

--- a/.agents/skills/write-pr-description/SKILL.md
+++ b/.agents/skills/write-pr-description/SKILL.md
@@ -20,7 +20,7 @@ Two parts of the template still apply:
 - **Demo.** UI changes need a capture from the real app running your branch. Never substitute a mock-up, a component harness, or a recreated screen. If you cannot run the app, say the demo is outstanding and why, rather than filling the space with something that proves nothing.
 - **Testing.** Keep the substance under a `## Tests` heading. You do not need the template's three subheadings unless the change is large enough that they help.
 
-Drop the Checklist and Contributor Resources. They exist for first-time outside contributors and the team does not fill them in.
+Drop the Checklist and Contributor Resources if the author is a core maintainer of the repo. They exist for first-time outside contributors and the team does not fill them in.
 
 ## 1. Title
 

--- a/web/AGENTS.md
+++ b/web/AGENTS.md
@@ -10,6 +10,15 @@ the detail this file only summarizes.
 ## Before committing
 
 - Run `pnpm lint-fix` within the `web` folder.
+- A new user-facing feature adds or refreshes Storybook stories for its new components in
+  `web/storybook` (`stories/entity-ui/` for the data-connected `@agenta/entity-ui` surfaces).
+  Cover the states a reviewer cannot reach by clicking — empty, error, read-only, migration.
+  Nothing type-checks that package in CI, so run `pnpm --filter @agenta/storybook lint` and
+  build it once: a story whose component changed shape fails only at build time.
+- A change to any package `web/mobile` consumes (`chat`, `entities`, `entity-ui`,
+  `playground`, `playground-ui`, `shared`) gets a smoke check on `/m` before the PR is done.
+  Mobile is a separate host with its own providers and hydration, and it has broken silently
+  before — the desktop app looked fine while `/m` rendered nothing.
 - Theme colors have a single source of truth: `oss/src/styles/theme/palette.ts` (semantic
   roles with `{light, dark}` values). To change any color, edit `palette.ts`, run
   `pnpm generate:tailwind-tokens`, and commit the regenerated `theme-variables.css` +


### PR DESCRIPTION
Two standing rules for `web/AGENTS.md`, both from failures we hit this week rather than from principle.

## Stories for a new user-facing feature

The gateway connection rework shipped four new surfaces with no stories. While adding them I found the existing `AgentIntegrationDrawer` story had been dead for days — written against props that no longer existed — and that the whole Storybook could not build, because a story still imported a panel deleted in `f2ff465e43`.

Neither failure was visible to anyone: `@agenta/storybook` appears nowhere in `turbo.json`, and `web`'s `type-check` script covers only `oss` and `ee`. So the rule names the lint and build steps explicitly, since a story whose component changed shape fails only at build time.

## An `/m` smoke on shared-package changes

`web/mobile` is a separate host with its own providers and hydration, consuming six shared packages. It has broken silently before while the desktop app looked fine — the QueryClient host divergence being the documented case, where mutations reported success against an orphan cache.

## Notes

Docs only: one file, no code paths touched.

**On the base branch.** This is cut from `main` as briefed, which keeps the diff to a single file. If the convention is that this should land on `release/v0.114.2` instead, the branch needs recutting rather than retargeting — `main` is not an ancestor of that release branch, so the same commit shows 43 unrelated files against it.
