### PR TITLE
[fix] Capitalize integration category chips, not uppercase

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
@@ -251,7 +251,7 @@ function CategoryRail({
             <button
                 type="button"
                 onClick={() => onSelect(null)}
-                className={`shrink-0 cursor-pointer rounded border-0 px-2 py-1 text-left text-[13px] ${
+                className={`shrink-0 cursor-pointer rounded border-0 px-2 py-1 text-left text-[13px] [font-family:inherit] ${
                     active === null
                         ? "bg-[var(--ag-colorFillSecondary)] font-medium"
                         : "bg-transparent text-[var(--ag-colorTextSecondary)]"
@@ -267,8 +267,7 @@ function CategoryRail({
                         key={category.id}
                         type="button"
                         onClick={() => onSelect({id: category.id, name: category.name})}
-                        // The provider sends these lowercase; capitalize would mangle CRM and HR.
-                        className={`shrink-0 cursor-pointer truncate rounded border-0 px-2 py-1 text-left text-[13px] uppercase tracking-wide ${
+                        className={`shrink-0 cursor-pointer truncate rounded border-0 px-2 py-1 text-left text-[13px] capitalize [font-family:inherit] ${
                             active === category.id
                                 ? "bg-[var(--ag-colorFillSecondary)] font-medium"
                                 : "bg-transparent text-[var(--ag-colorTextSecondary)]"


### PR DESCRIPTION
## Context
The v0.114.2 drawer batch (#6354) made the add-integration drawer's category names ALL CAPS. Mahmoud's call: the category chips should capitalize the first letter only, not every character.

## Changes
The category chips now use `capitalize` instead of `uppercase` (so "productivity" renders as "Productivity" and "crm" as "Crm"). The letter-spacing added for the all-caps look is removed with it. Both the category chips and the "All apps" chip also inherit the drawer's font now; as plain buttons they fell back to Arial before.

## Tests / notes
- One file, class-string change only; prettier-clean.
- The section headings ("Categories", "Connected in your workspace") keep their existing small-caps label style; only the clickable category chips change.

## What to QA
- Open the add-integration drawer. The category list reads "Productivity", "Crm", "All apps" style, first letter capitalized, in the same font as the rest of the drawer.
