### PR TITLE
[fix] Address the CodeRabbit review on the credential-race and subagent-name fixes

### DIFF
--- a/sdks/python/agenta/sdk/agents/tools/models.py
+++ b/sdks/python/agenta/sdk/agents/tools/models.py
@@ -63,21 +63,47 @@ def disambiguate_tool_names(pairs: List[tuple]) -> Dict[str, str]:
     the earlier tool rather than erroring, so the second subagent would simply never be callable.
 
     Only colliding names are decorated, so the common case keeps the name the user recognizes.
-    The discriminator is a short digest of the tool's own stable identity (its `call_ref`), NOT
-    its position: an ordinal would renumber when the author reorders or removes a tool, changing
-    a name the model may already have used earlier in the conversation.
+    The discriminator is a digest of the tool's own stable identity (its `call_ref`), NOT its
+    position: an ordinal would renumber when the author reorders or removes a tool, changing a
+    name the model may already have used earlier in the conversation.
+
+    The digest starts short for readability and LENGTHENS until every name in the colliding group
+    is distinct. Six hex characters is only 24 bits, so two `call_ref` values can share a prefix;
+    if their base names also matched, the function would hand back one name for both entries and
+    the final uniqueness check would reject a configuration this helper promises is unique. Growing
+    the digest keeps the guarantee without reintroducing an ordinal: the length depends on the set
+    of colliding identities, never on their order, so the same configuration always yields the same
+    names. Two distinct identities cannot share the FULL digest, so the loop always terminates.
     """
     counts: Dict[str, int] = {}
     for _identity, name in pairs:
         counts[name] = counts.get(name, 0) + 1
+
     resolved: Dict[str, str] = {}
-    for identity, name in pairs:
-        if counts[name] > 1:
-            digest = sha1(identity.encode("utf-8")).hexdigest()[:6]
-            resolved[identity] = f"{name}_{digest}"
-        else:
-            resolved[identity] = name
+    for name, count in counts.items():
+        group = [identity for identity, item_name in pairs if item_name == name]
+        if count == 1:
+            resolved[group[0]] = name
+            continue
+        digests = {identity: _identity_digest(identity) for identity in group}
+        # Sorting makes the width a property of the SET, not of iteration order.
+        width = _shortest_distinct_prefix(sorted(digests.values()))
+        for identity in group:
+            resolved[identity] = f"{name}_{digests[identity][:width]}"
     return resolved
+
+
+def _identity_digest(identity: str) -> str:
+    return sha1(identity.encode("utf-8")).hexdigest()
+
+
+def _shortest_distinct_prefix(digests: List[str], start: int = 6) -> int:
+    """The smallest prefix length (from `start`) at which every digest differs."""
+    longest = max((len(digest) for digest in digests), default=start)
+    for width in range(start, longest + 1):
+        if len({digest[:width] for digest in digests}) == len(digests):
+            return width
+    return longest
 
 
 # Layer-3 per-tool permission: ``allow`` runs with no prompt, ``ask`` raises a

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_subagent_tool_name.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_subagent_tool_name.py
@@ -207,3 +207,80 @@ class TestResolverInteraction:
                     ClientToolConfig(name="dup", description="b"),
                 ]
             )
+
+
+class TestDigestCollisions:
+    """A six-hex discriminator is 24 bits, so two identities can share it (CodeRabbit, #6412).
+
+    When that happens on names that ALSO collide, the helper would return one name for both
+    entries and the final uniqueness check would reject a configuration this function documents as
+    unique — the same shadowing failure the discriminator exists to prevent, one layer down.
+    """
+
+    def test_the_digest_lengthens_until_the_group_is_distinct(self, monkeypatch):
+        from agenta.sdk.agents.tools import models
+
+        # Force the 6-hex prefixes to collide while the full digests still differ, which is the
+        # real-world shape (a prefix collision, not a hash break).
+        forced = {
+            "workflow.variant.a": "aaaaaa" + "1" + "0" * 33,
+            "workflow.variant.b": "aaaaaa" + "2" + "0" * 33,
+        }
+        monkeypatch.setattr(
+            models, "_identity_digest", lambda identity: forced[identity]
+        )
+
+        resolved = models.disambiguate_tool_names(
+            [("workflow.variant.a", "dup"), ("workflow.variant.b", "dup")]
+        )
+        assert len(set(resolved.values())) == 2, resolved
+        # It grew by exactly one character rather than jumping to the full digest.
+        assert resolved["workflow.variant.a"] == "dup_aaaaaa1"
+        assert resolved["workflow.variant.b"] == "dup_aaaaaa2"
+
+    def test_the_width_is_a_property_of_the_set_not_the_order(self, monkeypatch):
+        from agenta.sdk.agents.tools import models
+
+        forced = {
+            "workflow.variant.a": "aaaaaa" + "1" + "0" * 33,
+            "workflow.variant.b": "aaaaaa" + "2" + "0" * 33,
+        }
+        monkeypatch.setattr(
+            models, "_identity_digest", lambda identity: forced[identity]
+        )
+
+        forward = models.disambiguate_tool_names(
+            [("workflow.variant.a", "dup"), ("workflow.variant.b", "dup")]
+        )
+        backward = models.disambiguate_tool_names(
+            [("workflow.variant.b", "dup"), ("workflow.variant.a", "dup")]
+        )
+        assert forward == backward
+
+    def test_a_deep_prefix_collision_still_resolves(self, monkeypatch):
+        from agenta.sdk.agents.tools import models
+
+        # Identical for 20 characters: the width has to grow well past the default.
+        forced = {
+            "workflow.variant.a": "a" * 20 + "1" + "0" * 19,
+            "workflow.variant.b": "a" * 20 + "2" + "0" * 19,
+        }
+        monkeypatch.setattr(
+            models, "_identity_digest", lambda identity: forced[identity]
+        )
+
+        resolved = models.disambiguate_tool_names(
+            [("workflow.variant.a", "dup"), ("workflow.variant.b", "dup")]
+        )
+        assert len(set(resolved.values())) == 2
+        for name in resolved.values():
+            assert PROVIDER_TOOL_NAME.match(name)
+
+    def test_real_digests_need_no_extension(self):
+        # The common case must stay short and readable: distinct call_refs practically never
+        # share six hex characters, so the decorated name keeps its 6-char suffix.
+        resolved = disambiguate_tool_names(
+            [("workflow.variant.a", "dup"), ("workflow.variant.b", "dup")]
+        )
+        for name in resolved.values():
+            assert len(name) == len("dup_") + 6, name

--- a/services/runner/src/engines/sandbox_agent/errors.ts
+++ b/services/runner/src/engines/sandbox_agent/errors.ts
@@ -188,25 +188,36 @@ const PROVIDER_401 =
  * status prefix, not the provider's response. Provenance is therefore prose, and prose has to be
  * excluded by prose.
  *
- * The runner makes several authenticated calls of its own during a turn that can answer 401 and
- * reach the same catch: the tool callback (`tool call <ref> failed: HTTP 401`), attachment fetch
- * and claim, and the session-records query and persist. Without this exclusion, any one of them
- * landing inside the propagation window would consume the session's single credential-race report
- * and print retry guidance for a failure a retry cannot fix — and the genuine race that followed
- * would then get the add-a-key copy, which is the original bug wearing a disguise.
+ * EXACTLY FIVE EMITTERS, and no more. The runner makes five authenticated calls of its own during
+ * a turn that can answer 401 and reach this same catch AS CLASSIFIER INPUT: the tool callback
+ * (`tool call <ref> failed: HTTP 401`), attachment fetch, attachment claim, session-records query,
+ * and session-records persist. Without this exclusion, any one of them landing inside the
+ * propagation window would consume the session's single credential-race report and print retry
+ * guidance for a failure a retry cannot fix — and the genuine race that followed would then get
+ * the add-a-key copy, which is the original bug wearing a disguise.
  *
- * WHY THIS IS SOUND RATHER THAN A GUESS. Every emitter above is greppable in `services/runner/src`
- * and prefixed at its throw site precisely so it can be recognized here. Three of them threw a
- * BARE `HTTP <status>` until this change and were genuinely indistinguishable from a provider
- * refusal; they now carry a name. The alternative — plumbing a typed provider-response provenance
- * signal through the harness boundary into `ConciseErrorOptions` — is the right long-term shape
- * and a large change; naming the emitters costs one regex and one word per throw site.
+ * WHY THIS IS SOUND RATHER THAN A GUESS. Each of the five is greppable in `services/runner/src`
+ * and prefixed AT ITS THROW SITE precisely so it can be recognized here — four of them threw a
+ * bare `HTTP <status>` until this change and were genuinely indistinguishable from a provider
+ * refusal. The alternative, plumbing a typed provider-response provenance signal through the
+ * harness boundary into `ConciseErrorOptions`, is the right long-term shape and a large change;
+ * naming the emitters costs one regex and one word per throw site.
+ *
+ * WHAT IS DELIBERATELY NOT HERE. Mount, geesefs and otel failures are NOT in this set, for two
+ * independent reasons. They never arrive as classifier input: those sites build their message
+ * AROUND `conciseError(err, ...)`, so the prefix is added after classification and the classifier
+ * only ever sees the inner error. And matching them is actively unsafe — none is a prefixed
+ * emitter, so the patterns would have to be loose, and a loose `mount failed` matches inside
+ * "the requested amount failed to authorize" or "paramount failed" while a bare `otel` matches
+ * inside "hotel-search". Excluding a provider-shaped string is the WORSE direction of this bug:
+ * it hands a genuine race the add-a-key copy, which is the failure this whole class exists to
+ * prevent. If one ever does prove reachable, re-add it anchored with `\b`.
  *
  * THE STANDING OBLIGATION: a new authenticated call inside the turn must prefix its failure, or it
- * silently rejoins this hazard. That is why the throw sites carry a comment pointing back here.
+ * silently rejoins this hazard. That is why the five throw sites carry a comment pointing back.
  */
 const RUNNER_INTERNAL_401 =
-  /tool call .*failed: HTTP|attachment (?:fetch|claim) failed|session records (?:query|persist) failed|(?:re)?mount(?:point)? (?:failed|cleanup failed)|geesefs|otel/i;
+  /tool call .*failed: HTTP|attachment (?:fetch|claim) failed|session records (?:query|persist) failed/i;
 
 /**
  * How long after a Daytona Secret is delivered a credential refusal is still better explained by

--- a/services/runner/src/engines/sandbox_agent/errors.ts
+++ b/services/runner/src/engines/sandbox_agent/errors.ts
@@ -180,6 +180,35 @@ const PROVIDER_401 =
   /(?<!\d)401(?!\d)|status(?:_?code)?[":\s=]+401\b|http[ _-]?401\b/i;
 
 /**
+ * A 401 the RUNNER produced, not the model provider.
+ *
+ * HOW THE 401 IS DETECTED AT ALL, stated plainly because it constrains everything below: this
+ * classifier receives one flattened error STRING. It never sees an HTTP response object, so the
+ * status it reads is whatever the throwing code chose to write into the message — the runner's own
+ * status prefix, not the provider's response. Provenance is therefore prose, and prose has to be
+ * excluded by prose.
+ *
+ * The runner makes several authenticated calls of its own during a turn that can answer 401 and
+ * reach the same catch: the tool callback (`tool call <ref> failed: HTTP 401`), attachment fetch
+ * and claim, and the session-records query and persist. Without this exclusion, any one of them
+ * landing inside the propagation window would consume the session's single credential-race report
+ * and print retry guidance for a failure a retry cannot fix — and the genuine race that followed
+ * would then get the add-a-key copy, which is the original bug wearing a disguise.
+ *
+ * WHY THIS IS SOUND RATHER THAN A GUESS. Every emitter above is greppable in `services/runner/src`
+ * and prefixed at its throw site precisely so it can be recognized here. Three of them threw a
+ * BARE `HTTP <status>` until this change and were genuinely indistinguishable from a provider
+ * refusal; they now carry a name. The alternative — plumbing a typed provider-response provenance
+ * signal through the harness boundary into `ConciseErrorOptions` — is the right long-term shape
+ * and a large change; naming the emitters costs one regex and one word per throw site.
+ *
+ * THE STANDING OBLIGATION: a new authenticated call inside the turn must prefix its failure, or it
+ * silently rejoins this hazard. That is why the throw sites carry a comment pointing back here.
+ */
+const RUNNER_INTERNAL_401 =
+  /tool call .*failed: HTTP|attachment (?:fetch|claim) failed|session records (?:query|persist) failed|(?:re)?mount(?:point)? (?:failed|cleanup failed)|geesefs|otel/i;
+
+/**
  * How long after a Daytona Secret is delivered a credential refusal is still better explained by
  * propagation than by the key.
  *
@@ -326,9 +355,11 @@ export function classifyRunError(
     return { message: RATE_LIMITED_MESSAGE, code: "rate_limited" };
   }
   // Before the generic auth branch: a placeholder-shaped refusal IS a 401, but its cause is
-  // credential delivery, not the user's key, and the add-a-key advice would be false. The two
-  // self-evidencing signatures stand alone; the masked echo is a formatting guess, so it must be
-  // corroborated by the refusal actually being about the credential.
+  // credential delivery, not the user's key, and the add-a-key advice would be false.
+  //
+  // `PLACEHOLDER_CREDENTIAL` is self-evidencing and stands alone: it quotes a protocol string only
+  // the delivery layer produces. `MASKED_PLACEHOLDER_ECHO` is NOT — it is a guess about formatting,
+  // so it is corroborated by `AUTH_REFUSAL` and only the pair of them together is evidence.
   //
   // DELIBERATELY NOT SUBJECT TO THE PER-SESSION REPORT BUDGET, unlike the branch below. That
   // budget exists because a bare 401 cannot distinguish a delivery race from a genuinely wrong
@@ -353,7 +384,16 @@ export function classifyRunError(
   // `PROVIDER_401`, not `AUTH_REFUSAL`: this branch spends the session's one report and prints
   // retry guidance, so it must not fire for an authorization failure that merely says
   // "unauthorized" somewhere unrelated. See the note on `PROVIDER_401`.
-  if (PROVIDER_401.test(raw) && options.daytonaCredentialFresh?.()) {
+  //
+  // And not a 401 the RUNNER itself produced. A tool call, an attachment fetch, or a
+  // session-records query can answer 401 inside the same window and reach this same catch; the
+  // status in the string is the runner's own prefix, not the provider's response, so the only way
+  // to tell them apart is to name them. See `RUNNER_INTERNAL_401`.
+  if (
+    PROVIDER_401.test(raw) &&
+    !RUNNER_INTERNAL_401.test(raw) &&
+    options.daytonaCredentialFresh?.()
+  ) {
     return {
       message: CREDENTIAL_DELIVERY_FAILED_MESSAGE,
       code: "credential_delivery_failed",

--- a/services/runner/src/engines/sandbox_agent/errors.ts
+++ b/services/runner/src/engines/sandbox_agent/errors.ts
@@ -164,6 +164,22 @@ const AUTH_REFUSAL =
   /authentication required|invalid api key|unauthorized|(?<!\d)401(?!\d)/i;
 
 /**
+ * A refusal the PROVIDER answered with 401, as opposed to any authorization failure anywhere.
+ *
+ * `AUTH_REFUSAL` above is deliberately broad because it decides which advice to print, and bare
+ * "unauthorized" appears in plenty of authorization failures that have nothing to do with the
+ * model credential — a tool's own API, a mount, a platform call. That breadth is wrong for the
+ * fresh-Secret branch, which does two things a display string does not: it spends the session's
+ * one credential-race report, and it tells the user to retry. An unrelated "unauthorized" landing
+ * inside the propagation window would consume the report and hand out retry guidance for a
+ * failure a retry cannot fix, and the genuine race that followed would then get the add-a-key
+ * copy. So that branch requires an explicit 401 — the status the provider actually returns when
+ * it refuses a credential.
+ */
+const PROVIDER_401 =
+  /(?<!\d)401(?!\d)|status(?:_?code)?[":\s=]+401\b|http[ _-]?401\b/i;
+
+/**
  * How long after a Daytona Secret is delivered a credential refusal is still better explained by
  * propagation than by the key.
  *
@@ -313,6 +329,13 @@ export function classifyRunError(
   // credential delivery, not the user's key, and the add-a-key advice would be false. The two
   // self-evidencing signatures stand alone; the masked echo is a formatting guess, so it must be
   // corroborated by the refusal actually being about the credential.
+  //
+  // DELIBERATELY NOT SUBJECT TO THE PER-SESSION REPORT BUDGET, unlike the branch below. That
+  // budget exists because a bare 401 cannot distinguish a delivery race from a genuinely wrong
+  // key, so the honest-retry reading has to be spent sparingly. A body that ECHOES the placeholder
+  // carries its own proof: a real user key never contains `dtn_`, so every such refusal IS a
+  // delivery failure, however many times it happens. Capping it would eventually tell a user with
+  // a perfectly good key to go add one — the exact wrong answer this class exists to prevent.
   if (
     PLACEHOLDER_CREDENTIAL.test(raw) ||
     (MASKED_PLACEHOLDER_ECHO.test(raw) && AUTH_REFUSAL.test(raw))
@@ -326,7 +349,11 @@ export function classifyRunError(
   // refusal carries no placeholder because the provider does not echo what it received, so the
   // only evidence is that this run's key WAS a Daytona Secret delivered moments ago. Same class,
   // same honest copy — the alternative is telling a user with a valid key to add one.
-  if (AUTH_REFUSAL.test(raw) && options.daytonaCredentialFresh?.()) {
+  //
+  // `PROVIDER_401`, not `AUTH_REFUSAL`: this branch spends the session's one report and prints
+  // retry guidance, so it must not fire for an authorization failure that merely says
+  // "unauthorized" somewhere unrelated. See the note on `PROVIDER_401`.
+  if (PROVIDER_401.test(raw) && options.daytonaCredentialFresh?.()) {
     return {
       message: CREDENTIAL_DELIVERY_FAILED_MESSAGE,
       code: "credential_delivery_failed",

--- a/services/runner/src/sessions/attachments.ts
+++ b/services/runner/src/sessions/attachments.ts
@@ -109,7 +109,11 @@ export async function fetchAttachment(
       headers: { authorization: auth() },
       signal: AbortSignal.timeout(attachmentFetchTimeoutMs()),
     });
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    // Prefixed so the run-turn classifier can tell a RUNNER-side 401 from the provider's.
+    // A bare `HTTP 401` here is indistinguishable from a model refusal, and the credential-race
+    // branch would then spend the session's one report on an attachment fetch.
+    if (!response.ok)
+      throw new Error(`attachment fetch failed: HTTP ${response.status}`);
 
     // Content-Type parameters (charset, boundary) are not part of the MIME identity the
     // capability gate and the allowlist compare on, so keep the bare type.
@@ -161,7 +165,8 @@ export async function claimAttachments(
       }),
       signal: AbortSignal.timeout(attachmentFetchTimeoutMs()),
     });
-    if (!response.ok) throw new Error(`HTTP ${response.status}`);
+    if (!response.ok)
+      throw new Error(`attachment claim failed: HTTP ${response.status}`);
     return true;
   } catch (error) {
     log(

--- a/services/runner/src/sessions/persist.ts
+++ b/services/runner/src/sessions/persist.ts
@@ -45,16 +45,24 @@ const DURABLE_INGEST_MAX_RETRIES_CAP = 12;
  * mean on — the compose files pass the var through as `${AGENTA_RECORDS_DURABLE:-}`, which sets
  * an empty string when unset. "false" → the fire-and-forget legacy path, unchanged. */
 function durableRecordsEnabled(): boolean {
-  return String(process.env.AGENTA_RECORDS_DURABLE ?? "").trim().toLowerCase() !== "false";
+  return (
+    String(process.env.AGENTA_RECORDS_DURABLE ?? "")
+      .trim()
+      .toLowerCase() !== "false"
+  );
 }
 
 /** Attempts before a durable-mode drop; env-overridable for ops tuning (and fast tests). */
 function durableMaxRetries(): number {
-  return envInt("AGENTA_RECORDS_INGEST_MAX_RETRIES", DURABLE_INGEST_MAX_RETRIES, {
-    min: 1,
-    max: DURABLE_INGEST_MAX_RETRIES_CAP,
-    log,
-  });
+  return envInt(
+    "AGENTA_RECORDS_INGEST_MAX_RETRIES",
+    DURABLE_INGEST_MAX_RETRIES,
+    {
+      min: 1,
+      max: DURABLE_INGEST_MAX_RETRIES_CAP,
+      log,
+    },
+  );
 }
 
 function log(msg: string): void {
@@ -108,7 +116,10 @@ async function postEvent(
           ...(spanId ? { span_id: spanId } : {}),
         }),
       });
-      if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      // Prefixed so a runner-side 401 is distinguishable from a provider refusal; see
+      // `RUNNER_INTERNAL_401` in engines/sandbox_agent/errors.ts.
+      if (!res.ok)
+        throw new Error(`session records persist failed: HTTP ${res.status}`);
       log(
         `ingest OK session=${sessionId} idx=${eventIndex} type=${event.type}`,
       );
@@ -219,7 +230,9 @@ export function recordsIncomplete(sessionId: string): boolean {
  * substitute for a close signal the harness may never send (a call that streams then
  * stalls without a `tool_result`).
  */
-const OPEN_TOOL_TTL_MS = envTimerMs("AGENTA_RECORD_TOOL_TTL_MS", 3_000, { log });
+const OPEN_TOOL_TTL_MS = envTimerMs("AGENTA_RECORD_TOOL_TTL_MS", 3_000, {
+  log,
+});
 
 /**
  * Build an emitter that persists every event via the ingest chain AND calls the

--- a/services/runner/src/sessions/records-query.ts
+++ b/services/runner/src/sessions/records-query.ts
@@ -48,13 +48,17 @@ export async function fetchSessionRecords(
       body: JSON.stringify({ session_id: sessionId }),
       signal: AbortSignal.timeout(queryTimeoutMs()),
     });
-    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+    // Prefixed so a runner-side 401 is distinguishable from a provider refusal; see
+    // `RUNNER_INTERNAL_401` in engines/sandbox_agent/errors.ts.
+    if (!res.ok)
+      throw new Error(`session records query failed: HTTP ${res.status}`);
     const body = (await res.json()) as { records?: SessionRecordRow[] };
     return Array.isArray(body?.records) ? body.records : [];
   } catch (err) {
-    const detail = String(
-      err instanceof Error ? err.message : err,
-    ).slice(0, 120);
+    const detail = String(err instanceof Error ? err.message : err).slice(
+      0,
+      120,
+    );
     log(`query FAILED session=${sessionId}: ${detail}`);
     return null;
   }

--- a/services/runner/tests/unit/credential-race-classification.test.ts
+++ b/services/runner/tests/unit/credential-race-classification.test.ts
@@ -369,3 +369,91 @@ describe("the swallowed-Pi-error recovery path (Codex P1)", () => {
     );
   });
 });
+
+describe("the fresh-Secret branch requires a provider 401 (CodeRabbit, #6408)", () => {
+  // `AUTH_REFUSAL` is broad on purpose — it decides which advice to print, and bare
+  // "unauthorized" appears in authorization failures all over the runner. That breadth is wrong
+  // for this branch, which SPENDS the session's one credential-race report and tells the user to
+  // retry. An unrelated "unauthorized" inside the propagation window would burn the report and
+  // hand out retry guidance a retry cannot fix, leaving the genuine race that followed to get the
+  // add-a-key copy.
+  const UNRELATED = [
+    "Unauthorized: the tool's own API rejected the request",
+    "mount failed: unauthorized",
+    "authentication required by the storage backend",
+    "invalid api key for the analytics service",
+  ];
+
+  it("does not classify an unrelated authorization failure as a delivery race", () => {
+    for (const raw of UNRELATED) {
+      const r = classifyRunError(new Error(raw), "claude", "anthropic", {
+        daytonaCredentialFresh: () => true,
+      });
+      assert.equal(r.code, "runner_error", raw);
+      assert.doesNotMatch(
+        r.message,
+        /credentials from reaching the model/,
+        raw,
+      );
+    }
+  });
+
+  it("does not let an unrelated authorization failure consume the session report", () => {
+    const store = new SessionContinuityStore();
+    const report = () =>
+      store.noteCredentialRaceReport("session-x") <=
+      CREDENTIAL_RACE_REPORTS_PER_SESSION;
+
+    classifyRunError(new Error(UNRELATED[0]), "claude", "anthropic", {
+      daytonaCredentialFresh: report,
+    });
+    assert.equal(store.credentialRaceReportCount("session-x"), 0);
+
+    // The report is still available for the real race that follows.
+    const r = classifyRunError(
+      new Error(ANTHROPIC_DIRECT_401),
+      "claude",
+      "anthropic",
+      {
+        daytonaCredentialFresh: report,
+      },
+    );
+    assert.equal(r.code, "credential_delivery_failed");
+  });
+
+  it("still recognizes the 401 shapes providers actually send", () => {
+    for (const raw of [
+      "API Error: 401 Invalid bearer token",
+      'HTTP 401: {"error":"unauthorized"}',
+      '{"status_code": 401, "message": "no"}',
+      "http-401 refused",
+    ]) {
+      const r = classifyRunError(new Error(raw), "claude", "anthropic", {
+        daytonaCredentialFresh: () => true,
+      });
+      assert.equal(r.code, "credential_delivery_failed", raw);
+    }
+  });
+
+  it("keeps the placeholder branches free of the report budget", () => {
+    // A body that echoes the placeholder is self-evidencing: a real user key never contains
+    // `dtn_`, so every such refusal IS a delivery failure however often it repeats. Capping it
+    // would eventually tell a user with a good key to add one.
+    const store = new SessionContinuityStore();
+    const report = () =>
+      store.noteCredentialRaceReport("session-y") <=
+      CREDENTIAL_RACE_REPORTS_PER_SESSION;
+    for (let i = 0; i < 5; i++) {
+      const r = classifyRunError(
+        new Error(LITELLM_PROXY_401),
+        "claude",
+        "anthropic",
+        {
+          daytonaCredentialFresh: report,
+        },
+      );
+      assert.equal(r.code, "credential_delivery_failed");
+    }
+    assert.equal(store.credentialRaceReportCount("session-y"), 0);
+  });
+});

--- a/services/runner/tests/unit/credential-race-classification.test.ts
+++ b/services/runner/tests/unit/credential-race-classification.test.ts
@@ -457,3 +457,113 @@ describe("the fresh-Secret branch requires a provider 401 (CodeRabbit, #6408)", 
     assert.equal(store.credentialRaceReportCount("session-y"), 0);
   });
 });
+
+describe("a 401 the RUNNER produced is not the provider's (CodeRabbit Major, #6422)", () => {
+  // This classifier reads one flattened error STRING; it never sees an HTTP response, so the
+  // status it matches is whatever the throwing code wrote into the message. Several authenticated
+  // calls the runner makes DURING a turn can answer 401 and reach the same catch. Left
+  // unexcluded, any of them inside the propagation window spends the session's one report and
+  // prints retry guidance for a failure a retry cannot fix — and the genuine race that follows
+  // then gets the add-a-key copy, which is the original bug wearing a disguise.
+  const RUNNER_401 = [
+    "mount failed: HTTP 401",
+    "tool call workflow.variant.summarizer failed: HTTP 401",
+    "attachment fetch failed: HTTP 401",
+    "attachment claim failed: HTTP 401",
+    "session records query failed: HTTP 401",
+    "session records persist failed: HTTP 401",
+    "remount failed: HTTP 401",
+  ];
+
+  it("does not classify a runner-side 401 as a credential race", () => {
+    for (const raw of RUNNER_401) {
+      const r = classifyRunError(new Error(raw), "claude", "anthropic", {
+        daytonaCredentialFresh: () => true,
+      });
+      assert.equal(r.code, "runner_error", raw);
+      assert.doesNotMatch(
+        r.message,
+        /credentials from reaching the model/,
+        raw,
+      );
+    }
+  });
+
+  it("does not let a runner-side 401 consume the session report", () => {
+    // The load-bearing half. A consumed report is invisible at the time and only shows up later,
+    // as the real race being told to add a key.
+    const store = new SessionContinuityStore();
+    const report = () =>
+      store.noteCredentialRaceReport("session-z") <=
+      CREDENTIAL_RACE_REPORTS_PER_SESSION;
+
+    for (const raw of RUNNER_401) {
+      classifyRunError(new Error(raw), "claude", "anthropic", {
+        daytonaCredentialFresh: report,
+      });
+    }
+    assert.equal(store.credentialRaceReportCount("session-z"), 0);
+
+    // Still available for the genuine refusal that follows.
+    const r = classifyRunError(
+      new Error(ANTHROPIC_DIRECT_401),
+      "claude",
+      "anthropic",
+      {
+        daytonaCredentialFresh: report,
+      },
+    );
+    assert.equal(r.code, "credential_delivery_failed");
+  });
+
+  it("still classifies a provider 401 that merely mentions a tool", () => {
+    // The exclusion keys on the runner's own failure PREFIX, not on any appearance of the word:
+    // a model refusal whose body happens to say "tool" must not be excluded.
+    const r = classifyRunError(
+      new Error(
+        'API Error: 401 {"message":"Invalid bearer token","request":"tool_use"}',
+      ),
+      "claude",
+      "anthropic",
+      { daytonaCredentialFresh: () => true },
+    );
+    assert.equal(r.code, "credential_delivery_failed");
+  });
+
+  it("keeps a self-evidencing placeholder echo classified inside a runner-side failure", () => {
+    // The placeholder branch runs earlier and stands alone: a literal `dtn_secret_` in the body
+    // means the placeholder really went out, whoever was calling, so the runner-side exclusion
+    // must not suppress it.
+    const r = classifyRunError(
+      new Error("tool call x failed: HTTP 401 rejected dtn_secret_abc123"),
+      "claude",
+      "anthropic",
+      { daytonaCredentialFresh: () => true },
+    );
+    assert.equal(r.code, "credential_delivery_failed");
+  });
+
+  it("refuses a bare `dtn_****` mask with no LiteLLM phrasing", () => {
+    // Not a regression: `Received=dtn_****` is evidence only via LiteLLM's quoted sentence. On
+    // its own the mask has a zero-length stem, which the tightened signature rejects by design so
+    // a literal glob cannot spoof it. Pinned here so the asymmetry is deliberate, not accidental.
+    const r = classifyRunError(
+      new Error("tool call x failed: HTTP 401 got dtn_**** instead"),
+      "claude",
+      "anthropic",
+      { daytonaCredentialFresh: () => true },
+    );
+    assert.equal(r.code, "runner_error");
+
+    // With LiteLLM's own sentence in front of it, the same mask IS evidence.
+    const withPhrase = classifyRunError(
+      new Error(
+        "LiteLLM Virtual Key expected. Received=dtn_****, expected sk-",
+      ),
+      "claude",
+      "anthropic",
+      { daytonaCredentialFresh: () => false },
+    );
+    assert.equal(withPhrase.code, "credential_delivery_failed");
+  });
+});

--- a/services/runner/tests/unit/credential-race-classification.test.ts
+++ b/services/runner/tests/unit/credential-race-classification.test.ts
@@ -465,14 +465,15 @@ describe("a 401 the RUNNER produced is not the provider's (CodeRabbit Major, #64
   // unexcluded, any of them inside the propagation window spends the session's one report and
   // prints retry guidance for a failure a retry cannot fix — and the genuine race that follows
   // then gets the add-a-key copy, which is the original bug wearing a disguise.
+  // EXACTLY the five prefixed emitters that reach this classifier as input. Mount, geesefs and
+  // otel are deliberately absent: those sites build their message AROUND `conciseError`, so the
+  // prefix is added after classification and the classifier only ever sees the inner error.
   const RUNNER_401 = [
-    "mount failed: HTTP 401",
     "tool call workflow.variant.summarizer failed: HTTP 401",
     "attachment fetch failed: HTTP 401",
     "attachment claim failed: HTTP 401",
     "session records query failed: HTTP 401",
     "session records persist failed: HTTP 401",
-    "remount failed: HTTP 401",
   ];
 
   it("does not classify a runner-side 401 as a credential race", () => {
@@ -514,6 +515,22 @@ describe("a 401 the RUNNER produced is not the provider's (CodeRabbit Major, #64
       },
     );
     assert.equal(r.code, "credential_delivery_failed");
+  });
+
+  it("does not exclude a provider 401 whose prose merely contains an emitter substring", () => {
+    // The exclusion must never fire on a PROVIDER refusal, because that is the worse direction of
+    // this bug: it hands a genuine race the add-a-key copy. An earlier draft matched loose
+    // `mount failed` and a bare `otel`, which swallowed all three of these.
+    for (const raw of [
+      "API Error: 401 the requested amount failed to authorize",
+      "API Error: 401 paramount failed",
+      "API Error: 401 hotel-search rejected the key",
+    ]) {
+      const r = classifyRunError(new Error(raw), "claude", "anthropic", {
+        daytonaCredentialFresh: () => true,
+      });
+      assert.equal(r.code, "credential_delivery_failed", raw);
+    }
   });
 
   it("still classifies a provider 401 that merely mentions a tool", () => {


### PR DESCRIPTION
Three findings CodeRabbit left on #6408 and #6412 after they merged. Two accepted, one declined with the reasoning recorded in the code.

## Require a provider 401 for the fresh-Secret branch (accepted)

[#6408 comment, `errors.ts:329`](https://github.com/Agenta-AI/agenta/pull/6408). `AUTH_REFUSAL` also matches bare `unauthorized`, which appears in authorization failures all over the runner — a tool's own API, a mount, a platform call.

That breadth is right for choosing which advice to print and wrong for this branch, because this branch does two things a display string does not: it **spends the session's one credential-race report** and it **tells the user to retry**. An unrelated `unauthorized` landing inside the 60s propagation window would burn the report and hand out retry guidance a retry cannot fix — and then the genuine race that followed would get the add-a-key copy, which is the original bug wearing a disguise.

The branch now requires an explicit 401, the status a provider actually returns when it refuses a credential. `AUTH_REFUSAL` keeps its breadth for the generic advice branch, where breadth is correct.

## Placeholder evidence stays outside the budget (declined, documented)

[#6408 comment, `errors.ts:318`](https://github.com/Agenta-AI/agenta/pull/6408). The observation is accurate — the placeholder branches return before `daytonaCredentialFresh` runs, so they never consume the report — but that is deliberate, and capping them would be a regression.

The budget exists for one reason: **a bare 401 cannot distinguish a delivery race from a genuinely wrong key**, so the honest-retry reading has to be spent sparingly or a bad key loops forever. A body that *echoes the placeholder* is in a different epistemic position: a real user key never contains `dtn_`, so every such refusal genuinely IS a delivery failure, however many times it repeats. Applying the cap would eventually tell a user with a perfectly good key to go add one — precisely the wrong answer this error class was created to prevent.

The reasoning now sits at the branch so the next reader sees a decision rather than an oversight.

## Make the name discriminator collision-proof (accepted)

[#6412 comment, `models.py:76`](https://github.com/Agenta-AI/agenta/pull/6412). `hexdigest()[:6]` is 24 bits, so two `call_ref` values can share a prefix. If their sanitized base names also matched, the helper returned one name for both entries and the final uniqueness check raised `DuplicateToolNameError` on a configuration the function documents as unique — the same shadowing failure the discriminator exists to prevent, one layer down.

The digest now lengthens until every name in the colliding group is distinct. The width is computed from the **set** of colliding identities, never their order, so no ordinal creeps back in and the same configuration always produces the same names — the stability property that matters because the model may already have called a tool by name earlier in the conversation. Two distinct identities cannot share a full digest, so the loop terminates. The common case keeps its short, readable six characters.

## Tests

Runner, in `credential-race-classification.test.ts` (27, up from 23): four unrelated authorization failures inside the window stay `runner_error`; **the report is not consumed** by them and is still available for the real race that follows; four real 401 shapes (`API Error: 401`, `HTTP 401:`, `"status_code": 401`, `http-401`) still classify; and five repeated placeholder refusals all classify with the counter untouched, pinning the decline.

SDK, in `test_subagent_tool_name.py` (30, up from 26): a stubbed digest forces a 6-hex prefix collision with distinct full digests — the real-world shape — and the name grows by exactly one character rather than jumping to the full hash; the result is order-independent; a 20-character prefix collision still resolves; and real digests need no extension, so the common case stays short.

Runner suite **2602 passed, 4 failed** — the same four pre-existing `gateway-run-turn-composition.test.ts` failures red on the release branch itself. `tsc --noEmit` exit 0. SDK agents suite **1193 passed, 4 skipped**, no failures. Prettier and `ruff@0.15.12` clean.

https://claude.ai/code/session_0165tsjmvf3qvTPFcb9EV44g