### PR TITLE
[fix] Guard crypto.randomUUID so /m renders over plain HTTP

### DIFF
--- a/web/mobile/src/features/agents/AgentComposer.tsx
+++ b/web/mobile/src/features/agents/AgentComposer.tsx
@@ -5,6 +5,8 @@ import {HomeTaskComposer} from "@agenta/home-ui"
 import {useSetAtom} from "jotai"
 import {useRouter} from "next/router"
 
+import {newId} from "@/lib/ids"
+
 import {stashPendingTaskAtom, takePendingTaskAtom} from "../home/pendingTask"
 
 /**
@@ -26,7 +28,7 @@ export const AgentComposer = ({
     const router = useRouter()
     const stash = useSetAtom(stashPendingTaskAtom)
     const dropPendingTask = useSetAtom(takePendingTaskAtom)
-    const [sessionId] = useState(() => crypto.randomUUID())
+    const [sessionId] = useState(() => newId())
     const attachments = useComposerAttachments({sessionId})
 
     const start = async ({text}: {agentId: string; text: string}) => {

--- a/web/mobile/src/features/agents/useNewAgentAction.ts
+++ b/web/mobile/src/features/agents/useNewAgentAction.ts
@@ -10,6 +10,8 @@ import type {FileUIPart} from "ai"
 import {useSetAtom} from "jotai"
 import {useRouter} from "next/router"
 
+import {newId} from "@/lib/ids"
+
 import {stashPendingTaskAtom, takePendingTaskAtom} from "../home/pendingTask"
 
 import {agentHandoffPath, isSeededCreate} from "./agentHandoff"
@@ -58,7 +60,7 @@ export const useNewAgentAction = (base: string) => {
             const seed = params?.seedMessage?.trim() ?? ""
             const seedParts = params?.seedParts
             const seeded = isSeededCreate({seed, partCount: seedParts?.length ?? 0})
-            const sessionId = seeded ? (params?.sessionId ?? crypto.randomUUID()) : null
+            const sessionId = seeded ? (params?.sessionId ?? newId()) : null
             if (sessionId) {
                 // The session does not exist server-side until its first turn — mint the id, stash
                 // the instruction, and let the chat screen's engine send it once.

--- a/web/mobile/src/features/chat/useStartBlankSession.ts
+++ b/web/mobile/src/features/chat/useStartBlankSession.ts
@@ -3,6 +3,8 @@ import {useCallback} from "react"
 import {markSessionFresh} from "@agenta/chat/state"
 import {useRouter} from "next/router"
 
+import {newId} from "@/lib/ids"
+
 /**
  * Start a BLANK session with an agent and land on it.
  *
@@ -18,7 +20,7 @@ export const useStartBlankSession = (base: string) => {
     const router = useRouter()
     return useCallback(
         (agentId: string) => {
-            const sessionId = crypto.randomUUID()
+            const sessionId = newId()
             // Brand-new, never-run: the backend has no records for it yet. Without this the
             // conversation treats the empty hydration as a KNOWN session whose history was pruned
             // and shows "this session has no replayable history", which is alarming and false —

--- a/web/mobile/src/features/home/HomeComposer.tsx
+++ b/web/mobile/src/features/home/HomeComposer.tsx
@@ -7,6 +7,8 @@ import {HomeTaskComposer, type HomeTaskComposerAgent} from "@agenta/home-ui"
 import {useSetAtom} from "jotai"
 import {useRouter} from "next/router"
 
+import {newId} from "@/lib/ids"
+
 import {stashPendingTaskAtom, takePendingTaskAtom} from "./pendingTask"
 
 /**
@@ -29,7 +31,7 @@ export const HomeComposer = ({
     const stash = useSetAtom(stashPendingTaskAtom)
     const dropPendingTask = useSetAtom(takePendingTaskAtom)
     const [sessionId] = useState(() => {
-        const id = crypto.randomUUID()
+        const id = newId()
         // Same reason as the rail's "+": a session minted here has no durable records yet.
         markSessionFresh(id)
         return id

--- a/web/mobile/src/features/onboarding/FirstRunComposer.tsx
+++ b/web/mobile/src/features/onboarding/FirstRunComposer.tsx
@@ -5,6 +5,8 @@ import {stagedFilesToParts, useComposerAttachments} from "@agenta/chat/hooks"
 import {markSessionFresh} from "@agenta/chat/state"
 import type {RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 
+import {newId} from "@/lib/ids"
+
 import type {useNewAgentAction} from "../agents/useNewAgentAction"
 
 import {FIRST_RUN_COPY, FIRST_RUN_STARTERS} from "./copy"
@@ -38,7 +40,7 @@ export const FirstRunComposer = ({
 }) => {
     const inputRef = useRef<RichChatInputHandle | null>(null)
     const [sessionId] = useState(() => {
-        const id = crypto.randomUUID()
+        const id = newId()
         // Same reason as Home's composer: a session minted here has no durable records yet.
         markSessionFresh(id)
         return id

--- a/web/mobile/src/lib/ids.ts
+++ b/web/mobile/src/lib/ids.ts
@@ -1,0 +1,16 @@
+/**
+ * Client-side id generation.
+ *
+ * `crypto.randomUUID` exists only in a SECURE context. The dev stack is served over plain HTTP,
+ * where it is `undefined` — every unguarded call threw `crypto.randomUUID is not a function` and
+ * took the whole screen down, because these ids are minted during render.
+ *
+ * Ids from here are React keys and client-minted session ids, never anything security-bearing, so
+ * the fallback only has to be unique within a tab.
+ */
+export function newId(): string {
+    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
+        return crypto.randomUUID()
+    }
+    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+}

--- a/web/mobile/src/lib/ids.ts
+++ b/web/mobile/src/lib/ids.ts
@@ -1,16 +1,36 @@
-/**
- * Client-side id generation.
- *
- * `crypto.randomUUID` exists only in a SECURE context. The dev stack is served over plain HTTP,
- * where it is `undefined` — every unguarded call threw `crypto.randomUUID is not a function` and
- * took the whole screen down, because these ids are minted during render.
- *
- * Ids from here are React keys and client-minted session ids, never anything security-bearing, so
- * the fallback only has to be unique within a tab.
- */
+// `crypto.randomUUID` needs a secure context; over plain HTTP it is undefined and the unguarded
+// call threw during render, blanking the screen.
+
+const HEX = Array.from({length: 256}, (_, i) => i.toString(16).padStart(2, "0"))
+
+/** Fallback counter, so the no-crypto id claims sequence rather than randomness. */
+let sequence = 0
+
+const cryptoApi = (): Crypto | undefined => (typeof crypto === "undefined" ? undefined : crypto)
+
+/** RFC 4122 v4 from real entropy — insecure contexts still have `getRandomValues`. */
+function uuidFromRandomValues(api: Crypto): string {
+    const bytes = api.getRandomValues(new Uint8Array(16))
+    bytes[6] = (bytes[6] & 0x0f) | 0x40 // version 4
+    bytes[8] = (bytes[8] & 0x3f) | 0x80 // variant 10xx
+    const hex = Array.from(bytes, (byte) => HEX[byte])
+    return [
+        hex.slice(0, 4).join(""),
+        hex.slice(4, 6).join(""),
+        hex.slice(6, 8).join(""),
+        hex.slice(8, 10).join(""),
+        hex.slice(10, 16).join(""),
+    ].join("-")
+}
+
+/** A client-minted session id or React key. Never security-bearing. */
 export function newId(): string {
-    if (typeof crypto !== "undefined" && typeof crypto.randomUUID === "function") {
-        return crypto.randomUUID()
+    const api = cryptoApi()
+    if (api) {
+        if (typeof api.randomUUID === "function") return api.randomUUID()
+        if (typeof api.getRandomValues === "function") return uuidFromRandomValues(api)
     }
-    return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
+    // No crypto at all: unique within the tab, and honest about carrying no entropy.
+    sequence += 1
+    return `id-${Date.now().toString(36)}-${sequence.toString(36)}`
 }

--- a/web/mobile/tests/unit/ids.test.ts
+++ b/web/mobile/tests/unit/ids.test.ts
@@ -1,0 +1,49 @@
+/**
+ * Id generation across secure and insecure contexts.
+ *
+ * `crypto.randomUUID` is defined only in a secure context. Over plain HTTP — how the dev stack is
+ * served — it is `undefined`, and because these ids are minted during render, every unguarded call
+ * took the whole mobile screen down with "crypto.randomUUID is not a function".
+ */
+import {afterEach, describe, expect, it, vi} from "vitest"
+
+import {newId} from "../../src/lib/ids"
+
+const withCrypto = (value: unknown) => vi.stubGlobal("crypto", value as typeof globalThis.crypto)
+
+afterEach(() => {
+    vi.unstubAllGlobals()
+})
+
+describe("newId", () => {
+    it("uses crypto.randomUUID when the context is secure", () => {
+        const randomUUID = vi.fn(() => "11111111-2222-3333-4444-555555555555")
+        withCrypto({randomUUID})
+
+        expect(newId()).toBe("11111111-2222-3333-4444-555555555555")
+        expect(randomUUID).toHaveBeenCalledTimes(1)
+    })
+
+    it("returns an id over plain HTTP, where randomUUID is missing", () => {
+        // The regression: this threw, during render, and blanked the screen.
+        withCrypto({})
+
+        expect(() => newId()).not.toThrow()
+        expect(newId()).toMatch(/^[a-z0-9]+-[a-z0-9]+$/)
+    })
+
+    it("survives crypto being absent altogether", () => {
+        withCrypto(undefined)
+
+        expect(newId()).toBeTruthy()
+    })
+
+    it("does not repeat itself on the fallback path", () => {
+        // These ids key React lists and identify client-minted sessions, so a collision inside one
+        // tab would merge two sessions.
+        withCrypto({})
+
+        const ids = new Set(Array.from({length: 500}, () => newId()))
+        expect(ids.size).toBe(500)
+    })
+})

--- a/web/mobile/tests/unit/ids.test.ts
+++ b/web/mobile/tests/unit/ids.test.ts
@@ -1,15 +1,14 @@
-/**
- * Id generation across secure and insecure contexts.
- *
- * `crypto.randomUUID` is defined only in a secure context. Over plain HTTP — how the dev stack is
- * served — it is `undefined`, and because these ids are minted during render, every unguarded call
- * took the whole mobile screen down with "crypto.randomUUID is not a function".
- */
+// `crypto.randomUUID` needs a secure context; over plain HTTP the unguarded call blanked the screen.
 import {afterEach, describe, expect, it, vi} from "vitest"
 
 import {newId} from "../../src/lib/ids"
 
+const V4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/
+
 const withCrypto = (value: unknown) => vi.stubGlobal("crypto", value as typeof globalThis.crypto)
+
+/** The runtime's own implementation, captured before any stub replaces the global. */
+const getRandomValues = globalThis.crypto.getRandomValues.bind(globalThis.crypto)
 
 afterEach(() => {
     vi.unstubAllGlobals()
@@ -17,33 +16,46 @@ afterEach(() => {
 
 describe("newId", () => {
     it("uses crypto.randomUUID when the context is secure", () => {
-        const randomUUID = vi.fn(() => "11111111-2222-3333-4444-555555555555")
-        withCrypto({randomUUID})
+        const randomUUID = vi.fn(() => "11111111-2222-4333-8444-555555555555")
+        withCrypto({randomUUID, getRandomValues})
 
-        expect(newId()).toBe("11111111-2222-3333-4444-555555555555")
+        expect(newId()).toBe("11111111-2222-4333-8444-555555555555")
         expect(randomUUID).toHaveBeenCalledTimes(1)
     })
 
-    it("returns an id over plain HTTP, where randomUUID is missing", () => {
-        // The regression: this threw, during render, and blanked the screen.
-        withCrypto({})
+    it("builds a v4 UUID from getRandomValues over plain HTTP", () => {
+        // The regression: this threw, during render.
+        withCrypto({getRandomValues})
 
-        expect(() => newId()).not.toThrow()
-        expect(newId()).toMatch(/^[a-z0-9]+-[a-z0-9]+$/)
+        expect(newId()).toMatch(V4)
     })
 
-    it("survives crypto being absent altogether", () => {
+    it("sets the version and variant bits, not just the shape", () => {
+        withCrypto({getRandomValues})
+
+        for (let i = 0; i < 50; i++) {
+            const id = newId()
+            expect(id[14]).toBe("4")
+            expect("89ab").toContain(id[19])
+        }
+    })
+
+    it("does not repeat itself on the getRandomValues path", () => {
+        withCrypto({getRandomValues})
+
+        expect(new Set(Array.from({length: 500}, newId)).size).toBe(500)
+    })
+
+    it("still returns an id when crypto is absent altogether", () => {
         withCrypto(undefined)
 
-        expect(newId()).toBeTruthy()
+        expect(newId()).toMatch(/^id-[a-z0-9]+-[a-z0-9]+$/)
     })
 
-    it("does not repeat itself on the fallback path", () => {
-        // These ids key React lists and identify client-minted sessions, so a collision inside one
-        // tab would merge two sessions.
-        withCrypto({})
+    it("does not repeat itself on the counter path", () => {
+        // A collision inside one tab would merge two sessions.
+        withCrypto(undefined)
 
-        const ids = new Set(Array.from({length: 500}, () => newId()))
-        expect(ids.size).toBe(500)
+        expect(new Set(Array.from({length: 500}, newId)).size).toBe(500)
     })
 })


### PR DESCRIPTION
Over plain HTTP the mobile home renders blank with `TypeError: crypto.randomUUID is not a function`.

`crypto.randomUUID` exists only in a **secure context**. The dev stack is served over HTTP, so it is `undefined` there — and because these ids are minted during render, the throw takes the whole screen down rather than degrading. Production over HTTPS is unaffected.

## The fix

One guarded helper, `web/mobile/src/lib/ids.ts`, following the pattern already in `web/packages/agenta-entity-ui/src/DrillInView/components/PlaygroundConfigSection/llmConfig.ts`. Five call sites now use it:

- `features/home/HomeComposer.tsx`
- `features/onboarding/FirstRunComposer.tsx`
- `features/agents/AgentComposer.tsx`
- `features/agents/useNewAgentAction.ts`
- `features/chat/useStartBlankSession.ts`

One helper rather than five copies of the guard: `web/mobile/src/lib/` is where the app already keeps this kind of glue, and a future sixth call site should not have to rediscover the constraint.

These ids are React keys and client-minted session ids, never anything security-bearing, so the fallback only needs to be unique within a tab.

## Tests

`web/mobile/tests/unit/ids.test.ts` covers the secure path, the insecure path that used to throw, `crypto` absent entirely, and no repeats across 500 fallback ids — a collision inside one tab would merge two sessions.

## Notes

Pre-existing, not from any current work: `HomeComposer` was last touched in `beb5efa0b5` (Aug 21). Found while smoke-testing `/m` against the dev stack, where it blocks mobile testing entirely.

Mobile: 19 test files, 135 tests pass. Lint and `types:check` clean.
