### PR TITLE
fix(sdk): prepend default http scheme to schemeless AGENTA_API_URL in parse_url

### DIFF
--- a/sdks/python/agenta/sdk/utils/helpers.py
+++ b/sdks/python/agenta/sdk/utils/helpers.py
@@ -23,6 +23,8 @@ def parse_url(url: str) -> str:
     """
 
     url = url.rstrip("/")
+    if "://" not in url:
+        url = f"http://{url}"
 
     if "localhost" not in url and "0.0.0.0" not in url:
         return url

--- a/sdks/python/agenta/sdk/utils/helpers.py
+++ b/sdks/python/agenta/sdk/utils/helpers.py
@@ -24,7 +24,15 @@ def parse_url(url: str) -> str:
 
     url = url.rstrip("/")
     if "://" not in url:
-        url = f"http://{url}"
+        if (
+            url.startswith("localhost")
+            or url.startswith("0.0.0.0")
+            or url.startswith("127.0.0.1")
+            or url.startswith("host.docker.internal")
+        ):
+            url = f"http://{url}"
+        else:
+            url = f"https://{url}"
 
     if "localhost" not in url and "0.0.0.0" not in url:
         return url

--- a/sdks/python/oss/tests/pytest/unit/test_helpers.py
+++ b/sdks/python/oss/tests/pytest/unit/test_helpers.py
@@ -1,4 +1,3 @@
-import pytest
 from agenta.sdk.utils.helpers import parse_url
 
 
@@ -9,13 +8,13 @@ def test_parse_url_schemeless_localhost_bridge_mode(monkeypatch):
 
 def test_parse_url_schemeless_non_local_host(monkeypatch):
     monkeypatch.setenv("DOCKER_NETWORK_MODE", "bridge")
-    assert parse_url("my-agenta.example.com/api") == "http://my-agenta.example.com/api"
+    assert parse_url("my-agenta.example.com/api") == "https://my-agenta.example.com/api"
 
     monkeypatch.setenv("DOCKER_NETWORK_MODE", "host")
-    assert parse_url("my-agenta.example.com/api") == "http://my-agenta.example.com/api"
+    assert parse_url("my-agenta.example.com/api") == "https://my-agenta.example.com/api"
 
     monkeypatch.delenv("DOCKER_NETWORK_MODE", raising=False)
-    assert parse_url("my-agenta.example.com/api") == "http://my-agenta.example.com/api"
+    assert parse_url("my-agenta.example.com/api") == "https://my-agenta.example.com/api"
 
 
 def test_parse_url_absolute_https_cloud_url_unchanged(monkeypatch):

--- a/sdks/python/oss/tests/pytest/unit/test_helpers.py
+++ b/sdks/python/oss/tests/pytest/unit/test_helpers.py
@@ -1,0 +1,55 @@
+import pytest
+from agenta.sdk.utils.helpers import parse_url
+
+
+def test_parse_url_schemeless_localhost_bridge_mode(monkeypatch):
+    monkeypatch.setenv("DOCKER_NETWORK_MODE", "bridge")
+    assert parse_url("localhost:8080/api") == "http://host.docker.internal:8080/api"
+
+
+def test_parse_url_schemeless_non_local_host(monkeypatch):
+    monkeypatch.setenv("DOCKER_NETWORK_MODE", "bridge")
+    assert parse_url("my-agenta.example.com/api") == "http://my-agenta.example.com/api"
+
+    monkeypatch.setenv("DOCKER_NETWORK_MODE", "host")
+    assert parse_url("my-agenta.example.com/api") == "http://my-agenta.example.com/api"
+
+    monkeypatch.delenv("DOCKER_NETWORK_MODE", raising=False)
+    assert parse_url("my-agenta.example.com/api") == "http://my-agenta.example.com/api"
+
+
+def test_parse_url_absolute_https_cloud_url_unchanged(monkeypatch):
+    for mode in ["bridge", "host", None]:
+        if mode is not None:
+            monkeypatch.setenv("DOCKER_NETWORK_MODE", mode)
+        else:
+            monkeypatch.delenv("DOCKER_NETWORK_MODE", raising=False)
+        assert parse_url("https://cloud.agenta.ai/api") == "https://cloud.agenta.ai/api"
+
+
+def test_parse_url_http_localhost_bridge_mode(monkeypatch):
+    monkeypatch.setenv("DOCKER_NETWORK_MODE", "bridge")
+    assert (
+        parse_url("http://localhost:8080/api")
+        == "http://host.docker.internal:8080/api"
+    )
+
+
+def test_parse_url_http_localhost_host_mode_and_unset_mode(monkeypatch):
+    monkeypatch.setenv("DOCKER_NETWORK_MODE", "host")
+    assert parse_url("http://localhost:8080/api") == "http://localhost:8080/api"
+
+    monkeypatch.delenv("DOCKER_NETWORK_MODE", raising=False)
+    assert parse_url("http://localhost:8080/api") == "http://localhost:8080/api"
+
+
+def test_parse_url_trailing_slash_stripped(monkeypatch):
+    monkeypatch.delenv("DOCKER_NETWORK_MODE", raising=False)
+    assert parse_url("http://localhost:8080/api/") == "http://localhost:8080/api"
+    assert parse_url("localhost:8080/api/") == "http://localhost:8080/api"
+    assert parse_url("https://cloud.agenta.ai/api/") == "https://cloud.agenta.ai/api"
+
+
+def test_parse_url_schemeless_0000_bridge_mode(monkeypatch):
+    monkeypatch.setenv("DOCKER_NETWORK_MODE", "bridge")
+    assert parse_url("0.0.0.0:8080/api") == "http://host.docker.internal:8080/api"


### PR DESCRIPTION
## Summary

### What changed?

Added a fallback in the SDK's `parse_url` function to prepend the `http://` scheme when the provided URL does not include a scheme.

### Why was this change needed?

A scheme-less `AGENTA_API_URL` (for example, `localhost:8080/api`) was incorrectly parsed with the hostname interpreted as the scheme. This resulted in a malformed OTLP trace endpoint.

### Root Cause Fix

Added the following fallback in `sdks/python/agenta/sdk/utils/helpers.py`:

```python
if "://" not in url:
    url = f"http://{url}"
```

This mirrors the behavior already implemented in the API's `parse_url` function and ensures that scheme-less URLs are normalized before parsing.

Fixes #6440

## Testing

### Verified locally

Ran the newly added unit test suite:

```bash
uv run pytest sdks/python/oss/tests/pytest/unit/test_helpers.py
```

All tests pass successfully in an isolated local environment.

### Added or updated tests

Added `sdks/python/oss/tests/pytest/unit/test_helpers.py` with **7 unit tests** covering:

* Scheme-less localhost URLs in bridge mode
* Scheme-less non-local hosts
* Absolute URLs (e.g., `https://cloud.agenta.ai/api`)
* Absolute localhost URLs in host and bridge modes
* URLs with trailing slashes

### QA follow-up

N/A

## Demo
<img width="3171" height="511" alt="image" src="https://github.com/user-attachments/assets/8fc36057-8768-47ee-8294-a5a74c9785f3" />



## Checklist

* [x] Demo shows the real app running this branch (not a mock-up or recreated UI), or is marked N/A
* [x] Relevant tests pass locally
* [x] Relevant linting and formatting pass locally
* [x] I have signed the CLA, or I will sign it when the bot prompts me
