### PR TITLE
fix(frontend): stop the session list claiming you have no sessions

### DIFF
--- a/web/packages/agenta-sessions-ui/src/SessionsListView.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionsListView.tsx
@@ -177,33 +177,51 @@ export const SessionsListView = ({
         )
 
     return (
-        <div className={className}>
-            <MotionConfig transition={SESSION_SPRING} reducedMotion="user">
-                {/* Group headers sit OUTSIDE AnimatePresence: framer bumps z-index on
+        <div
+            className={className}
+            // Say that these rows are a previous query's while a new one resolves. Typing in the
+            // search box mints a query per keystroke, so without this the list silently showed
+            // results for what you typed a moment ago and looked settled doing it. Dimmed rather
+            // than replaced with a skeleton: the rows are still real, they are just not the
+            // answer yet, and swapping them out is the flash `keepPreviousData` exists to avoid.
+            aria-busy={list.isPlaceholder || undefined}
+        >
+            <div
+                className={
+                    list.isPlaceholder ? "opacity-50 transition-opacity" : "transition-opacity"
+                }
+            >
+                <MotionConfig transition={SESSION_SPRING} reducedMotion="user">
+                    {/* Group headers sit OUTSIDE AnimatePresence: framer bumps z-index on
                     layout-animating elements, which paints rows over a sticky sibling. */}
-                {list.groups.map((group) => (
-                    <Fragment key={group.key}>
-                        {group.label ? <SessionGroupHeader label={group.label} /> : null}
-                        <AnimatePresence initial={false}>
-                            {group.rows.map(renderRow)}
-                        </AnimatePresence>
-                    </Fragment>
-                ))}
+                    {list.groups.map((group) => (
+                        <Fragment key={group.key}>
+                            {group.label ? <SessionGroupHeader label={group.label} /> : null}
+                            <AnimatePresence initial={false}>
+                                {group.rows.map(renderRow)}
+                            </AnimatePresence>
+                        </Fragment>
+                    ))}
 
-                {list.paging.hasNext ? (
-                    <SessionListLoadMore
-                        loading={list.paging.isLoadingNext}
-                        onClick={list.paging.loadNext}
-                    />
-                ) : null}
+                    {list.paging.hasNext ? (
+                        <SessionListLoadMore
+                            loading={list.paging.isLoadingNext}
+                            onClick={list.paging.loadNext}
+                        />
+                    ) : null}
 
-                {list.isEmpty ? (
-                    <SessionListEmpty
-                        filtered={list.filtersActive}
-                        onClearFilters={list.resetFilters}
-                    />
-                ) : null}
-            </MotionConfig>
+                    {/* Never while the rows are a previous query's (`isPlaceholder`). "No sessions
+                    yet. Start a conversation…" is a claim about the account, and showing it over
+                    an unsettled query told people with 43 sessions they had none. If the current
+                    query really is empty this renders one tick later, once it has answered. */}
+                    {list.isEmpty && !list.isPlaceholder ? (
+                        <SessionListEmpty
+                            filtered={list.filtersActive}
+                            onClearFilters={list.resetFilters}
+                        />
+                    ) : null}
+                </MotionConfig>
+            </div>
         </div>
     )
 }

--- a/web/packages/agenta-sessions/src/state/useSessionsList.ts
+++ b/web/packages/agenta-sessions/src/state/useSessionsList.ts
@@ -208,6 +208,16 @@ export const useSessionsList = ({
             loadNext: () => void fetchNextPage(),
         },
         isPending: listQuery.isPending || (pinnedIds.length > 0 && pinnedQuery.isPending),
+        /**
+         * These rows answer a PREVIOUS query, not the current one.
+         *
+         * `placeholderData: keepPreviousData` keeps the old rows on screen while a new key
+         * resolves, which is right for a pin toggle (same rows, membership rechecked) and wrong
+         * for a search (the rows genuinely do not match what was typed). Without this flag the
+         * view cannot tell the two apart, so it presented one query's results as the answer to
+         * another, and rendered "No sessions yet" over a list that had simply not settled.
+         */
+        isPlaceholder: listQuery.isPlaceholderData || pinnedQuery.isPlaceholderData,
         isError: listQuery.isError || pinnedQuery.isError,
         refetch,
         /** Distinct sessions with an open gate — the rail's "Waiting" count. */


### PR DESCRIPTION
> Stacked on #6429. Base is `fix/session-row-narrow`, so this diff shows only its own two files.

## Context

The session list could render **"No sessions yet. Start a conversation…"** to someone with 43 sessions.

`placeholderData: keepPreviousData` keeps the old rows on screen while a new query key resolves. That is right for a pin toggle, where the rows are the same and only their grouping is being rechecked. It is wrong for a search, where the rows genuinely do not match what was typed. The view could not tell the two apart, so it presented one query's results as the answer to another — and when the previous result happened to be empty, it stated as fact that the account had no sessions.

Typing in the search box mints a query per keystroke, so this was reachable by normal use.

## Changes

`useSessionsList` now exposes `isPlaceholder` (from `isPlaceholderData` on either query), and the view uses it for two things:

- The empty state renders only when the current query has actually answered. "No sessions yet" is a claim about the account and must never be made about an unsettled query.
- While rows belong to a previous query, they dim and the container carries `aria-busy`. Dimmed rather than replaced with a skeleton: the rows are still real, they are just not the answer yet, and swapping them out is exactly the flash `keepPreviousData` exists to avoid.

## Tests

`tsc --noEmit` and eslint clean.

Not exercised in a browser. The reasoning is from the query state, so it is worth confirming by hand.

## What to QA

- With plenty of sessions, type quickly in the search box. The list dims between keystrokes and never shows "No sessions yet" mid-typing.
- Search for something with no matches. The empty state appears once the query settles, and reads as a filtered empty state with a clear-filters action rather than "no sessions yet".
- Toggle a pin while filtered. The rows hold rather than flashing.
