### PR TITLE
[fix] Refuse a malformed harness kind with a structured error at commit and invoke (F4)

### DIFF
--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -20,6 +20,7 @@ from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.apis.fastapi.workflows.exceptions import handle_workflow_exceptions
 from oss.src.core.workflows.change_set import ChangeSetError
 from oss.src.core.workflows.service import (
+    InvalidAgentHarnessError,
     RevisionConflictError,
     WorkflowsService,
     SimpleWorkflowsService,
@@ -1645,6 +1646,10 @@ class WorkflowsRouter:
             )
         except RevisionConflictError as e:
             raise HTTPException(status_code=409, detail=e.to_detail()) from e
+        except InvalidAgentHarnessError as e:
+            # 422, the same status every other "your change is not committable" answer on this
+            # route uses: the request is well-formed, the configuration in it is not.
+            raise HTTPException(status_code=422, detail=e.to_detail()) from e
         except ChangeSetError as e:
             raise HTTPException(status_code=422, detail=e.to_detail()) from e
         except NonEmbeddableWorkflowReferenceError as e:

--- a/api/oss/src/core/tools/platform_handlers.py
+++ b/api/oss/src/core/tools/platform_handlers.py
@@ -775,7 +775,10 @@ async def handle_commit_revision(
     from oss.src.core.git.types import CommitLockTimeout, VariantNotFound
     from oss.src.core.workflows.change_set import AGENT_COMMIT_SCOPE, ChangeSetError
     from oss.src.core.workflows.dtos import WorkflowRevisionCommit
-    from oss.src.core.workflows.service import RevisionConflictError
+    from oss.src.core.workflows.service import (
+        InvalidAgentHarnessError,
+        RevisionConflictError,
+    )
     from oss.src.core.workflows.types import StaticWorkflowSlug
 
     if workflows_service is None:
@@ -835,6 +838,8 @@ async def handle_commit_revision(
             agent_context=True,
         )
     except ChangeSetError as e:
+        return PlatformHandlerResult.failure(AgentError(**e.to_detail()))
+    except InvalidAgentHarnessError as e:
         return PlatformHandlerResult.failure(AgentError(**e.to_detail()))
     except RevisionConflictError as e:
         return PlatformHandlerResult.failure(AgentError(**e.to_detail()))

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -23,6 +23,7 @@ from agenta.sdk.engines.running.utils import (
     retrieve_interface,
 )
 from agenta.sdk.engines.tracing.propagation import inject
+from agenta.sdk.agents import HarnessKind, InvalidHarnessKindError
 
 from oss.src.core.git.interfaces import GitDAOInterface
 from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterface
@@ -207,6 +208,77 @@ class RevisionConflictError(Exception):
             ),
             "details": details,
         }
+
+
+class InvalidAgentHarnessError(Exception):
+    """The commit carries an agent configuration whose harness the runtime cannot read.
+
+    A config with an unreadable ``harness.kind`` can never run, so storing it only moves the
+    failure somewhere less useful: the commit answered 200 and the invoke died on the enum's
+    bare ``ValueError`` as an unhandled 500 (finding F4). The write boundary is the outermost
+    place the caller can still be told which field is wrong, so it is refused here.
+    """
+
+    code = "invalid_harness_kind"
+
+    def __init__(self, *, value: Any, message: str) -> None:
+        super().__init__(message)
+        self.value = value
+        self.message = message
+
+    def to_detail(self) -> Dict[str, Any]:
+        """The canonical agent-actionable envelope. See `api/AGENTS.md`.
+
+        NOT retryable: the same bytes carry the same unreadable value forever. The caller has
+        a way forward, which is the `next_step`, so the allowed values travel in `details`
+        rather than only inside the message.
+        """
+        return {
+            "code": self.code,
+            "message": self.message,
+            "retryable": False,
+            "next_step": (
+                "Set agent.harness.kind to one of the allowed harnesses and send the "
+                "commit again."
+            ),
+            "details": {
+                "field": "parameters.agent.harness.kind",
+                "value": (
+                    self.value
+                    if isinstance(self.value, (str, int, float))
+                    else str(self.value)
+                ),
+                "allowed": sorted(kind.value for kind in HarnessKind),
+            },
+        }
+
+
+def _reject_unreadable_harness_kind(data: Optional[dict]) -> None:
+    """Refuse a commit whose agent template names a harness that does not exist.
+
+    Deliberately narrow. It reads ONE field, and only when the commit actually carries it, so
+    a workflow that is not an agent (and an agent commit that leaves the harness alone) takes
+    exactly the path it took before. An absent or null kind means "use the default" and is
+    left to the runtime, which is the behaviour every existing config relies on.
+    """
+    if not isinstance(data, dict):
+        return
+    parameters = data.get("parameters")
+    if not isinstance(parameters, dict):
+        return
+    agent = parameters.get("agent")
+    if not isinstance(agent, dict):
+        return
+    harness = agent.get("harness")
+    if not isinstance(harness, dict):
+        return
+    kind = harness.get("kind")
+    if kind is None or not str(kind).strip():
+        return
+    try:
+        HarnessKind.coerce(kind)
+    except InvalidHarnessKindError as e:
+        raise InvalidAgentHarnessError(value=kind, message=e.message) from e
 
 
 def _validate_persisted_shape(data: dict) -> None:
@@ -2170,6 +2242,11 @@ class WorkflowsService:
         candidate = self._build_revision_commit(
             workflow_revision_commit=workflow_revision_commit,
         )
+
+        # Checked on the CANDIDATE, so both commit forms are covered by one call: the delta arm
+        # has already merged its operations onto the head by here, and a full-data commit is
+        # the data as sent. An unrunnable agent config must not become a revision.
+        _reject_unreadable_harness_kind(candidate.data)
 
         # The no-change answer belongs to the ordered-operations surface. With the flag off
         # the commit path stays exactly today's: a legacy delta or a full-data commit that

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -1,4 +1,5 @@
 import json
+from math import isfinite
 from typing import Any, Dict, Optional, List, Union, TYPE_CHECKING
 from uuid import UUID, uuid4
 
@@ -210,6 +211,21 @@ class RevisionConflictError(Exception):
         }
 
 
+def _json_safe_echo(value: Any) -> Any:
+    """A value echoed back to the caller must survive JSON serialization.
+
+    Python's json parser accepts the non-standard `NaN` and `Infinity` literals in a request
+    body, so a caller really can send one as a harness kind. Starlette serializes a response
+    with `allow_nan=False`, so echoing that float verbatim would raise inside the response and
+    turn this refusal into exactly the 500 it exists to replace.
+    """
+    if isinstance(value, float) and not isfinite(value):
+        return repr(value)
+    if isinstance(value, (str, int, float)):
+        return value
+    return str(value)
+
+
 class InvalidAgentHarnessError(Exception):
     """The commit carries an agent configuration whose harness the runtime cannot read.
 
@@ -243,11 +259,7 @@ class InvalidAgentHarnessError(Exception):
             ),
             "details": {
                 "field": "parameters.agent.harness.kind",
-                "value": (
-                    self.value
-                    if isinstance(self.value, (str, int, float))
-                    else str(self.value)
-                ),
+                "value": _json_safe_echo(self.value),
                 "allowed": sorted(kind.value for kind in HarnessKind),
             },
         }

--- a/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
@@ -17,7 +17,11 @@ from fastapi import HTTPException
 from oss.src.core.embeds.exceptions import NonEmbeddableWorkflowReferenceError
 from oss.src.core.git.types import CommitLockTimeout, VariantNotFound
 from oss.src.core.workflows.change_set import ChangeSetError, Reason
-from oss.src.core.workflows.service import CommitOutcome, RevisionConflictError
+from oss.src.core.workflows.service import (
+    CommitOutcome,
+    InvalidAgentHarnessError,
+    RevisionConflictError,
+)
 from oss.src.core.workflows.types import StaticWorkflowSlug
 
 
@@ -242,6 +246,33 @@ class TestDomainRefusals:
         assert caught.value.detail["details"]["current_revision_id"] == current
         assert caught.value.detail["retryable"] is False
         assert caught.value.detail["next_step"]
+
+    async def test_an_unreadable_harness_answers_422_and_names_the_field(
+        self, router, allow_access
+    ):
+        # F4: this used to answer 200 and persist a config that could never run. The failure
+        # then surfaced on invoke as an unhandled 500 whose body was a Python repr, far from
+        # the request that caused it.
+        router.workflows_service.commit_workflow_revision_checked.side_effect = (
+            InvalidAgentHarnessError(
+                value="not_a_real_harness",
+                message="invalid harness.kind (str) 'not_a_real_harness'",
+            )
+        )
+
+        with pytest.raises(HTTPException) as caught:
+            await _commit(router)
+
+        assert caught.value.status_code == 422
+        assert caught.value.detail["code"] == "invalid_harness_kind"
+        # Not retryable: the same bytes carry the same unreadable value forever. The way
+        # forward is the next_step, and the values that exist travel in `details`.
+        assert caught.value.detail["retryable"] is False
+        assert caught.value.detail["next_step"]
+        assert (
+            caught.value.detail["details"]["field"] == "parameters.agent.harness.kind"
+        )
+        assert "pi_core" in caught.value.detail["details"]["allowed"]
 
     async def test_a_change_set_refusal_answers_422(self, router, allow_access):
         router.workflows_service.commit_workflow_revision_checked.side_effect = (

--- a/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
@@ -13,6 +13,7 @@ from uuid import uuid4
 
 import pytest
 from fastapi import HTTPException
+from starlette.responses import JSONResponse
 
 from oss.src.core.embeds.exceptions import NonEmbeddableWorkflowReferenceError
 from oss.src.core.git.types import CommitLockTimeout, VariantNotFound
@@ -273,6 +274,31 @@ class TestDomainRefusals:
             caught.value.detail["details"]["field"] == "parameters.agent.harness.kind"
         )
         assert "pi_core" in caught.value.detail["details"]["allowed"]
+
+    @pytest.mark.parametrize(
+        "kind,echoed",
+        [(float("nan"), "nan"), (float("inf"), "inf")],
+    )
+    async def test_a_non_finite_kind_still_answers_422_and_not_a_500(
+        self, router, allow_access, kind, echoed
+    ):
+        # Python's json parser accepts the non-standard `NaN` and `Infinity` literals in a
+        # request body, and Starlette serializes with `allow_nan=False`. Echoing the float
+        # verbatim raised inside the response and turned this refusal back into a 500.
+        router.workflows_service.commit_workflow_revision_checked.side_effect = (
+            InvalidAgentHarnessError(
+                value=kind,
+                message=f"invalid harness.kind (float) {kind!r}",
+            )
+        )
+
+        with pytest.raises(HTTPException) as caught:
+            await _commit(router)
+
+        assert caught.value.status_code == 422
+        assert caught.value.detail["details"]["value"] == echoed
+        # What the client actually receives has to serialize.
+        JSONResponse(caught.value.detail)
 
     async def test_a_change_set_refusal_answers_422(self, router, allow_access):
         router.workflows_service.commit_workflow_revision_checked.side_effect = (

--- a/api/oss/tests/pytest/unit/workflows/test_commit_harness_validation.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_harness_validation.py
@@ -13,6 +13,7 @@ from unittest.mock import AsyncMock
 from uuid import uuid4
 
 import pytest
+from starlette.responses import JSONResponse
 
 from oss.src.core.workflows.dtos import WorkflowRevisionCommit
 from oss.src.core.workflows.service import (
@@ -45,6 +46,41 @@ class TestValuesItRefuses:
         assert detail["details"]["field"] == "parameters.agent.harness.kind"
         assert detail["details"]["value"] == "not_a_real_harness"
         assert set(detail["details"]["allowed"]) == {"pi_core", "claude", "codex"}
+
+
+class TestTheEchoedValueSurvivesTheResponse:
+    """The refusal must not become the 500 it exists to replace.
+
+    Python's json parser accepts the non-standard `NaN` and `Infinity` literals in a request
+    body, so a caller really can send one as a harness kind. Starlette serializes a response
+    with `allow_nan=False`, so echoing that float verbatim raised inside the response itself.
+    """
+
+    @pytest.mark.parametrize(
+        "kind,echoed",
+        [
+            (float("nan"), "nan"),
+            (float("inf"), "inf"),
+            (float("-inf"), "-inf"),
+        ],
+    )
+    def test_a_non_finite_float_is_echoed_as_text(self, kind, echoed):
+        with pytest.raises(InvalidAgentHarnessError) as caught:
+            _reject_unreadable_harness_kind(_data(kind))
+
+        detail = caught.value.to_detail()
+        assert detail["details"]["value"] == echoed
+        # The whole envelope has to survive the response, not just this field.
+        JSONResponse(detail)
+
+    @pytest.mark.parametrize("kind", [12345, "not_a_real_harness", 0])
+    def test_an_ordinary_value_is_still_echoed_as_itself(self, kind):
+        with pytest.raises(InvalidAgentHarnessError) as caught:
+            _reject_unreadable_harness_kind(_data(kind))
+
+        detail = caught.value.to_detail()
+        assert detail["details"]["value"] == kind
+        JSONResponse(detail)
 
 
 class TestCommitsItMustNotTouch:

--- a/api/oss/tests/pytest/unit/workflows/test_commit_harness_validation.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_harness_validation.py
@@ -1,0 +1,108 @@
+"""F4: a commit must not be able to store an agent config the runtime cannot run.
+
+The gate's H1 cell committed `harness.kind` as `12345` and as `"not_a_real_harness"`. Both were
+accepted with a 200. The config was then unrunnable forever, and the invoke that proved it died
+on an unhandled 500 whose body was a Python repr, far from the request that caused it.
+
+The check is deliberately narrow: one field, read only when the commit actually carries it. The
+cases below pin both halves of that — the values it refuses, and the far larger set of commits it
+must leave completely alone, including every config that never names a harness.
+"""
+
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import pytest
+
+from oss.src.core.workflows.dtos import WorkflowRevisionCommit
+from oss.src.core.workflows.service import (
+    InvalidAgentHarnessError,
+    WorkflowsService,
+    _reject_unreadable_harness_kind,
+)
+
+
+def _data(kind):
+    return {"parameters": {"agent": {"harness": {"kind": kind}}}}
+
+
+class TestValuesItRefuses:
+    @pytest.mark.parametrize("kind", [12345, "not_a_real_harness", 0, "pi", "claude "])
+    def test_a_kind_the_runtime_cannot_read_is_refused(self, kind):
+        with pytest.raises(InvalidAgentHarnessError) as caught:
+            _reject_unreadable_harness_kind(_data(kind))
+
+        assert caught.value.code == "invalid_harness_kind"
+
+    def test_the_envelope_names_the_field_the_value_and_what_is_allowed(self):
+        with pytest.raises(InvalidAgentHarnessError) as caught:
+            _reject_unreadable_harness_kind(_data("not_a_real_harness"))
+
+        detail = caught.value.to_detail()
+        assert detail["code"] == "invalid_harness_kind"
+        assert detail["retryable"] is False
+        assert detail["next_step"]
+        assert detail["details"]["field"] == "parameters.agent.harness.kind"
+        assert detail["details"]["value"] == "not_a_real_harness"
+        assert set(detail["details"]["allowed"]) == {"pi_core", "claude", "codex"}
+
+
+class TestCommitsItMustNotTouch:
+    @pytest.mark.parametrize("kind", ["pi_core", "claude", "codex", "PI_CORE"])
+    def test_a_readable_kind_passes(self, kind):
+        _reject_unreadable_harness_kind(_data(kind))
+
+    def test_a_legacy_pi_agenta_config_still_commits(self):
+        # The experiment is gone, but revisions saved while it existed still carry the value
+        # and must stay editable. The runtime maps it to plain Pi on read.
+        _reject_unreadable_harness_kind(_data("pi_agenta"))
+
+    @pytest.mark.parametrize("kind", [None, "", "   "])
+    def test_an_absent_kind_means_the_default_and_is_not_a_refusal(self, kind):
+        _reject_unreadable_harness_kind(_data(kind))
+
+    @pytest.mark.parametrize(
+        "data",
+        [
+            None,
+            {},
+            {"parameters": None},
+            {"parameters": {}},
+            {"parameters": {"agent": None}},
+            {"parameters": {"agent": {"instructions": "hi"}}},
+            {"parameters": {"agent": {"harness": None}}},
+            {"parameters": {"agent": {"harness": {}}}},
+            # A workflow that is not an agent at all: the prompt/chat shape.
+            {"parameters": {"prompt": {"llm_config": {"model": "gpt-5.5"}}}},
+        ],
+    )
+    def test_a_commit_that_does_not_carry_the_field_is_untouched(self, data):
+        _reject_unreadable_harness_kind(data)
+
+
+class TestNothingIsPersisted:
+    """The point of the boundary: the refusal happens BEFORE the write, not after it."""
+
+    @pytest.mark.asyncio
+    async def test_the_checked_commit_refuses_before_it_reaches_the_dao(self):
+        workflows_dao = AsyncMock()
+        # No head yet, so the base check has nothing to compare and the commit walks straight
+        # to the write it must not reach.
+        workflows_dao.fetch_revision.return_value = None
+        service = WorkflowsService(workflows_dao=workflows_dao)
+
+        with pytest.raises(InvalidAgentHarnessError):
+            await service.commit_workflow_revision_checked(
+                project_id=uuid4(),
+                user_id=uuid4(),
+                workflow_revision_commit=WorkflowRevisionCommit(
+                    slug="qa-h1-harness",
+                    workflow_variant_id=uuid4(),
+                    data={
+                        "uri": "agenta:builtin:agent:v0",
+                        "parameters": {"agent": {"harness": {"kind": 12345}}},
+                    },
+                ),
+            )
+
+        workflows_dao.commit_revision.assert_not_awaited()

--- a/sdks/python/agenta/sdk/agents/__init__.py
+++ b/sdks/python/agenta/sdk/agents/__init__.py
@@ -66,6 +66,7 @@ from .dtos import (
     HarnessCapabilities,
     HarnessIdentity,
     HarnessKind,
+    InvalidHarnessKindError,
     InvalidPermissionDefaultError,
     Message,
     NetworkEgress,
@@ -273,6 +274,7 @@ __all__ = [
     "LocalSandboxNotAllowedError",
     "UnsupportedHarnessError",
     "ToolResolutionError",
+    "InvalidHarnessKindError",
     "InvalidPermissionDefaultError",
     "AgentTemplateShapeError",
     # Adapters

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -1416,8 +1416,17 @@ def _parse_run_selection(
     if raw_harness is None or not str(raw_harness).strip():
         harness = str(defaults.harness).lower()
     else:
-        HarnessKind.coerce(raw_harness)
-        harness = str(raw_harness).lower()
+        resolved = HarnessKind.coerce(raw_harness)
+        # A STRING keeps its stored spelling, so a legacy value still normalizes exactly where
+        # it always did (`make_harness` maps `pi_agenta` to Pi; collapsing it here would change
+        # the harness identity a stored revision carries). A MEMBER has no spelling to keep, so
+        # it becomes its wire value: `str()` on one gives "HarnessKind.CLAUDE", which lower-cased
+        # to "harnesskind.claude" and made the SDK's own enum unusable as input.
+        harness = (
+            str(raw_harness).lower()
+            if not isinstance(raw_harness, HarnessKind)
+            else resolved.value
+        )
     sandbox = str(_section(params, "sandbox").get("kind") or defaults.sandbox).lower()
     permissions = _section(params, "runner").get("permissions")
     raw_default = permissions.get("default") if isinstance(permissions, dict) else None

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -55,7 +55,11 @@ class HarnessKind(str, Enum):
 
     @classmethod
     def coerce(cls, value: "HarnessKind | str") -> "HarnessKind":
-        """Accept either an enum or a loose string (the playground sends a string)."""
+        """Accept either an enum or a loose string (the playground sends a string).
+
+        Raises :class:`InvalidHarnessKindError` for anything else, so a value the runtime
+        cannot read fails as a named 400 rather than the enum's bare ``ValueError``.
+        """
         if isinstance(value, cls):
             return value
         normalized = str(value).lower()
@@ -64,7 +68,39 @@ class HarnessKind(str, Enum):
         # to plain Pi instead of refusing to load the config.
         if normalized == "pi_agenta":
             normalized = "pi_core"
-        return cls(normalized)
+        try:
+            return cls(normalized)
+        except ValueError as exc:
+            raise InvalidHarnessKindError(value) from exc
+
+
+class InvalidHarnessKindError(ErrorStatus, ValueError):
+    """``harness.kind`` names a harness this runtime does not have.
+
+    Maps to HTTP 400 so the caller is told the field, the value it sent, and the values that
+    exist. Before this, a malformed kind reached ``make_harness`` as the enum's bare
+    ``ValueError`` and surfaced as an unhandled 500 whose body was the Python repr, and the
+    commit that stored it answered 200 (finding F4).
+
+    It is also a ``ValueError``, because the enum has always raised one here and callers
+    (and tests) guard ``coerce`` on that type. Inheriting both keeps those guards working
+    while the middleware renders the coded status.
+    """
+
+    code: int = 400
+    type: str = f"{ERRORS_BASE_URL}#v0:agent:invalid-harness-kind"
+
+    def __init__(self, value: Any) -> None:
+        allowed = ", ".join(sorted(kind.value for kind in HarnessKind))
+        super().__init__(
+            code=self.code,
+            type=self.type,
+            message=(
+                f"invalid harness.kind ({type(value).__name__}) {value!r}; "
+                f"expected one of {allowed}"
+            ),
+        )
+        self.value = value
 
 
 # ---------------------------------------------------------------------------
@@ -1371,7 +1407,17 @@ def _parse_run_selection(
     ``harness`` from ``harness.kind``, ``sandbox`` from ``sandbox.kind``, and the runner policy
     from ``runner.permissions.default``. The kinds and permission mode are lower-cased so
     playground-supplied values match the bare runtime selectors."""
-    harness = str(_section(params, "harness").get("kind") or defaults.harness).lower()
+    # An absent, null, or blank kind means "use the default", which is what every config that
+    # never set a harness relies on. Anything else must name a harness this runtime has, and a
+    # kind it cannot read is refused HERE, where the template is parsed, rather than travelling
+    # to `make_harness` and surfacing as an unhandled 500 (finding F4). The returned value keeps
+    # its stored spelling, so a legacy value still normalizes where it always did.
+    raw_harness = _section(params, "harness").get("kind")
+    if raw_harness is None or not str(raw_harness).strip():
+        harness = str(defaults.harness).lower()
+    else:
+        HarnessKind.coerce(raw_harness)
+        harness = str(raw_harness).lower()
     sandbox = str(_section(params, "sandbox").get("kind") or defaults.sandbox).lower()
     permissions = _section(params, "runner").get("permissions")
     raw_default = permissions.get("default") if isinstance(permissions, dict) else None

--- a/sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py
@@ -12,7 +12,12 @@ from typing import Any, AsyncIterator, Dict, List, Optional
 
 import pytest
 
-from agenta.sdk.agents import AgentResult, HarnessKind, Message
+from agenta.sdk.agents import (
+    AgentResult,
+    HarnessKind,
+    InvalidHarnessKindError,
+    Message,
+)
 from agenta.sdk.agents.connections import (
     ConnectionResolutionError,
     ResolvedConnection,
@@ -381,6 +386,39 @@ async def test_default_composition_fails_closed_on_connection_resolution_failure
                 "pi_core", model={"provider": "openai", "model": "gpt-5.5"}
             ),
         )
+
+
+async def test_a_config_persisted_with_an_unreadable_harness_is_refused_with_a_shape():
+    """F4: a config stored before the commit boundary existed must still fail with a code.
+
+    The gate's H1 cell persisted `harness.kind` as `12345` and the invoke that followed died on
+    the enum's bare `ValueError`, which the remap turned into a 500 whose body was the Python
+    repr. The refusal now happens where the handler reads the template, before it selects a
+    backend or resolves anything, and it carries the field, the value, and the harnesses that
+    exist.
+    """
+    backend = _FakeBackend()
+
+    async def _must_not_run(*, model, context):
+        raise AssertionError("resolution must not run on an unreadable harness")
+
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_connection=_must_not_run,
+    )
+    handler = make_agent_handler(comp)
+
+    with pytest.raises(InvalidHarnessKindError) as caught:
+        await handler(
+            request=_request(),
+            messages=[{"role": "user", "content": "hi"}],
+            parameters=_params(12345, model={"provider": "openai", "model": "gpt-5.5"}),
+        )
+
+    assert caught.value.code == 400
+    assert "harness.kind" in caught.value.message
+    # Nothing ran: no session was created, so no turn can be stored for a config that cannot run.
+    assert backend.created_configs == []
 
 
 async def test_composition_override_replaces_default_gating():

--- a/sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py
@@ -421,6 +421,33 @@ async def test_a_config_persisted_with_an_unreadable_harness_is_refused_with_a_s
     assert backend.created_configs == []
 
 
+async def test_a_run_configured_with_the_harness_enum_itself_actually_runs():
+    """The SDK's own `HarnessKind` member must be usable as input, end to end.
+
+    `HarnessKind` is a `str` Enum, so `str(member)` is "HarnessKind.CLAUDE". Stringifying the
+    caller's value lower-cased that to "harnesskind.claude", which `make_harness` then refused —
+    valid input, rejected by the parser that was supposed to accept it.
+    """
+    backend = _FakeBackend(output="hi")
+    comp = AgentComposition(
+        select_backend=lambda template: backend,
+        resolve_connection=_no_connection,
+    )
+    handler = make_agent_handler(comp)
+
+    await handler(
+        request=_request(),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters=_params(HarnessKind.CLAUDE),
+    )
+
+    # It reached the backend, which is what a mangled value never did.
+    assert len(backend.created_configs) == 1
+    assert backend.created_effective_parameters[0]["agent"]["harness"]["kind"] == (
+        HarnessKind.CLAUDE
+    )
+
+
 async def test_composition_override_replaces_default_gating():
     """A composition MAY still fully replace resolve_session_connection (bare passthrough),
     proving the seam stays injectable rather than hardcoding the gate."""

--- a/sdks/python/oss/tests/pytest/unit/agents/test_dtos_harness_kind_refusal.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_dtos_harness_kind_refusal.py
@@ -101,6 +101,19 @@ class TestTemplateParsing:
         # Its stored spelling survives the parse exactly as before; `make_harness` maps it.
         assert AgentTemplate.from_params(_params("pi_agenta")).harness == "pi_agenta"
 
+    @pytest.mark.parametrize("member", list(HarnessKind))
+    def test_the_sdks_own_enum_is_usable_as_input(self, member):
+        # `HarnessKind` is a `str` Enum, so `str(member)` is "HarnessKind.CLAUDE", not "claude".
+        # Stringifying the caller's value lower-cased that to "harnesskind.claude", which then
+        # failed at `make_harness` — the SDK's own enum was not accepted by the SDK's parser.
+        assert AgentTemplate.from_params(_params(member)).harness == member.value
+
+    def test_a_member_survives_the_round_trip_back_to_a_harness(self):
+        # The parse and the lookup have to agree: whatever `from_params` produces must be a
+        # value `coerce` reads back, which is the hop that used to break.
+        parsed = AgentTemplate.from_params(_params(HarnessKind.CLAUDE)).harness
+        assert HarnessKind.coerce(parsed) is HarnessKind.CLAUDE
+
 
 class TestInvokeRemap:
     async def test_it_answers_400_with_the_field_and_the_allowed_values(self):

--- a/sdks/python/oss/tests/pytest/unit/agents/test_dtos_harness_kind_refusal.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_dtos_harness_kind_refusal.py
@@ -1,0 +1,119 @@
+"""F4: a harness kind the runtime cannot read must be refused with a shape, at every boundary.
+
+The gate's H1 cell committed `harness.kind` as `12345` and as `"not_a_real_harness"`. Both were
+persisted with a 200, and the invoke that followed died on the enum's bare `ValueError`: an
+unhandled HTTP 500 whose body was the Python repr, carrying no code a client could act on and
+no hint of which field was wrong.
+
+These cases pin the SDK half: `coerce` raises a typed, coded error; parsing a template refuses a
+bad kind where the template is read; and the invoke remap turns it into a 400 naming the field
+and the harnesses that exist, never a 500. An absent or null kind still means "use the default",
+which is what every stored config relies on.
+
+Run: uv run pytest oss/tests/pytest/unit/agents/test_dtos_harness_kind_refusal.py
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from agenta.sdk.agents.dtos import (
+    AgentTemplate,
+    HarnessKind,
+    InvalidHarnessKindError,
+)
+from agenta.sdk.decorators.routing import handle_invoke_failure
+
+
+def _params(kind):
+    return {"agent": {"harness": {"kind": kind}}}
+
+
+class TestCoerce:
+    @pytest.mark.parametrize("value", [12345, "not_a_real_harness", 0, [], {}])
+    def test_an_unreadable_kind_raises_the_coded_error(self, value):
+        with pytest.raises(InvalidHarnessKindError) as caught:
+            HarnessKind.coerce(value)
+
+        assert caught.value.code == 400
+        assert "harness.kind" in caught.value.message
+
+    def test_the_message_names_the_value_and_every_harness_that_exists(self):
+        with pytest.raises(InvalidHarnessKindError) as caught:
+            HarnessKind.coerce("not_a_real_harness")
+
+        message = caught.value.message
+        assert "not_a_real_harness" in message
+        for kind in HarnessKind:
+            assert kind.value in message
+
+    def test_it_is_still_a_value_error(self):
+        # The enum has always raised `ValueError` here, and callers guard on that type. The
+        # coded error inherits it so those guards keep working.
+        with pytest.raises(ValueError):
+            HarnessKind.coerce("not_a_real_harness")
+
+    @pytest.mark.parametrize(
+        "value,expected",
+        [
+            ("pi_core", HarnessKind.PI),
+            ("PI_CORE", HarnessKind.PI),
+            ("claude", HarnessKind.CLAUDE),
+            ("codex", HarnessKind.CODEX),
+            (HarnessKind.CLAUDE, HarnessKind.CLAUDE),
+            # A revision saved while the experiment existed still reads as plain Pi.
+            ("pi_agenta", HarnessKind.PI),
+        ],
+    )
+    def test_a_readable_kind_is_unchanged(self, value, expected):
+        assert HarnessKind.coerce(value) is expected
+
+
+class TestTemplateParsing:
+    @pytest.mark.parametrize("kind", [12345, "not_a_real_harness", 0])
+    def test_a_bad_kind_is_refused_where_the_template_is_read(self, kind):
+        # This is the invoke boundary: the handler parses the template before it selects a
+        # backend, so a config persisted before the fix fails here rather than at `make_harness`.
+        with pytest.raises(InvalidHarnessKindError):
+            AgentTemplate.from_params(_params(kind))
+
+    @pytest.mark.parametrize("kind", [None, "", "   "])
+    def test_an_absent_kind_still_means_the_default(self, kind):
+        # Unchanged behaviour, deliberately: null is how a caller says "whatever the default
+        # is", and refusing it would break every config that never set a harness.
+        assert (
+            AgentTemplate.from_params(_params(kind)).harness == AgentTemplate().harness
+        )
+
+    def test_a_template_with_no_harness_section_is_unchanged(self):
+        assert (
+            AgentTemplate.from_params({"agent": {"instructions": "hi"}}).harness
+            == AgentTemplate().harness
+        )
+
+    @pytest.mark.parametrize("kind", ["pi_core", "claude", "codex"])
+    def test_a_readable_kind_parses_to_itself(self, kind):
+        assert AgentTemplate.from_params(_params(kind)).harness == kind
+
+    def test_a_legacy_pi_agenta_revision_still_parses(self):
+        # Its stored spelling survives the parse exactly as before; `make_harness` maps it.
+        assert AgentTemplate.from_params(_params("pi_agenta")).harness == "pi_agenta"
+
+
+class TestInvokeRemap:
+    async def test_it_answers_400_with_the_field_and_the_allowed_values(self):
+        response = await handle_invoke_failure(InvalidHarnessKindError("not_a_harness"))
+        body = json.dumps(json.loads(bytes(response.body)))
+
+        assert response.status_code == 400
+        assert "harness.kind" in body
+        assert "invalid-harness-kind" in body
+
+    async def test_the_bare_value_error_it_replaced_would_have_been_a_500(self):
+        # The shape of the defect: an unclassified exception is a 500 whose body is the repr.
+        response = await handle_invoke_failure(
+            ValueError("'12345' is not a valid HarnessKind")
+        )
+        assert response.status_code == 500

--- a/services/oss/tests/pytest/unit/agent/test_template_shape_validation.py
+++ b/services/oss/tests/pytest/unit/agent/test_template_shape_validation.py
@@ -14,7 +14,11 @@ from __future__ import annotations
 
 import pytest
 
-from agenta.sdk.agents import AgentTemplate, AgentTemplateShapeError
+from agenta.sdk.agents import (
+    AgentTemplate,
+    AgentTemplateShapeError,
+    InvalidHarnessKindError,
+)
 from agenta.sdk.models.workflows import WorkflowServiceRequest
 
 from oss.src.agent import app
@@ -180,3 +184,23 @@ async def test_handler_raises_on_flat_template():
             messages=[{"role": "user", "content": "hi"}],
             parameters={"agent": {"harness": "claude", "sandbox": "daytona"}},
         )
+
+
+@pytest.mark.parametrize("kind", [12345, "not_a_real_harness"])
+async def test_handler_raises_a_coded_400_on_an_unreadable_harness_kind(kind):
+    """F4: the shape is right, the harness is not. It must still be a named 400.
+
+    This is the case a config persisted before the commit boundary existed still reaches. It
+    used to travel as far as ``make_harness`` and surface as an unhandled 500 whose body was
+    the enum's ``ValueError`` repr, so the caller learned neither the field nor the values it
+    could have sent.
+    """
+    with pytest.raises(InvalidHarnessKindError) as caught:
+        await app._agent(
+            request=WorkflowServiceRequest(),
+            messages=[{"role": "user", "content": "hi"}],
+            parameters={"agent": {"harness": {"kind": kind}}},
+        )
+
+    assert caught.value.code == 400
+    assert "harness.kind" in caught.value.message


### PR DESCRIPTION
## The defect

Found live by the gate's new bad-harness cell (H1). A malformed `harness.kind` (`12345`, `"not_a_real_harness"`) was ACCEPTED by the commit API with a 200, which persisted an agent config that can never run. Invoking that revision then died on an unhandled HTTP 500 whose body was the bare Python repr: `'12345' is not a valid HarnessKind`. The caller learned neither which field was wrong nor which values exist, and got no code to branch on.

The trace: `HarnessKind.coerce` (`sdks/python/agenta/sdk/agents/dtos.py`) did `str(value).lower()` and then `cls(normalized)`, so a non-member raised the enum's plain `ValueError`. Nothing above `make_harness` (`sdks/python/agenta/sdk/agents/adapters/harnesses.py:158`) caught it, and `handle_invoke_failure` maps an unclassified exception to 500 with a stack trace. Nothing at the commit boundary looked at the field at all.

The core invariant did hold throughout: no turn ran, no rows were stored, and the harness was never silently defaulted to Pi. This changes the refusal SHAPE and stops an unrunnable config from being stored.

## The fix, at both boundaries

**Commit** — `api/oss/src/core/workflows/service.py`. A new `_reject_unreadable_harness_kind` runs on the CANDIDATE revision inside `commit_workflow_revision_checked`, which is the one point both commit forms pass through: a delta has already been merged onto the head by then, and a full-data commit is the data as sent. It raises the domain exception `InvalidAgentHarnessError`, which carries the agent-actionable envelope (`code`, `message`, `retryable: false`, `next_step`, `details` with the field, the value, and the allowed harnesses). The route maps it to 422, the same status every other "your change is not committable" answer on that route uses, and the agent's own commit tool returns the identical envelope as an `AgentError` rather than raising.

The check is deliberately narrow. It reads one field, only when the commit carries it, so a workflow that is not an agent takes exactly its old path.

**Invoke** — `sdks/python/agenta/sdk/agents/dtos.py`. `HarnessKind.coerce` now raises `InvalidHarnessKindError`, an `ErrorStatus` with code 400 and type `...#v0:agent:invalid-harness-kind`, whose message names the field, the value with its type, and every harness that exists. `AgentTemplate.from_params` validates a present kind where the template is read, which is before the handler selects a backend or resolves anything, so a config persisted before this fix now fails closed with a code instead of a 500.

Two deliberate choices worth a reviewer's eye:

- The error is **also a `ValueError`**. The enum has always raised one there and callers (including an existing SDK test) guard on that type, so inheriting both keeps those guards working while the middleware renders the coded status. A dedicated `ErrorStatus` was chosen over the `agent_run_failed` code the brief suggested: this is a malformed request, not a run that failed, and it matches the neighbouring `AgentTemplateShapeError` in the same file, which is also a coded 400. Either satisfies the H1 cell, which accepts any 4xx or coded frame whose text names the harness.
- I did **not** wrap the `make_harness` call site. With `coerce` typed, the only remaining bare `ValueError` there is the unreachable branch for an enum member with no adapter class, which is our bug, not the caller's. Relabelling it as a 400 would blame the caller for a server defect, so it stays a 500.

An absent, null, or blank kind still means "use the default" at both boundaries, unchanged, because that is what every config that never set a harness relies on. A legacy `pi_agenta` revision still reads as plain Pi.

## Tests

Four files, at each boundary:

- `sdks/python/oss/tests/pytest/unit/agents/test_dtos_harness_kind_refusal.py` (new, 26 cases): coerce refuses `12345`, an unknown string, `0`, `[]`, `{}`; the message names the value and every harness; it is still a `ValueError`; readable kinds and `pi_agenta` are unchanged; absent/null/blank still default; the invoke remap answers 400 with the field, and the bare `ValueError` it replaced is pinned as the 500 it used to be.
- `sdks/python/oss/tests/pytest/unit/agents/test_agent_composition_seam.py`: a pre-persisted bad config driven through the real handler refuses with the coded error, and no session is created, so no turn can be stored.
- `services/oss/tests/pytest/unit/agent/test_template_shape_validation.py`: the same refusal through the deployed agent service handler.
- `api/oss/tests/pytest/unit/workflows/test_commit_harness_validation.py` (new, 24 cases) and `test_commit_endpoint.py`: the values refused, the far larger set of commits left alone (no agent, no harness, no kind, prompt-only), the envelope's contents, the 422 mapping, and the DAO never being awaited, which is the "nothing is persisted" proof.

Results: API unit suite 2872 passed, SDK unit suite 2512 passed, services unit suite 162 passed. `ruff format` and `ruff check` clean with `ruff@0.15.12`, the version CI pins. One pre-existing failure, `sdks .../agents/test_streaming.py::test_cli_stream_terminal_only_on_empty_request`, fails identically with every change in this branch stashed, so it is not from this work.

Both new suites were verified to fail without the fix: removing the commit-path call makes the "nothing is persisted" case fail, and the SDK cases cannot even import without the new error type.

https://claude.ai/code/session_0165tsjmvf3qvTPFcb9EV44g