### PR TITLE
[fix] Keep the run credential when a localhost API URL is bridge-rewritten (F1)

### DIFF
--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -360,14 +360,47 @@ export function isAgentaIngest(endpoint: string): boolean {
   );
 }
 
+/** Hosts the api rewrites to `host.docker.internal` before it dispatches a run. */
+const BRIDGE_REWRITTEN_HOSTS = new Set(["localhost", "0.0.0.0"]);
+
+/**
+ * The same base as the api would hand a dispatched run, or undefined when the api leaves it alone.
+ *
+ * A self-hoster's natural `AGENTA_API_URL` is a localhost URL, but a sandboxed run cannot reach
+ * the host that way from inside its own container, so the api rewrites `localhost` and `0.0.0.0`
+ * to `host.docker.internal` on the way out (`parse_url`, `api/oss/src/utils/helpers.py`). The
+ * runner reads only the raw env value, so the configured base and the endpoint it is handed can
+ * never string-match, and every run of such a deployment loses its platform credential.
+ *
+ * The mirror is deliberately exact: same scheme, port, and path, and only the two hosts the api
+ * rewrites. `127.0.0.1` is absent because the api does not rewrite it, so admitting it would
+ * widen the allowlist past the platform's own rewrite for no deployment that exists.
+ */
+function bridgeRewrittenBase(base: string): string | undefined {
+  let url: URL;
+  try {
+    url = new URL(base);
+  } catch {
+    return undefined;
+  }
+  if (!BRIDGE_REWRITTEN_HOSTS.has(url.hostname)) return undefined;
+  url.hostname = "host.docker.internal";
+  return url.toString().replace(/\/+$/, "");
+}
+
 /** The api bases `isAgentaIngest` accepts, in precedence order. Exported so a rejection can name
  * what it compared against — the failure is always a configuration gap, never a code path. */
 export function configuredIngestBases(): string[] {
-  return [
+  const configured = [
     process.env.AGENTA_API_INTERNAL_URL,
     process.env.AGENTA_API_URL,
     CLOUD_API_BASE,
   ].filter((base): base is string => Boolean(base));
+
+  return configured.flatMap((base) => {
+    const bridged = bridgeRewrittenBase(base);
+    return bridged ? [base, bridged] : [base];
+  });
 }
 
 /**

--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -360,21 +360,52 @@ export function isAgentaIngest(endpoint: string): boolean {
   );
 }
 
-/** Hosts the api rewrites to `host.docker.internal` before it dispatches a run. */
+/** Hosts the platform rewrites to `host.docker.internal` before it dispatches a run. */
 const BRIDGE_REWRITTEN_HOSTS = new Set(["localhost", "0.0.0.0"]);
 
 /**
- * The same base as the api would hand a dispatched run, or undefined when the api leaves it alone.
+ * The same base the platform would hand a dispatched run, or undefined when it rewrites nothing.
  *
  * A self-hoster's natural `AGENTA_API_URL` is a localhost URL, but a sandboxed run cannot reach
- * the host that way from inside its own container, so the api rewrites `localhost` and `0.0.0.0`
- * to `host.docker.internal` on the way out (`parse_url`, `api/oss/src/utils/helpers.py`). The
- * runner reads only the raw env value, so the configured base and the endpoint it is handed can
- * never string-match, and every run of such a deployment loses its platform credential.
+ * the host that way from inside its own container, so the trace endpoint is rewritten to
+ * `host.docker.internal` on the way out. The runner reads only the raw env value, so the
+ * configured base and the endpoint it is handed can never string-match, and every run of such a
+ * deployment loses its platform credential.
  *
- * The mirror is deliberately exact: same scheme, port, and path, and only the two hosts the api
- * rewrites. `127.0.0.1` is absent because the api does not rewrite it, so admitting it would
- * widen the allowlist past the platform's own rewrite for no deployment that exists.
+ * The authority for that rewrite is `parse_url` in `sdks/python/agenta/sdk/utils/helpers.py`, NOT
+ * the api's same-named twin in `api/oss/src/utils/helpers.py`. The endpoint on the wire is
+ * `ag.tracing.otlp_url`, which the agent service derives through the SDK's copy; the api's copy
+ * shapes the service URL a run is POSTed to. The two differ, and the differences are what the
+ * limits below are about.
+ *
+ * The mirror is deliberately exact: same scheme, port, and path, and only the two hosts the
+ * rewrite touches. Three things it deliberately does NOT do:
+ *
+ *   - `127.0.0.1` earns no alias. Neither copy of `parse_url` rewrites it, so that deployment
+ *     already matches its own raw base and the bridge form is a pair the platform cannot produce.
+ *   - A scheme-less base earns no alias, because it cannot help. The SDK's `parse_url` does no
+ *     scheme defaulting (unlike the api's), so a scheme-less `AGENTA_API_URL` yields an equally
+ *     scheme-less ENDPOINT, which `new URL` reads as an opaque `localhost:`-scheme path. Both
+ *     sides are then unparseable and no aliasing here can make them agree. Such a deployment is
+ *     broken further upstream — the OTLP exporter target itself is malformed — and the fix is
+ *     scheme defaulting in the SDK's `parse_url`, not a wider allowlist.
+ *   - The alias is not gated on the docker network mode, even though the rewrite is: the SDK's
+ *     `parse_url` rewrites only when `DOCKER_NETWORK_MODE` is exactly `bridge`, so in `host` mode
+ *     (and when the var is unset) the platform dispatches the unrewritten localhost endpoint,
+ *     which the raw base already matches, and this alias is merely unused. Gating it is not
+ *     possible and would not be safe: the runner's environment carries no `DOCKER_NETWORK_MODE`
+ *     (it takes no `env_file` by design, and the var is absent from its `environment:` block in
+ *     every compose file), so the runner cannot tell "unset" from "bridge, but invisible to me" —
+ *     and those two need OPPOSITE answers. A mode-gated alias would read "unset" and emit
+ *     nothing on exactly the bridge deployments this exists to fix.
+ *
+ * What that last point leaves is a residual width: in host mode the allowlist also admits
+ * `host.docker.internal` on the configured port, an endpoint the platform will not dispatch
+ * there. It is not an attack surface. The endpoint is always platform-dispatched — the runner
+ * reads it from the run request the agent service builds — and reaching the runner directly needs
+ * `AGENTA_RUNNER_TOKEN` inside the compose network, where a forged request carries its own
+ * credential anyway. The only real exposure is a third-party collector on the docker host at the
+ * exact port of the configured Agenta api, which in practice is that api.
  */
 function bridgeRewrittenBase(base: string): string | undefined {
   let url: URL;

--- a/services/runner/tests/unit/platform-credential-attribution.test.ts
+++ b/services/runner/tests/unit/platform-credential-attribution.test.ts
@@ -178,6 +178,158 @@ describe("platform credential attribution", () => {
   });
 });
 
+/**
+ * F1: a self-hoster sets `AGENTA_API_URL` to a localhost URL, which is the natural value for a
+ * local docker-compose stack. The api rewrites that host to `host.docker.internal` before it
+ * dispatches the run, so the endpoint the runner is handed can never string-match the raw env
+ * value it holds, and the strict branch drops the credential on a correctly configured platform.
+ * Repro: probe session f9483f76 on the rel1144 stack, "trace endpoint host host.docker.internal:8480
+ * is not Agenta ingest ... dropping the run credential".
+ */
+describe("bridge-rewritten localhost ingest", () => {
+  const LOCAL_BASE = "http://localhost:8480/api";
+  const BRIDGE_ENDPOINT = "http://host.docker.internal:8480/api/otlp/v1/traces";
+
+  it("uses the credential when a localhost base is handed its bridge-rewritten endpoint", () => {
+    vi.stubEnv("AGENTA_API_URL", LOCAL_BASE);
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(request(BRIDGE_ENDPOINT), log),
+      CREDENTIAL,
+    );
+    assert.deepEqual(lines, []);
+  });
+
+  it("uses the credential for the 0.0.0.0 form the api rewrites the same way", () => {
+    vi.stubEnv("AGENTA_API_URL", "http://0.0.0.0:8480/api");
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(request(BRIDGE_ENDPOINT), log),
+      CREDENTIAL,
+    );
+    assert.deepEqual(lines, []);
+  });
+
+  it("admits the bridge form of the internal hop too", () => {
+    vi.stubEnv("AGENTA_API_INTERNAL_URL", "http://localhost:8000");
+    vi.stubEnv("AGENTA_API_URL", PUBLIC_BASE);
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(
+        request("http://host.docker.internal:8000/otlp/v1/traces"),
+        log,
+      ),
+      CREDENTIAL,
+    );
+    assert.deepEqual(lines, []);
+  });
+
+  it("still admits the localhost endpoint itself, for a host-network deployment", () => {
+    // `parse_url` returns the url unchanged when the api runs with network mode "host", so the
+    // raw match this fix widens must keep working exactly as before.
+    vi.stubEnv("AGENTA_API_URL", LOCAL_BASE);
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(
+        request("http://localhost:8480/api/otlp/v1/traces"),
+        log,
+      ),
+      CREDENTIAL,
+    );
+    assert.deepEqual(lines, []);
+  });
+
+  it("does not admit host.docker.internal on another port", () => {
+    // The mirror carries the port across, so a different port is a different deployment.
+    vi.stubEnv("AGENTA_API_URL", LOCAL_BASE);
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(
+        request("http://host.docker.internal:9999/api/otlp/v1/traces"),
+        log,
+      ),
+      "",
+    );
+    assert.equal(lines.length, 1);
+    assert.match(lines[0]!, /dropping the run credential/);
+  });
+
+  it("does not admit host.docker.internal on another path", () => {
+    vi.stubEnv("AGENTA_API_URL", LOCAL_BASE);
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(
+        request("http://host.docker.internal:8480/collector/v1/traces"),
+        log,
+      ),
+      "",
+    );
+    assert.equal(lines.length, 1);
+    assert.match(lines[0]!, /dropping the run credential/);
+  });
+
+  it("keeps dropping an unrelated host when the base is a localhost url", () => {
+    vi.stubEnv("AGENTA_API_URL", LOCAL_BASE);
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(
+        request("https://collector.thirdparty.example/v1/traces"),
+        log,
+      ),
+      "",
+    );
+    assert.equal(lines.length, 1);
+    assert.match(lines[0]!, /dropping the run credential/);
+    assert.match(lines[0]!, /collector\.thirdparty\.example/);
+  });
+
+  it("leaves a 127.0.0.1 base alone, because the api does not rewrite that host", () => {
+    // `parse_url` rewrites only `localhost` and `0.0.0.0`, so a 127.0.0.1 deployment matches
+    // itself and never sees the bridge form. Admitting it would widen the allowlist past the
+    // platform's own rewrite.
+    vi.stubEnv("AGENTA_API_URL", "http://127.0.0.1:8480/api");
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(
+        request("http://127.0.0.1:8480/api/otlp/v1/traces"),
+        log,
+      ),
+      CREDENTIAL,
+    );
+    assert.deepEqual(lines, []);
+
+    resetPlatformCredentialWarnings();
+    assert.equal(
+      platformCredentialForRequest(request(BRIDGE_ENDPOINT), log),
+      "",
+    );
+    assert.equal(lines.length, 1);
+    assert.match(lines[0]!, /dropping the run credential/);
+  });
+
+  it("does not arm the strict branch when only a localhost internal hop is configured", () => {
+    // The unconfigured-base behaviour must stay exactly as it is: the runner keeps the credential
+    // and names the gap rather than failing closed on an undecidable attribution.
+    vi.stubEnv("AGENTA_API_INTERNAL_URL", "http://localhost:8000");
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(request(PUBLIC_ENDPOINT), log),
+      CREDENTIAL,
+    );
+    assert.equal(lines.length, 1);
+    assert.match(lines[0]!, /AGENTA_API_URL is not set/);
+  });
+});
+
 describe("publicApiBaseConfigured", () => {
   it("is false when only the internal hop is set", () => {
     vi.stubEnv("AGENTA_API_INTERNAL_URL", INTERNAL_BASE);

--- a/services/runner/tests/unit/platform-credential-attribution.test.ts
+++ b/services/runner/tests/unit/platform-credential-attribution.test.ts
@@ -315,6 +315,43 @@ describe("bridge-rewritten localhost ingest", () => {
     assert.match(lines[0]!, /dropping the run credential/);
   });
 
+  it("still admits the localhost endpoint host mode dispatches, with no alias involved", () => {
+    // The SDK's `parse_url` rewrites only when DOCKER_NETWORK_MODE is exactly "bridge". In
+    // `host` mode, and when the var is unset, the platform dispatches the localhost endpoint
+    // unchanged, so the raw base is what has to match and the alias is simply unused. The
+    // runner cannot see the mode (no env_file by design, and the var is not in its compose
+    // `environment:` block), and it cannot tell "unset" from "bridge but invisible", so the
+    // alias is emitted unconditionally rather than gated. See `bridgeRewrittenBase`.
+    vi.stubEnv("AGENTA_API_URL", LOCAL_BASE);
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(
+        request("http://localhost:8480/api/otlp/v1/traces"),
+        log,
+      ),
+      CREDENTIAL,
+    );
+    assert.deepEqual(lines, []);
+  });
+
+  it("derives no alias from a scheme-less base, which no aliasing could rescue", () => {
+    // The SDK's `parse_url` does no scheme defaulting, so a scheme-less `AGENTA_API_URL`
+    // produces an equally scheme-less ENDPOINT: `new URL` reads "localhost:" as the scheme and
+    // both sides normalize to nonsense. Admitting the bridge form here would fix nothing and
+    // would mirror the api's copy of `parse_url`, which is not what shapes this value. Such a
+    // deployment is broken upstream, at the exporter target itself.
+    vi.stubEnv("AGENTA_API_URL", "localhost:8480/api");
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(request(BRIDGE_ENDPOINT), log),
+      "",
+    );
+    assert.equal(lines.length, 1);
+    assert.match(lines[0]!, /dropping the run credential/);
+  });
+
   it("does not arm the strict branch when only a localhost internal hop is configured", () => {
     // The unconfigured-base behaviour must stay exactly as it is: the runner keeps the credential
     // and names the gap rather than failing closed on an undecidable attribution.


### PR DESCRIPTION
## The bug

A self-hoster who sets `AGENTA_API_URL` to a localhost URL, which is the natural value for a local docker-compose stack, gets a runner that drops its own platform credential. Every agent run then fails with "record log is unreadable".

The two halves disagree by construction. Before it dispatches a run, the platform rewrites a `localhost` or `0.0.0.0` API URL to `host.docker.internal` so a sandboxed run can reach the host from inside its own container. The rewrite lives in `parse_url` at `sdks/python/agenta/sdk/utils/helpers.py`, the SDK copy: the endpoint on the wire is `ag.tracing.otlp_url`, which the agent service derives through that function. (An earlier version of this description named the API's same-named twin in `api/oss/src/utils/helpers.py`. That one shapes the service URL a run is POSTed to, not this endpoint, and the two copies differ. Corrected while verifying the review findings; see the comment below.) The runner, though, builds its trusted-ingest allowlist from the RAW env values (`configuredIngestBases` in `services/runner/src/tracing/otel.ts`). The configured base and the endpoint the runner is handed can therefore never string-match, so `platformCredentialForRequest` (`services/runner/src/engines/sandbox_agent/runtime-policy.ts:48-84`) takes the strict fail-closed branch and returns an empty credential. Session persist and query then 401.

The strictness arrived with commit 2f08b8a8 on 2026-08-25 and first shipped in v0.114.2. Repro evidence: probe session `f9483f76` on the rel1144 stack, before its env was changed, logged `[sessions] trace endpoint host host.docker.internal:8480 is not Agenta ingest ... dropping the run credential`.

## The fix

The allowlist now also admits the bridge-rewritten form of a configured base. The mirror is deliberately exact: same scheme, port, and path, and only the two hosts `parse_url` rewrites, so the allowlist recognizes the platform's own rewrite and nothing else. Every other refusal stays as strict as it is today, including the unconfigured-base behavior that 2f08b8a8 fixed, which this change does not touch.

One deviation from the brief, called out for review: `127.0.0.1` is NOT admitted. Neither copy of `parse_url` rewrites it, so a `127.0.0.1` deployment already matches itself and never sees the bridge form. Admitting it would widen the allowlist past any pair the platform can produce. A test pins that behavior with the reason, and it is one line to change if you want the wider net.

## Tests

Nine cases in `services/runner/tests/unit/platform-credential-attribution.test.ts`: a localhost base admits its `host.docker.internal` endpoint at the same port, the `0.0.0.0` form does too, the internal hop gets the same treatment, the plain localhost endpoint still works for a host-network deployment, and the refusals hold for another port, another path, an unrelated third-party host, the `127.0.0.1` case, and the unconfigured-base case. With the source change stashed, exactly the three admit cases fail and the six strictness cases still pass.

`pnpm test` in `services/runner` is green at 2573 passed across 156 files, and `pnpm run typecheck` is clean. Note that the gateway composition tests need `pnpm run build:extension` first; without that artifact 4 of them fail on any checkout.

Live verification on the QA stack happens post-gate, by flipping its `AGENTA_API_URL` back to a localhost value and running an agent turn.

https://claude.ai/code/session_0165tsjmvf3qvTPFcb9EV44g
