### PR TITLE
chore(gate): silence a synthetic placeholder fixture in the secret scan

### DIFF
--- a/.agents/skills/agent-release-gate/resources/test_out_of_credit_skip.py
+++ b/.agents/skills/agent-release-gate/resources/test_out_of_credit_skip.py
@@ -47,7 +47,7 @@ NON_CREDIT_ERRORS = [
     "Too many requests right now. Try again in a moment.",
     "rate_limit_error: please slow down",
     # The placeholder race. This is the defect C5 exists to catch; it must never become a SKIP.
-    "LiteLLM Virtual Key expected. Received=dtn_secret_abc123",
+    "LiteLLM Virtual Key expected. Received=dtn_secret_abc123",  # gitleaks:allow
     "A temporary issue kept this run's credentials from reaching the model. Send the message again.",
     # Ordinary failures.
     "agent run failed",

--- a/.gitleaksignore
+++ b/.gitleaksignore
@@ -301,3 +301,4 @@ ea3257c7cc43d635b7bd8a16863d26df8d012c85:api/oss/tests/pytest/unit/secrets/test_
 84bb7fe0c9f926c6a60d7bd8577ba64043b655e7:api/oss/tests/pytest/unit/secrets/test_managed_secrets.py:generic-api-key:241
 84bb7fe0c9f926c6a60d7bd8577ba64043b655e7:api/oss/tests/pytest/unit/secrets/test_managed_secrets.py:generic-api-key:248
 84bb7fe0c9f926c6a60d7bd8577ba64043b655e7:api/oss/tests/pytest/unit/secrets/test_managed_secrets.py:generic-api-key:303
+e30afd32abeb0b51f22a0590b5bf44899978712b:.agents/skills/agent-release-gate/resources/test_out_of_credit_skip.py:generic-api-key:50


### PR DESCRIPTION
The gate test fixture in test_out_of_credit_skip.py carries the literal probe string `Received=dtn_secret_abc123`, which the generic-api-key rule reads as a credential. It is a synthetic token, not a secret. This adds the finding's fingerprint to .gitleaksignore (the file's established pattern for benign historic findings) and an inline gitleaks:allow on the line for future edits. The branch-range scan is clean locally after this commit.

https://claude.ai/code/session_0165tsjmvf3qvTPFcb9EV44g