### PR TITLE
[fix] Raise the free-credits per-key tpm cap to 1,000,000

### DIFF
--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -248,7 +248,7 @@ async def _mint_key(
     for attempt in range(_MINT_ATTEMPTS):
         try:
             # The proxy caps what a key may ask for (`upperbound_key_generate_params`:
-            # max_budget 5, max_parallel_requests 2, rpm 30, tpm 200000, duration 90d)
+            # max_budget 5, max_parallel_requests 2, rpm 30, tpm 1000000, duration 90d)
             # and fills an OMITTED duration with its cap, so every funded key expires
             # after 90 days. Send no duration rather than a longer one. Raising
             # `grant_usd` or a per-key limit in the policy payload ABOVE a cap makes

--- a/api/ee/src/core/starter_credits_bridge/types.py
+++ b/api/ee/src/core/starter_credits_bridge/types.py
@@ -194,5 +194,5 @@ DEVELOPMENT_POLICY_VALUES: dict = {
     "grant_usd": 5.0,
     "key_max_parallel_requests": 2,
     "key_rpm_limit": 30,
-    "key_tpm_limit": 200_000,
+    "key_tpm_limit": 1_000_000,
 }

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -849,7 +849,7 @@ class TestMintPolicyResolution:
         assert policy is not None
         assert policy.grant_usd == 5.0
         assert policy.global_daily == 1000
-        assert policy.key_tpm_limit == 200_000
+        assert policy.key_tpm_limit == 1_000_000
         assert policy.block_digit_locals is False
         # The built-in domain list still applies through the union.
         assert policy.is_freemail("gmail.com") is True


### PR DESCRIPTION
## Context

The free-credits proxy refused 12 calls in 72 hours on EU cloud with "Rate limit exceeded ... Limit type: tokens. Current limit: 200000", including 4 in a row for one account. Every free-credits key is minted with a 200,000 tokens-per-minute cap, and a single Gemini Flash turn can carry close to its 1M-token context, so ordinary first-run use trips the cap. The user sees a failed run.

## Changes

The per-key cap becomes 1,000,000 tokens per minute. The $5 key budget and the 30 requests-per-minute limit stay as the real bounds on spend and rate.

This PR carries the agenta side: `DEVELOPMENT_POLICY_VALUES` (the policy a deployment without PostHog runs on) and the mint-path comment. The value lives in three more places, in a forced order:

1. `agenta_cloud` `hosting/docker-compose/litellm/config.yaml`: the proxy's mint bounds (upperbound + default). Committed on `feat/litellm-proxy` (99f417a3c); must deploy FIRST, because a PostHog payload above the proxy's upperbound fails every mint with HTTP 400.
2. The PostHog payload `starter-credits-bridge-policy`: raise `key_tpm_limit` after that deploy. Cloud reads only this.
3. Existing minted keys keep 200k until a `/key/update` pass on the proxy admin route.

## Tests

- `ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py`: 72 passed. The development-policy assertion follows the new value; the fixtures that feed arbitrary payloads keep their own numbers.

https://claude.ai/code/session_014s6jqKCsVKsNMmnrJVJkZt
