### PR TITLE
[fix] A live-route repair no longer clears every other eviction check

### DIFF
--- a/docs/design/lifecycle-cold-warm-audit/README.md
+++ b/docs/design/lifecycle-cold-warm-audit/README.md
@@ -17,6 +17,13 @@ harness.
    checks (all four proven warm with the probe). Fixed by re-asking the ordered checks
    after each repair; four pinned tests.
 
+   Review found a second half of the same finding: re-asking returned the FIRST unresolved
+   reason, and that reason alone chose the teardown. `history` sorts ahead of the credential
+   checks, so a model switch carrying both an edited transcript and an undeliverable
+   rotation evicted as `history`, mapped to `continuity-invalid`, and PARKED a sandbox whose
+   daemon still held the old key. The eviction is now NAMED by the first reason and DISPOSED
+   by all of them, strictest wins; pinned with the three-way combination.
+
 2. **`modelCapabilities` defeats the live model route across modality changes.** It is
    per-turn data (read only by the attachment-delivery chain) but sits in the fingerprint
    and the `harnessSession` facet, and it CHANGES WITH THE MODEL (resolved input

--- a/docs/design/lifecycle-cold-warm-audit/README.md
+++ b/docs/design/lifecycle-cold-warm-audit/README.md
@@ -1,0 +1,66 @@
+# Cold/warm lifecycle audit — 2026-08-29
+
+A fresh-context audit of the session lifecycle code, commissioned after the harnessKind
+wire-spelling bug (#6364) to find more of its class. Method: read
+`reconciliation-router.ts`, `desired-state.ts`, `session-coordinator.ts`,
+`session-identity.ts`, `session-pool.ts`, `engine.ts`, `run-plan.ts` and their tests;
+cross-check every wire literal against `protocol.ts` and the Python SDK; confirm each
+behavioral claim with a throwaway probe built on the `lifecycle-live-routes.test.ts`
+harness.
+
+## Findings, most severe first
+
+1. **FIXED (#6372). The live route cleared every mismatch reason.** The coordinator's
+   else-if chain found only the FIRST reason, and a successful live model apply set
+   `mismatch = undefined` wholesale. A model switch riding an edited transcript, a rotated
+   credential, an expiring mount lease, or a stale tail continued warm past the skipped
+   checks (all four proven warm with the probe). Fixed by re-asking the ordered checks
+   after each repair; four pinned tests.
+
+2. **`modelCapabilities` defeats the live model route across modality changes.** It is
+   per-turn data (read only by the attachment-delivery chain) but sits in the fingerprint
+   and the `harnessSession` facet, and it CHANGES WITH THE MODEL (resolved input
+   modalities). Switching between a vision model and a text-only model moves two facets,
+   the mixed plan rebuilds, and the one live route works only when the two models agree on
+   modalities. Fix: move it to the per-turn-volatile list (the `workflowRevision` /
+   `isDraft` precedent), pinned in `lifecycle-desired-state.test.ts`.
+
+3. **`harnessMode` is normalized in the fingerprint but raw in the facet.** The two views
+   can disagree (measured: fingerprint equal while `harnessSession` moves), which poisons
+   later plans into rebuilding. Reachable today only through a direct runner caller.
+   Fix: normalize in one place; add the reverse-direction "no input drift" assertion (a
+   change that moves a facet must move the fingerprint).
+
+4. **The agent-mount artifact id is in no fingerprint and no facet (under-eviction).**
+   `runContext.workflow.artifact.id` signs the agent mount, sets its env var, and appends
+   its guidance — all baked at acquire — yet a changed or newly present id reuses the warm
+   sandbox (measured). Fix: add the id alone to the `sandbox` facet + fingerprint, with an
+   eviction test.
+
+5. **`toolCallback.endpoint` is fingerprinted but consumed per-turn (over-eviction).** Low
+   reachability (stable per-deployment URL); same fix class as 2.
+
+6. **`configFingerprint` matches `codex` on a bare wire literal inline.** Correct today,
+   but the exact shape of the #6364 bug (a literal plus a silent fall-through). Fix:
+   one exported harness normalizer used by `configFingerprint`, `run-plan.ts`, and
+   `reconciliation-router.ts`, with a round-trip test over the SDK enum.
+
+7. **`applyReconcilePlan` treats every `apply-live` action as a model change** (ignores
+   `action.facet`). Unreachable today; becomes real the moment the credential plan routes
+   through the applier. Fix: switch on the facet, refuse the rest, one test.
+
+8. **`connection` `{mode, slug}` evicts on every harness but only Pi consumes it.** Very
+   low reachability; listed for completeness.
+
+Verified clean: the harness wire spellings after #6364 (both normalizers agree, with a
+plan-build assertion), and the shadow-router's decision scoping.
+
+## Standing checks born from this
+
+- Gate: L1's model case is blocking on claude AND pi_core (#6371).
+- New Relic: alert policy "Runner lifecycle audit" (policy 1731651) pages the operator
+  Slack webhook on any `DISAGREE` or `harness=unknown` runner log line.
+- Unit: the repair-scoping pinned tests in `lifecycle-live-routes.test.ts` (#6372).
+
+Findings 2-8 are queued work; each names its cheapest check above so the fix and the pin
+land together.

--- a/services/runner/src/lifecycle/session-coordinator.ts
+++ b/services/runner/src/lifecycle/session-coordinator.ts
@@ -905,22 +905,42 @@ export async function runWithKeepalive(
     // Comparing anyway evicts the warm session on every turn of every conversation. The session
     // id already binds the request to this conversation; the client simply no longer asserts it.
     const clientAssertsHistory = !carriesMinimalHistory(request);
-    let mismatch: string | undefined;
-    if (cfgFp !== existing.configFingerprint) mismatch = "config";
-    else if (clientAssertsHistory && priorFp !== existing.historyFingerprint)
-      mismatch = "history";
-    else if (credMismatch) mismatch = credMismatch;
-    else if (
-      // Still-valid credentials that cannot cover a worst-case turn are expiring, not expired:
-      // rebuild at the boundary rather than let the turn die under the mount.
-      mountCredentialsExpireBy(existing.credentialEpoch, requiredValidThroughMs)
-    )
-      mismatch = "credentials-expiring";
-    else if (!tailIsFreshUserMessage(request)) mismatch = "tail";
+    /**
+     * EVERY reason is re-evaluated after a repair, not only the first one found.
+     *
+     * The old shape was an else-if chain feeding the two repair doors below, and a successful
+     * repair set `mismatch = undefined`. That cleared the answer to EVERY question when the
+     * repair had answered exactly one: a model switch riding with an edited transcript took the
+     * live route and then continued warm on a native conversation that still held the unedited
+     * turn; paired with a rotated credential it ran on the old baked key; paired with an
+     * expiring mount lease it let the turn die under the mount. So a repair marks ITS reason
+     * repaired and asks again, and the remaining checks keep their order and their comments.
+     */
+    const repaired = new Set<string>();
+    const firstMismatch = (): string | undefined => {
+      if (!repaired.has("config") && cfgFp !== existing.configFingerprint)
+        return "config";
+      if (clientAssertsHistory && priorFp !== existing.historyFingerprint)
+        return "history";
+      if (credMismatch && !repaired.has(credMismatch)) return credMismatch;
+      if (
+        // Still-valid credentials that cannot cover a worst-case turn are expiring, not expired:
+        // rebuild at the boundary rather than let the turn die under the mount.
+        mountCredentialsExpireBy(
+          existing.credentialEpoch,
+          requiredValidThroughMs,
+        )
+      )
+        return "credentials-expiring";
+      if (!tailIsFreshUserMessage(request)) return "tail";
+      return undefined;
+    };
+    let mismatch = firstMismatch();
 
     // STEP 6. A pure configuration mismatch gets one chance to be satisfied on the live
     // environment. Everything else — credentials, continuity, an expiring lease — is decided
-    // above and never reaches this door.
+    // by `firstMismatch` and never reaches this door; a successful apply answers ONLY the
+    // config question, so the remaining reasons are asked again.
     if (mismatch === "config") {
       // Pass the plan we ACTED ON: the apply has already committed the new applied state, so
       // recomputing here would yield an empty plan and the counter could not name the route.
@@ -933,13 +953,15 @@ export async function runWithKeepalive(
           "environment",
           appliedPlan,
         );
-        mismatch = undefined;
+        repaired.add("config");
+        mismatch = firstMismatch();
       }
     }
 
     // STEP 8. A rotated credential gets the same chance. The other credential mismatches do NOT:
     // `credentials-expired` and `credentials-expiring` are mount-lease facts that the mount
     // subsystem repairs by re-signing, and delivering a model key would not extend a lease.
+    // Same contract as step 6: a delivery answers only the rotation, so ask again.
     if (mismatch === "credentials-rotated") {
       const deliveredPlan = await tryCredentialRoute(existing);
       if (deliveredPlan) {
@@ -951,7 +973,8 @@ export async function runWithKeepalive(
           deliveredPlan,
           "rotate-in-place",
         );
-        mismatch = undefined;
+        repaired.add("credentials-rotated");
+        mismatch = firstMismatch();
       }
     }
 

--- a/services/runner/src/lifecycle/session-coordinator.ts
+++ b/services/runner/src/lifecycle/session-coordinator.ts
@@ -40,7 +40,10 @@ import {
   type SessionEnvironment,
 } from "../engines/sandbox_agent.ts";
 import type { MountCredentials } from "../engines/sandbox_agent/mount.ts";
-import type { TeardownReason } from "../engines/sandbox_agent/teardown.ts";
+import {
+  teardownDisposition,
+  type TeardownReason,
+} from "../engines/sandbox_agent/teardown.ts";
 import {
   mechanismForRotation,
   runCredentialDelivery,
@@ -595,6 +598,26 @@ export async function runWithKeepalive(
     return "runtime-incompatible";
   };
 
+  /**
+   * The teardown for a set of unresolved reasons: the strictest one wins.
+   *
+   * An eviction is named by its FIRST unresolved reason, but the sandbox's fate must answer
+   * ALL of them. `history` sorts before the credential checks, so a turn that changed the
+   * model, edited its transcript, AND carried a rotation the port could not deliver was
+   * evicted as `history`, mapped to `continuity-invalid`, and PARKED — leaving a sandbox whose
+   * daemon still held the old credential for the next turn to resume onto. Deleting when any
+   * reason says delete costs a rebuild; parking when one says delete is the stale-material bug
+   * `teardown.ts` exists to prevent.
+   */
+  const strictestTeardown = (mismatches: string[]): TeardownReason => {
+    const reasons = mismatches.map(mismatchTeardownReason);
+    return (
+      reasons.find((r) => teardownDisposition(r) === "delete") ??
+      reasons[0] ??
+      "compatibility-mismatch"
+    );
+  };
+
   const notifyParkedLive = async (env: SessionEnvironment): Promise<void> => {
     if (resolveKeepaliveProvider(request) !== "daytona") return;
     // Best-effort: the session is already parked, so an activity-refresh failure must not turn
@@ -917,12 +940,18 @@ export async function runWithKeepalive(
      * repaired and asks again, and the remaining checks keep their order and their comments.
      */
     const repaired = new Set<string>();
-    const firstMismatch = (): string | undefined => {
+    /**
+     * Every unresolved reason, in the order the checks are written. The FIRST one names the
+     * eviction, and the WHOLE list decides the teardown — see `strictestTeardown`.
+     */
+    const unresolvedMismatches = (): string[] => {
+      const reasons: string[] = [];
       if (!repaired.has("config") && cfgFp !== existing.configFingerprint)
-        return "config";
+        reasons.push("config");
       if (clientAssertsHistory && priorFp !== existing.historyFingerprint)
-        return "history";
-      if (credMismatch && !repaired.has(credMismatch)) return credMismatch;
+        reasons.push("history");
+      if (credMismatch && !repaired.has(credMismatch))
+        reasons.push(credMismatch);
       if (
         // Still-valid credentials that cannot cover a worst-case turn are expiring, not expired:
         // rebuild at the boundary rather than let the turn die under the mount.
@@ -931,10 +960,11 @@ export async function runWithKeepalive(
           requiredValidThroughMs,
         )
       )
-        return "credentials-expiring";
-      if (!tailIsFreshUserMessage(request)) return "tail";
-      return undefined;
+        reasons.push("credentials-expiring");
+      if (!tailIsFreshUserMessage(request)) reasons.push("tail");
+      return reasons;
     };
+    const firstMismatch = (): string | undefined => unresolvedMismatches()[0];
     let mismatch = firstMismatch();
 
     // STEP 6. A pure configuration mismatch gets one chance to be satisfied on the live
@@ -985,6 +1015,10 @@ export async function runWithKeepalive(
       mismatch = "mount-lost";
 
     if (mismatch) {
+      // The eviction is NAMED by the first unresolved reason and DISPOSED by all of them. The
+      // backstop only fires when the list is already empty, so `mount-lost` stands alone.
+      const allMismatches =
+        mismatch === "mount-lost" ? ["mount-lost"] : unresolvedMismatches();
       // A config mismatch names the changed FIELDS (names only — the digests never carry
       // values), so "what evicted this warm session" is answerable from the log line alone
       // instead of needing production database access to reconstruct.
@@ -998,15 +1032,22 @@ export async function runWithKeepalive(
       klog(
         `mismatch (${mismatch}) key=${key}` +
           (changedFields.length ? ` fields=[${changedFields.join(",")}]` : "") +
+          // Name the rest too: they do not name the eviction but they DO decide the teardown,
+          // so a parked-vs-deleted sandbox is explainable from this one line.
+          (allMismatches.length > 1
+            ? ` also=[${allMismatches.slice(1).join(",")}]`
+            : "") +
           `; evict + cold`,
       );
       // A transcript mismatch is a decision about the CONVERSATION, not the environment, so it
-      // is logged but never counted against the router. See `DecisionScope`.
+      // is logged but never counted against the router. See `DecisionScope`. A continuity reason
+      // riding WITH an environment reason is an environment decision: the router must see the
+      // rebuild it is accountable for.
       shadowRoute(
         existing,
         "rebuild",
         `mismatch:${mismatch}`,
-        mismatch === "history" || mismatch === "tail"
+        allMismatches.every((r) => r === "history" || r === "tail")
           ? "continuity"
           : "environment",
         undefined,
@@ -1032,8 +1073,9 @@ export async function runWithKeepalive(
         `mismatch:${mismatch}`,
         // A failed delivery brings its own teardown reason, so the disposition travels with the
         // failure instead of being re-derived from a label. They agree today; the point is that
-        // they cannot drift.
-        credentialTeardown ?? mismatchTeardownReason(mismatch),
+        // they cannot drift. Otherwise every unresolved reason gets a vote and the strictest
+        // wins, so a continuity reason that merely sorts first cannot park a stale sandbox.
+        credentialTeardown ?? strictestTeardown(allMismatches),
       );
       return coldAndPark();
     }

--- a/services/runner/tests/unit/lifecycle-live-routes.test.ts
+++ b/services/runner/tests/unit/lifecycle-live-routes.test.ts
@@ -773,6 +773,43 @@ describe("A REPAIR ANSWERS ONLY ITS OWN QUESTION (audit finding 1)", () => {
     );
   });
 
+  it("a model change plus an edited transcript plus an undeliverable rotation DELETES", async () => {
+    // The eviction is named by the FIRST unresolved reason and disposed by ALL of them.
+    // `history` sorts ahead of the credential checks, so this combination was evicted as
+    // `history`, mapped to `continuity-invalid`, and PARKED — handing the next turn a sandbox
+    // whose daemon still held the old key. The name may stay `history`; the disposition may not.
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(
+      withSecret("sk-a", turn1),
+      undefined,
+      undefined,
+      ctx,
+    );
+    await runWithKeepalive(
+      withSecret(
+        "sk-b",
+        turn2({
+          model: "m2",
+          messages: [
+            { role: "user", content: "EDITED" },
+            { role: "assistant", content: "hi" },
+            { role: "user", content: "more" },
+          ],
+        }),
+      ),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(calls.acquire, 2, "the combination must evict");
+    assert.deepEqual(
+      calls.acquiredEnvs[0]?.destroyReasons,
+      ["runtime-incompatible"],
+      "a stale credential outranks a continuity-only park",
+    );
+  });
+
   it("a model change plus a STALE tail still rebuilds", async () => {
     const { engine, calls } = makeEngine();
     const ctx = makeCtx(engine);

--- a/services/runner/tests/unit/lifecycle-live-routes.test.ts
+++ b/services/runner/tests/unit/lifecycle-live-routes.test.ts
@@ -691,6 +691,112 @@ describe("FAIL CLOSED: everything that must still rebuild", () => {
   });
 });
 
+describe("A REPAIR ANSWERS ONLY ITS OWN QUESTION (audit finding 1)", () => {
+  // The live route used to set `mismatch = undefined` wholesale, so a model switch riding with
+  // an edited transcript, a rotated credential, or a stale tail cleared THOSE checks too and
+  // continued warm on an environment that failed them. Each case here pairs the live-applicable
+  // model change with one other mismatch and asserts the rebuild still happens. The wasted
+  // in-place apply before the rebuild is acceptable; the reuse was not.
+
+  it("a model change plus an EDITED transcript still rebuilds", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(
+      turn2({
+        model: "m2",
+        messages: [
+          { role: "user", content: "EDITED" },
+          { role: "assistant", content: "hi" },
+          { role: "user", content: "more" },
+        ],
+      }),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(
+      calls.acquire,
+      2,
+      "the edited history must evict, model route or not",
+    );
+  });
+
+  it("a model change plus a ROTATED credential with no delivery port still rebuilds", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(
+      withSecret("sk-a", turn1),
+      undefined,
+      undefined,
+      ctx,
+    );
+    await runWithKeepalive(
+      withSecret("sk-b", turn2({ model: "m2" })),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(
+      calls.acquire,
+      2,
+      "an undeliverable rotation must evict; the old key must never serve the turn",
+    );
+  });
+
+  it("a model change plus a DELIVERABLE rotation chains both repairs and stays warm", async () => {
+    const { port, deliveries } = makeCredentialPort();
+    const { engine, calls } = makeEngine({ credentialPort: port });
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(
+      withSecret("sk-a", turn1),
+      undefined,
+      undefined,
+      ctx,
+    );
+    await runWithKeepalive(
+      withSecret("sk-b", turn2({ model: "m2" })),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(
+      calls.acquire,
+      1,
+      "both doors repaired their own reason: warm",
+    );
+    assert.equal(deliveries.length, 1, "the rotation was actually delivered");
+    assert.equal(
+      calls.applied.length,
+      1,
+      "the model change was actually applied",
+    );
+  });
+
+  it("a model change plus a STALE tail still rebuilds", async () => {
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1, undefined, undefined, ctx);
+    await runWithKeepalive(
+      turn2({
+        model: "m2",
+        messages: [
+          { role: "user", content: "hello" },
+          { role: "assistant", content: "hi" },
+        ],
+      }),
+      undefined,
+      undefined,
+      ctx,
+    );
+    assert.equal(
+      calls.acquire,
+      2,
+      "a tail that is not a fresh user turn must evict",
+    );
+  });
+});
+
 describe("the disagreement counters stay quiet", () => {
   it("an instructions change agrees on a REBUILD, so the withdrawal is silent too", async () => {
     // Why the fix moved the capability table and not only the live set. Dropping


### PR DESCRIPTION
## Context

Found by the cold/warm code audit that followed #6364. The coordinator computed the eviction reason with an else-if chain (config first), and a successful live model route then set `mismatch = undefined` wholesale. The repair answered one question and cleared the answers to all of them. Proven with a test harness, warm reuse (`acquire == 1`) in every case:

- a model switch riding an **edited transcript** continued warm on a native conversation that still held the unedited turn, so the model answered text the user had deleted;
- riding a **rotated credential** with no delivery port, the turn ran on the old baked key, silently if the old key still worked;
- riding an **expiring mount lease**, the turn ran under a mount about to lose its credentials;
- riding a **stale tail**, the tail check was skipped.

The claude live route has been exposed since step 6 shipped. #6364 makes the route fire for `pi_core` too, so this fix belongs in the same stack.

## Changes

Before: one `mismatch` value from an else-if chain; a successful repair cleared it entirely.

After: the ordered checks live in one `firstMismatch()` function; each repair door (the live config route, the credential delivery route) marks its own reason repaired and asks again. The remaining reasons keep their order and their semantics. A model switch with a deliverable rotation chains both repairs and stays warm; any unrepaired reason still evicts.

One accepted cost: when a model switch rides a bad pairing, the in-place apply happens before the other mismatch is discovered, on an environment that is then destroyed. A wasted `setModel` on a doomed sandbox is harmless; the warm reuse was not.

## Tests

- Four new cases pin the bad pairings (edited transcript, undeliverable rotation, stale tail rebuild; deliverable rotation plus model switch chains and stays warm, with the delivery and the apply both asserted).
- Full runner suite green (157 files / 2579 tests), typecheck clean.

Stacked on #6370.

https://claude.ai/code/session_014s6jqKCsVKsNMmnrJVJkZt
