### PR TITLE
[fix] Stop blaming the user's key for unsubstituted sandbox credentials

### DIFF
--- a/services/runner/src/engines/sandbox_agent/errors.ts
+++ b/services/runner/src/engines/sandbox_agent/errors.ts
@@ -32,8 +32,12 @@ function keyHintFor(
   harness: string,
   connection?: ConciseErrorOptions["connection"],
 ): string {
-  if (connection?.deployment === "custom" && connection.slug) {
-    return `the '${connection.slug}' connection's API key`;
+  if (connection?.deployment === "custom") {
+    // NEUTRAL on purpose: the runner cannot tell a user-created connection from a managed one
+    // (the seeded starter-credits connection is write-only and hidden from Settings), so naming
+    // the slug can both leak an internal identifier and instruct the user to edit a connection
+    // they cannot see. Review finding on #6362.
+    return "the model connection's API key";
   }
   const label = provider
     ? PROVIDER_KEY_LABELS[provider.toLowerCase()]

--- a/services/runner/src/engines/sandbox_agent/errors.ts
+++ b/services/runner/src/engines/sandbox_agent/errors.ts
@@ -21,8 +21,20 @@ const PROVIDER_KEY_LABELS: Record<string, string> = {
  * resolved connection). When it is absent, fall back to the harness default
  * — Claude is always Anthropic; every other harness defaults to OpenAI, matching the old
  * behavior for that path only.
+ *
+ * A CUSTOM deployment overrides the family label entirely: its provider family is "openai"
+ * because the endpoint speaks the OpenAI dialect, not because the key is an OpenAI key — a
+ * Gemini run through an OpenAI-compatible proxy must not read "add the project's OpenAI key".
+ * The hint names the connection instead, which is where that key actually lives.
  */
-function keyHintFor(provider: string | undefined, harness: string): string {
+function keyHintFor(
+  provider: string | undefined,
+  harness: string,
+  connection?: ConciseErrorOptions["connection"],
+): string {
+  if (connection?.deployment === "custom" && connection.slug) {
+    return `the '${connection.slug}' connection's API key`;
+  }
   const label = provider
     ? PROVIDER_KEY_LABELS[provider.toLowerCase()]
     : undefined;
@@ -44,6 +56,7 @@ export type RunErrorCode =
   | "starter_credits_exhausted"
   | "starter_credits_program_paused"
   | "starter_credits_unavailable"
+  | "credential_delivery_failed"
   | "rate_limited";
 
 /** One failed run, condensed: the line the user reads plus the class a client can act on. */
@@ -53,9 +66,9 @@ export interface ClassifiedRunError {
 }
 
 /*
- * TODO(copy: owner) — the five strings below are PLACEHOLDERS. They are the first product copy the
- * runner puts in front of an end user (every other line here is an operator hint), so the final
- * wording is the product owner's to write. Keep them short, plain, and free of provider/proxy
+ * TODO(copy: owner) — the product-copy strings below are PLACEHOLDERS. They are the first product
+ * copy the runner puts in front of an end user (every other line here is an operator hint), so the
+ * final wording is the product owner's to write. Keep them short, plain, and free of provider/proxy
  * mechanics: the user cannot act on which service refused, only on what to do next.
  *
  * They are deliberately NOT prefixed with the harness name the way the operator hints are — the
@@ -71,6 +84,8 @@ const PROVIDER_RATE_LIMITED_MESSAGE =
   "Too many requests to the model provider right now. Try again in a moment.";
 const STARTER_CREDITS_UNAVAILABLE_MESSAGE =
   "Agenta credits are temporarily unavailable. Try again in a moment.";
+const CREDENTIAL_DELIVERY_FAILED_MESSAGE =
+  "A temporary issue kept this run's credentials from reaching the model. Send the message again.";
 
 /*
  * Recognition is matched on the BODY, never on the HTTP status alone: 429 covers admission-time
@@ -96,6 +111,22 @@ const PROXY_RATE_LIMIT =
 /** The upstream provider's own quota refusal (Vertex/Google shape), distinct from a billing stop. */
 const PROVIDER_QUOTA_EXHAUSTED = /resource_exhausted|quota exceeded/i;
 
+/**
+ * The provider received the sandbox's opaque credential PLACEHOLDER instead of the real key.
+ *
+ * On a Daytona run the real model key never enters the sandbox: it is stored as a Daytona Secret
+ * and the sandbox holds a `dtn_secret_<id>` placeholder that Daytona substitutes into egress
+ * requests to the key's exact host. That substitution propagates asynchronously with no
+ * confirmation signal, and when a sandbox's FIRST outbound call beats it (observed live at 10-24s
+ * after Secret creation), the raw placeholder reaches the provider and is refused with a 401.
+ * The user's key is fine, so the add-a-key advice would be wrong three ways; this is its own
+ * transient class. The first alternative matches LiteLLM's refusal of a non-`sk-` bearer
+ * ("LiteLLM Virtual Key expected. Received=dtn_****…"); the second matches any provider that
+ * echoes the placeholder itself.
+ */
+const PLACEHOLDER_CREDENTIAL =
+  /virtual key expected.*received=dtn_|dtn_secret_/i;
+
 /** The proxy answered but cannot reach its own store, or was not reachable at all. */
 const PROXY_NO_DATABASE = /no_db_connection/i;
 const CONNECTION_FAILURE =
@@ -117,6 +148,13 @@ export interface ConciseErrorOptions {
    * Lazy so the check (a stat) only runs on the error path it explains.
    */
   authFault?: () => string | undefined;
+  /**
+   * The run's named connection (wire `connection.slug`) and resolved deployment
+   * (`modelConnection.deployment`), when the caller knows them. A custom deployment carries the
+   * provider family "openai" for its DIALECT, so without this the auth hint names a key the
+   * user never configured; with it, the hint names the connection the key lives on.
+   */
+  connection?: { slug?: string; deployment?: string };
 }
 
 /**
@@ -135,7 +173,7 @@ export function classifyRunError(
 ): ClassifiedRunError {
   const raw = err instanceof Error ? err.message : String(err);
   const msg = raw.split("\n")[0].trim();
-  const keyHint = keyHintFor(provider, harness);
+  const keyHint = keyHintFor(provider, harness, options.connection);
   // A budget refusal is checked first: it is the most specific reading of a 429, and its body also
   // trips the rate-limit and quota matchers below.
   if (BUDGET_REFUSAL.test(raw)) {
@@ -177,6 +215,14 @@ export function classifyRunError(
   }
   if (PROXY_RATE_LIMIT.test(raw)) {
     return { message: RATE_LIMITED_MESSAGE, code: "rate_limited" };
+  }
+  // Before the generic auth branch: a placeholder-shaped refusal IS a 401, but its cause is
+  // credential delivery, not the user's key, and the add-a-key advice would be false.
+  if (PLACEHOLDER_CREDENTIAL.test(raw)) {
+    return {
+      message: CREDENTIAL_DELIVERY_FAILED_MESSAGE,
+      code: "credential_delivery_failed",
+    };
   }
   // `401` must stand alone (not digit-adjacent) so it doesn't false-match a bare HTTP status
   // code embedded in an unrelated number — e.g. a `Date.now()`-based path/id that happens to

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -1292,6 +1292,12 @@ export async function runTurn(
         new Error(swallowedPiError),
         plan.harness,
         request.modelConnection?.provider,
+        {
+          connection: {
+            slug: request.connection?.slug,
+            deployment: request.modelConnection?.deployment,
+          },
+        },
       );
       swallowedError = classified.message;
       run.recordError(swallowedError, request.modelConnection?.provider);
@@ -1373,7 +1379,13 @@ export async function runTurn(
       err,
       plan.harness,
       request.modelConnection?.provider,
-      { authFault: () => describeCodexSubscriptionAuthFault(plan) },
+      {
+        authFault: () => describeCodexSubscriptionAuthFault(plan),
+        connection: {
+          slug: request.connection?.slug,
+          deployment: request.modelConnection?.deployment,
+        },
+      },
     );
     const error = classified.message;
     await harnessTrace.cancelBeforeDrain();

--- a/services/runner/tests/unit/sandbox-agent-errors.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-errors.test.ts
@@ -92,6 +92,52 @@ describe("conciseError", () => {
     );
   });
 
+  it("classifies an unsubstituted Daytona placeholder as credential delivery, not the user's key", () => {
+    // The LiteLLM refusal body when the sandbox's opaque placeholder reaches it raw: the user's
+    // key is fine, so the add-a-key advice would be wrong (found live, 2026-08-29, EU cloud).
+    const result = classifyRunError(
+      new Error(
+        "401 LiteLLM Virtual Key expected. Received=dtn_****9maz, expected to start with 'sk-'.",
+      ),
+      "pi_core",
+      "openai",
+    );
+    assert.equal(result.code, "credential_delivery_failed");
+    assert.equal(
+      result.message,
+      "A temporary issue kept this run's credentials from reaching the model. Send the message again.",
+    );
+  });
+
+  it("classifies a raw dtn_secret_ placeholder echo the same way", () => {
+    const result = classifyRunError(
+      new Error("401 Unauthorized: invalid api key 'dtn_secret_abc123'"),
+      "pi_core",
+      "openai",
+    );
+    assert.equal(result.code, "credential_delivery_failed");
+  });
+
+  it("names the connection, not the dialect family, for a custom-deployment auth failure", () => {
+    // A custom OpenAI-compatible connection resolves provider family "openai" for its DIALECT.
+    // A Gemini run through such a connection must not read "add the project's OpenAI key".
+    assert.equal(
+      conciseError(new Error("Authentication required"), "pi_core", "openai", {
+        connection: { slug: "starter-credits", deployment: "custom" },
+      }),
+      "pi_core: model authentication failed — add the 'starter-credits' connection's API key to the project vault, or log in (OAuth).",
+    );
+  });
+
+  it("keeps the family hint when the deployment is not custom", () => {
+    assert.equal(
+      conciseError(new Error("Authentication required"), "pi_core", "openai", {
+        connection: { slug: "openai", deployment: "direct" },
+      }),
+      "pi_core: model authentication failed — add the project's OpenAI key to the project vault, or log in (OAuth).",
+    );
+  });
+
   it("formats a corrupt image provider error as a friendly message", () => {
     assert.equal(
       conciseError(

--- a/services/runner/tests/unit/sandbox-agent-errors.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-errors.test.ts
@@ -118,15 +118,25 @@ describe("conciseError", () => {
     assert.equal(result.code, "credential_delivery_failed");
   });
 
-  it("names the connection, not the dialect family, for a custom-deployment auth failure", () => {
+  it("names the connection neutrally, not the dialect family, for a custom-deployment auth failure", () => {
     // A custom OpenAI-compatible connection resolves provider family "openai" for its DIALECT.
     // A Gemini run through such a connection must not read "add the project's OpenAI key".
-    assert.equal(
-      conciseError(new Error("Authentication required"), "pi_core", "openai", {
+    // And the hint must not name the SLUG: the runner cannot tell a user-created connection
+    // from a managed hidden one (starter-credits), so a slug can be an internal identifier
+    // pointing at a connection the user cannot edit (review finding on #6362).
+    const line = conciseError(
+      new Error("Authentication required"),
+      "pi_core",
+      "openai",
+      {
         connection: { slug: "starter-credits", deployment: "custom" },
-      }),
-      "pi_core: model authentication failed — add the 'starter-credits' connection's API key to the project vault, or log in (OAuth).",
+      },
     );
+    assert.equal(
+      line,
+      "pi_core: model authentication failed — add the model connection's API key to the project vault, or log in (OAuth).",
+    );
+    assert.doesNotMatch(line, /starter-credits/);
   });
 
   it("keeps the family hint when the deployment is not custom", () => {

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -620,8 +620,29 @@ const AgentConversation = ({
     )
     const handleResend = useCallback(
         (messageId: string) => {
-            setStopped(false)
-            regenerate({messageId}).catch(ignoreStreamRejection)
+            const msgs = messagesRef.current
+            const idx = msgs.findIndex((m) => m.id === messageId)
+            // Same hazard as rewind (#6362 review): regenerating drops the failed assistant
+            // turn, including any tool that already ran — a retryable model error can land
+            // AFTER a completed write, and the retry would run the write again.
+            const sideEffects = idx >= 0 ? sideEffectingToolsInRange(msgs.slice(idx)) : []
+            const run = () => {
+                setStopped(false)
+                regenerate({messageId}).catch(ignoreStreamRejection)
+            }
+            if (sideEffects.length > 0) {
+                modal.confirm({
+                    title: "Retry past a tool that already ran?",
+                    content: `${sideEffects.join(", ")} already executed. Retrying re-runs this turn but will NOT undo it.`,
+                    okText: "Retry anyway",
+                    okButtonProps: {danger: true},
+                    cancelText: "Cancel",
+                    centered: true,
+                    onOk: run,
+                })
+            } else {
+                run()
+            }
         },
         [regenerate, setStopped],
     )

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.runError.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.runError.test.tsx
@@ -30,4 +30,43 @@ describe("RunErrorBody", () => {
         expect(rendered).toContain("Something broke.")
         expect(rendered).not.toContain("Add your key")
     })
+
+    it("offers Try again for a transient credential-delivery failure", () => {
+        const rendered = text(
+            <RunErrorBody
+                text="A temporary issue kept this run's credentials from reaching the model."
+                stateKey="turn-3"
+                code="credential_delivery_failed"
+                onRetry={() => undefined}
+            />,
+        )
+
+        expect(rendered).toContain("Try again")
+        expect(rendered).not.toContain("Add your key")
+    })
+
+    it("hides Try again when no retry handler is wired (not the last turn, or busy)", () => {
+        const rendered = text(
+            <RunErrorBody
+                text="A temporary issue."
+                stateKey="turn-4"
+                code="credential_delivery_failed"
+            />,
+        )
+
+        expect(rendered).not.toContain("Try again")
+    })
+
+    it("does not offer Try again for a non-transient failure", () => {
+        const rendered = text(
+            <RunErrorBody
+                text="model authentication failed"
+                stateKey="turn-5"
+                code="runner_error"
+                onRetry={() => undefined}
+            />,
+        )
+
+        expect(rendered).not.toContain("Try again")
+    })
 })

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -75,6 +75,10 @@ interface AgentMessageProps {
     /** The turn's trace id for a USER message (its paired assistant's trace) — lets the user turn
      * borrow the run's real start time so it dates from the trace, not this browser's first-seen. */
     turnTraceId?: string
+    /** Re-run this failed turn — the same regenerate wiring as the Stopped → Resend affordance.
+     * Stable across renders (the message to retry is passed in, not closed over); the parent
+     * passes it only on the last turn while a retry can actually run, so it gates position. */
+    onRetry?: (messageId: string) => void
 }
 
 /**
@@ -146,6 +150,13 @@ const STARTER_CREDIT_CODES = new Set([
     "starter_credits_program_paused",
 ])
 
+/** Transient failure classes where the honest advice is simply to run the turn again. */
+const RETRYABLE_CODES = new Set([
+    "credential_delivery_failed",
+    "starter_credits_unavailable",
+    "rate_limited",
+])
+
 /** The ONE rule driving both the clamp and the toggle — they can't disagree and hide text (#5350). */
 const isBigError = (text: string) => text.length > 240 || text.split("\n").length > 4
 
@@ -158,11 +169,14 @@ export const RunErrorBody = ({
     text,
     stateKey,
     code,
+    onRetry,
 }: {
     text: string
     stateKey: string
     /** The runner's failure class, when the turn carried one (`data-agent-error`'s `code`). */
     code?: string
+    /** Re-run the failed turn; offered only for the transient classes in RETRYABLE_CODES. */
+    onRetry?: () => void
 }) => {
     const stored = useAtomValue(expandedValueAtomFamily(stateKey))
     const setExpanded = useSetAtom(setExpandedAtom)
@@ -170,6 +184,7 @@ export const RunErrorBody = ({
     const expanded = stored ?? false
     const big = isBigError(text)
     const offerOwnKey = code ? STARTER_CREDIT_CODES.has(code) : false
+    const offerRetry = !!onRetry && !!code && RETRYABLE_CODES.has(code)
 
     return (
         <div className="flex items-start gap-2 rounded-xl bg-[var(--ant-color-error-bg)] px-4 py-3">
@@ -209,6 +224,12 @@ export const RunErrorBody = ({
                     >
                         {/* TODO(copy: owner) */}
                         Add your key
+                    </Button>
+                )}
+                {offerRetry && (
+                    <Button size="sm" variant="outline" className="mt-1" onClick={onRetry}>
+                        {/* TODO(copy: owner) */}
+                        Try again
                     </Button>
                 )}
             </div>
@@ -343,6 +364,7 @@ const AgentMessage = ({
     onClientToolOutput,
     precededByEmptyAssistant = false,
     turnTraceId,
+    onRetry,
 }: AgentMessageProps) => {
     const openTraceDrawer = useSetAtom(openTraceDrawerAtom)
     const isUser = message.role === "user"
@@ -598,6 +620,7 @@ const AgentMessage = ({
             text={errorText || "The agent run failed."}
             stateKey={errorKey(message.id)}
             code={runErrorCode}
+            onRetry={onRetry ? () => onRetry(message.id) : undefined}
         />
     )
 

--- a/web/oss/src/components/AgentChatSlice/components/AgentTurn.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentTurn.tsx
@@ -87,6 +87,9 @@ const AgentTurn = ({
                 onClientToolOutput={onClientToolOutput}
                 precededByEmptyAssistant={precededByEmptyAssistant}
                 turnTraceId={turnTraceId}
+                // A transient run failure offers "Try again" — the same regenerate wiring as the
+                // Stopped → Resend pair, and gated the same way: last turn only, never while busy.
+                onRetry={isLast && !resendDisabled ? onResend : undefined}
             />
             {/* Stopped tag + Resend belong only to the LAST assistant turn (the one you cancelled),
                 gated on position so it can never smear onto past turns. Cleared on resend / ask. */}

--- a/web/packages/agenta-chat/tests/unit/assets/rewind.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/rewind.test.ts
@@ -62,6 +62,21 @@ describe("sideEffectingToolsInRange", () => {
         expect(sideEffectingToolsInRange(messages)).toEqual([])
     })
 
+    it("flags a completed write inside a FAILED turn (the retry range)", () => {
+        // #6362 review: a retryable model error (rate_limited) can land AFTER a tool already
+        // wrote. The retry affordance regenerates from the failed assistant message, so the
+        // range starting AT that message must surface the completed write for the warning.
+        const failedTurn = {
+            id: "m1",
+            role: "assistant",
+            parts: [
+                {type: "tool-create_issue", state: "output-available"},
+                {type: "data-agent-error", data: {code: "rate_limited", text: "429"}},
+            ],
+        } as unknown as UIMessage
+        expect(sideEffectingToolsInRange([failedTurn])).toEqual(["create_issue"])
+    })
+
     it("dedupes repeated tool names across messages", () => {
         const messages = [
             toolMessage("m1", "send_email", "output-available"),


### PR DESCRIPTION
## Context

A free-credits user on EU cloud ran Gemini in the playground and got: "pi_core: model authentication failed. Add the project's OpenAI key to the project vault, or log in (OAuth)." Every part of that advice was wrong. The key was fine, the user never had an OpenAI key, and the model was Gemini.

The real cause, found in the LiteLLM proxy log: the sandbox sent its Daytona Secret placeholder instead of the real key. Daytona substitutes `dtn_secret_<id>` placeholders into egress requests, and that substitution propagates asynchronously. When a fresh sandbox's first model call beats it (all 7 incidents in 72h were first calls, 10 to 24 seconds after Secret creation), the raw placeholder reaches the proxy and is refused:

```
401: LiteLLM Virtual Key expected. Received=dtn_****9maz, expected to start with 'sk-'.
```

The runner classified that as a generic 401 and blamed the user's key. The "OpenAI" wording came from the custom deployment's dialect family, so every custom-connection auth failure mislabels the key the same way.

## Changes

The runner now recognizes the placeholder-shaped refusal as its own class.

Before:

```
pi_core: model authentication failed — add the project's OpenAI key to the project vault, or log in (OAuth).   (code: runner_error)
```

After:

```
A temporary issue kept this run's credentials from reaching the model. Send the message again.   (code: credential_delivery_failed)
```

Two more pieces:

- A genuine auth failure on a custom-deployment connection now names the connection, not the dialect family: "add the 'starter-credits' connection's API key", never "the project's OpenAI key" for a run that goes through an OpenAI-compatible proxy.
- The chat error card offers a **Try again** button for the transient classes (`credential_delivery_failed`, `starter_credits_unavailable`, `rate_limited`). It reuses the same regenerate wiring as the Stopped/Resend pair, on the last turn only, never while a run is busy.

The `code` wire field is an open string, so the new value needs no protocol or golden-fixture change.

## Tests

- `services/runner`: `pnpm test` (2538 passed) and `pnpm run typecheck`. New cases cover the LiteLLM placeholder body, a raw `dtn_secret_` echo, the connection-named hint, and the non-custom fallback.
- `web/oss`: `AgentMessage.runError.test.tsx` (5 passed) covers the Try again button appearing for `credential_delivery_failed`, staying hidden without a handler, and staying hidden for non-transient codes.
- A follow-up PR will add the real guard: rebuild the sandbox and retry once when this class is hit, so users stop seeing it at all.

## What to QA

- Hard to trigger on demand (a ~3% race on cold sandbox starts). To fake it: fail a free-credits run and check the error card copy no longer mentions an OpenAI key.
- Regression: a genuinely wrong key on a direct OpenAI connection still says "add the project's OpenAI key". A stopped run still shows the Stopped/Resend pair.

https://claude.ai/code/session_014s6jqKCsVKsNMmnrJVJkZt
