### PR TITLE
fix(frontend): open the overview from an agent card with no playground

### DIFF
--- a/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentCard.tsx
@@ -144,6 +144,7 @@ export const AgentCard = ({
 
     // The card's default open affordance is the playground where there is one; otherwise the
     // overview is the only thing this surface can open.
+    const open = isGrid ? onOpenOverview : (onOpenPlayground ?? onOpenOverview)
     const hasMenu = Boolean(onOpenPlayground || onRename || onArchive)
 
     const menu = (
@@ -193,15 +194,15 @@ export const AgentCard = ({
         <div
             role="button"
             tabIndex={0}
-            // Agents page opens the overview; the home rail keeps opening the playground.
-            onClick={isGrid ? onOpenOverview : onOpenPlayground}
+            // Agents page opens the overview; the home rail keeps opening the playground, and
+            // falls back to the overview on a surface that has no playground (mobile).
+            onClick={open}
             onKeyDown={(event) => {
                 // Only the card itself: the menu trigger is a child with its own Enter/Space.
                 if (event.target !== event.currentTarget) return
                 if (event.key === "Enter" || event.key === " ") {
                     event.preventDefault()
-                    if (isGrid) onOpenOverview()
-                    else onOpenPlayground?.()
+                    open()
                 }
             }}
             className={`group box-border flex cursor-pointer flex-col transition-colors ${


### PR DESCRIPTION
## Context

An agent card on a surface with no playground was an inert control: it carried `role="button"` and `cursor-pointer`, and did nothing when clicked or activated.

The non-grid path went straight to `onOpenPlayground`, which is optional:

```tsx
onClick={isGrid ? onOpenOverview : onOpenPlayground}
...
if (isGrid) onOpenOverview()
else onOpenPlayground?.()
```

On a surface that passes none — mobile, which has no playground route — `onClick` was `undefined` and the keyboard branch resolved to a no-op.

## Changes

Falls back to the overview, which the comment directly above already claimed was the behaviour: *"The card's default open affordance is the playground where there is one; otherwise the overview is the only thing this surface can open."* The code was not honouring it.

```ts
const open = isGrid ? onOpenOverview : (onOpenPlayground ?? onOpenOverview)
```

Click and Enter/Space now share that one handler, so the two cannot drift apart. `onOpenOverview` is required, so `onClick` can no longer be `undefined`.

## Tests

`@agenta/entity-ui`: 598 tests pass. `tsc --noEmit`, eslint and prettier clean.

## What to QA

- On `/m`, click an agent card in the home rail. It opens the agent overview. Enter and Space do the same.
- Regression: on the desktop Agents page (grid), a card still opens the overview.
- Regression: on the desktop home rail, a card still opens the playground rather than the overview.
