### PR TITLE
[fix] Integration drawer polish batch from live QA

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -417,8 +417,10 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
      */
     const openIntegrationPermissions = useCallback(
         (row: IntegrationRow) => {
-            migrateIntegrationEntries({provider: row.provider, integration: row.integration})
+            // Target first: migration writes the whole config back up the tree, and a re-render
+            // cascade from that write used to swallow the open on a legacy row's first click.
             setPermissionTarget({provider: row.provider, integration: row.integration})
+            migrateIntegrationEntries({provider: row.provider, integration: row.integration})
         },
         [migrateIntegrationEntries],
     )

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -417,8 +417,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
      */
     const openIntegrationPermissions = useCallback(
         (row: IntegrationRow) => {
-            // Target first: migration writes the whole config back up the tree, and a re-render
-            // cascade from that write used to swallow the open on a legacy row's first click.
+            // Target first: the migration write below re-renders the tree and swallowed the open.
             setPermissionTarget({provider: row.provider, integration: row.integration})
             migrateIntegrationEntries({provider: row.provider, integration: row.integration})
         },

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
@@ -16,6 +16,7 @@ import {useCallback, useEffect, useMemo, useState} from "react"
 
 import {
     isConnectionValid,
+    toolIntegrationDetailQueryFamily,
     toolIntegrationsSearchAtom,
     useToolCatalogCategories,
     useToolCatalogIntegrations,
@@ -25,15 +26,19 @@ import {
     type ToolCatalogIntegrationDetails,
     type ToolConnection,
 } from "@agenta/entities/gatewayTool"
+import {connectionDisplayName} from "@agenta/shared/utils"
 import {ScrollSentinel} from "@agenta/ui"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
 import {Button, RadioGroup, RadioGroupItem, SearchInput, Spinner} from "@agenta/ui/ui"
 import {Check, Plugs} from "@phosphor-icons/react"
-import {useSetAtom} from "jotai"
+import {atom, useAtomValue, useSetAtom} from "jotai"
 
 import ConnectDrawer from "../../../gatewayTool/drawers/ConnectDrawer"
 import {ProviderLogo, SubSectionHeader} from "../sectionGroups"
 import type {GatewayConnectionTarget, IntegrationRow} from "../toolUtils"
+
+import {INTEGRATION_DRAWER_WIDTH} from "./drawerWidths"
+import {catalogSections, type CategorySelection} from "./integrationCatalogFilters"
 
 type CatalogIntegration = ToolCatalogIntegration | ToolCatalogIntegrationDetails
 
@@ -76,10 +81,9 @@ function groupConnections(connections: ToolConnection[]): ConnectedGroup[] {
     return [...groups.values()]
 }
 
-const connectionLabel = (connection: ToolConnection): string => {
-    const slug = connection.slug ?? ""
-    return connection.name && connection.name !== slug ? `${slug} · ${connection.name}` : slug
-}
+/** Connections are shown by NAME. The slug is an identifier, not a label. */
+const connectionLabel = (connection: ToolConnection | undefined): string =>
+    connectionDisplayName(connection)
 
 /** A row in "Connected in your workspace": quick-add, or open the connection chooser. */
 function ConnectedRow({
@@ -98,6 +102,10 @@ function ConnectedRow({
     const [choosing, setChoosing] = useState(false)
     const currentSlug = row?.entry?.connection
     const [selected, setSelected] = useState(() => currentSlug ?? group.connections[0]?.slug ?? "")
+    const selectedName = connectionLabel(
+        group.connections.find((connection) => connection.slug === selected) ??
+            group.connections[0],
+    )
 
     // Adding again would give one integration two model-facing surfaces, so one the agent already
     // holds offers no Add. Choosing another connection edits the entry, which an integration still
@@ -193,7 +201,7 @@ function ConnectedRow({
                                 setChoosing(false)
                             }}
                         >
-                            {added ? `Use ${selected}` : `Add with ${selected}`}
+                            {added ? `Use ${selectedName}` : `Add with ${selectedName}`}
                         </Button>
                     </div>
                 </div>
@@ -231,18 +239,19 @@ function CategoryRail({
     onSelect,
 }: {
     active: string | null
-    onSelect: (category: string | null) => void
+    onSelect: (category: CategorySelection | null) => void
 }) {
     const {categories, isLoading} = useToolCatalogCategories()
     return (
-        <div className="flex w-44 shrink-0 flex-col gap-1 overflow-y-auto border-0 border-r border-solid border-[var(--ag-colorBorderSecondary)] p-3">
-            <span className="px-2 text-[11px] font-medium uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
+        // min-h-0: without it the rail's own content sets its height and the list never scrolls.
+        <div className="flex min-h-0 w-44 shrink-0 flex-col gap-1 border-0 border-r border-solid border-[var(--ag-colorBorderSecondary)] p-3">
+            <span className="shrink-0 px-2 text-[11px] font-medium uppercase tracking-wide text-[var(--ag-colorTextTertiary)]">
                 Categories
             </span>
             <button
                 type="button"
                 onClick={() => onSelect(null)}
-                className={`cursor-pointer rounded border-0 px-2 py-1 text-left text-[13px] ${
+                className={`shrink-0 cursor-pointer rounded border-0 px-2 py-1 text-left text-[13px] ${
                     active === null
                         ? "bg-[var(--ag-colorFillSecondary)] font-medium"
                         : "bg-transparent text-[var(--ag-colorTextSecondary)]"
@@ -251,20 +260,25 @@ function CategoryRail({
                 All apps
             </button>
             {isLoading ? <Spinner size="small" /> : null}
-            {categories.map((category) => (
-                <button
-                    key={category.id}
-                    type="button"
-                    onClick={() => onSelect(category.id)}
-                    className={`cursor-pointer truncate rounded border-0 px-2 py-1 text-left text-[13px] ${
-                        active === category.id
-                            ? "bg-[var(--ag-colorFillSecondary)] font-medium"
-                            : "bg-transparent text-[var(--ag-colorTextSecondary)]"
-                    }`}
-                >
-                    {category.name}
-                </button>
-            ))}
+            {/* Only the categories scroll; the heading and All apps stay put. */}
+            <div className="flex min-h-0 flex-1 flex-col gap-1 overflow-y-auto">
+                {categories.map((category) => (
+                    <button
+                        key={category.id}
+                        type="button"
+                        onClick={() => onSelect({id: category.id, name: category.name})}
+                        // The provider sends these lowercase; uppercase matches the drawer's other
+                        // labels and keeps acronyms (CRM, HR) right, which capitalize would not.
+                        className={`shrink-0 cursor-pointer truncate rounded border-0 px-2 py-1 text-left text-[13px] uppercase tracking-wide ${
+                            active === category.id
+                                ? "bg-[var(--ag-colorFillSecondary)] font-medium"
+                                : "bg-transparent text-[var(--ag-colorTextSecondary)]"
+                        }`}
+                    >
+                        {category.name}
+                    </button>
+                ))}
+            </div>
         </div>
     )
 }
@@ -276,7 +290,7 @@ function IntegrationCatalogContent({
     onAddIntegration,
 }: Omit<AgentIntegrationDrawerProps, "open" | "onClose">) {
     const [query, setQuery] = useState("")
-    const [category, setCategoryState] = useState<string | null>(null)
+    const [category, setCategoryState] = useState<CategorySelection | null>(null)
     const [connectTarget, setConnectTarget] = useState<CatalogIntegration | null>(null)
     // The integration a just-finished connect flow should land, once its connection shows up.
     const [pendingAdd, setPendingAdd] = useState<string | null>(null)
@@ -310,18 +324,56 @@ function IntegrationCatalogContent({
     )
 
     const allConnectedGroups = useMemo(() => groupConnections(connections), [connections])
+
+    // The connected integrations' catalog details, read through the SAME query atoms each row uses,
+    // so this shares their cache instead of fetching again. Needed for the category filter below.
     const connectedKeys = useMemo(
-        () => new Set(allConnectedGroups.map((group) => group.integrationKey)),
+        () => allConnectedGroups.map((group) => group.integrationKey).sort(),
         [allConnectedGroups],
     )
-    // Filter here rather than inside each row, so the section count matches the rows it heads.
-    const connectedGroups = useMemo(() => {
-        const needle = query.trim().toLowerCase()
-        if (!needle) return allConnectedGroups
-        return allConnectedGroups.filter((group) =>
-            group.integrationKey.toLowerCase().includes(needle),
-        )
-    }, [allConnectedGroups, query])
+    const connectedDetailsAtom = useMemo(
+        () =>
+            atom((get) =>
+                connectedKeys.map((key) => ({
+                    key,
+                    integration: get(toolIntegrationDetailQueryFamily(key)).data?.integration,
+                })),
+            ),
+        [connectedKeys],
+    )
+    const connectedDetails = useAtomValue(connectedDetailsAtom)
+    const {categoriesByIntegration, namesByIntegration} = useMemo(() => {
+        const categoriesMap = new Map<string, readonly string[]>()
+        const namesMap = new Map<string, string>()
+        for (const {key, integration} of connectedDetails) {
+            if (!integration) continue
+            categoriesMap.set(key, integration.categories ?? [])
+            if (integration.name) namesMap.set(key, integration.name)
+        }
+        return {categoriesByIntegration: categoriesMap, namesByIntegration: namesMap}
+    }, [connectedDetails])
+
+    // Both sections in one call. Filtering the connected list here rather than inside each row
+    // keeps the section count equal to the rows it heads.
+    const {connected: connectedGroups, connectable: catalogRows} = useMemo(
+        () =>
+            catalogSections({
+                integrations,
+                groups: allConnectedGroups,
+                query,
+                category,
+                categoriesByIntegration,
+                namesByIntegration,
+            }),
+        [
+            integrations,
+            allConnectedGroups,
+            query,
+            category,
+            categoriesByIntegration,
+            namesByIntegration,
+        ],
+    )
     const rowsByIntegration = useMemo(
         () => new Map(integrationRows.map((row) => [groupKey(row.provider, row.integration), row])),
         [integrationRows],
@@ -355,18 +407,13 @@ function IntegrationCatalogContent({
         setPendingAdd(null)
     }, [pendingAdd, allConnectedGroups, addIntegration])
 
-    const catalogRows = useMemo(
-        () => integrations.filter((integration) => !connectedKeys.has(integration.key)),
-        [integrations, connectedKeys],
-    )
-
     return (
         <div className="flex min-h-0 flex-1">
             <CategoryRail
-                active={category}
+                active={category?.id ?? null}
                 onSelect={(next) => {
                     setCategoryState(next)
-                    setCategory?.(next)
+                    setCategory?.(next?.id ?? null)
                 }}
             />
             <div className="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">
@@ -401,7 +448,7 @@ function IntegrationCatalogContent({
                         </div>
                     ) : catalogRows.length === 0 ? (
                         <span className="px-1 py-4 text-xs text-[var(--ag-colorTextTertiary)]">
-                            No apps left to connect here.
+                            No apps here.
                         </span>
                     ) : (
                         <div className="overflow-hidden rounded border border-solid border-[var(--ag-colorBorderSecondary)]">
@@ -460,7 +507,7 @@ export function AgentIntegrationDrawer({
             open={open}
             onClose={onClose}
             placement="right"
-            width={680}
+            width={INTEGRATION_DRAWER_WIDTH}
             // Explicit exit only — an accidental backdrop click mid-connect must not drop the flow.
             closeOnLayoutClick={false}
             destroyOnClose

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
@@ -267,8 +267,7 @@ function CategoryRail({
                         key={category.id}
                         type="button"
                         onClick={() => onSelect({id: category.id, name: category.name})}
-                        // The provider sends these lowercase; uppercase matches the drawer's other
-                        // labels and keeps acronyms (CRM, HR) right, which capitalize would not.
+                        // The provider sends these lowercase; capitalize would mangle CRM and HR.
                         className={`shrink-0 cursor-pointer truncate rounded border-0 px-2 py-1 text-left text-[13px] uppercase tracking-wide ${
                             active === category.id
                                 ? "bg-[var(--ag-colorFillSecondary)] font-medium"
@@ -325,8 +324,7 @@ function IntegrationCatalogContent({
 
     const allConnectedGroups = useMemo(() => groupConnections(connections), [connections])
 
-    // The connected integrations' catalog details, read through the SAME query atoms each row uses,
-    // so this shares their cache instead of fetching again. Needed for the category filter below.
+    // Read through the SAME query atoms each row uses, so this shares their cache.
     const connectedKeys = useMemo(
         () => allConnectedGroups.map((group) => group.integrationKey).sort(),
         [allConnectedGroups],
@@ -353,8 +351,7 @@ function IntegrationCatalogContent({
         return {categoriesByIntegration: categoriesMap, namesByIntegration: namesMap}
     }, [connectedDetails])
 
-    // Both sections in one call. Filtering the connected list here rather than inside each row
-    // keeps the section count equal to the rows it heads.
+    // Filtered here, not inside each row, so the section count matches the rows it heads.
     const {connected: connectedGroups, connectable: catalogRows} = useMemo(
         () =>
             catalogSections({

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer.tsx
@@ -33,6 +33,7 @@ import ConnectionStatusBadge from "../../../gatewayTool/components/ConnectionSta
 import {
     INTEGRATION_PRESETS,
     TOOL_PERMISSION_OPTIONS,
+    isDescriptionTruncatable,
     partitionToolsByAccess,
     presetPermissions,
     readIntegrationPreset,
@@ -113,15 +114,16 @@ const ToolRow = memo(function ToolRow({
     const [preview, setPreview] = useState<HTMLSpanElement | null>(null)
     const [overflows, setOverflows] = useState(false)
     const description = tool.description?.trim()
-    // A line break hides text no width measurement can see, so it counts as truncation on its own.
-    const multiline = Boolean(description?.includes("\n"))
-    // Measured only while collapsed: expanding changes the very box the measurement reads, which
-    // is what used to make the toggle vanish on the way back.
+    // Measured only while collapsed: expanding changes the very box the measurement reads.
     useLayoutEffect(() => {
+        if (!description) {
+            setOverflows(false)
+            return
+        }
         if (!preview || expanded) return
         setOverflows(preview.scrollWidth > preview.clientWidth)
     }, [preview, expanded, description])
-    const truncatable = multiline || overflows
+    const truncatable = isDescriptionTruncatable(description, overflows)
 
     return (
         <div
@@ -492,8 +494,7 @@ function DrawerTitle({
     const connection = findTargetConnection(connections, target, connectionSlug)
 
     return (
-        // w-full + min-w-0: the header is a flex-1 title slot that will not shrink on its own, so
-        // without these the status badge is pushed past the drawer's edge.
+        // w-full + min-w-0: the title slot will not shrink alone, pushing the badge past the edge.
         <div className="flex w-full min-w-0 items-center gap-2.5">
             <ProviderLogo logo={integration?.logo ?? null} size={22} />
             <div className="flex min-w-0 flex-1 flex-col">

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer.tsx
@@ -13,7 +13,7 @@
  * Built for scale: a provider integration can list 50 to 200 tools, so the body carries a search
  * box, two collapsible groups (read-only and write and delete), and a per-group row cap.
  */
-import {memo, useMemo, useState} from "react"
+import {memo, useLayoutEffect, useMemo, useState} from "react"
 
 import {
     useToolConnectionsQuery,
@@ -56,6 +56,7 @@ import type {
     GatewayPermission,
 } from "../toolUtils"
 
+import {INTEGRATION_DRAWER_WIDTH} from "./drawerWidths"
 import {humanizeActionKey} from "./itemDescriptors"
 import {PolicyGlyph} from "./PermissionGlyph"
 import {PermissionPolicySelect} from "./PermissionPolicySelect"
@@ -110,10 +111,17 @@ const ToolRow = memo(function ToolRow({
 }) {
     const [expanded, setExpanded] = useState(false)
     const [preview, setPreview] = useState<HTMLSpanElement | null>(null)
+    const [overflows, setOverflows] = useState(false)
     const description = tool.description?.trim()
-    // Offer "Show more" only when the one-line preview actually cuts the text off. A character
-    // count guesses, and guesses both ways at this font size.
-    const truncatable = Boolean(preview && preview.scrollWidth > preview.clientWidth)
+    // A line break hides text no width measurement can see, so it counts as truncation on its own.
+    const multiline = Boolean(description?.includes("\n"))
+    // Measured only while collapsed: expanding changes the very box the measurement reads, which
+    // is what used to make the toggle vanish on the way back.
+    useLayoutEffect(() => {
+        if (!preview || expanded) return
+        setOverflows(preview.scrollWidth > preview.clientWidth)
+    }, [preview, expanded, description])
+    const truncatable = multiline || overflows
 
     return (
         <div
@@ -121,9 +129,11 @@ const ToolRow = memo(function ToolRow({
                 expanded ? "bg-[var(--ag-colorFillQuaternary)]" : ""
             }`}
         >
-            <div className="flex items-center gap-2.5">
+            {/* items-start, not items-center: the select must stay put while the row grows. */}
+            <div className="flex items-start gap-2.5">
                 <div className="flex min-w-0 flex-1 flex-col">
-                    <div className="flex items-center gap-1.5">
+                    {/* Matches the select's h-control so the name line stays level with it. */}
+                    <div className="flex min-h-[28px] items-center gap-1.5">
                         <span className="truncate text-[13px] font-medium">
                             {tool.name || humanizeActionKey(tool.key)}
                         </span>
@@ -140,11 +150,22 @@ const ToolRow = memo(function ToolRow({
                         <span
                             ref={setPreview}
                             className={`text-xs text-[var(--ag-colorTextTertiary)] ${
-                                expanded ? "hidden" : "truncate"
+                                expanded
+                                    ? "whitespace-pre-line leading-relaxed text-[var(--ag-colorTextSecondary)]"
+                                    : "truncate"
                             }`}
                         >
                             {description}
                         </span>
+                    ) : null}
+                    {truncatable ? (
+                        <button
+                            type="button"
+                            onClick={() => setExpanded((value) => !value)}
+                            className="mt-1 w-fit cursor-pointer border-0 bg-transparent p-0 text-xs text-[var(--ag-colorLink)]"
+                        >
+                            {expanded ? "Show less" : "Show more"}
+                        </button>
                     ) : null}
                 </div>
                 <PermissionPolicySelect
@@ -156,25 +177,13 @@ const ToolRow = memo(function ToolRow({
                     aria-label={`Permission for ${tool.key}`}
                     triggerClassName={
                         permission === "deny"
-                            ? "w-auto shrink-0 border-[var(--ag-colorErrorBorder)] bg-[var(--ag-colorErrorBg)] text-[var(--ag-colorErrorText)]"
-                            : "w-auto shrink-0"
+                            ? "w-auto min-w-[132px] shrink-0 border-[var(--ag-colorErrorBorder)] bg-[var(--ag-colorErrorBg)] text-[var(--ag-colorErrorText)]"
+                            : "w-auto min-w-[132px] shrink-0"
                     }
+                    // The panel is pinned to the trigger; a compact chip wraps every option label.
+                    contentClassName="w-auto min-w-[260px]"
                 />
             </div>
-            {expanded && description ? (
-                <span className="text-xs leading-relaxed text-[var(--ag-colorTextSecondary)]">
-                    {description}
-                </span>
-            ) : null}
-            {truncatable ? (
-                <button
-                    type="button"
-                    onClick={() => setExpanded((value) => !value)}
-                    className="w-fit cursor-pointer border-0 bg-transparent p-0 text-xs text-[var(--ag-colorLink)]"
-                >
-                    {expanded ? "Show less" : "Show more"}
-                </button>
-            ) : null}
         </div>
     )
 })
@@ -370,7 +379,8 @@ function DrawerBody({
             : null
 
     return (
-        <div className="flex min-h-0 flex-1 flex-col gap-3.5 overflow-y-auto p-4">
+        // Stable gutter: expanding a row must not summon a scrollbar that shifts every control left.
+        <div className="flex min-h-0 flex-1 flex-col gap-3.5 overflow-y-auto p-4 [scrollbar-gutter:stable]">
             <div className="flex flex-col gap-1.5">
                 <span className="text-xs text-[var(--ag-colorTextSecondary)]">
                     Default permission
@@ -482,7 +492,9 @@ function DrawerTitle({
     const connection = findTargetConnection(connections, target, connectionSlug)
 
     return (
-        <div className="flex items-center gap-2.5">
+        // w-full + min-w-0: the header is a flex-1 title slot that will not shrink on its own, so
+        // without these the status badge is pushed past the drawer's edge.
+        <div className="flex w-full min-w-0 items-center gap-2.5">
             <ProviderLogo logo={integration?.logo ?? null} size={22} />
             <div className="flex min-w-0 flex-1 flex-col">
                 <span className="truncate text-sm font-semibold">
@@ -495,7 +507,8 @@ function DrawerTitle({
             </div>
             {/* Shows Pending and Inactive too, which is exactly what an author needs here. */}
             {connection ? (
-                <span className="shrink-0 font-normal">
+                // text-xs: the drawer title is 16px, and every other meta label here is 12px.
+                <span className="shrink-0 text-xs font-normal">
                     <ConnectionStatusBadge connection={connection} />
                 </span>
             ) : null}
@@ -514,7 +527,7 @@ export function IntegrationPermissionDrawer({
             open={open}
             onClose={onClose}
             placement="right"
-            width={480}
+            width={INTEGRATION_DRAWER_WIDTH}
             destroyOnClose
             title={<DrawerTitle target={body.target} connectionSlug={body.connectionSlug} />}
             styles={{

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
@@ -116,6 +116,10 @@ export function ItemRow({
     return (
         <div
             style={status ? {borderColor: STATUS_BORDER[status.tone]} : undefined}
+            // The WHOLE row opens the item. The right-hand group (status, tags, `extra`, chevron)
+            // used to be dead: a click on the chevron — where the affordance points — did nothing,
+            // which read as "the row needs several clicks". The remove button stops propagation.
+            onClick={interactive ? onEdit : undefined}
             className={cn(
                 "group flex items-center gap-2.5 rounded border border-solid border-[var(--ag-c-EAEFF5)] px-3 py-2 transition-colors",
                 // Item cards read as white sheets sitting ON the expanded section's band.
@@ -126,12 +130,11 @@ export function ItemRow({
             )}
         >
             {/* The `role="button"` region is a SIBLING of the remove button, never its ancestor
-                (axe nested-interactive) — same split as SubscriptionChildRow. The outer flex
-                still supplies the gap between the two groups, so geometry is unchanged. */}
+                (axe nested-interactive) — same split as SubscriptionChildRow. It carries the
+                keyboard affordance only; the click is handled once, on the row. */}
             <div
                 role={interactive ? "button" : undefined}
                 tabIndex={interactive ? 0 : undefined}
-                onClick={interactive ? onEdit : undefined}
                 onKeyDown={
                     interactive
                         ? (e) => {

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
@@ -116,9 +116,7 @@ export function ItemRow({
     return (
         <div
             style={status ? {borderColor: STATUS_BORDER[status.tone]} : undefined}
-            // The WHOLE row opens the item. The right-hand group (status, tags, `extra`, chevron)
-            // used to be dead: a click on the chevron — where the affordance points — did nothing,
-            // which read as "the row needs several clicks". The remove button stops propagation.
+            // The whole row opens it; the chevron and tags used to be a dead target.
             onClick={interactive ? onEdit : undefined}
             className={cn(
                 "group flex items-center gap-2.5 rounded border border-solid border-[var(--ag-c-EAEFF5)] px-3 py-2 transition-colors",

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/PermissionPolicySelect.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/PermissionPolicySelect.tsx
@@ -44,6 +44,8 @@ export interface PermissionPolicySelectProps {
     container?: HTMLElement | null
     /** Trigger sizing/colour override — the drawer's per-tool select is a compact inline chip. */
     triggerClassName?: string
+    /** Menu width override. The panel is pinned to the trigger, which wraps a compact chip's rows. */
+    contentClassName?: string
     size?: "sm" | "default"
 }
 
@@ -57,6 +59,7 @@ export function PermissionPolicySelect({
     onOpenChange,
     container,
     triggerClassName = "w-full",
+    contentClassName,
     size,
 }: PermissionPolicySelectProps) {
     const selected = options.find((option) => option.value === value)
@@ -76,7 +79,7 @@ export function PermissionPolicySelect({
                     </span>
                 </SelectValue>
             </SelectTrigger>
-            <SelectContent container={container}>
+            <SelectContent container={container} className={contentClassName}>
                 {options.map((option) => (
                     <div key={option.value}>
                         {option.separatorBefore ? <SelectSeparator /> : null}
@@ -84,7 +87,7 @@ export function PermissionPolicySelect({
                             <span className="flex items-center gap-2.5 py-0.5">
                                 {option.icon}
                                 <span className="flex flex-col">
-                                    <span>{option.title}</span>
+                                    <span className="whitespace-nowrap">{option.title}</span>
                                     <span className="text-xs leading-snug text-colorTextTertiary">
                                         {option.help}
                                     </span>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/drawerWidths.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/drawerWidths.ts
@@ -1,0 +1,2 @@
+/** Shared width for the integration drawers, so add and permissions open at the same size. */
+export const INTEGRATION_DRAWER_WIDTH = 680

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/integrationCatalogFilters.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/integrationCatalogFilters.ts
@@ -1,0 +1,96 @@
+/**
+ * The add-integration drawer's list arithmetic, kept out of the component so it can be tested.
+ *
+ * Two rules the drawer used to get wrong:
+ * - A connected integration STAYS in the connectable list. Connecting again is how an author gets
+ *   a second account, so the catalog never subtracts what is already connected.
+ * - Picking a category filters BOTH lists. The catalog is filtered server-side; the connected list
+ *   is the project's own connections, so it is filtered here against each integration's categories.
+ */
+
+/** The category a rail button stands for. `id` drives the server query, `name` is what apps carry. */
+export interface CategorySelection {
+    id: string
+    name: string
+}
+
+const norm = (value: string): string => value.trim().toLowerCase()
+
+/**
+ * Whether an integration belongs to the selected category. Integrations carry category NAMES
+ * (the provider's own labels); the rail's `id` is the provider's slug for the same thing, so both
+ * are accepted — a provider that starts sending one where it sent the other cannot empty the list.
+ */
+export function matchesCategory(
+    categories: readonly string[] | null | undefined,
+    selected: CategorySelection | null,
+): boolean {
+    if (!selected) return true
+    if (!categories || categories.length === 0) return false
+    const wanted = new Set([norm(selected.name), norm(selected.id)])
+    return categories.some((category) => wanted.has(norm(category)))
+}
+
+export interface ConnectedGroupLike {
+    integrationKey: string
+}
+
+export interface ConnectedFilterOptions<T extends ConnectedGroupLike> {
+    groups: readonly T[]
+    /** The raw search box text. */
+    query: string
+    category: CategorySelection | null
+    /** Categories per integration key, from each integration's catalog detail. */
+    categoriesByIntegration: ReadonlyMap<string, readonly string[]>
+    /** Display name per integration key, so a search matches what the row actually shows. */
+    namesByIntegration?: ReadonlyMap<string, string>
+}
+
+/**
+ * The connected rows a search and a category leave standing. Filtering here rather than inside each
+ * row keeps the section count equal to the rows it heads.
+ *
+ * An integration whose detail has not loaded yet keeps its row under a category filter: hiding it
+ * would make rows blink out and back as details arrive.
+ */
+export function filterConnectedGroups<T extends ConnectedGroupLike>({
+    groups,
+    query,
+    category,
+    categoriesByIntegration,
+    namesByIntegration,
+}: ConnectedFilterOptions<T>): T[] {
+    const needle = norm(query)
+    return groups.filter((group) => {
+        if (needle) {
+            const name = namesByIntegration?.get(group.integrationKey) ?? ""
+            const haystack = `${group.integrationKey} ${name}`.toLowerCase()
+            if (!haystack.includes(needle)) return false
+        }
+        if (!category) return true
+        const categories = categoriesByIntegration.get(group.integrationKey)
+        if (categories === undefined) return true
+        return matchesCategory(categories, category)
+    })
+}
+
+export interface CatalogIntegrationLike {
+    key: string
+}
+
+/**
+ * The drawer's two sections, built together so the relationship between them is stated once.
+ *
+ * `connectable` is the WHOLE catalog, connected apps included. Subtracting them made a second
+ * account unreachable — Connect is the only way to make one and it lives on these rows — so an app
+ * the project already has appears twice: under Connected, and again here.
+ */
+export function catalogSections<G extends ConnectedGroupLike, I extends CatalogIntegrationLike>({
+    integrations,
+    ...connectedOptions
+}: ConnectedFilterOptions<G> & {integrations: readonly I[]}): {
+    connected: G[]
+    connectable: readonly I[]
+} {
+    return {connected: filterConnectedGroups(connectedOptions), connectable: integrations}
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/integrationPolicy.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/integrationPolicy.ts
@@ -181,6 +181,22 @@ export interface CatalogToolInfo {
     stale?: boolean
 }
 
+/**
+ * Whether a tool row should offer its "Show more" toggle.
+ *
+ * `overflows` is the row's own width measurement, taken only while collapsed. Two rules it cannot
+ * supply: a description carrying a NEWLINE hides text no width measurement can see, and a row with
+ * no description at all must never offer a toggle — a row reused for the same tool key after the
+ * description went away keeps the last measurement, and without this it grew a toggle over nothing.
+ */
+export function isDescriptionTruncatable(
+    description: string | undefined,
+    overflows: boolean,
+): boolean {
+    if (!description) return false
+    return description.includes("\n") || overflows
+}
+
 export interface ToolPartition {
     readOnly: CatalogToolInfo[]
     write: CatalogToolInfo[]

--- a/web/packages/agenta-entity-ui/src/gatewayTool/drawers/ConnectDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTool/drawers/ConnectDrawer.tsx
@@ -63,8 +63,7 @@ export default function ConnectDrawer({
     // One suffix per drawer instance keeps the derived slug stable while the author edits the name.
     const slugSuffixRef = useRef(randomAlphanumeric(3))
 
-    // The author names the connection; the slug is derived and never shown. The API rejects a null
-    // slug, so it is still computed and sent — it is just not something to author.
+    // The slug is derived, not authored. Still sent: the API 500s on a null one.
     const {connections} = useToolConnectionsQuery()
     const existingCount = connections.filter(
         (connection) => connection.integration_key === integrationKey,
@@ -79,8 +78,7 @@ export default function ConnectDrawer({
         slugSuffixRef.current,
     )
 
-    // The connections list settles after mount, so the "(main)" / "(secondary)" seed can only be
-    // known late. Re-seed until the author types something of their own.
+    // The connections count lands after mount, so re-seed until the author types their own.
     useEffect(() => {
         if (!nameTouchedRef.current) setName(seedName)
     }, [seedName])

--- a/web/packages/agenta-entity-ui/src/gatewayTool/drawers/ConnectDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTool/drawers/ConnectDrawer.tsx
@@ -1,12 +1,13 @@
-import {useCallback, useRef, useState} from "react"
+import {useCallback, useEffect, useRef, useState} from "react"
 
 import {
     createToolConnection,
     fetchToolConnection,
     invalidateToolConnections,
+    useToolConnectionsQuery,
 } from "@agenta/entities/gatewayTool"
 import {getAgentaApiUrl, getAgentaWebUrl} from "@agenta/shared/api"
-import {generateDefaultSlug, randomAlphanumeric} from "@agenta/shared/utils"
+import {defaultConnectionName, generateDefaultSlug, randomAlphanumeric} from "@agenta/shared/utils"
 import {EnhancedModal, ModalContent, ModalFooter, message} from "@agenta/ui"
 import {
     Divider,
@@ -59,44 +60,54 @@ export default function ConnectDrawer({
     onSuccess,
 }: Props) {
     const [loading, setLoading] = useState(false)
-    // Track whether the user has manually edited the slug field.
-    // While false, slug auto-tracks the name field.
-    const slugTouchedRef = useRef(false)
+    // One suffix per drawer instance keeps the derived slug stable while the author edits the name.
     const slugSuffixRef = useRef(randomAlphanumeric(3))
 
-    const buildDefaultSlug = useCallback((name: string) => {
-        return generateDefaultSlug(name, slugSuffixRef.current)
-    }, [])
+    // The author names the connection; the slug is derived and never shown. The API rejects a null
+    // slug, so it is still computed and sent — it is just not something to author.
+    const {connections} = useToolConnectionsQuery()
+    const existingCount = connections.filter(
+        (connection) => connection.integration_key === integrationKey,
+    ).length
+    const seedName = defaultConnectionName(integrationName, existingCount)
 
-    // Explicitly controlled form state (the antd Form was internal-only here).
-    const [name, setName] = useState(integrationName)
-    const [slug, setSlug] = useState(() => buildDefaultSlug(integrationName || ""))
-    const [slugError, setSlugError] = useState<string | null>(null)
+    const nameTouchedRef = useRef(false)
+    const [name, setName] = useState(seedName)
+    const [nameError, setNameError] = useState<string | null>(null)
+    const slug = generateDefaultSlug(
+        name || integrationName || integrationKey,
+        slugSuffixRef.current,
+    )
+
+    // The connections list settles after mount, so the "(main)" / "(secondary)" seed can only be
+    // known late. Re-seed until the author types something of their own.
+    useEffect(() => {
+        if (!nameTouchedRef.current) setName(seedName)
+    }, [seedName])
 
     const availableModes = resolveAvailableModes(authSchemes)
     const [selectedMode, setSelectedMode] = useState<AuthMode>(availableModes[0] || "oauth")
 
     const handleClose = useCallback(() => {
-        slugTouchedRef.current = false
+        nameTouchedRef.current = false
         slugSuffixRef.current = randomAlphanumeric(3)
-        setName(integrationName)
-        setSlug(buildDefaultSlug(integrationName || ""))
-        setSlugError(null)
+        setName(seedName)
+        setNameError(null)
         setLoading(false)
         onClose()
-    }, [onClose, integrationName, buildDefaultSlug])
+    }, [onClose, seedName])
 
     // The shared one, not a local copy: it also invalidates ["triggers", "connections"], which
     // this drawer was missing — a tool connected here left the triggers list stale.
     const invalidateConnections = invalidateToolConnections
 
     const handleSubmit = useCallback(async () => {
-        // Was the antd `required` rule on the slug Form.Item — now the direct path.
-        if (!slug.trim()) {
-            setSlugError("Required")
+        // The name is now the only authored field, so it carries the validation the slug used to.
+        if (!name.trim() || !slug.trim()) {
+            setNameError("Required")
             return
         }
-        setSlugError(null)
+        setNameError(null)
         try {
             setLoading(true)
 
@@ -218,37 +229,20 @@ export default function ConnectDrawer({
 
                 {/* Form (explicitly controlled — no antd Form) */}
                 <div className="flex flex-col gap-4">
-                    <Field label="Name" tooltip="Display name for this connection">
+                    <Field
+                        label="Name"
+                        required
+                        tooltip="Display name for this connection"
+                        error={nameError}
+                    >
                         <Input
                             placeholder={`e.g. My ${integrationName} Account`}
                             value={name}
+                            aria-invalid={nameError ? true : undefined}
                             onChange={(e) => {
+                                nameTouchedRef.current = true
                                 setName(e.target.value)
-                                // Was in the Input's onChange inside the antd Form —
-                                // slug auto-tracks name until the user edits the slug.
-                                if (!slugTouchedRef.current) {
-                                    setSlug(
-                                        buildDefaultSlug(e.target.value || integrationName || ""),
-                                    )
-                                }
-                            }}
-                        />
-                    </Field>
-
-                    <Field
-                        label="Slug"
-                        required
-                        tooltip="Unique identifier used in tool call slugs — lowercase letters, numbers, and hyphens only"
-                        error={slugError}
-                    >
-                        <Input
-                            placeholder={`e.g. my-${integrationKey}`}
-                            value={slug}
-                            aria-invalid={slugError ? true : undefined}
-                            onChange={(e) => {
-                                slugTouchedRef.current = true
-                                setSlug(e.target.value)
-                                if (slugError && e.target.value.trim()) setSlugError(null)
+                                if (nameError && e.target.value.trim()) setNameError(null)
                             }}
                         />
                     </Field>

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerConnectDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerConnectDrawer.tsx
@@ -1,8 +1,12 @@
 import {useCallback, useEffect, useRef, useState} from "react"
 
-import {createTriggerConnection, fetchTriggerConnection} from "@agenta/entities/gatewayTrigger"
+import {
+    createTriggerConnection,
+    fetchTriggerConnection,
+    useTriggerConnectionsQuery,
+} from "@agenta/entities/gatewayTrigger"
 import {getAgentaApiUrl, getAgentaWebUrl, getHostQueryClient} from "@agenta/shared/api"
-import {generateDefaultSlug, randomAlphanumeric} from "@agenta/shared/utils"
+import {defaultConnectionName, generateDefaultSlug, randomAlphanumeric} from "@agenta/shared/utils"
 import {EnhancedModal, message, ModalContent, ModalFooter} from "@agenta/ui"
 import {
     Divider,
@@ -83,50 +87,54 @@ export default function TriggerConnectDrawer({
     onSuccess,
 }: Props) {
     const [loading, setLoading] = useState(false)
-    const slugTouchedRef = useRef(false)
+    const nameTouchedRef = useRef(false)
     const slugSuffixRef = useRef(randomAlphanumeric(3))
 
-    const buildDefaultSlug = useCallback((name: string) => {
-        return generateDefaultSlug(name, slugSuffixRef.current)
-    }, [])
+    // The author names the connection; the slug is derived and never shown. The API rejects a null
+    // slug, so it is still computed and sent — it is just not something to author.
+    const {connections} = useTriggerConnectionsQuery()
+    const existingCount = connections.filter(
+        (connection) => connection.integration_key === integrationKey,
+    ).length
+    const seedName = defaultConnectionName(integrationName, existingCount)
 
-    // Explicit controlled fields (the antd Form/useForm pair is gone). `slugError` carries
-    // the one antd rule ({required: true, message: "Required"}), checked on submit.
-    const [name, setName] = useState(integrationName)
-    const [slug, setSlug] = useState(() => buildDefaultSlug(integrationName || ""))
-    const [slugError, setSlugError] = useState<string | null>(null)
+    const [name, setName] = useState(seedName)
+    const [nameError, setNameError] = useState<string | null>(null)
+    const slug = generateDefaultSlug(
+        name || integrationName || integrationKey,
+        slugSuffixRef.current,
+    )
 
     const availableModes = resolveAvailableModes(authSchemes)
     const [selectedMode, setSelectedMode] = useState<AuthMode>(availableModes[0] || "oauth")
 
-    // Re-seed per open (was antd `initialValues` + `destroyOnClose` remount semantics):
-    // the state lives on this component, which stays mounted across opens.
+    // Re-seed per open, and again when the connections list settles and the "(main)" /
+    // "(secondary)" count becomes known — but never over something the author typed.
     useEffect(() => {
         if (!open) return
-        setName(integrationName)
-        setSlug(buildDefaultSlug(integrationName || ""))
-        slugTouchedRef.current = false
-        setSlugError(null)
-    }, [open, integrationKey, integrationName, buildDefaultSlug])
+        nameTouchedRef.current = false
+        setNameError(null)
+    }, [open, integrationKey])
+    useEffect(() => {
+        if (!nameTouchedRef.current) setName(seedName)
+    }, [seedName])
 
     const handleClose = useCallback(() => {
-        // Was `form.resetFields()`: rewind the controlled fields to their defaults.
-        slugTouchedRef.current = false
+        nameTouchedRef.current = false
         slugSuffixRef.current = randomAlphanumeric(3)
-        setName(integrationName)
-        setSlug(generateDefaultSlug(integrationName || "", slugSuffixRef.current))
-        setSlugError(null)
+        setName(seedName)
+        setNameError(null)
         setLoading(false)
         onClose()
-    }, [integrationName, onClose])
+    }, [seedName, onClose])
 
     const handleSubmit = useCallback(async () => {
-        // Was `form.validateFields()`: the only rule is slug required.
-        if (!slug.trim()) {
-            setSlugError("Required")
+        // The name is now the only authored field, so it carries the validation the slug used to.
+        if (!name.trim() || !slug.trim()) {
+            setNameError("Required")
             return
         }
-        setSlugError(null)
+        setNameError(null)
         try {
             setLoading(true)
 
@@ -250,41 +258,17 @@ export default function TriggerConnectDrawer({
                 <div className="flex flex-col gap-4">
                     <Field
                         label={<LabelTooltip label="Name" tip="Display name for this connection" />}
+                        required
+                        error={nameError}
                     >
                         <Input
                             placeholder={`e.g. My ${integrationName} Account`}
                             value={name}
+                            aria-invalid={nameError ? true : undefined}
                             onChange={(e) => {
+                                nameTouchedRef.current = true
                                 setName(e.target.value)
-                                if (!slugTouchedRef.current) {
-                                    // Was Form.setFieldValue("slug", …) inside onChange —
-                                    // moved onto the direct controlled path.
-                                    setSlug(
-                                        buildDefaultSlug(e.target.value || integrationName || ""),
-                                    )
-                                }
-                            }}
-                        />
-                    </Field>
-
-                    <Field
-                        label={
-                            <LabelTooltip
-                                label="Slug"
-                                tip="Unique identifier — lowercase letters, numbers, and hyphens only"
-                            />
-                        }
-                        required
-                        error={slugError}
-                    >
-                        <Input
-                            placeholder={`e.g. my-${integrationKey}`}
-                            value={slug}
-                            aria-invalid={slugError ? true : undefined}
-                            onChange={(e) => {
-                                slugTouchedRef.current = true
-                                setSlug(e.target.value)
-                                if (slugError && e.target.value.trim()) setSlugError(null)
+                                if (nameError && e.target.value.trim()) setNameError(null)
                             }}
                         />
                     </Field>

--- a/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerConnectDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTrigger/drawers/TriggerConnectDrawer.tsx
@@ -90,8 +90,7 @@ export default function TriggerConnectDrawer({
     const nameTouchedRef = useRef(false)
     const slugSuffixRef = useRef(randomAlphanumeric(3))
 
-    // The author names the connection; the slug is derived and never shown. The API rejects a null
-    // slug, so it is still computed and sent — it is just not something to author.
+    // The slug is derived, not authored. Still sent: the API 500s on a null one.
     const {connections} = useTriggerConnectionsQuery()
     const existingCount = connections.filter(
         (connection) => connection.integration_key === integrationKey,
@@ -108,8 +107,7 @@ export default function TriggerConnectDrawer({
     const availableModes = resolveAvailableModes(authSchemes)
     const [selectedMode, setSelectedMode] = useState<AuthMode>(availableModes[0] || "oauth")
 
-    // Re-seed per open, and again when the connections list settles and the "(main)" /
-    // "(secondary)" count becomes known — but never over something the author typed.
+    // Re-seed per open and when the count lands, but never over something the author typed.
     useEffect(() => {
         if (!open) return
         nameTouchedRef.current = false

--- a/web/packages/agenta-entity-ui/tests/unit/descriptionTruncatable.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/descriptionTruncatable.test.ts
@@ -1,0 +1,38 @@
+/**
+ * When a tool row offers its "Show more" toggle.
+ *
+ * The row measures its own description width, but the measurement alone gets two cases wrong: a
+ * description whose text is hidden behind a NEWLINE rather than past the right edge, and a row
+ * reused for the same tool key after the description went away, which keeps the last measurement.
+ * The second is reachable: a key that leaves the provider catalog comes back through `withStaleTools`
+ * as `{key, stale: true}` with no description, and React keeps the row's state across that swap.
+ */
+import {describe, expect, it} from "vitest"
+
+import {isDescriptionTruncatable} from "../../src/DrillInView/SchemaControls/integrationPolicy"
+
+describe("isDescriptionTruncatable", () => {
+    it("offers the toggle when the one-line preview cuts the text off", () => {
+        expect(isDescriptionTruncatable("a very long single line", true)).toBe(true)
+    })
+
+    it("leaves a short single-line description alone", () => {
+        expect(isDescriptionTruncatable("Read one issue", false)).toBe(false)
+    })
+
+    it("offers the toggle for a newline even when the first line fits", () => {
+        expect(isDescriptionTruncatable("Merges a PR.\n\nFails on a closed PR.", false)).toBe(true)
+    })
+
+    it("never offers a toggle with no description, whatever the last measurement said", () => {
+        expect(isDescriptionTruncatable(undefined, true)).toBe(false)
+        expect(isDescriptionTruncatable("", true)).toBe(false)
+    })
+
+    it("does not offer a toggle for a stale row that used to overflow", () => {
+        // The row's state before the catalog dropped the key.
+        expect(isDescriptionTruncatable("a very long single line", true)).toBe(true)
+        // The same row after `withStaleTools` replaced it with a description-less entry.
+        expect(isDescriptionTruncatable(undefined, true)).toBe(false)
+    })
+})

--- a/web/packages/agenta-entity-ui/tests/unit/integrationCatalogFilters.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/integrationCatalogFilters.test.ts
@@ -9,11 +9,7 @@ import {
 const DEV = {id: "developer-tools", name: "developer tools"}
 const COMMS = {id: "communication", name: "communication"}
 
-const groups = [
-    {integrationKey: "github"},
-    {integrationKey: "slack"},
-    {integrationKey: "linear"},
-]
+const groups = [{integrationKey: "github"}, {integrationKey: "slack"}, {integrationKey: "linear"}]
 
 const categoriesByIntegration = new Map<string, readonly string[]>([
     ["github", ["developer tools"]],
@@ -68,7 +64,9 @@ describe("filterConnectedGroups", () => {
     })
 
     it("filters the CONNECTED list by the selected category, not just the catalog", () => {
-        expect(keys(filterConnectedGroups({...base, query: "", category: COMMS}))).toEqual(["slack"])
+        expect(keys(filterConnectedGroups({...base, query: "", category: COMMS}))).toEqual([
+            "slack",
+        ])
     })
 
     it("applies the search and the category together", () => {

--- a/web/packages/agenta-entity-ui/tests/unit/integrationCatalogFilters.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/integrationCatalogFilters.test.ts
@@ -1,0 +1,153 @@
+import {describe, expect, it} from "vitest"
+
+import {
+    catalogSections,
+    filterConnectedGroups,
+    matchesCategory,
+} from "../../src/DrillInView/SchemaControls/agentTemplate/integrationCatalogFilters"
+
+const DEV = {id: "developer-tools", name: "developer tools"}
+const COMMS = {id: "communication", name: "communication"}
+
+const groups = [
+    {integrationKey: "github"},
+    {integrationKey: "slack"},
+    {integrationKey: "linear"},
+]
+
+const categoriesByIntegration = new Map<string, readonly string[]>([
+    ["github", ["developer tools"]],
+    ["slack", ["communication"]],
+    ["linear", ["productivity"]],
+])
+
+const namesByIntegration = new Map([
+    ["github", "GitHub"],
+    ["slack", "Slack"],
+    ["linear", "Linear"],
+])
+
+const keys = <T extends {integrationKey: string}>(rows: T[]) => rows.map((r) => r.integrationKey)
+
+describe("matchesCategory", () => {
+    it("matches on the provider's category name", () => {
+        expect(matchesCategory(["developer tools"], DEV)).toBe(true)
+    })
+
+    it("matches on the rail's category id, which is the same thing slugified", () => {
+        expect(matchesCategory(["developer-tools"], DEV)).toBe(true)
+    })
+
+    it("ignores case, because the provider sends these lowercase", () => {
+        expect(matchesCategory(["Developer Tools"], DEV)).toBe(true)
+    })
+
+    it("does not match a different category", () => {
+        expect(matchesCategory(["communication"], DEV)).toBe(false)
+    })
+
+    it("matches everything when no category is selected", () => {
+        expect(matchesCategory([], null)).toBe(true)
+        expect(matchesCategory(undefined, null)).toBe(true)
+    })
+
+    it("excludes an app with no categories once a category is picked", () => {
+        expect(matchesCategory([], DEV)).toBe(false)
+    })
+})
+
+describe("filterConnectedGroups", () => {
+    const base = {groups, categoriesByIntegration, namesByIntegration}
+
+    it("keeps every row with no search and no category", () => {
+        expect(keys(filterConnectedGroups({...base, query: "", category: null}))).toEqual([
+            "github",
+            "slack",
+            "linear",
+        ])
+    })
+
+    it("filters the CONNECTED list by the selected category, not just the catalog", () => {
+        expect(keys(filterConnectedGroups({...base, query: "", category: COMMS}))).toEqual(["slack"])
+    })
+
+    it("applies the search and the category together", () => {
+        expect(keys(filterConnectedGroups({...base, query: "git", category: COMMS}))).toEqual([])
+        expect(keys(filterConnectedGroups({...base, query: "git", category: DEV}))).toEqual([
+            "github",
+        ])
+    })
+
+    it("searches the display name too, not only the integration key", () => {
+        expect(
+            keys(
+                filterConnectedGroups({
+                    groups: [{integrationKey: "gcal"}],
+                    categoriesByIntegration: new Map(),
+                    namesByIntegration: new Map([["gcal", "Google Calendar"]]),
+                    query: "calendar",
+                    category: null,
+                }),
+            ),
+        ).toEqual(["gcal"])
+    })
+
+    it("keeps a row whose catalog detail has not loaded yet, so rows do not blink out", () => {
+        expect(
+            keys(
+                filterConnectedGroups({
+                    groups: [{integrationKey: "notion"}],
+                    categoriesByIntegration: new Map(),
+                    namesByIntegration: new Map(),
+                    query: "",
+                    category: DEV,
+                }),
+            ),
+        ).toEqual(["notion"])
+    })
+})
+
+describe("catalogSections", () => {
+    const integrations = [{key: "github"}, {key: "slack"}, {key: "notion"}]
+
+    it("lists an already-connected integration in BOTH sections, so a second account is reachable", () => {
+        const {connected, connectable} = catalogSections({
+            integrations,
+            groups,
+            query: "",
+            category: null,
+            categoriesByIntegration,
+            namesByIntegration,
+        })
+
+        expect(keys(connected)).toContain("github")
+        expect(connectable.map((i) => i.key)).toContain("github")
+    })
+
+    it("does not subtract the connected apps from the catalog", () => {
+        const {connectable} = catalogSections({
+            integrations,
+            groups,
+            query: "",
+            category: null,
+            categoriesByIntegration,
+            namesByIntegration,
+        })
+
+        expect(connectable.map((i) => i.key)).toEqual(["github", "slack", "notion"])
+    })
+
+    it("narrows only the connected section, since the catalog is filtered server-side", () => {
+        const {connected, connectable} = catalogSections({
+            integrations,
+            groups,
+            query: "",
+            category: COMMS,
+            categoriesByIntegration,
+            namesByIntegration,
+        })
+
+        expect(keys(connected)).toEqual(["slack"])
+        expect(connectable).toHaveLength(3)
+    })
+})

--- a/web/packages/agenta-settings-ui/src/tools/ConnectModal.tsx
+++ b/web/packages/agenta-settings-ui/src/tools/ConnectModal.tsx
@@ -1,6 +1,11 @@
 import {useCallback, useEffect, useRef, useState} from "react"
 
-import {useToolsConnections, type CreateConnectionInput} from "@agenta/entities/gatewayTool"
+import {
+    useToolConnectionsQuery,
+    useToolsConnections,
+    type CreateConnectionInput,
+} from "@agenta/entities/gatewayTool"
+import {defaultConnectionName, generateDefaultSlug, randomAlphanumeric} from "@agenta/shared/utils"
 import {
     Button,
     Dialog,
@@ -49,10 +54,23 @@ export default function ConnectModal({
 }: Props) {
     const {handleCreate, invalidate} = useToolsConnections(integrationKey)
     const [loading, setLoading] = useState(false)
-    const [slug, setSlug] = useState("")
-    const [name, setName] = useState("")
-    const [slugError, setSlugError] = useState<string | null>(null)
+
+    // The author names the connection; the slug is derived from it and never shown.
+    const {connections} = useToolConnectionsQuery()
+    const existingCount = connections.filter(
+        (connection) => connection.integration_key === integrationKey,
+    ).length
+    const seedName = defaultConnectionName(integrationName, existingCount)
+    const slugSuffixRef = useRef(randomAlphanumeric(3))
+    const nameTouchedRef = useRef(false)
+
+    const [name, setName] = useState(seedName)
+    const [nameError, setNameError] = useState<string | null>(null)
     const [createError, setCreateError] = useState<string | null>(null)
+
+    useEffect(() => {
+        if (!nameTouchedRef.current) setName(seedName)
+    }, [seedName])
 
     /** The OAuth popup watcher. Held in a ref so unmount and a retry can both stop it. */
     const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
@@ -67,28 +85,30 @@ export default function ConnectModal({
 
     const handleClose = useCallback(() => {
         clearPoll()
-        setSlug("")
-        setName("")
-        setSlugError(null)
+        nameTouchedRef.current = false
+        slugSuffixRef.current = randomAlphanumeric(3)
+        setName(seedName)
+        setNameError(null)
         setCreateError(null)
         setLoading(false)
         onClose()
-    }, [clearPoll, onClose])
+    }, [clearPoll, onClose, seedName])
 
     const handleSubmit = useCallback(async () => {
-        if (!slug.trim()) {
-            setSlugError("Required")
+        const trimmedName = name.trim()
+        if (!trimmedName) {
+            setNameError("Required")
             return
         }
-        setSlugError(null)
+        setNameError(null)
         setCreateError(null)
 
         try {
             setLoading(true)
 
             const payload: CreateConnectionInput = {
-                slug: slug.trim(),
-                name: name.trim() || slug.trim(),
+                slug: generateDefaultSlug(trimmedName, slugSuffixRef.current),
+                name: trimmedName,
                 mode: selectedMode,
             }
 
@@ -133,7 +153,7 @@ export default function ConnectModal({
                 error instanceof Error ? error.message : "Couldn't create the connection",
             )
         }
-    }, [slug, name, selectedMode, clearPoll, handleCreate, handleClose, invalidate])
+    }, [name, selectedMode, clearPoll, handleCreate, handleClose, invalidate])
 
     return (
         <Dialog open={open} onOpenChange={(next) => (next ? undefined : handleClose())}>
@@ -144,22 +164,19 @@ export default function ConnectModal({
 
                 <div className="flex flex-col gap-4">
                     <Field
-                        label="Connection Slug"
+                        label="Name"
                         required
-                        tooltip="A unique identifier for this connection"
-                        error={slugError}
+                        tooltip="Display name for this connection"
+                        error={nameError}
                     >
                         <Input
-                            value={slug}
-                            onChange={(event) => setSlug(event.target.value)}
-                            placeholder="e.g. my-gmail"
-                        />
-                    </Field>
-
-                    <Field label="Display Name">
-                        <Input
                             value={name}
-                            onChange={(event) => setName(event.target.value)}
+                            aria-invalid={nameError ? true : undefined}
+                            onChange={(event) => {
+                                nameTouchedRef.current = true
+                                setName(event.target.value)
+                                if (nameError && event.target.value.trim()) setNameError(null)
+                            }}
                             placeholder="e.g. My Gmail Account"
                         />
                     </Field>

--- a/web/packages/agenta-shared/src/utils/connectionSlug.ts
+++ b/web/packages/agenta-shared/src/utils/connectionSlug.ts
@@ -39,3 +39,27 @@ export function generateDefaultSlug(name: string, suffix = randomAlphanumeric(3)
     const base = slugify(name)
     return base ? `${base}-${suffix}` : suffix
 }
+
+/** Ordinal words for the first connections of an integration; later ones fall back to a number. */
+const CONNECTION_ORDINALS = ["main", "secondary"]
+
+/**
+ * The name a new connection is offered, given how many the integration already has.
+ * "GitHub" → "GitHub (main)", then "GitHub (secondary)", then "GitHub (3)".
+ */
+export function defaultConnectionName(integrationName: string, existingCount = 0): string {
+    const base = integrationName.trim() || "Connection"
+    const index = Math.max(0, Math.trunc(existingCount))
+    const ordinal = CONNECTION_ORDINALS[index] ?? String(index + 1)
+    return `${base} (${ordinal})`
+}
+
+/**
+ * What a connection is CALLED in the UI. A slug is an identifier, never a label — it only stands
+ * in when a connection carries no name at all.
+ */
+export function connectionDisplayName(
+    connection: {name?: string | null; slug?: string | null} | null | undefined,
+): string {
+    return connection?.name?.trim() || connection?.slug?.trim() || ""
+}

--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -211,6 +211,8 @@ export type {
 // Gateway Tool Slug utilities
 export {
     slugify as connectionSlugify,
+    connectionDisplayName,
+    defaultConnectionName,
     generateDefaultSlug,
     randomAlphanumeric,
 } from "./connectionSlug"

--- a/web/packages/agenta-shared/tests/unit/connectionSlug.test.ts
+++ b/web/packages/agenta-shared/tests/unit/connectionSlug.test.ts
@@ -1,0 +1,87 @@
+import {describe, expect, it} from "vitest"
+
+import {
+    connectionDisplayName,
+    defaultConnectionName,
+    generateDefaultSlug,
+    slugify,
+} from "../../src/utils/connectionSlug"
+
+// The connect forms no longer show a slug field: the author types a NAME and the slug is derived
+// from it. These cover the derivation those forms now depend on, and the names they seed.
+
+describe("defaultConnectionName", () => {
+    it("names the first connection of an integration '(main)'", () => {
+        expect(defaultConnectionName("GitHub", 0)).toBe("GitHub (main)")
+    })
+
+    it("names the second one '(secondary)'", () => {
+        expect(defaultConnectionName("GitHub", 1)).toBe("GitHub (secondary)")
+    })
+
+    it("numbers the ones past the two named ordinals", () => {
+        expect(defaultConnectionName("GitHub", 2)).toBe("GitHub (3)")
+        expect(defaultConnectionName("GitHub", 5)).toBe("GitHub (6)")
+    })
+
+    it("defaults to the first when no count is given", () => {
+        expect(defaultConnectionName("Slack")).toBe("Slack (main)")
+    })
+
+    it("trims the integration name", () => {
+        expect(defaultConnectionName("  Google Calendar  ", 0)).toBe("Google Calendar (main)")
+    })
+
+    it("falls back to a generic noun rather than an empty parenthetical", () => {
+        expect(defaultConnectionName("", 0)).toBe("Connection (main)")
+    })
+
+    it("tolerates a nonsense count instead of producing 'undefined'", () => {
+        expect(defaultConnectionName("GitHub", -3)).toBe("GitHub (main)")
+        expect(defaultConnectionName("GitHub", 1.9)).toBe("GitHub (secondary)")
+    })
+})
+
+describe("connectionDisplayName", () => {
+    it("shows the name", () => {
+        expect(connectionDisplayName({name: "GitHub (main)", slug: "github-7mx"})).toBe(
+            "GitHub (main)",
+        )
+    })
+
+    it("falls back to the slug only when there is no name at all", () => {
+        expect(connectionDisplayName({name: null, slug: "github-7mx"})).toBe("github-7mx")
+        expect(connectionDisplayName({name: "   ", slug: "github-7mx"})).toBe("github-7mx")
+    })
+
+    it("is empty rather than undefined for a missing connection", () => {
+        expect(connectionDisplayName(undefined)).toBe("")
+        expect(connectionDisplayName(null)).toBe("")
+    })
+})
+
+describe("generateDefaultSlug from a default connection name", () => {
+    it("derives a URL-safe slug from the seeded name", () => {
+        expect(generateDefaultSlug(defaultConnectionName("GitHub", 0), "7mx")).toBe(
+            "github-main-7mx",
+        )
+        expect(generateDefaultSlug(defaultConnectionName("Google Calendar", 1), "a1b")).toBe(
+            "google-calendar-secondary-a1b",
+        )
+    })
+
+    it("produces nothing the connection API rejects — no dots, no doubled underscores", () => {
+        const slug = generateDefaultSlug("My v1.2 Account __ prod", "zzz")
+        expect(slug).not.toContain(".")
+        expect(slug).not.toContain("__")
+        expect(slug).toMatch(/^[a-z0-9][a-z0-9-]*$/)
+    })
+
+    it("still yields a slug when the name has no usable characters", () => {
+        expect(generateDefaultSlug("!!!", "q7t")).toBe("q7t")
+    })
+
+    it("keeps slugify's contract the derivation rests on", () => {
+        expect(slugify("  Hello_World  ")).toBe("hello-world")
+    })
+})

--- a/web/storybook/fixtures/gatewayIntegration.ts
+++ b/web/storybook/fixtures/gatewayIntegration.ts
@@ -42,6 +42,39 @@ export const GITHUB_TOOLS: ToolCatalogAction[] = [
     {key: "GITHUB_DELETE_REPO", name: "Delete repository", description: "Remove a repo"},
 ]
 
+/** Long enough to truncate on one line, and carrying the line breaks the provider ships. */
+export const VERBOSE_DESCRIPTION = [
+    "Creates a new issue in a GitHub repository, assigning it to the given milestone.",
+    "",
+    "Requires the repository to exist and the token to carry the issues:write scope.",
+    "Labels and assignees must already exist on the repository.",
+].join("\n")
+
+/** A first line short enough to fit, with the rest of the text hidden behind the line break. */
+export const SHORT_FIRST_LINE_DESCRIPTION = ["Merges a PR.", "", "Fails on a closed PR."].join("\n")
+
+/** Catalog for the truncation and line-break cases in the permission drawer. */
+export const GITHUB_TOOLS_VERBOSE: ToolCatalogAction[] = [
+    {
+        key: "GITHUB_GET_ISSUE",
+        name: "Get issue",
+        description: VERBOSE_DESCRIPTION,
+        read_only: true,
+    },
+    {
+        key: "GITHUB_MERGE_PR",
+        name: "Merge pull request",
+        description: SHORT_FIRST_LINE_DESCRIPTION,
+        read_only: false,
+    },
+    {
+        key: "GITHUB_CREATE_ISSUE",
+        name: "Create issue",
+        description: VERBOSE_DESCRIPTION,
+        read_only: false,
+    },
+]
+
 export const GITHUB_DETAIL: ToolCatalogIntegrationDetails = {
     key: "github",
     name: "GitHub",
@@ -83,20 +116,24 @@ export function connection(
     slug: string,
     integrationKey: string,
     flags: {is_active: boolean; is_valid: boolean} = {is_active: true, is_valid: true},
+    /** Real connections carry a name distinct from the slug — that is what the UI must show. */
+    name: string = slug,
 ): ToolConnection {
     return {
         id: `conn-${slug}`,
         slug,
-        name: slug,
+        name,
         provider_key: PROVIDER,
         integration_key: integrationKey,
         flags,
     } as ToolConnection
 }
 
-export const GITHUB_WORK = connection("github-work", "github")
-export const GITHUB_PERSONAL = connection("github-personal", "github")
-export const SLACK_OPS = connection("slack-ops", "slack")
+const ACTIVE = {is_active: true, is_valid: true}
+
+export const GITHUB_WORK = connection("github-work", "github", ACTIVE, "GitHub (main)")
+export const GITHUB_PERSONAL = connection("github-personal", "github", ACTIVE, "GitHub (secondary)")
+export const SLACK_OPS = connection("slack-ops", "slack", ACTIVE, "Slack (main)")
 /** Connected but not usable — the add drawer shows a reconnect hint instead of Add. */
 export const LINEAR_BROKEN = connection("linear-main", "linear", {
     is_active: true,
@@ -109,25 +146,58 @@ const infinitePage = (page: Record<string, unknown>) => ({pages: [page], pagePar
  * Everything an integration surface reads: the project connections, the per-integration detail
  * (each row's logo and display name), the complete action catalog, and the browse lists.
  */
+/** As the provider sends them: lowercase, and far more than a rail can show without scrolling. */
+export const LOWERCASE_CATEGORIES = [
+    {id: "developer-tools", name: "developer tools"},
+    {id: "communication", name: "communication"},
+    {id: "productivity", name: "productivity"},
+    {id: "crm", name: "crm"},
+    {id: "marketing", name: "marketing"},
+    {id: "analytics", name: "analytics"},
+    {id: "support", name: "support"},
+    {id: "finance", name: "finance"},
+    {id: "hr", name: "hr"},
+    {id: "design", name: "design"},
+    {id: "storage", name: "storage"},
+    {id: "scheduling", name: "scheduling"},
+    {id: "e-commerce", name: "e-commerce"},
+    {id: "security", name: "security"},
+    {id: "documents", name: "documents"},
+]
+
 export function integrationQueries(
     scope: StoryScope,
     options: {
         connections?: ToolConnection[]
         catalog?: ToolCatalogAction[]
         catalogIntegrations?: ToolCatalogIntegration[]
+        categories?: {id: string; name: string}[]
     } = {},
 ): [QueryKey, unknown][] {
     const connections = options.connections ?? [GITHUB_WORK]
     const catalog = options.catalog ?? GITHUB_TOOLS
     const integrations = options.catalogIntegrations ?? CATALOG_INTEGRATIONS
+    const categories = options.categories ?? [
+        {id: "dev", name: "Developer Tools"},
+        {id: "comms", name: "Communication"},
+        {id: "prod", name: "Productivity"},
+    ]
 
     return [
         // The project-wide connections list.
         [["tools", "connections", scope.projectId], {connections, count: connections.length}],
-        // Per-integration detail — each row's logo and display name.
-        [["tools", "catalog", "integrationDetail", PROVIDER, "github"], GITHUB_DETAIL],
-        [["tools", "catalog", "integrationDetail", PROVIDER, "slack"], SLACK_DETAIL],
-        [["tools", "catalog", "integrationDetail", PROVIDER, "linear"], LINEAR_DETAIL],
+        // Per-integration detail — each row's logo, display name and categories. Wrapped in
+        // `{integration}`, which is the shape the hook reads (`query.data?.integration`); seeded
+        // bare, every consumer silently fell back to the raw integration key.
+        [
+            ["tools", "catalog", "integrationDetail", PROVIDER, "github"],
+            {integration: GITHUB_DETAIL},
+        ],
+        [["tools", "catalog", "integrationDetail", PROVIDER, "slack"], {integration: SLACK_DETAIL}],
+        [
+            ["tools", "catalog", "integrationDetail", PROVIDER, "linear"],
+            {integration: LINEAR_DETAIL},
+        ],
         // The COMPLETE catalog the permission drawer partitions and counts.
         [["tools", "catalog", "integrationCatalog", scope.projectId, PROVIDER, "github"], catalog],
         // The add drawer's browse lists.
@@ -135,15 +205,6 @@ export function integrationQueries(
             ["tools", "catalog", "integrations", PROVIDER, "", ""],
             infinitePage({integrations, cursor: null, total: integrations.length}),
         ],
-        [
-            ["tools", "catalog", "categories", PROVIDER],
-            {
-                categories: [
-                    {id: "dev", name: "Developer Tools"},
-                    {id: "comms", name: "Communication"},
-                    {id: "prod", name: "Productivity"},
-                ],
-            },
-        ],
+        [["tools", "catalog", "categories", PROVIDER], {categories}],
     ]
 }

--- a/web/storybook/stories/entity-ui/AgentIntegrationDrawer.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentIntegrationDrawer.stories.tsx
@@ -12,6 +12,7 @@ import {
     GITHUB_WORK,
     integrationQueries,
     LINEAR_BROKEN,
+    LOWERCASE_CATEGORIES,
     SLACK_OPS,
 } from "../../fixtures/gatewayIntegration"
 
@@ -132,6 +133,44 @@ export const InvalidConnection: Story = {
         },
     },
     render: () => <DrawerHost />,
+}
+
+/**
+ * The categories as the provider actually sends them: lowercase, and more of them than the rail can
+ * show at once. They must read as names, and the list must scroll on its own without carrying the
+ * "Categories" heading and "All apps" off the top.
+ *
+ * GitHub and Slack are connected AND still listed under "All apps" — connecting again is the only
+ * way to add a second account, so the catalog never subtracts what is already connected.
+ */
+export const LowercaseCategories: Story = {
+    parameters: {
+        agenta: {
+            queries: (scope: StoryScope) =>
+                integrationQueries(scope, {
+                    connections: [GITHUB_WORK, SLACK_OPS],
+                    categories: LOWERCASE_CATEGORIES,
+                }),
+        },
+    },
+    render: () => <DrawerHost />,
+}
+
+/**
+ * Two accounts for one app, shown by NAME. The slug is an identifier that happens to be unique;
+ * it tells an author nothing about which account they are picking.
+ */
+export const NamedConnections: Story = {
+    parameters: {
+        agenta: {
+            queries: (scope: StoryScope) =>
+                integrationQueries(scope, {
+                    connections: [GITHUB_WORK, GITHUB_PERSONAL, SLACK_OPS],
+                    categories: LOWERCASE_CATEGORIES,
+                }),
+        },
+    },
+    render: () => <DrawerHost tools={[entry("github", GITHUB_WORK.slug ?? "")]} />,
 }
 
 /**

--- a/web/storybook/stories/entity-ui/ConnectDrawer.stories.tsx
+++ b/web/storybook/stories/entity-ui/ConnectDrawer.stories.tsx
@@ -1,6 +1,6 @@
+import {ConnectDrawer} from "@agenta/entity-ui/gatewayTool"
 import type {Meta, StoryObj} from "@storybook/nextjs"
 
-import ConnectDrawer from "../../../packages/agenta-entity-ui/src/gatewayTool/drawers/ConnectDrawer"
 import type {StoryScope} from "../../.storybook/decorators/withAgentaData"
 import {GITHUB_WORK, integrationQueries} from "../../fixtures/gatewayIntegration"
 

--- a/web/storybook/stories/entity-ui/ConnectDrawer.stories.tsx
+++ b/web/storybook/stories/entity-ui/ConnectDrawer.stories.tsx
@@ -1,0 +1,76 @@
+import type {Meta, StoryObj} from "@storybook/nextjs"
+
+import ConnectDrawer from "../../../packages/agenta-entity-ui/src/gatewayTool/drawers/ConnectDrawer"
+import type {StoryScope} from "../../.storybook/decorators/withAgentaData"
+import {GITHUB_WORK, integrationQueries} from "../../fixtures/gatewayIntegration"
+
+/**
+ * **Data-connected modal story.** Making a connection to an integration.
+ *
+ * The author names the connection and nothing else. The slug is derived from that name and never
+ * shown: it is a wire identifier (it ends up inside `tools__composio__github__ACTION__<slug>`),
+ * carries provider rules an author has no reason to learn, and every earlier version of this form
+ * asked for it first and let the name go blank.
+ *
+ * The name is seeded from how many connections the integration already has, so a second account
+ * arrives as "(secondary)" rather than a second thing called "GitHub".
+ */
+const meta = {
+    title: "@agenta/entity-ui/GatewayTool/ConnectDrawer",
+    component: ConnectDrawer,
+    parameters: {
+        layout: "padded",
+        docs: {
+            description: {
+                component:
+                    "Connect form: a Name field and an auth method. No slug field — the slug is " +
+                    "derived from the name.",
+            },
+        },
+    },
+} satisfies Meta<typeof ConnectDrawer>
+
+export default meta
+type Story = StoryObj
+
+const noop = () => undefined
+
+const host = (props: Partial<Parameters<typeof ConnectDrawer>[0]> = {}) => (
+    <div data-vrt-subject className="min-h-[520px]">
+        <ConnectDrawer
+            open
+            integrationKey="github"
+            integrationName="GitHub"
+            integrationDescription="Repos, issues and pull requests"
+            authSchemes={["oauth", "api_key"]}
+            onClose={noop}
+            {...props}
+        />
+    </div>
+)
+
+/** The project's first GitHub connection: seeded "GitHub (main)". */
+export const FirstConnection: Story = {
+    parameters: {
+        agenta: {queries: (scope: StoryScope) => integrationQueries(scope, {connections: []})},
+    },
+    render: () => host(),
+}
+
+/** A second one, from the same form: seeded "GitHub (secondary)". */
+export const SecondConnection: Story = {
+    parameters: {
+        agenta: {
+            queries: (scope: StoryScope) => integrationQueries(scope, {connections: [GITHUB_WORK]}),
+        },
+    },
+    render: () => host(),
+}
+
+/** One auth scheme, so the method select is not offered — Name is the whole form. */
+export const SingleAuthScheme: Story = {
+    parameters: {
+        agenta: {queries: (scope: StoryScope) => integrationQueries(scope, {connections: []})},
+    },
+    render: () => host({authSchemes: ["oauth"]}),
+}

--- a/web/storybook/stories/entity-ui/IntegrationPermissionDrawer.stories.tsx
+++ b/web/storybook/stories/entity-ui/IntegrationPermissionDrawer.stories.tsx
@@ -6,7 +6,12 @@ import type {Meta, StoryObj} from "@storybook/nextjs"
 // Imported from source: the DrillInView barrel does not re-export the permission drawer.
 import {IntegrationPermissionDrawer} from "../../../packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer"
 import type {StoryScope} from "../../.storybook/decorators/withAgentaData"
-import {GITHUB_TOOLS, GITHUB_WORK, integrationQueries} from "../../fixtures/gatewayIntegration"
+import {
+    GITHUB_TOOLS,
+    GITHUB_TOOLS_VERBOSE,
+    GITHUB_WORK,
+    integrationQueries,
+} from "../../fixtures/gatewayIntegration"
 
 // Shows what is SAVED; it never resolves `inherit`, because only the runner computes an effective
 // permission.
@@ -147,6 +152,17 @@ export const WithAgentPolicy: Story = {
 export const UnmigratedTwoConnections: Story = {
     parameters: seeded(),
     render: () => <DrawerHost permissions={null} connectionSlug="" />,
+}
+
+/**
+ * Descriptions that do not fit one line. Expanding a row must keep the permission select where it
+ * was, keep the provider's line breaks, and keep the toggle through a Show more / Show less round
+ * trip. "Merge pull request" has a short first line and a hidden second one — the toggle has to
+ * offer itself for that too, which a width measurement alone never sees.
+ */
+export const LongDescriptions: Story = {
+    parameters: seeded(GITHUB_TOOLS_VERBOSE),
+    render: () => <DrawerHost permissions={{default: "inherit", tools: {}}} />,
 }
 
 /** Read-only revision: every control is inert, and the policy stays readable. */


### PR DESCRIPTION
## Context

Live QA of the gateway connection rework turned up 16 issues across the three integration surfaces: the per-tool permission drawer, the add-integration drawer, and the integration row in the playground config panel. Most are small on their own, but they share four root causes worth stating.

**A measurement taken against the wrong box.** The permission drawer decided whether a tool description was truncated by reading `scrollWidth` off the element it had just hidden. Expanding a row therefore moved the permission select by 4px, and a Show more / Show less round trip left the toggle measuring a 0-wide box and concluding nothing was truncated, so the button vanished.

**A slug where a name belongs.** Every form that creates a connection asked for a slug. It is a wire identifier that ends up inside `tools__composio__github__ACTION__<slug>`, it carries provider rules an author has no reason to learn, and in Settings it was the first and only required field while the display name was optional. That is why connection pickers across the app show slug-shaped text.

**A list that subtracted itself.** The add drawer removed already-connected apps from the catalog. Connect is the only way to make a second connection and it lives on those catalog rows, so a second account was unreachable.

**A dead click target.** Only the left half of an integration row was clickable. The chevron, where the affordance points, did nothing.

## Changes

### Tool permission drawer

Truncation is measured only while the row is collapsed, so expanding can no longer erase the evidence for the toggle. A description carrying a newline offers the toggle even when its first line fits, because that text is hidden too and no width measurement can see it. The expanded text renders `whitespace-pre-line`, so the provider's line breaks survive. The row aligns to the top and keeps the description in place instead of hiding it, so the select stays put; the scroll container gets a stable gutter so an expanding row cannot summon a scrollbar and shift every control left.

The select's menu is pinned to its trigger, and the trigger is a compact 181px chip, so the option labels never had room:

Before: panel 181px wide, "Follow agent policy" wrapped across three lines, rows 50/68/124px tall.
After: panel 296px, every row a uniform 50px (title line + help line), nothing wrapped.

Both integration drawers now share one width constant (680) instead of the permission drawer opening at 480. Its header can shrink, so the "Connected" badge is no longer pushed past the edge, and the badge takes the 13px every other meta label in the drawer uses instead of inheriting 16px from the title slot.

### Add-integration drawer

The category rail has `overflow-y-auto`, but as a flex item with the default `min-height: auto` its content set its height, so it overflowed a body that clips rather than scrolls. It takes `min-h-0`, and only the categories scroll: the heading and "All apps" stay pinned.

Category names arrive lowercase from the provider and are uppercased in CSS. The stored value is untouched.

Connected rows led with the slug and the confirm button said "Add with github-7mx":

Before: `github-7mx · GitHub (main)` / `Use github-7mx`
After: `GitHub (main)` / `Use GitHub (main)`

The catalog no longer subtracts connected apps, so a connected integration appears twice, once under Connected and once as connectable. Picking a category now filters both lists. The connected list is the project's own connections rather than a server query, so it is filtered client-side against each integration's categories, read through the same detail query atoms the rows already subscribe to. Integrations carry category names and the rail carries the provider's slugified id, so both are accepted, case-insensitively. Connected search matches the display name too, not just the integration key.

The list arithmetic moved into `integrationCatalogFilters` so the dual listing and the shared category filter are each stated once and tested.

### Connection creation

All three create surfaces ask for a name only: the tools connect modal, the triggers connect modal, and Settings > Tools (which had no derivation at all). The slug is derived from the name with the existing `generateDefaultSlug` and still sent. The API types it optional, but both routers do `"." in slug` before anything else, so a null slug is a 500 rather than a default. Nothing about the wire changes.

Names are seeded from how many connections the integration already has: "GitHub (main)", then "GitHub (secondary)", then "GitHub (3)". The author can edit them. The seed lands late, when the connections query settles, but never over something already typed.

### Playground config panel

The row itself carries the click now, so the chevron and the permission summary open the drawer. The identity block keeps `role="button"` and its keyboard handler, so the accessible target is unchanged, and the remove button still stops propagation. The open handler also wrote the whole agent config back up the tree (the legacy-entry migration) before setting the drawer's local target; the target is set first now, so a re-render cascade from that write cannot land on top of the open.

## Per-item status

| # | Issue | Status | Commit |
|---|---|---|---|
| 1 | Show more shifts the permission selector | Fixed | `c8e7da0` |
| 2 | Descriptions lose line breaks after Show more | Fixed | `c8e7da0` |
| 3 | Show more disappears after a round trip | Fixed | `c8e7da0` |
| 4 | Permission selector too narrow, labels wrap | Fixed | `c8e7da0` |
| 5 | Permission drawer narrower than its siblings | Fixed | `c8e7da0` |
| 6 | Category list cannot scroll | Fixed | `0c35cd3` |
| 7 | Category names render lowercase | Fixed | `0c35cd3` |
| 8 | Connected rows show the slug | Fixed | `0c35cd3` |
| 9 | Connected app missing from the connectable list | Fixed | `0c35cd3` |
| 10 | Slug creation and editing shown to the author | Fixed | `99a1cf3` |
| 11 | Connection picker shows slugs | Fixed | `0c35cd3` |
| 12 | No default connection names | Fixed | `99a1cf3` |
| 13 | Category does not filter the connected list | Fixed | `0c35cd3` |
| 14 | Integration row needs several clicks | Fixed | `352716d` |
| 15 | "Connected" label not visible in the drawer | Fixed | `c8e7da0` |
| 16 | "Connected" uses the wrong font | Fixed | `c8e7da0` |

## Tests

- 28 new unit tests: `integrationCatalogFilters.test.ts` (category matching, the shared filter, and the dual-listing invariant) and `connectionSlug.test.ts` (default names, display names, and that the derived slug never produces the dots or doubled underscores the API rejects). `connectionSlug.ts` had no tests before.
- Full suites green: 591 tests in `@agenta/entity-ui`, 380 in `@agenta/shared`.
- `pnpm type-check` (oss + ee) and `pnpm lint-fix` clean.
- Every fix was reproduced and then re-verified in Storybook by measuring the DOM, not by eye. Recorded before/after: select y 244 to 240 on expand, now steady at 240; toggles surviving a round trip 1 of 3, now 3 of 3; menu panel 181px to 296px; drawer 480px to 680px; badge 16px to 13px; rail scroll 0px of overflow to 401px scrollable in a 349px box.
- Three new stories drive the cases that were previously unreachable: `IntegrationPermissionDrawer/LongDescriptions`, `AgentIntegrationDrawer/LowercaseCategories`, `AgentIntegrationDrawer/NamedConnections`, plus a new `ConnectDrawer` story file.
- The storybook detail fixture was seeding the raw integration object where the hook reads `data.integration`, so every consumer of `useToolIntegrationDetail` silently fell back to the raw key ("github" instead of "GitHub") across the whole story family. Fixed in the same pass.

## What to QA

- Open an integration's permission drawer from the playground config panel. It opens at the same width as the add drawer, and the "Connected" badge is visible in the header at the same size as the text under the title.
- Expand a tool description with Show more. The permission select does not move, the provider's line breaks are preserved, and Show less puts the button back. Do it twice.
- Open a per-tool permission select. "Follow agent policy" fits on one line.
- Open the add-integration drawer with more categories than fit. The category list scrolls while "Categories" and "All apps" stay put, and the names read as names, not lowercase.
- Pick a category. Both the connected list and the catalog narrow, and the count above each list matches its rows.
- Find an app you already have connected. It appears under Connected and again under All apps with a Connect button. Use it to make a second connection: the form asks only for a name, seeded "<App> (secondary)", with no slug field.
- Regression: the connection still authorizes end to end. The derived slug is what gets sent, and the API rejects a missing one, so a create that 500s or a broken OAuth redirect is the thing to watch.
- Regression: click an integration row on the chevron, on the permission label, and on the name. All three open the drawer on the first click. The trash icon still removes without opening it.
- Regression: create a connection from Settings > Tools and from a trigger. Both ask for a name only and still work.
