### PR TITLE
[fix] Close two smaller lifecycle gaps: per-turn endpoint eviction, apply-live facet

### DIFF
--- a/docs/design/lifecycle-cold-warm-audit/README.md
+++ b/docs/design/lifecycle-cold-warm-audit/README.md
@@ -32,32 +32,34 @@ harness.
    modalities. Fix: move it to the per-turn-volatile list (the `workflowRevision` /
    `isDraft` precedent), pinned in `lifecycle-desired-state.test.ts`.
 
-3. **`harnessMode` is normalized in the fingerprint but raw in the facet.** The two views
+3. **FIXED (#6399, with 6). `harnessMode` is normalized in the fingerprint but raw in the facet.** The two views
    can disagree (measured: fingerprint equal while `harnessSession` moves), which poisons
    later plans into rebuilding. Reachable today only through a direct runner caller.
    Fix: normalize in one place; add the reverse-direction "no input drift" assertion (a
    change that moves a facet must move the fingerprint).
 
-4. **The agent-mount artifact id is in no fingerprint and no facet (under-eviction).**
+4. **FIXED (#6398). The agent-mount artifact id is in no fingerprint and no facet (under-eviction).**
    `runContext.workflow.artifact.id` signs the agent mount, sets its env var, and appends
    its guidance — all baked at acquire — yet a changed or newly present id reuses the warm
    sandbox (measured). Fix: add the id alone to the `sandbox` facet + fingerprint, with an
    eviction test.
 
-5. **`toolCallback.endpoint` is fingerprinted but consumed per-turn (over-eviction).** Low
+5. **FIXED (#6400). `toolCallback.endpoint` is fingerprinted but consumed per-turn (over-eviction).** Low
    reachability (stable per-deployment URL); same fix class as 2.
 
-6. **`configFingerprint` matches `codex` on a bare wire literal inline.** Correct today,
+6. **FIXED (#6399). `configFingerprint` matches `codex` on a bare wire literal inline.** Correct today,
    but the exact shape of the #6364 bug (a literal plus a silent fall-through). Fix:
    one exported harness normalizer used by `configFingerprint`, `run-plan.ts`, and
    `reconciliation-router.ts`, with a round-trip test over the SDK enum.
 
-7. **`applyReconcilePlan` treats every `apply-live` action as a model change** (ignores
+7. **FIXED (#6400). `applyReconcilePlan` treats every `apply-live` action as a model change** (ignores
    `action.facet`). Unreachable today; becomes real the moment the credential plan routes
    through the applier. Fix: switch on the facet, refuse the rest, one test.
 
-8. **`connection` `{mode, slug}` evicts on every harness but only Pi consumes it.** Very
-   low reachability; listed for completeness.
+8. **DECLINED. `connection` `{mode, slug}` evicts on every harness but only Pi consumes it.** Very
+   low reachability; listed for completeness. Declined on review: design Decision 7 pins that a
+   custom provider identity change cold-starts on EVERY harness, and its test covers non-Pi.
+   The decline is recorded beside the field in `session-identity.ts` (#6400).
 
 Verified clean: the harness wire spellings after #6364 (both normalizers agree, with a
 plan-build assertion), and the shadow-router's decision scoping.
@@ -69,5 +71,4 @@ plan-build assertion), and the shadow-router's decision scoping.
   Slack webhook on any `DISAGREE` or `harness=unknown` runner log line.
 - Unit: the repair-scoping pinned tests in `lifecycle-live-routes.test.ts` (#6372).
 
-Findings 2-8 are queued work; each names its cheapest check above so the fix and the pin
-land together.
+Every finding is now fixed or declined; each fix landed with its pin (see the PR on each row).

--- a/services/runner/src/engines/sandbox_agent/run-plan.ts
+++ b/services/runner/src/engines/sandbox_agent/run-plan.ts
@@ -419,6 +419,15 @@ export function buildRunPlan(
   const runnerConfig = loadRunnerConfig();
   const defaultProvider = sandboxProvider ?? runnerConfig.providers.default;
   const enabled = enabledProviders ?? runnerConfig.providers.enabled;
+  // Fail CLOSED on a non-string harness, matching `harnessKindOf`: `/stream` decodes with an
+  // unchecked `JSON.parse`, so a malformed payload can put `null`, `0`, or `false` here, and a
+  // bare `||` would quietly run it as Pi while the lifecycle router classifies it `unknown`.
+  if (request.harness !== undefined && typeof request.harness !== "string") {
+    return {
+      ok: false,
+      error: `Unrecognized harness ${JSON.stringify(request.harness)}: not a string.`,
+    };
+  }
   const harness = request.harness || "pi_core";
   const sandboxId = request.sandbox || defaultProvider || "local";
 

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -303,10 +303,13 @@ function configShape(request: AgentRunRequest) {
         ...server,
         connection: {
           ...server.connection,
+          // `?? []` matches the facet digest's normalization (`credentialShapes`): an omitted
+          // array and an empty one are the same configuration, and the two identity views
+          // must agree on that or a no-op request cold-evicts with a DISAGREE log.
           credentials: server.connection?.credentials?.map((credential) => ({
             binding: credential.binding,
             usage: credential.usage,
-          })),
+          })) ?? [],
         },
       })) ?? null,
     // No `toolCallback.endpoint` (audit finding 5): every turn reads the INCOMING request's

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -272,6 +272,9 @@ function configShape(request: AgentRunRequest) {
     // (audit findings 3 and 6) resolves Codex defaults and ignores the field elsewhere, and the
     // facet digest uses the same call, so the two views can never disagree about a mode change.
     harnessMode: normalizedHarnessMode(request.harness, request.harnessMode),
+    // Hashed on EVERY harness, deliberately (audit finding 8 proposed scoping this to Pi and
+    // was declined): design Decision 7 pins that a custom provider identity change cold-starts
+    // rather than reusing a mismatched live session, and the pinned test covers non-Pi too.
     connection: request.connection ?? null,
     modelConnection: request.modelConnection
       ? {
@@ -306,7 +309,10 @@ function configShape(request: AgentRunRequest) {
           })),
         },
       })) ?? null,
-    toolCallbackEndpoint: request.toolCallback?.endpoint ?? null,
+    // No `toolCallback.endpoint` (audit finding 5): every turn reads the INCOMING request's
+    // callback (`run-turn.ts` builds each dispatch from it), nothing bakes the endpoint into
+    // the environment, and hashing it evicted a warm session when the per-deployment gateway
+    // URL moved. The endpoint's per-turn AUTHORIZATION was already excluded.
     // No `gatewayGuidance` and no `gatewayPolicy`: both are DERIVED from the agent's gateway
     // connections at resolve time. The guidance is spliced into the prompt at environment build
     // (`buildRunPlan`) and its wording treats the integration names as examples, so a warm

--- a/services/runner/src/environment/apply-plan.ts
+++ b/services/runner/src/environment/apply-plan.ts
@@ -181,6 +181,17 @@ export async function applyReconcilePlan(
       }
 
       case "apply-live": {
+        if (action.facet !== "model") {
+          // `apply-live` names an OPERATION, not a target: the plan says which facet asked for
+          // it, and the model is the only one this applier knows how to install live. A future
+          // plan that routes another facet here (the credential plan is the expected first) must
+          // fail into a rebuild, not have its change silently installed as a model (audit
+          // finding 7).
+          log(
+            `live-route: no live applier for facet '${action.facet}'; rebuilding`,
+          );
+          return false;
+        }
         // The only live session-level operation: `setModel` on the running session. Strict, so a
         // model the harness will not accept throws here and the whole plan fails rather than
         // silently leaving the session on its previous model while we report the new one.

--- a/services/runner/src/lifecycle/desired-state.ts
+++ b/services/runner/src/lifecycle/desired-state.ts
@@ -203,9 +203,10 @@ export function normalizeDesiredState(
 
   // TOOL CATALOG: what the model can see and call. It is its own facet because it is the one
   // the adapters could eventually apply live. v1 routes it to a session reopen on every harness.
+  // No `toolCallback.endpoint` (audit finding 5): it is read from the incoming request every
+  // turn, so it is per-turn routing, not environment identity.
   const toolCatalog = canonical({
     customTools: request.customTools ?? null,
-    toolCallbackEndpoint: request.toolCallback?.endpoint ?? null,
   });
 
   return {

--- a/services/runner/tests/unit/lifecycle-apply-plan.test.ts
+++ b/services/runner/tests/unit/lifecycle-apply-plan.test.ts
@@ -217,4 +217,33 @@ describe("applyReconcilePlan: refresh-workspace installs the INCOMING configurat
     assert.equal(applied, false);
     assert.equal(committed.length, 0);
   });
+
+  it("refuses an apply-live action for a facet it cannot install (audit finding 7)", async () => {
+    // The arm used to treat EVERY `apply-live` as a model change. The day another facet routes
+    // here (the credential plan is the expected first), that would install the wrong thing and
+    // commit the new configuration. It must fail into a rebuild instead, without calling the
+    // model applier at all.
+    const env = makeEnv();
+    const request: AgentRunRequest = {
+      harness: "claude",
+      model: "m1",
+      messages: [],
+    } as never;
+    const plan = buildPlan(
+      [{ facet: "runtime", kind: "apply-live", reason: "r" }],
+      ["runtime"],
+    );
+
+    let modelApplierCalled = false;
+    const applied = await applyReconcilePlan(env, request, plan, () => {}, {
+      applyModel: async () => {
+        modelApplierCalled = true;
+        return "m1";
+      },
+    });
+
+    assert.equal(applied, false, "the caller must rebuild");
+    assert.equal(committed.length, 0, "and applied state must not advance");
+    assert.equal(modelApplierCalled, false, "the model applier must not run");
+  });
 });

--- a/services/runner/tests/unit/lifecycle-desired-state.test.ts
+++ b/services/runner/tests/unit/lifecycle-desired-state.test.ts
@@ -171,12 +171,31 @@ describe("facet normalization: stability and coverage", () => {
       // (finding 5); a moved deployment must not evict every warm session.
       { toolCallback: { endpoint: "https://gateway-2/tools/call" } as never },
     ]) {
-      assert.deepEqual(
-        movedBy(overrides),
-        [],
-        JSON.stringify(overrides).slice(0, 40),
+      const label = JSON.stringify(overrides).slice(0, 40);
+      assert.deepEqual(movedBy(overrides), [], label);
+      // BOTH identity views must ignore a volatile: a field that sneaks back into the
+      // fingerprint alone would cold-evict every warm session while this facet probe
+      // stayed green (Codex review of the finding-5 change).
+      assert.equal(
+        configFingerprint({ ...BASE, ...overrides } as AgentRunRequest),
+        configFingerprint(BASE),
+        `fingerprint moved: ${label}`,
       );
     }
+  });
+
+  it("omitted MCP credentials equal an empty credential array, in BOTH views", () => {
+    // The facet digest normalized an omitted array to [] while the fingerprint kept the
+    // omission, so two identical requests disagreed in one view only: a cold evict with an
+    // empty live plan and a DISAGREE log (Codex review of the finding-3 change).
+    const server = { name: "s", connection: { url: "https://mcp.test" } };
+    const omitted = { ...BASE, mcpServers: [server] } as never as AgentRunRequest;
+    const empty = {
+      ...BASE,
+      mcpServers: [{ ...server, connection: { ...server.connection, credentials: [] } }],
+    } as never as AgentRunRequest;
+    assert.equal(configFingerprint(omitted), configFingerprint(empty));
+    assert.deepEqual(digestsOf(omitted), digestsOf(empty));
   });
 
   it("the fingerprint and the facets agree about harness-mode changes (finding 3)", () => {

--- a/services/runner/tests/unit/lifecycle-desired-state.test.ts
+++ b/services/runner/tests/unit/lifecycle-desired-state.test.ts
@@ -110,13 +110,9 @@ describe("facet ownership: one field moves exactly one facet", () => {
       overrides: { customTools: [{ name: "t" }] as never },
       facet: "toolCatalog",
     },
-    {
-      what: "the tool callback endpoint",
-      overrides: {
-        toolCallback: { endpoint: "https://gateway/tools/call" } as never,
-      },
-      facet: "toolCatalog",
-    },
+    // The tool callback endpoint left this table with audit finding 5: it is read from the
+    // incoming request every turn, so it moves NO facet. The per-turn-volatile suite below
+    // pins that instead.
   ];
 
   for (const { what, overrides, facet } of cases) {
@@ -171,6 +167,9 @@ describe("facet normalization: stability and coverage", () => {
           trace: { trace_id: "abc" },
         } as never,
       },
+      // The per-deployment gateway URL is read from the incoming request every turn
+      // (finding 5); a moved deployment must not evict every warm session.
+      { toolCallback: { endpoint: "https://gateway-2/tools/call" } as never },
     ]) {
       assert.deepEqual(
         movedBy(overrides),
@@ -245,10 +244,6 @@ describe("facet normalization: stability and coverage", () => {
       ["permissions", { permissions: { default: "deny" } as never }],
       ["sandboxPermission", { sandboxPermission: "none" as never }],
       ["mcpServers", { mcpServers: [{ name: "x", connection: {} }] as never }],
-      [
-        "toolCallback.endpoint",
-        { toolCallback: { endpoint: "https://gateway/tools/call" } as never },
-      ],
     ];
 
     for (const [name, overrides] of probes) {

--- a/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-run-plan.test.ts
@@ -59,6 +59,20 @@ describe("buildRunPlan", () => {
     assert.equal(created, false);
   });
 
+  it("refuses a non-string harness instead of running it as Pi", () => {
+    // `/stream` decodes with an unchecked JSON.parse, so `null`/`0`/`false` can land here. The
+    // lifecycle router classifies those `unknown` (fail closed); the plan must not quietly
+    // default them to Pi and diverge (Codex review of the harness-normalizer change).
+    for (const junk of [null, 0, false, {}]) {
+      const result = buildRunPlan({
+        harness: junk,
+        messages: [{ role: "user", content: "hi" }],
+      } as never);
+      assert.equal(result.ok, false, JSON.stringify(junk));
+      if (!result.ok) assert.match(result.error, /harness/i);
+    }
+  });
+
   it("accepts an attachment-only current user turn", () => {
     const result = buildRunPlan(
       {


### PR DESCRIPTION
Cold/warm audit findings 5 and 7 (docs/design/lifecycle-cold-warm-audit). Finding 8 was reviewed and declined; the decline is documented in `session-identity.ts` because design Decision 7 pins that a custom provider identity change must cold-start on every harness.

## Finding 5: the tool callback endpoint is per-turn, not identity

Every turn builds its tool dispatch from the incoming request's callback. Nothing bakes the endpoint into the environment. But the endpoint rode the fingerprint and the `toolCatalog` facet, so a moved per-deployment gateway URL evicted every warm session for nothing. It is now out of the hash, documented in the exclusion list, and pinned per-turn-volatile in both directions.

## Finding 7: an apply-live action must install only the facet it names

The apply-live arm ignored `action.facet` and treated every such action as a model change. That is unreachable today, but the day another facet routes through the applier (the credential plan is the expected first), its change would be silently installed as a model and committed as applied. The arm now refuses any facet but `model` and fails into a rebuild. The pin also asserts the model applier never runs on a refused action.

## How to verify

Run `pnpm exec vitest run tests/unit/lifecycle-desired-state.test.ts tests/unit/lifecycle-apply-plan.test.ts tests/unit/session-pool.test.ts` in `services/runner`.

Stacked on #6399. This is the top of the audit-findings stack.

https://claude.ai/code/session_0165tsjmvf3qvTPFcb9EV44g