### PR TITLE
[test] Gate blocks when a model switch loses the warm sandbox

### DIFF
--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -344,10 +344,13 @@ ever reaches the stream. An empty ledger FAILS a cell; missing evidence is not e
 
 - `resources/matrix_l1_lifecycle_routes.py` — **MANDATORY. [mechanism-blind]** the routing matrix
   itself: for each kind of mid-conversation config change, assert the route the runner took. One
-  sandbox id = applied in place, two = rebuilt. Blocks on the four unambiguous cases (no change
-  must stay warm; an instructions edit, a permissions edit and a tool-catalog edit must escalate)
-  and reports the `model` case rather than guessing at a deployment's connection shape. This is
-  the cell that would have caught the `cold1` rot described below.
+  sandbox id = applied in place, two = rebuilt. Blocks on six cases: no change must stay warm; an
+  instructions edit, a permissions edit and a tool-catalog edit must escalate; and a
+  same-connection model switch must stay warm on BOTH claude and pi_core. The pi_core model case
+  (added 2026-08-29) is the standing trap for the wire-spelling bug class: the router once keyed
+  its table on the bare "pi" literal while the wire carries "pi_core", every playground model
+  switch silently rebuilt, and the claude-only case could not see it (#6364). This is the cell
+  that would have caught the `cold1` rot described below.
 - `resources/matrix_l2_approval_across_config_change.py` — **MANDATORY. [coached]** the killer
   combination: an approval answered while a config change rides along in the SAME request. It is
   the regression test for the applied-state bug (the pool used to stamp the INCOMING fingerprint

--- a/.agents/skills/agent-release-gate/resources/LESSONS.md
+++ b/.agents/skills/agent-release-gate/resources/LESSONS.md
@@ -228,6 +228,22 @@ around — `CODEX_SQLITE_HOME` is split onto container-local disk) and hard link
   the API reads S3 directly, so a hit is store-side proof, and the same listing shows any 0-byte
   objects — the fingerprint of this whole bug class.
 
+## Two Daytona-era traps for the lifecycle (L*) cases — 2026-08-31
+
+**Fixture connections must be vault-backed.** A fixture built by copying the Claude defaults and
+changing only the harness keeps `llm.connection = {"mode":"self_managed","slug":null}`. A
+self_managed Pi run needs the `PI_CODING_AGENT_DIR` mount, which a gate deployment does not have,
+so turn 1 errors and the case fails before it tests anything. Set
+`llm.connection = {"mode":"agenta","slug":null}` on every non-default-harness fixture (caught on
+#6371; the Pi fixtures in `matrix_l5_live_route_observed.py` and `bench_lib.py` already do this).
+
+**A stuck-substitution rebuild is not an eviction.** Since the credential preflight (#6370), a
+fresh Daytona sandbox whose Secret wiring failed (a vendor-side per-sandbox fault, a few percent
+of creates) is convicted at ~10s and rebuilt ONCE. A warm-reuse case that counts sandbox ids can
+therefore see two ids without any lifecycle regression. Before ruling a warm case failed, grep
+the runner log for `[credential-preflight] STUCK`: if it fired inside the run, re-run the case
+instead of reporting the eviction.
+
 ## The checklist for the next QA run
 
 1. `docker ps` — is anything restarting? If yes, wait.

--- a/.agents/skills/agent-release-gate/resources/matrix_l1_lifecycle_routes.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l1_lifecycle_routes.py
@@ -48,11 +48,14 @@ sandbox survived" is worth nothing unless the running harness actually OBSERVED 
 `matrix_l5_live_route_observed.py` for the other half; a green here plus a red there means the
 runner is keeping a sandbox that is quietly running the old configuration.
 
-THE `model` CASE IS EVIDENCE-ONLY, ON PURPOSE. Changing the model id should move the `model`
-facet alone (apply-live, warm), but if a deployment's connection shape is keyed off the model
-then the `runtime` facet moves too and the plan escalates -- correctly. Rather than encode a
-guess as a blocker, this cell REPORTS the observed route for `model` and blocks only on the four
-cases whose routing is unambiguous in the capability table.
+THE `model` CASES ARE BLOCKING, AND THERE ARE TWO OF THEM. A same-connection model switch moves
+the `model` facet alone (apply-live, warm): an alias switch on claude, and a fully-qualified id
+switch on pi_core. The pi_core variant exists because of a caught bug class: the router once
+keyed its capability table on the bare literal "pi" while the wire carries "pi_core", so every
+playground Pi run fell into the fail-closed all-rebuild row, the live model route never fired,
+and a claude-only cell could not see it (#6364). If this case goes red on a facet OTHER than
+`model` moving (the shadow line names it), that red is the discovery mechanism working: it names
+the next over-eviction to remove, not a reason to demote the case.
 
   uv run matrix_l1_lifecycle_routes.py
 """
@@ -65,6 +68,8 @@ import uuid
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 from qa_matrix_lib import (  # noqa: E402
     LIVE_TOOLS,
+    PI_CORE_HAIKU_MODEL,
+    PI_CORE_HARNESS_KIND,
     agent_config,
     archive,
     create_workflow,
@@ -117,10 +122,22 @@ CASES = [
     (
         "model",
         1,
-        False,
-        "the `model` facet is the other live route (setModel on the running session), but a "
-        "deployment whose connection shape is keyed off the model moves `runtime` too and "
-        "correctly escalates -- reported, not blocking",
+        True,
+        "the `model` facet is the other live route (setModel on the running session). An "
+        "alias-to-alias switch on the same self_managed anthropic connection moves no other "
+        "facet (the connection shape and the resolved modalities are identical), so a rebuild "
+        "here means the live route is broken",
+    ),
+    (
+        "model_pi_core",
+        1,
+        True,
+        "the SAME model-switch assertion on the pi_core harness. This is the standing trap for "
+        "the wire-spelling class of bug: the lifecycle router once keyed its capability table "
+        "on the bare literal 'pi' while the wire carries 'pi_core', so every playground Pi run "
+        "fell into the fail-closed all-rebuild row and every model switch threw the warm "
+        "sandbox away (fixed in #6364) -- and the claude-only model case above could not see "
+        "it. A same-provider id switch moves only the `model` facet",
     ),
 ]
 
@@ -150,6 +167,10 @@ def mutate(case: str, params: dict) -> dict:
         return p
     if case == "model":
         agent["llm"]["model"] = "sonnet"
+        return p
+    if case == "model_pi_core":
+        # Same provider, same connection, a different fully qualified id: only `model` moves.
+        agent["llm"]["model"] = "claude-sonnet-5"
         return p
     raise ValueError(f"unknown case {case}")
 
@@ -186,11 +207,22 @@ def l1():
         cfg = agent_config(instructions=BASELINE)
         rev_id, _ = seed_and_baseline(wf, var, cfg, hexid)
         base_params = {"agent": {**cfg, "tools": LIVE_TOOLS}}
+        # The pi_core variant of the model case runs the whole session on pi_core with a fully
+        # qualified id (the harness rejects bare aliases; see the module notes in qa_matrix_lib).
+        pi_base_params = json.loads(json.dumps(base_params))
+        pi_base_params["agent"]["harness"] = {"kind": PI_CORE_HARNESS_KIND}
+        pi_base_params["agent"]["llm"]["model"] = PI_CORE_HAIKU_MODEL
 
         results = []
         blocking_failures = []
         for case, expected, blocking, why in CASES:
-            r = run_case(case, wf, var, rev_id, base_params)
+            r = run_case(
+                case,
+                wf,
+                var,
+                rev_id,
+                pi_base_params if case == "model_pi_core" else base_params,
+            )
             r["expected_sandboxes"] = expected
             r["blocking"] = blocking
             r["rationale"] = why

--- a/.agents/skills/agent-release-gate/resources/matrix_l1_lifecycle_routes.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_l1_lifecycle_routes.py
@@ -212,6 +212,14 @@ def l1():
         pi_base_params = json.loads(json.dumps(base_params))
         pi_base_params["agent"]["harness"] = {"kind": PI_CORE_HARNESS_KIND}
         pi_base_params["agent"]["llm"]["model"] = PI_CORE_HAIKU_MODEL
+        # Vault-backed auth, not the inherited self_managed default: a self_managed Pi run
+        # needs a PI_CODING_AGENT_DIR mount, which a gate deployment does not have, and turn 1
+        # would then fail before this case tests any lifecycle routing. Matches the Pi
+        # fixtures in matrix_l5_live_route_observed.py and bench_lib.py.
+        pi_base_params["agent"]["llm"]["connection"] = {
+            "mode": "agenta",
+            "slug": None,
+        }
 
         results = []
         blocking_failures = []


### PR DESCRIPTION
## Context

This week's lifecycle bug (#6364) was visible to the release gate and the gate stayed green. L1's `model` case actually observed the wrong route, but it was evidence-only (not blocking) and it ran only on the claude harness, while the bug hit only `pi_core`: the router keyed its capability table on the bare `pi` literal, the wire carries `pi_core`, and every playground model switch silently rebuilt the warm sandbox.

Per our standing rule, a missed bug births a standing check.

## Changes

Two changes to `matrix_l1_lifecycle_routes.py`:

- The `model` case becomes **blocking**. An alias-to-alias switch on the same self_managed anthropic connection moves only the `model` facet, so a rebuild there is a broken live route, not a deployment quirk.
- A second blocking variant, `model_pi_core`, runs the whole session on `pi_core` with a fully qualified same-provider id switch (`claude-haiku-4-5` to `claude-sonnet-5`). This is the exact shape the bug class hides in: per-harness routing keyed off wire spellings.

If the pi_core case ever goes red because a facet other than `model` moved, the shadow log line names the facet, and that red is the discovery mechanism working: it names the next over-eviction to remove. The docstring says so, so nobody demotes the case to make the gate green.

## Tests

This IS the test; it runs against a live deployment as part of the gate matrix (`uv run matrix_l1_lifecycle_routes.py`). It has not been run against a deployment carrying #6364 yet; the first gate run after that lands is the verification, and the case is expected red against any deployment without #6364.

https://claude.ai/code/session_014s6jqKCsVKsNMmnrJVJkZt
