### PR TITLE
[fix] Hide the single-question form stepper [AGE-4241]

### DIFF
--- a/web/packages/agenta-chat/src/components/ElicitationDock.tsx
+++ b/web/packages/agenta-chat/src/components/ElicitationDock.tsx
@@ -380,6 +380,7 @@ const LiveCard = ({
     const touchCls = touch
         ? "relative after:absolute after:-inset-x-1 after:-inset-y-2 after:content-['']"
         : ""
+    const showQuestionStepper = steps.length > 1
 
     return (
         <div
@@ -396,26 +397,30 @@ const LiveCard = ({
         >
             <Eyebrow label={askerLabel}>
                 <div className="ml-auto flex items-center gap-0.5">
-                    <NavButton
-                        label="Previous question"
-                        disabled={!stepper.canGoBack}
-                        onClick={stepper.back}
-                    >
-                        <CaretLeft size={11} />
-                    </NavButton>
-                    <span
-                        aria-live="polite"
-                        className="min-w-[26px] text-center text-[11px] tabular-nums text-colorTextTertiary"
-                    >
-                        {stepper.position}/{stepper.total}
-                    </span>
-                    <NavButton
-                        label="Next question"
-                        disabled={!stepper.canGoForward}
-                        onClick={stepper.forward}
-                    >
-                        <CaretRight size={11} />
-                    </NavButton>
+                    {showQuestionStepper ? (
+                        <>
+                            <NavButton
+                                label="Previous question"
+                                disabled={!stepper.canGoBack}
+                                onClick={stepper.back}
+                            >
+                                <CaretLeft size={11} />
+                            </NavButton>
+                            <span
+                                aria-live="polite"
+                                className="min-w-[26px] text-center text-[11px] tabular-nums text-colorTextTertiary"
+                            >
+                                {stepper.position}/{stepper.total}
+                            </span>
+                            <NavButton
+                                label="Next question"
+                                disabled={!stepper.canGoForward}
+                                onClick={stepper.forward}
+                            >
+                                <CaretRight size={11} />
+                            </NavButton>
+                        </>
+                    ) : null}
                     <Button
                         variant="ghost"
                         size="icon-sm"
@@ -431,16 +436,18 @@ const LiveCard = ({
                 </div>
             </Eyebrow>
 
-            <div className="flex gap-1" aria-hidden>
-                {steps.map((candidate, index) => (
-                    <span
-                        key={candidate.name}
-                        className={`h-0.5 flex-1 rounded-full ${
-                            index < stepper.position ? "bg-colorText" : "bg-colorFillTertiary"
-                        }`}
-                    />
-                ))}
-            </div>
+            {showQuestionStepper ? (
+                <div className="flex gap-1" aria-hidden>
+                    {steps.map((candidate, index) => (
+                        <span
+                            key={candidate.name}
+                            className={`h-0.5 flex-1 rounded-full ${
+                                index < stepper.position ? "bg-colorText" : "bg-colorFillTertiary"
+                            }`}
+                        />
+                    ))}
+                </div>
+            ) : null}
 
             {/* pb-1 so the control does not sit flush against the actions; the card's own gap
                 alone read as cramped under a field. */}

--- a/web/packages/agenta-chat/tests/unit/components/elicitationDockSettle.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/components/elicitationDockSettle.test.tsx
@@ -97,6 +97,22 @@ describe("the reserved box", () => {
 })
 
 describe("chrome", () => {
+    it("hides the question stepper when the form has only one question", () => {
+        const {container} = setup({
+            message: "One question",
+            requestedSchema: {
+                type: "object",
+                properties: {name: {type: "string", title: "Your name"}},
+            },
+        })
+        const card = container.querySelector('[role="group"]') as HTMLElement
+
+        expect(screen.queryByLabelText("Previous question")).toBeNull()
+        expect(screen.queryByText("1/1")).toBeNull()
+        expect(screen.queryByLabelText("Next question")).toBeNull()
+        expect(card.querySelector(":scope > [aria-hidden]")).toBeNull()
+    })
+
     it("uses real Button components for the nav, so a disabled control stays chrome-less", () => {
         // A raw <button> here grew a visible 1px box the moment it was disabled — the exact case
         // the `ghost` variant's own note in @agenta/ui warns about.
@@ -269,7 +285,7 @@ describe("automation", () => {
         fireEvent.keyDown(box, {key: "Enter", shiftKey: true})
 
         expect(onOutput).not.toHaveBeenCalled()
-        expect(screen.getByText("1/1")).toBeTruthy()
+        expect(screen.queryByText("1/1")).toBeNull()
     })
 
     it("leaves plain Enter alone in a textarea, so the browser inserts the newline", () => {
@@ -287,7 +303,7 @@ describe("automation", () => {
 
         // Nothing intercepts it, so the browser's own newline stands and the step does not move.
         expect(onOutput).not.toHaveBeenCalled()
-        expect(screen.getByText("1/1")).toBeTruthy()
+        expect(screen.queryByText("1/1")).toBeNull()
     })
 
     it("advances immediately on a digit, with no hold", () => {
@@ -353,7 +369,7 @@ describe("multi-select", () => {
         fireEvent.click(screen.getByText("Releases"))
 
         // Still on the one and only question — a checkbox list is not done until you say so.
-        expect(screen.getByText("1/1")).toBeTruthy()
+        expect(screen.queryByText("1/1")).toBeNull()
         expect(onOutput).not.toHaveBeenCalled()
 
         fireEvent.click(screen.getByText("Send answers"))


### PR DESCRIPTION
## Context

A docked form with one question still showed disabled previous and next buttons, a `1/1` counter, and a one-segment progress bar. Those controls were rendered for every form even though a single-question form has nowhere to navigate.

Closes #6456.

## Changes

The dock now renders its question navigation, counter, and progress bar only when the form contains more than one question. Single-question forms keep the dismiss and answer actions. Multi-question forms keep the existing stepper behavior.

## Tests / notes

- `pnpm --filter @agenta/chat test` (55 files, 576 tests)
- `pnpm --filter @agenta/chat build`
- `pnpm --filter @agenta/chat lint`
- `pnpm format`
- `pnpm lint-fix` (25 workspace tasks)
- The real-app demo is outstanding because Docker is not available in the local environment. No mock or component-harness capture is included.
- AI assistance: Codex helped implement and verify the change. The author reviewed the diff and test evidence.

## What to QA

- Open a question form with exactly one question. The previous and next controls, `1/1` counter, and progress bar are absent; dismiss and answer actions still work.
- Open a form with two or more questions. The navigation controls, counter, and progress bar still appear and track the current question.
