### PR TITLE
[fix] Keep the new session button next to the last session tab [AGE-4215]

### DIFF
--- a/web/packages/agenta-sessions-ui/src/SessionTabStrip.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionTabStrip.tsx
@@ -29,15 +29,11 @@ const fadeMask = (left: boolean, right: boolean): string => {
     return `linear-gradient(to right, ${start}, ${end})`
 }
 
-/** Footprint of the inline New session (+) — the 28px button plus the 4px it sits off the last
- * chip. Room the strip must have spare before the button leaves the pinned cluster and goes back
- * inline. Un-pinning also widens the scroller by roughly the same amount, so demanding the whole
- * footprint up front leaves the button comfortably inside the strip and can't flip-flop. */
+/** Footprint of the inline New session (+): the 28px button plus the 4px it sits off the last chip. */
 const INLINE_ADD_PX = 32
 
-/** Width the chips occupy, which `scrollWidth` cannot report while they fit: the scroller is
- * `flex-1`, so a strip with room to spare reports `scrollWidth === clientWidth` and looks exactly
- * like one filled to the millimetre. Measured off the chips themselves instead. */
+/** Chips' own width. `scrollWidth` can't give it: the scroller is `flex-1`, so a strip with room to
+ * spare reports `scrollWidth === clientWidth`, exactly like one filled to the millimetre. */
 const chipsWidth = (el: HTMLElement): number => {
     const first = el.firstElementChild as HTMLElement | null
     const last = el.lastElementChild as HTMLElement | null
@@ -95,11 +91,8 @@ export const SessionTabStrip = ({
     // Edge fade is applied per side only where the strip is actually scrolled past its content, so
     // a strip that fits (single tab, no scroll) shows no fade on either edge.
     const [fade, setFade] = useState({left: false, right: false})
-    // New session (+) rides inside the scroller, right after the last tab, while the tabs still fit
-    // — that is where it is discoverable. It only moves out to the pinned cluster once the tabs
-    // fill the strip, where inline would mean scrolling to reach it. Starts inline so the common
-    // case (a strip with room) never flashes the button across the bar: the first measure runs in
-    // the scroller's ref callback, before paint.
+    // New session (+) sits inline after the last tab while they fit, pinned once they overflow.
+    // Starts inline so the common case never flashes it across the bar (first measure is pre-paint).
     const [pinAdd, setPinAdd] = useState(false)
     const pinAddRef = useRef(false)
     const stripElRef = useRef<HTMLDivElement | null>(null)
@@ -109,11 +102,9 @@ export const SessionTabStrip = ({
         const overflow = el.scrollWidth - el.clientWidth > 1
         const left = overflow && el.scrollLeft > 1
         const right = overflow && el.scrollLeft < el.scrollWidth - el.clientWidth - 1
-        // Chips resize per frame while animating in and out — bail on an unchanged mask so the
-        // measure doesn't re-render the strip on every one of those frames.
+        // Chips resize per frame while animating; bail on an unchanged mask to avoid re-rendering.
         setFade((prev) => (prev.left === left && prev.right === right ? prev : {left, right}))
-        // Pin as soon as the chips (with the inline button among them) overflow; un-pin once the
-        // chips alone leave the button's footprint spare.
+        // Pin once the chips overflow; un-pin once they leave the button's footprint spare.
         const pin = pinAddRef.current ? el.clientWidth - chipsWidth(el) < INLINE_ADD_PX : overflow
         if (pin !== pinAddRef.current) {
             pinAddRef.current = pin
@@ -148,14 +139,15 @@ export const SessionTabStrip = ({
             el.addEventListener("scroll", measureFade, {passive: true})
             const ro = new ResizeObserver(() => measureFade())
             ro.observe(el)
-            // Watch the chips too, not just the scroll box: they animate their width in and out,
-            // and a chip leaving the DOM never resizes the box — so content-only changes would
-            // otherwise strand the fade and the add button's spot on a stale measurement.
+            // Watch the chips too: they animate their width, and a removed chip never resizes the box.
             const observeChildren = () => {
                 for (const child of Array.from(el.children)) ro.observe(child)
             }
             observeChildren()
-            const mo = new MutationObserver(observeChildren)
+            const mo = new MutationObserver(() => {
+                observeChildren()
+                measureFade()
+            })
             mo.observe(el, {childList: true})
             measureFade()
             stripCleanupRef.current = () => {
@@ -167,8 +159,7 @@ export const SessionTabStrip = ({
         },
         [measureFade],
     )
-    // A ResizeObserver watches the element box, not its content — remeasure when the tab set
-    // changes, and after the add button moves (which resizes the scroller from the other side).
+    // Remeasure when the tab set changes, and after the add button moves (it resizes the scroller).
     useEffect(() => {
         measureFade()
     }, [remeasureKey, pinAdd, measureFade])
@@ -196,8 +187,7 @@ export const SessionTabStrip = ({
             </span>
         </SimpleTooltip>
     ) : null
-    // Inline it as the scroller's last child, so it trails the last chip. Kept out of the reorder
-    // values, so it is never a drag slot.
+    // Scroller's last child, so it trails the last chip. Not a reorder value, so never a drag slot.
     const inlineAdd =
         canAdd && !pinAdd ? (
             <div className="ml-1 flex shrink-0 items-center">{addButton}</div>
@@ -241,8 +231,7 @@ export const SessionTabStrip = ({
             ) : (
                 <div className="min-w-0 flex-1" />
             )}
-            {/* Fixed session-actions cluster. New session (+) only lands here once the chips fill
-                the strip — inline it would then be scrolled out of reach. */}
+            {/* Fixed session-actions cluster; (+) lands here only when inline would scroll out of reach. */}
             {(canAdd && pinAdd) || extra ? (
                 <div className="flex shrink-0 items-center gap-1">
                     {pinAdd ? addButton : null}

--- a/web/packages/agenta-sessions-ui/src/SessionTabStrip.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionTabStrip.tsx
@@ -29,6 +29,23 @@ const fadeMask = (left: boolean, right: boolean): string => {
     return `linear-gradient(to right, ${start}, ${end})`
 }
 
+/** Footprint of the inline New session (+) — the 28px button plus the 4px it sits off the last
+ * chip. Room the strip must have spare before the button leaves the pinned cluster and goes back
+ * inline. Un-pinning also widens the scroller by roughly the same amount, so demanding the whole
+ * footprint up front leaves the button comfortably inside the strip and can't flip-flop. */
+const INLINE_ADD_PX = 32
+
+/** Width the chips occupy, which `scrollWidth` cannot report while they fit: the scroller is
+ * `flex-1`, so a strip with room to spare reports `scrollWidth === clientWidth` and looks exactly
+ * like one filled to the millimetre. Measured off the chips themselves instead. */
+const chipsWidth = (el: HTMLElement): number => {
+    const first = el.firstElementChild as HTMLElement | null
+    const last = el.lastElementChild as HTMLElement | null
+    if (!first || !last) return 0
+    const trailing = parseFloat(getComputedStyle(last).marginRight) || 0
+    return last.offsetLeft + last.offsetWidth + trailing - first.offsetLeft
+}
+
 export interface SessionTabStripProps {
     /** The chips — `SessionTab`s, each in its own `shrink-0` wrapper. */
     children?: ReactNode
@@ -78,15 +95,30 @@ export const SessionTabStrip = ({
     // Edge fade is applied per side only where the strip is actually scrolled past its content, so
     // a strip that fits (single tab, no scroll) shows no fade on either edge.
     const [fade, setFade] = useState({left: false, right: false})
+    // New session (+) rides inside the scroller, right after the last tab, while the tabs still fit
+    // — that is where it is discoverable. It only moves out to the pinned cluster once the tabs
+    // fill the strip, where inline would mean scrolling to reach it. Starts inline so the common
+    // case (a strip with room) never flashes the button across the bar: the first measure runs in
+    // the scroller's ref callback, before paint.
+    const [pinAdd, setPinAdd] = useState(false)
+    const pinAddRef = useRef(false)
     const stripElRef = useRef<HTMLDivElement | null>(null)
     const measureFade = useCallback(() => {
         const el = stripElRef.current
         if (!el) return
         const overflow = el.scrollWidth - el.clientWidth > 1
-        setFade({
-            left: overflow && el.scrollLeft > 1,
-            right: overflow && el.scrollLeft < el.scrollWidth - el.clientWidth - 1,
-        })
+        const left = overflow && el.scrollLeft > 1
+        const right = overflow && el.scrollLeft < el.scrollWidth - el.clientWidth - 1
+        // Chips resize per frame while animating in and out — bail on an unchanged mask so the
+        // measure doesn't re-render the strip on every one of those frames.
+        setFade((prev) => (prev.left === left && prev.right === right ? prev : {left, right}))
+        // Pin as soon as the chips (with the inline button among them) overflow; un-pin once the
+        // chips alone leave the button's footprint spare.
+        const pin = pinAddRef.current ? el.clientWidth - chipsWidth(el) < INLINE_ADD_PX : overflow
+        if (pin !== pinAddRef.current) {
+            pinAddRef.current = pin
+            setPinAdd(pin)
+        }
     }, [])
     // React 19 registers onWheel as passive, so preventDefault would be a no-op. Attach a native
     // non-passive listener that maps vertical wheel delta to horizontal scroll; also track scroll +
@@ -116,24 +148,60 @@ export const SessionTabStrip = ({
             el.addEventListener("scroll", measureFade, {passive: true})
             const ro = new ResizeObserver(() => measureFade())
             ro.observe(el)
+            // Watch the chips too, not just the scroll box: they animate their width in and out,
+            // and a chip leaving the DOM never resizes the box — so content-only changes would
+            // otherwise strand the fade and the add button's spot on a stale measurement.
+            const observeChildren = () => {
+                for (const child of Array.from(el.children)) ro.observe(child)
+            }
+            observeChildren()
+            const mo = new MutationObserver(observeChildren)
+            mo.observe(el, {childList: true})
             measureFade()
             stripCleanupRef.current = () => {
                 el.removeEventListener("wheel", onWheel)
                 el.removeEventListener("scroll", measureFade)
+                mo.disconnect()
                 ro.disconnect()
             }
         },
         [measureFade],
     )
-    // A ResizeObserver watches the element box, not its content — remeasure when the tab set changes.
+    // A ResizeObserver watches the element box, not its content — remeasure when the tab set
+    // changes, and after the add button moves (which resizes the scroller from the other side).
     useEffect(() => {
         measureFade()
-    }, [remeasureKey, measureFade])
+    }, [remeasureKey, pinAdd, measureFade])
 
     const maskStyle = {
         maskImage: fadeMask(fade.left, fade.right),
         WebkitMaskImage: fadeMask(fade.left, fade.right),
     }
+
+    const canAdd = Boolean(showTabs && onAdd)
+    const addButton = canAdd ? (
+        <SimpleTooltip title={addTooltip ?? "New session"}>
+            {/* Non-disabled span trigger: tooltips don't fire on a disabled button. */}
+            <span className="inline-flex">
+                <Button
+                    variant="ghost"
+                    size="icon-sm"
+                    aria-label="New session"
+                    onClick={onAdd}
+                    disabled={addDisabled}
+                    className="h-7 w-7 shrink-0 p-0"
+                >
+                    <PlusIcon size={14} />
+                </Button>
+            </span>
+        </SimpleTooltip>
+    ) : null
+    // Inline it as the scroller's last child, so it trails the last chip. Kept out of the reorder
+    // values, so it is never a drag slot.
+    const inlineAdd =
+        canAdd && !pinAdd ? (
+            <div className="ml-1 flex shrink-0 items-center">{addButton}</div>
+        ) : null
 
     return (
         <div
@@ -162,36 +230,22 @@ export const SessionTabStrip = ({
                         style={maskStyle}
                     >
                         {children}
+                        {inlineAdd}
                     </Reorder.Group>
                 ) : (
                     <div ref={scrollStripRef} className={SCROLLER_CLASS} style={maskStyle}>
                         {children}
+                        {inlineAdd}
                     </div>
                 )
             ) : (
                 <div className="min-w-0 flex-1" />
             )}
-            {/* Fixed session-actions cluster — pinned outside the scroll area so New session (+) sits
-                at the end of the tab strip without scrolling away, grouped with any extras. */}
-            {(showTabs && onAdd) || extra ? (
+            {/* Fixed session-actions cluster. New session (+) only lands here once the chips fill
+                the strip — inline it would then be scrolled out of reach. */}
+            {(canAdd && pinAdd) || extra ? (
                 <div className="flex shrink-0 items-center gap-1">
-                    {showTabs && onAdd ? (
-                        <SimpleTooltip title={addTooltip ?? "New session"}>
-                            {/* Non-disabled span trigger: tooltips don't fire on a disabled button. */}
-                            <span className="inline-flex">
-                                <Button
-                                    variant="ghost"
-                                    size="icon-sm"
-                                    aria-label="New session"
-                                    onClick={onAdd}
-                                    disabled={addDisabled}
-                                    className="h-7 w-7 shrink-0 p-0"
-                                >
-                                    <PlusIcon size={14} />
-                                </Button>
-                            </span>
-                        </SimpleTooltip>
-                    ) : null}
+                    {pinAdd ? addButton : null}
                     {extra}
                 </div>
             ) : null}


### PR DESCRIPTION
Fixes #6387

## Context

In the playground session bar, the New session (+) button sat in the top-right corner even when the tabs left plenty of room next to them. It read as a bar-level action rather than "add one more tab", and it was easy to miss. Regression after v0.103.0.

The button lived in the fixed actions cluster outside the scroller, so its position never depended on how much room the tabs took.

## Changes

`SessionTabStrip` now renders the button as the scroller's last child, trailing the last tab, while the tabs fit. It moves to the pinned actions cluster only once they overflow, where inline would mean scrolling to reach it.

Both hosts render this one strip (desktop through `SessionTagBar`, mobile through `SessionTabRail`), so the change covers both.

Two supporting fixes were needed to make the placement hold up:

**Placement is measured from the chips, not from `scrollWidth`.** The scroller is `flex-1`, so a strip with room to spare reports `scrollWidth === clientWidth` and is indistinguishable from one filled to the millimetre. A first version keyed off that measurement pinned the button correctly but never brought it back inline after you closed a tab. It now measures the chips directly:

```js
last.offsetLeft + last.offsetWidth + marginRight(last) - first.offsetLeft
```

and brings the button back inline once the chips leave its 32px footprint spare.

**The `ResizeObserver` watches the chips, not just the scroll box.** Chips animate their width in and out, and a chip leaving the DOM never resizes the box, so a content-only change left the measurement stale. This also fixes the same staleness in the existing edge fade, which could stay on after the chips stopped overflowing. The fade setter now bails on an unchanged value so the per-frame measurements during a chip animation do not re-render the strip.

## Tests

- `pnpm --filter @agenta/sessions-ui check` (tsc, eslint) and its 11 unit tests pass. `pnpm lint-fix` is clean across `web`.
- jsdom has no layout, so `scrollWidth`/`clientWidth` are always 0 and this cannot be unit tested. I extracted the layout and the measurement into a standalone browser harness instead and drove it there: the button stays inline for 1 to 5 tabs, pins at 6, and comes back inline at 5, the same boundary in both directions. Sweeping the bar from 200px to 1200px in 1px steps produced no width at which the button oscillates between the two spots.
- Demo is outstanding. Verifying in the real playground needs the docker stack and a live agent session, which I could not run here. The behaviour is worth a look on a real bar before merge.

## What to QA

- Open a playground with two or three sessions. The + sits right after the last tab, not in the corner.
- Open sessions until the tabs fill the bar. The + moves to the right end and stays reachable while you scroll the tabs sideways.
- Close sessions until the tabs fit again. The + returns next to the last tab.
- Repeat on `/m`. Mobile shares the same strip.
- Regression: with the tabs overflowing, check the edge fade. Tabs should still dissolve at whichever edge they are scrolled past, and the fade should clear once they fit again.
- Regression: drag a tab to reorder it. The + is not a drag slot and the order still saves.
