### PR TITLE
[fix] Key the lifecycle capability table by the wire harness spellings

### DIFF
--- a/services/runner/src/lifecycle/reconciliation-router.ts
+++ b/services/runner/src/lifecycle/reconciliation-router.ts
@@ -220,9 +220,15 @@ const V1_CAPABILITIES: Readonly<
 };
 
 export function harnessKind(request: AgentRunRequest): HarnessKind {
-  const harness = request.harness;
-  if (harness === "pi" || harness === "claude" || harness === "codex")
-    return harness;
+  // Mirror `buildRunPlan`'s normalization exactly: the WIRE carries `pi_core` / `pi_agenta`
+  // (an empty harness defaults to `pi_core`), never the bare "pi" this table is keyed by.
+  // Matching only the literals sent every playground Pi run into the fail-closed `unknown`
+  // row, whose every facet says rebuild — which disabled the live model-switch route and
+  // made the shadow log plan a rebuild for every Pi config change.
+  const harness = request.harness || "pi_core";
+  if (harness === "pi" || harness === "pi_core" || harness === "pi_agenta")
+    return "pi";
+  if (harness === "claude" || harness === "codex") return harness;
   return "unknown";
 }
 

--- a/services/runner/src/lifecycle/reconciliation-router.ts
+++ b/services/runner/src/lifecycle/reconciliation-router.ts
@@ -225,6 +225,15 @@ export function harnessKind(request: AgentRunRequest): HarnessKind {
   // Matching only the literals sent every playground Pi run into the fail-closed `unknown`
   // row, whose every facet says rebuild — which disabled the live model-switch route and
   // made the shadow log plan a rebuild for every Pi config change.
+  //
+  // Only an ABSENT or EMPTY harness takes that `pi_core` default. `/stream` decodes its body
+  // with an unchecked `JSON.parse(raw) as AgentRunRequest`, so a malformed payload can put
+  // `null`, `0`, or `false` in this field, and a bare `||` would hand each of them Pi's live
+  // routes. A non-string is not a harness spelling we recognize, so it falls to `unknown` and
+  // rebuilds. The real client always sends a string (`wire.py` writes `harness.value`), so
+  // this costs a wasted rebuild only on input that should not exist.
+  if (request.harness !== undefined && typeof request.harness !== "string")
+    return "unknown";
   const harness = request.harness || "pi_core";
   if (harness === "pi" || harness === "pi_core" || harness === "pi_agenta")
     return "pi";

--- a/services/runner/tests/unit/lifecycle-reconcile-plan.test.ts
+++ b/services/runner/tests/unit/lifecycle-reconcile-plan.test.ts
@@ -251,6 +251,11 @@ describe("plan construction per facet", () => {
     assert.equal(harnessKind({ ...BASE, harness: "pi_core" } as never), "pi");
     assert.equal(harnessKind({ ...BASE, harness: "pi_agenta" } as never), "pi");
     assert.equal(harnessKind({ ...BASE, harness: undefined } as never), "pi");
+    // `/stream` decodes its body unchecked, so a non-string can reach here. It must not
+    // borrow Pi's live routes through the `|| "pi_core"` default.
+    for (const junk of [null, 0, false, 1, {}, []]) {
+      assert.equal(harnessKind({ ...BASE, harness: junk } as never), "unknown");
+    }
     assert.equal(
       capabilitiesFor({ ...BASE, harness: "pi_core" } as never).model,
       "apply-live",

--- a/services/runner/tests/unit/lifecycle-reconcile-plan.test.ts
+++ b/services/runner/tests/unit/lifecycle-reconcile-plan.test.ts
@@ -246,6 +246,15 @@ describe("plan construction per facet", () => {
 
   it("an unknown harness fails closed to a rebuild", () => {
     assert.equal(harnessKind({ ...BASE, harness: "future-thing" } as never), "unknown");
+    // The wire spellings of Pi, and the empty default, all resolve to the "pi" capability row —
+    // "pi_core" landing in `unknown` sent every playground run to the fail-closed all-rebuild row.
+    assert.equal(harnessKind({ ...BASE, harness: "pi_core" } as never), "pi");
+    assert.equal(harnessKind({ ...BASE, harness: "pi_agenta" } as never), "pi");
+    assert.equal(harnessKind({ ...BASE, harness: undefined } as never), "pi");
+    assert.equal(
+      capabilitiesFor({ ...BASE, harness: "pi_core" } as never).model,
+      "apply-live",
+    );
     const capabilities = capabilitiesFor({ ...BASE, harness: "future-thing" } as never);
     assert.equal(capabilities.toolCatalog, "rebuild-sandbox");
     assert.equal(capabilities.workspaceFiles, "rebuild-sandbox");


### PR DESCRIPTION
## Context

While tracing why a config change evicted a user's warm sandbox (the placeholder-401 investigation, #6362), the reconcile shadow log showed `harness=unknown` on every playground run. The lifecycle router's `harnessKind` matched only the bare literals `pi`, `claude`, `codex`, but the wire carries `pi_core` or `pi_agenta`, and an empty harness defaults to `pi_core`. Every playground Pi run therefore resolved to `unknown` and took the fail-closed capability row, where every facet maps to a full sandbox rebuild.

Two real costs:

- The one live route that already ships (a model-only switch applies live through `setModel`) never fired for Pi. Every model switch in the playground tore down the warm sandbox, created fresh Daytona Secrets, and re-entered the substitution-propagation race that produces the placeholder 401s.
- Every Pi shadow-log line planned an all-rebuild, so the DISAGREE audit the migration relies on was noise for the main harness.

## Changes

`harnessKind` now normalizes exactly as `buildRunPlan` does before keying the capability table.

Before: `harness: "pi_core"` resolved to `unknown` (model switch plans `rebuild-sandbox`).

After: `pi_core`, `pi_agenta`, bare `pi`, and the empty default all resolve to `pi` (model switch plans `apply-live`; a harness-session change plans `reopen-session`).

`claude` and `codex` were already correct and are unchanged. A genuinely unknown harness still fails closed.

## Tests

- New assertions in `lifecycle-reconcile-plan.test.ts` pin the wire spellings, the empty default, and the recovered `apply-live` model route.
- Full runner suite: 156 files pass; `pnpm run typecheck` clean.

## What to QA

- In the playground on a Daytona session, send a turn, switch only the model, send again. The second turn should reuse the same sandbox (fast start, no rebuild in the runner log).
- Regression: switching the harness (Pi to Claude) must still rebuild.

https://claude.ai/code/session_014s6jqKCsVKsNMmnrJVJkZt
