### PR TITLE
[6347] fix(frontend): Clear redundant tool permission overrides

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/integrationPolicy.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/integrationPolicy.ts
@@ -5,11 +5,9 @@
  *
  * A preset is a DISPLAY of the saved shape, never a saved value. Writing one sets
  * `permissions.default` and clears `permissions.tools`; reading one maps the saved shape back.
- * Setting any per-tool value makes the shown preset Custom, because `tools` is no longer empty.
+ * Setting a per-tool value that differs from the default makes the shown preset Custom.
  *
- * The override count is the NUMBER OF SAVED ENTRIES in `tools`, including an entry whose value
- * happens to equal the current default. Counting only entries that differ from the preset would
- * disagree with the Custom label itself, and could show "Custom" with a count of zero.
+ * New per-tool writes remove values equal to the default; readers still count legacy saved entries.
  *
  * Pure translation only — no React, and nothing here resolves `inherit`. The runner is the only
  * place that computes an effective permission; a second copy of the compiler in TypeScript would
@@ -154,20 +152,16 @@ export function savedToolPermission(
     return permissions.tools[toolKey] ?? permissions.default
 }
 
-/**
- * Set one tool's value, keeping the default and every other tool. The entry is saved even when it
- * equals the current default: the author set it deliberately, it survives a later change of
- * default, and it is what keeps the override count and the Custom label saying the same thing.
- *
- * The one place that per-tool merge is written. Every writer goes through it, so the drawer, the
- * config write-through, and the tests cannot drift apart.
- */
+/** Set one tool value; values equal to the current default clear the redundant entry. */
 export function mergeToolPermission(
     permissions: GatewayConnectionPermissions,
     toolKey: string,
     permission: GatewayPermission,
 ): GatewayConnectionPermissions {
-    return {default: permissions.default, tools: {...permissions.tools, [toolKey]: permission}}
+    const tools = {...permissions.tools}
+    if (permission === permissions.default) delete tools[toolKey]
+    else tools[toolKey] = permission
+    return {default: permissions.default, tools}
 }
 
 /** One catalog tool, reduced to what the drawer needs. */

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolPermission.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolPermission.ts
@@ -340,12 +340,7 @@ export function withConnectionPermissions(
     return wrap({...template, tools: setGatewayConnectionPermissions(tools, target, permissions)})
 }
 
-/**
- * Set one tool's permission on an integration's connection entry. The entry is saved even when its
- * value equals the current default: the author set it deliberately, and it survives a later change
- * of default. That redundancy is intended — it is also what keeps the override count and the Custom
- * label saying the same thing.
- */
+/** Set one integration tool permission, clearing a value equal to the current default. */
 export function withConnectionToolPermission(
     parameters: unknown,
     target: GatewayConnectionTarget,

--- a/web/packages/agenta-entity-ui/tests/unit/integrationPresets.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/integrationPresets.test.ts
@@ -62,9 +62,8 @@ describe("reading a preset back", () => {
         expect(readIntegrationPreset(permissions).preset).toBe("custom")
     })
 
-    it("F7: the override count is the number of saved entries, redundant ones included", () => {
-        // GET_ISSUE repeats the default. It still counts: the author set it deliberately, and it
-        // survives a later change of default.
+    it("F7: legacy redundant entries remain visible and count as saved overrides", () => {
+        // Readers report legacy persisted entries; new per-tool writes normalize them.
         const permissions: GatewayConnectionPermissions = {
             default: "ask",
             tools: {GET_ISSUE: "ask", DELETE_REPOSITORY: "deny"},
@@ -73,7 +72,7 @@ describe("reading a preset back", () => {
         expect(integrationPermissionSummary(permissions).label).toBe("Custom · 2")
     })
 
-    it("F7: a single redundant entry never reads as Custom with a count of zero", () => {
+    it("F7: one legacy redundant entry still reads as Custom with a count of one", () => {
         const permissions: GatewayConnectionPermissions = {
             default: "ask",
             tools: {GET_ISSUE: "ask"},
@@ -121,6 +120,18 @@ describe("switching between a preset and Custom", () => {
         const twice = mergeToolPermission(once, "GET_ISSUE", "deny")
         expect(twice.tools).toEqual({GET_ISSUE: "deny"})
         expect(readIntegrationPreset(twice).overrideCount).toBe(1)
+    })
+
+    it("F8: setting a tool back to the default removes its override", () => {
+        const current: GatewayConnectionPermissions = {
+            default: "inherit",
+            tools: {DOWNLOAD_FILE: "ask", DELETE_FILE: "deny", UPLOAD_FILE: "deny"},
+        }
+        const next = mergeToolPermission(current, "UPLOAD_FILE", "inherit")
+
+        expect(next.tools).toEqual({DOWNLOAD_FILE: "ask", DELETE_FILE: "deny"})
+        expect(readIntegrationPreset(next)).toEqual({preset: "custom", overrideCount: 2})
+        expect(integrationPermissionSummary(next).label).toBe("Custom · 2")
     })
 
     it("F9: picking a preset while on Custom clears the overrides", () => {

--- a/web/packages/agenta-entity-ui/tests/unit/toolPermission.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/toolPermission.test.ts
@@ -353,12 +353,19 @@ describe("F15: the connection policy write-through", () => {
         })
     })
 
-    it("saves a per-tool value that equals the current default", () => {
-        // Redundancy is intended: the author set it deliberately and it survives a later change of
-        // default. It is also what keeps the override count and the Custom label agreeing.
-        const parameters = wrapConnection({default: "ask", tools: {}})
+    it("removes a per-tool value that equals the current default", () => {
+        const parameters = wrapConnection({
+            default: "ask",
+            tools: {GET_ISSUE: "allow", CREATE_ISSUE: "deny"},
+        })
         const next = withConnectionToolPermission(parameters, GITHUB, "GET_ISSUE", "ask")
-        expect(connectionEntry(next).policy.permissions.tools).toEqual({GET_ISSUE: "ask"})
+        expect(connectionEntry(next).policy.permissions.tools).toEqual({CREATE_ISSUE: "deny"})
+    })
+
+    it("keeps an explicit inherit value when the current default differs", () => {
+        const parameters = wrapConnection({default: "deny", tools: {}})
+        const next = withConnectionToolPermission(parameters, GITHUB, "GET_ISSUE", "inherit")
+        expect(connectionEntry(next).policy.permissions.tools).toEqual({GET_ISSUE: "inherit"})
     })
 
     it("writes a whole preset, clearing the per-tool map", () => {


### PR DESCRIPTION
## Summary

Closes #6347.

Changing a tool permission back to the integration default still persisted a per-tool entry. Because the preset reader counts saved tool entries, the drawer continued to show an inflated `Custom · N` override count.

This change normalizes new per-tool writes in `mergeToolPermission`: when the selected permission equals the current integration default, it removes that tool key while preserving every other override. Values that differ from the default, including an explicit `inherit` under a `deny` default, are still persisted. Existing revisions with legacy redundant entries remain readable without being silently rewritten.

## Testing

### Verified locally

- `pnpm --filter @agenta/entity-ui test`: 43 files, 600 tests passed
- `pnpm --filter @agenta/entity-ui test -- integrationPresets.test.ts toolPermission.test.ts`: 2 files, 54 tests passed
- `pnpm turbo run build --filter=@agenta/entity-ui`: 4 tasks passed
- `pnpm --filter @agenta/entity-ui lint`: passed
- `git diff --cached --check`: passed before commit

Local validation used Node.js 22.15.0 and pnpm 11.1.2. The workspace requests Node.js 24.x, so GitHub CI should provide the authoritative Node 24 result.

### Added or updated tests

- Added the reported three-tool regression: resetting `UPLOAD_FILE` to the `inherit` default removes only that key and changes the derived count and label from 3 to 2.
- Updated the connection write-through test to verify the normalized policy is what gets saved while unrelated overrides remain.
- Added a negative guard proving explicit `inherit` remains when the current default is `deny`.
- Kept reader coverage for legacy redundant entries so existing revisions are not silently reinterpreted.

### QA follow-up

- In a real app with a configured Composio integration, start with three tool overrides, change one tool to Follow agent policy, save, and reopen the drawer.
- Confirm only the two effective overrides remain and the label reads `Custom · 2`.
- Confirm an explicit Follow agent policy choice is retained when the integration default is Deny.

## Demo

N/A. I could not run a configured Agenta/Composio application, so I did not substitute a mock or recreated screenshot. The exact policy transformation and saved write-through are covered by unit tests; the real-app checks are listed above for QA.

## Checklist

- [x] Demo shows the real app running this branch (not a mock-up or recreated UI), or is marked N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources

- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)
