### PR TITLE
fix(frontend): stop the running-elsewhere strip promising progress it cannot see

### DIFF
--- a/web/packages/agenta-chat/src/components/RunningElsewhereStrip.tsx
+++ b/web/packages/agenta-chat/src/components/RunningElsewhereStrip.tsx
@@ -15,6 +15,14 @@ import {cn} from "@agenta/ui/ui"
  * and the transcript already shows the turn working, so a second "running" banner is noise — and
  * one that mounts and unmounts around every turn shifts the layout twice per run.
  *
+ * The copy stops short of promising the transcript WILL move. `is_running` says a turn took the
+ * lock, not that anything is still serving it: a runner that dies mid-turn leaves the flag set
+ * until its shutdown drain completes, or failing that until the orphan sweep clears it
+ * (`ORPHAN_THRESHOLD_SECONDS`, 300s). Measured on a dev stack, that window runs from ~20s to a few
+ * minutes. Asserting progress through it told people to keep waiting on a run that was over, so
+ * the second sentence names that possibility instead. It is deliberately not a call to action:
+ * only /m passes a Stop here, and the desktop has no control to point at.
+ *
  * Matches the `running` dot in the session bar (`bg-colorInfo`, pulsing) so the two read as one
  * signal.
  */
@@ -40,6 +48,7 @@ export const RunningElsewhereStrip = ({
         </span>
         <span className="text-colorTextSecondary text-xs">
             This session is running somewhere else — the transcript updates as the turn progresses.
+            If it stays still, the run may have already ended.
         </span>
         {action ? <span className="ml-auto shrink-0">{action}</span> : null}
     </div>


### PR DESCRIPTION
## Context

The running-elsewhere strip asserted:

> This session is running somewhere else — the transcript updates as the turn progresses.

That is a claim about the future, and `is_running` cannot support it. The flag says a turn took the lock, not that anything is still serving it.

A runner that dies mid-turn leaves it set until its shutdown drain completes, or failing that until the orphan sweep clears it (`ORPHAN_THRESHOLD_SECONDS`, 300s, swept every 60s). Measured on a dev stack by starting a run, confirming `is_running: true`, then killing the runner:

| how the runner died | flag cleared after |
| --- | --- |
| `docker restart` (SIGTERM, drain completes) | ~23s |
| drain does not complete | orphan sweep, up to ~300s |

Through that window the strip told the user to expect updates that were never coming, so they waited instead of retrying. The Stop button (where one is offered) clears it instantly, but nothing suggested pressing it.

## Changes

One sentence. The first half still describes the normal case, which is the common one and genuinely useful; the second stops the strip overstating what the flag proves:

> This session is running somewhere else — the transcript updates as the turn progresses. **If it stays still, the run may have already ended.**

Deliberately **not** a call to action. Only `/m` passes a Stop into this strip; the desktop call site (`AgentComposerDock`) passes none, so naming a control would be false there.

The flag and the sweep are left alone. `is_running` is not wrong — a turn really did hold the lock — and the backstop already exists.

### What I did not do

My first attempt was to shorten `RUNNING_TTL_SECONDS` from 3600 to 120 so a dead runner self-cleared. I dropped it before opening anything, for two reasons found while checking:

- The UI reads `flags.is_running` from the **database row**, which `_mirror_flags` writes from Redis. With a dead runner nothing re-mirrors, so expiring the Redis key sooner changes nothing the user sees.
- The orphan sweep already does this job at 300s, and its threshold is reasoned (`"a live turn beats every 30s, so this much silence means the owning runner died"`). Tightening it risks declaring live sessions dead.

## Tests

`@agenta/chat`: 566 tests pass. `tsc --noEmit` and prettier clean. Nothing pinned the old sentence (no test or snapshot matches it).

Verified in the browser on the EE dev stack, with the strip forced to render by rewriting the liveness response client-side, since the test agent answers in ~2s and no natural run lasts long enough to observe:

| viewport | strip height | overflows | Stop right edge |
| --- | --- | --- | --- |
| 1280px | 62px | no | n/a (desktop passes no Stop) |
| 390px | 72px | no | 377 of 390 |
| 360px | 90px | no | 347 of 360 |

The longer sentence wraps to 2 lines on desktop and 3-4 on a small phone. It stays inside the viewport at every width and the Stop button remains reachable. Worth a reviewer's eye on whether 90px is acceptable above the composer at 360px; it is a transient state, but it is taller than before.

## What to QA

- Open a session in two tabs and send from one. The other shows the strip, now ending with "If it stays still, the run may have already ended."
- On `/m`, the Stop button still sits at the end of the strip and still clears the state immediately.
- Check the strip at 360px. It is taller than before; confirm it does not crowd the composer unacceptably.
- Regression: the strip must still NOT appear in the tab that is doing the streaming.
