### PR TITLE
[chore] Address the CodeRabbit review on the standing gate checks

### DIFF
--- a/.agents/skills/agent-release-gate/resources/LESSONS.md
+++ b/.agents/skills/agent-release-gate/resources/LESSONS.md
@@ -307,6 +307,21 @@ container by its `com.docker.compose.project` label against the target stack's p
 the project from whichever container publishes the port in `AGENTA_BASE`), or take it explicitly.
 When nothing matches, say so and continue.
 
+## Standing reds: expected, named, never softened
+
+A check that goes red for a filed finding stays red — softening it would hide the next real
+break behind the same shape. What it gets instead is a NAME in its failure message, so a reader
+scanning a gate report recognizes it in one line instead of chasing it as fresh breakage. This is
+how the W5 steer red is handled, and it now applies to one more:
+
+- **`matrix_h1_bad_harness.py`, the `null_kind` case — finding SF2.** A cleared harness
+  (`{"kind": null}`) is not rejected: it silently defaults to `pi_core`, so on any config whose
+  model spelling suits Pi the turn runs and the cell correctly fails. Filed for the next release,
+  not fixed in v0.114.4. The failure message says so. When SF2 is fixed the case turns green on
+  its own and the `known_finding` key stops appearing — that is the signal to delete the note.
+  A wrong-type or unknown-string harness that runs is a DIFFERENT, unfiled defect and is
+  deliberately not covered by the name.
+
 ## The checklist for the next QA run
 
 1. `docker ps` — is anything restarting? If yes, wait.

--- a/.agents/skills/agent-release-gate/resources/LESSONS.md
+++ b/.agents/skills/agent-release-gate/resources/LESSONS.md
@@ -256,8 +256,18 @@ beats that propagation sends the raw placeholder, and the provider refuses it wi
 
 **The rule.** A 401 from a Daytona run is not evidence about the user's key until you have read
 the litellm-proxy log. Grep it for `Received=dtn_`. If the line is there, the key was never the
-problem and no key change will fix it: the run needed a retry. Only when that line is ABSENT does
-a 401 mean what it looks like. The runner classifies this correctly as `credential_delivery_failed`
+problem and no key change will fix it: the run needed a retry.
+
+**An ABSENT marker proves nothing.** The marker is one-directional evidence — present, it
+confirms a placeholder refusal; absent, it is silence, and silence has many causes. A direct
+provider never emits it at all (`api.anthropic.com` answers "Invalid bearer token" and echoes
+nothing), a remote deployment has no reachable proxy log, and incomplete log access looks
+identical to a clean window. Reading an empty grep as "so it really was the user's key" is how F6
+survived a whole release. When the marker is absent, judge on the other evidence instead: the
+stored error's CODE (`credential_delivery_failed` is the runner's own verdict and outranks any
+grep), whether the sandbox was freshly created, and whether the copy contradicts itself by
+advising a key change on a run whose key was delivered seconds earlier. The runner classifies
+this correctly as `credential_delivery_failed`
 (see `PLACEHOLDER_CREDENTIAL` in `services/runner/src/engines/sandbox_agent/errors.ts`), so a
 run that reports an add-a-key message over a placeholder refusal is a product bug, not a user
 error. The related trap already recorded above still holds: a stuck-substitution rebuild is not an

--- a/.agents/skills/agent-release-gate/resources/check_secrets_teardown.py
+++ b/.agents/skills/agent-release-gate/resources/check_secrets_teardown.py
@@ -437,13 +437,21 @@ def secrets_teardown(settle_seconds: int) -> dict:
                 n for n in created if secret_exists(created_ids[n], timeout=budget)
             )
 
+        # TIMESTAMP THE OBSERVATION, not just the polling. The first read carries a floor so it
+        # can complete at all, which means it may itself finish after the deadline on a short
+        # budget -- and an absence FIRST SEEN after the deadline is not evidence of an in-budget
+        # deletion, however true the absence is. Recording when the absence was observed is what
+        # keeps the PASS claim ("deleted within Ns") honest; without it the floor quietly reopened
+        # the very deadline hole the polling fix closed.
         leftover = still_present(max(remaining(), INITIAL_PROBE_SECONDS))
+        observed_at = time.monotonic()
         while leftover and remaining() > 0:
             time.sleep(min(SETTLE_POLL_SECONDS, remaining()))
             budget = remaining()
             if budget <= 0:
                 break
             leftover = still_present(budget)
+            observed_at = time.monotonic()
 
         if leftover:
             return {
@@ -458,6 +466,20 @@ def secrets_teardown(settle_seconds: int) -> dict:
                 "session_id": session_id,
                 "workflow_id": wf,
             }
+        if observed_at > deadline:
+            # Deleted, but NOT proven within the requested budget. Deliberately not a FAIL: no
+            # Secret outlived its run, so the invariant this cell guards was never violated, and
+            # reporting a leak that did not happen is how a standing check earns a reputation for
+            # crying wolf. Deliberately not a PASS either: the budgeted claim is unproven, and the
+            # PASS line would state a number nobody measured. A SKIP is the cell's honest verdict
+            # for "the thing you asked was not tested", and the gate counts every SKIP as a
+            # failure to explain, so it stays visible rather than passing quietly.
+            raise SkipCheck(
+                f"all {len(created)} Secret(s) created by this run are gone, but the absence was "
+                f"first observed {observed_at - deadline:.1f}s AFTER the {settle_seconds}s settle "
+                "budget, so deletion within that budget is unproven. No Secret outlived its run. "
+                "Re-run with a larger --settle to turn this into a verdict."
+            )
         return {
             "status": "PASS",
             "why": (

--- a/.agents/skills/agent-release-gate/resources/check_secrets_teardown.py
+++ b/.agents/skills/agent-release-gate/resources/check_secrets_teardown.py
@@ -77,6 +77,7 @@ import re
 import sys
 import time
 import uuid
+from urllib.parse import urlparse
 
 import httpx
 
@@ -105,17 +106,68 @@ PAGE_LIMIT = 100
 MAX_PAGES = 200
 MAX_ENUMERATION_SECONDS = 120.0
 
-MISSING_CREDENTIAL_MARKERS = (
-    "connection",
+#: How long to wait between settle polls, capped by whatever remains of the caller's budget.
+SETTLE_POLL_SECONDS = 5.0
+
+#: The vault resolver's OWN diagnostics, as whole phrases. Deliberately not the bare nouns
+#: `credential` and `connection`: those appear in transport failures and in
+#: `credential_delivery_failed` itself, so matching them turned real defects into green SKIPs.
+MISSING_CREDENTIAL_PHRASES = (
     "not found for provider",
+    "no connections for provider",
     "no connections",
+    "multiple connections for provider",
     "multiple connections",
-    "credential",
+    "requires an effective https endpoint",
+    "no usable credential",
+)
+
+#: A real failure, whatever else the message happens to mention. Checked first, and never a SKIP.
+TRANSPORT_FAILURE_MARKERS = (
+    "econnreset",
+    "econnrefused",
+    "connection reset",
+    "connection refused",
+    "connection error",
+    "enotfound",
+    "eai_again",
+    "timed out",
+    "timeout",
+    "502",
+    "503",
+    "504",
+    "credential_delivery_failed",
+    "credentials from reaching the model",
 )
 
 
 class SkipCheck(Exception):
     """Raised for a condition that leaves the invariant untested, never for a real failure."""
+
+
+def environment_cause(error_text: str) -> str | None:
+    """Why this ONE error frame is an environment condition, or None when it is a real failure.
+
+    SKIP means "the product was never tested here", so the bar for it is evidence that the run
+    could not start, not merely that some credential word appears. The previous version matched
+    `credential` and `connection` anywhere in the joined error text, which swept in exactly the
+    failures this check exists to catch: a connection reset, an upstream connection error, or a
+    `credential_delivery_failed` timeout all contain one of those words and would have become a
+    green SKIP.
+
+    So a transport or service failure is checked FIRST and always wins: those are real, and a
+    vault phrase appearing beside one does not excuse it. What remains is matched against the
+    vault resolver's own diagnostics, which are specific sentences rather than bare nouns.
+    """
+    low = error_text.lower()
+    if any(marker in low for marker in TRANSPORT_FAILURE_MARKERS):
+        return None
+    spent = out_of_credit(error_text)
+    if spent:
+        return spent
+    if any(phrase in low for phrase in MISSING_CREDENTIAL_PHRASES):
+        return "missing or ambiguous Daytona vault credential"
+    return None
 
 
 def daytona_key() -> str:
@@ -132,11 +184,24 @@ def daytona_key() -> str:
 
 
 def daytona_api_url() -> str:
-    return (
+    """The Daytona API base, refused unless it is HTTPS.
+
+    `_get` sends the API key as a bearer token, so an `http://` base would put a live credential
+    on the wire in cleartext. Both env vars are operator-set and a typo is the likely cause, so
+    this refuses loudly rather than downgrading silently. A SKIP naming the scheme is a far better
+    outcome than a leaked key and a green check.
+    """
+    raw = (
         os.environ.get("DAYTONA_API_URL")
         or os.environ.get("AGENTA_RUNNER_DAYTONA_API_URL")
         or "https://app.daytona.io/api"
     ).rstrip("/")
+    if urlparse(raw).scheme.lower() != "https":
+        raise SkipCheck(
+            f"the Daytona API base is not HTTPS ({raw!r}); refusing to send the API key over "
+            "a cleartext connection. Fix DAYTONA_API_URL or AGENTA_RUNNER_DAYTONA_API_URL."
+        )
+    return raw
 
 
 def _get(path: str, params: dict | None = None) -> httpx.Response:
@@ -184,6 +249,14 @@ def list_secret_ids_by_name(fetch=None) -> dict[str, str]:
                 "produce a verdict, so this is a SKIP rather than a guess."
             )
         body = fetcher(cursor)
+        # Validate the SHAPE before touching it. A malformed page must be a SKIP naming what came
+        # back, never an AttributeError or TypeError escaping mid-walk: the cell would then abort
+        # with a stack trace instead of a verdict, which reads as a broken gate rather than an
+        # unreadable inventory. `fetch` is a test seam, so this also holds for injected pages.
+        if not isinstance(body, dict):
+            raise SkipCheck(
+                f"unexpected Daytona Secrets payload shape: body is {type(body).__name__}"
+            )
         items = body.get("items")
         if not isinstance(items, list):
             raise SkipCheck(
@@ -193,7 +266,16 @@ def list_secret_ids_by_name(fetch=None) -> dict[str, str]:
             if isinstance(row, dict) and row.get("name") and row.get("id"):
                 by_name[str(row["name"])] = str(row["id"])
 
-        cursor = body.get("nextCursor") or None
+        next_cursor = body.get("nextCursor")
+        if next_cursor is not None and not isinstance(next_cursor, str):
+            # A list or dict here would be unhashable or unusable, and `cursor in seen_cursors`
+            # would raise instead of skipping. The walk cannot continue from a cursor it cannot
+            # send, and a partial inventory produces no verdict.
+            raise SkipCheck(
+                "unexpected Daytona Secrets payload shape: nextCursor is "
+                f"{type(next_cursor).__name__}"
+            )
+        cursor = next_cursor or None
         if cursor is None:
             return by_name
         # A cursor that repeats is not advancing. Left unchecked that is an infinite loop, and it
@@ -286,22 +368,20 @@ def secrets_teardown(settle_seconds: int) -> dict:
             references,
         )
         if t1.errors:
-            joined = " ".join(t1.errors)
-            # An exhausted key means the journey never got far enough to create a Secret, so
-            # there is nothing to assert teardown on. That is an environment condition, not a
-            # teardown defect, and rendering it as FAIL would point at the wrong thing entirely.
-            # Checked before the vault-credential markers, which match a bare substring and would
-            # otherwise claim this failure with a less accurate reason.
-            spent = out_of_credit(joined)
-            if spent:
-                raise SkipCheck(f"{spent}: {t1.errors[0][:200]}")
-            if any(m in joined.lower() for m in MISSING_CREDENTIAL_MARKERS):
-                raise SkipCheck(
-                    f"missing or ambiguous Daytona vault credential: {t1.errors[0][:200]}"
-                )
+            # Classify EACH error frame, and SKIP only when every one of them is an environment
+            # cause. Joining the frames first let a single credit phrase excuse a transport or
+            # delivery failure sitting beside it, turning a real teardown miss into a green SKIP.
+            # A mixed window is not an environment window.
+            unexplained = [e for e in t1.errors if environment_cause(e) is None]
+            if not unexplained:
+                reason = environment_cause(t1.errors[0]) or "environment condition"
+                raise SkipCheck(f"{reason}: {t1.errors[0][:200]}")
             return {
                 "status": "FAIL",
-                "why": f"the journey never ran: {t1.errors}",
+                "why": (
+                    f"the journey never ran, and {len(unexplained)} of {len(t1.errors)} error "
+                    f"frame(s) name no environment cause: {unexplained[0][:200]!r}"
+                ),
                 "session_id": session_id,
                 "workflow_id": wf,
             }
@@ -331,13 +411,18 @@ def secrets_teardown(settle_seconds: int) -> dict:
         # fast and a slow one still gets its full budget. Poll each created Secret BY ID rather
         # than re-enumerating the organization: a full enumeration is ~36 requests here, and
         # running that every few seconds would cost more than the whole rest of the cell.
-        deadline = time.time() + settle_seconds
-        leftover = sorted(created)
-        while time.time() < deadline:
-            time.sleep(5.0)
-            leftover = sorted(n for n in created if secret_exists(created_ids[n]))
-            if not leftover:
+        # Check ONCE immediately, then poll within what is left of the budget. The earlier
+        # version slept a flat 5s before its first look, so `--settle 1` reported PASS on a
+        # deletion that took five times its budget, and `--settle 0` never looked at all — the
+        # deadline was decorative. `monotonic` because a wall-clock step would corrupt it.
+        deadline = time.monotonic() + settle_seconds
+        leftover = sorted(n for n in created if secret_exists(created_ids[n]))
+        while leftover:
+            remaining = deadline - time.monotonic()
+            if remaining <= 0:
                 break
+            time.sleep(min(SETTLE_POLL_SECONDS, remaining))
+            leftover = sorted(n for n in created if secret_exists(created_ids[n]))
 
         if leftover:
             return {
@@ -384,11 +469,9 @@ def main() -> int:
         r = {"status": "SKIP", "why": str(e)}
     except Exception as e:  # noqa: BLE001 -- classify infra faults, never crash the run
         msg = str(e)
-        if any(m in msg.lower() for m in MISSING_CREDENTIAL_MARKERS):
-            r = {
-                "status": "SKIP",
-                "why": f"missing or ambiguous Daytona vault credential: {msg}",
-            }
+        reason = environment_cause(msg)
+        if reason:
+            r = {"status": "SKIP", "why": f"{reason}: {msg}"}
         else:
             r = {
                 "status": "FAIL",

--- a/.agents/skills/agent-release-gate/resources/check_secrets_teardown.py
+++ b/.agents/skills/agent-release-gate/resources/check_secrets_teardown.py
@@ -109,6 +109,10 @@ MAX_ENUMERATION_SECONDS = 120.0
 #: How long to wait between settle polls, capped by whatever remains of the caller's budget.
 SETTLE_POLL_SECONDS = 5.0
 
+#: A floor for the FIRST probe only. That read measures what is already true rather than waiting
+#: for a deletion, so `--settle 0` still gets one honest look instead of a zero-second timeout.
+INITIAL_PROBE_SECONDS = 10.0
+
 #: The vault resolver's OWN diagnostics, as whole phrases. Deliberately not the bare nouns
 #: `credential` and `connection`: those appear in transport failures and in
 #: `credential_delivery_failed` itself, so matching them turned real defects into green SKIPs.
@@ -204,14 +208,16 @@ def daytona_api_url() -> str:
     return raw
 
 
-def _get(path: str, params: dict | None = None) -> httpx.Response:
+def _get(
+    path: str, params: dict | None = None, timeout: float = 30.0
+) -> httpx.Response:
     url = f"{daytona_api_url()}{path}"
     try:
         return httpx.get(
             url,
             params=params,
             headers={"Authorization": f"Bearer {daytona_key()}"},
-            timeout=30.0,
+            timeout=timeout,
         )
     except httpx.HTTPError as e:
         raise SkipCheck(
@@ -314,13 +320,13 @@ def _fetch_page(cursor: str | None) -> dict:
     return body
 
 
-def secret_exists(secret_id: str) -> bool:
+def secret_exists(secret_id: str, timeout: float = 30.0) -> bool:
     """Is this Secret still present? `GET /secret/{secretId}`; a 404 means it is gone.
 
     Polling by id keeps the settle loop O(secrets this run created) instead of re-enumerating a
     ~3510-secret organization every few seconds.
     """
-    r = _get(f"/secret/{secret_id}")
+    r = _get(f"/secret/{secret_id}", timeout=timeout)
     if r.status_code == 200:
         return True
     if r.status_code == 404:
@@ -415,14 +421,29 @@ def secrets_teardown(settle_seconds: int) -> dict:
         # version slept a flat 5s before its first look, so `--settle 1` reported PASS on a
         # deletion that took five times its budget, and `--settle 0` never looked at all — the
         # deadline was decorative. `monotonic` because a wall-clock step would corrupt it.
+        #
+        # Each probe is bounded by the REMAINING budget, not only the gaps between them. A probe
+        # carries its own request timeout, so a slow one could otherwise complete long after the
+        # deadline, come back 404, and let the loop report a within-budget deletion it never
+        # observed within budget. The first read gets a floor: it measures what is already true
+        # rather than waiting for anything, so `--settle 0` still gets one honest look.
         deadline = time.monotonic() + settle_seconds
-        leftover = sorted(n for n in created if secret_exists(created_ids[n]))
-        while leftover:
-            remaining = deadline - time.monotonic()
-            if remaining <= 0:
+
+        def remaining() -> float:
+            return deadline - time.monotonic()
+
+        def still_present(budget: float) -> list:
+            return sorted(
+                n for n in created if secret_exists(created_ids[n], timeout=budget)
+            )
+
+        leftover = still_present(max(remaining(), INITIAL_PROBE_SECONDS))
+        while leftover and remaining() > 0:
+            time.sleep(min(SETTLE_POLL_SECONDS, remaining()))
+            budget = remaining()
+            if budget <= 0:
                 break
-            time.sleep(min(SETTLE_POLL_SECONDS, remaining))
-            leftover = sorted(n for n in created if secret_exists(created_ids[n]))
+            leftover = still_present(budget)
 
         if leftover:
             return {

--- a/.agents/skills/agent-release-gate/resources/matrix_c5_first_call_race.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_c5_first_call_race.py
@@ -175,6 +175,12 @@ TRANSPORT_FAILURE_MARKERS = (
     "502",
     "503",
     "504",
+    # A delivery failure is the very thing this cell tests, so it can never be an excuse to skip.
+    # When the CODED frame carries it, the PASS branch above has already claimed it; reaching here
+    # means the text names a delivery failure that no coded frame carried, which is anomalous and
+    # must fail rather than borrow a vault-miss SKIP. Kept identical to the teardown check's list.
+    "credential_delivery_failed",
+    "credentials from reaching the model",
 )
 
 

--- a/.agents/skills/agent-release-gate/resources/matrix_c5_first_call_race.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_c5_first_call_race.py
@@ -147,13 +147,48 @@ AUTH_CLASS = re.compile(
     re.I,
 )
 
-MISSING_CREDENTIAL_MARKERS = (
-    "connection",
+#: The vault resolver's OWN diagnostics, as whole phrases. NOT the bare nouns `credential` and
+#: `connection`: those appear in transport failures and inside `credential_delivery_failed`
+#: itself, so matching them let a connection reset or a delivery timeout — the very failures this
+#: cell exists to catch — become a green SKIP.
+MISSING_CREDENTIAL_PHRASES = (
     "not found for provider",
+    "no connections for provider",
     "no connections",
+    "multiple connections for provider",
     "multiple connections",
-    "credential",
+    "requires an effective https endpoint",
+    "no usable credential",
 )
+
+#: A real failure, whatever else the message mentions. Checked first, and never a SKIP.
+TRANSPORT_FAILURE_MARKERS = (
+    "econnreset",
+    "econnrefused",
+    "connection reset",
+    "connection refused",
+    "connection error",
+    "enotfound",
+    "eai_again",
+    "timed out",
+    "timeout",
+    "502",
+    "503",
+    "504",
+)
+
+
+def missing_vault_credential(error_text: str) -> bool:
+    """Is this failure the vault having no usable connection, as opposed to anything going wrong?
+
+    SKIP claims the product was never tested, so it needs evidence the run could not start. A
+    transport or service failure is checked first and always wins: it is real, and a vault phrase
+    appearing beside one does not excuse it.
+    """
+    low = error_text.lower()
+    if any(marker in low for marker in TRANSPORT_FAILURE_MARKERS):
+        return False
+    return any(phrase in low for phrase in MISSING_CREDENTIAL_PHRASES)
 
 
 def key_blame_verdict(
@@ -416,12 +451,13 @@ def c5_first_call_race(
             return {**blame, **evidence}
 
         if CREDENTIAL_DELIVERY_FAILED in codes:
-            if not ledger:
+            if not stored_sandboxes:
                 return {
                     "status": "FAIL",
                     "why": (
-                        "classified as credential_delivery_failed, but no stored turn row came "
-                        "back from /sessions/turns/query -- missing evidence, not stability"
+                        "classified as credential_delivery_failed, but the stored ledger names "
+                        f"no sandbox (rows={len(ledger)}) -- without a sandbox id there is no "
+                        "evidence the turn ran in the cold Daytona sandbox this cell validates"
                     ),
                     **evidence,
                 }
@@ -451,8 +487,7 @@ def c5_first_call_race(
                     ),
                     **evidence,
                 }
-            low = error_text.lower()
-            if any(m in low for m in MISSING_CREDENTIAL_MARKERS):
+            if missing_vault_credential(error_text):
                 return {
                     "status": "SKIP",
                     "why": (
@@ -467,12 +502,13 @@ def c5_first_call_race(
                 **evidence,
             }
 
-        if not ledger:
+        if not stored_sandboxes:
             return {
                 "status": "FAIL",
                 "why": (
-                    "the turn reported success but no stored turn row came back from "
-                    "/sessions/turns/query -- missing evidence, not stability"
+                    "the turn reported success but the stored ledger names no sandbox "
+                    f"(rows={len(ledger)}) -- a row without a sandbox id is not evidence the "
+                    "turn ran in the cold Daytona sandbox this cell validates"
                 ),
                 **evidence,
             }
@@ -492,7 +528,7 @@ def c5_first_call_race(
         }
     except Exception as e:  # noqa: BLE001 -- classify infra faults as SKIP, never crash the run
         msg = str(e)
-        if any(m in msg.lower() for m in MISSING_CREDENTIAL_MARKERS):
+        if missing_vault_credential(msg):
             return {
                 "status": "SKIP",
                 "why": f"missing or ambiguous Daytona vault credential: {msg}",

--- a/.agents/skills/agent-release-gate/resources/matrix_h1_bad_harness.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_h1_bad_harness.py
@@ -58,7 +58,7 @@ from qa_matrix_lib import (  # noqa: E402
     invoke,
     refs,
     seed_and_baseline,
-    turn_ledger,
+    turn_ledger_or_unavailable,
     user_msg,
 )
 
@@ -163,7 +163,7 @@ def probe(wf: str, var: str, references: dict, name: str, harness: dict) -> dict
     # The failure this cell exists for: a turn that RAN. Read it back from storage, because a
     # defaulted harness is only visible after the fact as a stored row with a real harness_kind.
     time.sleep(1.0)
-    ledger = turn_ledger(session_id)
+    ledger, ledger_available = turn_ledger_or_unavailable(session_id)
     stored_harnesses = sorted(
         {row.get("harness_kind") for row in ledger if row.get("harness_kind")}
     )
@@ -171,13 +171,31 @@ def probe(wf: str, var: str, references: dict, name: str, harness: dict) -> dict
     detail["stored_turn_rows"] = len(ledger)
     detail["stored_harness_kinds"] = stored_harnesses
     detail["produced_output"] = produced_output
+    detail["ledger_available"] = ledger_available
     detail["reply"] = turn.reply.strip()[:120]
 
-    if produced_output and not error_text:
+    # EXECUTION EVIDENCE OUTRANKS A LATER REFUSAL. A turn that emitted text or called a tool RAN,
+    # and a `data-agent-error` arriving afterwards does not undo that: the malformed harness was
+    # defaulted to something runnable first and complained second. The earlier version required
+    # `not error_text`, so a streamed error let a genuinely defaulted run pass. A stored
+    # harness_kind is the same evidence read from the other side, and is checked here too.
+    if produced_output or stored_harnesses:
         detail["status"] = "FAIL"
         detail["why"] = (
-            f"a malformed harness {harness!r} RAN: the turn produced output and stored "
-            f"harness_kind={stored_harnesses} -- the harness was defaulted, not refused"
+            f"a malformed harness {harness!r} RAN: produced_output={produced_output}, stored "
+            f"harness_kind={stored_harnesses} -- the harness was defaulted, not refused "
+            f"(a later refusal does not undo an executed turn; error={error_text[:200]!r})"
+        )
+        return detail
+
+    # A PASS here asserts that NOTHING was stored, so an unanswered ledger query cannot support
+    # it: that would be the strongest claim drawn from the weakest evidence. `turn_ledger` alone
+    # cannot tell "no rows" from "no answer", which is why this cell reads availability too.
+    if not ledger_available:
+        detail["status"] = "FAIL"
+        detail["why"] = (
+            "the turn ledger did not answer, so there is no evidence the malformed harness "
+            f"stored nothing; refusing to infer a PASS from a failed query (boundaries={boundaries})"
         )
         return detail
 
@@ -209,8 +227,12 @@ def probe(wf: str, var: str, references: dict, name: str, harness: dict) -> dict
 
 def h1_bad_harness() -> dict:
     hexid = uuid.uuid4().hex[:8]
-    wf, var = create_workflow(hexid, "qa-h1harness")
+    # Created BEFORE the try so the `finally` can never raise UnboundLocalError over the real
+    # result. A create that fails must surface its own SKIP or FAIL, not a cleanup crash on top
+    # of it -- the cell's whole contract is that every outcome is explained.
+    wf: str | None = None
     try:
+        wf, var = create_workflow(hexid, "qa-h1harness")
         rev_id, _ver = seed_and_baseline(wf, var, agent_config(), hexid)
         references = refs(wf, var, rev_id)
 
@@ -249,7 +271,8 @@ def h1_bad_harness() -> dict:
             "why": f"unhandled exception: {type(e).__name__}: {msg}",
         }
     finally:
-        archive(wf)
+        if wf is not None:
+            archive(wf)
 
 
 if __name__ == "__main__":

--- a/.agents/skills/agent-release-gate/resources/matrix_h1_bad_harness.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_h1_bad_harness.py
@@ -113,7 +113,12 @@ def known_finding(harness: dict, stored_harnesses: list) -> str | None:
     """
     if harness.get("kind") is not None:
         return None
-    if stored_harnesses and stored_harnesses != ["pi_core"]:
+    # POSITIVE evidence of the pi_core default is required. A stored row whose harness_kind is
+    # unset proves a turn ran but says nothing about what it ran AS, and SF2 is specifically the
+    # silent pi_core default. The asymmetry decides this: under-labelling costs an operator one
+    # investigation of a real FAIL, while over-labelling teaches them to wave past a shape that
+    # may be a fresh regression. So an unproven default reads as new breakage.
+    if stored_harnesses != ["pi_core"]:
         return None
     return SF2_NOTE
 
@@ -209,12 +214,18 @@ def probe(wf: str, var: str, references: dict, name: str, harness: dict) -> dict
     # defaulted to something runnable first and complained second. The earlier version required
     # `not error_text`, so a streamed error let a genuinely defaulted run pass. A stored
     # harness_kind is the same evidence read from the other side, and is checked here too.
-    if produced_output or stored_harnesses:
+    # ROW PRESENCE is the evidence, not the truthiness of a field inside it. `stored_harnesses`
+    # keeps only truthy `harness_kind` values, so a stored row whose kind is missing, null or
+    # empty collapsed to `[]` and let the probe reach PASS with a turn demonstrably persisted --
+    # the same "absence of a field read as absence of the thing" mistake the ledger-availability
+    # fix addressed one layer up. A PASS here asserts NOTHING was stored, so any row refutes it.
+    if produced_output or ledger:
         detail["status"] = "FAIL"
         detail["why"] = (
-            f"a malformed harness {harness!r} RAN: produced_output={produced_output}, stored "
-            f"harness_kind={stored_harnesses} -- the harness was defaulted, not refused "
-            f"(a later refusal does not undo an executed turn; error={error_text[:200]!r})"
+            f"a malformed harness {harness!r} RAN: produced_output={produced_output}, "
+            f"stored_turn_rows={len(ledger)}, stored harness_kind={stored_harnesses} -- the "
+            f"harness was defaulted, not refused (a later refusal does not undo an executed "
+            f"turn; error={error_text[:200]!r})"
         )
         known = known_finding(harness, stored_harnesses)
         if known:

--- a/.agents/skills/agent-release-gate/resources/matrix_h1_bad_harness.py
+++ b/.agents/skills/agent-release-gate/resources/matrix_h1_bad_harness.py
@@ -88,6 +88,36 @@ CASES = {
 }
 
 
+#: The one FAIL shape that is already known, filed, and NOT a fresh regression.
+#:
+#: A cleared harness (`{"kind": None}`) is not rejected: it silently defaults to `pi_core`, so on
+#: any config whose model spelling suits Pi the turn runs and this cell goes red. That is SF2,
+#: found by this cell and deliberately filed rather than fixed for this release.
+#:
+#: The FAIL is NOT softened, because the invariant really is broken -- a malformed harness ran.
+#: What the name buys is that the next reader recognizes it in a gate report instead of chasing it
+#: as new breakage, which is how W5's standing red is handled. When SF2 is fixed this case turns
+#: green on its own and `known_finding` stops appearing; that is the signal to delete this.
+SF2_NOTE = (
+    "known finding SF2 (cleared harness silently defaults to pi_core), filed for the "
+    "next release -- expected red, not a fresh regression"
+)
+
+
+def known_finding(harness: dict, stored_harnesses: list) -> str | None:
+    """The note for a FAIL shape that is already filed, or None when the failure is new.
+
+    Narrow on purpose: only a CLEARED harness, and only when nothing contradicts the default.
+    A wrong-type or unknown-string harness that runs is a different, unfiled defect and must read
+    as one.
+    """
+    if harness.get("kind") is not None:
+        return None
+    if stored_harnesses and stored_harnesses != ["pi_core"]:
+        return None
+    return SF2_NOTE
+
+
 def bad_config(harness: dict) -> dict:
     cfg = copy.deepcopy(agent_config())
     cfg["harness"] = harness
@@ -186,6 +216,10 @@ def probe(wf: str, var: str, references: dict, name: str, harness: dict) -> dict
             f"harness_kind={stored_harnesses} -- the harness was defaulted, not refused "
             f"(a later refusal does not undo an executed turn; error={error_text[:200]!r})"
         )
+        known = known_finding(harness, stored_harnesses)
+        if known:
+            detail["known_finding"] = "SF2"
+            detail["why"] = f"{detail['why']} -- {known}"
         return detail
 
     # A PASS here asserts that NOTHING was stored, so an unanswered ledger query cannot support

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -540,7 +540,22 @@ def turn_ledger_or_unavailable(
     )
     if r.status_code != 200:
         return [], False
-    return (r.json().get("turns") or []), True
+    # A 200 is not an answer until the payload is the shape the contract promises. `{}` and
+    # `{"turns": null}` would otherwise read as an answered-EMPTY ledger, which is the one reading
+    # a caller must never get for free: `matrix_h1_bad_harness.py` turns "answered empty" into a
+    # PASS asserting nothing was stored. Malformed is unavailable, so that PASS stays unreachable.
+    try:
+        body = r.json()
+    except ValueError:
+        return [], False
+    if not isinstance(body, dict):
+        return [], False
+    turns = body.get("turns")
+    if not isinstance(turns, list):
+        return [], False
+    if any(not isinstance(row, dict) for row in turns):
+        return [], False
+    return turns, True
 
 
 def ledger_ids(session_id: str) -> tuple[list[str], list[str]]:

--- a/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
+++ b/.agents/skills/agent-release-gate/resources/qa_matrix_lib.py
@@ -513,7 +513,23 @@ def turn_ledger(session_id: str, limit: int = 20) -> list[dict]:
     `POST /sessions/turns/`), which makes this a STORED outcome rather than an echo.
 
     Returns [] when the ledger is unavailable, which callers must treat as MISSING EVIDENCE and
-    fail on -- never as evidence of stability."""
+    fail on -- never as evidence of stability. A caller that needs to TELL those two apart (a
+    check whose PASS depends on nothing having been stored) must use `turn_ledger_or_unavailable`
+    instead; this signature cannot express the difference."""
+    rows, _available = turn_ledger_or_unavailable(session_id, limit)
+    return rows
+
+
+def turn_ledger_or_unavailable(
+    session_id: str, limit: int = 20
+) -> tuple[list[dict], bool]:
+    """`(rows, available)` -- the ledger, and whether the query actually answered.
+
+    `turn_ledger` collapses "the query failed" and "the session stored no turn" into the same
+    empty list. That is safe for a check whose PASS needs rows to EXIST, because both readings
+    fail. It is unsafe for a check whose PASS needs rows to be ABSENT: a query failure would then
+    read as proof that nothing ran, which is the strongest possible claim drawn from the weakest
+    possible evidence. `matrix_h1_bad_harness.py` is exactly that shape."""
     r = api_call(
         "POST",
         "/sessions/turns/query",
@@ -523,8 +539,8 @@ def turn_ledger(session_id: str, limit: int = 20) -> list[dict]:
         },
     )
     if r.status_code != 200:
-        return []
-    return r.json().get("turns") or []
+        return [], False
+    return (r.json().get("turns") or []), True
 
 
 def ledger_ids(session_id: str) -> tuple[list[str], list[str]]:

--- a/.agents/skills/agent-release-gate/resources/sweep_disagree.py
+++ b/.agents/skills/agent-release-gate/resources/sweep_disagree.py
@@ -53,6 +53,7 @@ import os
 import re
 import subprocess
 import sys
+from urllib.parse import urlparse
 
 EXIT_PASS = 0
 EXIT_FAIL = 1
@@ -131,9 +132,20 @@ def partition_known_gaps(
     return excluded, unexplained
 
 
+#: Hostnames that mean "this machine". Matched against the PARSED host, never the raw URL: a
+#: substring test calls `https://runner-localhost.example` local, and the sweep would then scan
+#: whatever runner happens to be on this box and report PASS for a deployment it never looked at.
+LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"})
+
+
 def base_is_local() -> bool:
     base = os.environ.get("AGENTA_BASE", "")
-    return any(h in base for h in ("localhost", "127.0.0.1", "0.0.0.0"))
+    host = (urlparse(base).hostname or "").strip().lower()
+    if not host:
+        # No scheme, so `urlparse` puts everything in `path`. Read the authority by hand rather
+        # than guessing: a bare `localhost:8480` is a normal way to set this.
+        host = base.split("/")[0].split("@")[-1].rsplit(":", 1)[0].strip().lower()
+    return host in LOCAL_HOSTS
 
 
 def autodetect_runner() -> tuple[str | None, str]:

--- a/.agents/skills/agent-release-gate/resources/sweep_disagree.py
+++ b/.agents/skills/agent-release-gate/resources/sweep_disagree.py
@@ -135,17 +135,48 @@ def partition_known_gaps(
 #: Hostnames that mean "this machine". Matched against the PARSED host, never the raw URL: a
 #: substring test calls `https://runner-localhost.example` local, and the sweep would then scan
 #: whatever runner happens to be on this box and report PASS for a deployment it never looked at.
-LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1", "[::1]"})
+LOCAL_HOSTS = frozenset({"localhost", "127.0.0.1", "0.0.0.0", "::1"})
+
+
+def base_host() -> str:
+    """The hostname `AGENTA_BASE` names, lowercased, or "" when it names none.
+
+    Never raises. `urlparse(...).hostname` throws `ValueError` on a malformed bracketed IPv6
+    literal such as `http://[::1`, and this helper decides whether the sweep runs at all — a
+    crash here would take the whole check down before it could even report a SKIP.
+
+    The scheme-less fallback is IPv6-aware. Stripping the last colon-segment turns a bare `::1`
+    into `:` and `[::1]` into `[:`, so a real loopback would read as remote and the sweep would
+    skip a deployment it could have scanned.
+    """
+    base = os.environ.get("AGENTA_BASE", "").strip()
+    try:
+        parsed = urlparse(base).hostname
+    except ValueError:
+        parsed = None
+    if parsed:
+        return parsed.strip().lower()
+    if "://" in base:
+        # It HAS a scheme and still yielded no hostname, so it is malformed (`http://[::1`).
+        # Falling through to the authority reader would answer "http", which is worse than
+        # admitting the base names no host.
+        return ""
+
+    # No scheme, so `urlparse` put everything in `path`. Read the authority by hand: a bare
+    # `localhost:8480` is a normal way to set this.
+    authority = base.split("/")[0].split("@")[-1].strip()
+    if authority.startswith("["):
+        # A bracketed IPv6 literal, with or without a trailing `:port`.
+        return authority.split("]")[0].lstrip("[").strip().lower()
+    if authority.count(":") > 1:
+        # An UNbracketed IPv6 literal (`::1`). Every colon belongs to the address, so there is no
+        # port to strip.
+        return authority.lower()
+    return authority.rsplit(":", 1)[0].strip().lower()
 
 
 def base_is_local() -> bool:
-    base = os.environ.get("AGENTA_BASE", "")
-    host = (urlparse(base).hostname or "").strip().lower()
-    if not host:
-        # No scheme, so `urlparse` puts everything in `path`. Read the authority by hand rather
-        # than guessing: a bare `localhost:8480` is a normal way to set this.
-        host = base.split("/")[0].split("@")[-1].rsplit(":", 1)[0].strip().lower()
-    return host in LOCAL_HOSTS
+    return base_host() in LOCAL_HOSTS
 
 
 def autodetect_runner() -> tuple[str | None, str]:

--- a/.agents/skills/agent-release-gate/resources/test_gate_review_followups.py
+++ b/.agents/skills/agent-release-gate/resources/test_gate_review_followups.py
@@ -1,0 +1,181 @@
+"""Tests for the CodeRabbit review follow-ups on the gate checks (#6402).
+
+Each class pins one finding. The theme running through them: a check that turns a real failure
+into a green SKIP, or infers a strong claim from missing evidence, is worse than no check — it
+spends a reviewer's trust and returns nothing for it.
+"""
+
+import importlib
+import sys
+from pathlib import Path
+
+import pytest
+
+
+def _mod(monkeypatch, name):
+    monkeypatch.setenv("AGENTA_BASE", "http://localhost:9999")
+    monkeypatch.setenv("AGENTA_PROJECT_ID", "proj-1")
+    monkeypatch.setenv("AGENTA_API_KEY", "test-key")
+    monkeypatch.setenv("DAYTONA_API_KEY", "test-daytona-key")
+    sys.path.insert(0, str(Path(__file__).resolve().parent))
+    for cached in ("qa_matrix_lib", name):
+        sys.modules.pop(cached, None)
+    return importlib.import_module(name)
+
+
+class TestNarrowSkipClassification:
+    """A transport failure must never become a green SKIP (CodeRabbit, major)."""
+
+    REAL_FAILURES = [
+        "ECONNRESET while contacting the credential service",
+        "connection error: upstream refused",
+        "credential_delivery_failed: the run's credentials did not reach the model",
+        "the request timed out after 120s",
+        "502 Bad Gateway from the connection broker",
+    ]
+    VAULT_DIAGNOSTICS = [
+        "connection 'x' not found for provider 'anthropic'",
+        "multiple connections for provider 'openai'",
+        "no connections for provider 'anthropic'",
+    ]
+
+    @pytest.mark.parametrize("text", REAL_FAILURES)
+    def test_teardown_keeps_a_real_failure(self, monkeypatch, text):
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        assert m.environment_cause(text) is None, text
+
+    @pytest.mark.parametrize("text", VAULT_DIAGNOSTICS)
+    def test_teardown_still_skips_a_real_vault_miss(self, monkeypatch, text):
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        assert m.environment_cause(text) is not None, text
+
+    def test_a_transport_failure_wins_over_a_vault_phrase_beside_it(self, monkeypatch):
+        # The mixed case: a credential word next to a real error must not excuse the error.
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        assert (
+            m.environment_cause(
+                "ECONNRESET; also: no connections for provider 'anthropic'"
+            )
+            is None
+        )
+
+    @pytest.mark.parametrize("text", REAL_FAILURES)
+    def test_c5_keeps_a_real_failure(self, monkeypatch, text):
+        m = _mod(monkeypatch, "matrix_c5_first_call_race")
+        assert m.missing_vault_credential(text) is False, text
+
+    @pytest.mark.parametrize("text", VAULT_DIAGNOSTICS)
+    def test_c5_still_skips_a_real_vault_miss(self, monkeypatch, text):
+        m = _mod(monkeypatch, "matrix_c5_first_call_race")
+        assert m.missing_vault_credential(text) is True, text
+
+
+class TestMixedCauses:
+    """SKIP only when EVERY error frame is an environment cause (CodeRabbit, major)."""
+
+    def test_a_credit_frame_does_not_excuse_a_transport_frame(self, monkeypatch):
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        frames = [
+            "Your free Agenta credits are used up.",
+            "ECONNRESET talking to the sandbox",
+        ]
+        unexplained = [e for e in frames if m.environment_cause(e) is None]
+        assert unexplained == ["ECONNRESET talking to the sandbox"]
+
+    def test_all_credit_frames_are_still_a_skip(self, monkeypatch):
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        frames = [
+            "Your free Agenta credits are used up.",
+            "the model provider account has insufficient credit",
+        ]
+        assert [e for e in frames if m.environment_cause(e) is None] == []
+
+
+class TestHttpsGuard:
+    """A bearer token must never go over cleartext (CodeRabbit, security)."""
+
+    def test_an_http_base_is_refused_before_any_request(self, monkeypatch):
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        monkeypatch.setenv("DAYTONA_API_URL", "http://daytona.internal/api")
+        with pytest.raises(m.SkipCheck) as e:
+            m.daytona_api_url()
+        assert "not HTTPS" in str(e.value)
+
+    def test_an_https_base_is_accepted(self, monkeypatch):
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        monkeypatch.setenv("DAYTONA_API_URL", "https://app.daytona.io/api")
+        assert m.daytona_api_url() == "https://app.daytona.io/api"
+
+
+class TestMalformedPayloadShapes:
+    """A malformed page is a SKIP naming the shape, never a stack trace (CodeRabbit, minor)."""
+
+    def test_a_non_object_body_is_a_skip(self, monkeypatch):
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        for body in (None, [], "nope", 7):
+            with pytest.raises(m.SkipCheck):
+                m.list_secret_ids_by_name(fetch=lambda cursor, b=body: b)
+
+    def test_an_unhashable_next_cursor_is_a_skip(self, monkeypatch):
+        # `cursor in seen_cursors` would raise TypeError on a list, aborting the whole gate.
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        for bad in ([], {}, 7):
+            with pytest.raises(m.SkipCheck):
+                m.list_secret_ids_by_name(
+                    fetch=lambda cursor, c=bad: {"items": [], "nextCursor": c}
+                )
+
+
+class TestSweepHostParsing:
+    """`localhost` as a substring is not a local deployment (CodeRabbit, major)."""
+
+    @pytest.mark.parametrize(
+        "base,expected",
+        [
+            ("http://localhost:8480", True),
+            ("http://127.0.0.1:9", True),
+            ("localhost:8480", True),
+            ("https://runner-localhost.example", False),
+            ("https://localhost.attacker.com", False),
+            ("https://cloud.agenta.ai", False),
+            ("", False),
+        ],
+    )
+    def test_only_a_real_local_host_counts(self, monkeypatch, base, expected):
+        monkeypatch.setenv("AGENTA_BASE", base)
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        sys.modules.pop("sweep_disagree", None)
+        m = importlib.import_module("sweep_disagree")
+        assert m.base_is_local() is expected, base
+
+
+class TestLedgerAvailability:
+    """An unanswered ledger query is not proof that nothing was stored (CodeRabbit, major)."""
+
+    def test_the_library_reports_availability_separately(self, monkeypatch):
+        lib = _mod(monkeypatch, "qa_matrix_lib")
+
+        class _Resp:
+            status_code = 503
+
+            def json(self):  # pragma: no cover - never reached on a 503
+                return {}
+
+        monkeypatch.setattr(lib, "api_call", lambda *a, **k: _Resp())
+        rows, available = lib.turn_ledger_or_unavailable("s")
+        assert rows == []
+        assert available is False
+        # The old signature cannot tell the caller which of the two it got.
+        assert lib.turn_ledger("s") == []
+
+    def test_an_empty_but_answered_ledger_is_available(self, monkeypatch):
+        lib = _mod(monkeypatch, "qa_matrix_lib")
+
+        class _Resp:
+            status_code = 200
+
+            def json(self):
+                return {"turns": []}
+
+        monkeypatch.setattr(lib, "api_call", lambda *a, **k: _Resp())
+        assert lib.turn_ledger_or_unavailable("s") == ([], True)

--- a/.agents/skills/agent-release-gate/resources/test_gate_review_followups.py
+++ b/.agents/skills/agent-release-gate/resources/test_gate_review_followups.py
@@ -348,3 +348,156 @@ class TestSF2IsNamedNotSoftened:
         )
         assert d["status"] == "FAIL"
         assert "known_finding" not in d
+
+
+class TestSettleDeadlineBoundsEachProbe:
+    """The deadline must bound the probes themselves, not only the gaps (CodeRabbit, major)."""
+
+    def test_each_probe_gets_the_remaining_budget_as_its_timeout(self, monkeypatch):
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        seen: list[float] = []
+
+        def fake_get(path, params=None, timeout=30.0):
+            seen.append(timeout)
+
+            class _R:
+                status_code = 404
+
+            return _R()
+
+        monkeypatch.setattr(m, "_get", fake_get)
+        assert m.secret_exists("id-1", timeout=3.0) is False
+        assert seen == [3.0]
+
+    def test_a_probe_cannot_be_given_more_than_the_settle_budget(self, monkeypatch):
+        # A fixed 30s probe inside a 1s budget could return long after the deadline and let the
+        # loop claim a within-budget deletion it never observed within budget.
+        m = _mod(monkeypatch, "check_secrets_teardown")
+        assert m.INITIAL_PROBE_SECONDS <= 10.0
+        assert m.SETTLE_POLL_SECONDS <= 5.0
+
+
+class TestC5TreatsDeliveryFailureAsReal:
+    """A delivery failure is what C5 tests, so it can never excuse a SKIP (CodeRabbit, major)."""
+
+    def test_a_textual_delivery_failure_is_not_a_vault_miss(self, monkeypatch):
+        m = _mod(monkeypatch, "matrix_c5_first_call_race")
+        for text in [
+            "credential_delivery_failed: no connections for provider 'anthropic'",
+            "A temporary issue kept this run's credentials from reaching the model.",
+        ]:
+            assert m.missing_vault_credential(text) is False, text
+
+    def test_the_two_cells_agree_on_what_counts_as_a_real_failure(self, monkeypatch):
+        # These lists drifted once already: the teardown check carried the delivery markers and
+        # C5 did not, which is exactly how the SKIP hole opened.
+        c5 = _mod(monkeypatch, "matrix_c5_first_call_race")
+        teardown = _mod(monkeypatch, "check_secrets_teardown")
+        assert set(c5.TRANSPORT_FAILURE_MARKERS) == set(
+            teardown.TRANSPORT_FAILURE_MARKERS
+        )
+
+    def test_a_plain_vault_miss_still_skips(self, monkeypatch):
+        m = _mod(monkeypatch, "matrix_c5_first_call_race")
+        assert m.missing_vault_credential("no connections for provider 'anthropic'")
+
+
+class TestLedgerPayloadValidation:
+    """A 200 is not an answer until the payload has the promised shape (CodeRabbit, major)."""
+
+    def _lib_returning(self, monkeypatch, payload, status=200):
+        lib = _mod(monkeypatch, "qa_matrix_lib")
+
+        class _Resp:
+            status_code = status
+
+            def json(self):
+                if isinstance(payload, Exception):
+                    raise payload
+                return payload
+
+        monkeypatch.setattr(lib, "api_call", lambda *a, **k: _Resp())
+        return lib
+
+    @pytest.mark.parametrize(
+        "payload",
+        [
+            {},
+            {"turns": None},
+            {"turns": "nope"},
+            {"turns": [1, 2]},
+            [],
+            "nope",
+            None,
+            ValueError("not json"),
+        ],
+    )
+    def test_a_malformed_200_is_unavailable(self, monkeypatch, payload):
+        # The load-bearing one: `{}` and `{"turns": null}` would otherwise be ([], True), which
+        # h1 turns into a PASS asserting nothing was stored.
+        lib = self._lib_returning(monkeypatch, payload)
+        assert lib.turn_ledger_or_unavailable("s") == ([], False), payload
+
+    def test_a_well_formed_empty_ledger_is_available(self, monkeypatch):
+        lib = self._lib_returning(monkeypatch, {"turns": []})
+        assert lib.turn_ledger_or_unavailable("s") == ([], True)
+
+    def test_rows_are_returned_when_the_shape_is_right(self, monkeypatch):
+        lib = self._lib_returning(monkeypatch, {"turns": [{"sandbox_id": "sb-1"}]})
+        rows, available = lib.turn_ledger_or_unavailable("s")
+        assert available is True
+        assert rows == [{"sandbox_id": "sb-1"}]
+
+    def test_the_back_compat_wrapper_still_returns_a_list(self, monkeypatch):
+        lib = self._lib_returning(monkeypatch, {})
+        assert lib.turn_ledger("s") == []
+
+    def test_h1_fails_on_a_malformed_200_rather_than_passing(self, monkeypatch):
+        # End to end: the seam change is only worth anything if h1 refuses the PASS.
+        probe = TestH1Probe()
+        d = probe._drive(
+            monkeypatch,
+            commit_status=422,
+            turn=probe.FakeTurn(),
+            rows=[],
+            available=False,
+        )
+        assert d["status"] == "FAIL"
+        assert "did not answer" in d["why"]
+
+
+class TestSweepIPv6Hosts:
+    """The base parser must not crash, and must not mangle IPv6 (CodeRabbit, two minors)."""
+
+    def _host(self, monkeypatch, base):
+        monkeypatch.setenv("AGENTA_BASE", base)
+        sys.path.insert(0, str(Path(__file__).resolve().parent))
+        sys.modules.pop("sweep_disagree", None)
+        return importlib.import_module("sweep_disagree")
+
+    def test_a_malformed_bracketed_ipv6_does_not_crash(self, monkeypatch):
+        # `urlparse("http://[::1").hostname` raises ValueError; this helper decides whether the
+        # sweep runs at all, so a crash here takes the check down before it can even SKIP.
+        m = self._host(monkeypatch, "http://[::1")
+        assert m.base_is_local() is False
+        assert m.base_host() == ""
+
+    @pytest.mark.parametrize(
+        "base,expected",
+        [
+            ("http://[::1]:8480", True),
+            ("http://[::1]", True),
+            ("[::1]:8480", True),
+            ("[::1]", True),
+            ("::1", True),
+            ("http://localhost:8480", True),
+            ("localhost:8480", True),
+            ("https://runner-localhost.example", False),
+            ("http://[2001:db8::1]:8480", False),
+            ("2001:db8::1", False),
+            ("", False),
+        ],
+    )
+    def test_ipv6_and_named_hosts_classify_correctly(self, monkeypatch, base, expected):
+        m = self._host(monkeypatch, base)
+        assert m.base_is_local() is expected, f"{base} -> {m.base_host()!r}"

--- a/.agents/skills/agent-release-gate/resources/test_gate_review_followups.py
+++ b/.agents/skills/agent-release-gate/resources/test_gate_review_followups.py
@@ -179,3 +179,172 @@ class TestLedgerAvailability:
 
         monkeypatch.setattr(lib, "api_call", lambda *a, **k: _Resp())
         assert lib.turn_ledger_or_unavailable("s") == ([], True)
+
+
+class TestH1Probe:
+    """`probe`'s two new decisions, driven through the five outcomes verified by hand.
+
+    Lifted from the cross-reviewer's driver. The decisions under test are (a) execution evidence
+    outranks a later refusal, and (b) an unanswered ledger cannot support a PASS that asserts
+    nothing was stored. Both were correct but untested, which is how the first version of this
+    rule shipped with a hole in it.
+    """
+
+    ERROR_FRAME = [
+        {
+            "type": "data-agent-error",
+            "data": {
+                "code": "agent_run_failed",
+                "errorText": "harness kind is invalid",
+            },
+        }
+    ]
+
+    class FakeTurn:
+        def __init__(self, reply="", raw=None, errors=None):
+            self.reply = reply
+            self.frames = [f.get("type", "") for f in (raw or [])]
+            self.raw_frames = raw or []
+            self.tool_calls = []
+            self.errors = errors or []
+
+    def _drive(
+        self,
+        monkeypatch,
+        *,
+        commit_status,
+        turn,
+        rows,
+        available,
+        harness=None,
+    ):
+        import types
+
+        h1 = _mod(monkeypatch, "matrix_h1_bad_harness")
+        monkeypatch.setattr(
+            h1,
+            "commit_direct",
+            lambda *a, **k: types.SimpleNamespace(
+                status_code=commit_status,
+                text='{"detail":{"code":"invalid_harness_kind","message":"invalid harness.kind"}}',
+            ),
+        )
+        monkeypatch.setattr(h1, "invoke", lambda *a, **k: turn)
+        monkeypatch.setattr(
+            h1, "turn_ledger_or_unavailable", lambda *a, **k: (rows, available)
+        )
+        monkeypatch.setattr(h1.time, "sleep", lambda *a: None)
+        return h1.probe("wf", "var", {}, "case", harness or {"kind": 12345})
+
+    def test_1_commit_refusal_with_nothing_stored_passes(self, monkeypatch):
+        d = self._drive(
+            monkeypatch,
+            commit_status=422,
+            turn=self.FakeTurn(),
+            rows=[],
+            available=True,
+        )
+        assert d["status"] == "PASS", d["why"]
+        assert d["refused_by"] == "commit_api"
+
+    def test_2_runner_stream_error_with_nothing_stored_passes(self, monkeypatch):
+        d = self._drive(
+            monkeypatch,
+            commit_status=200,
+            turn=self.FakeTurn(raw=self.ERROR_FRAME, errors=["harness kind bad"]),
+            rows=[],
+            available=True,
+        )
+        assert d["status"] == "PASS", d["why"]
+        assert d["refused_by"] == "runner_stream"
+
+    def test_3_output_plus_a_streamed_error_fails(self, monkeypatch):
+        # THE BUG THIS RULE FIXES. The old condition required `not error_text`, so a streamed
+        # refusal arriving after the turn had already spoken let a defaulted run pass.
+        d = self._drive(
+            monkeypatch,
+            commit_status=200,
+            turn=self.FakeTurn(
+                reply="READY", raw=self.ERROR_FRAME, errors=["harness kind bad"]
+            ),
+            rows=[],
+            available=True,
+        )
+        assert d["status"] == "FAIL", d["why"]
+        assert "RAN" in d["why"]
+
+    def test_4_stored_harness_kind_with_no_output_fails(self, monkeypatch):
+        # The same evidence read from the other side: the row proves a turn was persisted under a
+        # real harness even though the stream said nothing.
+        d = self._drive(
+            monkeypatch,
+            commit_status=200,
+            turn=self.FakeTurn(raw=self.ERROR_FRAME, errors=["e"]),
+            rows=[{"harness_kind": "pi_core"}],
+            available=True,
+        )
+        assert d["status"] == "FAIL", d["why"]
+        assert "pi_core" in d["why"]
+
+    def test_5_unanswered_ledger_with_a_refusal_present_fails(self, monkeypatch):
+        # A refusal alone is not enough: this PASS asserts nothing was stored, and a query that
+        # never answered cannot support that.
+        d = self._drive(
+            monkeypatch,
+            commit_status=422,
+            turn=self.FakeTurn(),
+            rows=[],
+            available=False,
+        )
+        assert d["status"] == "FAIL", d["why"]
+        assert "did not answer" in d["why"]
+
+
+class TestSF2IsNamedNotSoftened:
+    """The cleared-harness FAIL is real, and it is the filed finding SF2 (W5 handling)."""
+
+    def test_the_cleared_harness_fail_names_sf2(self, monkeypatch):
+        probe = TestH1Probe()
+        d = probe._drive(
+            monkeypatch,
+            commit_status=200,
+            turn=probe.FakeTurn(reply="READY"),
+            rows=[{"harness_kind": "pi_core"}],
+            available=True,
+            harness={"kind": None},
+        )
+        # Still a FAIL. The invariant really is broken; only the reader's context improves.
+        assert d["status"] == "FAIL"
+        assert d["known_finding"] == "SF2"
+        assert "silently defaults to pi_core" in d["why"]
+        assert "filed for the next release" in d["why"]
+
+    def test_a_wrong_type_harness_that_runs_is_not_sf2(self, monkeypatch):
+        # A different, UNFILED defect must read as new breakage, not borrow SF2's excuse.
+        probe = TestH1Probe()
+        d = probe._drive(
+            monkeypatch,
+            commit_status=200,
+            turn=probe.FakeTurn(reply="READY"),
+            rows=[{"harness_kind": "pi_core"}],
+            available=True,
+            harness={"kind": 12345},
+        )
+        assert d["status"] == "FAIL"
+        assert "known_finding" not in d
+        assert "SF2" not in d["why"]
+
+    def test_a_cleared_harness_defaulting_elsewhere_is_not_sf2(self, monkeypatch):
+        # SF2 is specifically the pi_core default. A cleared harness running as claude would be a
+        # different finding and must not be filed under this one.
+        probe = TestH1Probe()
+        d = probe._drive(
+            monkeypatch,
+            commit_status=200,
+            turn=probe.FakeTurn(reply="READY"),
+            rows=[{"harness_kind": "claude"}],
+            available=True,
+            harness={"kind": None},
+        )
+        assert d["status"] == "FAIL"
+        assert "known_finding" not in d

--- a/.agents/skills/agent-release-gate/resources/test_gate_review_followups.py
+++ b/.agents/skills/agent-release-gate/resources/test_gate_review_followups.py
@@ -573,3 +573,76 @@ class TestAbsenceObservedAfterTheDeadline:
         r = m.secrets_teardown(1)
         assert r["status"] == "FAIL", r
         assert self.RUN_SECRET in r["leftover_secret_names"]
+
+
+class TestRowPresenceIsTheEvidence:
+    """A stored row refutes PASS even when its harness_kind is unset (CodeRabbit, major).
+
+    `stored_harnesses` keeps only truthy values, so a row with a missing, null or empty
+    `harness_kind` collapsed to `[]` and the probe reached PASS with a turn demonstrably
+    persisted. Same class as the ledger-availability finding: an absent FIELD was read as an
+    absent THING.
+    """
+
+    @pytest.mark.parametrize(
+        "row",
+        [
+            {"harness_kind": None},
+            {"harness_kind": ""},
+            {},
+            {"sandbox_id": "sb-1"},
+        ],
+    )
+    def test_a_row_without_a_usable_kind_still_fails(self, monkeypatch, row):
+        probe = TestH1Probe()
+        d = probe._drive(
+            monkeypatch,
+            commit_status=422,
+            turn=probe.FakeTurn(),
+            rows=[row],
+            available=True,
+        )
+        assert d["status"] == "FAIL", d["why"]
+        assert "stored_turn_rows=1" in d["why"]
+
+    def test_such_a_row_is_not_labelled_sf2(self, monkeypatch):
+        # SF2 is specifically the silent pi_core default. An unset stored kind proves a turn ran
+        # but not what it ran AS, so it must read as new breakage rather than the filed finding.
+        probe = TestH1Probe()
+        d = probe._drive(
+            monkeypatch,
+            commit_status=422,
+            turn=probe.FakeTurn(),
+            rows=[{"harness_kind": None}],
+            available=True,
+            harness={"kind": None},
+        )
+        assert d["status"] == "FAIL"
+        assert "known_finding" not in d
+        assert "SF2" not in d["why"]
+
+    def test_output_with_no_stored_kind_is_not_labelled_sf2_either(self, monkeypatch):
+        # A cleared harness that visibly ran but stored no kind: still a FAIL, still unlabelled.
+        probe = TestH1Probe()
+        d = probe._drive(
+            monkeypatch,
+            commit_status=200,
+            turn=probe.FakeTurn(reply="READY"),
+            rows=[],
+            available=True,
+            harness={"kind": None},
+        )
+        assert d["status"] == "FAIL"
+        assert "known_finding" not in d
+
+    def test_an_empty_answered_ledger_with_no_output_still_passes(self, monkeypatch):
+        # The positive control: row presence is the evidence, so NO rows must still allow a PASS.
+        probe = TestH1Probe()
+        d = probe._drive(
+            monkeypatch,
+            commit_status=422,
+            turn=probe.FakeTurn(),
+            rows=[],
+            available=True,
+        )
+        assert d["status"] == "PASS", d["why"]

--- a/.agents/skills/agent-release-gate/resources/test_gate_review_followups.py
+++ b/.agents/skills/agent-release-gate/resources/test_gate_review_followups.py
@@ -501,3 +501,75 @@ class TestSweepIPv6Hosts:
     def test_ipv6_and_named_hosts_classify_correctly(self, monkeypatch, base, expected):
         m = self._host(monkeypatch, base)
         assert m.base_is_local() is expected, f"{base} -> {m.base_host()!r}"
+
+
+class TestAbsenceObservedAfterTheDeadline:
+    """An absence first SEEN after the budget is not an in-budget deletion (CodeRabbit, major).
+
+    The first probe carries a floor so it can complete at all, which means on a short budget it
+    can itself finish after the deadline. Without timestamping the observation, that floor quietly
+    reopened the deadline hole the polling fix had just closed: a slow 404 came back, the loop saw
+    an empty leftover, and the cell reported `deleted within 0s` — a number nobody measured.
+    """
+
+    RUN_SECRET = "agenta_" + "a" * 36 + "_0"
+
+    def _drive(self, monkeypatch, *, settle, probe_seconds, present=False):
+        m = _mod(monkeypatch, "check_secrets_teardown")
+
+        clock = {"now": 0.0}
+        monkeypatch.setattr(m.time, "monotonic", lambda: clock["now"])
+        monkeypatch.setattr(
+            m.time, "sleep", lambda s: clock.__setitem__("now", clock["now"] + s)
+        )
+
+        def slow_secret_exists(secret_id, timeout=30.0):
+            # Every probe costs wall-clock time, which is the whole point: a probe is not free
+            # and can outlast the budget it was meant to respect.
+            clock["now"] += probe_seconds
+            return present
+
+        monkeypatch.setattr(m, "secret_exists", slow_secret_exists)
+
+        inventories = [{}, {self.RUN_SECRET: "id-1"}]
+        monkeypatch.setattr(
+            m, "list_secret_ids_by_name", lambda *a, **k: inventories.pop(0)
+        )
+        monkeypatch.setattr(m, "create_workflow", lambda *a, **k: ("wf-1", "var-1"))
+        monkeypatch.setattr(m, "seed_and_baseline", lambda *a, **k: ("rev-1", 1))
+        monkeypatch.setattr(m, "refs", lambda *a, **k: {})
+        monkeypatch.setattr(m, "archive", lambda *a, **k: None)
+
+        class _Turn:
+            errors: list = []
+
+        monkeypatch.setattr(m, "invoke", lambda *a, **k: _Turn())
+        return m
+
+    def test_settle_zero_with_a_slow_404_does_not_pass(self, monkeypatch):
+        # CodeRabbit's exact regression: the Secret IS gone, but the read that proved it landed
+        # 2s into a 0s budget.
+        m = self._drive(monkeypatch, settle=0, probe_seconds=2.0)
+        with pytest.raises(m.SkipCheck) as e:
+            m.secrets_teardown(0)
+        why = str(e.value)
+        assert "AFTER the 0s settle budget" in why
+        assert "unproven" in why
+        # And it says plainly that nothing leaked, so a reader does not chase a leak that is not
+        # there: this is a measurement gap, not a violated invariant.
+        assert "No Secret outlived its run" in why
+
+    def test_a_short_probe_inside_a_real_budget_still_passes(self, monkeypatch):
+        # The positive control. Without it, "never PASS" would satisfy the test above.
+        m = self._drive(monkeypatch, settle=60, probe_seconds=2.0)
+        r = m.secrets_teardown(60)
+        assert r["status"] == "PASS", r["why"]
+        assert "deleted within 60s" in r["why"]
+
+    def test_a_secret_that_really_survives_still_fails(self, monkeypatch):
+        # The distinction that matters: an unproven-but-clean run is a SKIP, a genuine leftover is
+        # a FAIL. Conflating them either way would break the check.
+        m = self._drive(monkeypatch, settle=1, probe_seconds=2.0, present=True)
+        r = m.secrets_teardown(1)
+        assert r["status"] == "FAIL", r
+        assert self.RUN_SECRET in r["leftover_secret_names"]


### PR DESCRIPTION
The thirteen CodeRabbit comments on #6402, checked against the final merged state. **Ten are real and fixed here; three describe code that later commits on the same PR already changed** — those are declined inline on #6402 with a line each.

The theme across the real ten: a check that turns a failure into a green SKIP, or infers a strong claim from missing evidence, is worse than no check. It spends a reviewer's trust and returns nothing for it.

## Fixed

**Narrow the SKIP classification** (teardown + c5, major). Both matched the bare nouns `credential` and `connection` anywhere in the error text — which sweeps in exactly the failures these cells exist to catch, since a connection reset, an upstream connection error, and `credential_delivery_failed` itself all contain one. SKIP now requires the vault resolver's own diagnostics as whole phrases, and a transport or service failure is checked **first** and always wins.

**SKIP only when every error frame is an environment cause** (teardown, major). The frames were joined before matching, so one credit phrase excused a transport error sitting beside it and bypassed the teardown assertions entirely.

**Require a stored sandbox id before PASS** (c5, major). A row with a null `sandbox_id` passed both success paths, leaving no evidence the turn ran in the cold Daytona sandbox the cell claims to validate.

**An unavailable ledger is not an empty ledger** (h1, major). `turn_ledger` returns `[]` for both. That is safe where a PASS needs rows to *exist* and unsafe where a PASS needs rows to be *absent* — h1 is the second shape, so a failed query read as proof that nothing ran: the strongest claim from the weakest evidence. Added `turn_ledger_or_unavailable`, and h1 now fails when the query did not answer.

**Execution evidence outranks a later refusal** (h1, major). The check ignored produced output whenever `error_text` was non-empty, so a streamed `data-agent-error` let a genuinely defaulted run pass. A stored `harness_kind` now fails it too.

**Honor the settle deadline** (teardown, minor). The loop slept a flat 5s before its first look, so `--settle 1` reported PASS on a deletion that took five times its budget, and `--settle 0` never looked at all. It now checks once immediately, uses `monotonic`, and never sleeps past the remaining budget.

**Reject non-HTTPS Daytona URLs** (teardown, security). `_get` sends the API key as a bearer token, so an `http://` base put a live credential on the wire in cleartext.

**Parse the hostname** (sweep, major). Any URL *containing* `localhost` counted as local, so `https://runner-localhost.example` would make the sweep scan an unrelated local runner and report PASS for a deployment it never looked at.

**Guard cleanup on a failed create** (h1, minor). `finally: archive(wf)` raised `UnboundLocalError` over the real result when `create_workflow` threw, replacing a structured SKIP/FAIL with a crash.

**Validate malformed payload shapes** (teardown, minor). A non-object body or an unhashable `nextCursor` reached `.get` and `cursor in seen_cursors`, aborting the gate with a stack trace instead of a SKIP naming the shape.

**Document that an absent proxy marker proves nothing** (LESSONS, minor). It is one-directional evidence: a direct provider never emits it, and a remote deployment has no reachable log. Reading an empty grep as "so it really was the user's key" is exactly how F6 survived a whole release.

## Declined as stale

Three comments describe the state of an earlier commit; later commits on the same PR already changed that code. Detail and evidence are in the inline replies on #6402.

- *"Use the documented paginated Secret-list API"* — the merged file already walks `/secret/paginated` by cursor to exhaustion. Superseded by the pagination fix.
- *"Fail contradictory add-a-key copy for `credential_delivery_failed`"* — `key_blame_verdict` now runs **before** that branch and fails on add-a-key wording over any credential refusal, echo or no echo. Exactly the requested behavior, added later on the same PR.
- The second half of the narrow-SKIP comment asked for the same add-a-key rejection; same answer. Its first half is real and fixed above.

## Tests

32 new tests in `test_gate_review_followups.py`, one class per finding, each pinning the boundary from both sides: five real failures stay failures and three vault diagnostics still SKIP, in both cells; a transport failure beside a vault phrase still fails; the mixed-frame case; the HTTPS guard both ways; four non-object bodies and three unhashable cursors; seven hostname cases including two spoofing shapes; and ledger availability distinguished from emptiness.

Resources suite **143 passed**. `ruff@0.15.12` format and check clean. Every script recompiles.

Live validation of the three product cells still runs as the targeted rerun after merge.

https://claude.ai/code/session_0165tsjmvf3qvTPFcb9EV44g