### PR TITLE
[fix] Give the config Files drawer its own drive scope [#6388]

### DIFF
--- a/web/packages/agenta-entity-ui/src/drive/StorageSection.tsx
+++ b/web/packages/agenta-entity-ui/src/drive/StorageSection.tsx
@@ -25,6 +25,7 @@ import {AnimatePresence, MotionConfig, motion} from "motion/react"
 import {type DriveId} from "./DriveExplorer"
 import {DriveFileRow, DriveRetryButton, SKELETON_ROW_COUNT} from "./DriveFileRow"
 import {DriveItemContextMenu, useCopyDrivePath, useDriveItemDownload} from "./DriveItemContextMenu"
+import {DriveSessionProvider} from "./driveSessionContext"
 import {FilesDrawer} from "./FilesDrawer"
 import {driveQuickLookAtomFamily} from "./quickLook"
 import {filesDrawerStagedAtomFamily} from "./SessionFilesDrawer"
@@ -99,7 +100,7 @@ export default function StorageSection({
      * host resolves it (a package cannot read the app's chat slice). */
     scope: string
 }) {
-    const {drive} = useConfigDrive(revisionId, sessionId)
+    const {drive, sessionId: resolvedSessionId, artifactId} = useConfigDrive(revisionId, sessionId)
     // A row opens the chat's DOCKED pane on that file with the tree collapsed; the header's icon
     // opens the browse-all DRAWER instead (see StorageFilesHeader).
     const {openPane: openPaneRoot} = useSessionFilesPane(scope, sessionId ?? "")
@@ -273,17 +274,26 @@ export default function StorageSection({
             </AnimatePresence>
 
             {/* The ONE Files drawer (DriveExplorer: lazy per-directory loading + the single header).
-                Same component the chat uses; only the open-atom + resolved drive differ. */}
-            <FilesDrawer
-                open={drawerOpen}
-                onClose={() => setDrawerOpen(false)}
-                drive={drive}
-                driveIds={driveIds}
-                scope="session"
-                initialPath={null}
-                stagedFiles={[]}
-                onStagedChange={setPaneStaged}
-            />
+                Same component the chat uses; only the open-atom + resolved drive differ.
+
+                Its own DriveSessionProvider because the drive it browses is THIS section's, not an
+                ancestor's. The listing arrives as a prop, but the per-file actions inside read the
+                ids from context — and the only providers were the chat surfaces, so on a
+                configuration page with no conversation open there was no context at all and the
+                files resolved to no mount (#6388). `useConfigDrive` already resolved both ids from
+                the edited revision; the artifact one does not need a session to exist. */}
+            <DriveSessionProvider sessionId={resolvedSessionId} artifactId={artifactId ?? null}>
+                <FilesDrawer
+                    open={drawerOpen}
+                    onClose={() => setDrawerOpen(false)}
+                    drive={drive}
+                    driveIds={driveIds}
+                    scope="session"
+                    initialPath={null}
+                    stagedFiles={[]}
+                    onStagedChange={setPaneStaged}
+                />
+            </DriveSessionProvider>
         </div>
     )
 }


### PR DESCRIPTION
Fixes #6388.

## Context

Open an agent's configuration page when no session is running, go to the Files section, and nothing works.

The listing itself is fine. `StorageSection` resolves the drive through `useConfigDrive` and hands it to the drawer as a prop, and `useSessionDriveSummary` already models the no-session case: with no cwd mount it treats the agent's durable folder as the whole drive.

The per-file actions are the problem. Inside the drawer, `DriveFileCard` and friends read the session and artifact ids from `DriveSessionContext`, and the only components that ever provided it are the chat surfaces: `AgentChatPanel`, `AgentConversation`, and mobile's `SessionWorkspace`. On a configuration page with no conversation open there is no provider anywhere in the tree, so every file resolved to no mount.

## Changes

`StorageSection` now provides the drive scope around its own drawer instead of hoping an ancestor supplies it. It already had both ids from `useConfigDrive`, and the artifact id does not need a session to exist.

```
<DriveSessionProvider sessionId={resolvedSessionId} artifactId={artifactId ?? null}>
    <FilesDrawer ... />
</DriveSessionProvider>
```

The surface that resolves the drive is now the one that declares it.

## Tests / notes

- `@agenta/entity-ui` unit suite passes (598), lint and both app typechecks clean.
- Not reproduced in a browser. The desktop app is not part of the local docker stack, so the failing surface could not be loaded. The diagnosis is from the code path, and it is specific: the provider genuinely does not exist above `StorageSection` on that page.
- On `/m` this path already had an ancestor provider, so the bug never reproduced there. The nested provider resolves the same two ids, so it should be a no-op on mobile. Worth a click-through on `/m`'s config Files section before merging, since that is the case this could regress.

## What to QA

- Open an agent that has files but no running session, go to its configuration page, open Files. The agent's files list, and opening one previews it instead of doing nothing.
- Regression: open a session on `/m`, open the config pane's Files section, open a file. It behaves as before.
