### PR TITLE
test(gate): let GW1 run on a stage that refuses the local sandbox

### DIFF
--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -37,6 +37,16 @@ uv run resources/qa_product.py --cell C1 --only chat              # one journey
 uv run resources/qa_product.py --cell S2 --only warm --only cold1 --require-store  # continuity
 ```
 
+**EXPORT the three variables, do not just set them.** The driver falls back to an env FILE when
+`AGENTA_*` is absent from its environment, which is helpful interactively and dangerous in a
+release run: a credentials file of bare `KEY=value` lines sourced with `. file` sets the shell
+only, the child `uv run` process inherits nothing, and the driver silently runs the whole gate
+against WHATEVER DEPLOYMENT the fallback file names. The failure surfaces as `401 Invalid
+credentials` from a stage whose key you just watched answer 200, or worse as a green run
+recorded against the wrong stack. Use `set -a` around the source, or `export` each variable,
+and confirm the stage in the results before trusting them. (Cost a staging gate run on
+2026-08-28; the fallback degrades to "wrong deployment", never to "no credentials".)
+
 Paths are relative to this skill's directory. The deployment's vault must hold the provider keys
 the cells use (Anthropic / OpenAI / OpenRouter). If the three env vars are unset the driver stops
 immediately and names exactly what is missing; a legacy `--env-file <path>` fallback also exists.

--- a/.agents/skills/agent-release-gate/resources/matrix_gw1_gateway_tools.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_gw1_gateway_tools.py
@@ -71,6 +71,11 @@ PROVIDER = os.environ.get("AGENTA_QA_GW1_PROVIDER", "openrouter")
 # `agenta` reads the project's vault key; `self_managed` uses the operator's own subscription.
 # Overridable because a deployment that has no vault key for the model still has to run GW1.
 CONNECTION_MODE = os.environ.get("AGENTA_QA_GW1_CONNECTION_MODE", "agenta")
+# Not every deployment enables the local sandbox: a cloud stage answers `sandbox 'local' is
+# not enabled on this deployment` with a 403, which fails every leg for an environment reason
+# that reads exactly like a product failure. This cell is about the GATEWAY, not the sandbox,
+# so the sandbox is a knob and `daytona` is the right value on any stage that refuses local.
+SANDBOX = os.environ.get("AGENTA_QA_GW1_SANDBOX", "local")
 
 # An upstream MODEL-provider failure is not a product verdict. A gate that fails a release
 # because a provider key ran out of daily credit teaches people to ignore red, so these are
@@ -83,6 +88,9 @@ UPSTREAM_MARKERS = (
     "rate limit",
     "insufficient_quota",
     "quota",
+    # The stage refusing the sandbox is an environment answer too, and it arrives as a 403
+    # naming the sandbox. Set AGENTA_QA_GW1_SANDBOX=daytona and re-run.
+    "is not enabled on this deployment",
 )
 
 
@@ -217,7 +225,7 @@ def agent_parameters(
             "mcps": [],
             "skills": [],
             "harness": {"kind": "pi_core"},
-            "sandbox": {"kind": "local"},
+            "sandbox": {"kind": SANDBOX},
         }
     }
 


### PR DESCRIPTION
**QA tooling only. Nothing in this PR ships in any image, no redeploy is needed, and the gate scripts run from a local checkout.** It changes two files under `.agents/skills/agent-release-gate/`.

## Why

The staging gate run for this release exposed two problems in the gate itself, not in the product.

**GW1 could not run on staging.** The cell pinned `sandbox: local`, and staging refuses that with `403 sandbox 'local' is not enabled on this deployment`. Every leg went red for a sandbox reason that says nothing about the gateway — and GW1 is the cell the path triggers make *mandatory* for any release touching gateway code, so it failing for an environment reason would have blocked the release run or, worse, been waved through as noise.

**The gate could silently run against the wrong deployment.** The driver falls back to an env file when `AGENTA_*` is absent from its environment. `~/.agenta-staging.env` holds bare `KEY=value` lines, so `. ~/.agenta-staging.env` sets the shell only, `uv run` inherits nothing, and the driver quietly used the fallback file's credentials — a different stack. It surfaced as `401 Invalid credentials` from a stage whose key had answered `200` on every REST route seconds earlier. The dangerous direction is that this degrades to "wrong deployment", not to "no credentials": a green run could have been recorded against the wrong stack.

## What changed

- `matrix_gw1_gateway_tools.py`: the sandbox becomes `AGENTA_QA_GW1_SANDBOX` (default `local`, set `daytona` on a stage that refuses local), and `is not enabled on this deployment` joins the billing markers the cell already classifies as an environment **SKIP** rather than a product **FAIL**.
- `SKILL.md`: a short "export the three variables, do not just set them" note under Run it, with the failure signature so the next person recognises it in one read.

## Result

With the sandbox knob, **GW1 passed on staging on its shipped default** — `gemini-2.5-flash` on the OpenRouter vault key, all three legs:

```
search     searches=1 allow_offered=True ask_offered=True denied_key_leaked=False silent=[]
allow_run  attempts=1 executed=1 real_payload=True unexpected_approval=False silent=[]
ask_run    parked=True row_found=True identity_ok=True answered=True
           final_status=resolved verdict=approved silent=[]
```

That default had never passed end to end before: the local OpenRouter key hit its daily 402 wall ([#6341](https://github.com/Agenta-AI/agenta/issues/6341)) before it could be proven. Staging's key is not exhausted, so the shipped default now has a real green run behind it rather than an untested claim.

Full staging write-up, including the cells blocked by billing and by stage policy: `/home/mahmoud/agenta-qa-evidence/release-v0.114.2/qa/staging/RESULTS.md`.

## Follow-up, not in this PR

The L, W and I2 cells are still pinned to `sandbox=local` and so cannot run on any stage that refuses it. They need the same knob. Deliberately left for after the release rather than changed mid-flight.
