### PR TITLE
[fix] Pick up commits the playground was not open to witness [#6380]

### DIFF
--- a/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
+++ b/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useMemo} from "react"
 
 import {isLocalDraftId} from "@agenta/entities/shared"
-import {invalidateAgentCommittedRevisionCache, workflowMolecule} from "@agenta/entities/workflow"
+import {workflowMolecule} from "@agenta/entities/workflow"
 import {createWorkflowRevisionAdapter} from "@agenta/entity-ui/selection"
 import {playgroundController} from "@agenta/playground"
 import {registerAgentAutoCommitHandler} from "@agenta/playground/state"
@@ -56,15 +56,6 @@ const AgentRevisionSelector = ({variantId}: {variantId: string}) => {
             }),
         [onAfterCommit, onCommitted],
     )
-
-    // A commit can land while this playground is closed — the agent commits itself mid-session,
-    // or the same agent is driven from another surface. The invalidation that follows a commit
-    // only refetches ACTIVE observers, and this playground had none, so on return the revision
-    // queries were still inside their staleTime and answered with the superseded version (#6380).
-    // Revalidate once on mount: here the observers are active, so this actually refetches.
-    useEffect(() => {
-        invalidateAgentCommittedRevisionCache()
-    }, [])
 
     const switchEntity = useSetAtom(playgroundController.actions.switchEntity)
     const handleSwitchVariant = useCallback(

--- a/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
+++ b/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
@@ -1,7 +1,7 @@
 import {useCallback, useEffect, useMemo} from "react"
 
 import {isLocalDraftId} from "@agenta/entities/shared"
-import {workflowMolecule} from "@agenta/entities/workflow"
+import {invalidateAgentCommittedRevisionCache, workflowMolecule} from "@agenta/entities/workflow"
 import {createWorkflowRevisionAdapter} from "@agenta/entity-ui/selection"
 import {playgroundController} from "@agenta/playground"
 import {registerAgentAutoCommitHandler} from "@agenta/playground/state"
@@ -56,6 +56,15 @@ const AgentRevisionSelector = ({variantId}: {variantId: string}) => {
             }),
         [onAfterCommit, onCommitted],
     )
+
+    // A commit can land while this playground is closed — the agent commits itself mid-session,
+    // or the same agent is driven from another surface. The invalidation that follows a commit
+    // only refetches ACTIVE observers, and this playground had none, so on return the revision
+    // queries were still inside their staleTime and answered with the superseded version (#6380).
+    // Revalidate once on mount: here the observers are active, so this actually refetches.
+    useEffect(() => {
+        invalidateAgentCommittedRevisionCache()
+    }, [])
 
     const switchEntity = useSetAtom(playgroundController.actions.switchEntity)
     const handleSwitchVariant = useCallback(

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -2947,6 +2947,11 @@ export function invalidateAgentCommittedRevisionCache(options?: StoreOptions) {
         const qc = store.get(queryClientAtom)
         qc.invalidateQueries({queryKey: ["workflows", "latestRevision"], exact: false})
         qc.invalidateQueries({queryKey: ["workflows", "inspect"], exact: false})
+        // The version SELECTOR reads the revisions list, not the latest-revision tag, so leaving
+        // it out left the freshly committed version missing from the picker until a reload
+        // (#6380) — the config had already moved on to a version you could not name.
+        qc.invalidateQueries({queryKey: ["workflows", "revisionsByWorkflow"], exact: false})
+        qc.invalidateQueries({queryKey: ["workflows", "revisions"], exact: false})
     } catch {
         // queryClientAtom may not be initialized yet
     }

--- a/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
@@ -1,4 +1,7 @@
+import {useEffect} from "react"
+
 import {
+    invalidateAgentCommittedRevisionCache,
     workflowMolecule,
     workflowRevisionsByWorkflowListDataAtomFamily,
     workflowRevisionsByWorkflowQueryAtomFamily,
@@ -112,6 +115,17 @@ export const AgentRevisionStatus = ({
     onSelectRevision,
     className,
 }: AgentRevisionStatusProps) => {
+    // A commit can land while this surface is closed — the agent commits itself mid-session, or
+    // the same agent is driven from another surface (the desktop playground and `/m` share one
+    // agent). The invalidation that follows a commit refetches ACTIVE observers only, and a closed
+    // surface has none, so on return the revision queries were still inside their staleTime and
+    // this chip named the superseded version (#6380). Revalidate once on mount, where the
+    // observers ARE active. It lives here, in the shared chip, because every host that shows a
+    // revision has the problem — putting it in one app's wrapper fixed only that app.
+    useEffect(() => {
+        invalidateAgentCommittedRevisionCache()
+    }, [])
+
     const data = useAtomValue(workflowMolecule.selectors.data(revisionId || ""))
     const isDirty = useAtomValue(workflowMolecule.selectors.isDirty(revisionId || ""))
     const isAgent = useAtomValue(workflowMolecule.selectors.isAgent(revisionId || ""))


### PR DESCRIPTION
Fixes #6380.

## Context

An agent commits a new revision while you are not looking at its playground. You come back, and the playground still has the old version selected. Sometimes the new version is not even in the version picker until you reload the page.

The playground only learns about a new revision from the `data-committed-revision` stream part, which its own mounted chat receives. When the playground is closed, nobody is listening. The invalidation that runs after a commit does not close the gap either, because `invalidateQueries` refetches active observers only, and a closed playground has none. The revision queries were therefore still inside their 30 second `staleTime` on return, and answered with the superseded revision.

The picker had a second, separate cause: `invalidateAgentCommittedRevisionCache` invalidated the latest-revision tag and the inspect query, but not the revisions lists that the picker actually reads.

## Changes

Two small changes.

`invalidateAgentCommittedRevisionCache` now also invalidates the revision lists:

```
workflows/latestRevision   (already)
workflows/inspect          (already)
workflows/revisionsByWorkflow
workflows/revisions
```

That is why the config could move to a version the picker could not name.

`AgentRevisionStatus` revalidates once on mount. There the observers are active, so the refetch actually happens.

It lives in that shared chip on purpose. The issue says the problem occurs on mobile, and `AgentRevisionStatus` is rendered by both the desktop playground's revision selector and `/m`'s session top bar. An earlier draft of this fix put the revalidation in the desktop-only wrapper, which fixed exactly one of the two surfaces the bug was reported against.

## Tests / notes

- `@agenta/entities` suite passes (1460), both app typechecks clean.
- Verified on `/m`: leave a session, re-enter it without a reload so the cache stays warm, and `POST /api/workflows/revisions/query` now fires on remount instead of the queries answering from inside their `staleTime`.
- Not covered: a commit landing in another browser tab that is already open. A tab switch is not a remount, so that tab stays stale until you navigate. Fixing it needs focus-based revalidation, which is a broader behaviour change than this issue asks for.

## What to QA

- Open an agent's playground, note the version. Leave it. Drive the same agent from `/m` until it commits. Return to the playground: the new version is selected, and it appears in the picker without a reload.
- Regression: edit config in the playground and let auto-commit run. The version chip still advances and the picker still lists every revision.
