### PR TITLE
[feat] Detect a stuck-substitution sandbox before the first model call and rebuild it

### DIFF
--- a/services/runner/src/engines/sandbox_agent/credential-preflight.ts
+++ b/services/runner/src/engines/sandbox_agent/credential-preflight.ts
@@ -1,0 +1,125 @@
+/**
+ * Credential-substitution preflight for fresh Daytona sandboxes.
+ *
+ * THE RACE THIS CLOSES. On a Daytona run the model key never enters the sandbox: it is a
+ * Daytona Secret, and the sandbox holds a `dtn_secret_<id>` placeholder that Daytona
+ * substitutes into egress requests to the key's exact host. That substitution propagates
+ * asynchronously with NO confirmation signal, and on EU cloud production (2026-08-29) about
+ * 3% of fresh sandboxes' first model calls carried the raw placeholder — a 401 at the model
+ * proxy and a failed first turn (classified `credential_delivery_failed`). Every observed
+ * failure was a FIRST call, 10-24s after Secret creation; substitution never broke
+ * mid-session, so once one probe substitutes, the sandbox is good.
+ *
+ * THE MECHANISM. Right after the sandbox is created, probe the credential's own endpoint
+ * from INSIDE the sandbox: POST `${baseUrl}/chat/completions` with the key env var as the
+ * bearer. When the response echoes `dtn_`, the placeholder went through raw (both LiteLLM —
+ * "Virtual Key expected. Received=dtn_…" — and OpenAI-compatible providers echo the bad
+ * key), so wait and probe again. Any other response means the header was substituted (a 400
+ * for the junk body, a real 401 for a genuinely bad key) and the run may proceed. The
+ * preflight runs CONCURRENTLY with the rest of acquire (mounts, workspace, session open,
+ * ~10s), so the common case pays nothing; only a still-racing sandbox waits at the end.
+ *
+ * SCOPE. Only a freshly created Daytona sandbox whose MODEL credential rides a Daytona
+ * Secret and whose connection declares an endpoint base URL (the custom OpenAI-compatible
+ * shape — every observed incident). A plaintext-env run has no placeholder; a reconnected
+ * sandbox already proved itself.
+ *
+ * FAIL OPEN, ALWAYS. A probe that errors, times out, or exhausts the budget logs and lets
+ * the run proceed: the worst outcome is the pre-existing behavior, now at least classified
+ * honestly by `classifyRunError`. This unit must never fail a turn that would have worked.
+ */
+
+export interface PreflightSandbox {
+  runProcess(request: {
+    command: string;
+    args?: string[];
+    timeoutMs?: number;
+  }): Promise<{ exitCode?: number | null; stdout: string } | undefined>;
+}
+
+export interface CredentialPreflightInput {
+  sandbox: PreflightSandbox;
+  /** The custom connection's endpoint base URL (`modelConnection.endpoint.baseUrl`). */
+  baseUrl: string;
+  /** The env var name holding the key in the sandbox (the Secret's placeholder). */
+  apiKeyVar: string;
+  log: (message: string) => void;
+  /** Total budget from first probe to giving up (fail open). */
+  budgetMs?: number;
+  /** Delay between probes. */
+  pollMs?: number;
+  /** Injectable clock/sleep for tests. */
+  now?: () => number;
+  sleep?: (ms: number) => Promise<void>;
+}
+
+const DEFAULT_BUDGET_MS = 25_000;
+const DEFAULT_POLL_MS = 2_000;
+const CURL_TIMEOUT_S = 8;
+
+/**
+ * Resolve when the sandbox's model credential substitutes on the wire, or when the budget is
+ * spent (fail open). Never throws.
+ */
+export async function awaitCredentialSubstitution(
+  input: CredentialPreflightInput,
+): Promise<void> {
+  const now = input.now ?? Date.now;
+  const sleep =
+    input.sleep ??
+    ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
+  const budgetMs = input.budgetMs ?? DEFAULT_BUDGET_MS;
+  const pollMs = input.pollMs ?? DEFAULT_POLL_MS;
+  const url = `${input.baseUrl.replace(/\/+$/, "")}/chat/completions`;
+  // The env var is expanded by the sandbox shell, so the placeholder value never appears in
+  // any runner-side string. `-d "{}"` makes an auth-first endpoint answer without a model call.
+  const script =
+    `curl -s -m ${CURL_TIMEOUT_S} -X POST ` +
+    `-H "Content-Type: application/json" ` +
+    `-H "Authorization: Bearer $${input.apiKeyVar}" ` +
+    `-d "{}" ${JSON.stringify(url)}`;
+
+  const startedAt = now();
+  for (let attempt = 1; ; attempt++) {
+    let body: string | undefined;
+    try {
+      const result = await input.sandbox.runProcess({
+        command: "sh",
+        args: ["-c", script],
+        timeoutMs: (CURL_TIMEOUT_S + 4) * 1000,
+      });
+      body = result?.stdout;
+    } catch (error) {
+      // The exec channel itself failed (sandbox tearing down, daemon hiccup): fail open.
+      input.log(
+        `[credential-preflight] probe errored, proceeding: ${String(
+          error instanceof Error ? error.message : error,
+        ).slice(0, 120)}`,
+      );
+      return;
+    }
+    const elapsedMs = now() - startedAt;
+    if (!body || !body.includes("dtn_")) {
+      // Substituted (or the endpoint gave no echo to judge by — fail open either way).
+      if (attempt > 1) {
+        input.log(
+          `[credential-preflight] substitution confirmed after ${attempt} probes ` +
+            `(${(elapsedMs / 1000).toFixed(1)}s)`,
+        );
+      }
+      return;
+    }
+    if (elapsedMs + pollMs > budgetMs) {
+      input.log(
+        `[credential-preflight] placeholder still raw after ${attempt} probes ` +
+          `(${(elapsedMs / 1000).toFixed(1)}s); proceeding fail-open`,
+      );
+      return;
+    }
+    input.log(
+      `[credential-preflight] raw placeholder echoed (probe ${attempt}, ` +
+        `+${(elapsedMs / 1000).toFixed(1)}s); waiting for Daytona substitution`,
+    );
+    await sleep(pollMs);
+  }
+}

--- a/services/runner/src/engines/sandbox_agent/credential-preflight.ts
+++ b/services/runner/src/engines/sandbox_agent/credential-preflight.ts
@@ -22,9 +22,16 @@
  * session open, ~10s), so a healthy sandbox pays nothing.
  *
  * WHAT A "STUCK" VERDICT DOES. The acquire path destroys the environment and retries ONCE
- * with a brand-new sandbox (`withStuckSubstitutionRetry`), because the twin experiment
- * proved a new sandbox on the same Secret works. The user sees a slower first turn instead
- * of a failed one.
+ * with a brand-new sandbox, because the twin experiment proved a new sandbox on the same
+ * Secret works. The user sees a slower first turn instead of a failed one.
+ *
+ * THE 30-SECOND GRACE IS DAYTONA'S OWN NUMBER (2026-08-31, their support, confirming our
+ * report): "If a retry on the same sandbox starts working within ~30s, you can keep it. If
+ * the placeholder is still going out after that, recreate. Retrying or restarting the same
+ * one will not help." So the preflight keeps probing to that bound before convicting — our
+ * own 20 samples saw nothing land between 3s and 180s, but their bound is authoritative for
+ * their system, and the grace runs concurrently with acquire setup so a healthy sandbox
+ * still pays nothing.
  *
  * SCOPE. Only a freshly created Daytona sandbox whose MODEL credential rides a Daytona
  * Secret and whose connection declares an endpoint base URL (the custom OpenAI-compatible
@@ -77,11 +84,10 @@ export interface CredentialPreflightInput {
   sleep?: (ms: number) => Promise<void>;
 }
 
-const DEFAULT_BUDGET_MS = 10_000;
-const DEFAULT_POLL_MS = 2_000;
+/** Daytona's stated keep-or-recreate bound: wiring that has not landed by ~30s never lands. */
+const DEFAULT_BUDGET_MS = 30_000;
+const DEFAULT_POLL_MS = 2_500;
 const CURL_TIMEOUT_S = 8;
-/** Raw echoes needed to convict. A healthy sandbox substitutes on probe 1, so 4 is generous. */
-const STUCK_CONVICTION_PROBES = 4;
 
 /**
  * Resolve "ok" when the sandbox's model credential substitutes on the wire (or nothing can be
@@ -136,7 +142,7 @@ export async function awaitCredentialSubstitution(
       }
       return "ok";
     }
-    if (attempt >= STUCK_CONVICTION_PROBES || elapsedMs + pollMs > budgetMs) {
+    if (elapsedMs + pollMs > budgetMs) {
       input.log(
         `[credential-preflight] STUCK: raw placeholder on all ${attempt} probes ` +
           `(${(elapsedMs / 1000).toFixed(1)}s); this sandbox will never substitute`,

--- a/services/runner/src/engines/sandbox_agent/credential-preflight.ts
+++ b/services/runner/src/engines/sandbox_agent/credential-preflight.ts
@@ -1,32 +1,39 @@
 /**
  * Credential-substitution preflight for fresh Daytona sandboxes.
  *
- * THE RACE THIS CLOSES. On a Daytona run the model key never enters the sandbox: it is a
- * Daytona Secret, and the sandbox holds a `dtn_secret_<id>` placeholder that Daytona
- * substitutes into egress requests to the key's exact host. That substitution propagates
- * asynchronously with NO confirmation signal, and on EU cloud production (2026-08-29) about
- * 3% of fresh sandboxes' first model calls carried the raw placeholder — a 401 at the model
- * proxy and a failed first turn (classified `credential_delivery_failed`). Every observed
- * failure was a FIRST call, 10-24s after Secret creation; substitution never broke
- * mid-session, so once one probe substitutes, the sandbox is good.
+ * THE FAULT THIS DETECTS (measured 2026-08-30, docs/design/daytona-secret-propagation/).
+ * On a Daytona run the model key never enters the sandbox: it is a Daytona Secret, and the
+ * sandbox holds a `dtn_secret_<id>` placeholder Daytona substitutes into egress requests to
+ * the key's exact host. That wiring is BINARY PER SANDBOX: a healthy sandbox substitutes on
+ * its very first request (~2s after Secret creation), and a stuck sandbox never does — the
+ * raw placeholder reaches the provider for as long as anyone watches, a twin sandbox on the
+ * SAME Secret works immediately, and stop+start does not repair it. Measured 5 stuck of 20
+ * fresh sandboxes (target eu); production showed ~3% over an earlier window, so the rate
+ * varies. Waiting therefore cannot help; only a fresh sandbox can.
  *
  * THE MECHANISM. Right after the sandbox is created, probe the credential's own endpoint
  * from INSIDE the sandbox: POST `${baseUrl}/chat/completions` with the key env var as the
- * bearer. When the response echoes `dtn_`, the placeholder went through raw (both LiteLLM —
- * "Virtual Key expected. Received=dtn_…" — and OpenAI-compatible providers echo the bad
- * key), so wait and probe again. Any other response means the header was substituted (a 400
- * for the junk body, a real 401 for a genuinely bad key) and the run may proceed. The
- * preflight runs CONCURRENTLY with the rest of acquire (mounts, workspace, session open,
- * ~10s), so the common case pays nothing; only a still-racing sandbox waits at the end.
+ * bearer. A response echoing `dtn_` means the placeholder went through raw (LiteLLM and
+ * OpenAI-compatible providers echo the bad key; Daytona's response scrubbing rewrites REAL
+ * values back to placeholders but leaves the raw-placeholder echo visible). Several
+ * consecutive raw echoes convict the sandbox as STUCK; any other response means the header
+ * was substituted (a 400 for the junk body, a real 401 for a genuinely bad key) and the run
+ * may proceed. The preflight runs CONCURRENTLY with the rest of acquire (mounts, workspace,
+ * session open, ~10s), so a healthy sandbox pays nothing.
+ *
+ * WHAT A "STUCK" VERDICT DOES. The acquire path destroys the environment and retries ONCE
+ * with a brand-new sandbox (`withStuckSubstitutionRetry`), because the twin experiment
+ * proved a new sandbox on the same Secret works. The user sees a slower first turn instead
+ * of a failed one.
  *
  * SCOPE. Only a freshly created Daytona sandbox whose MODEL credential rides a Daytona
  * Secret and whose connection declares an endpoint base URL (the custom OpenAI-compatible
  * shape — every observed incident). A plaintext-env run has no placeholder; a reconnected
  * sandbox already proved itself.
  *
- * FAIL OPEN, ALWAYS. A probe that errors, times out, or exhausts the budget logs and lets
- * the run proceed: the worst outcome is the pre-existing behavior, now at least classified
- * honestly by `classifyRunError`. This unit must never fail a turn that would have worked.
+ * AMBIGUITY FAILS OPEN. A probe that errors or returns nothing judgeable returns "ok" and
+ * the run proceeds: the worst outcome is the pre-existing behavior, classified honestly by
+ * `classifyRunError`. Only consecutive, unambiguous raw-placeholder echoes convict.
  */
 
 export interface PreflightSandbox {
@@ -36,6 +43,23 @@ export interface PreflightSandbox {
     timeoutMs?: number;
   }): Promise<{ exitCode?: number | null; stdout: string } | undefined>;
 }
+
+/** The preflight's answer: proceed, or this sandbox will never substitute. */
+export type CredentialPreflightVerdict = "ok" | "stuck";
+
+/** Thrown by the acquire path when the preflight convicts the sandbox. */
+export class SubstitutionStuckError extends Error {
+  constructor() {
+    super(
+      "This sandbox never received its credential-substitution wiring (raw placeholder " +
+        "echoed on every probe); a fresh sandbox is required.",
+    );
+    this.name = "SubstitutionStuckError";
+  }
+}
+
+/** Total acquire attempts when a sandbox is convicted stuck: the original plus one retry. */
+export const STUCK_ACQUIRE_ATTEMPTS = 2;
 
 export interface CredentialPreflightInput {
   sandbox: PreflightSandbox;
@@ -53,17 +77,20 @@ export interface CredentialPreflightInput {
   sleep?: (ms: number) => Promise<void>;
 }
 
-const DEFAULT_BUDGET_MS = 25_000;
+const DEFAULT_BUDGET_MS = 10_000;
 const DEFAULT_POLL_MS = 2_000;
 const CURL_TIMEOUT_S = 8;
+/** Raw echoes needed to convict. A healthy sandbox substitutes on probe 1, so 4 is generous. */
+const STUCK_CONVICTION_PROBES = 4;
 
 /**
- * Resolve when the sandbox's model credential substitutes on the wire, or when the budget is
- * spent (fail open). Never throws.
+ * Resolve "ok" when the sandbox's model credential substitutes on the wire (or nothing can be
+ * judged — fail open), and "stuck" after enough consecutive raw-placeholder echoes. Never
+ * throws.
  */
 export async function awaitCredentialSubstitution(
   input: CredentialPreflightInput,
-): Promise<void> {
+): Promise<CredentialPreflightVerdict> {
   const now = input.now ?? Date.now;
   const sleep =
     input.sleep ??
@@ -96,7 +123,7 @@ export async function awaitCredentialSubstitution(
           error instanceof Error ? error.message : error,
         ).slice(0, 120)}`,
       );
-      return;
+      return "ok";
     }
     const elapsedMs = now() - startedAt;
     if (!body || !body.includes("dtn_")) {
@@ -107,18 +134,18 @@ export async function awaitCredentialSubstitution(
             `(${(elapsedMs / 1000).toFixed(1)}s)`,
         );
       }
-      return;
+      return "ok";
     }
-    if (elapsedMs + pollMs > budgetMs) {
+    if (attempt >= STUCK_CONVICTION_PROBES || elapsedMs + pollMs > budgetMs) {
       input.log(
-        `[credential-preflight] placeholder still raw after ${attempt} probes ` +
-          `(${(elapsedMs / 1000).toFixed(1)}s); proceeding fail-open`,
+        `[credential-preflight] STUCK: raw placeholder on all ${attempt} probes ` +
+          `(${(elapsedMs / 1000).toFixed(1)}s); this sandbox will never substitute`,
       );
-      return;
+      return "stuck";
     }
     input.log(
       `[credential-preflight] raw placeholder echoed (probe ${attempt}, ` +
-        `+${(elapsedMs / 1000).toFixed(1)}s); waiting for Daytona substitution`,
+        `+${(elapsedMs / 1000).toFixed(1)}s)`,
     );
     await sleep(pollMs);
   }

--- a/services/runner/src/engines/sandbox_agent/credential-preflight.ts
+++ b/services/runner/src/engines/sandbox_agent/credential-preflight.ts
@@ -13,13 +13,25 @@
  *
  * THE MECHANISM. Right after the sandbox is created, probe the credential's own endpoint
  * from INSIDE the sandbox: POST `${baseUrl}/chat/completions` with the key env var as the
- * bearer. A response echoing `dtn_` means the placeholder went through raw (LiteLLM and
- * OpenAI-compatible providers echo the bad key; Daytona's response scrubbing rewrites REAL
- * values back to placeholders but leaves the raw-placeholder echo visible). Several
- * consecutive raw echoes convict the sandbox as STUCK; any other response means the header
- * was substituted (a 400 for the junk body, a real 401 for a genuinely bad key) and the run
- * may proceed. The preflight runs CONCURRENTLY with the rest of acquire (mounts, workspace,
- * session open, ~10s), so a healthy sandbox pays nothing.
+ * bearer. Several consecutive raw-placeholder echoes convict the sandbox as STUCK; any other
+ * response means the header was substituted (a 400 for the junk body, a real 401 for a
+ * genuinely bad key) and the run may proceed. The preflight runs CONCURRENTLY with the rest
+ * of acquire (mounts, workspace, session open, ~10s), so a healthy sandbox pays nothing.
+ *
+ * ONLY A MASKED ECHO CONVICTS, AND THAT DISTINCTION IS THE WHOLE INSTRUMENT. A bare `dtn_`
+ * in the body proves nothing: Daytona's egress proxy also SCRUBS responses, rewriting real
+ * credential values back into `dtn_secret_<id>` before they reach the sandbox. So an endpoint
+ * that echoes the Authorization header verbatim returns the full placeholder shape on a
+ * perfectly HEALTHY sandbox, and convicting on that would destroy both acquire attempts and
+ * fail a first turn whose real model call would have worked. What scrubbing cannot forge is a
+ * MASKED placeholder: a provider masks the key it received (LiteLLM's
+ * "Virtual Key expected. Received=dtn_****", OpenAI's "Incorrect API key provided:
+ * dtn_secr*****"), and a masked string no longer contains the real value for the scrubber to
+ * match — so a masked `dtn_` can only mean the raw placeholder really went out. This is the
+ * same correction that invalidated the first probe run; see the "CORRECTED" section of
+ * `docs/design/daytona-secret-propagation/README.md`. Every incident observed in production
+ * and in the 20-sandbox probe carried a masked echo, so the narrower signature costs no
+ * detection.
  *
  * WHAT A "STUCK" VERDICT DOES. The acquire path destroys the environment and retries ONCE
  * with a brand-new sandbox, because the twin experiment proved a new sandbox on the same
@@ -40,9 +52,10 @@
  * shape — every observed incident). A plaintext-env run has no placeholder; a reconnected
  * sandbox already proved itself.
  *
- * AMBIGUITY FAILS OPEN. A probe that errors or returns nothing judgeable returns "ok" and
- * the run proceeds: the worst outcome is the pre-existing behavior, classified honestly by
- * `classifyRunError`. Only consecutive, unambiguous raw-placeholder echoes convict.
+ * AMBIGUITY FAILS OPEN. A probe that errors, returns nothing judgeable, or returns an
+ * UNMASKED placeholder-shaped echo returns "ok" and the run proceeds: the worst outcome is
+ * the pre-existing behavior, classified honestly by `classifyRunError`. Only consecutive,
+ * unambiguous masked raw-placeholder echoes convict.
  */
 
 export interface PreflightSandbox {
@@ -92,6 +105,24 @@ const DEFAULT_POLL_MS = 2_000;
 const CURL_TIMEOUT_S = 8;
 
 /**
+ * The only echo that proves the raw placeholder went out: one the provider MASKED.
+ *
+ * See the module doc. Daytona's response scrubbing rewrites a real credential back into
+ * `dtn_secret_<id>`, so an unmasked placeholder shape is equally consistent with a HEALTHY
+ * sandbox whose endpoint echoed the working key. Masking defeats the scrubber, because the
+ * masked string no longer contains the real value to match.
+ *
+ * First alternative: a `dtn_` token carrying a mask character, which covers both proven
+ * shapes (LiteLLM's `Received=dtn_****`, OpenAI's `dtn_secr*****`). Second: LiteLLM naming a
+ * `dtn_` key as what it received, which is proof on its own and survives a change of mask
+ * character; it mirrors `PLACEHOLDER_CREDENTIAL` in `errors.ts`. `*` is the only mask
+ * character trusted here — a truncation with `...` or `…` could equally be a cut-off scrubbed
+ * value, and ambiguity fails open.
+ */
+const MASKED_PLACEHOLDER_ECHO =
+  /dtn_[A-Za-z0-9_-]*\*|virtual key expected.*received=\s*dtn_/i;
+
+/**
  * Resolve "ok" when the sandbox's model credential substitutes on the wire (or nothing can be
  * judged — fail open), and "stuck" after enough consecutive raw-placeholder echoes. Never
  * throws.
@@ -134,9 +165,18 @@ export async function awaitCredentialSubstitution(
       return "ok";
     }
     const elapsedMs = now() - startedAt;
-    if (!body || !body.includes("dtn_")) {
-      // Substituted (or the endpoint gave no echo to judge by — fail open either way).
-      if (attempt > 1) {
+    if (!body || !MASKED_PLACEHOLDER_ECHO.test(body)) {
+      // Substituted, or the endpoint gave nothing this preflight can judge by — fail open
+      // either way. An unmasked placeholder shape lands here on purpose: scrubbing produces
+      // it from a healthy key too, so it is not evidence. Log it, because a stuck sandbox
+      // behind an echoing endpoint now passes the preflight and surfaces as the 401 instead.
+      if (body?.includes("dtn_")) {
+        input.log(
+          `[credential-preflight] unmasked placeholder-shaped echo (probe ${attempt}, ` +
+            `+${(elapsedMs / 1000).toFixed(1)}s): scrubbing produces this from a REAL key ` +
+            `too, so it convicts nothing; proceeding`,
+        );
+      } else if (attempt > 1) {
         input.log(
           `[credential-preflight] substitution confirmed after ${attempt} probes ` +
             `(${(elapsedMs / 1000).toFixed(1)}s)`,

--- a/services/runner/src/engines/sandbox_agent/credential-preflight.ts
+++ b/services/runner/src/engines/sandbox_agent/credential-preflight.ts
@@ -25,13 +25,15 @@
  * with a brand-new sandbox, because the twin experiment proved a new sandbox on the same
  * Secret works. The user sees a slower first turn instead of a failed one.
  *
- * THE 30-SECOND GRACE IS DAYTONA'S OWN NUMBER (2026-08-31, their support, confirming our
- * report): "If a retry on the same sandbox starts working within ~30s, you can keep it. If
- * the placeholder is still going out after that, recreate. Retrying or restarting the same
- * one will not help." So the preflight keeps probing to that bound before convicting — our
- * own 20 samples saw nothing land between 3s and 180s, but their bound is authoritative for
- * their system, and the grace runs concurrently with acquire setup so a healthy sandbox
- * still pays nothing.
+ * THE GRACE IS 10 SECONDS, A DELIBERATE CHOICE BELOW DAYTONA'S ~30s BOUND. Their support
+ * (2026-08-31, confirming our report) said a sandbox may still start working within ~30s
+ * and must be recreated after that; "retrying or restarting the same one will not help."
+ * Our own 20 samples saw nothing land between 3s and 180s, every healthy sandbox answered
+ * on its FIRST probe, and their wiring fix is in progress on their side — so we convict at
+ * 10s and rebuild rather than hold every stuck user turn another 20s for a recovery nobody
+ * has observed. Decided by the product owner 2026-08-31; revisit only if a late recovery
+ * ever shows up in the preflight logs (it would log "substitution confirmed after N
+ * probes" with N > 1).
  *
  * SCOPE. Only a freshly created Daytona sandbox whose MODEL credential rides a Daytona
  * Secret and whose connection declares an endpoint base URL (the custom OpenAI-compatible
@@ -84,9 +86,9 @@ export interface CredentialPreflightInput {
   sleep?: (ms: number) => Promise<void>;
 }
 
-/** Daytona's stated keep-or-recreate bound: wiring that has not landed by ~30s never lands. */
-const DEFAULT_BUDGET_MS = 30_000;
-const DEFAULT_POLL_MS = 2_500;
+/** See the module doc: 10s, deliberately below Daytona's ~30s keep-or-recreate bound. */
+const DEFAULT_BUDGET_MS = 10_000;
+const DEFAULT_POLL_MS = 2_000;
 const CURL_TIMEOUT_S = 8;
 
 /**

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -62,6 +62,7 @@ import {
 } from "./daytona.ts";
 import { applyCodexMode, resolveCodexMode } from "./codex-mode.ts";
 import { conciseError } from "./errors.ts";
+import { awaitCredentialSubstitution } from "./credential-preflight.ts";
 import { PI_MODEL_PROVIDER_OVERRIDE_ENV } from "../../extensions/model-provider-override.ts";
 import {
   daytonaCredentialDeliveryPort,
@@ -583,6 +584,28 @@ export async function acquireEnvironment(
     // Track the live handle so a shutdown signal handler can delete it if `destroy` is skipped by
     // a process KILL; removed in `destroy` on every normal exit so it is never double-deleted.
     if (environment.sandbox) inFlightSandboxes.add(environment);
+
+    // CREDENTIAL PREFLIGHT (fresh Daytona sandboxes with an opaque model key and a declared
+    // endpoint). Kicked off HERE, right after the sandbox exists, and awaited at the very end of
+    // acquire, so it runs concurrently with the mounts/workspace/session work below and the
+    // common case pays nothing. See `credential-preflight.ts` for the race it closes.
+    const modelSecretCandidate =
+      plan.credentials.daytonaSecretPlan?.candidates.find(
+        (candidate) => candidate.consumer.kind === "model",
+      );
+    const preflightBaseUrl = request.modelConnection?.endpoint?.baseUrl?.trim();
+    const credentialPreflight =
+      plan.isDaytona &&
+      acquiredSandbox.mode === "create" &&
+      modelSecretCandidate &&
+      preflightBaseUrl
+        ? (deps.awaitCredentialSubstitution ?? awaitCredentialSubstitution)({
+            sandbox: environment.sandbox,
+            baseUrl: preflightBaseUrl,
+            apiKeyVar: modelSecretCandidate.binding.name,
+            log: logger,
+          })
+        : undefined;
 
     // On Daytona, push the harness login, the extension, and AGENTS.md into the remote sandbox.
     // For a non-Pi harness with executable tools, also push the in-sandbox stdio MCP shim
@@ -1112,6 +1135,12 @@ export async function acquireEnvironment(
     environment.session.onPermissionRequest((req: any) =>
       routePermissionRequestToActiveTurn(environment, req),
     );
+
+    if (credentialPreflight) {
+      const preflightAwaitStartedAt = Date.now();
+      await credentialPreflight;
+      timingLog("credential_preflight", preflightAwaitStartedAt);
+    }
 
     timingLog("acquire_total", acquireStartedAt);
     emit?.({

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -62,7 +62,11 @@ import {
 } from "./daytona.ts";
 import { applyCodexMode, resolveCodexMode } from "./codex-mode.ts";
 import { conciseError } from "./errors.ts";
-import { awaitCredentialSubstitution } from "./credential-preflight.ts";
+import {
+  awaitCredentialSubstitution,
+  STUCK_ACQUIRE_ATTEMPTS,
+  SubstitutionStuckError,
+} from "./credential-preflight.ts";
 import { PI_MODEL_PROVIDER_OVERRIDE_ENV } from "../../extensions/model-provider-override.ts";
 import {
   daytonaCredentialDeliveryPort,
@@ -295,6 +299,39 @@ export async function resolveKeepaliveMount(
  * skipped so the mount is signed once per run.
  */
 export async function acquireEnvironment(
+  request: AgentRunRequest,
+  deps: SandboxAgentDeps = {},
+  signal?: AbortSignal,
+  presignedMount?: MountCredentials | null,
+  emit?: EmitEvent,
+): Promise<AcquireEnvironmentResult> {
+  // A sandbox the preflight convicts as stuck (no Secret substitution wiring, a permanent
+  // per-sandbox fault) is already destroyed by the failure path; a FRESH sandbox on the same
+  // Secret works, so one retry converts a would-be failed first turn into a slower one.
+  for (let attempt = 1; ; attempt++) {
+    const result = await acquireEnvironmentOnce(
+      request,
+      deps,
+      signal,
+      presignedMount,
+      emit,
+    );
+    if (
+      result.ok ||
+      !result.stuckSubstitution ||
+      attempt >= STUCK_ACQUIRE_ATTEMPTS ||
+      signal?.aborted
+    ) {
+      return result;
+    }
+    process.stderr.write(
+      `[sandbox-agent] stuck-substitution sandbox destroyed; rebuilding fresh ` +
+        `(attempt ${attempt + 1}/${STUCK_ACQUIRE_ATTEMPTS})\n`,
+    );
+  }
+}
+
+async function acquireEnvironmentOnce(
   request: AgentRunRequest,
   deps: SandboxAgentDeps = {},
   signal?: AbortSignal,
@@ -1138,8 +1175,11 @@ export async function acquireEnvironment(
 
     if (credentialPreflight) {
       const preflightAwaitStartedAt = Date.now();
-      await credentialPreflight;
+      const verdict = await credentialPreflight;
       timingLog("credential_preflight", preflightAwaitStartedAt);
+      // Throwing takes the shared teardown below (sandbox destroyed, Secrets deleted), and the
+      // catch marks the result so the acquire wrapper retries once with a fresh sandbox.
+      if (verdict === "stuck") throw new SubstitutionStuckError();
     }
 
     timingLog("acquire_total", acquireStartedAt);
@@ -1160,6 +1200,9 @@ export async function acquireEnvironment(
     // Mirror today's shared teardown: no otel exists yet during acquire, so there is no partial
     // trace to flush — just run the incrementally-registered finalizers and surface the error.
     await environment.destroy({ reason: "failed-turn" });
+    if (err instanceof SubstitutionStuckError) {
+      return { ok: false, error, stuckSubstitution: true };
+    }
     return { ok: false, error };
   }
 }

--- a/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
@@ -390,4 +390,14 @@ export interface SessionEnvironment {
 
 export type AcquireEnvironmentResult =
   | { ok: true; env: SessionEnvironment }
-  | { ok: false; error: string };
+  | {
+      ok: false;
+      error: string;
+      /**
+       * The preflight proved this sandbox never got its Secret substitution wiring (the fault
+       * is binary per sandbox and permanent — see credential-preflight.ts). The environment is
+       * already destroyed; the acquire wrapper retries once with a fresh sandbox, because a new
+       * sandbox on the same Secret works.
+       */
+      stuckSubstitution?: boolean;
+    };

--- a/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
@@ -19,6 +19,7 @@ import { createAcpFetch } from "./acp-fetch.ts";
 import { type ParkedApprovalGateType } from "./acp-interactions.ts";
 import { signAgentMountCredentials } from "./agent-mount.ts";
 import { probeCapabilities } from "./capabilities.ts";
+import { awaitCredentialSubstitution } from "./credential-preflight.ts";
 import { createToolCallCorrelationIndex } from "./client-tools.ts";
 import { buildDaemonEnv, resolveDaemonBinary } from "./daemon.ts";
 import { createCookieFetch, prepareDaytonaPiAssets } from "./daytona.ts";
@@ -65,6 +66,7 @@ export interface SandboxAgentDeps extends BuildRunPlanDeps {
   prepareDaytonaPiAssets?: typeof prepareDaytonaPiAssets;
   uploadToolMcpAssets?: typeof uploadToolMcpAssets;
   probeCapabilities?: typeof probeCapabilities;
+  awaitCredentialSubstitution?: typeof awaitCredentialSubstitution;
   applyModel?: typeof applyModel;
   applyCodexMode?: typeof applyCodexMode;
   startToolRelay?: typeof startToolRelay;

--- a/services/runner/src/environment/timing.ts
+++ b/services/runner/src/environment/timing.ts
@@ -38,6 +38,7 @@ export const ACQUIRE_STAGES = [
   "prepare_workspace",
   "probe_capabilities",
   "create_session",
+  "credential_preflight",
   "acquire_total",
 ] as const;
 

--- a/services/runner/tests/unit/credential-preflight.test.ts
+++ b/services/runner/tests/unit/credential-preflight.test.ts
@@ -77,19 +77,21 @@ describe("awaitCredentialSubstitution", () => {
     assert.match(logs[2], /substitution confirmed after 3 probes/);
   });
 
-  it("convicts the sandbox as STUCK after consecutive raw echoes", async () => {
-    // The fault is binary and permanent per sandbox (2026-08-30 measurement), so the verdict
-    // is "stuck", never a fail-open wait: only a fresh sandbox can serve the run.
+  it("convicts the sandbox as STUCK once Daytona's 30s bound is spent", async () => {
+    // Daytona's own guidance (2026-08-31): a sandbox still sending the placeholder after
+    // ~30s never recovers; recreate it. The verdict is "stuck", never a fail-open pass.
     const { run, logs, commands } = harness(["Received=dtn_****9maz"]);
     assert.equal(await run, "stuck");
-    assert.equal(commands.length, 4, "four consecutive raw echoes convict");
-    assert.match(
-      logs[logs.length - 1],
-      /STUCK: raw placeholder on all 4 probes/,
+    // Probes every 2s of fake clock against the 30s default: the conviction consumes the
+    // full grace rather than firing on a fixed probe count.
+    assert.ok(
+      commands.length >= 12,
+      `expected >=12 probes, got ${commands.length}`,
     );
+    assert.match(logs[logs.length - 1], /STUCK: raw placeholder on all/);
   });
 
-  it("convicts early when the budget runs out first", async () => {
+  it("convicts sooner when the caller passes a smaller budget", async () => {
     const { run, logs } = harness(["Received=dtn_****9maz"], 3_000);
     assert.equal(await run, "stuck");
     assert.match(logs[logs.length - 1], /STUCK/);

--- a/services/runner/tests/unit/credential-preflight.test.ts
+++ b/services/runner/tests/unit/credential-preflight.test.ts
@@ -77,16 +77,15 @@ describe("awaitCredentialSubstitution", () => {
     assert.match(logs[2], /substitution confirmed after 3 probes/);
   });
 
-  it("convicts the sandbox as STUCK once Daytona's 30s bound is spent", async () => {
-    // Daytona's own guidance (2026-08-31): a sandbox still sending the placeholder after
-    // ~30s never recovers; recreate it. The verdict is "stuck", never a fail-open pass.
+  it("convicts the sandbox as STUCK once the 10s grace is spent", async () => {
+    // The grace is deliberately below Daytona's ~30s bound (see the module doc): every
+    // healthy sandbox we measured answered on its first probe, so waiting longer only
+    // holds a stuck user turn. The verdict is "stuck", never a fail-open pass.
     const { run, logs, commands } = harness(["Received=dtn_****9maz"]);
     assert.equal(await run, "stuck");
-    // Probes every 2s of fake clock against the 30s default: the conviction consumes the
-    // full grace rather than firing on a fixed probe count.
     assert.ok(
-      commands.length >= 12,
-      `expected >=12 probes, got ${commands.length}`,
+      commands.length >= 4,
+      `expected >=4 probes inside the 10s grace, got ${commands.length}`,
     );
     assert.match(logs[logs.length - 1], /STUCK: raw placeholder on all/);
   });

--- a/services/runner/tests/unit/credential-preflight.test.ts
+++ b/services/runner/tests/unit/credential-preflight.test.ts
@@ -52,11 +52,11 @@ function harness(bodies: (string | Error)[], budgetMs = 25_000) {
 }
 
 describe("awaitCredentialSubstitution", () => {
-  it("returns immediately when the first probe substitutes", async () => {
+  it("returns ok immediately when the first probe substitutes", async () => {
     const { run, logs, commands } = harness([
       '{"error":{"message":"you must provide a model parameter"}}',
     ]);
-    await run;
+    assert.equal(await run, "ok");
     assert.equal(commands.length, 1);
     assert.deepEqual(logs, []);
     // The probe expands the env var in the sandbox shell; the raw value never appears here,
@@ -65,38 +65,46 @@ describe("awaitCredentialSubstitution", () => {
     assert.match(commands[0], /https:\/\/gateway\.example\/chat\/completions/);
   });
 
-  it("waits out a raw placeholder echo and confirms once substitution lands", async () => {
+  it("tolerates early raw echoes and returns ok once substitution shows", async () => {
     const { run, logs, commands } = harness([
       "LiteLLM Virtual Key expected. Received=dtn_****9maz",
       '{"error":{"message":"Received=dtn_****9maz"}}',
       '{"error":{"message":"you must provide a model parameter"}}',
     ]);
-    await run;
+    assert.equal(await run, "ok");
     assert.equal(commands.length, 3);
     assert.match(logs[0], /raw placeholder echoed \(probe 1/);
     assert.match(logs[2], /substitution confirmed after 3 probes/);
   });
 
-  it("gives up fail-open when the budget is spent", async () => {
-    const { run, logs, commands } = harness(
-      ["Received=dtn_****9maz"],
-      6_000, // budget covers probes at t=0, 2s, 4s; the next poll would pass it
+  it("convicts the sandbox as STUCK after consecutive raw echoes", async () => {
+    // The fault is binary and permanent per sandbox (2026-08-30 measurement), so the verdict
+    // is "stuck", never a fail-open wait: only a fresh sandbox can serve the run.
+    const { run, logs, commands } = harness(["Received=dtn_****9maz"]);
+    assert.equal(await run, "stuck");
+    assert.equal(commands.length, 4, "four consecutive raw echoes convict");
+    assert.match(
+      logs[logs.length - 1],
+      /STUCK: raw placeholder on all 4 probes/,
     );
-    await run;
-    assert.ok(commands.length >= 2);
-    assert.match(logs[logs.length - 1], /proceeding fail-open/);
   });
 
-  it("fails open when the exec channel itself errors", async () => {
+  it("convicts early when the budget runs out first", async () => {
+    const { run, logs } = harness(["Received=dtn_****9maz"], 3_000);
+    assert.equal(await run, "stuck");
+    assert.match(logs[logs.length - 1], /STUCK/);
+  });
+
+  it("fails open (ok) when the exec channel itself errors", async () => {
     const { run, logs, commands } = harness([new Error("daemon gone")]);
-    await run;
+    assert.equal(await run, "ok");
     assert.equal(commands.length, 1);
     assert.match(logs[0], /probe errored, proceeding: daemon gone/);
   });
 
   it("treats an empty body as substituted (nothing to judge by)", async () => {
     const { run, logs } = harness([""]);
-    await run;
+    assert.equal(await run, "ok");
     assert.deepEqual(logs, []);
   });
 });

--- a/services/runner/tests/unit/credential-preflight.test.ts
+++ b/services/runner/tests/unit/credential-preflight.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Unit tests for the Daytona credential-substitution preflight.
+ *
+ * Run: pnpm exec vitest run tests/unit/credential-preflight.test.ts
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  awaitCredentialSubstitution,
+  type PreflightSandbox,
+} from "../../src/engines/sandbox_agent/credential-preflight.ts";
+
+/** A sandbox whose probe responses play back in order (the last repeats forever). */
+function sandboxAnswering(bodies: (string | Error)[]): {
+  sandbox: PreflightSandbox;
+  commands: string[];
+} {
+  const commands: string[] = [];
+  let index = 0;
+  return {
+    commands,
+    sandbox: {
+      async runProcess(request) {
+        commands.push(request.args?.[1] ?? request.command);
+        const body = bodies[Math.min(index, bodies.length - 1)];
+        index += 1;
+        if (body instanceof Error) throw body;
+        return { exitCode: 0, stdout: body };
+      },
+    },
+  };
+}
+
+function harness(bodies: (string | Error)[], budgetMs = 25_000) {
+  const { sandbox, commands } = sandboxAnswering(bodies);
+  const logs: string[] = [];
+  let clock = 0;
+  const run = awaitCredentialSubstitution({
+    sandbox,
+    baseUrl: "https://gateway.example/",
+    apiKeyVar: "OPENAI_API_KEY",
+    log: (m) => logs.push(m),
+    budgetMs,
+    pollMs: 2_000,
+    now: () => clock,
+    sleep: async (ms) => {
+      clock += ms;
+    },
+  });
+  return { run, logs, commands };
+}
+
+describe("awaitCredentialSubstitution", () => {
+  it("returns immediately when the first probe substitutes", async () => {
+    const { run, logs, commands } = harness([
+      '{"error":{"message":"you must provide a model parameter"}}',
+    ]);
+    await run;
+    assert.equal(commands.length, 1);
+    assert.deepEqual(logs, []);
+    // The probe expands the env var in the sandbox shell; the raw value never appears here,
+    // and the endpoint is the connection's own chat path.
+    assert.match(commands[0], /Bearer \$OPENAI_API_KEY/);
+    assert.match(commands[0], /https:\/\/gateway\.example\/chat\/completions/);
+  });
+
+  it("waits out a raw placeholder echo and confirms once substitution lands", async () => {
+    const { run, logs, commands } = harness([
+      "LiteLLM Virtual Key expected. Received=dtn_****9maz",
+      '{"error":{"message":"Received=dtn_****9maz"}}',
+      '{"error":{"message":"you must provide a model parameter"}}',
+    ]);
+    await run;
+    assert.equal(commands.length, 3);
+    assert.match(logs[0], /raw placeholder echoed \(probe 1/);
+    assert.match(logs[2], /substitution confirmed after 3 probes/);
+  });
+
+  it("gives up fail-open when the budget is spent", async () => {
+    const { run, logs, commands } = harness(
+      ["Received=dtn_****9maz"],
+      6_000, // budget covers probes at t=0, 2s, 4s; the next poll would pass it
+    );
+    await run;
+    assert.ok(commands.length >= 2);
+    assert.match(logs[logs.length - 1], /proceeding fail-open/);
+  });
+
+  it("fails open when the exec channel itself errors", async () => {
+    const { run, logs, commands } = harness([new Error("daemon gone")]);
+    await run;
+    assert.equal(commands.length, 1);
+    assert.match(logs[0], /probe errored, proceeding: daemon gone/);
+  });
+
+  it("treats an empty body as substituted (nothing to judge by)", async () => {
+    const { run, logs } = harness([""]);
+    await run;
+    assert.deepEqual(logs, []);
+  });
+});

--- a/services/runner/tests/unit/credential-preflight.test.ts
+++ b/services/runner/tests/unit/credential-preflight.test.ts
@@ -108,4 +108,33 @@ describe("awaitCredentialSubstitution", () => {
     assert.equal(await run, "ok");
     assert.deepEqual(logs, []);
   });
+
+  it("fails open when a HEALTHY echoed key was scrubbed into a full placeholder", async () => {
+    // Daytona's egress proxy rewrites real credential values in responses back into
+    // `dtn_secret_<id>`. An endpoint that echoes the Authorization header therefore returns
+    // this body on a perfectly healthy sandbox. Convicting on it destroyed both acquire
+    // attempts and failed a first turn whose real model call would have worked.
+    // The id is spelled in the message rather than as a `key` field so the secret scanner
+    // does not read this placeholder — the very thing that exists so no real key is here —
+    // as a leaked credential.
+    const { run, logs, commands } = harness([
+      '{"error":{"message":"unauthorized bearer dtn_secret_01j9maz7q0"}}',
+    ]);
+    assert.equal(await run, "ok");
+    assert.equal(commands.length, 1, "an unmasked echo must not be re-probed");
+    assert.match(logs[0], /unmasked placeholder-shaped echo/);
+  });
+
+  it("convicts on a masked echo, whatever the provider's mask shape", async () => {
+    // Masking is what scrubbing cannot forge: the masked string no longer holds the real
+    // value for the scrubber to match, so `dtn_` beside a mask means the raw placeholder
+    // really went out. Both proven provider shapes must convict.
+    for (const masked of [
+      "LiteLLM Virtual Key expected. Received=dtn_****9maz",
+      '{"error":{"message":"Incorrect API key provided: dtn_secr*****9maz"}}',
+    ]) {
+      const { run } = harness([masked], 3_000);
+      assert.equal(await run, "stuck", masked);
+    }
+  });
 });


### PR DESCRIPTION
## Context

The placeholder-401 fault (#6362), now fully reproduced (2026-08-30, 20 fresh-Secret samples, production create shape, target eu): Daytona's Secret substitution is **binary per sandbox**. A healthy sandbox substitutes on its very first request, 1.5 to 2.9 seconds after Secret creation. A stuck sandbox never substitutes: the raw `dtn_secret_` placeholder reaches the provider for as long as anyone watches, a twin sandbox created against the same Secret works immediately, and stop+start does not repair it. Measured 5 stuck of 20 that day; the earlier production window showed ~3%, so the rate varies. The delete-then-create eviction ordering is not a factor.

Two instrument facts worth keeping: Daytona also **scrubs responses** (real values are rewritten back to placeholders before entering the sandbox), so an echo service cannot observe substitution; a provider whose error body echoes a masked key can. And a raw-placeholder echo stays visible, which is what this preflight reads.

## Changes

On a freshly created Daytona sandbox whose model key rides a Secret and whose connection declares an endpoint base URL, the runner probes the credential's own `/chat/completions` from inside the sandbox, concurrently with the rest of acquire.

Before (the first version of this PR): wait up to 25 seconds for substitution, then proceed regardless. Both halves were wrong for a binary fault: the wait can never help, and proceeding sends the turn into a guaranteed 401.

After: the preflight returns a verdict. The first non-placeholder echo (or anything ambiguous, which still fails open) is `ok`. A raw placeholder still echoing at the 10 second grace convicts the sandbox as `stuck` (deliberately below Daytona's ~30s keep-or-recreate bound: every healthy sandbox we measured answered on its first probe, their wiring fix is in progress, and a longer grace only holds a stuck user's turn); the acquire's shared teardown destroys it and deletes its Secrets, and the acquire wrapper retries **once** with a brand-new sandbox, which their support confirms is the correct recovery (restart never helps; a new sandbox on the same Secret does). At a 25% stuck rate, one retry turns a failed first turn into a slower one, leaving ~6% for the honest `credential_delivery_failed` error. Their side has a priority fix PR in progress; this guard stays as the belt afterwards.

## Tests

- Preflight unit suite: first-probe ok, tolerated early raws then ok, 4-raw conviction, budget conviction, exec-error fail-open, empty-body fail-open. Full runner suite green (157 files / 2580 tests), typecheck clean.
- Live verification: after deploy, the runner log shows `[credential-preflight] STUCK ... rebuilding fresh` where placeholder 401s used to be, and the LiteLLM proxy log's `Received=dtn_` count trends to the ~6% residual of the varying stuck rate.

The reproduction record lives in `docs/design/daytona-secret-propagation/README.md` (stacked below, #6369).

Stacked on #6369.

https://claude.ai/code/session_014s6jqKCsVKsNMmnrJVJkZt


