### PR TITLE
fix(runner): preserve public values during redaction

### DIFF
--- a/sdks/python/agenta/sdk/agents/handler.py
+++ b/sdks/python/agenta/sdk/agents/handler.py
@@ -51,7 +51,10 @@ from agenta.sdk.agents.dtos import RunContext, RunContextRun
 from agenta.sdk.engines.running.errors import ForceNotSupportedV0Error
 from agenta.sdk.redaction.context import get_active_redactor, redaction_context
 from agenta.sdk.redaction.redactor import Redactor
-from agenta.sdk.redaction.seed import seed_from_request
+from agenta.sdk.redaction.seed import (
+    is_non_secret_credential_locator,
+    seed_from_request,
+)
 from agenta.sdk.models.workflows import (
     WorkflowInvokeRequestFlags,
     WorkflowServiceRequest,
@@ -276,6 +279,12 @@ def make_agent_handler(composition: Optional[AgentComposition] = None):
                     credential.value
                     for credential in (
                         resolved_connection.credentials if resolved_connection else []
+                    )
+                    if not (
+                        credential.binding.kind == "environment"
+                        and is_non_secret_credential_locator(
+                            credential.binding.name, credential.value
+                        )
                     )
                 ),
                 *(

--- a/sdks/python/agenta/sdk/redaction/seed.py
+++ b/sdks/python/agenta/sdk/redaction/seed.py
@@ -99,11 +99,33 @@ def _looks_secret(name: str) -> bool:
     return bool(blocklist) and any(b in name for b in blocklist)
 
 
+def _looks_like_file_path(value: str) -> bool:
+    trimmed = value.strip()
+    return trimmed.startswith(("/", "./", "../", "~/", "\\\\")) or (
+        len(trimmed) >= 3
+        and trimmed[0].isalpha()
+        and trimmed[1] == ":"
+        and trimmed[2] in ("/", "\\")
+    )
+
+
+def is_non_secret_credential_locator(name: str, value: str) -> bool:
+    """Whether a provider-SDK environment value locates credentials but is not material."""
+    upper = name.upper()
+    return upper == "AWS_PROFILE" or (
+        upper == "GOOGLE_APPLICATION_CREDENTIALS" and _looks_like_file_path(value)
+    )
+
+
 def curated_env_secret_values() -> List[str]:
     """The VALUES (never the names) of every env var whose name is selected by the matchers."""
     values: List[str] = []
     for name, value in os.environ.items():
-        if value and _looks_secret(name.upper()):
+        if (
+            value
+            and _looks_secret(name.upper())
+            and not is_non_secret_credential_locator(name, value)
+        ):
             values.append(value)
     return values
 

--- a/sdks/python/oss/tests/pytest/unit/agents/test_redaction_scope.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_redaction_scope.py
@@ -105,7 +105,13 @@ class _CapturingBackend(Backend):
         return _FakeSession(AgentResult(output=self._output, events=[], usage={}))
 
 
-def _make_handler(secret: str, backend: _CapturingBackend):
+def _make_handler(
+    secret: str,
+    backend: _CapturingBackend,
+    *,
+    binding_name: str = "OPENAI_API_KEY",
+    usage: str = "opaque_http",
+):
     async def _resolve(*, model, context):
         return ResolvedConnection(
             provider="openai",
@@ -114,9 +120,9 @@ def _make_handler(secret: str, backend: _CapturingBackend):
             credential_mode="env",
             credentials=[
                 {
-                    "binding": {"kind": "environment", "name": "OPENAI_API_KEY"},
+                    "binding": {"kind": "environment", "name": binding_name},
                     "value": secret,
-                    "usage": "opaque_http",
+                    "usage": usage,
                 }
             ],
             endpoint={"base_url": "https://93.184.216.34/v1"},
@@ -145,6 +151,42 @@ def _messages() -> List[Dict[str, str]]:
 def _knows(redactor: Redactor, secret: str) -> bool:
     """True when `secret` is in the redactor's deny-set (it gets scrubbed)."""
     return secret not in (redactor.redact_string(f"x {secret}", sink="test") or "")
+
+
+async def test_path_credential_locator_does_not_enter_the_run_deny_set():
+    path = "/run/secrets/service-account"
+    backend = _CapturingBackend()
+
+    await _make_handler(
+        path,
+        backend,
+        binding_name="GOOGLE_APPLICATION_CREDENTIALS",
+        usage="local_use",
+    )(
+        request=WorkflowServiceRequest(),
+        messages=_messages(),
+        parameters=_params(),
+    )
+
+    assert not _knows(backend.captured_redactors[0], path)
+
+
+async def test_pasted_credential_material_still_enters_the_run_deny_set():
+    material = '{"private_key":"fake-private-key-DO-NOT-USE"}'
+    backend = _CapturingBackend()
+
+    await _make_handler(
+        material,
+        backend,
+        binding_name="GOOGLE_APPLICATION_CREDENTIALS",
+        usage="local_use",
+    )(
+        request=WorkflowServiceRequest(),
+        messages=_messages(),
+        parameters=_params(),
+    )
+
+    assert _knows(backend.captured_redactors[0], material)
 
 
 # --------------------------------------------------------------------------- #

--- a/sdks/python/oss/tests/pytest/unit/test_redaction_seed.py
+++ b/sdks/python/oss/tests/pytest/unit/test_redaction_seed.py
@@ -81,6 +81,18 @@ class TestCuratedEnvSecretValuesDefaults:
                 f"{name} must not be seeded with the default (empty) prefix list"
             )
 
+    def test_google_application_credentials_path_is_not_seeded(self, monkeypatch):
+        path = "/run/secrets/service-account"
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", path)
+        values = curated_env_secret_values()
+        assert path not in values
+
+    def test_google_application_credentials_material_is_still_seeded(self, monkeypatch):
+        material = '{"private_key":"fake-private-key-DO-NOT-USE"}'
+        monkeypatch.setenv("GOOGLE_APPLICATION_CREDENTIALS", material)
+        values = curated_env_secret_values()
+        assert material in values
+
     def test_aws_bearer_token_bedrock_is_seeded_via_default_blocklist(
         self, monkeypatch
     ):

--- a/services/runner/src/engines/sandbox_agent/harness-trace-port.ts
+++ b/services/runner/src/engines/sandbox_agent/harness-trace-port.ts
@@ -1,7 +1,11 @@
 import { randomBytes } from "node:crypto";
 
 import type { AgentRunRequest } from "../../protocol.ts";
-import { sandboxVisibleSecretValues, type Redactor } from "../../redaction.ts";
+import {
+  modelEnvironmentSecretValues,
+  sandboxVisibleSecretValues,
+  type Redactor,
+} from "../../redaction.ts";
 import type { createSandboxAgentOtel } from "../../tracing/otel.ts";
 import { createPiTraceTurnExport } from "../../tracing/pi-trace-turn-export.ts";
 import {
@@ -143,13 +147,15 @@ function piTracePort(options: {
           content: request.telemetry?.capture?.content?.enabled !== false,
         },
         skills: plan.workspace.skillDirs.map((skill) => skill.name),
-        // Only values visible inside the sandbox cross this boundary. In particular, the runner
-        // OTLP authorization never enters the control file.
+        // Only secret values visible inside the sandbox cross this boundary. Approved public
+        // model configuration and the runner OTLP authorization never enter the control file.
         redaction: {
           knownValues: [
             ...new Set(
               [
-                ...Object.values(request.modelConnection?.environment ?? {}),
+                ...modelEnvironmentSecretValues(
+                  request.modelConnection?.environment,
+                ),
                 ...sandboxVisibleSecretValues(env),
               ].filter((value): value is string => !!value),
             ),

--- a/services/runner/src/redaction.ts
+++ b/services/runner/src/redaction.ts
@@ -188,12 +188,57 @@ function looksSecret(name: string): boolean {
   );
 }
 
+function looksLikeFilePath(value: string): boolean {
+  const trimmed = value.trim();
+  return (
+    trimmed.startsWith("/") ||
+    trimmed.startsWith("./") ||
+    trimmed.startsWith("../") ||
+    trimmed.startsWith("~/") ||
+    /^[A-Za-z]:[\\/]/.test(trimmed) ||
+    trimmed.startsWith("\\\\")
+  );
+}
+
+/** Some provider SDK settings travel through credential-shaped fields because the SDK reads
+ * them locally, even though their values are locators rather than credential material. */
+function isNonSecretCredentialLocator(name: string, value: string): boolean {
+  const upper = name.toUpperCase();
+  return (
+    upper === "AWS_PROFILE" ||
+    (upper === "GOOGLE_APPLICATION_CREDENTIALS" && looksLikeFilePath(value))
+  );
+}
+
+const PUBLIC_MODEL_ENVIRONMENT_BINDINGS: ReadonlySet<string> = new Set([
+  "AWS_REGION",
+  "AWS_DEFAULT_REGION",
+  "GOOGLE_CLOUD_PROJECT",
+  "GOOGLE_CLOUD_LOCATION",
+]);
+
+/** Keep the public provider configuration named by the wire contract out of the deny-set while
+ * conservatively redacting unknown legacy environment bindings. */
+export function modelEnvironmentSecretValues(
+  environment: Record<string, string> = {},
+): string[] {
+  return Object.entries(environment)
+    .filter(([name]) => !PUBLIC_MODEL_ENVIRONMENT_BINDINGS.has(name))
+    .map(([, value]) => value);
+}
+
 /** The VALUES (never the names) of every process env var whose name is selected by the
  * PREFIX/SUFFIX/BLOCKLIST matchers. Mirrors `seed.py`'s `curated_env_secret_values`. */
 export function curatedEnvSecretValues(): string[] {
   const values: string[] = [];
   for (const [name, value] of Object.entries(process.env)) {
-    if (value && looksSecret(name)) values.push(value);
+    if (
+      value &&
+      looksSecret(name) &&
+      !isNonSecretCredentialLocator(name, value)
+    ) {
+      values.push(value);
+    }
   }
   return values;
 }
@@ -399,10 +444,15 @@ export function seedFromEnv(options?: {
 /** The shape `seedForRun` reads off an `AgentRunRequest` (structural, to avoid importing the
  * wire types into the redaction primitive). */
 export interface RunSeedSource {
-  /** Resolved model routing: typed credential values plus the materialized environment values. */
+  /** Resolved model routing. Approved `environment` bindings are public config; unknown legacy
+   * bindings remain fail-safe. `credentials` carries secrets and provider-SDK locators. */
   modelConnection?: {
     environment?: Record<string, string>;
-    credentials?: Array<{ value?: string }>;
+    credentials?: Array<{
+      value?: string;
+      binding?: { kind?: string; name?: string };
+      usage?: string;
+    }>;
   };
   /** Resolved MCP servers: each connection's typed secret header credential values. */
   mcpServers?: Array<{
@@ -414,21 +464,29 @@ export interface RunSeedSource {
 }
 
 /**
- * Every credential-bearing value the request's TYPED shapes carry: the model connection's
- * credential values and materialized environment values, plus each MCP server connection's
- * credential values. This is a superset of whatever subset actually lands in the sandbox env
- * (on a Daytona Secrets run the opaque values leave the plaintext env for the secret plan, but
- * they still transit runner memory and can be echoed by the model), so the deny-set seeds from
- * the request, not from the delivered environment.
+ * Every credential-bearing value the request's TYPED shapes carry: unknown legacy model
+ * environment values, actual model credential values, and MCP credential values. Approved public
+ * model configuration and provider-SDK locators stay readable.
  */
 export function requestSecretValues(
   request: RunSeedSource,
 ): Array<string | undefined> {
   return [
-    ...Object.values(request.modelConnection?.environment ?? {}),
-    ...(request.modelConnection?.credentials ?? []).map(
-      (credential) => credential.value,
-    ),
+    ...modelEnvironmentSecretValues(request.modelConnection?.environment),
+    ...(request.modelConnection?.credentials ?? [])
+      .filter(
+        (credential) =>
+          !(
+            credential.value &&
+            credential.binding?.kind === "environment" &&
+            credential.binding.name &&
+            isNonSecretCredentialLocator(
+              credential.binding.name,
+              credential.value,
+            )
+          ),
+      )
+      .map((credential) => credential.value),
     ...(request.mcpServers ?? []).flatMap((server) =>
       (server.connection?.credentials ?? []).map(
         (credential) => credential.value,

--- a/services/runner/tests/unit/redaction-sinks.test.ts
+++ b/services/runner/tests/unit/redaction-sinks.test.ts
@@ -15,6 +15,8 @@ import { ExportResultCode, type ExportResult } from "@opentelemetry/core";
 import type { ReadableSpan, SpanExporter } from "@opentelemetry/sdk-trace-base";
 
 import {
+  curatedEnvSecretValues,
+  modelEnvironmentSecretValues,
   Redactor,
   sandboxVisibleSecretValues,
   seedForRun,
@@ -136,6 +138,64 @@ describe("seedForRun (WP1.1 — the deny-set source)", () => {
     expect(
       seedForRun(runRequest).redactString(`key is ${PER_RUN_KEY}`, "test"),
     ).not.toContain(PER_RUN_KEY);
+  });
+
+  it("keeps approved public model bindings readable and unknown legacy bindings fail-safe", () => {
+    expect(
+      modelEnvironmentSecretValues({
+        AWS_REGION: "eu-west-1",
+        GOOGLE_CLOUD_PROJECT: "plain-project-name",
+        LEGACY_GATEWAY_AUTH: "legacy-secret-value",
+      }),
+    ).toEqual(["legacy-secret-value"]);
+  });
+
+  it("keeps public model configuration and credential locator paths readable", () => {
+    const adcPath = "/run/secrets/service-account";
+    const serviceAccountJson =
+      '{"private_key":"fake-private-key-DO-NOT-USE"}';
+    const redactor = seedForRun({
+      modelConnection: {
+        environment: {
+          AWS_REGION: "eu-west-1",
+          GOOGLE_CLOUD_PROJECT: "plain-project-name",
+        },
+        credentials: [
+          {
+            binding: {
+              kind: "environment",
+              name: "GOOGLE_APPLICATION_CREDENTIALS",
+            },
+            value: adcPath,
+            usage: "local_use",
+          },
+          {
+            binding: {
+              kind: "environment",
+              name: "GOOGLE_APPLICATION_CREDENTIALS",
+            },
+            value: serviceAccountJson,
+            usage: "local_use",
+          },
+        ],
+      },
+    });
+
+    const ordinary = `region=eu-west-1 project=plain-project-name credentials=${adcPath}`;
+    expect(redactor.redactString(ordinary, "test")).toBe(ordinary);
+    expect(
+      redactor.redactString(`credentials=${serviceAccountJson}`, "test"),
+    ).not.toContain(serviceAccountJson);
+  });
+
+  it("does not infer that GOOGLE_APPLICATION_CREDENTIALS paths are secret values", () => {
+    const adcPath = "/run/secrets/service-account";
+    vi.stubEnv("GOOGLE_APPLICATION_CREDENTIALS", adcPath);
+    vi.stubEnv("OPENAI_API_KEY", PER_RUN_KEY);
+
+    const values = curatedEnvSecretValues();
+    expect(values).not.toContain(adcPath);
+    expect(values).toContain(PER_RUN_KEY);
   });
 
   it("also seeds the run credential from the OTLP auth header", () => {
@@ -266,22 +326,46 @@ describe("persisted transcript sink (WP1.4)", () => {
     expect(JSON.stringify(postedBodies[0])).not.toContain(PER_RUN_KEY);
   });
 
-  it("leaves ordinary user content untouched (we redact leaks, not conversation)", async () => {
+  it("leaves ordinary user content and public model configuration untouched", async () => {
+    const adcPath = "/run/secrets/service-account";
+    const publicRegion = "eu-west-1";
+    const redactor = seedForRun({
+      ...runRequest,
+      modelConnection: {
+        ...runRequest.modelConnection,
+        environment: { AWS_REGION: publicRegion },
+        credentials: [
+          ...runRequest.modelConnection.credentials,
+          {
+            binding: {
+              kind: "environment",
+              name: "GOOGLE_APPLICATION_CREDENTIALS",
+            },
+            value: adcPath,
+            usage: "local_use",
+          },
+        ],
+      },
+    });
     const { emit, flush } = buildPersistingEmitter(
       "sess-redact-content",
       () => RUN_CREDENTIAL,
       undefined,
-      seedForRun(runRequest),
+      redactor,
     );
 
-    // A deliberately-pasted key-SHAPED string that is not a live secret must survive: the
-    // known-value pass has zero false positives by construction.
+    // A deliberately-pasted key-shaped string that is not a live secret must survive too.
     const userPasted = "sk-user-pasted-this-on-purpose-000";
-    emit({ type: "message", text: `here is my sample ${userPasted}` });
+    emit({
+      type: "message",
+      text: `sample=${userPasted} region=${publicRegion} credentials=${adcPath}`,
+    });
     await flush();
 
     const persisted = JSON.stringify(postedBodies[0]);
     expect(persisted).toContain(userPasted);
+    expect(persisted).toContain(publicRegion);
+    expect(persisted).toContain(adcPath);
     expect(persisted).not.toContain("[ag:redacted");
   });
 });


### PR DESCRIPTION
Public model configuration and credential locator paths were being replaced by the redaction placeholder in persisted chat records and traces. After a session rebuild, those false redactions could enter the model context and appear in generated files.

The runner now keeps `modelConnection.environment` out of the known-secret deny-set. The Python and TypeScript redaction paths also distinguish credential material from local provider configuration: `AWS_PROFILE` values and path-shaped `GOOGLE_APPLICATION_CREDENTIALS` values remain readable, while pasted service-account material and actual model, MCP, run, and mount credentials remain redacted.

## Before and after

Before:

```text
region=[ag:redacted:secret:st-1]
credentials=[ag:redacted:secret:ount]
```

After:

```text
region=eu-west-1
credentials=/run/secrets/service-account
```

Actual credential values still use the existing redaction placeholder.

## Tests

- `services/runner`: 2,526 unit tests passed. Ten unrelated filesystem-watch tests fail because this execution environment cannot arm the required directory watcher.
- `services/runner`: changed orchestration suite passed, 69 tests.
- `services/runner`: redaction sink suite passed, 17 tests.
- `services/runner`: TypeScript type check passed.
- `services/runner`: Pi extension build passed.
- `sdks/python`: 39 redaction and write-only-secret tests passed.
- `ruff format --check` passed for all changed Python files.
- `git diff --check` passed.

## How to review

1. Start with `services/runner/src/redaction.ts`. It defines which provider values are actual secret material and removes public model environment values from request seeding.
2. Read `sdks/python/agenta/sdk/redaction/seed.py` and `sdks/python/agenta/sdk/agents/handler.py` for the matching Python behavior.
3. Check `harness-trace-port.ts` to confirm Pi receives only sandbox secret values for trace redaction.
4. Review the TypeScript and Python regression tests for public values, path locators, and real credential material.