### PR TITLE
fix(runner): count an OAuth token as a usable Claude subscription

### DIFF
--- a/services/runner/src/subscription-status.ts
+++ b/services/runner/src/subscription-status.ts
@@ -75,6 +75,16 @@ interface LoginProbe {
   dirEnv: string;
   /** The login artifact inside that directory. */
   file: string;
+  /**
+   * Env vars that are a COMPLETE credential on their own, so the harness authenticates with no
+   * login file at all. Any one of them set means `ready`: the run inherits it (the harness's
+   * group in `PROVIDER_ENV_VAR_GROUPS`) and uses it exactly as it would the file.
+   *
+   * Subscription tokens only. An `*_API_KEY` belongs to the `agenta` connection mode and is a
+   * vault key the user pastes, not a plan they pay for — reporting one here would put a
+   * "subscription login found" against a key, which is the same lie `isOAuthLogin` avoids.
+   */
+  tokenEnv?: readonly string[];
   /** Omitted when the harness is not tied to one provider. */
   provider?: string;
   /**
@@ -137,6 +147,13 @@ const PROBES: Record<SubscriptionHarness, LoginProbe> = {
   claude: {
     dirEnv: "CLAUDE_CONFIG_DIR",
     file: ".credentials.json",
+    // The documented fallback when no login is mounted (the EE compose override names it for an
+    // expired session, regenerated with `claude setup-token`).
+    tokenEnv: [
+      "CLAUDE_CODE_OAUTH_TOKEN",
+      "ANTHROPIC_AUTH_TOKEN",
+      "ANTHROPIC_OAUTH_TOKEN",
+    ],
     provider: "anthropic",
   },
   // `pi_core` and `pi_agenta` both drive the ACP agent "pi" (see run-plan.ts), so they read the
@@ -170,10 +187,24 @@ interface ProbeResult {
  * The reads are async so a hung or slow mount (a stalled network filesystem) blocks only this
  * request, never the runner's event loop and the runs sharing it.
  */
+/** A token that authenticates on its own, so no login file has to exist. */
+function hasTokenCredential(
+  probe: LoginProbe,
+  env: NodeJS.ProcessEnv,
+): boolean {
+  return (probe.tokenEnv ?? []).some((name) => (env[name] ?? "").trim() !== "");
+}
+
 async function probeState(
   probe: LoginProbe,
   env: NodeJS.ProcessEnv,
 ): Promise<ProbeResult> {
+  // Checked before the mount, and it wins over every file verdict: the run inherits this token and
+  // the harness authenticates with it whatever the mount holds, so a missing, empty or unreadable
+  // file is not a missing login. Probing only the file reported `login_missing` for a deployment
+  // that could run, and the UI turned that into "you have no runnable model" and blocked every
+  // agent behind "add your model provider key".
+  if (hasTokenCredential(probe, env)) return { state: "ready" };
   const dir = env[probe.dirEnv]?.trim();
   if (!dir) return { state: "not_configured" };
   // stat follows symlinks, so a Codex login reached through the runner-owned home's symlink

--- a/services/runner/tests/unit/subscription-status.test.ts
+++ b/services/runner/tests/unit/subscription-status.test.ts
@@ -289,6 +289,98 @@ describe("harnessSubscriptionStatus", () => {
     );
   });
 
+  it("reports ready from an OAuth token alone, with no login file mounted", async () => {
+    // The deployment CAN run: `CLAUDE_CODE_OAUTH_TOKEN` is in the harness's inherited env group,
+    // so the run authenticates with it. Probing only the file called this `login_missing`, and the
+    // UI turned that into "no runnable model" and disabled the composer.
+    assert.deepEqual(
+      await harnessSubscriptionStatus("claude", {
+        CLAUDE_CODE_OAUTH_TOKEN: "fake-oauth-token",
+      }),
+      { state: "ready", provider: "anthropic" },
+    );
+  });
+
+  it("accepts either Anthropic auth-token variable the harness reads", async () => {
+    for (const name of ["ANTHROPIC_AUTH_TOKEN", "ANTHROPIC_OAUTH_TOKEN"]) {
+      assert.equal(
+        (await harnessSubscriptionStatus("claude", { [name]: "fake-token" }))
+          .state,
+        "ready",
+        `${name} should authenticate the harness`,
+      );
+    }
+  });
+
+  it("prefers the token over every file verdict on the same mount", async () => {
+    // A missing, empty or unparseable file is not a missing login when a token authenticates.
+    const cases: [string, NodeJS.ProcessEnv][] = [
+      ["absent", mount("CLAUDE_CONFIG_DIR")],
+      ["empty", mount("CLAUDE_CONFIG_DIR", ".credentials.json", "")],
+      ["not JSON", mount("CLAUDE_CONFIG_DIR", ".credentials.json", "nope")],
+    ];
+    for (const [label, env] of cases) {
+      assert.equal(
+        (
+          await harnessSubscriptionStatus("claude", {
+            ...env,
+            CLAUDE_CODE_OAUTH_TOKEN: "fake-oauth-token",
+          })
+        ).state,
+        "ready",
+        `a ${label} login file must not override a usable token`,
+      );
+    }
+  });
+
+  it("ignores a blank token, so an unset fallback still reports the file's verdict", async () => {
+    // The EE compose override defaults the variable to "", which must not read as a credential.
+    assert.equal(
+      (
+        await harnessSubscriptionStatus("claude", {
+          ...mount("CLAUDE_CONFIG_DIR"),
+          CLAUDE_CODE_OAUTH_TOKEN: "   ",
+        })
+      ).state,
+      "login_missing",
+    );
+  });
+
+  it("never counts an API key as a subscription", async () => {
+    // `ANTHROPIC_API_KEY` is the `agenta` connection mode: a vault key someone pasted, not a plan.
+    assert.equal(
+      (
+        await harnessSubscriptionStatus("claude", {
+          ...mount("CLAUDE_CONFIG_DIR"),
+          ANTHROPIC_API_KEY: "sk-fake",
+        })
+      ).state,
+      "login_missing",
+    );
+  });
+
+  it("gives no harness but Claude a token route", async () => {
+    // Codex and Pi authenticate from their own login files; neither has a token fallback.
+    assert.equal(
+      (
+        await harnessSubscriptionStatus("codex", {
+          ...mount("CODEX_HOME"),
+          CLAUDE_CODE_OAUTH_TOKEN: "fake-oauth-token",
+        })
+      ).state,
+      "login_missing",
+    );
+    assert.equal(
+      (
+        await harnessSubscriptionStatus("pi_core", {
+          ...mount("PI_CODING_AGENT_DIR"),
+          CLAUDE_CODE_OAUTH_TOKEN: "fake-oauth-token",
+        })
+      ).state,
+      "login_missing",
+    );
+  });
+
   it("reports unsupported for a harness this runner cannot check", async () => {
     assert.deepEqual(await harnessSubscriptionStatus("cursor", {}), {
       state: "unsupported",


### PR DESCRIPTION
## Context

A runner authenticated by `CLAUDE_CODE_OAUTH_TOKEN` reported that it had no Claude subscription. The UI turned that into "you have no runnable model" and blocked every agent behind a strip reading **"Add your model provider key to run this agent"** — a key a subscription-backed agent does not use, so the one instruction on screen was impossible to follow.

The probe decided `ready` vs `login_missing` by stat-ing a single file:

```ts
claude: { dirEnv: "CLAUDE_CONFIG_DIR", file: ".credentials.json", provider: "anthropic" }
```

But the file is not the only way the harness authenticates. `CLAUDE_CODE_OAUTH_TOKEN` sits in the `anthropic` group of `PROVIDER_ENV_VAR_GROUPS`, so a run inherits it and the harness uses it. The EE dev compose override documents that variable as the supported fallback for an expired session, regenerated with `claude setup-token`. Configure it without mounting a credentials file and the deployment can run while the probe insists it cannot.

Observed on the EE dev stack:

```
runner container : CLAUDE_CODE_OAUTH_TOKEN set, no /claude-config/.credentials.json
subscription-status -> {"claude":{"state":"login_missing","provider":"anthropic"}}
UI               : composer disabled, "Add your model provider key to run this agent."
```

## Changes

A `LoginProbe` may now declare `tokenEnv`: environment variables that are a complete credential on their own. The token is checked before the mount and wins over every file verdict, because a missing, empty or unparseable login file is not a missing login when a token authenticates.

Claude declares the three variables the harness actually reads: `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_OAUTH_TOKEN`.

Subscription tokens only. `ANTHROPIC_API_KEY` is deliberately excluded: an API key is the `agenta` connection mode, a vault key someone pasted rather than a plan they pay for, and reporting it here would put "subscription login found" against a key. That is the same lie `isOAuthLogin` already avoids for Pi.

Codex and Pi are unchanged, since neither has a token route.

## Tests

- 6 new cases: a token alone reports ready, either Anthropic auth variable works, the token beats a missing/empty/unparseable file, a blank token still yields the file's verdict (the compose override defaults it to `""`), an API key never counts as a subscription, and no harness but Claude gets a token route.
- `subscription-status.test.ts` 28 pass, `tsc --noEmit` clean.
- Verified live: with the token set and no credentials file present, `claude` went `login_missing` to `ready`.
- Unrelated pre-existing failures elsewhere in the runner suite were confirmed present on `main` with this change stashed.

## What to QA

- On a deployment whose runner has `CLAUDE_CODE_OAUTH_TOKEN` set and no mounted `.credentials.json`, the Claude row reads "Subscription login found" rather than "Login file is missing", and agents using it are runnable.
- Regression: with neither a token nor a file, the row still reports `login_missing`. With a valid mounted login and no token, it still reports ready.
- Regression: a project holding only an `ANTHROPIC_API_KEY` must NOT show a Claude subscription.
