### PR TITLE
chore(api): move InvalidAgentHarnessError to the workflow type module

### DIFF
--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -20,11 +20,11 @@ from oss.src.apis.fastapi.git.exceptions import handle_git_exceptions
 from oss.src.apis.fastapi.workflows.exceptions import handle_workflow_exceptions
 from oss.src.core.workflows.change_set import ChangeSetError
 from oss.src.core.workflows.service import (
-    InvalidAgentHarnessError,
     RevisionConflictError,
     WorkflowsService,
     SimpleWorkflowsService,
 )
+from oss.src.core.workflows.types import InvalidAgentHarnessError
 from oss.src.core.environments.service import (
     EnvironmentsService,
 )

--- a/api/oss/src/core/tools/platform_handlers.py
+++ b/api/oss/src/core/tools/platform_handlers.py
@@ -775,11 +775,11 @@ async def handle_commit_revision(
     from oss.src.core.git.types import CommitLockTimeout, VariantNotFound
     from oss.src.core.workflows.change_set import AGENT_COMMIT_SCOPE, ChangeSetError
     from oss.src.core.workflows.dtos import WorkflowRevisionCommit
-    from oss.src.core.workflows.service import (
+    from oss.src.core.workflows.service import RevisionConflictError
+    from oss.src.core.workflows.types import (
         InvalidAgentHarnessError,
-        RevisionConflictError,
+        StaticWorkflowSlug,
     )
-    from oss.src.core.workflows.types import StaticWorkflowSlug
 
     if workflows_service is None:
         raise PlatformToolHandlerRefused("commit_revision is unavailable.")

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -1,5 +1,4 @@
 import json
-from math import isfinite
 from typing import Any, Dict, Optional, List, Union, TYPE_CHECKING
 from uuid import UUID, uuid4
 
@@ -125,6 +124,7 @@ from oss.src.core.workflows.interfaces import StaticWorkflowProvider
 from oss.src.core.workflows.static_catalog import normalize_static_version
 from oss.src.core.workflows.dtos import WorkflowServiceDetachedResponse
 from oss.src.core.workflows.types import (
+    InvalidAgentHarnessError,
     StaticWorkflowSlug,
     WorkflowServiceUrlMissing,
     WorkflowDetachedStartFailed,
@@ -208,60 +208,6 @@ class RevisionConflictError(Exception):
                 "send the commit again with the new base_revision_id."
             ),
             "details": details,
-        }
-
-
-def _json_safe_echo(value: Any) -> Any:
-    """A value echoed back to the caller must survive JSON serialization.
-
-    Python's json parser accepts the non-standard `NaN` and `Infinity` literals in a request
-    body, so a caller really can send one as a harness kind. Starlette serializes a response
-    with `allow_nan=False`, so echoing that float verbatim would raise inside the response and
-    turn this refusal into exactly the 500 it exists to replace.
-    """
-    if isinstance(value, float) and not isfinite(value):
-        return repr(value)
-    if isinstance(value, (str, int, float)):
-        return value
-    return str(value)
-
-
-class InvalidAgentHarnessError(Exception):
-    """The commit carries an agent configuration whose harness the runtime cannot read.
-
-    A config with an unreadable ``harness.kind`` can never run, so storing it only moves the
-    failure somewhere less useful: the commit answered 200 and the invoke died on the enum's
-    bare ``ValueError`` as an unhandled 500 (finding F4). The write boundary is the outermost
-    place the caller can still be told which field is wrong, so it is refused here.
-    """
-
-    code = "invalid_harness_kind"
-
-    def __init__(self, *, value: Any, message: str) -> None:
-        super().__init__(message)
-        self.value = value
-        self.message = message
-
-    def to_detail(self) -> Dict[str, Any]:
-        """The canonical agent-actionable envelope. See `api/AGENTS.md`.
-
-        NOT retryable: the same bytes carry the same unreadable value forever. The caller has
-        a way forward, which is the `next_step`, so the allowed values travel in `details`
-        rather than only inside the message.
-        """
-        return {
-            "code": self.code,
-            "message": self.message,
-            "retryable": False,
-            "next_step": (
-                "Set agent.harness.kind to one of the allowed harnesses and send the "
-                "commit again."
-            ),
-            "details": {
-                "field": "parameters.agent.harness.kind",
-                "value": _json_safe_echo(self.value),
-                "allowed": sorted(kind.value for kind in HarnessKind),
-            },
         }
 
 

--- a/api/oss/src/core/workflows/types.py
+++ b/api/oss/src/core/workflows/types.py
@@ -5,7 +5,8 @@ These are raised by the workflows service and translated to HTTP responses at th
 never raise ``HTTPException`` directly.
 """
 
-from typing import Optional
+from math import isfinite
+from typing import Any, Dict, Optional
 
 # Reserved-slug detection is canonical in the SDK (it also drives is_static inference there). The
 # API re-exports it so every write path can reject a reserved slug and every read path can
@@ -15,6 +16,7 @@ from agenta.sdk.engines.running.utils import (  # noqa: F401
     STATIC_SLUG_PREFIX,
     is_static_workflow_slug,
 )
+from agenta.sdk.agents import HarnessKind
 
 
 class WorkflowError(Exception):
@@ -42,6 +44,66 @@ class StaticWorkflowSlug(WorkflowError):
                 f"Choose a different slug than '{slug}'."
             )
         )
+
+
+def _json_safe_echo(value: Any) -> Any:
+    """A value echoed back to the caller must survive JSON serialization.
+
+    Python's json parser accepts the non-standard `NaN` and `Infinity` literals in a request
+    body, so a caller really can send one as a harness kind. Starlette serializes a response
+    with `allow_nan=False`, so echoing that float verbatim would raise inside the response and
+    turn this refusal into exactly the 500 it exists to replace.
+    """
+    if isinstance(value, float) and not isfinite(value):
+        return repr(value)
+    if isinstance(value, (str, int, float)):
+        return value
+    return str(value)
+
+
+class InvalidAgentHarnessError(Exception):
+    """The commit carries an agent configuration whose harness the runtime cannot read.
+
+    A config with an unreadable ``harness.kind`` can never run, so storing it only moves the
+    failure somewhere less useful: the commit answered 200 and the invoke died on the enum's
+    bare ``ValueError`` as an unhandled 500 (finding F4). The write boundary is the outermost
+    place the caller can still be told which field is wrong, so it is refused here.
+
+    Deliberately NOT a :class:`WorkflowError`. That base takes a positional message and exists
+    for the failures ``handle_workflow_exceptions`` translates one by one; this one carries a
+    value and an agent-actionable envelope, and the commit route maps it to 422 itself. Joining
+    the family would change nothing today and would put it in the path of any future broad
+    ``except WorkflowError``, which is a behavior change this move does not want to make.
+    """
+
+    code = "invalid_harness_kind"
+
+    def __init__(self, *, value: Any, message: str) -> None:
+        super().__init__(message)
+        self.value = value
+        self.message = message
+
+    def to_detail(self) -> Dict[str, Any]:
+        """The canonical agent-actionable envelope. See `api/AGENTS.md`.
+
+        NOT retryable: the same bytes carry the same unreadable value forever. The caller has
+        a way forward, which is the `next_step`, so the allowed values travel in `details`
+        rather than only inside the message.
+        """
+        return {
+            "code": self.code,
+            "message": self.message,
+            "retryable": False,
+            "next_step": (
+                "Set agent.harness.kind to one of the allowed harnesses and send the "
+                "commit again."
+            ),
+            "details": {
+                "field": "parameters.agent.harness.kind",
+                "value": _json_safe_echo(self.value),
+                "allowed": sorted(kind.value for kind in HarnessKind),
+            },
+        }
 
 
 class WorkflowServiceUrlMissing(WorkflowError):

--- a/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_endpoint.py
@@ -20,10 +20,12 @@ from oss.src.core.git.types import CommitLockTimeout, VariantNotFound
 from oss.src.core.workflows.change_set import ChangeSetError, Reason
 from oss.src.core.workflows.service import (
     CommitOutcome,
-    InvalidAgentHarnessError,
     RevisionConflictError,
 )
-from oss.src.core.workflows.types import StaticWorkflowSlug
+from oss.src.core.workflows.types import (
+    InvalidAgentHarnessError,
+    StaticWorkflowSlug,
+)
 
 
 VARIANT_ID = uuid4()

--- a/api/oss/tests/pytest/unit/workflows/test_commit_harness_validation.py
+++ b/api/oss/tests/pytest/unit/workflows/test_commit_harness_validation.py
@@ -17,10 +17,10 @@ from starlette.responses import JSONResponse
 
 from oss.src.core.workflows.dtos import WorkflowRevisionCommit
 from oss.src.core.workflows.service import (
-    InvalidAgentHarnessError,
     WorkflowsService,
     _reject_unreadable_harness_kind,
 )
+from oss.src.core.workflows.types import InvalidAgentHarnessError
 
 
 def _data(kind):


### PR DESCRIPTION
Addresses the CodeRabbit review comment on [#6409](https://github.com/Agenta-AI/agenta/pull/6409): `InvalidAgentHarnessError` is a workflow-domain exception that the FastAPI router and the platform tool handler both import, and per the API layering rules in `api/AGENTS.md` a domain exception belongs in the core type module. It now lives in `api/oss/src/core/workflows/types.py`, beside the `WorkflowError` family, instead of in the service that raises it.

**Zero behavior change.** The class keeps its exact inheritance, its `code`, its `__init__` signature, and its `to_detail` envelope, so the router's 422 mapping and the agent commit tool's `AgentError` envelope both work exactly as before. The API unit suite passes 2880 tests, the same count as before the move, which is the signal this refactor should produce.

Three notes for the reviewer:

The private `_json_safe_echo` helper moves with the class. Nothing else uses it, and leaving it behind would make `types.py` import from `service.py`, which inverts the layering this change is fixing.

The class stays a plain `Exception` rather than joining `WorkflowError`. That base takes a positional message and exists for the failures `handle_workflow_exceptions` translates one by one, while this one carries a value and an agent-actionable envelope that the commit route maps itself. Joining the family would change nothing today, but it would put the class in the path of any future broad `except WorkflowError`, which is a behavior change a placement-only PR should not make. The reasoning is now a paragraph in the class docstring, which is the one addition beyond a pure move. Say the word if you would rather it join the family.

`RevisionConflictError` is untouched, as scoped. It predates this work and stays in `service.py`.

https://claude.ai/code/session_0165tsjmvf3qvTPFcb9EV44g