### PR TITLE
[fix] Remove duplicate runner credential import

### DIFF
--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -15,7 +15,6 @@
  * engine runner so the HTTP behavior can be tested with a fake engine (no live harness).
  */
 import { apiBase, runWithRequestApiBase } from "./apiBase.ts";
-import { runCredential } from "./engines/sandbox_agent/runtime-policy.ts";
 import { loadDurableDecisions } from "./sessions/interactions.ts";
 import { randomUUID, timingSafeEqual } from "node:crypto";
 import {


### PR DESCRIPTION
## Context
Merging #6281 into the release branch combined a release-only standalone import with the PR import block. The resulting release tree imported `runCredential` twice, so runner TypeScript compilation and all runner CI jobs failed.

## Changes
Remove the duplicate standalone import and keep the consolidated runtime-policy import block. Runtime behavior is unchanged.

## Tests
- `pnpm run typecheck`
- `pnpm exec vitest run tests/unit/platform-credential-attribution.test.ts` (10 tests passed)