### PR TITLE
[MAR-116] fix(website): Emit final canonical sitemap URLs

### DIFF
--- a/website/astro.config.mjs
+++ b/website/astro.config.mjs
@@ -28,6 +28,16 @@ export default defineConfig({
     sitemap({
       // The 404 page must never appear in the sitemap.
       filter: (page) => !page.endsWith("/404") && !page.endsWith("/404/"),
+      // Astro emits directory routes with a trailing slash even though the
+      // Cloudflare asset handler redirects them to their no-slash canonical.
+      // Publish the final URL so crawlers never have to follow that redirect.
+      serialize: (item) => ({
+        ...item,
+        url:
+          item.url === "https://agenta.ai/"
+            ? item.url
+            : item.url.replace(/\/$/, ""),
+      }),
     }),
   ],
   vite: {

--- a/website/scripts/verify-build.mjs
+++ b/website/scripts/verify-build.mjs
@@ -124,13 +124,35 @@ if (existsSync(specPath)) {
   }
 }
 
-// 6. The twins must not be indexed as pages of their own.
+// 6. Sitemap entries must be final, self-canonical page URLs. The site root is
+//    the only URL whose path legitimately ends in a slash.
 const sitemap = resolve(dist, "sitemap-0.xml");
 if (existsSync(sitemap)) {
-  check(
-    !readFileSync(sitemap, "utf8").includes(".md<"),
-    "sitemap-0.xml lists a .md twin.",
+  const sitemapXml = readFileSync(sitemap, "utf8");
+  check(!sitemapXml.includes(".md<"), "sitemap-0.xml lists a .md twin.");
+
+  const urls = [...sitemapXml.matchAll(/<loc>([^<]+)<\/loc>/g)].map(
+    ([, url]) => url,
   );
+  for (const url of urls) {
+    const { pathname } = new URL(url);
+    check(
+      pathname === "/" || !pathname.endsWith("/"),
+      `sitemap URL has a trailing slash: ${url}`,
+    );
+
+    const html = resolve(
+      dist,
+      pathname === "/" ? "index.html" : `${pathname.slice(1)}/index.html`,
+    );
+    check(existsSync(html), `sitemap URL has no built page: ${url}`);
+    if (existsSync(html)) {
+      const canonical = readFileSync(html, "utf8").match(
+        /<link rel="canonical" href="([^"]+)"/,
+      )?.[1];
+      check(canonical === url, `sitemap URL is not self-canonical: ${url}`);
+    }
+  }
 }
 
 if (failures.length > 0) {


### PR DESCRIPTION
## Context
The marketing sitemap listed directory-style URLs with trailing slashes. Cloudflare redirected those URLs to no-slash pages, so crawlers had to follow a redirect before reaching the page's canonical URL.

## Changes
The Astro sitemap serializer now removes the trailing slash from every entry except the site root.

Before: `https://agenta.ai/blog/`

After: `https://agenta.ai/blog`

The post-build verifier now rejects sitemap entries that have a trailing slash, lack a generated HTML page, or differ from that page's canonical tag.

## Tests
- `pnpm build`
- `pnpm test` (51 tests passed)
- Prettier check for both changed files
- `git diff --check`
- Generated sitemap: 48 entries, zero non-root trailing-slash URLs, all self-canonical

## What to QA
- Open `/sitemap-0.xml` on the PR preview. Every entry except `https://agenta.ai/` should have no trailing slash.
- Request several sitemap URLs without following redirects. Each should return 200 and its HTML canonical should equal the sitemap URL.
- Regression: `/sitemap-index.xml` should still reference the generated sitemap and no Markdown twin should appear in it.

Linear: https://linear.app/agenta/issue/MAR-116/fix-the-marketing-sitemap-to-emit-final-canonical-urls