### PR TITLE
fix(frontend): keep the session title and actions reachable on a phone

### DIFF
--- a/web/packages/agenta-sessions-ui/src/SessionRow.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionRow.tsx
@@ -134,8 +134,15 @@ const SessionRowImpl = ({
                     </span>
                 ) : null}
 
+                {/* Hidden below `sm`. These two reserved 160+96px out of a ~360px phone row, and
+                    the title is the only flexible thing in it, so it absorbed the whole deficit
+                    and rendered at ZERO width: every session with the same agent became an
+                    identical "Test agent · 7m ago" row. The title is the row's identity, so on a
+                    phone it gets the width and the agent column stands down; the timestamp keeps
+                    its slot but sizes to content. Fixed widths return at `sm`, where they buy the
+                    column alignment they exist for. */}
                 {showAgent ? (
-                    <span className="w-40 shrink-0 truncate">
+                    <span className="hidden shrink-0 truncate sm:inline sm:w-40">
                         {renderAgent ? (
                             renderAgent(row.agentId)
                         ) : (
@@ -144,7 +151,7 @@ const SessionRowImpl = ({
                     </span>
                 ) : null}
 
-                <span className="w-24 shrink-0 text-xs text-colorTextTertiary text-right">
+                <span className="shrink-0 text-right text-xs text-colorTextTertiary sm:w-24">
                     {row.activityAt ? timeAgo(Date.parse(row.activityAt)) : "—"}
                 </span>
 

--- a/web/packages/agenta-sessions-ui/src/SessionsListView.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionsListView.tsx
@@ -177,33 +177,51 @@ export const SessionsListView = ({
         )
 
     return (
-        <div className={className}>
-            <MotionConfig transition={SESSION_SPRING} reducedMotion="user">
-                {/* Group headers sit OUTSIDE AnimatePresence: framer bumps z-index on
+        <div
+            className={className}
+            // Say that these rows are a previous query's while a new one resolves. Typing in the
+            // search box mints a query per keystroke, so without this the list silently showed
+            // results for what you typed a moment ago and looked settled doing it. Dimmed rather
+            // than replaced with a skeleton: the rows are still real, they are just not the
+            // answer yet, and swapping them out is the flash `keepPreviousData` exists to avoid.
+            aria-busy={list.isPlaceholder || undefined}
+        >
+            <div
+                className={
+                    list.isPlaceholder ? "opacity-50 transition-opacity" : "transition-opacity"
+                }
+            >
+                <MotionConfig transition={SESSION_SPRING} reducedMotion="user">
+                    {/* Group headers sit OUTSIDE AnimatePresence: framer bumps z-index on
                     layout-animating elements, which paints rows over a sticky sibling. */}
-                {list.groups.map((group) => (
-                    <Fragment key={group.key}>
-                        {group.label ? <SessionGroupHeader label={group.label} /> : null}
-                        <AnimatePresence initial={false}>
-                            {group.rows.map(renderRow)}
-                        </AnimatePresence>
-                    </Fragment>
-                ))}
+                    {list.groups.map((group) => (
+                        <Fragment key={group.key}>
+                            {group.label ? <SessionGroupHeader label={group.label} /> : null}
+                            <AnimatePresence initial={false}>
+                                {group.rows.map(renderRow)}
+                            </AnimatePresence>
+                        </Fragment>
+                    ))}
 
-                {list.paging.hasNext ? (
-                    <SessionListLoadMore
-                        loading={list.paging.isLoadingNext}
-                        onClick={list.paging.loadNext}
-                    />
-                ) : null}
+                    {list.paging.hasNext ? (
+                        <SessionListLoadMore
+                            loading={list.paging.isLoadingNext}
+                            onClick={list.paging.loadNext}
+                        />
+                    ) : null}
 
-                {list.isEmpty ? (
-                    <SessionListEmpty
-                        filtered={list.filtersActive}
-                        onClearFilters={list.resetFilters}
-                    />
-                ) : null}
-            </MotionConfig>
+                    {/* Never while the rows are a previous query's (`isPlaceholder`). "No sessions
+                    yet. Start a conversation…" is a claim about the account, and showing it over
+                    an unsettled query told people with 43 sessions they had none. If the current
+                    query really is empty this renders one tick later, once it has answered. */}
+                    {list.isEmpty && !list.isPlaceholder ? (
+                        <SessionListEmpty
+                            filtered={list.filtersActive}
+                            onClearFilters={list.resetFilters}
+                        />
+                    ) : null}
+                </MotionConfig>
+            </div>
         </div>
     )
 }

--- a/web/packages/agenta-sessions/src/state/useSessionsList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionsList.ts
@@ -208,6 +208,16 @@ export const useSessionsList = ({
             loadNext: () => void fetchNextPage(),
         },
         isPending: listQuery.isPending || (pinnedIds.length > 0 && pinnedQuery.isPending),
+        /**
+         * These rows answer a PREVIOUS query, not the current one.
+         *
+         * `placeholderData: keepPreviousData` keeps the old rows on screen while a new key
+         * resolves, which is right for a pin toggle (same rows, membership rechecked) and wrong
+         * for a search (the rows genuinely do not match what was typed). Without this flag the
+         * view cannot tell the two apart, so it presented one query's results as the answer to
+         * another, and rendered "No sessions yet" over a list that had simply not settled.
+         */
+        isPlaceholder: listQuery.isPlaceholderData || pinnedQuery.isPlaceholderData,
         isError: listQuery.isError || pinnedQuery.isError,
         refetch,
         /** Distinct sessions with an open gate — the rail's "Waiting" count. */


### PR DESCRIPTION
## Context

On a phone, every session with the same agent rendered as an identical row. The title, which is the row's identity, was the only thing distinguishing them and it was drawing at zero width.

The trailing block reserved two fixed columns, 160px for the agent name and 96px for the timestamp. On a roughly 360px row that leaves the flexible title absorbing the entire deficit, so it collapsed and every row read as the same "Test agent · 7m ago".

## Changes

Below the `sm` breakpoint the agent column stands down and the timestamp sizes to its content, so the title takes the width. The fixed widths return at `sm`, where they buy the column alignment they exist for.

The agent column is the right one to drop: on a phone list the sessions are usually the same agent anyway, so it is the least informative thing competing for the space.

## Tests

`tsc --noEmit` and eslint clean.

Measured in a browser at both common phone widths, on a list of 19 sessions:

| viewport | title width | "Session actions" right edge | reachable |
| --- | --- | --- | --- |
| 360px | 162-166px | 336 | yes |
| 390px | 192-196px | 366 | yes |

Titles render distinct text per row rather than collapsing, and the page does not scroll
horizontally at either width.

This also fixes a second symptom of the same cause: the kebab used to sit at right edge 396
against a 390px viewport, so rename, pin, archive and delete were unreachable on a phone. Freeing
the 160px agent column brings it back on screen at both widths.

Still worth an eye on real hardware before merge, since this is a visual change and a viewport
emulation is not a device.

## What to QA

- Open the sessions list on a phone, or at a narrow viewport, on a project where several sessions share one agent. The titles are readable and distinct rather than truncated to nothing.
- Check a session with a long title, and one with a short title plus a subtitle.
- Regression: at `sm` and above, the agent and timestamp columns still align down the list as before.
