### PR TITLE
[fix] A changed agent artifact now evicts the warm session

### DIFF
--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -212,6 +212,10 @@ function canonicalJson(value: unknown): string {
  * They stay in `runContext` for tool binding and observability; they simply no longer decide
  * whether an environment may be reused.
  *
+ * One `runContext` field is deliberately IN the hash although the object as a whole is
+ * excluded: `workflow.artifact.id`, because the agent mount it selects is baked at acquire
+ * (audit finding 4; see the field comment in `configShape`).
+ *
  * `modelCapabilities` left the hash the same way (2026-08-30, cold/warm audit finding 2). It is
  * the resolved model's input modalities, read ONLY by the per-turn attachment-delivery chain —
  * nothing bakes it into the environment. And because it changes WITH the model, hashing it made
@@ -256,6 +260,13 @@ function configShape(request: AgentRunRequest) {
   const shape = {
     harness: request.harness ?? null,
     sandbox: request.sandbox ?? null,
+    // The ONE `runContext` field that is environment identity (audit finding 4). The agent
+    // artifact id signs the agent mount, mounts an artifact-keyed store prefix, sets the
+    // mount env var, and selects the durable-storage guidance — all baked at acquire. Without
+    // it a warm sandbox kept serving a session whose storage folder had changed, with the
+    // wrong (or no) agent mount attached. The REST of `runContext` stays out: revision ids,
+    // variant identity, and trace identity are per-turn metadata (the step-1 rule).
+    agentArtifactId: request.runContext?.workflow?.artifact?.id?.trim() || null,
     model: request.model ?? null,
     // Harness mode is applied once, at session acquire (codex-mode.ts). Normalize Codex defaults
     // and ignore the field for other harnesses so only effective mode changes evict warm sessions.

--- a/services/runner/src/lifecycle/desired-state.ts
+++ b/services/runner/src/lifecycle/desired-state.ts
@@ -110,6 +110,11 @@ export function normalizeDesiredState(
     provider: request.sandbox ?? null,
     harness: request.harness ?? null,
     sandboxPermission: request.sandboxPermission ?? null,
+    // The agent artifact id lives here because the mount it selects is created with the
+    // sandbox and has no live remount route: a changed (or newly present) id can only be
+    // served by a rebuild (audit finding 4). The rest of `runContext` stays out of every
+    // facet — it is per-turn metadata.
+    agentArtifactId: request.runContext?.workflow?.artifact?.id?.trim() || null,
   });
 
   // RUNTIME: what is baked into the agent daemon at start. Model connection, process

--- a/services/runner/tests/unit/lifecycle-desired-state.test.ts
+++ b/services/runner/tests/unit/lifecycle-desired-state.test.ts
@@ -160,6 +160,17 @@ describe("facet normalization: stability and coverage", () => {
       // The resolved model's input modalities ride the request per turn and change with the
       // model; hashing them refused the live route on any cross-modality model switch.
       { modelCapabilities: { inputModalities: ["text"] } as never },
+      // The rest of runContext is per-turn metadata: a committed revision or a trace id must
+      // never evict. Only `workflow.artifact.id` is identity (it selects the agent mount).
+      {
+        runContext: {
+          workflow: {
+            revision: { id: "rev-2", version: "7" },
+            variant: { id: "var-2" },
+          },
+          trace: { trace_id: "abc" },
+        } as never,
+      },
     ]) {
       assert.deepEqual(
         movedBy(overrides),
@@ -176,6 +187,10 @@ describe("facet normalization: stability and coverage", () => {
     const probes: Array<[string, Partial<AgentRunRequest>]> = [
       ["sandbox", { sandbox: "daytona" }],
       ["harness", { harness: "pi" }],
+      [
+        "runContext.workflow.artifact.id",
+        { runContext: { workflow: { artifact: { id: "art-2" } } } } as never,
+      ],
       ["model", { model: "m2" }],
       ["agentsMd", { agentsMd: "x" }],
       ["systemPrompt", { systemPrompt: "x" }],

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -278,6 +278,41 @@ describe("configFingerprint", () => {
     }
   });
 
+  it("evicts when the agent artifact changes, and ignores the rest of runContext", () => {
+    // Audit finding 4: the artifact id selects the agent mount, which is baked at acquire —
+    // a warm sandbox must never serve a session whose storage folder changed. Every other
+    // runContext field is per-turn metadata and must never evict (the step-1 rule).
+    const withContext = (runContext: unknown): AgentRunRequest =>
+      ({ ...base, runContext }) as AgentRunRequest;
+    const artifactA = withContext({ workflow: { artifact: { id: "art-a" } } });
+    assert.notEqual(
+      configFingerprint(artifactA),
+      configFingerprint(
+        withContext({ workflow: { artifact: { id: "art-b" } } }),
+      ),
+      "a changed artifact id must evict",
+    );
+    assert.notEqual(
+      configFingerprint(base),
+      configFingerprint(artifactA),
+      "absent-to-present must evict too (the mount appears)",
+    );
+    assert.equal(
+      configFingerprint(artifactA),
+      configFingerprint(
+        withContext({
+          workflow: {
+            artifact: { id: "art-a" },
+            revision: { id: "rev-9" },
+            variant: { id: "var-9" },
+          },
+          trace: { trace_id: "xyz" },
+        }),
+      ),
+      "revision/variant/trace identity stays per-turn metadata",
+    );
+  });
+
   it("excludes the derived gateway guidance, so an integration add never evicts", () => {
     // The guidance text carries the integration NAMES as examples and refreshes at
     // environment build. Hashing it would cold every warm session on each integration add —


### PR DESCRIPTION
Cold/warm audit finding 4 (docs/design/lifecycle-cold-warm-audit).

## What was wrong

The agent-mount artifact id is baked at acquire: it signs the mount, sets the mount env var, and lands in the prompt guidance. But it sat in no fingerprint and no facet. A run that switched to a different agent artifact, or gained one, reused the warm sandbox that was built for the old agent. A probe measured the reuse.

## The fix

- `runContext.workflow.artifact.id` now rides the `sandbox` facet and the config fingerprint. A change rebuilds; everything else in `runContext` stays volatile.
- A pinned test proves the id evicts and that revision, variant, and trace ids still do not.

## How to verify

Run `pnpm exec vitest run tests/unit/lifecycle-desired-state.test.ts tests/unit/session-pool.test.ts` in `services/runner`.

Part of the audit-findings stack; base is #6374.

https://claude.ai/code/session_0165tsjmvf3qvTPFcb9EV44g