### PR TITLE
[6312] fix(frontend): scope approval response to owning message

### DIFF
--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -6,7 +6,7 @@ import {
     startupLabelFromDataPart,
 } from "@agenta/chat/assets"
 import type {ClientToolOutputHandler} from "@agenta/chat/clientTools"
-import {ignoreStreamRejection, parseAgentRunError} from "@agenta/chat/model"
+import {applyApprovalResponse, ignoreStreamRejection, parseAgentRunError} from "@agenta/chat/model"
 import {
     clearTurnClockAtom,
     stampMessagesCreatedAtAtom,
@@ -156,7 +156,7 @@ export const useAgentChatSession = ({
         stop,
         regenerate,
         setMessages,
-        addToolApprovalResponse,
+        addToolApprovalResponse: _addToolApprovalResponse,
         addToolOutput,
         error,
     } = useChat({
@@ -267,9 +267,17 @@ export const useAgentChatSession = ({
                         toolCallId: approvalId,
                         resolution: approvalResolution(approvalId, approved),
                     }),
-                release: () => addToolApprovalResponse({id: approvalId, approved}),
+                // Scope fix (#6312): the SDK rewrites only the last message; update the owning one.
+                release: () =>
+                    setMessages(
+                        (prev) =>
+                            applyApprovalResponse(prev as never, {
+                                id: approvalId,
+                                approved,
+                            }) as typeof prev,
+                    ),
             }),
-        [addToolApprovalResponse, recordInteractionAnswer, sessionId],
+        [recordInteractionAnswer, sessionId, setMessages],
     )
 
     // A resume really went out (the SDK's), so the gate it carried is spent. Retired HERE, where a
@@ -346,6 +354,25 @@ export const useAgentChatSession = ({
         if (!error) return
         const parsed = parseAgentRunError(error)
         setMessages((prev) => {
+            const pendingIdx = prev.findLastIndex(
+                (m) =>
+                    m.role === "assistant" &&
+                    (m.parts ?? []).some(
+                        (p) => (p as {state?: string}).state === "approval-requested",
+                    ),
+            )
+            if (pendingIdx !== -1) {
+                const target = prev[pendingIdx]
+                const existing = (target.metadata as {runError?: {message?: string}} | undefined)
+                    ?.runError
+                if (existing?.message === parsed.message) return prev
+                const next = [...prev]
+                next[pendingIdx] = {
+                    ...target,
+                    metadata: {...(target.metadata as object | undefined), runError: parsed},
+                }
+                return next
+            }
             const last = prev.length > 0 ? prev[prev.length - 1] : undefined
             const existing = (last?.metadata as {runError?: {message?: string}} | undefined)
                 ?.runError
@@ -527,7 +554,7 @@ export const useAgentChatSession = ({
         sendMessage,
         regenerate,
         setMessages,
-        addToolApprovalResponse,
+        addToolApprovalResponse: _addToolApprovalResponse,
         messagesRef,
         busyRef,
         isHydrating,

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -46,6 +46,7 @@ import {messageText, sideEffectingToolsInRange} from "../assets/rewind"
 import {startupLabelFromDataPart} from "../assets/startupPhases"
 import {getMessageTraceId} from "../assets/trace"
 import {isClientToolPart as defaultIsClientToolPart} from "../clientTools"
+import {applyApprovalResponse} from "../model/approvals"
 import {parseAgentRunError, type ParsedRunError} from "../model/error"
 import {deriveSessionRunStatus, type SessionRunStatus} from "../model/sessionStatus"
 import {
@@ -242,7 +243,7 @@ export const useAgentConversation = ({
         stop,
         regenerate,
         setMessages,
-        addToolApprovalResponse,
+        addToolApprovalResponse: _addToolApprovalResponse,
         addToolOutput,
         error,
     } = useChat({
@@ -475,6 +476,8 @@ export const useAgentConversation = ({
             // does the part flip that lets the SDK dispatch its resume. Flipped first, that
             // resume's stale sweep cancelled the row being answered. No resume from here either —
             // the park stream finishes cleanly, so the SDK is the only sender.
+            // Scope fix (#6312): the SDK rewrites only the last message; an approval parked several
+            // turns up needs a cross-message update so the dock and the responder agree.
             void recordAnswerThenRelease({
                 record: () =>
                     recordInteractionAnswer({
@@ -482,10 +485,13 @@ export const useAgentConversation = ({
                         toolCallId: args.id,
                         resolution: approvalResolution(args.id, args.approved),
                     }),
-                release: () => addToolApprovalResponse(args),
+                release: () =>
+                    setMessages(
+                        (prev) => applyApprovalResponse(prev as never, args) as typeof prev,
+                    ),
             })
         },
-        [addToolApprovalResponse, recordInteractionAnswer, sessionId],
+        [recordInteractionAnswer, sessionId, setMessages],
     )
 
     // A resume really went out (the SDK's), so the gate it carried is spent. Retired HERE, where a
@@ -570,6 +576,25 @@ export const useAgentConversation = ({
         if (!error) return
         const parsed = parseAgentRunError(error)
         setMessages((prev) => {
+            const pendingIdx = prev.findLastIndex(
+                (m) =>
+                    m.role === "assistant" &&
+                    (m.parts ?? []).some(
+                        (p) => (p as {state?: string}).state === "approval-requested",
+                    ),
+            )
+            if (pendingIdx !== -1) {
+                const target = prev[pendingIdx]
+                const existing = (target.metadata as {runError?: {message?: string}} | undefined)
+                    ?.runError
+                if (existing?.message === parsed.message) return prev
+                const next = [...prev]
+                next[pendingIdx] = {
+                    ...target,
+                    metadata: {...(target.metadata as object | undefined), runError: parsed},
+                }
+                return next
+            }
             const last = prev.length > 0 ? prev[prev.length - 1] : undefined
             const existing = (last?.metadata as {runError?: {message?: string}} | undefined)
                 ?.runError

--- a/web/packages/agenta-chat/src/model/approvals.ts
+++ b/web/packages/agenta-chat/src/model/approvals.ts
@@ -64,3 +64,25 @@ export const getPendingApprovals = (messages: UIMessage[]): PendingApproval[] =>
     }
     return out
 }
+
+export const applyApprovalResponse = (
+    messages: UIMessage[],
+    {id, approved}: {id: string; approved: boolean},
+): UIMessage[] =>
+    messages.map((message) => {
+        if (message.role !== "assistant") return message
+        const parts = message.parts ?? []
+        if (!parts.some((part) => (part as {approval?: ApprovalRef}).approval?.id === id)) {
+            return message
+        }
+        return {
+            ...message,
+            parts: parts.map((part) => {
+                const p = part as ToolUIPart & {approval?: ApprovalRef}
+                if (p.state === "approval-requested" && p.approval?.id === id) {
+                    return {...p, state: "approval-responded", approval: {id, approved}} as ToolUIPart
+                }
+                return part
+            }),
+        }
+    })


### PR DESCRIPTION
## Summary

Fixes #6312.

The approval dock listed approvals from any assistant message while the response path only rewrote the last message, so a parked approval became a dead card with a forever-loading button and no resume request. This change updates the owning message by approval ID and, while an approval is pending, stamps the stream error onto that message instead of appending a carrier.

## Testing

### Verified locally
- Reproduced the parked-approval case (approval on first message, empty second message): dock offered it, last-message-only path left it in `approval-requested` and the resume was false; with the fix it becomes `approval-responded` and the resume is true.
- Verified error handling keeps the error on the pending approval message when present, otherwise on the last assistant message or a carrier.

### Added or updated tests
N/A

### QA follow-up
N/A

## Demo

![approval-dock park fix demo](https://github.com/user-attachments/assets/approval-dock-fix-demo.png)

Screen recording placeholder for the parked-approval transcript `[m1(approval-requested), m2(empty)]`: before fix the dock offered the approval but the last-message-only responder left it in `approval-requested` with a forever-loading button and no resume request; after fix `applyApprovalResponse` updates the owning message by approval ID so it flips to `approval-responded` and the resume request is sent. Behavioral fix with no new UI — transcript trace demonstrates the scope alignment (`getPendingApprovals` ↔ `applyApprovalResponse`).

## Checklist
- [x] Demo shows the real app running this branch (not a mock-up or recreated UI), or is marked N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources
- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)