### PR TITLE
[fix] Reach the project switcher on a phone [AGE-4197]

### DIFF
--- a/web/mobile/src/components/ui/sheet.tsx
+++ b/web/mobile/src/components/ui/sheet.tsx
@@ -26,7 +26,11 @@ function SheetOverlay({className, ...props}: React.ComponentProps<typeof SheetPr
         <SheetPrimitive.Overlay
             data-slot="sheet-overlay"
             className={cn(
-                "fixed inset-0 z-50 bg-black/50 data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0",
+                // No dim on a phone. iOS composites the status-bar strip from the page's top
+                // colour, so any alpha here darkens that strip while the drawer beside it stays
+                // light — the seam that reads as the drawer failing to reach the top. With the
+                // scrim clear the strip lands on the body colour, which is the rail's own.
+                "fixed inset-0 z-50 bg-transparent data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 lg:bg-black/50",
                 className,
             )}
             {...props}
@@ -55,20 +59,23 @@ function SheetContent({
                 data-slot="sheet-content"
                 className={cn(
                     "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
+                    // The phone-width shadows carry the separation the scrim used to: below lg the
+                    // overlay is clear, so the panel's own edge is all that lifts it off the page.
+                    // Cast away from the edge the sheet is anchored to.
                     side === "right" &&
-                        "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm",
+                        "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm max-lg:shadow-[-8px_0_24px_-6px_rgb(0_0_0/0.28)]",
                     side === "left" &&
-                        "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm",
+                        "inset-y-0 left-0 h-full w-3/4 border-r data-[state=closed]:slide-out-to-left data-[state=open]:slide-in-from-left sm:max-w-sm max-lg:shadow-[8px_0_24px_-6px_rgb(0_0_0/0.28)]",
                     side === "top" &&
                         "inset-x-0 top-0 h-auto border-b data-[state=closed]:slide-out-to-top data-[state=open]:slide-in-from-top",
                     // A bottom sheet is full-bleed on a phone, but a window this wide would
                     // stretch a two-field form across the whole screen — so it caps and centres,
                     // and rounds its top the way it does against a phone's edge.
                     side === "bottom" &&
-                        "inset-x-0 bottom-0 mx-auto h-auto max-h-[85vh] w-full max-w-[560px] overflow-y-auto rounded-t-2xl border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:border-x",
+                        "inset-x-0 bottom-0 mx-auto h-auto max-h-[85vh] w-full max-w-[560px] overflow-y-auto rounded-t-2xl border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom sm:border-x max-lg:shadow-[0_-8px_24px_-6px_rgb(0_0_0/0.28)]",
                     // Bottom sheet on a phone…
                     side === "responsive" &&
-                        "inset-x-0 bottom-0 mx-auto h-auto max-h-[85vh] w-full max-w-[560px] overflow-y-auto rounded-t-2xl border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom",
+                        "inset-x-0 bottom-0 mx-auto h-auto max-h-[85vh] w-full max-w-[560px] overflow-y-auto rounded-t-2xl border-t data-[state=closed]:slide-out-to-bottom data-[state=open]:slide-in-from-bottom max-lg:shadow-[0_-8px_24px_-6px_rgb(0_0_0/0.28)]",
                     // …and the app's right-edge drawer from lg up, which is where the settings
                     // rail also stops being a phone layout. Every bottom-sheet property is
                     // unset explicitly — Tailwind would otherwise keep the narrower rule.

--- a/web/mobile/src/components/ui/sheet.tsx
+++ b/web/mobile/src/components/ui/sheet.tsx
@@ -26,10 +26,7 @@ function SheetOverlay({className, ...props}: React.ComponentProps<typeof SheetPr
         <SheetPrimitive.Overlay
             data-slot="sheet-overlay"
             className={cn(
-                // No dim on a phone. iOS composites the status-bar strip from the page's top
-                // colour, so any alpha here darkens that strip while the drawer beside it stays
-                // light — the seam that reads as the drawer failing to reach the top. With the
-                // scrim clear the strip lands on the body colour, which is the rail's own.
+                // No dim on a phone: alpha also darkens iOS's strip above the drawer.
                 "fixed inset-0 z-50 bg-transparent data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:animate-in data-[state=open]:fade-in-0 lg:bg-black/50",
                 className,
             )}
@@ -59,9 +56,7 @@ function SheetContent({
                 data-slot="sheet-content"
                 className={cn(
                     "fixed z-50 flex flex-col gap-4 bg-background shadow-lg transition ease-in-out data-[state=closed]:animate-out data-[state=closed]:duration-300 data-[state=open]:animate-in data-[state=open]:duration-500",
-                    // The phone-width shadows carry the separation the scrim used to: below lg the
-                    // overlay is clear, so the panel's own edge is all that lifts it off the page.
-                    // Cast away from the edge the sheet is anchored to.
+                    // Below lg the overlay is clear, so these shadows carry the separation instead.
                     side === "right" &&
                         "inset-y-0 right-0 h-full w-3/4 border-l data-[state=closed]:slide-out-to-right data-[state=open]:slide-in-from-right sm:max-w-sm max-lg:shadow-[-8px_0_24px_-6px_rgb(0_0_0/0.28)]",
                     side === "left" &&

--- a/web/mobile/src/features/nav/CreateProjectSheet.tsx
+++ b/web/mobile/src/features/nav/CreateProjectSheet.tsx
@@ -1,0 +1,80 @@
+import {useEffect, useState} from "react"
+
+import {Button} from "@/components/ui/button"
+import {Input} from "@/components/ui/input"
+import {
+    Sheet,
+    SheetContent,
+    SheetDescription,
+    SheetFooter,
+    SheetHeader,
+    SheetTitle,
+} from "@/components/ui/sheet"
+
+/**
+ * Create-project prompt, as the app's own sheet rather than the shared `NamePromptModal` —
+ * that one renders an antd modal, which /m does not ship and which laid out badly here with a
+ * keyboard open. `responsive` puts it on the bottom edge on a phone and the right edge from lg.
+ */
+export const CreateProjectSheet = ({
+    open,
+    onOpenChange,
+    onSubmit,
+    isPending,
+}: {
+    open: boolean
+    onOpenChange: (open: boolean) => void
+    onSubmit: (name: string) => void
+    isPending?: boolean
+}) => {
+    const [name, setName] = useState("")
+
+    useEffect(() => {
+        if (!open) setName("")
+    }, [open])
+
+    const submit = () => {
+        const trimmed = name.trim()
+        if (trimmed && !isPending) onSubmit(trimmed)
+    }
+
+    return (
+        <Sheet open={open} onOpenChange={(next) => (isPending ? undefined : onOpenChange(next))}>
+            <SheetContent side="responsive">
+                <SheetHeader>
+                    <SheetTitle>Create project</SheetTitle>
+                    <SheetDescription>Projects keep agents and sessions apart.</SheetDescription>
+                </SheetHeader>
+                <form
+                    className="flex flex-col gap-3 px-4"
+                    onSubmit={(event) => {
+                        event.preventDefault()
+                        submit()
+                    }}
+                >
+                    <Input
+                        autoFocus
+                        value={name}
+                        placeholder="Project name"
+                        onChange={(event) => setName(event.target.value)}
+                    />
+                    {/* Submit-on-enter without a visible button inside the form: the footer's
+                        Create sits outside it, where the sheet's layout puts it. */}
+                    <button type="submit" className="hidden" aria-hidden tabIndex={-1} />
+                </form>
+                <SheetFooter>
+                    <Button disabled={!name.trim() || isPending} onClick={submit}>
+                        {isPending ? "Creating…" : "Create"}
+                    </Button>
+                    <Button
+                        variant="outline"
+                        disabled={isPending}
+                        onClick={() => onOpenChange(false)}
+                    >
+                        Cancel
+                    </Button>
+                </SheetFooter>
+            </SheetContent>
+        </Sheet>
+    )
+}

--- a/web/mobile/src/features/nav/CreateProjectSheet.tsx
+++ b/web/mobile/src/features/nav/CreateProjectSheet.tsx
@@ -11,11 +11,7 @@ import {
     SheetTitle,
 } from "@/components/ui/sheet"
 
-/**
- * Create-project prompt, as the app's own sheet rather than the shared `NamePromptModal` —
- * that one renders an antd modal, which /m does not ship and which laid out badly here with a
- * keyboard open. `responsive` puts it on the bottom edge on a phone and the right edge from lg.
- */
+/** Create-project prompt. Not the shared `NamePromptModal`: that renders antd, which /m bans. */
 export const CreateProjectSheet = ({
     open,
     onOpenChange,
@@ -39,7 +35,7 @@ export const CreateProjectSheet = ({
     }
 
     return (
-        <Sheet open={open} onOpenChange={(next) => (isPending ? undefined : onOpenChange(next))}>
+        <Sheet open={open} onOpenChange={onOpenChange}>
             <SheetContent side="responsive">
                 <SheetHeader>
                     <SheetTitle>Create project</SheetTitle>
@@ -58,19 +54,15 @@ export const CreateProjectSheet = ({
                         placeholder="Project name"
                         onChange={(event) => setName(event.target.value)}
                     />
-                    {/* Submit-on-enter without a visible button inside the form: the footer's
-                        Create sits outside it, where the sheet's layout puts it. */}
+                    {/* Enter submits; the visible Create sits in the footer, outside this form. */}
                     <button type="submit" className="hidden" aria-hidden tabIndex={-1} />
                 </form>
                 <SheetFooter>
+                    {/* Pending blocks submitting only: a dismissed create still lands and refetches. */}
                     <Button disabled={!name.trim() || isPending} onClick={submit}>
                         {isPending ? "Creating…" : "Create"}
                     </Button>
-                    <Button
-                        variant="outline"
-                        disabled={isPending}
-                        onClick={() => onOpenChange(false)}
-                    >
+                    <Button variant="outline" onClick={() => onOpenChange(false)}>
                         Cancel
                     </Button>
                 </SheetFooter>

--- a/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
+++ b/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
@@ -1,7 +1,6 @@
 import {useMemo, useState} from "react"
 
 import {
-    NamePromptModal,
     ProjectOrgSwitcherView,
     type SwitcherEntry,
     type SwitcherThemeControl,
@@ -14,6 +13,8 @@ import {fetchProjects, writeLastContext} from "@/lib/context"
 
 import {useLogout} from "../auth/useLogout"
 import {groupByOrganization} from "../context/workspaceGroups"
+
+import {CreateProjectSheet} from "./CreateProjectSheet"
 
 /**
  * The drawer's header switcher: the desktop rail's component, bound to mobile's project data.
@@ -130,12 +131,9 @@ export const DrawerProjectSwitcher = ({
                 onCreateProject={() => setCreateOpen(true)}
                 onLogout={() => void logout()}
             />
-            <NamePromptModal
-                title="Create project"
-                label="Project name"
-                placeholder="Project name"
+            <CreateProjectSheet
                 open={createOpen}
-                onCancel={() => setCreateOpen(false)}
+                onOpenChange={setCreateOpen}
                 onSubmit={(name) => createProject.mutate(name)}
                 isPending={createProject.isPending}
             />

--- a/web/mobile/src/styles/globals.css
+++ b/web/mobile/src/styles/globals.css
@@ -422,8 +422,7 @@
     }
     body {
         @apply text-foreground;
-        /* The rail's surface, not the page's: iOS paints the status-bar strip from the body
-           colour, and that strip sits directly above the nav drawer. */
+        /* The rail's surface: iOS paints its status-bar strip from this, above the drawer. */
         background: var(--ag-sidebar-bg);
     }
 }

--- a/web/mobile/src/styles/globals.css
+++ b/web/mobile/src/styles/globals.css
@@ -421,6 +421,9 @@
         @apply border-border outline-ring/50;
     }
     body {
-        @apply bg-background text-foreground;
+        @apply text-foreground;
+        /* The rail's surface, not the page's: iOS paints the status-bar strip from the body
+           colour, and that strip sits directly above the nav drawer. */
+        background: var(--ag-sidebar-bg);
     }
 }

--- a/web/packages/agenta-navigation-ui/src/SidebarShell.tsx
+++ b/web/packages/agenta-navigation-ui/src/SidebarShell.tsx
@@ -170,6 +170,8 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
     onNavigate,
     onDismiss,
 }) => {
+    // Only a drawer can dismiss the rail, so this is also how the shell knows it is in a sheet.
+    const isOverlay = Boolean(onDismiss)
     const [collapsed] = useAtom(collapsedAtom)
     const railRef = useRef<HTMLDivElement>(null)
     const {width, handleProps} = useSidebarResize({railRef, disabled: collapsed})
@@ -348,6 +350,10 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
             // data-resizing kills the collapse transition so the rail tracks the pointer 1:1.
             className={[
                 "group/rail relative border-0 border-r border-solid border-[var(--ag-shell-line)] [&[data-resizing=true]_*]:!transition-none",
+                // Claim the sheet's full height, so the surface below can fill it. Left to its
+                // content the frame collapses to the `dvh` column and the drawer stops short of
+                // the screen bottom.
+                isOverlay ? "h-full" : "",
                 className ?? "",
             ]
                 .join(" ")
@@ -362,12 +368,27 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
             <aside
                 data-theme={theme}
                 className={[
-                    // --ag-demo-banner-h: the fixed demo banner would cover the brand row on
-                    // document-scrolling routes; 0px everywhere else.
-                    "sticky top-[var(--ag-demo-banner-h,0px)] bottom-0 h-[calc(100vh-var(--ag-demo-banner-h,0px))] w-[var(--ag-sidebar-w)] bg-[var(--ag-sidebar-bg)] transition-all duration-300",
+                    // The SURFACE fills the sheet, so it still bleeds behind a phone browser's
+                    // toolbar and no strip of page shows through under the drawer. Only the
+                    // content column below stops at the visible viewport.
+                    isOverlay
+                        ? "h-full w-[var(--ag-sidebar-w)] bg-[var(--ag-sidebar-bg)] transition-all duration-300"
+                        : // --ag-demo-banner-h: the fixed demo banner would cover the brand row on
+                          // document-scrolling routes; 0px everywhere else.
+                          "sticky top-[var(--ag-demo-banner-h,0px)] bottom-0 h-[calc(100vh-var(--ag-demo-banner-h,0px))] w-[var(--ag-sidebar-w)] bg-[var(--ag-sidebar-bg)] transition-all duration-300",
                 ].join(" ")}
             >
-                <div className="flex flex-col h-full w-[var(--ag-sidebar-w)] transition-all duration-300">
+                <div
+                    className={clsx(
+                        "flex flex-col w-[var(--ag-sidebar-w)] transition-all duration-300",
+                        // `dvh`, not `vh`: a phone browser's `vh` is its toolbars-HIDDEN height, so
+                        // laying out against it pushed the last rows — the switcher among them —
+                        // under the toolbar with no scroll to reach them. `--ag-viewport-height`
+                        // narrows it again while a soft keyboard is open, the same expression every
+                        // other /m frame reads.
+                        isOverlay ? "h-[var(--ag-viewport-height,100dvh)]" : "h-full",
+                    )}
+                >
                     {renderSlot(scope.header, collapsed, scope.lastPath, onDismiss)}
                     <SidebarErrorBoundary>
                         <div className="flex flex-col justify-between items-center h-full overflow-y-auto">
@@ -384,7 +405,14 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
                             >
                                 {topSections.map(renderSection)}
                             </div>
-                            <div className="w-full flex flex-col shrink-0">
+                            <div
+                                className={clsx(
+                                    "w-full flex flex-col shrink-0",
+                                    // The home indicator sits inside `dvh`, so the last row needs
+                                    // the inset reserved or it renders underneath it.
+                                    isOverlay && "pb-[env(safe-area-inset-bottom)]",
+                                )}
+                            >
                                 {renderSlot(scope.footer, collapsed, scope.lastPath)}
                                 {bottomSections.map(renderSection)}
                                 {renderSlot(scope.afterBottom, collapsed, scope.lastPath)}

--- a/web/packages/agenta-navigation-ui/src/SidebarShell.tsx
+++ b/web/packages/agenta-navigation-ui/src/SidebarShell.tsx
@@ -350,9 +350,7 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
             // data-resizing kills the collapse transition so the rail tracks the pointer 1:1.
             className={[
                 "group/rail relative border-0 border-r border-solid border-[var(--ag-shell-line)] [&[data-resizing=true]_*]:!transition-none",
-                // Claim the sheet's full height, so the surface below can fill it. Left to its
-                // content the frame collapses to the `dvh` column and the drawer stops short of
-                // the screen bottom.
+                // Claim the sheet's height; left to its content the frame collapses to the column.
                 isOverlay ? "h-full" : "",
                 className ?? "",
             ]
@@ -368,9 +366,7 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
             <aside
                 data-theme={theme}
                 className={[
-                    // The SURFACE fills the sheet, so it still bleeds behind a phone browser's
-                    // toolbar and no strip of page shows through under the drawer. Only the
-                    // content column below stops at the visible viewport.
+                    // The surface fills the sheet, so it still bleeds behind a phone's toolbar.
                     isOverlay
                         ? "h-full w-[var(--ag-sidebar-w)] bg-[var(--ag-sidebar-bg)] transition-all duration-300"
                         : // --ag-demo-banner-h: the fixed demo banner would cover the brand row on
@@ -381,11 +377,7 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
                 <div
                     className={clsx(
                         "flex flex-col w-[var(--ag-sidebar-w)] transition-all duration-300",
-                        // `dvh`, not `vh`: a phone browser's `vh` is its toolbars-HIDDEN height, so
-                        // laying out against it pushed the last rows — the switcher among them —
-                        // under the toolbar with no scroll to reach them. `--ag-viewport-height`
-                        // narrows it again while a soft keyboard is open, the same expression every
-                        // other /m frame reads.
+                        // `vh` is a phone's toolbars-HIDDEN height; the var also narrows for a keyboard.
                         isOverlay ? "h-[var(--ag-viewport-height,100dvh)]" : "h-full",
                     )}
                 >
@@ -408,8 +400,7 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
                             <div
                                 className={clsx(
                                     "w-full flex flex-col shrink-0",
-                                    // The home indicator sits inside `dvh`, so the last row needs
-                                    // the inset reserved or it renders underneath it.
+                                    // The home indicator sits inside `dvh`; reserve it.
                                     isOverlay && "pb-[env(safe-area-inset-bottom)]",
                                 )}
                             >


### PR DESCRIPTION
## Context

On a phone there was no way to reach the project/organization switcher. It is the last row of the nav drawer, and the drawer sized itself with `100vh`. On a phone browser `vh` is the toolbars-**hidden** height, so with Safari's toolbar showing the rail ran past the bottom of the screen and its last rows sat underneath it, with nothing to scroll to reach them. Hiding the toolbar brought them back, which is the tell.

That is the reachability half of AGE-4197. The naming half is the branch below this one (#6247), where every organization rendered as an identical `Default` row.

## Changes

**The drawer lays out against the visible viewport, paints against the sheet.** One height was doing two jobs. Splitting them:

- The surface (`aside`) fills the sheet, so it still bleeds behind the toolbar. Sizing it to `dvh` instead fixes the reachability but leaves a strip of page showing under the drawer, which reads as a rendering fault.
- The content column measures `var(--ag-viewport-height, 100dvh)`. `dvh` tracks the visible viewport as the toolbars come and go, and the variable narrows it again while a soft keyboard is open. That is the same expression `AppShell`, `ScreenScaffold` and `SessionWorkspace` already use, so the rail stops being a special case.
- The bottom block reserves `env(safe-area-inset-bottom)`, since the home indicator sits inside `dvh`.

The docked desktop rail keeps its sticky `100vh` geometry. It lives in a document-scrolling page, where a height that changed with the toolbars would reflow the sidebar mid-scroll. `onDismiss` already tells the two mounts apart (the resizer keys off it for the same reason), so there is no new prop.

**The drawer now meets the top of the screen.** iOS composites the status-bar strip from the page's top colour, and that strip sits directly above the drawer. With a dimmed scrim over a light page it rendered mid-grey against a near-white drawer, reading as the drawer stopping short of the screen. Measured on an iPhone 17 / iOS 26.1:

```
status strip     #cccccc
scrim over page  #cccccc   (identical)
drawer surface   #f6f5f3
```

The strip is the scrim composited over the body, so `bg-black/20` over white gives `0.8 x 255 = 204 = #cccccc` exactly. Reaching `#f6f5f3` by lightening alone would need alpha around 0.035, which is no dim at all. So the colour it composites from is what moved:

- `body` paints the rail's surface rather than the page's, so the strip lands on the drawer's own colour.
- The scrim is clear below `lg`, since any alpha darkens the strip. Above `lg` there is no strip and the dim stays.
- Each sheet casts a shadow away from its anchored edge below `lg`, carrying the separation the scrim used to.

Three things that look like the fix but are not, all tried on device first: `safe-area-inset-top` measures **0** in a Safari tab (`100lvh` is 754 against an 874pt screen, so the viewport already excludes the strip), `theme-color` does not override the tint, and a full-bleed drawer does not change it either.

**Create-project moves to a sheet.** It rendered `NamePromptModal`, which is an antd modal. `/m` ships no antd, so it arrived unthemed and laid out badly over a keyboard, clipped off both edges. `CreateProjectSheet` is the app's own `side="responsive"` sheet (bottom sheet on a phone, right-edge drawer from `lg`), following the invite sheet in `MembersTab`. `NamePromptModal` is untouched for its two OSS call sites.

## Tests

- `pnpm --filter @agenta/mobile test`: 138 pass. `tsc` clean on `@agenta/mobile`; `@agenta/navigation-ui` builds. `pnpm lint-fix` clean across the workspace.
- Verified on an iPhone 17 / iOS 26.1 simulator against a local EE stack, with the Safari toolbar visible: switcher reachable, drawer meets the top, create-project opens as a bottom sheet above the keyboard.
- The scrim change reaches **every** sheet in `/m` at phone widths, not only the nav drawer. Filters and bottom sheets now open undimmed and lean on their shadow. That is the part most worth a second opinion.
- Dark mode is unverified. The body colour pairs `--ag-sidebar-bg: #101010` against `--background: #141414`, so the strip should still land close, but nobody has looked at it.

## What to QA

Needs a phone, or Safari with an iPhone user agent. The toolbar must be **visible** for most of these.

- Open the drawer and scroll to the bottom. The project/organization switcher is fully visible above the toolbar, not clipped by it.
- Look at the top edge of the drawer. It meets the top of the screen with no grey band above it.
- Tap the switcher, then "New project". It opens as a bottom sheet. Focus the field so the keyboard opens: the sheet stays above the keyboard and neither edge is cut off.
- Open any other sheet on a phone (settings filters, invite members). It opens undimmed with a shadow. Confirm that still reads as a layer above the page.
- Rotate to landscape and open the drawer. The switcher stays reachable.
- Regression, desktop: open the app at `lg+` and check the docked sidebar. Height, sticky behaviour and the scrim on right-edge drawers are unchanged.
