### PR TITLE
fix(frontend): repair gateway integration drawers

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
@@ -21,6 +21,7 @@ import {
     useToolCatalogCategories,
     useToolCatalogIntegrations,
     useToolConnectionsQuery,
+    useToolConnectionActions,
     useToolIntegrationDetail,
     type ToolCatalogIntegration,
     type ToolCatalogIntegrationDetails,
@@ -28,12 +29,21 @@ import {
 } from "@agenta/entities/gatewayTool"
 import {connectionDisplayName} from "@agenta/shared/utils"
 import {ScrollSentinel} from "@agenta/ui"
+import {modal} from "@agenta/ui/app-message"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
-import {Button, RadioGroup, RadioGroupItem, SearchInput, Spinner} from "@agenta/ui/ui"
+import {
+    Button,
+    LoadingButton,
+    RadioGroup,
+    RadioGroupItem,
+    SearchInput,
+    Spinner,
+} from "@agenta/ui/ui"
 import {Check, Plugs} from "@phosphor-icons/react"
 import {atom, useAtomValue, useSetAtom} from "jotai"
 
 import ConnectDrawer from "../../../gatewayTool/drawers/ConnectDrawer"
+import {useReconnectToolConnection} from "../../../gatewayTool/hooks/useReconnectToolConnection"
 import {ProviderLogo, SubSectionHeader} from "../sectionGroups"
 import type {GatewayConnectionTarget, IntegrationRow} from "../toolUtils"
 
@@ -96,6 +106,7 @@ function ConnectedRow({
     row: IntegrationRow | undefined
     onAdd: (slug: string) => void
 }) {
+    const {handleDelete} = useToolConnectionActions()
     const {integration} = useToolIntegrationDetail(group.integrationKey)
     const name = integration?.name || group.integrationKey
     const multiple = group.connections.length > 1
@@ -113,6 +124,7 @@ function ConnectedRow({
     const added = Boolean(row)
     const swappable = Boolean(row?.entry)
     const single = group.connections[0]
+    const reconnectable = Boolean(single?.id && !isConnectionValid(single))
 
     const subtitle = choosing
         ? "Choose connection"
@@ -157,14 +169,35 @@ function ConnectedRow({
                     </Button>
                 ) : null}
                 {!chooserButton && !added ? (
-                    <Button
-                        variant="outline"
-                        size="sm"
-                        onClick={() => onAdd(single.slug ?? "")}
-                        disabled={!single.slug}
-                    >
-                        Add
-                    </Button>
+                    <div className="flex shrink-0 items-center gap-1.5">
+                        {reconnectable ? <ReconnectButton connection={single} /> : null}
+                        <Button
+                            variant="outline"
+                            size="sm"
+                            onClick={() => onAdd(single.slug ?? "")}
+                            disabled={!single.slug}
+                        >
+                            Add
+                        </Button>
+                        {reconnectable ? (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => {
+                                    modal.confirm({
+                                        title: "Remove connection",
+                                        content:
+                                            "Remove this incomplete connection? This action cannot be undone.",
+                                        okText: "Remove",
+                                        okButtonProps: {danger: true},
+                                        onOk: () => handleDelete(single.id ?? ""),
+                                    })
+                                }}
+                            >
+                                Remove
+                            </Button>
+                        ) : null}
+                    </div>
                 ) : null}
             </div>
             {choosing ? (
@@ -207,6 +240,20 @@ function ConnectedRow({
                 </div>
             ) : null}
         </div>
+    )
+}
+
+function ReconnectButton({connection}: {connection: ToolConnection}) {
+    const {reconnect, reconnectingId} = useReconnectToolConnection()
+    return (
+        <LoadingButton
+            variant="outline"
+            size="sm"
+            loading={reconnectingId === connection.id}
+            onClick={() => reconnect(connection.id ?? "")}
+        >
+            Reconnect
+        </LoadingButton>
     )
 }
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/AgentIntegrationDrawer.tsx
@@ -124,7 +124,7 @@ function ConnectedRow({
     const added = Boolean(row)
     const swappable = Boolean(row?.entry)
     const single = group.connections[0]
-    const reconnectable = Boolean(single?.id && !isConnectionValid(single))
+    const reconnectable = !multiple && Boolean(single?.id && !isConnectionValid(single))
 
     const subtitle = choosing
         ? "Choose connection"
@@ -168,17 +168,19 @@ function ConnectedRow({
                         {choosing ? "Cancel" : added ? "Change" : "Add"}
                     </Button>
                 ) : null}
-                {!chooserButton && !added ? (
+                {!chooserButton && (!added || reconnectable) ? (
                     <div className="flex shrink-0 items-center gap-1.5">
                         {reconnectable ? <ReconnectButton connection={single} /> : null}
-                        <Button
-                            variant="outline"
-                            size="sm"
-                            onClick={() => onAdd(single.slug ?? "")}
-                            disabled={!single.slug}
-                        >
-                            Add
-                        </Button>
+                        {!added ? (
+                            <Button
+                                variant="outline"
+                                size="sm"
+                                onClick={() => onAdd(single.slug ?? "")}
+                                disabled={!single.slug}
+                            >
+                                Add
+                            </Button>
+                        ) : null}
                         {reconnectable ? (
                             <Button
                                 variant="outline"

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer.tsx
@@ -13,7 +13,7 @@
  * Built for scale: a provider integration can list 50 to 200 tools, so the body carries a search
  * box, two collapsible groups (read-only and write and delete), and a per-group row cap.
  */
-import {memo, useEffect, useLayoutEffect, useMemo, useState} from "react"
+import {memo, useEffect, useLayoutEffect, useMemo, useRef, useState} from "react"
 
 import {
     useToolConnectionsQuery,
@@ -526,12 +526,13 @@ export function IntegrationPermissionDrawer({
     onChangeToolPermission: _onChangeToolPermission,
     ...body
 }: IntegrationPermissionDrawerProps) {
-    // The controls edit a local policy until Done. Closing through the drawer affordance is a
-    // cancel action, so it must not write into the agent's draft configuration.
+    // Permission edits stay local until Done; closing the drawer cancels them.
     const [draftPermissions, setDraftPermissions] = useState(permissions)
+    const wasOpen = useRef(open)
 
     useEffect(() => {
-        if (open) setDraftPermissions(permissions)
+        if (open && !wasOpen.current) setDraftPermissions(permissions)
+        wasOpen.current = open
     }, [open, permissions])
 
     const saveAndClose = () => {

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer.tsx
@@ -13,7 +13,7 @@
  * Built for scale: a provider integration can list 50 to 200 tools, so the body carries a search
  * box, two collapsible groups (read-only and write and delete), and a per-group row cap.
  */
-import {memo, useLayoutEffect, useMemo, useState} from "react"
+import {memo, useEffect, useLayoutEffect, useMemo, useState} from "react"
 
 import {
     useToolConnectionsQuery,
@@ -34,6 +34,7 @@ import {
     INTEGRATION_PRESETS,
     TOOL_PERMISSION_OPTIONS,
     isDescriptionTruncatable,
+    mergeToolPermission,
     partitionToolsByAccess,
     presetPermissions,
     readIntegrationPreset,
@@ -520,8 +521,24 @@ function DrawerTitle({
 export function IntegrationPermissionDrawer({
     open,
     onClose,
+    permissions,
+    onChangePermissions,
+    onChangeToolPermission: _onChangeToolPermission,
     ...body
 }: IntegrationPermissionDrawerProps) {
+    // The controls edit a local policy until Done. Closing through the drawer affordance is a
+    // cancel action, so it must not write into the agent's draft configuration.
+    const [draftPermissions, setDraftPermissions] = useState(permissions)
+
+    useEffect(() => {
+        if (open) setDraftPermissions(permissions)
+    }, [open, permissions])
+
+    const saveAndClose = () => {
+        if (draftPermissions) onChangePermissions(draftPermissions)
+        onClose()
+    }
+
     return (
         <EnhancedDrawer
             rootClassName="ag-drawer-elevated"
@@ -536,14 +553,23 @@ export function IntegrationPermissionDrawer({
             }}
             footer={
                 <div className="flex items-center justify-end">
-                    <Button variant="default" onClick={onClose}>
+                    <Button variant="default" onClick={saveAndClose}>
                         Done
                     </Button>
                 </div>
             }
         >
-            {body.permissions ? (
-                <DrawerBody {...body} permissions={body.permissions} />
+            {draftPermissions ? (
+                <DrawerBody
+                    {...body}
+                    permissions={draftPermissions}
+                    onChangePermissions={setDraftPermissions}
+                    onChangeToolPermission={(toolKey, permission) =>
+                        setDraftPermissions((current) =>
+                            current ? mergeToolPermission(current, toolKey, permission) : current,
+                        )
+                    }
+                />
             ) : (
                 <UnmigratedNotice target={body.target} />
             )}


### PR DESCRIPTION
## Summary

Closing an integration permission drawer with the X wrote permission changes into the agent draft, even though the X reads as cancel. The drawer now keeps permission edits locally and applies them only when the user clicks Done.

Invalid OAuth connections in Add integration were marked `needs reconnect` but only offered Add. They now expose Reconnect and Remove actions directly in that drawer.

The reported All Apps count mismatch was investigated separately. The current catalog intentionally shows connected integrations in both sections so users can connect another account; the displayed count matches the rendered rows.

Fixes #6348 

## Testing

### Verified locally

- Ran `pnpm --filter @agenta/entity-ui lint`.
- Ran `pnpm --filter @agenta/entity-ui build`.
- Ran `pnpm --filter @agenta/entity-ui test:unit`.
- Verified locally in the real app:
  - Change a tool permission, close with X, reopen the drawer. The change is discarded.
  - An invalid connection in Add integration shows Reconnect and Remove.
  - Google Calendar and GitHub searches show All Apps counts that match their rendered rows.

### Added or updated tests

N/A. The existing catalog unit tests already cover the intentional behavior of showing connected integrations in both Connected in your workspace and All Apps.

### QA follow-up
  
N/A

## Demo

Attach real-app captures from this branch:

- `Before #1.mp4`: Closing the permission drawer with X persists the edited permission.

https://github.com/user-attachments/assets/bbcd151b-cc08-44e4-ad1f-9a6925d3bb3d

- `After #1.mp4`: Closing the permission drawer with X discards the edited permission.

https://github.com/user-attachments/assets/129ece9e-20ce-431b-8d33-d4b6ea01f511

- `Before #2.mp4`: An invalid connection in Add integration is marked `needs reconnect` but offers only Add.

https://github.com/user-attachments/assets/287819fb-08bf-4a65-91c0-edc751800077

- `After #2.mp4`: An invalid connection in Add integration now offers Reconnect and Remove.

https://github.com/user-attachments/assets/ff71f0bc-3c2e-4ac3-b1de-d220e44d2f0e
 
- Screenshots showing Google Calendar (`3` rows / `ALL APPS 3`) and GitHub (`6` rows / `ALL APPS 6`) count verification. No code change was needed for this reported behavior.
<img width="357" height="438" alt="Screenshot 2026-08-31 at 1 37 47 AM" src="https://github.com/user-attachments/assets/c51d3a44-f3ca-43fc-a13c-e0f8a079e525" />
<img width="478" height="443" alt="Screenshot 2026-08-31 at 1 37 03 AM" src="https://github.com/user-attachments/assets/1550e657-798d-497a-b53d-bb4f7e64597a" />


## Checklist

- [x] Demo shows the real app running this branch (not a mock-up or recreated UI), or is marked N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me