### PR TITLE
[fix] Treat the local host aliases as one host for OTLP ingest matching

### DIFF
--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -340,12 +340,40 @@ export function resolveOtlpTraceEndpoint(endpoint?: string): string {
  * public URL while the runner's own hop is internal. The full normalized ingest URL must match,
  * because a third-party collector may share the Agenta host behind a different proxy path.
  */
+/**
+ * Host names that all denote THIS deployment's own API host.
+ *
+ * A service running in bridge mode cannot reach the host through `localhost` — that name resolves
+ * to its own container — so the SDK rewrites a configured `localhost`/`0.0.0.0` API URL to
+ * `host.docker.internal` before using it (`agenta/sdk/utils/helpers.py`, `parse_url`). The endpoint
+ * that then arrives on a run request names a DIFFERENT alias than the base configured here, and
+ * comparing them verbatim says "this is somebody else's collector" about the deployment's own
+ * ingest. The credential is withheld on that basis and every session call the runner makes comes
+ * back 401 — with nothing in the message pointing at a hostname.
+ *
+ * Folding the aliases together does not widen who gets the credential: the endpoint must still
+ * equal one of the operator-configured API bases, port and path included. Only the spelling of the
+ * local host is treated as interchangeable, which is the same equivalence the SDK's rewrite asserts.
+ */
+const LOCAL_HOST_ALIASES = new Set([
+  "localhost",
+  "127.0.0.1",
+  "0.0.0.0",
+  "[::1]",
+  "::1",
+  "host.docker.internal",
+]);
+
 export function isAgentaIngest(endpoint: string): boolean {
   const normalize = (value: string): string | undefined => {
     try {
       const url = new URL(value);
       const path = url.pathname.replace(/\/+$/, "") || "/";
-      return `${url.origin}${path}`;
+      const host = LOCAL_HOST_ALIASES.has(url.hostname)
+        ? "__local__"
+        : url.hostname;
+      const port = url.port ? `:${url.port}` : "";
+      return `${url.protocol}//${host}${port}${path}`;
     } catch {
       return undefined;
     }

--- a/services/runner/tests/unit/otel-agenta-ingest.test.ts
+++ b/services/runner/tests/unit/otel-agenta-ingest.test.ts
@@ -1,0 +1,95 @@
+/**
+ * `isAgentaIngest` decides whether an OTLP endpoint is THIS deployment's own ingest, and so
+ * whether the export credential is attached. Say no about our own host and the batch goes out
+ * unauthenticated: every runner session call comes back 401, with nothing in the message naming
+ * a hostname.
+ *
+ * That is exactly what a local stack hit. A service in bridge mode cannot reach the host through
+ * `localhost` — the name resolves to its own container — so the SDK rewrites a configured
+ * `localhost` API URL to `host.docker.internal` (`agenta/sdk/utils/helpers.py`, `parse_url`). The
+ * endpoint arriving on the run request then spells the host differently from the configured base,
+ * and a verbatim comparison called the deployment's own ingest somebody else's collector.
+ *
+ * The pin is two-sided: the local aliases are interchangeable, and NOTHING else is — a third-party
+ * collector on the same host, another port, or another path must still be treated as foreign, or
+ * the credential leaks to it.
+ *
+ * Run: pnpm exec vitest run tests/unit/otel-agenta-ingest.test.ts
+ */
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { isAgentaIngest } from "../../src/tracing/otel.ts";
+
+const TRACES = "/otlp/v1/traces";
+const envKeys = ["AGENTA_API_URL", "AGENTA_API_INTERNAL_URL"] as const;
+const saved: Partial<Record<(typeof envKeys)[number], string | undefined>> = {};
+
+beforeEach(() => {
+  for (const key of envKeys) {
+    saved[key] = process.env[key];
+    delete process.env[key];
+  }
+});
+
+afterEach(() => {
+  for (const key of envKeys) {
+    if (saved[key] === undefined) delete process.env[key];
+    else process.env[key] = saved[key];
+  }
+});
+
+describe("isAgentaIngest", () => {
+  it("recognizes the configured base itself", () => {
+    process.env.AGENTA_API_URL = "http://localhost/api";
+    expect(isAgentaIngest(`http://localhost/api${TRACES}`)).toBe(true);
+  });
+
+  it("recognizes the cloud ingest with nothing configured", () => {
+    expect(isAgentaIngest(`https://cloud.agenta.ai/api${TRACES}`)).toBe(true);
+  });
+
+  // The regression: the SDK's bridge-mode rewrite renames the host, and the credential was
+  // withheld from our own ingest on that basis alone.
+  it.each([
+    "127.0.0.1",
+    "0.0.0.0",
+    "host.docker.internal",
+    "[::1]",
+  ])("treats %s as the same host as a configured localhost", (alias) => {
+    process.env.AGENTA_API_URL = "http://localhost/api";
+    expect(isAgentaIngest(`http://${alias}/api${TRACES}`)).toBe(true);
+  });
+
+  it("folds the alias in the other direction too", () => {
+    process.env.AGENTA_API_URL = "http://host.docker.internal/api";
+    expect(isAgentaIngest(`http://localhost/api${TRACES}`)).toBe(true);
+  });
+
+  it("matches against the internal base, not only the public one", () => {
+    process.env.AGENTA_API_URL = "https://agenta.example.com/api";
+    process.env.AGENTA_API_INTERNAL_URL = "http://localhost:8000/api";
+    expect(isAgentaIngest(`http://127.0.0.1:8000/api${TRACES}`)).toBe(true);
+  });
+
+  // The other side of the fold: aliasing the host name must not alias anything else, or a
+  // third-party collector sharing the host would be handed the credential.
+  it("does not match a different port on the same host", () => {
+    process.env.AGENTA_API_URL = "http://localhost:8000/api";
+    expect(isAgentaIngest(`http://localhost:4318/api${TRACES}`)).toBe(false);
+  });
+
+  it("does not match a different path on the same host", () => {
+    process.env.AGENTA_API_URL = "http://localhost/api";
+    expect(isAgentaIngest("http://localhost/collector/v1/traces")).toBe(false);
+  });
+
+  it("does not match a foreign host", () => {
+    process.env.AGENTA_API_URL = "http://localhost/api";
+    expect(isAgentaIngest(`http://jaeger.internal/api${TRACES}`)).toBe(false);
+  });
+
+  it("rejects an unparseable endpoint rather than throwing", () => {
+    process.env.AGENTA_API_URL = "http://localhost/api";
+    expect(isAgentaIngest("not a url")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Context

Every session call the runner made came back 401, and nothing in the error named a hostname.

`isAgentaIngest` decides whether an OTLP endpoint is this deployment's own ingest, and therefore whether the export credential gets attached. It compared `origin + path` verbatim.

A service in bridge mode cannot reach the host through `localhost`, because that name resolves to its own container. So the SDK rewrites a configured `localhost` API URL to `host.docker.internal` before using it (`agenta/sdk/utils/helpers.py`, `parse_url`). The endpoint that then arrives on a run request spells the host differently from the configured base, the comparison concluded "this is somebody else's collector" about our own ingest, and the credential was withheld.

## Changes

The six names that all mean "this host" now normalize to one token before comparing:

```
localhost  127.0.0.1  0.0.0.0  ::1  [::1]  host.docker.internal
```

Before, with `AGENTA_API_URL=http://localhost/api`:

```
endpoint http://host.docker.internal/api/otlp/v1/traces  ->  foreign, no credential  ->  401
```

After:

```
endpoint http://host.docker.internal/api/otlp/v1/traces  ->  ours, credential attached
```

This does not widen who gets the credential. The endpoint must still equal one of the operator-configured API bases exactly, port and path included. Only the spelling of the local host is interchangeable, which is the same equivalence the SDK's rewrite already asserts.

## Tests

New `tests/unit/otel-agenta-ingest.test.ts`, 12 cases. Verified as a real regression pin: with the fix reverted, 6 fail and 6 pass. The 6 that keep passing are the negative half, which is the point of including them. A different port, a different path, a foreign host and an unparseable endpoint are all still rejected, so folding the aliases cannot leak the credential to a third-party collector sharing the machine.

Note for anyone running the runner suite locally: `services/runner/node_modules` may be stale and missing `@opentelemetry/otlp-transformer`, which makes every test importing `src/tracing/otel.ts` fail to load. `pnpm install` in `services/runner` fixes it. Unrelated to this change.

Also unrelated and pre-existing on main: 19 failures in `commit-authorization`, `sandbox-agent-acp-interactions` and `workspace-import`. Confirmed identical on a clean tree.
