### PR TITLE
[fix] A cross-modality model switch keeps the warm sandbox

### DIFF
--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -211,6 +211,13 @@ function canonicalJson(value: unknown): string {
  * sandbox that was still perfectly usable, which is the exact cost this project exists to remove.
  * They stay in `runContext` for tool binding and observability; they simply no longer decide
  * whether an environment may be reused.
+ *
+ * `modelCapabilities` left the hash the same way (2026-08-30, cold/warm audit finding 2). It is
+ * the resolved model's input modalities, read ONLY by the per-turn attachment-delivery chain —
+ * nothing bakes it into the environment. And because it changes WITH the model, hashing it made
+ * the plan for a vision-to-text model switch move a second facet, so the live `setModel` route
+ * was refused and the switch rebuilt the sandbox. The model id itself stays in the hash; its
+ * per-turn side facts do not.
  */
 export function configFingerprint(request: AgentRunRequest): string {
   return sha256(canonicalJson(configShape(request)));
@@ -272,7 +279,6 @@ function configShape(request: AgentRunRequest) {
           ),
         }
       : null,
-    modelCapabilities: request.modelCapabilities ?? null,
     agentsMd: request.agentsMd ?? null,
     systemPrompt: request.systemPrompt ?? null,
     appendSystemPrompt: request.appendSystemPrompt ?? null,

--- a/services/runner/src/lifecycle/desired-state.ts
+++ b/services/runner/src/lifecycle/desired-state.ts
@@ -176,9 +176,11 @@ export function normalizeDesiredState(
   // own facet: section 1.4 exempts permission TIGHTENING from apply-live entirely, and it must
   // take effect or fail closed before execution continues. `mcpServers` is here because the
   // server LIST is only read at session initialization and no live API exists on any harness.
+  // No `modelCapabilities`: it is per-turn data (the attachment chain reads the incoming
+  // request every turn) and it changes WITH the model, so hashing it here made a cross-modality
+  // model switch move `harnessSession` beside `model` and refuse the live route (audit finding 2).
   const harnessSession = canonical({
     harnessMode: request.harnessMode ?? null,
-    modelCapabilities: request.modelCapabilities ?? null,
     permissions: request.permissions ?? null,
     mcpServers:
       request.mcpServers?.map((server) => ({

--- a/services/runner/tests/unit/lifecycle-desired-state.test.ts
+++ b/services/runner/tests/unit/lifecycle-desired-state.test.ts
@@ -45,8 +45,16 @@ describe("facet ownership: one field moves exactly one facet", () => {
     overrides: Partial<AgentRunRequest>;
     facet: Facet;
   }> = [
-    { what: "the sandbox provider", overrides: { sandbox: "daytona" }, facet: "sandbox" },
-    { what: "the harness kind", overrides: { harness: "pi" }, facet: "sandbox" },
+    {
+      what: "the sandbox provider",
+      overrides: { sandbox: "daytona" },
+      facet: "sandbox",
+    },
+    {
+      what: "the harness kind",
+      overrides: { harness: "pi" },
+      facet: "sandbox",
+    },
     {
       what: "the sandbox permission",
       overrides: { sandboxPermission: "none" as never },
@@ -69,7 +77,11 @@ describe("facet ownership: one field moves exactly one facet", () => {
       overrides: { agentsMd: "new instructions" },
       facet: "workspaceFiles",
     },
-    { what: "the system prompt", overrides: { systemPrompt: "sp" }, facet: "prompts" },
+    {
+      what: "the system prompt",
+      overrides: { systemPrompt: "sp" },
+      facet: "prompts",
+    },
     {
       what: "the skills",
       overrides: {
@@ -145,8 +157,15 @@ describe("facet normalization: stability and coverage", () => {
       { messages: [{ role: "user" as const, content: "different" }] },
       { turnId: "another-turn" },
       { context: { propagation: { traceparent: "00-abc-def-01" } } as never },
+      // The resolved model's input modalities ride the request per turn and change with the
+      // model; hashing them refused the live route on any cross-modality model switch.
+      { modelCapabilities: { inputModalities: ["text"] } as never },
     ]) {
-      assert.deepEqual(movedBy(overrides), [], JSON.stringify(overrides).slice(0, 40));
+      assert.deepEqual(
+        movedBy(overrides),
+        [],
+        JSON.stringify(overrides).slice(0, 40),
+      );
     }
   });
 
@@ -161,13 +180,18 @@ describe("facet normalization: stability and coverage", () => {
       ["agentsMd", { agentsMd: "x" }],
       ["systemPrompt", { systemPrompt: "x" }],
       ["appendSystemPrompt", { appendSystemPrompt: "x" }],
-      ["skills", { skills: [{ name: "s", description: "d", body: "b" }] as never }],
+      [
+        "skills",
+        { skills: [{ name: "s", description: "d", body: "b" }] as never },
+      ],
       ["customTools", { customTools: [{ name: "t" }] as never }],
-      ["harnessFiles", { harnessFiles: [{ path: "a", content: "b" }] as never }],
+      [
+        "harnessFiles",
+        { harnessFiles: [{ path: "a", content: "b" }] as never },
+      ],
       ["permissions", { permissions: { default: "deny" } as never }],
       ["sandboxPermission", { sandboxPermission: "none" as never }],
       ["mcpServers", { mcpServers: [{ name: "x", connection: {} }] as never }],
-      ["modelCapabilities", { modelCapabilities: { vision: true } as never }],
       [
         "toolCallback.endpoint",
         { toolCallback: { endpoint: "https://gateway/tools/call" } as never },
@@ -175,7 +199,9 @@ describe("facet normalization: stability and coverage", () => {
     ];
 
     for (const [name, overrides] of probes) {
-      const changed = configFingerprint({ ...BASE, ...overrides }) !== configFingerprint(BASE);
+      const changed =
+        configFingerprint({ ...BASE, ...overrides }) !==
+        configFingerprint(BASE);
       assert.ok(changed, `precondition: ${name} must move the fingerprint`);
       assert.notDeepEqual(
         movedBy(overrides),
@@ -205,7 +231,10 @@ describe("facet normalization: stability and coverage", () => {
       } as never,
     });
     assert.deepEqual(
-      changedFacets(digestsOf(withSecret("sk-a")), digestsOf(withSecret("sk-b"))),
+      changedFacets(
+        digestsOf(withSecret("sk-a")),
+        digestsOf(withSecret("sk-b")),
+      ),
       [],
       "only the credential SHAPE is hashed, never its value",
     );
@@ -235,9 +264,8 @@ describe("facet normalization: stability and coverage", () => {
     // Same reasoning on the session side. Section 1.4 exempts permission TIGHTENING from
     // apply-live entirely, so a permissions change must not ride the `setModel` route.
     assert.deepEqual(movedBy({ model: "m2" }), ["model"]);
-    assert.deepEqual(
-      movedBy({ permissions: { default: "deny" } as never }),
-      ["harnessSession"],
-    );
+    assert.deepEqual(movedBy({ permissions: { default: "deny" } as never }), [
+      "harnessSession",
+    ]);
   });
 });

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -389,8 +389,11 @@ describe("configFingerprint", () => {
     );
   });
 
-  it("changes when resolved model capabilities change", () => {
-    assert.notEqual(
+  it("ignores resolved model capabilities (per-turn data that rides with the model)", () => {
+    // Reversed 2026-08-30 (cold/warm audit finding 2): the modalities are read per turn by the
+    // attachment chain and change WITH the model, so hashing them refused the live setModel
+    // route on every cross-modality switch and rebuilt the sandbox for nothing.
+    assert.equal(
       configFingerprint(base),
       configFingerprint({
         ...base,


### PR DESCRIPTION
## Context

Cold/warm audit finding 2. Even with the router keying fixed (#6364), switching between a vision model and a text-only model still destroyed the warm sandbox. The request field `modelCapabilities` (the resolved model's input modalities) sits in the session fingerprint and the `harnessSession` facet, and it changes with the model. So a cross-modality switch moved two facets, the mixed plan refused the live `setModel` route, and the runner rebuilt: fresh Daytona Secrets, the substitution race of #6362, about 15 seconds. The Pi catalog splits 249 text-and-image models against 163 text-only ones, so this is ordinary playground use.

The field is per-turn data: only the attachment-delivery chain reads it, from each incoming request, every turn. Nothing bakes it into the sandbox, the daemon, or the harness session.

## Changes

Before: a model switch from `claude-sonnet-5` (text+image) to a text-only model planned `{model: apply-live, harnessSession: reopen-session}` and rebuilt.

After: it plans `{model: apply-live}` and applies live on the running session.

`modelCapabilities` leaves `configFingerprint` and the `harnessSession` facet, with the reason documented in both places, exactly the treatment `workflowRevision` and `isDraft` got in step 1. Attachment behavior is unchanged: the chain keeps reading the incoming request's value each turn.

## Tests

- The per-turn-volatile test gains the field (it must move no facet); the old "changes the fingerprint" assertion is reversed, with the reason in the comment.
- Full runner suite green (157 files / 2579 tests), typecheck clean.

## What to QA

- In the playground on a warm session, switch from a vision-capable model to a text-only model and send. The turn starts fast (no rebuild) and runs on the new model.
- Regression: attach an image, switch to a text-only model, send. The attachment handling still follows the new model's modalities.

Stacked on #6372.

https://claude.ai/code/session_014s6jqKCsVKsNMmnrJVJkZt
