### PR TITLE
[fix] One harness normalizer, shared by every identity view

### DIFF
--- a/services/runner/src/engines/sandbox_agent/pi-model-config.ts
+++ b/services/runner/src/engines/sandbox_agent/pi-model-config.ts
@@ -22,6 +22,7 @@
  * The input stays neutral in both cases — no Pi-specific wire field is introduced.
  */
 import type { AgentRunRequest } from "../../protocol.ts";
+import { harnessKindOf } from "../../harness-kind.ts";
 import type {
   PiBuiltinModel,
   PiBuiltinRegistry,
@@ -222,11 +223,9 @@ export class PiModelConfigError extends Error {
   }
 }
 
-/** Pi identity check, mirroring `buildRunPlan` (an empty harness defaults to `pi_core`). */
+/** Pi identity check: THE shared normalizer, so it can never drift from `buildRunPlan`. */
 function isPiHarness(harness: string | undefined): boolean {
-  const resolved = harness || "pi_core";
-  // "pi_agenta" is the removed experiment's spelling, still read as Pi (see run-plan.ts).
-  return resolved === "pi_core" || resolved === "pi_agenta";
+  return harnessKindOf(harness) === "pi";
 }
 
 /**

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -12,6 +12,7 @@ import {
 } from "../../protocol.ts";
 import { executableToolSpecs } from "../../tools/public-spec.ts";
 import { attachmentCountError } from "../../sessions/attachments.ts";
+import { harnessKindOf } from "../../harness-kind.ts";
 import { CODE_TOOL_UNSUPPORTED_MESSAGE } from "../../tools/code.ts";
 import { PI_USER_MCP_UNSUPPORTED_MESSAGE } from "../../tools/mcp-bridge.ts";
 import {
@@ -450,17 +451,17 @@ export function buildRunPlan(
 
   // The harness identity maps to a real ACP agent the daemon knows (`pi` / `claude`).
   // `pi_agenta` (a removed experiment: Pi plus a forced Agenta overlay) is read as Pi so an
-  // old stored request or replay still runs; `pi_core` and that legacy spelling both
+  // old stored request or replay still runs; the mapping is `harnessKindOf`, THE shared
+  // normalizer — `pi_core` and that legacy spelling both
   // run on the `pi` ACP agent; `claude` runs on the `claude` ACP agent. `harness` remains the
   // selected identity for logs, traces, and user-facing errors.
-  const acpAgent =
-    harness === "pi_core" || harness === "pi_agenta" ? "pi" : harness;
+  const acpAgent = harnessKindOf(harness) === "pi" ? "pi" : harness;
 
   // Debug assertion: every Pi identity must resolve to the `pi` ACP agent and nothing else may.
   // Catches a future harness-id typo (e.g. a new `pi_*` value forgotten here) at plan-build time
   // rather than as a daemon "unknown agent" error mid-run.
   assert(
-    (harness === "pi_core" || harness === "pi_agenta") === (acpAgent === "pi"),
+    (harnessKindOf(harness) === "pi") === (acpAgent === "pi"),
     `harness '${harness}' resolved to ACP agent '${acpAgent}', but pi identity mapping disagrees`,
   );
 

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -12,7 +12,7 @@ import {
   userTurnCarriesContent,
 } from "../../protocol.ts";
 import { approvalDecisionOf } from "../../responder.ts";
-import { resolveCodexMode } from "./codex-mode.ts";
+import { normalizedHarnessMode } from "../../harness-kind.ts";
 import type { TeardownReason } from "./teardown.ts";
 import { loadRunnerConfig } from "../../config/runner-config.ts";
 
@@ -268,12 +268,10 @@ function configShape(request: AgentRunRequest) {
     // variant identity, and trace identity are per-turn metadata (the step-1 rule).
     agentArtifactId: request.runContext?.workflow?.artifact?.id?.trim() || null,
     model: request.model ?? null,
-    // Harness mode is applied once, at session acquire (codex-mode.ts). Normalize Codex defaults
-    // and ignore the field for other harnesses so only effective mode changes evict warm sessions.
-    harnessMode:
-      request.harness === "codex"
-        ? resolveCodexMode(request.harnessMode)
-        : null,
+    // Harness mode is applied once, at session acquire (codex-mode.ts). The SHARED normalizer
+    // (audit findings 3 and 6) resolves Codex defaults and ignores the field elsewhere, and the
+    // facet digest uses the same call, so the two views can never disagree about a mode change.
+    harnessMode: normalizedHarnessMode(request.harness, request.harnessMode),
     connection: request.connection ?? null,
     modelConnection: request.modelConnection
       ? {

--- a/services/runner/src/harness-kind.ts
+++ b/services/runner/src/harness-kind.ts
@@ -1,0 +1,55 @@
+/**
+ * THE one harness-identity normalizer (cold/warm audit findings 3 and 6).
+ *
+ * The wire carries `pi_core` and `pi_agenta` (a removed experiment's spelling, still read for
+ * old stored configs), `claude`, and `codex`; an empty or absent harness defaults to `pi_core`.
+ * Three call sites used to re-derive that mapping with their own inline literals, and one of
+ * them (`reconciliation-router.harnessKind`) matched the bare "pi" the wire never carries — so
+ * every playground Pi run fell into the fail-closed all-rebuild capability row (#6364). A second
+ * drift (finding 3): the config fingerprint normalized the Codex harness mode while the facet
+ * digest took it raw, so the two views could disagree about whether anything changed.
+ *
+ * This module exists so that class of drift is unrepresentable: everything that asks "which
+ * harness family is this?" or "what is the effective harness mode?" asks HERE, and a round-trip
+ * test pins every wire spelling. Keep it dependency-light (one pure import) so any layer —
+ * engines, lifecycle, tracing — can use it without cycles.
+ */
+import { resolveCodexMode } from "./engines/sandbox_agent/codex-mode.ts";
+
+/** The harness FAMILY a wire spelling resolves to. `unknown` must always fail closed. */
+export type NormalizedHarnessKind = "pi" | "claude" | "codex" | "unknown";
+
+/** Every wire spelling this runner accepts, mapped to its family. */
+export function harnessKindOf(
+  harness: string | undefined,
+): NormalizedHarnessKind {
+  // Only an ABSENT or EMPTY harness takes the `pi_core` default. `/stream` decodes its body
+  // with an unchecked `JSON.parse(raw) as AgentRunRequest`, so a malformed payload can put
+  // `null`, `0`, or `false` in this field, and a bare `||` would hand each of them Pi's live
+  // routes. A non-string is not a harness spelling we recognize, so it fails closed. The real
+  // client always sends a string (`wire.py` writes `harness.value`), so this costs a wasted
+  // rebuild only on input that should not exist.
+  if (harness !== undefined && typeof harness !== "string") return "unknown";
+  const resolved = harness || "pi_core";
+  if (resolved === "pi" || resolved === "pi_core" || resolved === "pi_agenta")
+    return "pi";
+  if (resolved === "claude" || resolved === "codex") return resolved;
+  return "unknown";
+}
+
+/**
+ * The EFFECTIVE harness mode: what session acquire will actually apply.
+ *
+ * Codex normalizes through `resolveCodexMode` (an invalid or absent value becomes the default),
+ * and every other harness has no mode at all — so an explicitly-sent default, an absent field,
+ * and a mode on a harness that ignores it all normalize to the same value, and only a change
+ * the session would OBSERVE can move a fingerprint or a facet.
+ */
+export function normalizedHarnessMode(
+  harness: string | undefined,
+  harnessMode: string | undefined,
+): string | null {
+  return harnessKindOf(harness) === "codex"
+    ? resolveCodexMode(harnessMode)
+    : null;
+}

--- a/services/runner/src/lifecycle/desired-state.ts
+++ b/services/runner/src/lifecycle/desired-state.ts
@@ -26,6 +26,7 @@
 import { createHash } from "node:crypto";
 
 import type { AgentRunRequest } from "../protocol.ts";
+import { normalizedHarnessMode } from "../harness-kind.ts";
 
 /**
  * The facets, in the order the reconciliation plan must apply them.
@@ -185,7 +186,10 @@ export function normalizeDesiredState(
   // request every turn) and it changes WITH the model, so hashing it here made a cross-modality
   // model switch move `harnessSession` beside `model` and refuse the live route (audit finding 2).
   const harnessSession = canonical({
-    harnessMode: request.harnessMode ?? null,
+    // The SHARED normalizer, not the raw field (audit finding 3): the fingerprint normalizes
+    // the Codex mode, and a facet that took it raw could move while the fingerprint stayed
+    // still — poisoning every later plan for that session into a rebuild.
+    harnessMode: normalizedHarnessMode(request.harness, request.harnessMode),
     permissions: request.permissions ?? null,
     mcpServers:
       request.mcpServers?.map((server) => ({

--- a/services/runner/src/lifecycle/reconciliation-router.ts
+++ b/services/runner/src/lifecycle/reconciliation-router.ts
@@ -29,7 +29,9 @@ import {
   type ReconcilePlan,
 } from "./reconcile-plan.ts";
 
-export type HarnessKind = "pi" | "claude" | "codex" | "unknown";
+import { harnessKindOf, type NormalizedHarnessKind } from "../harness-kind.ts";
+
+export type HarnessKind = NormalizedHarnessKind;
 
 /**
  * What each harness can do about a changed facet.
@@ -220,26 +222,13 @@ const V1_CAPABILITIES: Readonly<
 };
 
 export function harnessKind(request: AgentRunRequest): HarnessKind {
-  // Mirror `buildRunPlan`'s normalization exactly: the WIRE carries `pi_core` (an empty
-  // harness defaults to it; `pi_agenta` is a removed experiment's spelling, still read as
-  // Pi so an old stored request replays), never the bare "pi" this table is keyed by.
-  // Matching only the literals sent every playground Pi run into the fail-closed `unknown`
-  // row, whose every facet says rebuild — which disabled the live model-switch route and
-  // made the shadow log plan a rebuild for every Pi config change.
-  //
-  // Only an ABSENT or EMPTY harness takes that `pi_core` default. `/stream` decodes its body
-  // with an unchecked `JSON.parse(raw) as AgentRunRequest`, so a malformed payload can put
-  // `null`, `0`, or `false` in this field, and a bare `||` would hand each of them Pi's live
-  // routes. A non-string is not a harness spelling we recognize, so it falls to `unknown` and
-  // rebuilds. The real client always sends a string (`wire.py` writes `harness.value`), so
-  // this costs a wasted rebuild only on input that should not exist.
-  if (request.harness !== undefined && typeof request.harness !== "string")
-    return "unknown";
-  const harness = request.harness || "pi_core";
-  if (harness === "pi" || harness === "pi_core" || harness === "pi_agenta")
-    return "pi";
-  if (harness === "claude" || harness === "codex") return harness;
-  return "unknown";
+  // Delegates to THE one normalizer (audit finding 6). This function's first version matched
+  // the bare "pi" literal the wire never carries, sending every playground Pi run into the
+  // fail-closed all-rebuild row (#6364) — the shared normalizer plus its round-trip test is
+  // what makes that drift unrepresentable now. The non-string fail-closed guard (an unchecked
+  // `JSON.parse` can put `null`, `0`, or `false` here) lives inside the normalizer too, so
+  // every caller gets it.
+  return harnessKindOf(request.harness);
 }
 
 export function capabilitiesFor(

--- a/services/runner/tests/unit/harness-kind.test.ts
+++ b/services/runner/tests/unit/harness-kind.test.ts
@@ -1,0 +1,72 @@
+/**
+ * The one harness-identity normalizer (audit findings 3 and 6).
+ *
+ * Run: pnpm exec vitest run tests/unit/harness-kind.test.ts
+ */
+import { describe, it } from "vitest";
+import assert from "node:assert/strict";
+
+import {
+  harnessKindOf,
+  normalizedHarnessMode,
+} from "../../src/harness-kind.ts";
+import { harnessKind } from "../../src/lifecycle/reconciliation-router.ts";
+import type { AgentRunRequest } from "../../src/protocol.ts";
+
+describe("harnessKindOf", () => {
+  it("round-trips every wire spelling the SDK can send", () => {
+    // The SDK's HarnessKind enum plus the legacy spelling and the empty default. A value
+    // added to the SDK without a row here must fail THIS test, not fall into `unknown` in
+    // production the way "pi_core" once did (#6364).
+    const table: Array<[string | undefined, string]> = [
+      ["pi_core", "pi"],
+      ["pi_agenta", "pi"], // removed experiment; old stored configs still carry it
+      ["pi", "pi"], // never on the wire, accepted defensively
+      ["claude", "claude"],
+      ["codex", "codex"],
+      ["", "pi"], // empty defaults to pi_core
+      [undefined, "pi"],
+      ["future-thing", "unknown"], // fail closed
+      // An unchecked `JSON.parse` can put a non-string here; each must fail closed rather
+      // than borrow Pi's default through a falsy `||` (#6364's review guard).
+      [null as never, "unknown"],
+      [0 as never, "unknown"],
+      [false as never, "unknown"],
+    ];
+    for (const [wire, kind] of table) {
+      assert.equal(harnessKindOf(wire), kind, `harnessKindOf(${wire})`);
+    }
+  });
+
+  it("is the same answer the lifecycle router gives", () => {
+    for (const harness of ["pi_core", "pi_agenta", "claude", "codex", "x"]) {
+      assert.equal(
+        harnessKind({ harness } as AgentRunRequest),
+        harnessKindOf(harness),
+        harness,
+      );
+    }
+  });
+});
+
+describe("normalizedHarnessMode", () => {
+  it("resolves only for codex, where the default and an absent value are equal", () => {
+    assert.equal(
+      normalizedHarnessMode("codex", undefined),
+      "agent-full-access",
+    );
+    assert.equal(
+      normalizedHarnessMode("codex", "agent-full-access"),
+      "agent-full-access",
+      "an explicitly-sent default equals an absent field",
+    );
+    assert.equal(normalizedHarnessMode("codex", "read-only"), "read-only");
+    assert.equal(
+      normalizedHarnessMode("codex", "not-a-mode"),
+      "agent-full-access",
+    );
+    // Every non-codex harness ignores the field entirely.
+    assert.equal(normalizedHarnessMode("pi_core", "read-only"), null);
+    assert.equal(normalizedHarnessMode("claude", "read-only"), null);
+  });
+});

--- a/services/runner/tests/unit/lifecycle-desired-state.test.ts
+++ b/services/runner/tests/unit/lifecycle-desired-state.test.ts
@@ -180,6 +180,44 @@ describe("facet normalization: stability and coverage", () => {
     }
   });
 
+  it("the fingerprint and the facets agree about harness-mode changes (finding 3)", () => {
+    // The fingerprint normalized the Codex mode while the facet took it raw, so an
+    // explicitly-sent default moved `harnessSession` but not the fingerprint — and a session
+    // poisoned that way rebuilt on every later mixed plan. Both views now share one
+    // normalizer; this pins the agreement in BOTH directions.
+    const codex = { ...BASE, harness: "codex" } as AgentRunRequest;
+    const agree = (a: AgentRunRequest, b: AgentRunRequest, why: string) => {
+      const fpMoved = configFingerprint(a) !== configFingerprint(b);
+      const facetsMoved =
+        JSON.stringify(digestsOf(a)) !== JSON.stringify(digestsOf(b));
+      assert.equal(fpMoved, facetsMoved, why);
+      return fpMoved;
+    };
+    assert.equal(
+      agree(
+        codex,
+        { ...codex, harnessMode: "agent-full-access" },
+        "explicit default",
+      ),
+      false,
+      "an explicitly-sent default equals an absent field in both views",
+    );
+    assert.equal(
+      agree(codex, { ...codex, harnessMode: "read-only" }, "real mode change"),
+      true,
+      "a real Codex mode change moves both views",
+    );
+    assert.equal(
+      agree(
+        BASE,
+        { ...BASE, harnessMode: "read-only" } as AgentRunRequest,
+        "non-codex",
+      ),
+      false,
+      "a mode on a harness that ignores it moves neither view",
+    );
+  });
+
   it("NO INPUT DRIFT: a field that moves the fingerprint also moves a facet", () => {
     // The load-bearing invariant. The shadow comparison is only meaningful when the facets see
     // exactly what the fingerprint sees. A field in the fingerprint but in no facet would make


### PR DESCRIPTION
Cold/warm audit findings 3 and 6 (docs/design/lifecycle-cold-warm-audit).

## What was wrong

Three call sites re-derived the harness wire-spelling map with their own inline literals. That is the exact shape of the #6364 bug: a literal plus a silent fall-through. On top of that, the config fingerprint normalized the Codex harness mode while the facet digest took the raw value, so the two identity views could disagree about whether anything changed and poison later plans into rebuilding.

## The fix

- New `src/harness-kind.ts` is THE one normalizer. `harnessKindOf` resolves every wire spelling, with the non-string fail-closed guard from #6364 inside it. `normalizedHarnessMode` resolves the one effective mode (Codex resolves defaults, every other harness gets `null`).
- The reconciliation router, `run-plan.ts`, `pi-model-config.ts`, the config fingerprint, and the facet digests all delegate to it.
- A round-trip test pins every wire spelling, including `null`/`0`/`false`. A drift test pins that a mode change moves the fingerprint and the facets together.

## How to verify

Run `pnpm exec vitest run tests/unit/harness-kind.test.ts tests/unit/lifecycle-desired-state.test.ts` in `services/runner`.

Stacked on #6398.

https://claude.ai/code/session_0165tsjmvf3qvTPFcb9EV44g