### PR TITLE
[feat] Stop evicting warm sessions when an integration is added

### DIFF
--- a/docs/design/agent-workflows/documentation/protocol.md
+++ b/docs/design/agent-workflows/documentation/protocol.md
@@ -119,6 +119,7 @@ Request fields include:
 | `sessionId` | External conversation id. The runtime is cold and receives history in `messages`. |
 | `agentsMd` | Instructions that become `AGENTS.md`. |
 | `systemPrompt`, `appendSystemPrompt` | Pi prompt overrides. The sandbox-agent engine writes `SYSTEM.md` / `APPEND_SYSTEM.md` into the per-run Pi agent dir, local and Daytona. |
+| `gatewayGuidance` | The derived gateway-tools instruction section (`{text, carrier}`). The runner splices it into the named prompt surface (`appendSystemPrompt` or `agentsMd`) at environment build; it is deliberately excluded from the session fingerprint, so adding an integration never evicts a warm session and the names list (worded as examples) refreshes on the next build. |
 | `skills` | Resolved inline skill packages (full `SKILL.md` content, with `@ag.embed` references inlined server-side), declared in the agent config. All three harnesses wire them; the runner materializes each into a skill dir (`pi_core`/`pi_agenta` through Pi's agent-dir scope, Claude under project-local `.claude/skills`). Omitted when none are declared. |
 | `model` | Requested model id. Not honored on the Pi ACP path; pi-acp accepts only its default model (see Ground Truth). |
 | `messages` | Conversation history and current turn. |

--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -20,7 +20,12 @@ from __future__ import annotations
 from typing import Optional, Sequence
 
 from ..flags import ordered_operations_enabled
+from typing import TYPE_CHECKING
+
 from ..skills import SkillFile, SkillTemplate
+
+if TYPE_CHECKING:  # circular at runtime: dtos imports skills, adapters import dtos
+    from ..dtos import GatewayGuidance
 from .agent_templates import build_agent_template_skill_files
 
 # Read once, at import, exactly like the op catalog builds its tool descriptions. The skill
@@ -1162,8 +1167,9 @@ def gateway_guidance(integration_names: Sequence[str]) -> Optional[str]:
     return f"""\
 ## Connected integrations
 
-You can reach these integrations with two tools: `search_tools` and `run_tool`.
-Configured integrations: {integrations}.
+You can reach your integrations with two tools: `search_tools` and `run_tool`.
+For instance, some of the integrations you have: {integrations}. Others may exist, and this
+list can go stale — `search_tools` is the source of truth for what is connected right now.
 
 - Search once per task, with a concrete description of what you want to do. Never repeat an
   equivalent query — a second search that means the same thing returns the same results.
@@ -1181,17 +1187,24 @@ Configured integrations: {integrations}.
   arguments — report it instead of looping."""
 
 
-def compose_gateway_guidance(
-    user: Optional[str],
-    integration_names: Sequence[str] = (),
-) -> Optional[str]:
-    """One prompt layer with the gateway guidance placed before the author's own text.
+def gateway_guidance_field(
+    integration_names: Sequence[str],
+    carrier: str,
+) -> Optional["GatewayGuidance"]:
+    """The ``gatewayGuidance`` wire field, or ``None`` when the agent has no connection.
 
-    Every harness carries the guidance, not only the Agenta one: each gets the same two
-    derived tools, so a section added to one prompt surface would leave the others holding
-    two tools and no instructions for using them. Which layer carries it is the adapter's
-    choice, so ``user`` is whatever text that adapter puts the guidance in front of: the
-    instructions file for the file-based harnesses, and ``append_system`` for Pi, whose
-    AGENTS.md is purely authored.
+    Every harness carries the guidance, not only one: each gets the same two derived tools,
+    so guidance on one prompt surface alone would leave the others holding two tools and no
+    instructions for using them. ``carrier`` stays the adapter's choice (the instructions
+    file for the file-based harnesses, ``append_system`` for Pi, whose AGENTS.md is purely
+    authored) — but the SPLICING now happens in the runner, at environment build time, so the
+    integration names stay out of the session fingerprint and adding an integration no longer
+    evicts a warm session. The names read as examples, so a list that goes stale mid-session
+    stays honest until the next cold or reopened session refreshes it.
     """
-    return _join(gateway_guidance(integration_names), user)
+    text = gateway_guidance(integration_names)
+    if not text:
+        return None
+    from ..dtos import GatewayGuidance
+
+    return GatewayGuidance(text=text, carrier=carrier)

--- a/sdks/python/agenta/sdk/agents/adapters/harnesses.py
+++ b/sdks/python/agenta/sdk/agents/adapters/harnesses.py
@@ -29,7 +29,7 @@ from ..dtos import (
 )
 from ..interfaces import Environment, Harness
 from ..tools.models import ToolSpec, coerce_tool_spec
-from .agenta_builtins import compose_gateway_guidance
+from .agenta_builtins import gateway_guidance_field
 
 
 def _opt_str(value: Any) -> Any:
@@ -74,9 +74,9 @@ class PiHarness(Harness):
             permission_default=config.permission_default,
             harness_permissions=config.agent.harness_permissions,
             system=_opt_str(extras.get("system")),
-            append_system=compose_gateway_guidance(
-                _opt_str(extras.get("append_system")),
-                config.gateway_integration_names,
+            append_system=_opt_str(extras.get("append_system")),
+            gateway_guidance=gateway_guidance_field(
+                config.gateway_integration_names, "appendSystemPrompt"
             ),
         )
 
@@ -94,8 +94,9 @@ class ClaudeHarness(Harness):
         # adapter) renders `.claude/settings.json` as a generic `harnessFiles` entry. No
         # claude-specific parsing happens here; the runner just writes the files into the cwd.
         return ClaudeAgentTemplate(
-            agents_md=compose_gateway_guidance(
-                config.agent.instructions, config.gateway_integration_names
+            agents_md=config.agent.instructions,
+            gateway_guidance=gateway_guidance_field(
+                config.gateway_integration_names, "agentsMd"
             ),
             model=config.agent.model,
             resolved_connection=config.resolved_connection,
@@ -122,8 +123,9 @@ class CodexHarness(Harness):
         # adapter) renders `.codex/config.toml` as a generic `harnessFiles` entry. No
         # codex-specific parsing happens here; the runner just writes the files into the cwd.
         return CodexAgentTemplate(
-            agents_md=compose_gateway_guidance(
-                config.agent.instructions, config.gateway_integration_names
+            agents_md=config.agent.instructions,
+            gateway_guidance=gateway_guidance_field(
+                config.gateway_integration_names, "agentsMd"
             ),
             model=config.agent.model,
             resolved_connection=config.resolved_connection,

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -697,6 +697,26 @@ class AgentTemplate(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+class GatewayGuidance(BaseModel):
+    """The derived gateway-tools instruction section, carried as its own wire field.
+
+    It used to be composed INTO the prompt strings (``append_system`` for Pi, ``agents_md``
+    for the file-based harnesses). That put the integration NAMES inside the session
+    fingerprint, so adding a second integration evicted a warm session for a one-word prompt
+    change. As a separate field the runner splices it into ``carrier`` when it BUILDS an
+    environment, and deliberately excludes it from the fingerprint: the text refreshes
+    whenever a session is built or reopened, and never evicts one on its own. The wording
+    presents the names as examples ("for instance"), so a list that goes stale mid-session
+    stays honest.
+    """
+
+    text: str
+    carrier: Literal["appendSystemPrompt", "agentsMd"]
+
+    def to_wire(self) -> Dict[str, Any]:
+        return {"text": self.text, "carrier": self.carrier}
+
+
 class HarnessAgentTemplate(BaseModel):
     """Base for a harness-specific config. A Harness produces one of these from the neutral
     config; a backend plumbs it as-is, with no business logic about how the harness works.
@@ -730,6 +750,9 @@ class HarnessAgentTemplate(BaseModel):
     # it into files for the wire (see :meth:`wire_harness_files`); the raw slice does not ride the
     # wire.
     harness_permissions: Dict[str, Any] = Field(default_factory=dict)
+    # The derived gateway-tools guidance, set by the adapter when the agent has at least one
+    # gateway connection. Rides the wire as ``gatewayGuidance``; see :class:`GatewayGuidance`.
+    gateway_guidance: Optional[GatewayGuidance] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -772,6 +795,14 @@ class HarnessAgentTemplate(BaseModel):
         """The system-prompt fields this harness contributes to the ``/run`` payload. Empty
         by default; a harness that exposes prompt overrides (Pi) emits them here."""
         return {}
+
+    def wire_gateway_guidance(self) -> Dict[str, Any]:
+        """The ``gatewayGuidance`` field for the ``/run`` payload. Omitted when the agent has
+        no gateway connection so a connection-free payload is unchanged (the golden wire
+        contract)."""
+        if not self.gateway_guidance:
+            return {}
+        return {"gatewayGuidance": self.gateway_guidance.to_wire()}
 
     def wire_mcp(self) -> Dict[str, Any]:
         """The ``mcpServers`` field for the ``/run`` payload. Omitted when none are declared so

--- a/sdks/python/agenta/sdk/agents/platform/gateway.py
+++ b/sdks/python/agenta/sdk/agents/platform/gateway.py
@@ -104,10 +104,12 @@ def _derived_tool_specs(integration_names: Sequence[str]) -> List[CallbackToolSp
     covers every configured integration, because the model selects the integration in the
     arguments rather than through the tool name.
 
-    ``search_tools`` names the connected integrations in its own description. "Never invent
-    an integration name" is only actionable next to the list of real ones, and a tool
-    description is read at every call while the prompt guidance can fall out of a long
-    context. Names only, the same ones the guidance already carries.
+    The tool descriptions deliberately do NOT name the connected integrations. The names
+    live in the ``gatewayGuidance`` prompt section instead: ``customTools`` is part of the
+    session fingerprint, so a names sentence here made ADDING AN INTEGRATION evict the warm
+    session for a one-word description change. With the descriptions stable, the derived
+    pair is byte-identical for any integration set, and only the FIRST connection (which
+    genuinely adds the two tools) changes session config.
 
     Both carry ``permission: "allow"``. That is not an authorization decision. It only opens
     the coarse harness gate so the call reaches the runner; the real boundary is the runner's
@@ -116,13 +118,6 @@ def _derived_tool_specs(integration_names: Sequence[str]) -> List[CallbackToolSp
     harness would resolve ``run_tool`` through the agent-wide mode and raise a second,
     meaningless approval card named ``run_tool`` before the runner saw the tool key at all.
     """
-    # The resolver only runs with at least one entry, so the empty join is unreachable
-    # today. Kept total anyway: a dangling "Connected integrations: ." is model-facing text.
-    connected = (
-        f" Connected integrations: {', '.join(sorted(integration_names))}."
-        if integration_names
-        else ""
-    )
     return [
         CallbackToolSpec(
             name="search_tools",
@@ -133,7 +128,6 @@ def _derived_tool_specs(integration_names: Sequence[str]) -> List[CallbackToolSp
                 "matches first — a cap, not the whole catalog. If the search fails, retry it "
                 "once and no more. If nothing matched, search again with a more specific "
                 "description of the task, then stop. Never invent an integration name."
-                f"{connected}"
             ),
             input_schema={
                 "type": "object",

--- a/sdks/python/agenta/sdk/agents/utils/wire.py
+++ b/sdks/python/agenta/sdk/agents/utils/wire.py
@@ -155,6 +155,7 @@ def request_to_wire(
         "telemetry": trace.telemetry_to_wire() if trace else None,
         **config.wire_tools(),
         **config.wire_prompt(),
+        **config.wire_gateway_guidance(),
         **config.wire_mcp(),
         **config.wire_skills(),
         **config.wire_sandbox_permission(),

--- a/sdks/python/agenta/sdk/agents/wire_models.py
+++ b/sdks/python/agenta/sdk/agents/wire_models.py
@@ -344,6 +344,13 @@ class WireGatewayIntegration(_WireModel):
     tools: Dict[str, WireGatewayTool] = Field(default_factory=dict)
 
 
+class WireGatewayGuidance(_WireModel):
+    """The derived gateway-tools instruction section (``gatewayGuidance`` on the request)."""
+
+    text: str
+    carrier: Literal["appendSystemPrompt", "agentsMd"]
+
+
 class WireGatewayPolicy(_WireModel):
     """The private compiled gateway policy (``gatewayPolicy`` on the request).
 
@@ -554,6 +561,12 @@ class WireRunRequest(_WireModel):
     # derived tools read the same table. Omitted when the agent configures no connection.
     gateway_policy: Optional[WireGatewayPolicy] = Field(
         default=None, alias="gatewayPolicy"
+    )
+    # The derived gateway-tools guidance and its prompt carrier. Its own field so the runner
+    # splices it at environment build and the session fingerprint can exclude it (an integration
+    # add must not evict a warm session). Omitted when the agent configures no connection.
+    gateway_guidance: Optional[WireGatewayGuidance] = Field(
+        default=None, alias="gatewayGuidance"
     )
     system_prompt: Optional[str] = Field(default=None, alias="systemPrompt")
     append_system_prompt: Optional[str] = Field(

--- a/sdks/python/oss/tests/pytest/unit/agents/golden/run_request.gateway_connection.json
+++ b/sdks/python/oss/tests/pytest/unit/agents/golden/run_request.gateway_connection.json
@@ -24,7 +24,7 @@
   "customTools": [
     {
       "name": "search_tools",
-      "description": "Find tools across the integrations connected to this agent. Describe the task you want to perform; the result carries the integration, the tool key, and the input schema to call it with. Returns at most 5 results, best matches first \u2014 a cap, not the whole catalog. If the search fails, retry it once and no more. If nothing matched, search again with a more specific description of the task, then stop. Never invent an integration name. Connected integrations: github.",
+      "description": "Find tools across the integrations connected to this agent. Describe the task you want to perform; the result carries the integration, the tool key, and the input schema to call it with. Returns at most 5 results, best matches first \u2014 a cap, not the whole catalog. If the search fails, retry it once and no more. If nothing matched, search again with a more specific description of the task, then stop. Never invent an integration name.",
       "inputSchema": {
         "type": "object",
         "properties": {
@@ -77,6 +77,10 @@
   },
   "permissions": {
     "default": "allow_reads"
+  },
+  "gatewayGuidance": {
+    "text": "## Connected integrations\n\nYou can reach your integrations with two tools: `search_tools` and `run_tool`.\nFor instance, some of the integrations you have: github. Others may exist, and this\nlist can go stale \u2014 `search_tools` is the source of truth for what is connected right now.\n\n- Search once per task, with a concrete description of what you want to do. Never repeat an\n  equivalent query \u2014 a second search that means the same thing returns the same results.\n- A search returns at most 5 results. That is a cap, not the whole catalog \u2014 if none fit,\n  narrow the description rather than concluding no such tool exists.\n- \"No configured tool matched this request.\" is not a failure. Refine the query ONCE and\n  search again \u2014 that is what the message asks for \u2014 then report if it still finds nothing.\n- \"Tool search is temporarily unavailable.\" is a temporary failure: retry it once and no more.\n- Use only an integration and a tool key that a search result returned. Never invent one.\n  Pass the BARE tool key, not a prefixed provider action id such as `GMAIL_FETCH_EMAILS`.\n- Copy the arguments from the input schema the search result returned.\n- Stop searching once a result is usable, and run it.\n- A run may pause for the user's approval or be refused outright: that is this agent's\n  permission policy, not a bug. A refusal will not succeed on a retry or with reshaped\n  arguments \u2014 report it instead of looping.",
+    "carrier": "appendSystemPrompt"
   },
   "gatewayPolicy": {
     "integrations": {

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_gateway_connection_resolve.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_gateway_connection_resolve.py
@@ -215,27 +215,28 @@ async def test_search_tools_names_the_connected_integrations(fake_http, connecti
     )
 
     search = next(s for s in resolution.tool_specs if s.name == "search_tools")
-    # Sorted, so the same agent always presents the same sentence.
-    assert search.description.endswith("Connected integrations: github, slack.")
-    # Names only. A slug is not the model's to know, and `run_tool` names no integration
-    # because it is told which one in the arguments.
+    # The descriptions are STABLE across integration sets: names live in the gatewayGuidance
+    # prompt section, because `customTools` is fingerprinted and a names sentence here made
+    # adding an integration evict the warm session.
+    assert "Connected integrations" not in search.description
+    # A slug is never the model's to know, on any surface.
     for slug in ["github-work", "slack-main"]:
         assert slug not in search.description
     run = next(s for s in resolution.tool_specs if s.name == "run_tool")
     assert "Connected integrations" not in run.description
 
 
-def test_an_empty_integration_list_leaves_no_dangling_sentence():
-    """The resolver's caller guards this, so it is only reachable by a future one.
-
-    Worth being total about: the failure mode is a malformed sentence in model-facing
-    text, which no type or test elsewhere would catch.
-    """
+def test_derived_specs_are_identical_for_any_integration_set():
+    """The stability guarantee itself: the two derived tools are byte-identical whether the
+    agent has zero, one, or many integrations, so only the FIRST connection (which adds the
+    tools) can change session config."""
     from agenta.sdk.agents.platform.gateway import _derived_tool_specs
 
-    search = next(s for s in _derived_tool_specs([]) if s.name == "search_tools")
+    none = _derived_tool_specs([])
+    many = _derived_tool_specs(["github", "slack", "linear"])
 
-    assert "Connected integrations" not in search.description
+    assert [s.model_dump() for s in none] == [s.model_dump() for s in many]
+    search = next(s for s in none if s.name == "search_tools")
     assert search.description.endswith("Never invent an integration name.")
 
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_harness_adapters.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_harness_adapters.py
@@ -324,9 +324,9 @@ _GATEWAY_POLICY = ResolvedGatewayPolicy(
 _AUTHOR_APPEND = "Be terse."
 _AUTHOR_INSTRUCTIONS = "My project rules."
 _HARNESS_CASES = [
-    (PiHarness, HarnessKind.PI, "append_system", _AUTHOR_APPEND),
-    (ClaudeHarness, HarnessKind.CLAUDE, "agents_md", _AUTHOR_INSTRUCTIONS),
-    (CodexHarness, HarnessKind.CODEX, "agents_md", _AUTHOR_INSTRUCTIONS),
+    (PiHarness, HarnessKind.PI, "append_system", "appendSystemPrompt", _AUTHOR_APPEND),
+    (ClaudeHarness, HarnessKind.CLAUDE, "agents_md", "agentsMd", _AUTHOR_INSTRUCTIONS),
+    (CodexHarness, HarnessKind.CODEX, "agents_md", "agentsMd", _AUTHOR_INSTRUCTIONS),
 ]
 
 
@@ -338,7 +338,9 @@ def test_every_registered_harness_declares_a_guidance_carrier():
     """
     from agenta.sdk.agents.adapters.harnesses import _HARNESSES
 
-    assert {kind for _cls, kind, _carrier, _author in _HARNESS_CASES} == set(_HARNESSES)
+    assert {kind for _cls, kind, _field, _carrier, _author in _HARNESS_CASES} == set(
+        _HARNESSES
+    )
 
 
 def _guidance_agent() -> AgentTemplate:
@@ -349,33 +351,43 @@ def _guidance_agent() -> AgentTemplate:
     )
 
 
-@pytest.mark.parametrize("harness_cls,kind,carrier,author_text", _HARNESS_CASES)
+@pytest.mark.parametrize(
+    "harness_cls,kind,prompt_field,carrier,author_text", _HARNESS_CASES
+)
 def test_gateway_guidance_reaches_every_harness(
-    make_env, harness_cls, kind, carrier, author_text
+    make_env, harness_cls, kind, prompt_field, carrier, author_text
 ):
     """Every harness gets the same two derived tools, so every one gets the instructions.
 
-    A section added to the Agenta preamble alone would leave Pi, Claude, and Codex holding
-    `search_tools` and `run_tool` with nothing telling them how to use them.
+    The guidance now rides its own `gatewayGuidance` wire field (spliced by the runner at
+    environment build, so integration adds stop evicting warm sessions); the adapter's job
+    is to emit the field with the right carrier and keep the prompt strings purely authored.
     """
     harness = harness_cls(make_env(supported=[kind]))
     config = _session_config(agent=_guidance_agent(), gateway_policy=_GATEWAY_POLICY)
 
     result = harness._to_harness_config(config)
 
-    text = getattr(result, carrier)
-    assert "search_tools" in text
-    assert "run_tool" in text
-    # The configured integration names, and only those.
-    assert "github, slack" in text
-    # The author's own text on that layer still comes last: the guidance is the platform half.
-    assert text.endswith(author_text)
-    assert text.index("search_tools") < text.index(author_text)
+    guidance = result.gateway_guidance
+    assert guidance is not None
+    assert guidance.carrier == carrier
+    assert "search_tools" in guidance.text
+    assert "run_tool" in guidance.text
+    # The configured integration names read as EXAMPLES, so a stale list stays honest.
+    assert "github, slack" in guidance.text
+    assert "Others may exist" in guidance.text
+    # The prompt strings stay purely authored: the runner does the splice, not the adapter.
+    assert getattr(result, prompt_field) == author_text
+    assert result.wire_gateway_guidance() == {
+        "gatewayGuidance": {"text": guidance.text, "carrier": carrier}
+    }
 
 
-@pytest.mark.parametrize("harness_cls,kind,carrier,author_text", _HARNESS_CASES)
+@pytest.mark.parametrize(
+    "harness_cls,kind,prompt_field,carrier,author_text", _HARNESS_CASES
+)
 def test_no_gateway_guidance_without_a_connection(
-    make_env, harness_cls, kind, carrier, author_text
+    make_env, harness_cls, kind, prompt_field, carrier, author_text
 ):
     """G6's prompt half: an agent with no connection entry gets no gateway section."""
     harness = harness_cls(make_env(supported=[kind]))
@@ -383,24 +395,25 @@ def test_no_gateway_guidance_without_a_connection(
 
     result = harness._to_harness_config(config)
 
-    text = getattr(result, carrier) or ""
+    assert result.gateway_guidance is None
+    assert result.wire_gateway_guidance() == {}
+    text = getattr(result, prompt_field) or ""
     assert "search_tools" not in text
-    assert "run_tool" not in text
 
 
-def test_pi_agents_md_stays_purely_authored(make_env):
-    """Pi's carrier is ``append_system``; AGENTS.md keeps only what the author wrote.
-
-    AGENTS.md is the project-conventions layer and a bare Pi run has no platform half of it,
-    so injecting there would put platform text in a file the author owns outright.
-    """
+def test_pi_prompt_strings_stay_purely_authored(make_env):
+    """Pi's guidance carrier is ``appendSystemPrompt``, but the SDK no longer splices it:
+    both prompt strings leave the adapter exactly as the author wrote them, and the field
+    carries the platform half for the runner to splice at build time."""
     harness = PiHarness(make_env(supported=[HarnessKind.PI]))
     config = _session_config(agent=_guidance_agent(), gateway_policy=_GATEWAY_POLICY)
 
     result = harness._to_harness_config(config)
 
     assert result.agents_md == _AUTHOR_INSTRUCTIONS
-    assert "search_tools" in result.append_system
+    assert result.append_system == _AUTHOR_APPEND
+    assert result.gateway_guidance is not None
+    assert result.gateway_guidance.carrier == "appendSystemPrompt"
 
 
 def test_gateway_guidance_is_never_stored_in_the_revision(make_env):
@@ -411,7 +424,8 @@ def test_gateway_guidance_is_never_stored_in_the_revision(make_env):
 
     result = harness._to_harness_config(config)
 
-    assert "search_tools" in result.append_system
+    assert result.gateway_guidance is not None
+    assert "search_tools" in result.gateway_guidance.text
     assert agent.instructions == _AUTHOR_INSTRUCTIONS
     assert agent.harness_extras == {"append_system": _AUTHOR_APPEND}
 
@@ -425,8 +439,9 @@ def test_gateway_guidance_carries_all_six_prompt_items():
     """
     section = gateway_guidance(["github", "slack"])
 
-    # 1. The configured integration names.
-    assert "Configured integrations: github, slack." in section
+    # 1. The configured integration names, framed as examples so a stale list stays honest.
+    assert "some of the integrations you have: github, slack" in section
+    assert "Others may exist" in section
     # 2. Search once per task, with a concrete description, and no equivalent repeats.
     assert "Search once per task, with a concrete description" in section
     assert "Never repeat an\n  equivalent query" in section
@@ -456,9 +471,11 @@ def test_gateway_guidance_is_absent_for_an_empty_policy():
     assert gateway_guidance([]) is None
 
 
-@pytest.mark.parametrize("harness_cls,kind,carrier,author_text", _HARNESS_CASES)
+@pytest.mark.parametrize(
+    "harness_cls,kind,prompt_field,carrier,author_text", _HARNESS_CASES
+)
 def test_gateway_policy_stays_out_of_every_harness_config(
-    make_env, harness_cls, kind, carrier, author_text
+    make_env, harness_cls, kind, prompt_field, carrier, author_text
 ):
     """Runner policy stays neutral while harnesses receive only names for guidance."""
     harness = harness_cls(make_env(supported=[kind]))

--- a/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
@@ -45,6 +45,7 @@ from agenta.sdk.agents import (
     ToolResolver,
     TraceContext,
 )
+from agenta.sdk.agents.adapters.agenta_builtins import gateway_guidance_field
 from agenta.sdk.agents.platform.gateway import _derived_tool_specs
 from agenta.sdk.agents.tools import (
     CompiledTool,
@@ -92,6 +93,7 @@ KNOWN_REQUEST_KEYS = {
     "toolCallback",
     "permissions",
     "gatewayPolicy",
+    "gatewayGuidance",
     "systemPrompt",
     "appendSystemPrompt",
     "skills",
@@ -321,6 +323,11 @@ def _gateway_connection_payload():
         # Straight from the producer, so the golden records what a real resolve emits.
         custom_tools=_derived_tool_specs(list(gateway_policy.integrations)),
         tool_callback=_CALLBACK,
+        # Straight from the same producer path the adapters use, so the golden pins the
+        # separate-field form (the guidance is spliced runner-side at environment build).
+        gateway_guidance=gateway_guidance_field(
+            list(gateway_policy.integrations), "appendSystemPrompt"
+        ),
     )
     return request_to_wire(
         harness=HarnessKind.PI,

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -677,8 +677,25 @@ export function buildRunPlan(
   const systemPrompt = isPi
     ? request.systemPrompt?.trim() || undefined
     : undefined;
+  // The gateway guidance is spliced HERE, at environment build time, guidance first and the
+  // author's text after it (the platform half leads, matching the old composed order). It is
+  // excluded from the session fingerprint on purpose, so this is the only moment the names
+  // list can change: a warm session keeps the text it was built with (the wording says the
+  // list may be stale), and the next cold or reopened session picks up the current names.
+  const guidance = request.gatewayGuidance?.text?.trim() || undefined;
+  const spliceGuidance = (
+    carrier: "appendSystemPrompt" | "agentsMd",
+    authored: string | undefined,
+  ): string | undefined => {
+    if (!guidance || request.gatewayGuidance?.carrier !== carrier)
+      return authored;
+    return authored ? `${guidance}\n\n${authored}` : guidance;
+  };
   const appendSystemPrompt = isPi
-    ? request.appendSystemPrompt?.trim() || undefined
+    ? spliceGuidance(
+        "appendSystemPrompt",
+        request.appendSystemPrompt?.trim() || undefined,
+      )
     : undefined;
 
   // Debug assertions: the derived run state must be self-consistent before the engine acts on
@@ -760,7 +777,10 @@ export function buildRunPlan(
       prompt: {
         text: prompt,
         turnText: buildTurnText(request, log),
-        agentsMd: request.agentsMd?.trim() || undefined,
+        agentsMd: spliceGuidance(
+          "agentsMd",
+          request.agentsMd?.trim() || undefined,
+        ),
         systemPrompt,
         appendSystemPrompt,
         hasSystemPrompt: !!(systemPrompt || appendSystemPrompt),

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -259,6 +259,11 @@ export function configFingerprint(request: AgentRunRequest): string {
         },
       })) ?? null,
     toolCallbackEndpoint: request.toolCallback?.endpoint ?? null,
+    // No `gatewayGuidance` and no `gatewayPolicy`: both are DERIVED from the agent's gateway
+    // connections at resolve time. The guidance is spliced into the prompt at environment build
+    // (`buildRunPlan`) and its wording treats the integration names as examples, so a warm
+    // session serving a slightly stale list is honest — and hashing it would evict a warm
+    // session every time an integration is added, the exact cost this exclusion removes.
     permissions: request.permissions ?? null,
     sandboxPermission: request.sandboxPermission ?? null,
     harnessFiles: request.harnessFiles ?? null,

--- a/services/runner/src/lifecycle/desired-state.ts
+++ b/services/runner/src/lifecycle/desired-state.ts
@@ -81,9 +81,14 @@ function canonical(value: unknown): string {
 
 /** Strip credential VALUES, keeping only the shape. Mirrors `configFingerprint`. */
 function credentialShapes(
-  credentials: ReadonlyArray<{ binding?: unknown; usage?: unknown }> | undefined,
+  credentials:
+    | ReadonlyArray<{ binding?: unknown; usage?: unknown }>
+    | undefined,
 ): unknown {
-  return (credentials ?? []).map((c) => ({ binding: c.binding, usage: c.usage }));
+  return (credentials ?? []).map((c) => ({
+    binding: c.binding,
+    usage: c.usage,
+  }));
 }
 
 /**
@@ -133,7 +138,9 @@ export function normalizeDesiredState(
     skills: request.skills ?? null,
   });
 
-  // PROMPTS: the system and append prompts.
+  // PROMPTS: the system and append prompts. `gatewayGuidance` is deliberately absent here and
+  // from every other facet (mirroring `configFingerprint`): it is derived config the runner
+  // splices at build time, refreshed by whatever rebuild happens anyway, never a reason for one.
   //
   // SEPARATE FROM `workspaceFiles`, and not live. For Pi these land as files under the agent
   // directory, and the adapter matrix records active-session observation as NOT GUARANTEED: a

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -703,6 +703,21 @@ export interface AgentRunRequest {
    */
   gatewayPolicy?: GatewayPolicy;
   /**
+   * The derived gateway-tools instruction section (how to use `search_tools` / `run_tool`,
+   * with the configured integration names as EXAMPLES), plus which prompt surface carries it.
+   *
+   * Its own field, deliberately OUTSIDE `configFingerprint` and the desired-state facets: the
+   * text is derived from the agent's connections at resolve time, and the runner splices it
+   * into `carrier` when it BUILDS an environment (`buildRunPlan`). So adding or removing an
+   * integration never evicts a warm session for a one-word prompt change; the names refresh
+   * on the next session build, and the wording says the list may be stale. When it was
+   * composed into the prompt strings upstream, every integration add went cold.
+   */
+  gatewayGuidance?: {
+    text: string;
+    carrier: "appendSystemPrompt" | "agentsMd";
+  };
+  /**
    * The declared sandbox security boundary (Layer 2). Omitted when unset. The network policy is
    * enforced on Daytona; on the local sidecar a restricted-network run is rejected under
    * `strict` (it cannot be a hard guarantee there). `filesystem` is declared-only.

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -357,10 +357,16 @@ describe("buildRunPlan", () => {
     assert.equal(result.plan.sandboxId, "local");
     assert.equal(result.plan.workspace.cwd, "/tmp/local-cwd");
     // Relay and telemetry are ephemeral runner files kept OFF the (possibly geesefs) cwd.
-    assert.ok(!result.plan.workspace.relayDir.startsWith(result.plan.workspace.cwd));
-    assert.ok(result.plan.workspace.relayDir.endsWith("/agenta/relay/local-cwd"));
     assert.ok(
-      result.plan.workspace.telemetryDir.endsWith("/agenta/telemetry/local-cwd"),
+      !result.plan.workspace.relayDir.startsWith(result.plan.workspace.cwd),
+    );
+    assert.ok(
+      result.plan.workspace.relayDir.endsWith("/agenta/relay/local-cwd"),
+    );
+    assert.ok(
+      result.plan.workspace.telemetryDir.endsWith(
+        "/agenta/telemetry/local-cwd",
+      ),
     );
     assert.equal(
       result.plan.workspace.usageOutPath,
@@ -372,7 +378,9 @@ describe("buildRunPlan", () => {
     assert.equal(result.plan.prompt.appendSystemPrompt, "append");
     assert.equal(result.plan.prompt.hasSystemPrompt, true);
     assert.equal(result.plan.credentials.hasApiKey, true);
-    assert.deepEqual(result.plan.credentials.modelEnvironment, { OPENAI_API_KEY: "key" });
+    assert.deepEqual(result.plan.credentials.modelEnvironment, {
+      OPENAI_API_KEY: "key",
+    });
     assert.equal(result.plan.workspace.sourcePiAgentDir, "/tmp/pi-agent");
     assert.deepEqual(
       result.plan.tools.executableToolSpecs.map((tool) => tool.name),
@@ -762,9 +770,14 @@ describe("buildRunPlan", () => {
         result.plan.workspace.toolMcpDir,
         "/home/sandbox/agenta/tool-mcp/agenta-fixed",
       );
-      assert.notEqual(result.plan.workspace.toolMcpDir, result.plan.workspace.relayDir);
+      assert.notEqual(
+        result.plan.workspace.toolMcpDir,
+        result.plan.workspace.relayDir,
+      );
       assert.ok(
-        !result.plan.workspace.toolMcpDir.startsWith(`${result.plan.workspace.relayDir}/`),
+        !result.plan.workspace.toolMcpDir.startsWith(
+          `${result.plan.workspace.relayDir}/`,
+        ),
         "the shim dir is never nested inside the relay dir (the relay loop sweeps it)",
       );
       assert.equal(
@@ -896,7 +909,10 @@ describe("buildRunPlan", () => {
         result.plan.tools.executableToolSpecs.map((tool) => tool.name),
         ["server_tool"],
       );
-      assert.equal(result.plan.tools.clientToolPauseDisposition, "cold-acknowledge");
+      assert.equal(
+        result.plan.tools.clientToolPauseDisposition,
+        "cold-acknowledge",
+      );
     });
 
     it("allows claude x daytona x client-ONLY tools (the shim advertises them and the relay parks)", () => {
@@ -1184,8 +1200,14 @@ describe("buildRunPlan", () => {
     // The FULL materialized environment sets hasApiKey: on a Daytona Secrets run the opaque key
     // leaves the plaintext env for the secret plan, but the harness still receives its binding.
     assert.equal(result.plan.credentials.hasApiKey, true);
-    assert.equal(result.plan.credentials.modelEnvironment.ANTHROPIC_API_KEY, undefined);
-    assert.equal(result.plan.credentials.daytonaSecretPlan?.candidates.length, 1);
+    assert.equal(
+      result.plan.credentials.modelEnvironment.ANTHROPIC_API_KEY,
+      undefined,
+    );
+    assert.equal(
+      result.plan.credentials.daytonaSecretPlan?.candidates.length,
+      1,
+    );
     // The resolved credentialMode is carried onto the plan (drives clear-then-apply).
     assert.equal(result.plan.credentials.credentialMode, "env");
     assert.equal(result.plan.prompt.systemPrompt, undefined);
@@ -1226,8 +1248,14 @@ describe("buildRunPlan", () => {
     const flagOn = buildRunPlan(localUseRequest, deps);
     assert.equal(flagOn.ok, true);
     if (!flagOn.ok) return;
-    assert.ok(flagOn.plan.credentials.daytonaSecretPlan, "flag on keeps the empty plan");
-    assert.equal(flagOn.plan.credentials.daytonaSecretPlan.candidates.length, 0);
+    assert.ok(
+      flagOn.plan.credentials.daytonaSecretPlan,
+      "flag on keeps the empty plan",
+    );
+    assert.equal(
+      flagOn.plan.credentials.daytonaSecretPlan.candidates.length,
+      0,
+    );
     // local_use values still reach sandbox create as plaintext env (by design).
     assert.equal(
       flagOn.plan.credentials.modelEnvironment.AWS_ACCESS_KEY_ID,
@@ -1307,10 +1335,17 @@ describe("buildRunPlan durableCwd (prefix-derived cwd)", () => {
 
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.equal(result.plan.workspace.cwd, "/tmp/agenta/mounts/proj-1/mount-abc");
+    assert.equal(
+      result.plan.workspace.cwd,
+      "/tmp/agenta/mounts/proj-1/mount-abc",
+    );
     // Relay dir is an ephemeral sibling (leaf = cwd basename), NOT inside the durable mount.
-    assert.ok(!result.plan.workspace.relayDir.startsWith(result.plan.workspace.cwd));
-    assert.ok(result.plan.workspace.relayDir.endsWith("/agenta/relay/mount-abc"));
+    assert.ok(
+      !result.plan.workspace.relayDir.startsWith(result.plan.workspace.cwd),
+    );
+    assert.ok(
+      result.plan.workspace.relayDir.endsWith("/agenta/relay/mount-abc"),
+    );
     // createLocalCwd received the durableCwd value.
     assert.deepEqual(localCwdCalls, ["/tmp/agenta/mounts/proj-1/mount-abc"]);
   });
@@ -1362,7 +1397,10 @@ describe("buildRunPlan durableCwd (prefix-derived cwd)", () => {
 
     assert.equal(result.ok, true);
     if (!result.ok) return;
-    assert.equal(result.plan.workspace.cwd, "/tmp/agenta-sandbox-agent-ephemeral");
+    assert.equal(
+      result.plan.workspace.cwd,
+      "/tmp/agenta-sandbox-agent-ephemeral",
+    );
     assert.deepEqual(localCwdCalls, [undefined]);
   });
 
@@ -1567,7 +1605,10 @@ describe("buildRunPlan runtime_provided (subscription) gates", () => {
       assert.equal(result.ok, true);
       if (!result.ok) return;
       assert.equal(result.plan.credentials.credentialMode, "runtime_provided");
-      assert.equal(result.plan.workspace.sourcePiAgentDir, "/agenta/harness/pi");
+      assert.equal(
+        result.plan.workspace.sourcePiAgentDir,
+        "/agenta/harness/pi",
+      );
     });
   });
 
@@ -1782,5 +1823,79 @@ describe("modelConnection validation", () => {
     );
     assert.equal(result.ok, false);
     if (!result.ok) assert.match(result.error, /modelConnection object/);
+  });
+});
+
+describe("gateway guidance splice", () => {
+  const base = {
+    harness: "pi_core",
+    messages: [{ role: "user", content: "hi" }],
+  } as unknown as AgentRunRequest;
+  const deps = { createLocalCwd: () => "local-cwd" };
+
+  it("splices the guidance ahead of the authored append prompt for Pi", () => {
+    const result = buildRunPlan(
+      {
+        ...base,
+        appendSystemPrompt: "Be terse.",
+        gatewayGuidance: {
+          text: "## Connected integrations\nuse search_tools",
+          carrier: "appendSystemPrompt",
+        },
+      } as unknown as AgentRunRequest,
+      deps,
+    );
+    assert.equal(result.ok, true);
+    assert.equal(
+      result.ok && result.plan.prompt.appendSystemPrompt,
+      "## Connected integrations\nuse search_tools\n\nBe terse.",
+    );
+  });
+
+  it("carries the guidance alone when nothing is authored on the carrier", () => {
+    const result = buildRunPlan(
+      {
+        ...base,
+        gatewayGuidance: { text: "guide", carrier: "appendSystemPrompt" },
+      } as unknown as AgentRunRequest,
+      deps,
+    );
+    assert.equal(result.ok, true);
+    assert.equal(result.ok && result.plan.prompt.appendSystemPrompt, "guide");
+    assert.equal(result.ok && result.plan.prompt.hasSystemPrompt, true);
+  });
+
+  it("splices into agentsMd for the file-based carrier", () => {
+    const result = buildRunPlan(
+      {
+        ...base,
+        harness: "claude",
+        agentsMd: "My rules.",
+        gatewayGuidance: { text: "guide", carrier: "agentsMd" },
+      } as unknown as AgentRunRequest,
+      deps,
+    );
+    assert.equal(result.ok, true);
+    assert.equal(
+      result.ok && result.plan.prompt.agentsMd,
+      "guide\n\nMy rules.",
+    );
+    // Claude never takes the Pi-only append field.
+    assert.equal(result.ok && result.plan.prompt.appendSystemPrompt, undefined);
+  });
+
+  it("leaves the prompts untouched without a guidance field", () => {
+    const result = buildRunPlan(
+      {
+        ...base,
+        appendSystemPrompt: "Be terse.",
+      } as unknown as AgentRunRequest,
+      deps,
+    );
+    assert.equal(result.ok, true);
+    assert.equal(
+      result.ok && result.plan.prompt.appendSystemPrompt,
+      "Be terse.",
+    );
   });
 });

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -257,6 +257,29 @@ describe("configFingerprint", () => {
     messages: [{ role: "user", content: "hi" }],
   };
 
+  it("excludes the derived gateway guidance, so an integration add never evicts", () => {
+    // The guidance text carries the integration NAMES as examples and refreshes at
+    // environment build. Hashing it would cold every warm session on each integration add —
+    // the exact cost the separate field removes.
+    const a = configFingerprint(base);
+    const b = configFingerprint({
+      ...base,
+      gatewayGuidance: {
+        text: "For instance, some of the integrations you have: github, slack.",
+        carrier: "agentsMd",
+      },
+    } as unknown as AgentRunRequest);
+    const c = configFingerprint({
+      ...base,
+      gatewayGuidance: {
+        text: "For instance, some of the integrations you have: github.",
+        carrier: "agentsMd",
+      },
+    } as unknown as AgentRunRequest);
+    assert.equal(a, b);
+    assert.equal(b, c);
+  });
+
   it("ignores per-turn volatiles and credential values", () => {
     const a = configFingerprint({
       ...base,

--- a/services/runner/tests/unit/wire-contract.test.ts
+++ b/services/runner/tests/unit/wire-contract.test.ts
@@ -50,6 +50,7 @@ const KNOWN_REQUEST_KEYS = [
   "toolCallback",
   "permissions",
   "gatewayPolicy",
+  "gatewayGuidance",
   "systemPrompt",
   "appendSystemPrompt",
   "skills",


### PR DESCRIPTION
## Context

Adding a second integration to an agent evicted its warm session, twice over. The integration names were written into the prompt guidance ("Configured integrations: github, slack.") and into the `search_tools` tool description, and both surfaces are hashed into the session fingerprint. So a one-word list change cost a full sandbox rebuild, fresh Daytona Secrets, and a pass through the substitution race of #6362. Editing an integration's tool permissions was already fine: `gatewayPolicy` sits outside the fingerprint.

## Changes

The guidance becomes its own wire field, and the names become examples.

Before: the SDK adapter spliced the guidance into `appendSystemPrompt` (Pi) or `agentsMd` (Claude, Codex), and the runner hashed the result.

After: the wire carries `gatewayGuidance: {text, carrier}`. The adapters keep the carrier choice but stop splicing, so the prompt strings leave the SDK purely authored. The runner splices guidance-first when it builds an environment (`buildRunPlan`), and `configFingerprint` plus the desired-state facets exclude the field by design, with the reason documented at both sites. The text refreshes exactly when a session is built, and never evicts one.

The wording changes with it: "For instance, some of the integrations you have: github, slack. Others may exist, and this list can go stale — `search_tools` is the source of truth." A list that goes stale mid-session is now honest.

The derived `search_tools` / `run_tool` descriptions drop their names sentence and are byte-identical for any integration set. So only the first connection, which genuinely adds the two tools, changes session config at all.

## Tests

- SDK: agents suite green (1131 passed). The gateway adapter tests now pin the field form, the stable tool descriptions, and the example wording; the golden `run_request.gateway_connection.json` pins the new field. Connection-free payloads are byte-identical to before.
- Runner: 156 files / 2569 tests green, typecheck clean. New cases: the splice (guidance-first, both carriers, guidance-alone), and a fingerprint test proving two requests differing only in `gatewayGuidance` hash equal.

## What to QA

- On a warm Daytona session with one integration connected, add a second integration, then send another turn. The turn starts fast (no rebuild), and the agent can use the new integration through `search_tools` immediately; its prompt still names only the first until the next cold start.
- Regression: a fresh session with integrations gets the guidance section with the integration names; an agent with no integrations gets no gateway text anywhere.

Stacked on #6367.

https://claude.ai/code/session_014s6jqKCsVKsNMmnrJVJkZt
