### PR TITLE
[fix] Wrap the chat error-card payload, keep it reachable, and offer Try again

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.runError.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.runError.test.tsx
@@ -57,7 +57,7 @@ describe("RunErrorBody", () => {
         expect(rendered).not.toContain("Try again")
     })
 
-    it("does not offer Try again for a non-transient failure", () => {
+    it("offers Try again for a generic runner failure (#6445)", () => {
         const rendered = text(
             <RunErrorBody
                 text="model authentication failed"
@@ -67,6 +67,43 @@ describe("RunErrorBody", () => {
             />,
         )
 
+        expect(rendered).toContain("Try again")
+    })
+
+    it("offers Try again for a failure that carried no code at all", () => {
+        const rendered = text(
+            <RunErrorBody text="Something broke." stateKey="turn-6" onRetry={() => undefined} />,
+        )
+
+        expect(rendered).toContain("Try again")
+    })
+
+    it("keeps Add your key (not Try again) for a starter-credit failure", () => {
+        const rendered = text(
+            <RunErrorBody
+                text="Out of starter credits."
+                stateKey="turn-7"
+                code="starter_credits_exhausted"
+                onRetry={() => undefined}
+            />,
+        )
+
+        expect(rendered).toContain("Add your key")
         expect(rendered).not.toContain("Try again")
+    })
+
+    it("gives a short raw JSON payload the Show more toggle even under the length cap (#6445)", () => {
+        const payload = `OpenAI API error (400): {"message":"Invalid 'tools[23].name'","code":"invalid_value"}`
+
+        expect(payload.length).toBeLessThan(240)
+        const rendered = text(<RunErrorBody text={payload} stateKey="turn-8" />)
+
+        expect(rendered).toContain("Show more")
+    })
+
+    it("keeps a short human reason as plain prose with no toggle", () => {
+        const rendered = text(<RunErrorBody text="The model timed out." stateKey="turn-9" />)
+
+        expect(rendered).not.toContain("Show more")
     })
 })

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -150,15 +150,11 @@ const STARTER_CREDIT_CODES = new Set([
     "starter_credits_program_paused",
 ])
 
-/** Transient failure classes where the honest advice is simply to run the turn again. */
-const RETRYABLE_CODES = new Set([
-    "credential_delivery_failed",
-    "starter_credits_unavailable",
-    "rate_limited",
-])
-
-/** The ONE rule driving both the clamp and the toggle — they can't disagree and hide text (#5350). */
-const isBigError = (text: string) => text.length > 240 || text.split("\n").length > 4
+/** The ONE rule driving both the clamp and the toggle — they can't disagree and hide text (#5350).
+ * A machine-shaped payload (raw JSON dump) always gets the collapsible block whatever its length:
+ * `break-all` wraps it, but only the expanded <pre> makes the whole thing reachable (#6445). */
+const isBigError = (text: string) =>
+    text.length > 240 || text.split("\n").length > 4 || text.includes('{"') || text.includes('":')
 
 /**
  * Failed-run body: the icon + "The agent run failed" + the reason. An everyday reason shows in
@@ -175,7 +171,8 @@ export const RunErrorBody = ({
     stateKey: string
     /** The runner's failure class, when the turn carried one (`data-agent-error`'s `code`). */
     code?: string
-    /** Re-run the failed turn; offered only for the transient classes in RETRYABLE_CODES. */
+    /** Re-run the failed turn; offered for any failure except the ones with a better action
+     * (STARTER_CREDIT_CODES get "Add your key" instead). */
     onRetry?: () => void
 }) => {
     const stored = useAtomValue(expandedValueAtomFamily(stateKey))
@@ -184,7 +181,9 @@ export const RunErrorBody = ({
     const expanded = stored ?? false
     const big = isBigError(text)
     const offerOwnKey = code ? STARTER_CREDIT_CODES.has(code) : false
-    const offerRetry = !!onRetry && !!code && RETRYABLE_CODES.has(code)
+    // Any failure the card can't route somewhere better gets a generic re-run; the handler
+    // (handleResend) already confirms before repeating a tool write, so this is safe.
+    const offerRetry = !!onRetry && !offerOwnKey
 
     return (
         <div className="flex items-start gap-2 rounded-xl bg-[var(--ant-color-error-bg)] px-4 py-3">
@@ -192,12 +191,12 @@ export const RunErrorBody = ({
             <div className="flex min-w-0 flex-col items-start gap-0.5">
                 <span className="text-xs font-medium text-colorError">The agent run failed</span>
                 {big && expanded ? (
-                    <pre className="m-0 max-h-60 w-full overflow-auto whitespace-pre-wrap break-words bg-transparent p-0 font-mono text-xs !text-colorErrorText">
+                    <pre className="m-0 max-h-60 w-full overflow-auto whitespace-pre-wrap break-all bg-transparent p-0 font-mono text-xs !text-colorErrorText">
                         {text}
                     </pre>
                 ) : (
                     <span
-                        className={`whitespace-pre-wrap break-words text-xs text-colorErrorText ${
+                        className={`whitespace-pre-wrap break-all text-xs text-colorErrorText ${
                             big ? "line-clamp-3" : ""
                         }`}
                         title={big ? text : undefined}

--- a/web/oss/src/components/AgentChatSlice/components/AgentTurn.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentTurn.tsx
@@ -87,7 +87,7 @@ const AgentTurn = ({
                 onClientToolOutput={onClientToolOutput}
                 precededByEmptyAssistant={precededByEmptyAssistant}
                 turnTraceId={turnTraceId}
-                // A transient run failure offers "Try again" — the same regenerate wiring as the
+                // A failed run offers "Try again" — the same regenerate wiring as the
                 // Stopped → Resend pair, and gated the same way: last turn only, never while busy.
                 onRetry={isLast && !resendDisabled ? onResend : undefined}
             />


### PR DESCRIPTION
## Summary

Fixes #6445.

The chat error card cut a raw provider payload off at the card edge mid-word, offered no way to reach the rest of the text, and no action to take. Three small changes in `RunErrorBody` (`web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx`), following the implementation path laid out in the issue:

1. **The payload wraps instead of overflowing.** `break-words` → `break-all` in both the plain span and the expanded `<pre>`. `overflow-wrap: break-word` does not affect intrinsic sizing, so inside the shrink-to-fit flex column (`items-start`) a space-less JSON tail kept its full unbroken width and overflowed under the bubble's `overflow-hidden`. `break-all` does affect sizing and wraps it — the same rule `IOBlock` in `ToolActivity.tsx` already uses for tool payloads.
2. **A machine-shaped payload always gets the "Show more" toggle.** `isBigError` now also treats text containing `{"` or `":` as big, so a raw JSON dump sitting under the 240-character threshold (the reported payload was ~237 chars) still gets the clamp + toggle + bounded scrollable `<pre>`, and the end of the payload is reachable. A short human reason still renders as plain prose.
3. **A generic Try again.** The retry predicate was allow-list based (`RETRYABLE_CODES`, three codes), so a generic `runner_error` got no action. Inverted to a deny-list: Try again is offered whenever the retry handler is wired, except for the starter-credit codes that already get their own "Add your key" button. The handler is the existing `handleResend` wiring (last turn only, never while busy), which already confirms before repeating a tool write. `RETRYABLE_CODES` is deleted as now unused.

The root cause of the change is that both reachability (the 240-char threshold) and actionability (the code allow-list) were gating on the wrong question; both gates are now shape/deny-list based so the failure class in the report — and any like it — gets a readable payload and an action.

## Testing

### Verified locally

- `pnpm vitest run src/components/AgentChatSlice/components/AgentMessage.runError.test.tsx` in `web/oss` — all tests pass.
- `pnpm lint-fix` in `web` — no changes flagged on the touched files.

### Added or updated tests

In `AgentMessage.runError.test.tsx`:
- flipped the `runner_error` case: it now asserts Try again **is** offered;
- new: a code-less failure with a wired handler gets Try again;
- new: a starter-credit failure keeps "Add your key" and does **not** get Try again;
- new: a raw JSON payload under the 240-char cap gets the "Show more" toggle;
- new: a short human reason stays plain prose with no toggle.

### QA follow-up

- Visually confirm the wrapped/collapsed rendering of a real provider 400 in the playground transcript (light + dark).
- Confirm Try again on a generic provider failure re-runs the turn and still routes through the existing resend confirmation when the turn repeated a tool write.

## Demo

I could not run the full Agenta stack in my environment, so per the contributing guide I am saying so here rather than substituting a mock-up. The behavior change is covered by the unit tests above; happy to add a real-app capture if a maintainer can run the branch, or to walk through anything unclear.

## Checklist
- [ ] Demo shows the real app running this branch (not a mock-up or recreated UI), or is marked N/A — **marked N/A above, could not run the app**
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me

🤖 Generated with [Claude Code](https://claude.com/claude-code)
