### PR TITLE
fix(website): enforce one canonical host and protocol

### DIFF
--- a/.github/workflows/16-website-production.yml
+++ b/.github/workflows/16-website-production.yml
@@ -83,9 +83,19 @@ jobs:
           fi
           echo "url=$url" >> "$GITHUB_OUTPUT"
 
+      # This zone-level rule runs before the marketing worker, static assets, and
+      # the /docs/* proxy. That is what lets every variant canonicalize in one hop.
+      - name: Enforce canonical host and protocol
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        run: cd website && node scripts/configure-canonical-redirect.mjs
+
       # Asserts the site serves AND that the edge worker's agent-readiness
       # behavior survived: content negotiation, Vary, 406, the JSON/markdown
       # 404s, /openapi.json — plus the static behavior it must not break
       # (the _redirects 308s and trailing-slash normalization).
       - name: Verify production serves the site
         run: cd website && bash scripts/verify-deployment.sh "${{ steps.deploy.outputs.url }}"
+
+      - name: Verify canonical host and protocol
+        run: cd website && bash scripts/verify-canonical-redirects.sh

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -146,7 +146,10 @@ Every merge to `main` that touches `website/**` deploys production, via
   `www.agenta.ai` requests directly to the equivalent `https://agenta.ai` URL with a
   308, preserving path and query string. This must remain a zone rule: it runs before
   the site worker, static assets, and the `/docs/*` proxy, avoiding redirect chains.
-  The deployment token therefore needs Zone Read and Dynamic URL Redirects Write.
+  The script also rejects Cloudflare's legacy Always Use HTTPS setting when it is on,
+  because that setting would add a redirect hop before the canonical rule. The
+  deployment token therefore needs Zone Read, Zone Settings Read, and Dynamic URL
+  Redirects Write.
 - **Guard:** runs only on `Agenta-AI/agenta`; same secrets as the preview workflow.
 
 - Static-first (`output: 'static'`); interactivity is browser-side React islands

--- a/website/AGENTS.md
+++ b/website/AGENTS.md
@@ -141,6 +141,12 @@ Every merge to `main` that touches `website/**` deploys production, via
   --config wrangler.production.jsonc` — a real deploy (not `versions upload`) to the
   separate production worker `agenta-website` (`preview_urls: false`, no routes yet;
   the `agenta.ai` domain is attached in the Cloudflare dashboard).
+- **Canonical URL:** after the worker deploy, `scripts/configure-canonical-redirect.mjs`
+  idempotently creates or updates one zone-level Single Redirect. It sends HTTP and
+  `www.agenta.ai` requests directly to the equivalent `https://agenta.ai` URL with a
+  308, preserving path and query string. This must remain a zone rule: it runs before
+  the site worker, static assets, and the `/docs/*` proxy, avoiding redirect chains.
+  The deployment token therefore needs Zone Read and Dynamic URL Redirects Write.
 - **Guard:** runs only on `Agenta-AI/agenta`; same secrets as the preview workflow.
 
 - Static-first (`output: 'static'`); interactivity is browser-side React islands

--- a/website/scripts/configure-canonical-redirect.mjs
+++ b/website/scripts/configure-canonical-redirect.mjs
@@ -1,0 +1,93 @@
+const API = "https://api.cloudflare.com/client/v4";
+export const RULE_REF = "agenta_canonical_host_and_protocol";
+
+export const canonicalRedirectRule = {
+  ref: RULE_REF,
+  description: "Canonicalize agenta.ai to HTTPS without www",
+  expression:
+    '(http.host eq "www.agenta.ai") or (http.host eq "agenta.ai" and not ssl)',
+  action: "redirect",
+  action_parameters: {
+    from_value: {
+      target_url: {
+        expression: 'concat("https://agenta.ai", http.request.uri.path)',
+      },
+      status_code: 308,
+      preserve_query_string: true,
+    },
+  },
+  enabled: true,
+};
+
+async function api(fetchImpl, token, path, init = {}) {
+  const response = await fetchImpl(`${API}${path}`, {
+    ...init,
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+      ...init.headers,
+    },
+  });
+  const payload = await response.json();
+  if (!response.ok || !payload.success) {
+    const detail = payload.errors?.map((error) => error.message).join("; ");
+    throw new Error(`Cloudflare API ${response.status}: ${detail || "request failed"}`);
+  }
+  return payload.result;
+}
+
+export async function configureCanonicalRedirect({
+  token,
+  fetchImpl = fetch,
+  zoneName = "agenta.ai",
+}) {
+  if (!token) throw new Error("CLOUDFLARE_API_TOKEN is required");
+
+  const zones = await api(
+    fetchImpl,
+    token,
+    `/zones?name=${encodeURIComponent(zoneName)}`,
+  );
+  if (zones.length !== 1) {
+    throw new Error(`Expected one Cloudflare zone named ${zoneName}, found ${zones.length}`);
+  }
+  const zoneId = zones[0].id;
+  const phasePath = `/zones/${zoneId}/rulesets/phases/http_request_dynamic_redirect/entrypoint`;
+
+  let ruleset;
+  try {
+    ruleset = await api(fetchImpl, token, phasePath);
+  } catch (error) {
+    // Cloudflare returns 404 when this zone has no Single Redirects ruleset yet.
+    if (!String(error.message).includes("Cloudflare API 404")) throw error;
+    return api(fetchImpl, token, `/zones/${zoneId}/rulesets`, {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Redirect rules",
+        description: "Zone-level URL canonicalization and forwarding",
+        kind: "zone",
+        phase: "http_request_dynamic_redirect",
+        rules: [canonicalRedirectRule],
+      }),
+    });
+  }
+
+  const existing = ruleset.rules.find((rule) => rule.ref === RULE_REF);
+  const rulesPath = `/zones/${zoneId}/rulesets/${ruleset.id}/rules`;
+  if (!existing) {
+    return api(fetchImpl, token, rulesPath, {
+      method: "POST",
+      body: JSON.stringify(canonicalRedirectRule),
+    });
+  }
+
+  return api(fetchImpl, token, `${rulesPath}/${existing.id}`, {
+    method: "PATCH",
+    body: JSON.stringify(canonicalRedirectRule),
+  });
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  await configureCanonicalRedirect({ token: process.env.CLOUDFLARE_API_TOKEN });
+  console.log("Canonical host and protocol redirect is configured.");
+}

--- a/website/scripts/configure-canonical-redirect.mjs
+++ b/website/scripts/configure-canonical-redirect.mjs
@@ -52,6 +52,18 @@ export async function configureCanonicalRedirect({
     throw new Error(`Expected one Cloudflare zone named ${zoneName}, found ${zones.length}`);
   }
   const zoneId = zones[0].id;
+
+  const alwaysUseHttps = await api(
+    fetchImpl,
+    token,
+    `/zones/${zoneId}/settings/always_use_https`,
+  );
+  if (alwaysUseHttps.value !== "off") {
+    throw new Error(
+      "Cloudflare Always Use HTTPS must be off to guarantee a one-hop canonical redirect",
+    );
+  }
+
   const phasePath = `/zones/${zoneId}/rulesets/phases/http_request_dynamic_redirect/entrypoint`;
 
   let ruleset;
@@ -77,13 +89,19 @@ export async function configureCanonicalRedirect({
   if (!existing) {
     return api(fetchImpl, token, rulesPath, {
       method: "POST",
-      body: JSON.stringify(canonicalRedirectRule),
+      body: JSON.stringify({
+        ...canonicalRedirectRule,
+        position: { before: "" },
+      }),
     });
   }
 
   return api(fetchImpl, token, `${rulesPath}/${existing.id}`, {
     method: "PATCH",
-    body: JSON.stringify(canonicalRedirectRule),
+    body: JSON.stringify({
+      ...canonicalRedirectRule,
+      position: { before: "" },
+    }),
   });
 }
 

--- a/website/scripts/configure-canonical-redirect.test.mjs
+++ b/website/scripts/configure-canonical-redirect.test.mjs
@@ -28,6 +28,7 @@ describe("canonical redirect configuration", () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(ok([{ id: "zone-id" }]))
+      .mockResolvedValueOnce(ok({ value: "off" }))
       .mockResolvedValueOnce(
         ok({
           id: "ruleset-id",
@@ -41,23 +42,44 @@ describe("canonical redirect configuration", () => {
 
     await configureCanonicalRedirect({ token: "test", fetchImpl });
 
-    const [url, request] = fetchImpl.mock.calls[2];
+    const [url, request] = fetchImpl.mock.calls[3];
     expect(url.endsWith("/zones/zone-id/rulesets/ruleset-id/rules/canonical-id")).toBe(true);
     expect(request.method).toBe("PATCH");
-    expect(JSON.parse(request.body)).toEqual(canonicalRedirectRule);
+    expect(JSON.parse(request.body)).toEqual({
+      ...canonicalRedirectRule,
+      position: { before: "" },
+    });
   });
 
   it("adds its rule without replacing existing rules", async () => {
     const fetchImpl = vi
       .fn()
       .mockResolvedValueOnce(ok([{ id: "zone-id" }]))
+      .mockResolvedValueOnce(ok({ value: "off" }))
       .mockResolvedValueOnce(ok({ id: "ruleset-id", rules: [] }))
       .mockResolvedValueOnce(ok({ id: "canonical-id" }));
 
     await configureCanonicalRedirect({ token: "test", fetchImpl });
 
-    const [url, request] = fetchImpl.mock.calls[2];
+    const [url, request] = fetchImpl.mock.calls[3];
     expect(url.endsWith("/zones/zone-id/rulesets/ruleset-id/rules")).toBe(true);
     expect(request.method).toBe("POST");
+    expect(JSON.parse(request.body)).toEqual({
+      ...canonicalRedirectRule,
+      position: { before: "" },
+    });
+  });
+
+  it("rejects the legacy HTTPS redirect to prevent redirect chains", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(ok([{ id: "zone-id" }]))
+      .mockResolvedValueOnce(ok({ value: "on" }));
+
+    await expect(
+      configureCanonicalRedirect({ token: "test", fetchImpl }),
+    ).rejects.toThrow("Cloudflare Always Use HTTPS must be off");
+
+    expect(fetchImpl).toHaveBeenCalledTimes(2);
   });
 });

--- a/website/scripts/configure-canonical-redirect.test.mjs
+++ b/website/scripts/configure-canonical-redirect.test.mjs
@@ -1,0 +1,63 @@
+import { describe, expect, it, vi } from "vitest";
+import {
+  RULE_REF,
+  canonicalRedirectRule,
+  configureCanonicalRedirect,
+} from "./configure-canonical-redirect.mjs";
+
+const ok = (result) =>
+  new Response(JSON.stringify({ success: true, errors: [], result }), {
+    status: 200,
+    headers: { "Content-Type": "application/json" },
+  });
+
+describe("canonical redirect configuration", () => {
+  it("uses one permanent redirect that preserves path and query", () => {
+    expect(canonicalRedirectRule.expression).toContain('http.host eq "www.agenta.ai"');
+    expect(canonicalRedirectRule.expression).toContain("not ssl");
+    expect(canonicalRedirectRule.action_parameters.from_value).toEqual({
+      target_url: {
+        expression: 'concat("https://agenta.ai", http.request.uri.path)',
+      },
+      status_code: 308,
+      preserve_query_string: true,
+    });
+  });
+
+  it("updates only its stable rule when the phase ruleset exists", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(ok([{ id: "zone-id" }]))
+      .mockResolvedValueOnce(
+        ok({
+          id: "ruleset-id",
+          rules: [
+            { id: "other-id", ref: "unrelated" },
+            { id: "canonical-id", ref: RULE_REF },
+          ],
+        }),
+      )
+      .mockResolvedValueOnce(ok({ id: "canonical-id" }));
+
+    await configureCanonicalRedirect({ token: "test", fetchImpl });
+
+    const [url, request] = fetchImpl.mock.calls[2];
+    expect(url.endsWith("/zones/zone-id/rulesets/ruleset-id/rules/canonical-id")).toBe(true);
+    expect(request.method).toBe("PATCH");
+    expect(JSON.parse(request.body)).toEqual(canonicalRedirectRule);
+  });
+
+  it("adds its rule without replacing existing rules", async () => {
+    const fetchImpl = vi
+      .fn()
+      .mockResolvedValueOnce(ok([{ id: "zone-id" }]))
+      .mockResolvedValueOnce(ok({ id: "ruleset-id", rules: [] }))
+      .mockResolvedValueOnce(ok({ id: "canonical-id" }));
+
+    await configureCanonicalRedirect({ token: "test", fetchImpl });
+
+    const [url, request] = fetchImpl.mock.calls[2];
+    expect(url.endsWith("/zones/zone-id/rulesets/ruleset-id/rules")).toBe(true);
+    expect(request.method).toBe("POST");
+  });
+});

--- a/website/scripts/verify-canonical-redirects.sh
+++ b/website/scripts/verify-canonical-redirects.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+failures=0
+
+check_redirect() { # check_redirect <source> <expected-location>
+  source_url=$1
+  expected_location=$2
+  headers=$(curl -sS -I --max-time 20 "$source_url")
+  status=$(printf '%s' "$headers" | awk 'toupper($1) ~ /^HTTP\// { code=$2 } END { print code }')
+  location=$(printf '%s' "$headers" | awk 'BEGIN { IGNORECASE=1 } /^location:/ { sub(/^[^:]+:[[:space:]]*/, ""); sub(/\r$/, ""); print; exit }')
+
+  if [ "$status" = "308" ] && [ "$location" = "$expected_location" ]; then
+    echo "  ok   $source_url -> $location (308)"
+  else
+    echo "::error::$source_url expected 308 to '$expected_location', got '$status' to '$location'"
+    failures=$((failures + 1))
+  fi
+}
+
+echo "Verifying canonical host and protocol redirects"
+check_redirect "http://agenta.ai/" "https://agenta.ai/"
+check_redirect "https://www.agenta.ai/pricing" "https://agenta.ai/pricing"
+check_redirect "http://www.agenta.ai/blog/prompt-versioning-guide?utm_source=canonical-test" \
+  "https://agenta.ai/blog/prompt-versioning-guide?utm_source=canonical-test"
+check_redirect "http://agenta.ai/favicon.svg" "https://agenta.ai/favicon.svg"
+check_redirect "https://www.agenta.ai/docs/observability/overview" \
+  "https://agenta.ai/docs/observability/overview"
+
+if [ "$failures" -gt 0 ]; then
+  echo "$failures canonical redirect check(s) failed."
+  exit 1
+fi
+echo "All canonical redirect checks passed."


### PR DESCRIPTION
## Summary

- enforce `https://agenta.ai` as the canonical origin with one permanent Cloudflare zone redirect
- preserve paths and query strings across HTTP and `www` variants
- verify marketing, blog, static asset, and docs-proxy URLs after production deployment
- document the required Cloudflare token permissions

## Testing

- `pnpm test` (54 tests)
- `pnpm run build`
- `bash -n scripts/verify-canonical-redirects.sh`
- `git diff --check`

Linear: [MAR-117](https://linear.app/agenta/issue/MAR-117/enforce-one-canonical-host-and-protocol)