### PR TITLE
fix(api): tell open session lists when a session appears or leaves

### DIFF
--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -640,6 +640,7 @@ class SessionStreamsService:
         proposed_name = normalize_session_name(request.name)
         proposed_references = request.references or None
 
+        created = False
         if prior_stream is None:
             try:
                 stream = await self._dao.create(
@@ -653,6 +654,7 @@ class SessionStreamsService:
                         references=proposed_references,
                     ),
                 )
+                created = True
             except SessionStreamAlreadyExists:
                 # `_start_turn` won the first-touch race; fall through and update its row.
                 stream = None
@@ -705,6 +707,15 @@ class SessionStreamsService:
                 project_id=project_id,
                 session_id=request.session_id,
                 state=WATCH_LIFECYCLE_RUNNING,
+            )
+
+        # A create is the session entering the project's lists, and `lifecycle` above rides the
+        # SESSION channel, which no list subscribes to. Without this a runner-first session
+        # reached no open list until that tab reloaded.
+        if created:
+            await self._publish_changed(
+                project_id=project_id,
+                session_id=request.session_id,
             )
 
         return SessionHeartbeatResult(
@@ -874,10 +885,13 @@ class SessionStreamsService:
         """Hard delete the merged stream row (S7 delete fan-out, WP5). Distinct
         from `kill`, which only soft-deletes via `delete_by_session_id`."""
         _validate_session_id(session_id)
-        return await self._dao.hard_delete_by_session_id(
+        deleted = await self._dao.hard_delete_by_session_id(
             project_id=project_id,
             session_id=session_id,
         )
+        if deleted:
+            await self._publish_changed(project_id=project_id, session_id=session_id)
+        return deleted
 
     async def archive(
         self,
@@ -889,11 +903,14 @@ class SessionStreamsService:
         """Soft-archive the stream row: set `archived_at` (hidden but restorable), distinct from
         kill's `deleted_at` so a killed session stays listed. Returns the archived confirmation."""
         _validate_session_id(session_id)
-        return await self._dao.set_archived_by_session_id(
+        archived = await self._dao.set_archived_by_session_id(
             project_id=project_id,
             user_id=user_id,
             session_id=session_id,
         )
+        if archived is not None:
+            await self._publish_changed(project_id=project_id, session_id=session_id)
+        return archived
 
     async def unarchive(
         self,
@@ -904,11 +921,14 @@ class SessionStreamsService:
     ) -> Optional[SessionStream]:
         """Reverse of `archive`: clears `archived_at`, restoring the session to the list."""
         _validate_session_id(session_id)
-        return await self._dao.clear_archived_by_session_id(
+        restored = await self._dao.clear_archived_by_session_id(
             project_id=project_id,
             user_id=user_id,
             session_id=session_id,
         )
+        if restored is not None:
+            await self._publish_changed(project_id=project_id, session_id=session_id)
+        return restored
 
     async def check_runner_concurrency_limit(self, *, project_id: UUID) -> None:
         """Raise ConcurrencyLimitExceeded if the per-project limit is reached."""
@@ -950,6 +970,10 @@ class SessionStreamsService:
             session_id=session_id,
         )
         created = False
+        # Set by every branch that puts the row back in front of a list: a fresh create, a killed
+        # tombstone re-nested, an archived row un-hidden. Each is once-per-session, unlike the
+        # per-turn `lifecycle` below.
+        listed = False
         if stream is None:
             try:
                 await self._dao.create(
@@ -963,6 +987,7 @@ class SessionStreamsService:
                     ),
                 )
                 created = True
+                listed = True
             except SessionStreamAlreadyExists:
                 # The unique slot is held by either a concurrent first touch (live row) or a
                 # soft-deleted tombstone (STOP_KILLS_SESSION / archive). The update reconciles
@@ -983,6 +1008,7 @@ class SessionStreamsService:
                     user_id=user_id,
                     session_id=session_id,
                 )
+                listed = True
                 updated = await self._dao.update(
                     project_id=project_id,
                     user_id=user_id,
@@ -997,6 +1023,7 @@ class SessionStreamsService:
                     user_id=user_id,
                     session_id=session_id,
                 )
+                listed = True
             # Same fill-once proposal the runner's beat makes, so a browser session is
             # titled even when the client's auto-title effect never runs.
             if name and updated is not None and updated.name is None:
@@ -1010,6 +1037,8 @@ class SessionStreamsService:
             session_id=session_id,
             state=WATCH_LIFECYCLE_RUNNING,
         )
+        if listed:
+            await self._publish_changed(project_id=project_id, session_id=session_id)
         return turn_id
 
     async def _mirror_flags(

--- a/api/oss/tests/pytest/unit/sessions/test_watch_session_list_publish.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watch_session_list_publish.py
@@ -1,0 +1,258 @@
+"""M3 live relay — the project-channel events a session LIST revalidates on.
+
+`session-changed` on the project channel is the only signal an open session list gets: the
+lists are cached with a stale time and no refetch interval, and `lifecycle` rides the
+per-session channel, which no list subscribes to. So every transition that changes WHICH rows
+a list shows has to publish here, or that list stays wrong until the tab reloads.
+
+The transitions: the row is created (a session sent from another tab, or minted by the
+runner's first beat), it is archived or hard-deleted (leaves the list), and it is unarchived
+or re-nested from a killed tombstone (returns to it).
+
+`lifecycle` deliberately stays off this channel. It fires twice per TURN, and a project-wide
+invalidation at that rate would refetch every open list on every turn boundary.
+"""
+
+from typing import Optional
+from unittest.mock import AsyncMock, patch
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+
+from agenta.sdk.models.workflows import WorkflowServiceRequestData
+
+from oss.src.core.sessions.streams.dtos import (
+    SessionHeartbeatRequest,
+    SessionStream,
+    SessionStreamCommandRequest,
+)
+from oss.src.core.sessions.streams.service import SessionStreamsService
+
+from unit.sessions.test_project_scoped_locks import _FakeRedis
+
+
+_PROJECT = uuid4()
+_USER = uuid4()
+
+
+class _RecordingPublisher:
+    """Records both families so a test can assert one fired and the other did not."""
+
+    def __init__(self, *, fail: bool = False):
+        self.changed_calls: list[tuple[str, str, str]] = []
+        self.lifecycle_calls: list[tuple[str, str, str]] = []
+        self.fail = fail
+
+    async def lifecycle(self, *, project_id: str, session_id: str, state: str) -> None:
+        self.lifecycle_calls.append((project_id, session_id, state))
+
+    async def changed(self, *, project_id: str, entity: str, id: str) -> None:
+        if self.fail:
+            raise RuntimeError("relay down")
+        self.changed_calls.append((project_id, entity, id))
+
+
+class _FakeStreamsDAO:
+    def __init__(self, existing: Optional[SessionStream] = None):
+        self.row = existing
+
+    async def get_by_session_id(self, *, project_id: UUID, session_id: str):
+        return self.row
+
+    async def create(self, *, project_id, user_id, stream):
+        self.row = SessionStream(
+            id=uuid4(),
+            project_id=project_id,
+            session_id=stream.session_id,
+            flags=stream.flags,
+            turn_id=stream.turn_id,
+        )
+        return self.row
+
+    async def update(self, *, project_id, user_id, session_id, stream):
+        prior = self.row
+        self.row = SessionStream(
+            id=prior.id if prior else uuid4(),
+            project_id=project_id,
+            session_id=session_id,
+            flags=stream.flags
+            if stream.flags is not None
+            else (prior.flags if prior else None),
+            turn_id=stream.turn_id
+            if stream.turn_id is not None
+            else (prior.turn_id if prior else None),
+        )
+        return self.row
+
+    async def delete_by_session_id(self, *, project_id, session_id):
+        return True
+
+
+@pytest_asyncio.fixture
+async def lock_engine():
+    from oss.src.dbs.redis.shared.engine import LockEngine
+
+    eng = LockEngine()
+    with patch.object(eng, "_client", return_value=_FakeRedis()):
+        yield eng
+
+
+def _service(lock_engine, *, dao=None, fail=False):
+    publisher = _RecordingPublisher(fail=fail)
+    service = SessionStreamsService(
+        streams_dao=dao if dao is not None else _FakeStreamsDAO(),
+        lock_engine=lock_engine,
+        watch_publisher=publisher,
+    )
+    return service, publisher
+
+
+def _session_id() -> str:
+    return f"session_{uuid4().hex[:12]}"
+
+
+async def _send(svc, session_id: str, *, force: bool = False):
+    return await svc.command(
+        project_id=_PROJECT,
+        user_id=_USER,
+        request=SessionStreamCommandRequest(
+            session_id=session_id,
+            data=WorkflowServiceRequestData(inputs={"messages": ["hi"]}),
+            force=force,
+        ),
+    )
+
+
+@pytest.mark.asyncio
+async def test_send_on_a_new_session_publishes_session_changed(lock_engine):
+    """The F11 case: a session started in one tab never reached another tab's open list."""
+    svc, publisher = _service(lock_engine)
+    session_id = _session_id()
+
+    await _send(svc, session_id)
+
+    assert publisher.changed_calls == [(str(_PROJECT), "session", session_id)]
+
+
+@pytest.mark.asyncio
+async def test_further_turns_on_the_same_session_do_not_republish(lock_engine):
+    """Row membership only changes once. A per-turn publish would invalidate every open list
+    on every send."""
+    svc, publisher = _service(lock_engine)
+    session_id = _session_id()
+
+    await _send(svc, session_id)
+    # The turn from the first send is still alive, so further turns are steers.
+    await _send(svc, session_id, force=True)
+    await _send(svc, session_id, force=True)
+
+    assert publisher.changed_calls == [(str(_PROJECT), "session", session_id)]
+    # The turn events still fire each time; they just stay off the project channel.
+    assert len(publisher.lifecycle_calls) > 1
+
+
+@pytest.mark.asyncio
+async def test_runner_first_heartbeat_publishes_session_changed(lock_engine):
+    """A trigger/cron session is minted by the runner's beat, never by `_start_turn`."""
+    svc, publisher = _service(lock_engine)
+    session_id = _session_id()
+
+    await svc.heartbeat(
+        project_id=_PROJECT,
+        request=SessionHeartbeatRequest(
+            session_id=session_id,
+            replica_id="replica-a",
+            turn_id="turn-1",
+            is_running=True,
+        ),
+    )
+
+    assert publisher.changed_calls == [(str(_PROJECT), "session", session_id)]
+
+
+@pytest.mark.asyncio
+async def test_subsequent_heartbeats_do_not_republish(lock_engine):
+    """The runner beats every 30s per session; only the first one creates the row."""
+    svc, publisher = _service(lock_engine)
+    session_id = _session_id()
+
+    for _ in range(3):
+        await svc.heartbeat(
+            project_id=_PROJECT,
+            request=SessionHeartbeatRequest(
+                session_id=session_id,
+                replica_id="replica-a",
+                turn_id="turn-1",
+                is_running=True,
+            ),
+        )
+
+    assert publisher.changed_calls == [(str(_PROJECT), "session", session_id)]
+
+
+@pytest.mark.asyncio
+async def test_archive_publishes_session_changed(lock_engine):
+    dao = AsyncMock()
+    dao.set_archived_by_session_id.return_value = object()
+    svc, publisher = _service(lock_engine, dao=dao)
+
+    await svc.archive(project_id=_PROJECT, user_id=_USER, session_id="session-1")
+
+    assert publisher.changed_calls == [(str(_PROJECT), "session", "session-1")]
+
+
+@pytest.mark.asyncio
+async def test_archive_that_matched_nothing_does_not_publish(lock_engine):
+    dao = AsyncMock()
+    dao.set_archived_by_session_id.return_value = None
+    svc, publisher = _service(lock_engine, dao=dao)
+
+    await svc.archive(project_id=_PROJECT, user_id=_USER, session_id="session-1")
+
+    assert publisher.changed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_unarchive_publishes_session_changed(lock_engine):
+    dao = AsyncMock()
+    dao.clear_archived_by_session_id.return_value = object()
+    svc, publisher = _service(lock_engine, dao=dao)
+
+    await svc.unarchive(project_id=_PROJECT, user_id=_USER, session_id="session-1")
+
+    assert publisher.changed_calls == [(str(_PROJECT), "session", "session-1")]
+
+
+@pytest.mark.asyncio
+async def test_hard_delete_publishes_session_changed(lock_engine):
+    dao = AsyncMock()
+    dao.hard_delete_by_session_id.return_value = True
+    svc, publisher = _service(lock_engine, dao=dao)
+
+    await svc.hard_delete(project_id=_PROJECT, session_id="session-1")
+
+    assert publisher.changed_calls == [(str(_PROJECT), "session", "session-1")]
+
+
+@pytest.mark.asyncio
+async def test_hard_delete_that_matched_nothing_does_not_publish(lock_engine):
+    dao = AsyncMock()
+    dao.hard_delete_by_session_id.return_value = False
+    svc, publisher = _service(lock_engine, dao=dao)
+
+    await svc.hard_delete(project_id=_PROJECT, session_id="session-1")
+
+    assert publisher.changed_calls == []
+
+
+@pytest.mark.asyncio
+async def test_a_broken_relay_never_fails_the_write(lock_engine):
+    """Same contract the other publish points hold: the DB write is already committed."""
+    svc, publisher = _service(lock_engine, fail=True)
+    session_id = _session_id()
+
+    result = await _send(svc, session_id)
+
+    assert result is not None
+    assert publisher.changed_calls == []


### PR DESCRIPTION
## Context

A session started in one tab did not reach another tab's session list until that tab was reloaded.

The lists are cached with a stale time and no refetch interval, so the project watch stream is the only thing that tells them the server moved. That stream carries exactly one session event, `session-changed`, and it was published from exactly one place: `set_header`, the rename path. Creating a session, archiving it, unarchiving it and deleting it were all silent, so a list only ever learned about renames.

Creation was the visible one. `_start_turn` and the runner's first `heartbeat` publish `lifecycle` instead, and that rides the per-session channel, which no list subscribes to.

The sidebar looked live throughout, which made this hard to see: it POLLS on a 15s interval while anything is alive. The list has no interval, so the same page showed a new session in one pane and not the other.

## Changes

`session-changed` is now published from every transition that changes which rows a list shows:

| transition | before | after |
| --- | --- | --- |
| `_start_turn` creates the row (new session) | `lifecycle`, session channel only | + `session-changed` |
| `heartbeat` creates the row (runner-first) | `lifecycle`, session channel only | + `session-changed` |
| killed tombstone re-nested, archived row un-hidden | nothing | `session-changed` |
| `archive` / `unarchive` / `hard_delete` | nothing | `session-changed` |
| `set_header` (rename) | `session-changed` | unchanged |

Each is once per session, so this adds no per-turn traffic.

`lifecycle` deliberately stays off the project channel. It fires twice per turn, and a project-wide invalidation at that rate would refetch every open list on every turn boundary.

## Tests

10 new unit tests in `test_watch_session_list_publish.py`, including the negatives that keep this cheap: further turns on a live session must not republish, repeated heartbeats must not republish, and an archive or delete that matched nothing must not publish. Also covers the existing contract that a broken relay never fails the write.

Full sessions suite: 484 passed, 41 skipped. `ruff format` and `ruff check` clean.

Verified live on the EE dev stack with an independent `EventSource` tapping `/sessions/watch`, list tab visible throughout, no reload at any point:

```
archive   (out-of-band)  15 -> 14 rows, top row changed     session-changed frame captured
unarchive (out-of-band)  14 -> 15 rows, top row restored    session-changed frame captured
create    (out-of-band)  15 -> 16 rows, new row at top      session-changed frame captured
delete    (out-of-band)  16 -> 15 rows, baseline restored
```

Every mutation was issued by `fetch` from the page, so the app's own React state had no knowledge of it. The list could only have refetched via the relay.

## What to QA

- Open the sessions list in one tab and a session in another. Send a message to start a new session. The list picks it up without a reload.
- Archive a session from one tab. It disappears from another tab's open list. Unarchive it and it returns.
- Delete a session. It leaves any open list.
- Regression: a busy chat must not make the list refetch on every turn. Watch the network while a multi-turn run streams; there should be no list refetch per turn.
