### PR TITLE
[#6336] docs(services): Design asynchronous agent config refresh

### DIFF
--- a/docs/design/agent-config-editing/contracts/adapter-matrix.md
+++ b/docs/design/agent-config-editing/contracts/adapter-matrix.md
@@ -3,6 +3,13 @@
 Status: proposed. This contract answers must-fix item 6 and answer section 3 of
 `research/design-gate-review-codex.md`.
 
+The later [active agent configuration refresh](../../agent-configuration-live-refresh/README.md)
+design separates installation from observation. Its asynchronous path may install a mutable
+runner or environment value without waiting for the harness to observe it. This document
+continues to govern claims that a harness observed a generation and the between-turn routes
+that depend on that claim. An unobserved asynchronous installation does not advance the whole
+applied fingerprint or suppress reconciliation on the next normal run.
+
 This contract corrects the matrix in `spikes/runner-spike.md` and in the runner block of
 `decisions.md`. The spike proved which mechanisms exist. It did not prove that a mechanism
 installs a new catalog. This contract adds the missing invariant and fixes four rows.
@@ -100,13 +107,15 @@ The runner splits tools into two objects that share one generation.
 | Object | Holds | Consumer |
 |---|---|---|
 | `ToolCatalogManifest` | Name, description, input schema, read-only hint, permission. Public metadata only. | The harness, through the shim or the extension. |
-| `ToolExecutionPlan` | Callback endpoint and authorization, call descriptors, context bindings, gateway references, timeouts, client-tool relay bindings. | The runner's relay and dispatch paths. |
+| `ToolExecutionPlan` | Stable call descriptors, context bindings, gateway references, timeouts, and client-tool relay bindings, combined at invocation time with callback endpoint and authorization. | The runner's relay and dispatch paths. |
 
 `services/runner/src/engines/sandbox_agent/tools/public-spec.ts` already separates public from
 private metadata. That is the seam to build on.
 
-Both objects carry `catalogGeneration`. The turn runner receives both as one unit, freshly built
-from the incoming request. It must not read either from `env.plan`.
+Both objects carry `catalogGeneration`. The active-configuration snapshot owns the stable
+manifest and execution descriptors. The turn runner combines those descriptors with callback
+delivery and run context from the incoming invocation envelope and receives both objects as one
+unit. It must not read either from `env.plan`.
 
 ### 2.4 The canonical generation payload
 
@@ -170,7 +179,7 @@ out.
 |---|---|
 | Callback authorization | It is per-turn credential material. It rotates on an ordinary turn. Including it would change the generation constantly and would invalidate every parked authorization for no security gain. |
 | Gateway or MCP credential values | Same reason. Credentials have their own subsystem and their own epoch comparison. |
-| The callback ENDPOINT | Borderline. It is routing, not a credential, and it is already in `configFingerprint`. An endpoint change today evicts the session, so it cannot silently change under a parked authorization. Revisit this if the endpoint ever leaves the fingerprint. |
+| The callback ENDPOINT | Per-invocation delivery. It remains in the legacy session-compatibility `configFingerprint`, so an endpoint change today evicts the session. It is excluded from the active-refresh design's stable `configuration.fingerprint`; that distinction must remain explicit until session identity migrates to facets. |
 | `runContext` values | Per-turn data. The BINDING PATHS are included; the values are not. |
 | Trace and telemetry identifiers | Per-turn. Never behavior. |
 | Tool ordering as delivered | The document sorts, so a reordered input does not churn the generation. |

--- a/docs/design/agent-configuration-live-refresh/README.md
+++ b/docs/design/agent-configuration-live-refresh/README.md
@@ -1,0 +1,76 @@
+# Active agent configuration refresh
+
+An agent can commit a new configuration revision while it is running. The commit is
+durable immediately, but the active runner continues with configuration resolved at run
+start. This project adds a private, asynchronous path that resolves the complete committed
+revision and installs every configuration facet the active runtime can change.
+
+The commit never waits for the refresh. The platform never creates a user message, an
+assistant message, a continuation, or another model invocation. Unsupported and failed
+facets keep their prior installed state unless a partially mutating adapter reports it
+untrusted.
+
+Tracking issue: [#6336](https://github.com/Agenta-AI/agenta/issues/6336).
+
+## Reading order
+
+1. [context.md](context.md) explains the current behavior, goals, and boundaries.
+2. [research.md](research.md) traces the existing code paths and records the gaps.
+3. [architecture.md](architecture.md) defines the complete asynchronous flow and ownership.
+4. [contracts.md](contracts.md) pins the private event, snapshot, and apply interfaces.
+5. [facet-matrix.md](facet-matrix.md) defines atomic groups and initial support.
+6. [plan.md](plan.md) orders the implementation into independently reviewable slices.
+7. [qa.md](qa.md) defines the required automated and live proof.
+8. [status.md](status.md) records the project state and decided behavior.
+
+## Terms
+
+**Agent configuration.** The committed configuration under `parameters.agent`, including
+the model, instructions, tools, skills, MCP servers, harness, and permissions.
+
+**Revision.** One immutable committed version of a workflow configuration.
+
+**Service.** The Python agent service under `services/oss/src/agent`. It uses the Python SDK
+to turn authored configuration into runner-ready configuration.
+
+**Runner.** The TypeScript service under `services/runner`. It owns active sandboxes,
+harness sessions, tool execution, and mutable runtime state.
+
+**Harness.** The coding agent process driven by the runner, such as Pi, Claude Code, or
+Codex.
+
+**Resolved configuration snapshot.** The complete runner-safe configuration produced by
+the same service and SDK pipeline used at run start. It contains resolved references and
+private runtime bindings, but no messages or current-turn telemetry.
+
+**Facet.** One coherent part of resolved configuration with one application lifecycle, for
+example gateway execution policy or workspace files.
+
+**Announced revision.** The latest committed revision the active runner has learned about.
+It is an ordering watermark even when retrieval or resolution later fails.
+
+**Desired facet value.** The value from the latest complete snapshot the runner validated
+for that facet. Unsupported facets still record this desired value.
+
+**Installed revision.** The revision whose value the runner successfully installed for one
+facet.
+
+**Observed revision.** An optional report from the consumer of a facet that it noticed an
+installed value. For a runner-owned facet, the runner is the consumer. For a harness-owned
+facet, the harness or its adapter is the consumer. Refresh never waits for this report.
+
+## Decided behavior
+
+- A successful commit and an active-runtime refresh are separate outcomes.
+- A successful commit returns to the model without waiting for resolution or installation.
+- The service retrieves the exact committed revision, never the latest revision by variant.
+- Initial runs and refreshes use one complete configuration resolver.
+- The service sends full snapshots. It never sends configuration patches.
+- The runner applies supported facets independently and applies each dependency group
+  atomically.
+- A facet is supported only when its application mechanism is generation-fenced. A mechanism
+  that can partially mutate must also roll back or report the installed state as untrusted.
+- An unsupported facet and a failure before mutation keep the previous installed value; a
+  partial external mutation records the last known value as untrusted.
+- No component creates model activity to make a configuration change take effect.
+- Gateway policy is the first supported facet, not a special refresh architecture.

--- a/docs/design/agent-configuration-live-refresh/architecture.md
+++ b/docs/design/agent-configuration-live-refresh/architecture.md
@@ -1,0 +1,367 @@
+# Architecture
+
+## Decision
+
+A successful agent configuration commit emits a private asynchronous invalidation. The
+agent service retrieves the exact complete revision, runs the same resolution pipeline as
+an initial invocation, and sends one complete resolved configuration snapshot to the runner
+that owns the active run. The runner installs each supported atomic facet independently.
+
+The commit result does not wait for this work. The refresh does not create model activity.
+
+## Complete flow
+
+```text
+Model or harness
+    |
+    | commit_revision
+    v
+Runner tool relay
+    |
+    | POST /tools/call
+    v
+API commit handler
+    |
+    | stores exact revision R
+    | returns normal tool result plus private committed-revision metadata
+    v
+Runner callback intake
+    |
+    +----> returns normal tool result to the harness immediately
+    |
+    +----> emits private StreamRecord(kind=control)
+                |
+                v
+          Python AgentStream
+                |
+                | consumes record and schedules background work
+                v
+          Agent service refresh handler
+                |
+                | retrieves exact revision R
+                | runs complete SDK/API resolution
+                v
+          ResolvedRunConfigSnapshot
+                |
+                | POST to runner-issued apply callback
+                v
+          Owning runner process
+                |
+                | validates target, order, and snapshot
+                | installs supported atomic facets
+                v
+          Per-facet result and telemetry
+```
+
+## Component ownership
+
+### API
+
+The API owns durable revisions, project resources, and the commit transaction. After a
+successful commit, it returns exact revision metadata beside the normal tool result. It does
+not resolve the full runner configuration and does not apply runtime state.
+
+The API emits no private event for `no_change`, refusal, validation failure, conflict, or
+transport failure.
+
+### Agent service and Python SDK
+
+The service owns composition. It retrieves the exact revision and calls one shared SDK
+resolution function used by both initial runs and refreshes. The resolver owns parsing,
+reference hydration, tool resolution, policy compilation, MCP resolution, model connection
+resolution, credential resolution, and harness adaptation.
+
+The service consumes the private runner control record and starts refresh work in the
+background. Resolution failure never fails or delays the public run stream.
+
+The background task captures the authenticated project principal from the original service
+invocation. It uses that principal to retrieve the revision and verifies that every control
+record and resolved revision belongs to the same project. Runner-supplied routing fields are
+never authorization.
+
+### Runner
+
+The runner detects trusted commit metadata on the existing API callback response. It adds
+active-run target information, records the highest announced revision sequence, and emits a
+private stream record.
+
+The owning runner process validates the returned snapshot and applies supported facets. It
+does not parse authored revisions, call the agent service, or duplicate SDK resolution.
+
+### Harness adapter
+
+An adapter may expose mechanisms for changing files, models, tool catalogs, MCP servers, or
+other state. The runner invokes those mechanisms when available. The asynchronous refresh
+does not wait for the harness to prove that a model noticed an installed value.
+
+Adapters may return a runner-issued generation token as untrusted best-effort observation
+evidence. The runner maps that token to its own installed state; an adapter never supplies
+authoritative digest or source provenance. Lack of observation does not roll back a
+successful installation.
+
+## One configuration resolver
+
+The current run handler performs composition inline. The first implementation change
+extracts a typed resolver:
+
+```python
+async def resolve_agent_configuration(
+    *,
+    parameters: dict,
+    composition: AgentComposition,
+    context: RuntimeResolutionContext,
+) -> ResolvedAgentConfiguration:
+    ...
+```
+
+Initial invocation:
+
+```text
+resolve_agent_configuration(parameters)
+    -> ResolvedRunConfigSnapshot with committed or inline source provenance
+    -> project facet values to existing /run fields
+    -> add secret-free configurationState
+    -> combine with RunInvocationEnvelope
+    -> POST /run
+```
+
+Commit refresh:
+
+```text
+retrieve exact committed revision
+    -> normalize and hydrate parameters
+    -> resolve_agent_configuration(parameters)
+    -> ResolvedRunConfigSnapshot
+    -> configured runner transport applies the opaque active-run target
+```
+
+The two paths share the resolver and snapshot serializer. Tests compare their snapshots for
+the same exact revision.
+
+An initial run built from unsaved parameters uses `source.kind: inline` with a secret-free
+parameters fingerprint. A refresh always uses `source.kind: committed`. This lets the shared
+snapshot represent current draft behavior without pretending that an immutable revision
+produced it. After the runner validates a committed snapshot, its source becomes desired for
+every facet, including unsupported facets.
+
+## Non-blocking behavior
+
+The runner forwards the normal `commit_revision` tool result as soon as the API call
+succeeds. It enqueues any accepted private control record before the corresponding public
+tool-result record and before a terminal `kind: result` record. Enqueue is local and does not
+wait for service resolution. The service schedules its handler without awaiting resolution
+in the stream iterator.
+
+The design accepts this race:
+
+```text
+commit result reaches model
+    -> model calls a tool immediately
+    -> refresh has not installed yet
+    -> tool call uses the prior installed generation
+```
+
+No component fences the tool call. A later call can use the new generation after it
+installs.
+
+## Complete snapshots, not patches
+
+The commit event carries identity only. It never says "add Google Drive" or "replace the
+instructions." The service retrieves the immutable revision and produces the complete
+desired snapshot.
+
+This permits duplicate, dropped, and reordered events. Any successful later refresh can
+reconstruct desired state without replaying earlier events.
+
+## Best-effort facet installation
+
+The runner validates the entire snapshot before mutation, then computes changes against
+per-facet installed state. It applies independent dependency groups separately.
+
+For each group:
+
+1. Prepare every changed value without mutating active state.
+2. Recheck that the attempt still matches the atomic announced-sequence cell.
+3. Invoke one generation-fenced adapter or runner-owned application mechanism. Runner-owned
+   cells use compare-and-swap publication. External adapters receive an attempt token and
+   must condition their externally visible commit on that token still being current.
+4. Atomically publish the prepared group after successful application.
+5. Record the installed generation for every facet in the group.
+6. On failure before mutation, keep every facet in that group at its prior installed value.
+7. If an adapter may have mutated before failure, mark the group `dirty`. Keep the last known
+   installed generation only as untrusted diagnostics.
+
+A failure in one group does not roll back successful independent groups.
+
+An application mechanism that cannot fence a generation remains unsupported. A mechanism
+that may partially mutate must additionally publish atomically, roll back, or report the
+group `dirty`. A stale attempt ID can suppress stale bookkeeping, but it cannot undo an
+external mutation, so bookkeeping alone is not a fence. The runner never holds its local
+application lock across slow adapter I/O.
+
+Topology is a dependency root. If the desired harness or sandbox topology differs from the
+active topology and topology installation is unsupported, every harness-dependent group is
+also unsupported for that snapshot. The runner must not apply Pi-adapted files or tools to an
+active Claude runtime.
+
+Tools are deferred while a turn runs or an approval is suspended. The environment, not the
+active-run callback target, owns the latest pending tools snapshot. A newer sequence replaces
+older pending work. A session-backed environment applies it after the current turn and before
+the next; an ephemeral environment discards it at teardown. While work is pending, a
+runner-owned fail-closed overlay blocks tools whose permission, credential binding, dispatch,
+or execution semantics changed and invalidates their pending approvals. The overlay cannot
+grant access.
+
+## Installed and observed state
+
+The runner records four distinct facts:
+
+```text
+announced:          the latest committed source learned by this run, for ordering
+desired:            the value in the latest complete snapshot validated for this facet
+last known installed: the value last installed successfully for this facet
+observed:           an optional installed value the consumer supplied evidence of seeing
+```
+
+An announcement advances before background retrieval. If retrieval or resolution fails,
+the announced watermark advances but desired facets do not. Validating a snapshot advances
+desired state for supported and unsupported facets. A `dirty` result retains the last known
+installed value for diagnostics but marks it untrusted; it does not claim that value remains
+active.
+
+Example after a partial best-effort refresh:
+
+```json
+{
+  "announcedSource": {"kind": "committed", "variantId": "v1", "revisionId": "r12", "version": "12", "sequence": 12},
+  "facets": {
+    "gatewayExecution": {
+      "status": "installed",
+      "desiredSource": {"kind": "committed", "variantId": "v1", "revisionId": "r12", "version": "12", "sequence": 12},
+      "lastKnownInstalledSource": {"kind": "committed", "variantId": "v1", "revisionId": "r12", "version": "12", "sequence": 12},
+      "installedTrusted": true
+    },
+    "harnessSession": {
+      "status": "unsupported",
+      "desiredSource": {"kind": "committed", "variantId": "v1", "revisionId": "r12", "version": "12", "sequence": 12},
+      "lastKnownInstalledSource": {"kind": "inline", "parametersFingerprint": "sha256:..."},
+      "installedTrusted": true
+    }
+  }
+}
+```
+
+Runner-owned facets are observed when installed because no harness state sits between the
+runner and enforcement. Harness-owned observation is optional and never blocks the commit
+or refresh.
+
+The existing `AppliedEnvironmentState` remains the source for normal warm-session
+reconciliation. An asynchronous installation does not advance its whole fingerprint. A
+harness-owned facet advances observed applied state only when the governing adapter contract
+permits it. A later normal `/run` therefore still reconciles an installed but unobserved file
+change.
+
+## Active-run targeting
+
+The control record carries a runner-issued opaque target for the process that owns the
+active run. It contains an `activeRunId` and owner routing handle. Separate delivery
+credentials carry short-lived authorization. The service gives both to its configured runner
+transport. It never follows a URL from the control record.
+
+The credential is bound to:
+
+- active run ID;
+- authenticated project principal;
+- optional session and turn identity when present;
+- runner owner;
+- expiration;
+- apply permission only.
+
+The runner removes the target when the turn or environment ends. Delivery to an expired
+target returns `stale_target` and changes nothing.
+
+Removing the active target does not remove environment-owned pending reconciliation. Pending
+work either runs at the next safe boundary in a retained environment or is discarded with an
+ephemeral environment.
+
+## Ordering and duplicate delivery
+
+The existing revision `version` remains a string. Private metadata also carries an integer
+`sequence` parsed from and verified against the stored decimal version. Each active run is
+bound to one variant. The runner rejects a commit event or snapshot for any other variant
+and records the highest sequence announced for the bound variant before emitting the private
+event.
+
+- A snapshot below the highest announced sequence is stale and cannot install.
+- A duplicate revision ID returns the prior result or an idempotent accepted result.
+- Application is serialized per active run.
+- A late completion carries an attempt ID and cannot overwrite a newer attempt.
+- The sequence watermark is an atomic cell. Local publication uses a compare-and-swap against
+  it; external adapters must enforce the same fence with their runner-issued attempt token.
+- A failure to resolve sequence N+1 does not make an older sequence N eligible again.
+
+## In-flight operations
+
+An operation captures the installed generation of each runner-owned execution facet at its
+start. It uses that capture until it ends. An atomic swap affects later operations only.
+
+Permission tightening, credential revocation, and binding invalidation are fail-closed
+exceptions. They immediately invalidate matching pending approvals. Before approval resume
+or authenticated API callback dispatch, the runner requires the call's captured composite
+generation to equal the currently installed composite generation and pass the current safety
+overlay. Callback dispatch is the irreversible linearization point. A callback already sent
+before publication may finish API validation and provider execution under its old capture.
+
+A cold approval resume never treats replayed effective parameters as current authority. The
+service retrieves and resolves the bound variant's current committed head under the captured
+project principal, and the runner establishes that generation before decision lookup. If the
+persisted approval's source and composite generation do not match, or current resolution
+fails, resume refuses the approval. The immutable revision store is the durable authority; no
+durable run-scoped configuration record is added.
+
+Pending approvals bind to the execution generation under which the call was planned. If a
+new execution generation changes the call's authorization or routing, the old approval
+cannot authorize execution under the new generation.
+
+Gateway approval binds a composite call generation made from the shared tool catalog
+generation and a secret-free gateway execution generation. It is included in the approval
+key, persisted approval interaction metadata, resume lookup, and final execution check.
+Rotating credential bytes does not change the generation, but changing their connection or
+action binding does.
+
+The API resolution response supplies opaque execution bindings for the selected provider
+connection and each catalog action. A connection binding commits to the actual provider
+account instance, not only the local connection row. An action binding commits to the
+canonical provider action definition and version, not only its stable key. The generation
+includes those bindings. Final API execution selects the connection, credentials, and action
+from one immutable/versioned resource snapshot and verifies the bindings in that same read
+before calling the provider. Raw provider connection and action IDs remain private and never
+reach the model.
+
+## Failure behavior
+
+| Failure | Result |
+|---|---|
+| Commit fails or returns `no_change` | No private event. |
+| Service cannot retrieve the revision | Existing installed state remains. Log and metric only. |
+| Complete resolution fails | Existing installed state remains. Log and metric only. |
+| Callback target expired | Return `stale_target`. No retry against another replica. |
+| Snapshot fails schema or secret validation | Reject the entire snapshot before mutation. |
+| One facet group is unsupported | Leave that group unchanged and continue independent groups. |
+| One facet group fails | Leave that group unchanged and continue independent groups. |
+| An adapter may have partially mutated | Mark that group `dirty`; normal reconciliation must not trust its last known installed generation. |
+| Snapshot arrives out of order | Return `stale_revision`. |
+| Service or runner restarts | The next ordinary run resolves full state. |
+
+No refresh failure changes the already successful commit result or creates a model-visible
+error.
+
+## Initial rollout
+
+The first enabled live facet is the runner-owned gateway execution group. Other groups can
+use the transport and state machinery but remain `unsupported` until their application
+mechanisms are implemented and tested.
+
+Subprocess runner transport remains unsupported because it has no active-run control path.
+HTTP runner deployments require trusted owner routing to the correct replica before
+enablement.

--- a/docs/design/agent-configuration-live-refresh/context.md
+++ b/docs/design/agent-configuration-live-refresh/context.md
@@ -1,0 +1,123 @@
+# Context
+
+## What happens today
+
+The agent service resolves configuration once before it sends a `/run` request to the
+runner. During that resolution, the service and SDK parse the agent template, resolve tools
+and MCP servers, resolve the model connection, compile private policies, and create the
+runner wire request.
+
+The agent can later call `commit_revision` inside the same active run. The API stores the
+new revision and returns a successful tool result. The active runner does not receive the
+new configuration. It continues with the values resolved before the run began.
+
+The gateway connection rework made this visible. An agent can add Google Drive and commit
+the new `gateway_connection`, but its active runner keeps the old private gateway policy.
+The same problem applies to every other configuration value the runtime could update.
+
+## Why the gateway-only proposal is too narrow
+
+The first proposal marked only `gatewayPolicy` stale. The runner would call a new service
+endpoint and replace that table before the next gateway call. That solves one symptom, but
+it creates a second configuration path:
+
+```text
+Run start: service and SDK resolve the complete configuration, then call the runner.
+Refresh:   runner calls the service for one policy table.
+```
+
+The runner would gain a new service dependency, and every later live configuration feature
+would need another special refresh. The proposal also coupled commit latency to the next
+gateway call and assumed that a successful commit added the intended integration.
+
+The platform already has a more general event: a configuration revision was committed. The
+follow-up should resolve that complete revision once and offer every changed facet to the
+runtime.
+
+## Goal
+
+After an agent commits configuration, update the mutable state of the active runtime on a
+best-effort basis without delaying the commit and without creating model activity.
+
+The expected sequence is:
+
+```text
+commit succeeds
+    -> runner returns the tool result immediately
+    -> service receives a private commit notification
+    -> service retrieves and resolves the exact complete revision
+    -> service sends a complete resolved snapshot to the active runner
+    -> runner installs every supported facet
+```
+
+## User-visible contract
+
+`commit_revision` reports whether the revision was saved. It does not claim that the active
+runtime installed every committed value.
+
+The refresh is asynchronous. A model action issued immediately after the commit may still
+observe the old state. The platform does not block that action, insert a message, or start a
+new model invocation to close the race.
+
+The next normal run still resolves the complete selected revision. It remains the eventual
+recovery path when an asynchronous refresh is lost, fails, or reaches a runtime that has
+already ended.
+
+The exact committed revision becomes the desired source even when the active run began from
+unsaved draft parameters. A supported facet may therefore replace a draft-derived value with
+the committed value. Unsupported facets keep their current value. The refresh does not merge
+the committed revision with the old draft because that would create a configuration that was
+never committed.
+
+## Goals
+
+- Reuse the complete run-start resolution path for committed configuration refreshes.
+- Keep commit latency independent from configuration retrieval and installation.
+- Keep private control records out of model, UI, trace, and session event surfaces.
+- Apply supported facets independently while preserving atomicity inside each dependency
+  group.
+- Record announced ordering separately from desired, last-known-installed, installed-trust,
+  failed, unsupported, and optionally observed state per facet.
+- Reject duplicate and out-of-order deliveries without rolling state backward.
+- Keep secret values protected by the same transport and redaction rules as `/run`.
+- Support the gateway execution policy as the first live-installed facet.
+
+## Non-goals
+
+- Guarantee that the first action after a commit sees the new configuration.
+- Guarantee that a harness notices a changed file or tool list.
+- Create a message, turn, continuation, or model invocation after a commit.
+- Rebuild or reopen a harness automatically when a facet cannot change live.
+- Make all configuration fields live-updatable in the first implementation.
+- Replace the ordinary run-start resolution path.
+- Replay configuration deltas inside the runner.
+- Store a durable run-scoped configuration record in the API.
+
+## Safety boundary
+
+Best effort does not mean field-by-field mutation. Fields that jointly define one behavior
+form an atomic dependency group. For example, gateway routing and gateway permission policy
+must swap together. A group either installs completely or keeps its previous value.
+
+An adapter operation that can mutate external state and then fail is not atomic. Every live
+adapter operation must be generation-fenced so a superseded attempt cannot become visible.
+It must separately provide atomic publication, rollback, or a `dirty` result that forces later
+reconciliation to distrust the last known installed state.
+
+Calls whose authenticated execution callback was already dispatched to the API finish under
+one immutable execution generation. A call that has not dispatched that callback, including a
+parked approval, must pass the current generation and fail-closed overlay immediately before
+dispatch. Callback dispatch is the runner's irreversible linearization point: it cannot recall
+the API request afterward. This makes tightening effective at the last boundary the runner
+controls without mixing old authorization with new routing inside a call.
+
+## Related work
+
+- [Gateway connection rework](../composio-tools-rework/README.md) provides the first
+  motivating facet.
+- [Agent config editing](../agent-config-editing/README.md) defines `commit_revision`,
+  revisions, and the runner desired-state architecture.
+- [Harness reconciliation matrix](../agent-config-editing/contracts/adapter-matrix.md)
+  defines optional harness observation and tool-catalog delivery behavior.
+- [Commit transaction](../agent-config-editing/contracts/commit-transaction.md) defines
+  exactly when a commit reports `committed` rather than `no_change`.

--- a/docs/design/agent-configuration-live-refresh/contracts.md
+++ b/docs/design/agent-configuration-live-refresh/contracts.md
@@ -1,0 +1,683 @@
+# Contracts
+
+This page pins the private interfaces. Each boundary preserves its existing casing: API
+responses use snake case, while runner stream and apply contracts use camel case.
+
+## Roles
+
+| Role | Meaning |
+|---|---|
+| Data | The authored or resolved values being processed. |
+| Config | Stable settings that define runtime behavior. |
+| Policy | What an operation is allowed to do. |
+| Credentials | Secret material used to authenticate one connection. |
+| Routing | Values that select a resource or destination. |
+| Protocol context | Trusted identity and ordering values for one exchange. |
+| Metadata | Descriptive values that do not change behavior. |
+
+## 1. API callback metadata
+
+Owner: API commit handler. Reader: runner callback intake. Visibility: private.
+
+`ToolCallResponse` gains an optional sibling to its existing model-visible `call` result:
+
+```json
+{
+  "call": {
+    "data": {
+      "content": "{\"status\":\"committed\",\"workflow_revision\":{...}}"
+    },
+    "status": {
+      "code": "STATUS_CODE_OK"
+    }
+  },
+  "control_events": [
+    {
+      "type": "configuration_committed",
+      "event_id": "01K...",
+      "source": {
+        "variant_id": "...",
+        "revision_id": "...",
+        "version": "12",
+        "sequence": 12
+      }
+    }
+  ]
+}
+```
+
+| Field | Role | Rule |
+|---|---|---|
+| `control_events` | Protocol context | Private side effects of the trusted callback. Never model content. |
+| `type` | Routing | Exactly `configuration_committed` for this contract. |
+| `event_id` | Protocol context | Unique stable ID for deduplication. |
+| `source.variant_id` | Routing | Variant that owns the committed revision. |
+| `source.revision_id` | Routing | Exact immutable revision to retrieve. |
+| `source.version` | Metadata | Existing stored string version, unchanged. |
+| `source.sequence` | Protocol context | Integer parsed from and verified against the decimal version. |
+
+The API emits this event only when the commit transaction returns `status: committed`.
+`no_change`, conflict, refusal, and failure emit none.
+
+The runner accepts this event only when all conditions hold:
+
+1. The authenticated API callback succeeded.
+2. The dispatched reserved operation was `commit_revision`.
+3. The normal tool result reports a successful commit.
+4. `version` matches `^(0|[1-9][0-9]*)$`, `sequence` is a safe integer, and
+   `String(sequence) == version`.
+5. Source identity is complete and valid.
+6. `source.variant_id` equals the active run's bound workflow variant.
+
+An ordinary gateway, workflow, MCP, or client tool cannot create a runner control event.
+
+## 2. Runner private stream record
+
+Owner: runner process that observed the commit. Reader: Python `AgentStream`. Visibility:
+service only.
+
+`StreamRecord` gains a third union arm:
+
+```json
+{
+  "kind": "control",
+  "control": {
+    "type": "configuration_invalidated",
+    "eventId": "01K...",
+    "source": {
+      "variantId": "...",
+      "revisionId": "...",
+      "version": "12",
+      "sequence": 12
+    },
+    "target": {
+      "activeRunId": "...",
+      "ownerId": "...",
+      "sessionId": "...",
+      "turnId": "..."
+    },
+    "delivery": {
+      "credentials": {
+        "authorization": "Bearer ..."
+      },
+      "expiresAt": "2026-08-27T15:05:00Z"
+    }
+  }
+}
+```
+
+| Field | Role | Rule |
+|---|---|---|
+| `kind` | Routing | Exactly `control`; distinct from public `event`. |
+| `control.type` | Routing | Exactly `configuration_invalidated`. |
+| `control.eventId` | Protocol context | Copied from trusted callback metadata. |
+| `source` | Routing and protocol context | Exact committed revision identity. |
+| `target.activeRunId` | Routing | Runner-issued identity present for session and non-session HTTP runs. |
+| `target.ownerId` | Routing | Opaque runner owner handle interpreted only by the configured runner transport. |
+| `target.sessionId` | Routing | Optional session scope check. |
+| `target.turnId` | Protocol context | Optional turn scope check. |
+| `delivery.credentials.authorization` | Credentials | Short-lived apply-only bearer. Never logged or persisted. |
+| `delivery.expiresAt` | Protocol context | Bounds credential and active-target lifetime. |
+
+`kind: control` uses a dedicated emitter. It must not pass through public `AgentEvent`,
+session persistence, trace content, Vercel conversion, SSE conversion, or model result
+handling.
+
+`AgentStream` consumes the record and schedules the configured service handler. It yields
+nothing for this record and never awaits refresh completion before reading later public
+records.
+
+The Python service advertises support on its internal HTTP `/run` request with:
+
+```http
+Agenta-Runner-Private-Capabilities: configuration-control-v1
+```
+
+The runner emits `kind: control` only when that exact token is present. Missing or unknown
+tokens mean no control records. HTTP permits unknown headers, so an older runner safely
+ignores the advertisement; subprocess transport remains unsupported.
+
+The service captures the authenticated project principal from the original invocation. It
+checks source revision ownership with that principal. No target or source field grants API
+access.
+
+The service passes `target` to its configured runner transport. It does not construct or
+follow a URL from this record. HTTP deployments must provide a trusted owner-routing
+implementation before enabling refresh.
+
+## 3. Resolved configuration snapshot
+
+Owner: Python service and SDK composition. Reader: runner. Visibility: private.
+
+Every facet uses this envelope:
+
+```ts
+interface ResolvedFacet<TConfig, TCredentials = never> {
+  digest: string
+  config: TConfig
+  credentials?: TCredentials
+}
+```
+
+Every behavior-bearing credential binding is part of `config`; `credentials` contains only
+secret bytes. `digest` is `sha256:` plus SHA-256 over `strictCanonicalJson` of
+`{"schemaVersion":1,"facet":"<facetName>","config":<config>}`. The runner rebuilds this
+payload from the strict typed DTO after intake and rejects the complete snapshot if any digest
+does not match. A facet publishes config and credentials as one dependency group. The runner
+derives any comparison-only credential epoch locally from credential material. The epoch never
+crosses the wire and never enters logs or digests.
+
+```json
+{
+  "schemaVersion": 1,
+  "source": {
+    "kind": "committed",
+    "variantId": "...",
+    "revisionId": "...",
+    "version": "12",
+    "sequence": 12
+  },
+  "configuration": {
+    "fingerprint": "sha256:...",
+    "facets": {
+      "topology": {"digest": "sha256:...", "config": {}},
+      "runtime": {"digest": "sha256:...", "config": {}, "credentials": {}},
+      "workspaceFiles": {"digest": "sha256:...", "config": {}},
+      "prompts": {"digest": "sha256:...", "config": {}},
+      "harnessFiles": {"digest": "sha256:...", "config": {}},
+      "model": {"digest": "sha256:...", "config": {}, "credentials": {}},
+      "harnessSession": {"digest": "sha256:...", "config": {}, "credentials": {}},
+      "toolCatalog": {"digest": "sha256:...", "config": {}},
+      "toolExecution": {"digest": "sha256:...", "config": {}, "credentials": {}},
+      "gatewayExecution": {"digest": "sha256:...", "config": {}}
+    }
+  }
+}
+```
+
+| Field | Role | Rule |
+|---|---|---|
+| `schemaVersion` | Protocol context | Integer version of this private contract. |
+| `source` | Routing and protocol context | Provenance used to build every facet. |
+| `configuration.fingerprint` | Metadata | Digest over secret-free canonical configuration. |
+| `configuration.facets` | Config and policy | Complete runner-safe desired values grouped by lifecycle. |
+
+`configuration.fingerprint` is `sha256:` plus SHA-256 over `strictCanonicalJson` of
+`{"schemaVersion":1,"facets":{<facetName>:<verifiedFacetDigest>}}` with every schema facet
+present. The runner recomputes it after verifying individual facet digests.
+
+Every use of `strictCanonicalJson` in this contract means the ten-rule serializer in
+[execution-authorization.md section 2.3.3](../agent-config-editing/contracts/execution-authorization.md#233-strictcanonicaljson),
+followed by SHA-256 over its UTF-8 bytes. Python implements those exact rules rather than a
+different JSON canonicalization standard. Shared Python/TypeScript fixtures cover key order,
+JSON-looking strings, numbers, lone surrogates, and rejection cases.
+
+This `configuration.fingerprint` covers only the stable snapshot. It is distinct from the
+legacy runner session-compatibility `configFingerprint`, which may continue to include
+invocation delivery such as callback endpoint until session identity migrates to the facet
+model. Refresh never attributes that legacy delivery value to a committed revision.
+
+The facet registry is exhaustive for schema version 1:
+
+| Facet | Existing `/run` fields and resolved values |
+|---|---|
+| `topology` | `harness`, `sandbox`, `sandboxPermission` |
+| `runtime` | Process/runtime provider settings derived from the selected backend |
+| `workspaceFiles` | `agentsMd`, resolved `skills`, and their complete managed-file projection |
+| `prompts` | `systemPrompt`, `appendSystemPrompt` |
+| `harnessFiles` | Complete `harnessFiles` set |
+| `model` | `model`, `modelCapabilities`, `connection`, `modelConnection`, with model credentials nested here |
+| `harnessSession` | `harnessMode`, `permissions`, `mcpServers`, with MCP credentials nested here |
+| `toolCatalog` | Model-visible projection of `customTools` |
+| `toolExecution` | Stable private dispatch descriptors, credential bindings, static headers, and code-tool environment values for all tools, including generic gateway routes; excludes per-invocation callback endpoint and authorization |
+| `gatewayExecution` | `gatewayPolicy`, integration connection and action bindings, search filtering, and approval generation |
+
+The existing `ToolExecutionPlan` is a run-time aggregate: its stable descriptors come from
+`toolExecution`, while callback endpoint, callback authorization, and current run context
+come from `RunInvocationEnvelope`. Their per-integration policy, resource binding, and
+approval behavior belong to `gatewayExecution`. Current trace, span, run, telemetry
+authorization, and exporter context are invocation-owned and never refreshed from a commit.
+
+`toolCatalog` and `toolExecution` are two facets in one atomic tools dependency group. They
+share the existing catalog generation. A model-visible catalog change and its private
+execution plan never publish independently. An execution-only change may keep the public
+manifest bytes unchanged, but it still advances their shared generation as defined by the
+harness reconciliation contract.
+
+`source` is a discriminated union:
+
+```ts
+type SnapshotSource =
+  | {
+      kind: "committed"
+      variantId: string
+      revisionId: string
+      version: string
+      sequence: number
+    }
+  | {
+      kind: "inline"
+      parametersFingerprint: string
+    }
+```
+
+Initial `/run` accepts either source because a playground invocation can use unsaved inline
+parameters. Asynchronous apply accepts only `kind: committed`. The resolved facet serializer
+is shared in both cases; committed revision identity is not required to represent an inline
+initial run.
+
+`parametersFingerprint` is `sha256:` plus SHA-256 over `strictCanonicalJson` of normalized
+`parameters.agent`, after every declared credential value is replaced by its stable,
+secret-free binding identifier. A literal credential without a resource binding is replaced
+by `{"$credential":"literal"}` at its existing JSON path; its bytes never enter the
+fingerprint, and its runner-local credential epoch detects rotation. An invocation is
+`committed` only when the service retrieved the exact immutable revision identified by the
+request. Supplied effective or unsaved parameters are `inline`, even when their bytes happen
+to equal a revision.
+
+Each facet has a strict Python and TypeScript DTO with unknown fields rejected. The DTOs
+reuse the corresponding `/run` value models rather than accepting untyped objects or arrays.
+The apply endpoint uses a dedicated `MAX_CONFIGURATION_APPLY_BODY_BYTES` no smaller than the
+largest stable configuration snapshot accepted by `/run`. The implementation must prove that
+every accepted initial stable snapshot is also transportable by apply; it must not inherit the
+smaller tool-callback body limit.
+
+The snapshot excludes:
+
+- messages and attachments;
+- session and turn identity;
+- current trace and span identity;
+- current run context values;
+- callback endpoint and callback authorization;
+- current telemetry authorization and exporter context;
+- interaction and approval state;
+- model output or tool results;
+- the redacted authored replay blob in `effectiveParameters`.
+
+The snapshot uses the same builder and serializer for initial `/run` configuration and
+asynchronous apply. An initial run combines it with a separate invocation envelope.
+
+### Initial `/run` projection
+
+Initial `/run` keeps the existing flattened `AgentRunRequest` configuration fields. The
+service projects each facet's `config` and `credentials` back to the fields listed in the
+facet registry, then adds one secret-free metadata sibling:
+
+```json
+{
+  "harness": "...",
+  "model": "...",
+  "customTools": [],
+  "messages": [],
+  "runContext": {},
+  "toolCallback": {"endpoint": "...", "authorization": "..."},
+  "configurationState": {
+    "schemaVersion": 1,
+    "boundVariantId": "v1",
+    "source": {"kind": "inline", "parametersFingerprint": "sha256:..."},
+    "fingerprint": "sha256:...",
+    "facets": {
+      "topology": {"digest": "sha256:..."},
+      "runtime": {"digest": "sha256:..."},
+      "workspaceFiles": {"digest": "sha256:..."},
+      "prompts": {"digest": "sha256:..."},
+      "harnessFiles": {"digest": "sha256:..."},
+      "model": {"digest": "sha256:..."},
+      "harnessSession": {"digest": "sha256:..."},
+      "toolCatalog": {"digest": "sha256:..."},
+      "toolExecution": {"digest": "sha256:..."},
+      "gatewayExecution": {"digest": "sha256:..."}
+    }
+  }
+}
+```
+
+The facet registry is the exhaustive projection map; no stable value exists only in
+`configurationState`, and config or credential bytes are not duplicated there. Messages,
+attachments, current run context, callback delivery, and telemetry form the invocation
+envelope and remain in their existing `/run` fields. `gatewayPolicy` is omitted when
+`gatewayExecution.config.integrations` is empty, preserving the existing wire contract; the
+runner normalizes omission to `{version: 1, integrations: {}}` before digest verification.
+Otherwise `gatewayPolicy` is exactly `GatewayExecutionConfig`.
+
+After strict intake, the runner reconstructs every facet from the flattened fields, recomputes
+and verifies its digest, derives local credential epochs, binds the active run to
+`configurationState.boundVariantId`, and initializes `desired` and
+`lastKnownInstalled` to the supplied source with `installedTrusted: true`. Runner-owned
+facets initialize `observed` to the same generation. Harness-owned facets initialize observed
+state only from the governing adapter acknowledgement. A committed initial source initializes
+`announcedSource` and its sequence; an inline source initializes no announced committed source.
+The first control event still must match `boundVariantId`. If `configurationState` is absent, an
+older request follows legacy run behavior and the runner does not advertise an actionable
+refresh target.
+
+Credential values do not enter `fingerprint`, event metadata, status responses, logs, or
+traces. The service and runner extend their active redactors before inspecting or applying
+the snapshot.
+
+Schema version 1 permits secrets only in these typed credential containers:
+
+- `snapshot.configuration.facets.runtime.credentials.environment` for process environment
+  secret values;
+- `snapshot.configuration.facets.model.credentials.provider` for model-provider
+  authentication;
+- `snapshot.configuration.facets.harnessSession.credentials.mcp` for MCP authentication;
+- `snapshot.configuration.facets.toolExecution.credentials.staticHeaders` and
+  `snapshot.configuration.facets.toolExecution.credentials.codeEnvironment` for tool-owned
+  secrets.
+
+The bounded pre-validation scan reads string leaves only under those exact paths. Typed
+validation rejects unknown credential containers and unknown fields without logging the raw
+value or body. The service also extends its redactor from every secret it resolved before
+serialization. Arbitrary authored data outside a credential field is not inferred to be a
+secret.
+
+If the desired topology differs from active topology and topology installation is
+unsupported, the runner also reports every harness-dependent facet unsupported. It does not
+apply values adapted for a different harness or sandbox.
+
+Schema version 1 fixes these dependencies:
+
+| Group | Depends on | Application boundary |
+|---|---|---|
+| Topology | None | Environment rebuild only initially. |
+| Runtime | Topology | Environment process boundary. |
+| Workspace files | Topology, runtime | Managed-file set replacement. |
+| Prompts | Topology, runtime | Harness adapter. |
+| Harness files | Topology, runtime | Managed-file set replacement. |
+| Model | Topology, runtime, harness session | Harness adapter. |
+| Harness session | Topology, runtime | Harness adapter. |
+| Tools (`toolCatalog` plus `toolExecution`) | Topology, runtime, harness session | Between turns only; never while approval-suspended. |
+| Gateway execution | None for private preinstallation | Runner-owned atomic cell; calls remain blocked unless matching generic gateway descriptors exist in the installed tools generation. |
+
+An unchanged dependency does not block an independently changed group. A changed unsupported
+dependency blocks only its descendants. Gateway execution may preinstall for a first
+connection, but it is not callable until the matching generic descriptors install. An
+execution-only tools change advances the shared tools generation and both tools facets'
+installed source; if public catalog bytes are unchanged, harness observation remains on the
+prior source because no harness reconciliation occurred.
+
+When a tools change cannot publish during the active or approval-suspended turn, the runner
+immediately installs a fail-closed safety overlay for every tool whose permission,
+credential binding, dispatch, or execution semantics changed. The overlay invalidates pending
+approvals and blocks execution until the complete tools group installs; it never grants new
+access. The environment reconciliation state owns only the latest pending tools snapshot and
+its attempt token. Newer sequences supersede older pending work. A session-backed environment
+applies it after the current turn ends and before the next starts. Active-target cleanup does
+not delete environment-owned pending work. Ephemeral environments discard it at teardown and
+recover through ordinary resolution on the next run.
+
+## 4. Apply request
+
+Owner: agent service refresh handler. Reader: owning runner process.
+
+The service gives the opaque target and delivery credential to its configured runner
+transport. The transport routes by `ownerId`; it never accepts an arbitrary destination URL.
+The body contains no callback credential:
+
+```json
+{
+  "eventId": "01K...",
+  "target": {
+    "activeRunId": "...",
+    "ownerId": "...",
+    "sessionId": "...",
+    "turnId": "..."
+  },
+  "snapshot": {
+    "schemaVersion": 1,
+    "source": {
+      "kind": "committed",
+      "variantId": "...",
+      "revisionId": "...",
+      "version": "12",
+      "sequence": 12
+    },
+    "configuration": {}
+  }
+}
+```
+
+| Field | Role | Rule |
+|---|---|---|
+| `eventId` | Protocol context | Connects apply telemetry to the invalidation. |
+| `target` | Routing and protocol context | Must exactly match the callback credential binding. |
+| `snapshot` | Config, policy, and credentials | Complete desired resolved configuration. |
+
+The runner validates before any mutation:
+
+1. Delivery credential, expiry, apply-only scope, owner, and active-run binding.
+2. Exact active-run match and optional session and turn match.
+3. Active target exists on this process.
+4. Raw body is within `MAX_CONFIGURATION_APPLY_BODY_BYTES` and snapshot schema version is
+   supported.
+5. Snapshot source has `kind: committed`, equals the event source registered for this
+   `eventId`, and its variant equals the active run's bound variant.
+6. Sequence is not below the highest announced sequence for the active run.
+7. A bounded, non-logging raw scan extracts string values only from declared credential
+   containers and extends the active redactor. Failure returns one value-free error.
+8. Every facet and credential arm passes strict typed intake. Validation errors contain paths
+   and codes only, never rejected values or the raw body.
+
+The service verifies before transport that its captured refresh principal retrieved the
+committed source from the same project as the original authenticated invocation. The runner
+does not repeat an API authorization decision for which it has no principal.
+
+## 5. Apply response
+
+The service may log aggregate status and metrics. It does not turn this response into a
+model-visible event.
+
+```json
+{
+  "status": "accepted",
+  "source": {
+    "kind": "committed",
+    "variantId": "v1",
+    "revisionId": "...",
+    "version": "12",
+    "sequence": 12
+  },
+  "facets": {
+    "gatewayExecution": {
+      "status": "installed",
+      "installedSource": {"kind": "committed", "variantId": "v1", "revisionId": "...", "version": "12", "sequence": 12},
+      "observedSource": {"kind": "committed", "variantId": "v1", "revisionId": "...", "version": "12", "sequence": 12}
+    },
+    "workspaceFiles": {
+      "status": "installed",
+      "installedSource": {"kind": "committed", "variantId": "v1", "revisionId": "...", "version": "12", "sequence": 12},
+      "observedSource": {"kind": "inline", "parametersFingerprint": "sha256:..."}
+    },
+    "harnessSession": {
+      "status": "unsupported",
+      "installedSource": {"kind": "inline", "parametersFingerprint": "sha256:..."}
+    },
+    "toolCatalog": {
+      "status": "pending",
+      "installedSource": {"kind": "inline", "parametersFingerprint": "sha256:..."}
+    }
+  }
+}
+```
+
+Top-level status values:
+
+| Value | Meaning |
+|---|---|
+| `accepted` | Snapshot was valid and at least one facet was evaluated. |
+| `duplicate` | This event or revision was already processed. |
+| `stale_revision` | A newer revision was already announced. |
+| `stale_target` | The active run ended or moved before delivery. |
+| `rejected` | Authentication, schema, scope, size, or secret validation failed. |
+
+Facet status values:
+
+| Value | Meaning |
+|---|---|
+| `unchanged` | Desired and installed values already match. |
+| `installed` | The runner or adapter installed the complete dependency group. |
+| `unsupported` | No installation mechanism exists for this active runtime. |
+| `failed` | An attempted installation failed and the prior value remains. |
+| `dirty` | The mechanism may have changed external state before failure. Prior installed state is no longer trusted. |
+| `superseded` | A newer attempt replaced this one before publication. |
+| `pending` | A generation-fenced installation is retained for an allowed lifecycle boundary. |
+
+Errors use stable codes and never include configuration or credential values.
+
+## 6. Per-facet state
+
+```ts
+type FacetInstallationStatus =
+  | "unchanged"
+  | "pending"
+  | "installing"
+  | "installed"
+  | "unsupported"
+  | "failed"
+  | "dirty"
+  | "superseded"
+
+interface FacetState {
+  desired: FacetGeneration
+  lastKnownInstalled?: FacetGeneration
+  installedTrusted: boolean
+  observed?: FacetGeneration
+  status: FacetInstallationStatus
+  attemptId?: string
+  errorCode?: string
+}
+
+interface FacetGeneration {
+  digest: string
+  source: SnapshotSource
+  credentialEpoch?: string // runner-local only; never serialized or logged
+}
+```
+
+The active-run registry separately stores `announcedSource`, the committed ordering watermark.
+An announcement advances it before resolution. A validated snapshot advances every facet's
+`desired`, including unsupported facets. Resolution failure advances neither desired nor
+installed state.
+
+`unchanged` requires both generation equality and `installedTrusted: true`. A dirty group
+must reconcile again even when its last known digest and epoch equal desired.
+
+Secret values are not part of digests. Each facet's credential bytes publish with the
+configuration that consumes them. The runner derives `credentialEpoch` with a process-local
+key from credential material. `unchanged` comparison and atomic publication compare both
+digest and credential epoch. A credential failure prevents that dependency group from
+publishing.
+
+Publishing one dependency group updates every member's last known installed state in one
+critical section. A partially prepared group never advances it. A dirty result preserves the
+last known value for diagnostics but sets `installedTrusted: false`; reconciliation must not
+claim that value is current. Observations carry only a runner-issued pending-generation token.
+The runner resolves it to its own installed generation and never trusts adapter-provided
+digest or source values.
+
+## 7. Gateway execution generation
+
+`gatewayExecution.config` is the strict `GatewayExecutionConfig` DTO. Initial `/run` projects
+it to the existing top-level `gatewayPolicy` field; asynchronous apply carries the same DTO
+under the facet:
+
+```ts
+interface GatewayExecutionConfig {
+  version: 1
+  integrations: Record<string, {
+    provider: string
+    connection: string
+    toolkitVersion: string
+    connectionBinding: string
+    tools: Record<string, {
+      permission: "allow" | "ask" | "deny"
+      readOnly: boolean | null
+      executionBinding: string
+    }>
+  }>
+}
+```
+
+Gateway approval and execution bind to the facet digest over this secret-free config:
+
+```json
+{
+  "version": 1,
+  "integrations": {
+    "googledrive": {
+      "provider": "composio",
+      "connection": "drive-main",
+      "toolkitVersion": "20250827_00",
+      "connectionBinding": "opaque:...",
+      "tools": {
+        "FIND_FILE": {
+          "permission": "allow",
+          "readOnly": true,
+          "executionBinding": "opaque:..."
+        }
+      }
+    }
+  }
+}
+```
+
+`gatewayExecutionGeneration` equals `gatewayExecution.digest`, including the standard facet
+domain wrapper. Strict canonical JSON sorts integration names and tool keys. The config
+includes opaque connection and action bindings because those values change the provider
+destination a person approves. It excludes callback endpoint and authorization because they
+are per-invocation delivery values.
+
+`POST /tools/resolve` produces `connectionBinding` from the actual provider account instance,
+not only the local connection row. It produces each `executionBinding` from the
+immutable/versioned canonical provider action definition, not only its stable key. The SDK
+carries those opaque private values into `gatewayExecution`; the runner carries the selected
+bindings in private gateway callback context.
+
+Approval uses a composite `gatewayCallGeneration` computed over `catalogGeneration` and this
+gateway execution generation. A changed generic dispatch descriptor therefore invalidates an
+old gateway approval even when gateway policy itself is unchanged.
+
+The exact composite is `sha256:` plus SHA-256 over `strictCanonicalJson` of:
+
+```json
+{
+  "version": 1,
+  "domain": "agenta.gateway-call",
+  "catalogGeneration": "sha256:...",
+  "gatewayExecutionGeneration": "sha256:..."
+}
+```
+
+The composite generation and opaque bindings are required at five points:
+
+1. The gateway gate computes the approval key from integration, tool, canonical arguments,
+   and generation.
+2. The approval interaction persists the generation beside the safe call representation.
+   It also persists bound variant ID and captured snapshot source.
+3. Durable decision lookup requires an exact generation and source match. On cold resume, the
+   service first retrieves and resolves the bound variant's current committed head under the
+   captured project principal; replayed effective parameters are not authority. Failure or
+   mismatch refuses the stored approval.
+4. Approval resume and final callback dispatch require the approved and captured generations
+   to equal the runner's currently installed composite generation and pass the current
+   fail-closed safety overlay. Publication invalidates affected pending approvals.
+   Authenticated callback dispatch is the irreversible linearization point; a callback already
+   sent to the API may finish validation and provider execution under an older generation.
+5. API execution reads one immutable/versioned connection-and-catalog snapshot, checks the
+   captured opaque bindings, and selects credentials plus canonical action from that same
+   snapshot before calling the provider. Reconnect or catalog update cannot interleave between
+   verification and selection.
+
+A mismatch refuses the old approval. It does not create a new message or automatic approval
+request.
+
+## 8. Compatibility
+
+- Older APIs omit `control_events`; commits behave exactly as today.
+- Older runners ignore unknown callback siblings and emit no control record.
+- The runner emits `kind: control` only when the `/run` request advertises
+  `configuration-control-v1`. Older SDKs omit it and never receive a control record.
+- Runner transports without trusted owner routing report refresh unsupported and emit no
+  actionable delivery target.
+- The ordinary next `/run` remains the complete recovery path.

--- a/docs/design/agent-configuration-live-refresh/facet-matrix.md
+++ b/docs/design/agent-configuration-live-refresh/facet-matrix.md
@@ -1,0 +1,153 @@
+# Facet installation matrix
+
+The service always resolves the complete committed revision. The runner groups its values
+by application lifecycle and installs each supported dependency group independently.
+
+This matrix defines initial support. `Unsupported` means the asynchronous refresh leaves
+the currently installed value unchanged. It does not reject the committed revision.
+
+## Dependency groups
+
+| Group | Values that move together | Initial support |
+|---|---|---|
+| Topology | Harness identity, sandbox provider, sandbox and network policy | Unsupported |
+| Runtime | Runtime process settings, provider endpoint, process environment | Unsupported |
+| Workspace files | Instructions and resolved skill files | Unsupported initially |
+| Prompts | System and append prompt configuration | Unsupported initially |
+| Harness files | Opaque harness configuration files | Unsupported initially |
+| Model | Model identifier, provider routing, connection binding, and credentials | Unsupported initially |
+| Harness session | Mode, permissions, MCP definitions, bindings, and credentials | Unsupported initially |
+| Tools | Model-visible catalog plus stable private dispatch descriptors, permissions, credential bindings, and their shared generation | Unsupported until adapter delivery exists |
+| Gateway execution | Gateway policy, opaque connection and action bindings, search filtering, and approval generation | Supported first |
+
+Current trace, span, run, and exporter context are invocation data, not a configuration
+group. Callback endpoint, callback authorization, telemetry authorization, and exporter
+context also remain in the per-invocation envelope. The snapshot excludes them.
+
+Topology is the dependency root for every harness-adapted group. Runtime depends on topology;
+workspace files, prompts, harness files, harness session, model, and tools depend on the
+active topology and runtime. Model and tools also depend on harness-session capabilities.
+Gateway execution can preinstall independently, but calls remain blocked until matching
+generic gateway descriptors exist in the installed tools generation. Gateway revocations
+publish immediately and fail closed even when stale generic tools remain.
+
+## Installation versus observation
+
+Installing a file means the runner replaced the managed file successfully. It does not mean
+the harness reread it. If an adapter can report observation, the runner records that fact
+separately.
+
+Installing a runner-owned execution policy makes it effective immediately for calls that
+start after publication. Its installed and observed versions are therefore equal.
+
+## Initial harness behavior
+
+| Change | Pi | Claude Code | Codex |
+|---|---|---|---|
+| Replace managed workspace files | Unsupported initially | Unsupported initially | Unsupported initially |
+| Change model | Unsupported initially | Unsupported initially | Unsupported initially |
+| Change model-visible tool catalog | Unsupported initially | Unsupported initially | Unsupported initially |
+| Change MCP servers | Unsupported initially | Unsupported initially | Unsupported initially |
+| Change runner-owned gateway policy | Supported | Supported | Supported |
+| Rotate callback authorization | Invocation-owned; not refreshed | Invocation-owned; not refreshed | Invocation-owned; not refreshed |
+
+The runner does not create a session reopen or model invocation for an unsupported change.
+Later slices may enable files, model state, credentials, or catalog delivery after their
+application mechanism is generation-fenced and can separately report partial mutation
+honestly. Catalog changes apply only between turns and never while an approval is suspended.
+Until then, a fail-closed runner overlay immediately blocks every changed tool and invalidates
+its pending approvals. Session-backed environments keep only the newest pending tools
+snapshot and apply it after the turn, before the next one; ephemeral environments discard it
+at teardown and rely on ordinary next-run resolution.
+
+## Gateway execution group
+
+The gateway group contains:
+
+- normalized per-tool `allow`, `ask`, or `deny` decisions;
+- integration-to-provider routing;
+- integration-to-connection routing;
+- read-only metadata used by approval display and policy;
+- gateway search filtering generation;
+- gateway execution generation and composite gateway call generation;
+- opaque provider connection and action bindings.
+
+All values come from one resolved snapshot and publish atomically.
+
+### Existing connection changes
+
+When the generic `search_tools` and `run_tool` pair already exists in the harness, the
+runner can install:
+
+- an added integration;
+- a removed integration;
+- a changed connection slug;
+- a changed default permission;
+- per-tool permission changes;
+- catalog drift reflected in the compiled table.
+
+The next gateway call captures the new group. A call rechecks current generation before
+authenticated API callback dispatch; an already dispatched callback keeps its prior capture.
+It executes only when the installed tools generation still contains matching generic gateway
+dispatch descriptors.
+
+### First connection
+
+The first `gateway_connection` requires both the private gateway group and the
+model-visible generic tool pair. Until tool-catalog delivery is supported for the active
+harness, the tool-catalog part reports `unsupported`.
+
+The private gateway group reports `installed`, while the tools group reports `unsupported`
+or `pending`. The runner must not claim that the integration is visible or callable merely
+because it preinstalled private policy. The next ordinary run installs the complete catalog.
+
+### Last connection removed
+
+Removing the last connection revokes the private gateway execution group immediately. A
+stale model-visible generic tool may remain, but the runner denies its calls because no
+integration exists in the installed private policy.
+
+### Search memory
+
+Any cached or remembered gateway search result was filtered under one policy generation.
+Publishing a new gateway group clears that memory. The model may still remember old prose,
+but execution remains runner-gated.
+
+## Credentials
+
+Credential values do not enter configuration digests. Their bindings do. A credential and
+the config that consumes it publish in one dependency group. The runner derives any
+comparison-only credential epoch locally. A refreshed credential installs only when the
+active consumer supports replacement.
+
+The service extends redaction before delivery. The runner performs a bounded non-logging
+credential scan and extends its redactor before typed validation. Failure to extend either
+redactor rejects the complete snapshot before any dependency group mutates.
+
+## Independent failure example
+
+Revision 12 changes gateway permissions, instructions, and MCP servers after a future file
+installation slice is enabled:
+
+```json
+{
+  "announcedSource": {"kind": "committed", "variantId": "v1", "revisionId": "r12", "version": "12", "sequence": 12},
+  "facets": {
+    "gatewayExecution": {
+      "status": "installed",
+      "desiredSource": {"kind": "committed", "variantId": "v1", "revisionId": "r12", "version": "12", "sequence": 12},
+      "lastKnownInstalledSource": {"kind": "committed", "variantId": "v1", "revisionId": "r12", "version": "12", "sequence": 12},
+      "installedTrusted": true
+    },
+    "harnessSession": {
+      "status": "unsupported",
+      "desiredSource": {"kind": "committed", "variantId": "v1", "revisionId": "r12", "version": "12", "sequence": 12},
+      "lastKnownInstalledSource": {"kind": "inline", "parametersFingerprint": "sha256:..."},
+      "installedTrusted": true
+    }
+  }
+}
+```
+
+This is a valid best-effort result. The platform does not claim that revision 12 is fully
+active. The next ordinary run resolves all facets from its selected revision.

--- a/docs/design/agent-configuration-live-refresh/plan.md
+++ b/docs/design/agent-configuration-live-refresh/plan.md
@@ -1,0 +1,222 @@
+# Implementation plan
+
+Each slice can merge with its behavior disabled or limited to the capability it proves. The
+first four slices build the general transport and state model. The fifth enables gateway
+policy as the first live facet.
+
+## Slice 1: shared complete configuration resolution
+
+Extract the run-start composition from `make_agent_handler()` into one typed resolver.
+
+Work:
+
+- Define `ResolvedAgentConfiguration` and `ResolvedRunConfigSnapshot` Python models.
+- Give snapshots committed or inline source provenance so unsaved draft runs remain
+  representable; permit only committed sources on asynchronous apply.
+- Separate stable resolved configuration from the per-turn invocation envelope.
+- Keep callback delivery and current telemetry authorization in the invocation envelope.
+- Make initial `/run` serialization consume the snapshot.
+- Project snapshot values to existing `/run` fields, add secret-free `configurationState`,
+  and initialize runner facet state from it.
+- Resolve exact revision references through the existing workflows API path.
+- Preserve vault, embed, tool, gateway, MCP, model connection, harness, and capability
+  resolution.
+- Separate credential values from secret-free configuration fingerprints.
+- Canonically hash each strict facet config and require runner recomputation before use.
+- Extend redaction coverage to every credential-bearing snapshot field.
+- Reject secret-bearing values outside the schema's declared credential containers.
+
+Exit proof:
+
+- Existing `/run` golden payloads remain byte-equivalent where the contract did not change.
+- Resolving one exact revision through initial and refresh entry points produces equal
+  snapshots.
+- No asynchronous refresh behavior exists yet.
+
+## Slice 2: private commit notification
+
+Add private commit metadata from API callback to service without changing model-visible
+events.
+
+Work:
+
+- Extend `ToolCallResponse` with typed private `control_events`.
+- Emit `configuration_committed` only after a successful durable commit.
+- Isolate existing cache invalidation and public event emission so their failure cannot turn
+  a durable commit into a failed tool result.
+- Parse it only on the trusted reserved `commit_revision` callback path.
+- Add `kind: control` to runner `StreamRecord`.
+- Advertise `configuration-control-v1` on the internal HTTP `/run`; emit the private union
+  arm only when advertised.
+- Add a dedicated control emitter outside public event persistence and tracing.
+- Consume control records in `AgentStream` without yielding a public event.
+- Install a service handler that schedules background work and contains failures.
+
+Exit proof:
+
+- Commit latency and model-visible content are unchanged.
+- A private record traverses only runner-to-service NDJSON. It never reaches public Vercel,
+  SSE, NDJSON, session history, or traces.
+- Failed and `no_change` commits emit no control record.
+
+## Slice 3: active-run callback transport
+
+Deliver snapshots to the runner process that owns the active run.
+
+Work:
+
+- Mint an `activeRunId` for every HTTP run, including runs without session identity.
+- Add a process-local active-run registry keyed by that ID.
+- Mint short-lived apply-only callback credentials for active HTTP runs.
+- Emit an opaque owner target in the private record. Never emit a destination URL.
+- Add or configure trusted owner routing from the service runner client to one runner
+  replica. Treat this as a rollout blocker, not an assumed existing capability.
+- Add the authenticated configuration apply endpoint.
+- Validate project, session, turn, event, revision, expiry, schema, and body size.
+- Bind each active run to one variant and reject cross-variant events or snapshots.
+- Serialize application per active run.
+- Clean registry entries and credentials on every terminal path.
+- Report subprocess transport as unsupported.
+
+Exit proof:
+
+- A callback reaches the owning replica through the configured control router in a
+  multi-replica test.
+- Wrong, expired, ended, or cross-run targets change no state.
+- Duplicate delivery is idempotent.
+- The endpoint accepts snapshots but reports all facets unsupported.
+
+## Slice 4: asynchronous facet state
+
+Represent partial best-effort convergence without advancing a false whole fingerprint.
+
+Work:
+
+- Define the facet and dependency-group registry.
+- Track the announced ordering watermark separately from desired, last-known-installed,
+  installed-trust, optional observed, failed, and unsupported state per facet.
+- Keep existing `AppliedEnvironmentState` as the observed state used by normal warm-session
+  reconciliation. Do not stamp its whole fingerprint after partial asynchronous installation.
+- Record the highest announced sequence before dispatching refresh work.
+- Reject stale snapshots and stale asynchronous completions.
+- Publish runner-owned state with compare-and-swap against the atomic announced sequence.
+- Require external adapters to condition their externally visible commit on a runner-issued
+  attempt token still being current.
+- Separately require atomic publication, rollback, or honest `dirty` reporting for partial
+  external mutation.
+- Continue independent groups after one group fails.
+- Store the newest lifecycle-deferred snapshot in environment reconciliation state, preserve
+  it across active-target cleanup, and supersede it by sequence.
+- Derive credential epochs runner-side and keep them outside wire values and secret-free
+  facet digests.
+- Add aggregate metrics without configuration values.
+
+Exit proof:
+
+- Partial success records exact per-facet provenance and process-local credential epochs.
+- A failed group leaves all of its facets unchanged, or marks them `dirty` when an external
+  adapter may have mutated.
+- A late sequence cannot roll state backward.
+- A later ordinary `/run` can compare against partial installed state.
+
+## Slice 5: gateway execution policy
+
+Enable the first runner-owned live group.
+
+Work:
+
+- Replace the once-per-turn gateway policy value with an atomic normalized cell.
+- Extend the strict gateway policy wire DTO with provider-account and versioned-action
+  bindings from `/tools/resolve`.
+- Capture one immutable gateway generation per call.
+- Publish policy, connection routing, search filtering, and approval generation together.
+- Extend gateway resolution with opaque provider connection and action bindings.
+- Clear gateway search memory after a successful swap.
+- Define a secret-free gateway execution generation and bind it to approval keys, persisted
+  interaction metadata, resume lookup, and final execution checks.
+- Compose it with the shared tools generation for gateway approval identity.
+- Install the deny-only safety overlay for changed tool permissions, credential bindings,
+  dispatch, or execution semantics before gateway refresh is enabled; invalidate affected
+  pending approvals while full tools reconciliation remains pending or unsupported.
+- On approval resume and callback dispatch, compare the capture with the currently installed
+  composite generation and invalidate stale parked approvals.
+- Carry opaque execution bindings in private callback context and verify them in the API
+  while selecting connection, credentials, and canonical action from one immutable/versioned
+  resource snapshot immediately before provider execution.
+- On cold approval resume, resolve the bound variant's current committed head before durable
+  decision lookup; never use replayed effective parameters as current-generation authority.
+- Handle first connection, last connection, addition, removal, connection switch, and
+  catalog drift as defined in [facet-matrix.md](facet-matrix.md).
+
+Exit proof:
+
+- A commit result returns without waiting.
+- A later same-run gateway call uses the new policy after installation.
+- An authenticated API callback dispatched before installation may finish under the old
+  generation; a merely started or parked call must pass the current generation before
+  callback dispatch.
+- A first connection is not falsely reported as model-visible.
+- Removing the last connection revokes execution even if the harness still shows the
+  generic tool.
+
+## Slice 6: file installation
+
+Install complete managed workspace file groups only after the environment supports a
+generation-fenced replacement or honest dirty-state reporting. Opaque harness permission
+files remain unsupported until their security contract permits live replacement.
+
+Work:
+
+- Build complete desired file sets, including deletions.
+- Add an atomic managed-set replacement mechanism, or return `dirty` if the provider can
+  partially mutate before failure.
+- Record installed state after replacement succeeds.
+- Record harness observation separately when an adapter supplies it.
+- Do not reopen a harness or create model activity after installation.
+
+Exit proof:
+
+- Add, replace, and delete produce the exact committed managed file set.
+- Failure before publication leaves the previous installed set; possible partial provider
+  mutation records `dirty`.
+- The refresh does not claim the harness observed the files without evidence.
+
+## Slice 7: additional facets
+
+Enable model, tool catalog, MCP, runtime, and credential groups one at a time. Each facet
+requires an adapter-specific application mechanism and tests. Unsupported remains a valid
+result until then.
+
+The tool catalog first requires implementing the planned `ToolCatalogManifest` and
+`ToolExecutionPlan` split so model-visible tools and private execution bindings cannot
+disagree accidentally. Those two facets remain one atomic tools dependency group and share
+one generation. Catalog changes install only between turns and never while an approval is
+suspended. The execution plan aggregates stable snapshot descriptors with callback delivery
+from the current invocation envelope. Slice 5 has already installed the required fail-closed
+overlay; this slice adds full live convergence rather than the safety boundary.
+
+## Rollout
+
+1. Ship slices 1 through 4 with facet installation disabled.
+2. Observe private event delivery, resolution latency, stale-target rate, and replica routing.
+3. Enable gateway installation behind an operator flag for internal projects.
+4. Run the gateway live cells across Pi, Claude Code, and Codex.
+5. Expand rollout while retaining a kill switch for asynchronous apply.
+6. Enable later facets separately after their own proof.
+
+## Metrics
+
+Record counts and latency for:
+
+- committed configuration events;
+- private events consumed;
+- exact revision retrieval and resolution;
+- stale and duplicate snapshots;
+- stale targets and wrong-replica attempts;
+- installation outcomes by facet and harness;
+- time from commit response to facet installation;
+- redaction or credential validation refusal;
+- gateway calls by captured policy generation.
+
+Metrics contain IDs, versions, facet names, status codes, and durations. They contain no
+authored configuration, tool arguments, connection slugs, or credential values.

--- a/docs/design/agent-configuration-live-refresh/qa.md
+++ b/docs/design/agent-configuration-live-refresh/qa.md
@@ -1,0 +1,187 @@
+# QA plan
+
+The tests prove three independent properties: commits stay non-blocking, private state does
+not leak, and supported facets install correctly without corrupting unsupported state.
+
+## API commit metadata
+
+- A successful `commit_revision` returns one `configuration_committed` control event with
+  exact variant ID, revision ID, stored string version, and verified integer sequence.
+- `no_change`, conflict, validation refusal, access refusal, and failed commit return none.
+- Failure in post-commit notification code cannot turn a durable commit into a reported
+  failure.
+- Control metadata is a sibling of model-visible content and never appears inside it.
+- Existing public committed-revision UI behavior remains unchanged.
+
+## Runner callback intake
+
+- Control events are accepted only for the authenticated reserved commit operation.
+- A gateway, workflow, client, or arbitrary callback cannot fabricate one.
+- Malformed source identity is ignored and logged without exposing callback content.
+- The runner records the highest announced sequence before emitting the private record.
+- Forwarding the normal tool result does not await private event delivery.
+
+## Private stream
+
+- `kind: control` is consumed by `AgentStream` and never yielded as a public `Event`.
+- A runner emits control records only when `/run` advertises
+  `configuration-control-v1`; absent and unknown tokens emit none.
+- It traverses private runner-to-service NDJSON but never enters public Vercel, SSE, NDJSON,
+  session persistence, or trace content.
+- An accepted control record is enqueued before its public tool result and before any
+  terminal result record.
+- A slow or failing service handler does not delay or fail the public stream.
+- Duplicate event IDs schedule at most one resolution attempt per service process.
+- Service shutdown cancels background work without changing the commit result.
+
+## Complete resolution
+
+- Initial and refresh paths produce equal snapshots for the same exact revision.
+- Initial `/run` projects facet values to existing fields, carries only digests and provenance
+  in `configurationState`, and initializes desired, trusted installed, observed, and local
+  credential-epoch state as contracted.
+- The runner recomputes every facet digest and rejects a mismatched digest before mutation.
+- A delayed worker for revision N still retrieves N after N+1 becomes head.
+- A mismatched returned variant, revision, version, or sequence is rejected.
+- Decimal versions `"9"` and `"10"` order by verified sequence, never lexical comparison.
+- Non-decimal and unsafe-integer versions do not produce a refresh control event.
+- A refresh that started from draft parameters resolves the exact committed revision as its
+  desired source instead of merging the prior draft into it.
+- An initial run from unsaved parameters uses inline source provenance and still shares the
+  same resolved facet serializer.
+- Tool, gateway, MCP, model connection, skills, embeds, harness, and permissions use the
+  same resolution code in both paths.
+- Gateway resolution carries API-produced opaque provider-account and versioned-action
+  bindings from `/tools/resolve` into the private execution facet.
+- Messages, trace identity, run context, interaction state, and effective replay parameters
+  do not enter the snapshot.
+- Secret values do not enter fingerprints, logs, traces, or apply responses.
+- Inline fingerprints use canonical normalized `parameters.agent` with declared credential
+  values replaced by stable bindings or the fixed literal-credential marker; equal normalized
+  inputs hash equally and literal secret bytes never enter the hash.
+- Unknown credential containers and unknown fields are rejected without value or raw-body
+  logging.
+
+## Active-run targeting
+
+- The configured control router sends the opaque owner target to the replica that emitted it.
+- The service never follows a URL supplied in a control record.
+- Wrong authenticated project principal, active run, optional session or turn, owner, event,
+  token, or revision is rejected.
+- Session and non-session HTTP runs both receive an `activeRunId`.
+- Expired credentials and ended turns return `stale_target`.
+- Oversized and unknown-schema snapshots are rejected before mutation.
+- Every stable snapshot accepted by `/run` fits the dedicated apply-body limit.
+- An apply snapshot with `source.kind: inline` is rejected before mutation.
+- A source variant different from the active run's bound variant is rejected.
+- Subprocess transport reports unsupported without exposing a callback.
+- Registry cleanup runs after success, failure, cancellation, pause, and teardown.
+
+## Ordering and idempotency
+
+- Duplicate event and snapshot delivery is idempotent.
+- Snapshot N cannot install after N+1 was announced.
+- A late completion from attempt N cannot overwrite attempt N+1.
+- Failure to resolve N+1 does not permit delayed N to install.
+- One active run accepts only its bound variant and maintains one sequence watermark.
+
+## Facet application
+
+- Independent groups can succeed and fail in one snapshot.
+- Failure during preparation mutates no value in that group.
+- Failure during adapter application leaves installed state unchanged or marks the group
+  `dirty` when external state may have changed.
+- Unsupported facets remain byte-identical.
+- A validated snapshot advances desired state for unsupported facets; a resolution failure
+  advances only the announced ordering watermark.
+- Successful groups record exact last-known-installed source, digest, and local credential
+  epoch with `installedTrusted: true`.
+- A dirty result preserves last-known-installed diagnostics but sets
+  `installedTrusted: false`.
+- Dirty state can never return `unchanged`; an equal desired generation retries
+  reconciliation.
+- Optional consumer observation echoes only a runner-issued pending token; the runner derives
+  observed digest and source from its own installed map.
+- Partial success never stamps the complete snapshot fingerprint as fully installed.
+- A topology mismatch makes every harness-dependent group unsupported.
+- A stale runner-owned compare-and-swap cannot publish after a newer sequence. A stale
+  external adapter attempt cannot commit externally visible mutation with an expired token.
+- A config change and the credential material it consumes publish together or not at all;
+  the runner derives the comparison epoch during publication.
+- A tools update received during a turn reports `pending`, survives active-target cleanup in
+  a retained environment, is superseded by a newer sequence, and applies before the next turn.
+- Ephemeral-environment teardown discards pending work and the next run resolves normally.
+- Changed tool permission, credential binding, dispatch, or execution semantics install an
+  immediate deny-only overlay and invalidate pending approvals until reconciliation succeeds.
+
+## Gateway execution
+
+- A call started before policy publication keeps one capture for filtering and planning but
+  must recheck the current generation before authenticated API callback dispatch.
+- The next call after publication uses the new capture throughout.
+- Search memory clears when gateway generation changes.
+- Add, remove, connection switch, default change, and per-tool override install atomically.
+- Removing the last connection denies later execution despite stale model-visible tools.
+- Adding the first connection may preinstall private gateway execution, but reports tools
+  unsupported or pending and blocks calls until matching generic descriptors install.
+- A malformed refreshed policy fails strict normalization and leaves the prior group.
+- An approval created under an old execution generation cannot authorize changed routing or
+  permission under a new generation.
+- Tightening permission or invalidating a binding while approval is parked invalidates it;
+  resume and callback dispatch compare with the currently installed composite generation.
+- An authenticated API callback dispatched before publication may finish; no older call that
+  has not yet dispatched its callback may cross the new fail-closed boundary.
+- The same generation check holds after durable approval persistence and cold-session resume.
+- Cold resume resolves the bound variant's current committed head before decision lookup;
+  replayed old effective parameters cannot reestablish an obsolete generation.
+- Reconnecting the same slug to another provider account changes the opaque connection
+  binding and invalidates the old approval.
+- Remapping the same tool key to another provider action changes the opaque execution binding
+  and is rejected by final API execution under the old generation.
+- Changing a generic gateway dispatch descriptor changes the composite gateway call
+  generation and invalidates an old approval even when gateway policy is unchanged.
+- Final API verification selects connection, credentials, and canonical action from one
+  immutable/versioned resource snapshot so reconnect cannot race between check and use.
+
+## No model activity
+
+Across every success and failure case, assert that refresh creates none of these:
+
+- user message;
+- assistant message;
+- synthetic continuation;
+- model invocation;
+- harness prompt;
+- automatic session reopen.
+
+## Live cells
+
+### Same-run gateway update
+
+Use an agent that already has one gateway connection. In one active run, have it commit a
+second integration and later search for a tool from it. Verify:
+
+- commit latency does not include refresh resolution;
+- no extra message or invocation appears;
+- the private snapshot identifies the exact committed revision;
+- a gateway call made after installation uses the new integration;
+- provider execution uses the resolved connection from that revision.
+
+Run this cell on Pi, Claude Code, and Codex because the supported facet is runner-owned.
+
+### Immediate-call race
+
+Delay service resolution, then call `search_tools` immediately after commit. Verify the
+call can use the prior policy and the platform does not block it. Release the delay and
+verify a later call uses the new policy.
+
+### Partial best effort
+
+Commit one revision that changes gateway policy, workspace files, and MCP configuration.
+Verify gateway policy installs, the initially unsupported workspace and harness-session
+groups remain on their prior installed versions, and no model activity is created.
+
+### Lost refresh recovery
+
+End the active run before snapshot delivery. Verify `stale_target`, then start a normal run
+from the committed revision and verify full run-start resolution uses it.

--- a/docs/design/agent-configuration-live-refresh/research.md
+++ b/docs/design/agent-configuration-live-refresh/research.md
@@ -1,0 +1,230 @@
+# Research
+
+## Current run-start resolution
+
+The API prepares a workflow invocation and embeds or retrieves the selected revision in
+`api/oss/src/core/workflows/service.py`. The service request then passes through vault,
+reference resolution, and normalization middleware. The final authored parameters reach
+the agent handler.
+
+`make_agent_handler()` in `sdks/python/agenta/sdk/agents/handler.py` currently performs the
+complete agent composition inline:
+
+1. Parse `AgentTemplate` from the normalized parameters.
+2. Select the backend and harness.
+3. Resolve tools, including gateway connections and gateway policy.
+4. Resolve MCP servers and their credentials.
+5. Resolve the model connection and credentials.
+6. Build `SessionConfig`.
+7. Adapt the neutral configuration to the selected harness.
+8. Serialize `AgentRunRequest` and call runner `/run`.
+
+The gateway resolver already calls API `POST /tools/resolve`. The API validates the project
+connection and returns catalog metadata. The SDK then calls the pure
+`compile_gateway_permissions()` function with authored policy, catalog metadata, and the
+agent-wide permission mode.
+
+The service therefore already depends on the API for resource resolution. The runner
+receives only the resolved result and should not duplicate the Python compiler.
+
+## Current commit path
+
+The model calls the reserved `commit_revision` platform tool. The runner sends it through
+the existing callback to API `POST /tools/call`. The API validates access, commits the
+revision, and returns a normal `ToolCallResponse`.
+
+The callback path is implemented in:
+
+- `services/runner/src/tools/callback.ts`
+- `api/oss/src/apis/fastapi/tools/router.py`
+- `api/oss/src/core/tools/platform_handlers.py`
+
+The successful platform handler already produces `committed_revision` metadata. The router
+uses it for post-commit cache invalidation and public event emission, then returns the normal
+`ToolCallResponse`. The runner callback parser currently reads `call` and discards sibling
+response fields. That parser is the trusted place to accept private commit metadata after the
+router includes it in the response.
+
+The router currently awaits cache invalidation and public event emission after the durable
+commit and before returning the response. A failure there can make a durable commit look
+failed. The notification slice must isolate all post-commit effects, not only the new private
+metadata.
+
+The public Vercel adapter separately derives a `data-committed-revision` event from a
+successful tool result. The playground uses it to select the committed revision. The new
+private control event must remain separate so it cannot enter the public stream or session
+history.
+
+## Current runner stream
+
+Runner `/run` returns newline-delimited `StreamRecord` values. The current union has public
+agent events and a terminal result. `AgentStream.__aiter__()` in
+`sdks/python/agenta/sdk/agents/streaming.py` parses those records before the service adapts
+them to Vercel, SSE, or NDJSON output.
+
+This gives the private notification a natural path. The runner must enqueue the control
+record before any terminal `kind: result` record because `AgentStream` stops at the terminal
+record:
+
+```text
+runner StreamRecord(kind=control)
+    -> AgentStream consumes it
+    -> service control handler starts background refresh
+    -> no public Event is created
+```
+
+The handler must schedule work without awaiting it in public stream iteration. A slow API
+or runner must not delay the model-visible tool result.
+
+## Exact revision retrieval
+
+The workflows API supports retrieving one revision by exact revision ID. A variant-only
+reference resolves the current head and is not suitable for asynchronous refresh.
+
+The private commit metadata must carry at least:
+
+- variant ID;
+- revision ID;
+- stored string version;
+- integer ordering sequence derived from that stored decimal version.
+
+The service verifies variant ID, revision ID, version, and sequence after retrieval. This
+prevents a delayed worker for sequence N from accidentally resolving sequence N+1 after the
+variant head advances.
+
+## Complete configuration extraction
+
+The run-start composition is inline inside `make_agent_handler()`. Reusing it requires one
+extraction before refresh behavior ships. The extracted function should accept normalized
+authored parameters and resolution context, then return a typed complete resolved
+configuration.
+
+`SessionConfig` is close to this object, but it does not by itself define the final
+harness-specific runner projection. `request_to_wire()` also mixes stable configuration
+with per-turn messages, session context, tracing, and effective parameters.
+
+The implementation needs two explicit objects:
+
+```text
+ResolvedRunConfigSnapshot
+    stable and private configuration that /run and /configuration/apply share
+
+RunInvocationEnvelope
+    messages, attachments, session and turn identity, tracing, and run context
+```
+
+The extraction must prove that an ordinary initial run produces the same wire values as
+before.
+
+## Existing desired and applied state
+
+The runner already normalizes desired state and tracks applied environment state:
+
+- `services/runner/src/lifecycle/desired-state.ts`
+- `services/runner/src/lifecycle/reconciliation-router.ts`
+- `services/runner/src/engines/sandbox_agent/applied-state.ts`
+- `services/runner/src/environment/apply-plan.ts`
+
+That state already carries semantic facet digests, one whole fingerprint, and one generation
+after successful reconciliation. It cannot represent independently published facet versions,
+failed or unsupported installation, or mixed-version state.
+
+The refresh needs per-facet revision and status state beside the existing observed applied
+state. The runner may install gateway policy from revision 12,
+workspace files from revision 12, and leave MCP configuration at revision 11. A whole
+fingerprint must not claim that revision 12 is completely active.
+
+## Installation and observation
+
+The existing harness reconciliation contract advances observed applied state only after a
+harness acknowledgement. This project introduces a separate concept: installation.
+
+The runner may replace an instructions file even when the active harness does not reread
+it. That file is installed from the new revision. Whether the harness observes it is an
+adapter concern and may remain unknown.
+
+Runner-owned values need no harness acknowledgement. The runner is their consumer, so a
+gateway execution policy is both installed and observed when the runner atomically swaps its
+private execution cell.
+
+This distinction permits asynchronous best effort without making false claims about what a
+model has already consumed.
+
+## Active-run targeting
+
+The service must send the snapshot to the runner process that owns the active run. The normal
+internal runner URL may be load balanced across replicas. Existing session affinity records
+identify a replica but do not route a new HTTP request to it.
+
+The runner control record therefore carries an opaque active-run target. The service gives
+that target to its configured runner transport. It never follows a runner-supplied URL. The
+HTTP transport needs an operator-configured control router or an equivalent trusted mapping
+from owner ID to replica. Production rollout is blocked until that routing mechanism exists.
+
+Subprocess runner transport closes stdin after the initial request and has no callback HTTP
+surface. The first implementation should report refresh transport as unsupported there and
+leave current state unchanged.
+
+## Active-run registry
+
+The existing session pool does not cover every HTTP run, including non-session and
+keepalive-disabled runs. The runner needs a process-local active-run registry keyed by a
+runner-issued `activeRunId`. Session and turn identity are optional scope checks. An entry owns:
+
+- the callback credential lifetime;
+- the active run's bound variant and its highest announced revision;
+- serialized snapshot application;
+- installed and observed facet state;
+- mutable runner-owned execution cells;
+- cleanup when the turn or environment ends.
+
+Applying a snapshot to an absent or ended target returns a benign stale-target result.
+
+## Ordering
+
+Two commits can resolve and arrive out of order. When the runner observes a commit event,
+it records the highest announced sequence before it emits the private control record. A
+snapshot older than that watermark cannot install later, even if the newer snapshot fails.
+
+Duplicate event IDs and revision IDs are idempotent. Snapshot application is serialized per
+active run. Independent facet groups may succeed independently inside one application.
+
+## Secrets and fingerprints
+
+The complete stable snapshot can carry model credentials, MCP credentials, code-tool
+environment values, and static tool headers. These values must use the same protected
+service-to-runner hop as `/run`. Tool callback authorization, current telemetry authorization,
+and exporter context remain invocation-owned and stay in the separate invocation envelope.
+
+Before either service or runner logs, traces, persists, or applies a refreshed snapshot, it
+must extend the active redactor with newly resolved secret values. Secret values must not
+enter configuration fingerprints, event metadata, apply responses, or logs.
+
+Current code needs specific audit work here. Code-tool environment values and arbitrary
+static headers can enter broad configuration hashes without complete redactor coverage.
+The snapshot extraction slice must close those gaps before live credential-bearing facets
+are enabled.
+
+## Gateway policy as the first facet
+
+The gateway branch already normalizes one `gatewayPolicy` at relay creation. Live
+installation replaces that fixed value with an atomic cell.
+
+Each gateway call captures one immutable policy generation at call start and uses it for:
+
+- authorization;
+- connection routing;
+- search filtering;
+- suggestion sanitization;
+- approval generation.
+
+A gateway call captures one generation, but rechecks the current generation before dispatching
+its authenticated API callback. A callback already sent finishes under its capture; a call
+that has not crossed that boundary fails closed after tightening. Gateway search memory clears
+after a successful swap because prior results were filtered under the old policy.
+
+The first gateway connection also changes the model-visible tool catalog. Installing its
+private policy alone does not make the tools visible. The separate tools dependency group
+reports unsupported until the selected harness can accept the derived tools and matching
+execution plan. Removing the last connection can still revoke private execution immediately
+even if stale generic tool names remain visible.

--- a/docs/design/agent-configuration-live-refresh/status.md
+++ b/docs/design/agent-configuration-live-refresh/status.md
@@ -1,0 +1,45 @@
+# Status
+
+Updated: 2026-08-28.
+
+## Current state
+
+The design is ready for review. No implementation has started.
+
+Tracking issue: [#6336](https://github.com/Agenta-AI/agenta/issues/6336).
+
+This project follows the gateway connection rework in PR
+[#6310](https://github.com/Agenta-AI/agenta/pull/6310). It supersedes that project's
+gateway-only live policy refresh proposal.
+
+## Decisions
+
+- Refresh is asynchronous and never delays the commit result.
+- The service retrieves the complete exact committed revision.
+- Initial runs and refreshes share one complete SDK resolution pipeline.
+- The service sends complete snapshots rather than patches.
+- The runner installs supported atomic facets independently.
+- Unsupported facets and failures before mutation keep prior installed state; possible partial
+  mutation marks the last known state untrusted.
+- Installation and harness observation are separate facts.
+- The platform creates no message, turn, continuation, model invocation, or automatic
+  session reopen.
+- The design accepts that an immediate action may run before refresh installation.
+- Gateway execution policy is the first enabled facet.
+- The ordinary next run remains the eventual recovery path.
+
+## Review focus
+
+Reviewers should confirm:
+
+1. The private event cannot enter model or public event surfaces.
+2. The snapshot cleanly separates stable configuration, credentials, and per-turn data.
+3. Replica-addressable active-run targeting works across hosted deployments.
+4. Per-facet installed state can represent partial best-effort convergence.
+5. Gateway publication keeps authorization, routing, search filtering, and approvals on one
+   generation per call.
+
+## Next step
+
+Approve or revise the contracts in this workspace. Implementation then starts with the
+shared complete configuration resolver, before any live behavior changes.

--- a/docs/design/composio-tools-rework/README.md
+++ b/docs/design/composio-tools-rework/README.md
@@ -34,6 +34,9 @@ Then read the working documents.
    should change to cover gateway tools.
 10. [status.md](status.md). Progress and the decisions taken during review.
 
+The gateway-only live policy proposal was superseded by the general
+[active agent configuration refresh](../agent-configuration-live-refresh/README.md) design.
+
 The authoring surface has its own specification, copied into this workspace so it is
 versioned on this branch: [ui-handoff.md](ui-handoff.md) and the design board
 [ui-handoff-board.html](ui-handoff-board.html). Section 2a of the board is the specification.

--- a/docs/design/composio-tools-rework/contracts.md
+++ b/docs/design/composio-tools-rework/contracts.md
@@ -59,18 +59,19 @@ The entry never holds credentials, provider account IDs, tool schemas, or `read_
 Owner: the API, at `api/oss/src/core/tools/dtos.py`.
 Reader: the Python SDK compiler.
 
-The compiler needs two fields per catalog tool.
+The compiler needs three fields per catalog tool.
 
 ```json
-{"key": "GET_ISSUE", "read_only": true}
+{"key": "GET_ISSUE", "read_only": true, "execution_binding": "opaque:..."}
 ```
 
 | Field | Role | Rules |
 | --- | --- | --- |
 | `key` | Routing | The stable Agenta tool key. |
 | `read_only` | Data | `true` is a read. `false` is a write. Absent means unknown. |
+| `execution_binding` | Protocol context | Opaque binding to the immutable/versioned canonical provider action definition. |
 
-The SDK defines its own input model for these two fields. It must not import an API model.
+The SDK defines its own input model for these three fields. It must not import an API model.
 
 `read_only` keeps its existing snake_case spelling on the HTTP wire. It is already spelled
 that way on `ToolCatalogAction`.
@@ -95,9 +96,10 @@ The response keeps `count`, `builtins`, and `custom`. It gains one field.
       "integration": "github",
       "connection": "github-work",
       "toolkit_version": "20250827_00",
+      "connection_binding": "opaque:...",
       "tools": [
-        {"key": "GET_ISSUE", "read_only": true},
-        {"key": "CREATE_ISSUE", "read_only": false}
+        {"key": "GET_ISSUE", "read_only": true, "execution_binding": "opaque:..."},
+        {"key": "CREATE_ISSUE", "read_only": false, "execution_binding": "opaque:..."}
       ]
     }
   ]
@@ -110,11 +112,16 @@ The response keeps `count`, `builtins`, and `custom`. It gains one field.
 | `gateway_connections[].integration` | Routing | Echoed from the request entry. |
 | `gateway_connections[].connection` | Routing | The validated connection slug. |
 | `gateway_connections[].toolkit_version` | Execution context | The concrete toolkit version resolved from `latest` for this run. |
-| `gateway_connections[].tools` | Data | The whole catalog for that version, key and `read_only` only. Input schemas stay at the API. |
+| `gateway_connections[].connection_binding` | Protocol context | Opaque binding to the actual provider account instance represented by the connection. |
+| `gateway_connections[].tools` | Data | The whole catalog for that concrete version. Input schemas stay at the API. |
+| `gateway_connections[].tools[].key` | Routing | Stable Agenta tool key. |
+| `gateway_connections[].tools[].read_only` | Data | Catalog read-only classification. |
+| `gateway_connections[].tools[].execution_binding` | Protocol context | Opaque binding to the immutable/versioned canonical provider action definition. |
 
-The API validates the connection here, as it does for the per-tool arm today. It does not
-read `policy`. It returns the catalog slice so the SDK makes one round trip per integration
-instead of one per tool.
+The API validates the connection here, as it does for the per-tool arm today. It produces
+both bindings from the same versioned connection and catalog resources used by final
+execution. It does not read `policy`. It returns the catalog slice so the SDK makes one round
+trip per integration instead of one per tool.
 
 Only the whole-catalog cache that serves this response, `tools:catalog:all`, is keyed by
 toolkit version. It is the only cache a run reads and it holds entries for 24 hours, so an
@@ -192,15 +199,17 @@ This rides the run request as one new top-level field, `gatewayPolicy`.
 ```json
 {
   "gatewayPolicy": {
+    "version": 1,
     "integrations": {
       "github": {
         "provider": "composio",
         "connection": "github-work",
         "toolkitVersion": "20250827_00",
+        "connectionBinding": "opaque:...",
         "tools": {
-          "GET_ISSUE": {"permission": "allow", "readOnly": true},
-          "CREATE_ISSUE": {"permission": "ask", "readOnly": false},
-          "DELETE_REPOSITORY": {"permission": "deny", "readOnly": false}
+          "GET_ISSUE": {"permission": "allow", "readOnly": true, "executionBinding": "opaque:..."},
+          "CREATE_ISSUE": {"permission": "ask", "readOnly": false, "executionBinding": "opaque:..."},
+          "DELETE_REPOSITORY": {"permission": "deny", "readOnly": false, "executionBinding": "opaque:..."}
         }
       }
     }
@@ -210,12 +219,15 @@ This rides the run request as one new top-level field, `gatewayPolicy`.
 
 | Field | Role | Rules |
 | --- | --- | --- |
+| `version` | Protocol context | Exactly `1`. |
 | `integrations` | Policy and routing | Keyed by integration. Only configured integrations appear. |
 | `.provider` | Routing | Selects the provider adapter at the API. |
 | `.connection` | Routing | The selected connection slug. |
 | `.toolkitVersion` | Execution context | The concrete toolkit version. `latest` never crosses this boundary. |
+| `.connectionBinding` | Protocol context | Opaque binding to the actual provider account instance. |
 | `.tools[key].permission` | Policy | One of `allow`, `ask`, `deny`. Never `inherit`. |
 | `.tools[key].readOnly` | Data | `true`, `false`, or `null`. Carried for the approval card and for logs. |
+| `.tools[key].executionBinding` | Protocol context | Opaque binding to the immutable/versioned canonical provider action definition. |
 
 Input schemas are deliberately absent. They are large, the policy rides every run request,
 and the runner needs a schema only for the at most five results one search returns. The
@@ -276,7 +288,11 @@ The runner adds one new sibling to `data`. The name is `context`.
     "provider": "composio",
     "integration": "slack",
     "connection": "slack-main",
-    "tool": "SEND_MESSAGE"
+    "tool": "SEND_MESSAGE",
+    "toolkit_version": "20250827_00",
+    "connection_binding": "opaque:...",
+    "execution_binding": "opaque:...",
+    "gateway_call_generation": "sha256:..."
   }
 }
 ```
@@ -291,6 +307,9 @@ The runner adds one new sibling to `data`. The name is `context`.
 | `context.tool` | Protocol context | Trusted. Absent for `gateway.search`. |
 | `context.toolkit_version` | Execution context | The run's concrete version. `gateway.run` only. Never `latest`. |
 | `context.toolkit_versions` | Execution context | One concrete version per configured integration. `gateway.search` only, because one search can rank into several. |
+| `context.connection_binding` | Protocol context | Opaque binding to the actual provider account instance. Absent for `gateway.search`. |
+| `context.execution_binding` | Protocol context | Opaque binding to the canonical provider action definition and version. Absent for `gateway.search`. |
+| `context.gateway_call_generation` | Protocol context | Composite tools and gateway execution generation captured by the runner. |
 
 The two version fields differ because the two calls differ. A run names one tool, so it
 carries one version. A search ranks across every configured integration, so it carries the
@@ -303,6 +322,11 @@ incomplete. Do not fall back to a default connection.
 `ToolCall` does not forbid extra fields today, so an older API silently drops `context`. The
 new routes are new, so an older API returns a 400 for an unknown call reference instead of
 running with no connection. Keep it that way. Do not add a fallback path.
+
+The follow-up [active configuration refresh contract](../agent-configuration-live-refresh/contracts.md#7-gateway-execution-generation)
+extends this callback with immutable execution bindings and the composite approval generation.
+The API verifies and selects connection, credentials, and canonical action from one
+immutable/versioned resource snapshot before provider execution.
 
 ## 7. The search result
 
@@ -404,12 +428,17 @@ The result is one explicit type, not a bare mapping, because the caller needs tw
 
 ```python
 class CompiledGatewayPolicy(BaseModel):
-    tools: Dict[str, CompiledTool]   # executable, one of allow, ask, deny
+    tools: Dict[str, CompiledTool]   # permission, read_only, execution_binding
     stale_keys: List[str]            # configured keys absent from the catalog
 ```
 
 `tools` feeds the resolved policy in section 5. `stale_keys` feeds the resolver warnings and
 the authoring surface. A stale key never appears in `tools`.
+
+`CatalogToolInfo` contains `key`, `read_only`, and `execution_binding`. `CompiledTool`
+contains `permission`, `read_only`, and the same `execution_binding`; the pure compiler must
+preserve it byte-for-byte. The gateway resolver separately copies the connection-level
+`connection_binding` from the resolve response into the integration entry in `gatewayPolicy`.
 
 Order, for each catalog tool:
 

--- a/docs/design/composio-tools-rework/handoff.md
+++ b/docs/design/composio-tools-rework/handoff.md
@@ -85,8 +85,10 @@ and connections never reach the model. The decided design is three pages:
 ## Open items
 
 Decisions for Mahmoud:
-- The [live policy refresh proposal](live-policy-refresh.md): same-turn availability
-  of an integration the agent just added. PROPOSAL status, awaiting a verdict.
+- The gateway-only [live policy refresh proposal](live-policy-refresh.md) is superseded.
+  The general [active agent configuration refresh](../agent-configuration-live-refresh/README.md)
+  design is tracked in [#6336](https://github.com/Agenta-AI/agenta/issues/6336). It resolves
+  the complete committed revision asynchronously and installs every supported runtime facet.
 - Visual token drift: nothing breaks the design; ~20 measured drifts with one likely
   shared cause (component defaults beating explicit tokens) and two copy drifts.
   Screenshots: `/home/mahmoud/agenta-qa-evidence/2026-08-27-visual-regression/`.

--- a/docs/design/composio-tools-rework/live-policy-refresh.md
+++ b/docs/design/composio-tools-rework/live-policy-refresh.md
@@ -1,12 +1,24 @@
-# Proposal: live gateway policy refresh
+# Superseded proposal: live gateway policy refresh
 
-Status: PROPOSAL, not decided. This page designs the "option 2" follow-up: after the
+Status: SUPERSEDED by
+[active agent configuration refresh](../agent-configuration-live-refresh/README.md), tracked
+in [#6336](https://github.com/Agenta-AI/agenta/issues/6336). This page remains as the
+historical gateway-only proposal. Do not implement it.
+
+The replacement resolves the complete exact committed revision through the normal service
+and SDK pipeline, then asynchronously offers every supported configuration facet to the
+active runner. It does not make the runner call a gateway-specific service endpoint, does
+not block the commit or the next tool call, and does not create model activity.
+
+This page originally designed the "option 2" follow-up: after the
 agent commits a new integration mid-turn, that integration's tools work in the SAME
 turn, with no turn boundary and no user message. The decided base design is in
 [data-model.md](data-model.md), [runtime-tools.md](runtime-tools.md), and
 [permission-layers.md](permission-layers.md).
 
-## What happens today, and the one fact that makes this cheap
+## Historical proposal
+
+### What happens today, and the one fact that makes this cheap
 
 The SDK compiles the agent's gateway policy once, at run start, and the runner enforces
 that snapshot for the whole turn. A `commit_revision` that adds an integration succeeds,

--- a/docs/design/composio-tools-rework/permission-layers.md
+++ b/docs/design/composio-tools-rework/permission-layers.md
@@ -89,12 +89,13 @@ each catalog tool:
 ```json
 {
   "key": "GET_ISSUE",
-  "read_only": true
+  "read_only": true,
+  "execution_binding": "opaque:..."
 }
 ```
 
-The catalog may carry additional fields for runtime discovery and execution. Permission
-compilation depends only on the stable Agenta tool key and the tri-state `read_only` hint:
+Permission decisions depend only on the stable Agenta tool key and tri-state `read_only` hint,
+but the compiler preserves the API-produced `execution_binding` byte-for-byte in its output:
 
 - `true`: a read operation;
 - `false`: a write operation;
@@ -108,11 +109,12 @@ operator `deny`.
 The compiler is a pure SDK function. Its inputs are:
 
 - one `gateway_connection` policy;
-- the integration's catalog tools and `read_only` hints;
+- the integration's catalog tools, `read_only` hints, and execution bindings;
 - the agent-wide runner permission mode.
 
-Its output contains only effective `allow`, `ask`, or `deny` values. `inherit` does not
-cross the service-to-runner boundary.
+Each output tool contains its effective `allow`, `ask`, or `deny` value, `read_only`, and
+unchanged execution binding. `inherit` does not cross the service-to-runner boundary. The
+resolver separately preserves the connection-level binding and concrete toolkit version.
 
 For each catalog tool, the compiler applies this order:
 
@@ -142,23 +144,28 @@ shape is:
 ```json
 {
   "gatewayPolicy": {
+    "version": 1,
     "integrations": {
       "github": {
         "provider": "composio",
         "connection": "github-work",
         "toolkitVersion": "20250827_00",
+        "connectionBinding": "opaque:...",
         "tools": {
           "GET_ISSUE": {
             "permission": "allow",
-            "readOnly": true
+            "readOnly": true,
+            "executionBinding": "opaque:..."
           },
           "CREATE_ISSUE": {
             "permission": "ask",
-            "readOnly": false
+            "readOnly": false,
+            "executionBinding": "opaque:..."
           },
           "DELETE_REPOSITORY": {
             "permission": "deny",
-            "readOnly": false
+            "readOnly": false,
+            "executionBinding": "opaque:..."
           }
         }
       }
@@ -213,8 +220,8 @@ The runner owns approval because it already owns the model turn and session life
 an `ask` call, it:
 
 1. Normalizes the call shape used for approval matching.
-2. Creates a `user_approval` interaction containing the integration, tool, and safe
-   representation of the arguments.
+2. Creates a `user_approval` interaction containing the integration, tool, safe
+   representation of the arguments, and composite gateway call generation.
 3. Records the pending interaction through the existing Sessions API.
 4. Pauses the turn.
 5. Resumes after the interaction answer arrives.
@@ -223,9 +230,21 @@ an `ask` call, it:
 The Tools API does not pause a run. The existing client-tool and approval machinery is
 extended in the runner for the semantic gateway-tool identity.
 
-Approval identity must include the integration and tool key in addition to the canonical
-arguments. Keying only on the coarse runtime tool name would mix unrelated integration
-tools.
+Approval identity must include the integration, tool key, canonical arguments, and composite
+gateway call generation. The generation binds the shared tools generation and gateway
+execution generation. Keying only on the coarse runtime tool name would mix unrelated
+integration tools, while omitting the generation would let routing or policy drift reuse an
+old approval.
+
+At resume and immediately before callback dispatch, the captured generation must still equal
+the runner's currently installed composite generation. Permission tightening, credential
+revocation, or binding invalidation cancels affected parked approvals. Only a provider request
+whose authenticated API callback was already dispatched before publication may finish under
+its prior generation. Callback dispatch is the runner's irreversible linearization point.
+
+For cold resume, the service resolves the bound variant's current committed head before
+durable decision lookup. Replayed effective parameters cannot establish the current
+generation; mismatch or resolution failure refuses the old approval.
 
 ## Operator override
 
@@ -251,8 +270,9 @@ The API changes for grouped gateway tools, but it does not become the permission
 
 The model supplies the integration, tool key, and arguments to the runner. After validating
 them against the resolved policy, the runner sends the selected provider, integration,
-connection, and tool as private callback context. Only the integration tool's arguments
-remain in the callback function arguments. A representative callback shape is:
+connection, tool, concrete toolkit version, opaque bindings, and captured generation as
+private callback context. Only the integration tool's arguments remain in the callback
+function arguments. A representative callback shape is:
 
 ```json
 {
@@ -271,7 +291,11 @@ remain in the callback function arguments. A representative callback shape is:
     "provider": "composio",
     "integration": "slack",
     "connection": "slack-main",
-    "tool": "SEND_MESSAGE"
+    "tool": "SEND_MESSAGE",
+    "toolkit_version": "20250827_00",
+    "connection_binding": "opaque:...",
+    "execution_binding": "opaque:...",
+    "gateway_call_generation": "sha256:..."
   }
 }
 ```
@@ -279,15 +303,18 @@ remain in the callback function arguments. A representative callback shape is:
 The API performs these checks at call time:
 
 1. The caller has project-level `RUN_TOOLS` access.
-2. The connection belongs to the project, provider, and integration.
+2. The connection belongs to the project, provider, and integration, and its opaque binding
+   identifies the same actual provider account instance.
 3. The connection is active and valid.
-4. The tool key exists in that integration's catalog.
-5. The catalog provides the canonical provider action ID. Execution never reconstructs
-   that ID with string concatenation.
+4. The tool key exists in that integration's concrete toolkit-version catalog.
+5. That catalog provides the canonical provider action definition matching the opaque
+   execution binding. Execution never reconstructs that ID with string concatenation.
 6. The arguments have the expected object shape.
 
-The API then executes through the existing provider adapter. These are resource, routing,
-and input-validity checks. They are not agent permission computation.
+The API reads and validates the connection, credentials, and canonical action from one
+immutable/versioned resource snapshot, then executes through the existing provider adapter.
+These are resource, routing, and input-validity checks. They are not agent permission
+computation.
 
 ## API changes
 

--- a/docs/design/composio-tools-rework/runtime-tools.md
+++ b/docs/design/composio-tools-rework/runtime-tools.md
@@ -56,6 +56,7 @@ At run start, the SDK sends the runner the private resolved gateway policy descr
 - configured providers and integrations;
 - the selected connection slug for each integration;
 - the concrete toolkit version resolved for this run;
+- opaque provider-account and canonical-action bindings;
 - the catalog tool keys;
 - the compiled `allow`, `ask`, or `deny` value for each tool.
 
@@ -279,9 +280,16 @@ The runner applies the private resolved policy before making the execution callb
 4. Apply the compiled tool permission.
 5. Reject `deny`, continue on `allow`, or start a user approval interaction on `ask`.
 
-Approval identity includes the integration, tool key, and canonical arguments. The
-approval card shows the integration tool and the arguments, not only the coarse
-`run_tool` name.
+Approval identity includes the integration, tool key, canonical arguments, and composite
+gateway call generation. The approval card shows the integration tool and the arguments,
+not only the coarse `run_tool` name.
+
+Approval resume and callback dispatch also require that generation to equal the runner's
+currently installed composite generation. A tightening or binding invalidation cancels a
+parked call; only an authenticated API callback already dispatched may finish under the older
+generation. Callback dispatch is the runner's irreversible linearization point.
+Cold resume first resolves the bound variant's current committed head rather than trusting
+replayed effective parameters.
 
 The runner forwards exactly the arguments that were checked or approved. It does not
 silently rewrite malformed input.
@@ -289,17 +297,21 @@ silently rewrite malformed input.
 ### API execution
 
 After the runner allows the call, it sends the selected provider, integration, connection,
-and tool key as private callback context. Only the integration tool's arguments remain in
-the callback function arguments. The API:
+tool key, opaque connection and action bindings, and captured gateway call generation as
+private callback context. Only the integration tool's arguments remain in the callback
+function arguments. The API:
 
 1. Checks project-level `RUN_TOOLS` access.
-2. Resolves the project connection and checks that it is active and valid.
+2. Resolves the project connection and verifies that its opaque binding still identifies the
+   same active provider account instance.
 3. Confirms that the tool key belongs to the selected integration at the run's concrete
    toolkit version.
-4. Reads the canonical provider action ID from that version's catalog.
+4. Verifies the opaque action binding and reads the canonical provider action definition from
+   that version's catalog.
 5. Validates that `arguments` is an object. Invalid input returns an actionable error; it
    is never replaced with `{}`.
-6. Executes through the provider adapter with the selected connection and the same concrete
+6. Selects connection, credentials, and canonical action from one immutable/versioned
+   resource snapshot, then executes through the provider adapter with the same concrete
    toolkit version.
 
 The API validates resource identity and routing. It does not recompute the agent's


### PR DESCRIPTION
## Context
An agent can commit a configuration revision while it is running, but the active runner continues with values resolved at run start. The earlier gateway-only refresh proposal solved one symptom and would have created a separate resolution path for each future live configuration facet.

This design PR is stacked on #6310 and tracks #6336. It defines contracts and implementation slices only; runtime implementation remains follow-up work.

## Changes
The design replaces gateway-specific refresh with one private asynchronous path for the complete committed configuration.

Before:

```text
commit -> gateway-specific stale flag -> gateway-specific pull
```

After:

```text
commit -> private exact-revision event -> shared resolver -> full snapshot -> supported atomic facets
```

It pins committed and inline provenance, active-run targeting, ordering and supersession, per-facet desired and installed state, credential redaction, fail-closed tool updates, and lifecycle boundaries. Gateway execution is the first enabled facet. Its approval identity binds the shared tools generation, concrete toolkit version, provider-account binding, and canonical-action binding.

The related gateway and harness-reconciliation documents now point to the general design and use the same execution contracts.

## Tests / notes
- `git diff --check`
- Rebased onto the latest `feat/gateway-connection-rework`, including toolkit-version pinning from #6337.
- Ran repeated independent architecture and security consistency reviews until no blocking or high-severity findings remained.
- Documentation only; no runtime tests were required.