### PR TITLE
[fix] Show effective integration permissions

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/IntegrationPermissionDrawer.tsx
@@ -37,7 +37,7 @@ import {
     partitionToolsByAccess,
     presetPermissions,
     readIntegrationPreset,
-    rollupGroupPermission,
+    rollupEffectiveGroupPermission,
     rollupLabel,
     savedToolPermission,
     withStaleTools,
@@ -202,6 +202,7 @@ function ToolGroup({
     tools,
     search,
     permissions,
+    agentPolicy,
     onChangeToolPermission,
     disabled,
 }: {
@@ -211,6 +212,7 @@ function ToolGroup({
     tools: CatalogToolInfo[]
     search: string
     permissions: GatewayConnectionPermissions
+    agentPolicy?: PermissionPolicy | null
     onChangeToolPermission: (toolKey: string, permission: GatewayPermission) => void
     disabled?: boolean
 }) {
@@ -221,12 +223,8 @@ function ToolGroup({
     const setOpen = () =>
         setExpanded((prev) => ({...prev, [storageKey]: !(prev[storageKey] ?? true)}))
     const rollup = useMemo(
-        () =>
-            rollupGroupPermission(
-                tools.map((tool) => tool.key),
-                permissions,
-            ),
-        [tools, permissions],
+        () => rollupEffectiveGroupPermission(tools, permissions, agentPolicy),
+        [tools, permissions, agentPolicy],
     )
     const matching = useMemo(() => {
         if (!search) return tools
@@ -435,6 +433,7 @@ function DrawerBody({
                         tools={readOnly}
                         search={search}
                         permissions={permissions}
+                        agentPolicy={agentPolicy}
                         onChangeToolPermission={onChangeToolPermission}
                         disabled={disabled}
                     />
@@ -445,6 +444,7 @@ function DrawerBody({
                         tools={write}
                         search={search}
                         permissions={permissions}
+                        agentPolicy={agentPolicy}
                         onChangeToolPermission={onChangeToolPermission}
                         disabled={disabled}
                     />

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/integrationPolicy.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/integrationPolicy.ts
@@ -11,10 +11,10 @@
  * happens to equal the current default. Counting only entries that differ from the preset would
  * disagree with the Custom label itself, and could show "Custom" with a count of zero.
  *
- * Pure translation only — no React, and nothing here resolves `inherit`. The runner is the only
- * place that computes an effective permission; a second copy of the compiler in TypeScript would
- * read an agent-wide mode this module does not own and the two would drift.
+ * Pure translation only — no React. Effective `inherit` values are resolved here for display only;
+ * the runner remains the source of truth for execution.
  */
+import {DEFAULT_PERMISSION_POLICY, type PermissionPolicy} from "./permissionPolicy"
 import type {GatewayConnectionPermissions, GatewayPermission} from "./toolUtils"
 
 export type IntegrationPreset = "always_ask" | "ask_writes" | "allow_all" | "deny_all" | "custom"
@@ -250,6 +250,38 @@ export function rollupGroupPermission(
         else if (shared !== value) return {kind: "mixed"}
     }
     return {kind: "shared", permission: shared as GatewayPermission}
+}
+
+/** Resolve a saved permission for display, using the same fail-safe defaults as the runner. */
+export function resolveEffectivePermission(
+    permission: GatewayPermission,
+    agentPolicy: PermissionPolicy | null | undefined,
+    readOnly: boolean | undefined,
+): Exclude<GatewayPermission, "inherit"> {
+    if (permission !== "inherit") return permission
+    const policy = agentPolicy ?? DEFAULT_PERMISSION_POLICY
+    if (policy === "allow_reads") return readOnly === true ? "allow" : "ask"
+    return policy
+}
+
+/** Roll up a group using effective display values, including the agent policy for `inherit`. */
+export function rollupEffectiveGroupPermission(
+    tools: Pick<CatalogToolInfo, "key" | "readOnly">[],
+    permissions: GatewayConnectionPermissions,
+    agentPolicy: PermissionPolicy | null | undefined,
+): GroupRollup {
+    if (tools.length === 0) return {kind: "empty"}
+    const values = tools.map((tool) =>
+        resolveEffectivePermission(
+            savedToolPermission(permissions, tool.key),
+            agentPolicy,
+            tool.readOnly,
+        ),
+    )
+    const first = values[0]
+    return values.every((value) => value === first)
+        ? {kind: "shared", permission: first}
+        : {kind: "mixed"}
 }
 
 const ROLLUP_LABELS: Record<GatewayPermission, string> = {

--- a/web/packages/agenta-entity-ui/tests/unit/integrationPresets.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/integrationPresets.test.ts
@@ -14,6 +14,9 @@ import {
     mergeToolPermission,
     presetPermissions,
     readIntegrationPreset,
+    rollupEffectiveGroupPermission,
+    rollupLabel,
+    resolveEffectivePermission,
     type IntegrationPreset,
 } from "../../src/DrillInView/SchemaControls/integrationPolicy"
 import type {GatewayConnectionPermissions} from "../../src/DrillInView/SchemaControls/toolUtils"
@@ -95,6 +98,49 @@ describe("reading a preset back", () => {
         expect(integrationPermissionSummary({default: "inherit", tools: {}}).label).toBe(
             "Allow reads",
         )
+    })
+})
+
+describe("effective inherited permissions", () => {
+    it("resolves allow_reads by tool access", () => {
+        expect(resolveEffectivePermission("inherit", "allow_reads", true)).toBe("allow")
+        expect(resolveEffectivePermission("inherit", "allow_reads", false)).toBe("ask")
+        expect(resolveEffectivePermission("inherit", "allow_reads", undefined)).toBe("ask")
+    })
+
+    it("resolves inherited permissions for every agent policy", () => {
+        for (const policy of ["allow", "ask", "deny"] as const) {
+            expect(resolveEffectivePermission("inherit", policy, true)).toBe(policy)
+            expect(resolveEffectivePermission("inherit", policy, false)).toBe(policy)
+        }
+    })
+
+    it("leaves explicit integration permissions unchanged", () => {
+        for (const permission of ["allow", "ask", "deny"] as const) {
+            expect(resolveEffectivePermission(permission, "allow_reads", true)).toBe(permission)
+        }
+    })
+
+    it("shows the allow-reads split in group rollups", () => {
+        const permissions: GatewayConnectionPermissions = {default: "inherit", tools: {}}
+        expect(
+            rollupLabel(
+                rollupEffectiveGroupPermission(
+                    [{key: "READ", readOnly: true}],
+                    permissions,
+                    "allow_reads",
+                ),
+            ),
+        ).toBe("runs automatically")
+        expect(
+            rollupLabel(
+                rollupEffectiveGroupPermission(
+                    [{key: "WRITE", readOnly: false}],
+                    permissions,
+                    "allow_reads",
+                ),
+            ),
+        ).toBe("asks first")
     })
 })
 


### PR DESCRIPTION
## Summary

The integration permission drawer showed `Follow agent policy` for both read-only and write/delete tools when the integration used the `Ask for write and delete` preset.

The root cause was that the drawer displayed the stored `inherit` value without resolving it against the agent-level permission policy. The runner already resolves this correctly, but the drawer did not show the effective result.

The drawer now resolves inherited permissions for display:

- Read-only tools follow `allow_reads` as `runs automatically`.
- Write, delete, and unknown tools follow `allow_reads` as `asks first`.
- Explicit Allow, Ask, and Deny permissions remain unchanged.

Fixes #6346 

## Testing

### Verified locally

- Ran `pnpm --filter @agenta/entity-ui lint`.
- Ran `pnpm --filter @agenta/entity-ui build`.
- Verified the real local app with the Text to PDF integration.
- Set the integration default to `Ask for write and delete`.
- Confirmed the drawer shows:
  - Read-only: `runs automatically`
  - Write and delete: `asks first`

### Added or updated tests

Added unit coverage for:

- Inherited permissions under `allow_reads`.
- Unknown tool access hints defaulting to Ask.
- Inherited permissions under Allow, Ask, and Deny policies.
- Explicit integration permissions remaining unchanged.
- Read-only and write/delete group rollups.

The focused test suite passes: 20 tests.

### QA follow-up

N/A

## Demo

Attach screenshots or videos captured from the real app running this branch:

- Before: both groups show `follows agent policy`.
<img width="1439" height="763" alt="Before" src="https://github.com/user-attachments/assets/840deb79-fc8c-48d0-bea5-5ea3f3d90ad1" />

- After: read-only shows `runs automatically`, and write and delete shows `asks first`.
<img width="1082" height="575" alt="After" src="https://github.com/user-attachments/assets/3ec9c747-9a18-4a33-9391-923960508afc" />


## Checklist

- [x] Demo shows the real app running this branch, not a mock-up or recreated UI
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me