### PR TITLE
fix(docs): monitor Cloudflare production routes

### DIFF
--- a/.github/workflows/20-docs-monitor.yml
+++ b/.github/workflows/20-docs-monitor.yml
@@ -1,0 +1,26 @@
+name: "20 - docs production monitor"
+
+on:
+  schedule:
+    - cron: "7,22,37,52 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: docs-production-monitor
+  cancel-in-progress: true
+
+jobs:
+  status:
+    name: Check sitemap and representative pages
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+      - name: Check browser and crawler responses
+        run: node docs/scripts/monitor-production.mjs

--- a/docs/README.md
+++ b/docs/README.md
@@ -45,13 +45,10 @@ The docs build to Cloudflare Workers Static Assets. Two workers serve the site:
 | `agenta-docs` | `wrangler.production.jsonc` | the production build, on its own `workers.dev` URL |
 | `agenta-docs-preview` | `wrangler.jsonc` | one version per pull request |
 
-**`https://agenta.ai/docs` does not point at these workers yet.** That hostname
-still goes through the older `new-docs-router` worker, which proxies to Vercel.
-Deploying `agenta-docs` changes no live traffic. The cutover is a separate,
-deliberate step: remove the `agenta.ai/docs*` route from `new-docs-router` and
-add `agenta.ai/docs` and `agenta.ai/docs/*` to `agenta-docs`. The exact patterns
-are commented in `wrangler.production.jsonc`. Rolling back means dropping those
-two routes and restoring the old one, which takes about a minute.
+`https://agenta.ai/docs` and all paths below it route directly to
+`agenta-docs`. The retired `new-docs-router` worker no longer proxies these
+requests to Vercel. The production routes are declared in
+`wrangler.production.jsonc` so later deployments preserve the cutover.
 
 Two GitHub Actions workflows drive them:
 
@@ -82,6 +79,12 @@ moves to it:
 ```bash
 node scripts/check-parity.mjs https://pr-1234-agenta-docs-preview.<subdomain>.workers.dev
 ```
+
+`scripts/monitor-production.mjs` is the smaller production health check. GitHub
+Actions runs it every 15 minutes against the sitemap and representative current,
+versioned, security, and API-reference pages. It checks normal, Googlebot, and
+Bingbot requests and rejects any Vercel challenge response or unexpectedly
+cacheable error.
 
 ## Changelog Guidelines
 

--- a/docs/scripts/monitor-production.mjs
+++ b/docs/scripts/monitor-production.mjs
@@ -1,0 +1,52 @@
+import process from "node:process";
+
+const origin = (process.env.DOCS_ORIGIN || "https://agenta.ai").replace(/\/$/, "");
+const timeoutMs = 30_000;
+const checks = [
+  { path: "/docs/sitemap.xml", type: "application/xml" },
+  { path: "/docs/", type: "text/html" },
+  { path: "/docs/1.0/", type: "text/html" },
+  { path: "/docs/administration/security/overview", type: "text/html" },
+  { path: "/docs/reference/api/accept-invitation", type: "text/html" },
+];
+const agents = [
+  ["browser", "agenta-docs-monitor/1.0"],
+  ["googlebot", "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"],
+  ["bingbot", "Mozilla/5.0 (compatible; bingbot/2.0; +http://www.bing.com/bingbot.htm)"],
+];
+
+let failures = 0;
+for (const { path, type } of checks) {
+  for (const [agent, userAgent] of agents) {
+    const response = await fetch(`${origin}${path}`, {
+      headers: { "user-agent": userAgent },
+      redirect: "follow",
+      signal: AbortSignal.timeout(timeoutMs),
+    });
+    const cacheControl = response.headers.get("cache-control") || "";
+    const challenge = response.headers.get("x-vercel-mitigated");
+    const contentType = response.headers.get("content-type") || "";
+    const errors = [];
+
+    if (response.status !== 200) errors.push(`HTTP ${response.status}`);
+    if (challenge) errors.push(`x-vercel-mitigated: ${challenge}`);
+    if (response.status !== 200 && /(?:s-maxage|max-age)\s*=\s*[1-9]/i.test(cacheControl)) {
+      errors.push(`cacheable error (${cacheControl})`);
+    }
+    if (!contentType.toLowerCase().includes(type)) {
+      errors.push(`expected ${type}, got ${contentType || "no content-type"}`);
+    }
+
+    if (errors.length) {
+      failures += 1;
+      console.error(`FAIL ${agent} ${path}: ${errors.join(", ")}`);
+    } else {
+      console.log(`PASS ${agent} ${path}`);
+    }
+  }
+}
+
+if (failures) {
+  console.error(`${failures} docs health check(s) failed`);
+  process.exit(1);
+}

--- a/docs/wrangler.production.jsonc
+++ b/docs/wrangler.production.jsonc
@@ -6,23 +6,15 @@
   // Deployed by .github/workflows/19-docs-production.yml on every merge to main
   // that touches docs/**.
   //
-  // No `routes` block yet. The docs are still served through the older
-  // `new-docs-router` worker, which proxies agenta.ai/docs/* to Vercel. Cutover
-  // is a deliberate one-time swap: remove the agenta.ai/docs* route from
-  // new-docs-router and add these two routes here.
-  //
-  //   "routes": [
-  //     { "pattern": "agenta.ai/docs", "zone_name": "agenta.ai" },
-  //     { "pattern": "agenta.ai/docs/*", "zone_name": "agenta.ai" }
-  //   ]
-  //
-  // new-docs-router keeps the docs.agenta.ai -> agenta.ai/docs redirect and the
-  // combined /sitemap_index.xml; only its Vercel proxy rule goes away.
   "name": "agenta-docs",
   "compatibility_date": "2026-08-01",
   // Production takes no per-version preview aliases; those live on the preview
   // worker.
   "preview_urls": false,
+  "routes": [
+    { "pattern": "agenta.ai/docs", "zone_name": "agenta.ai" },
+    { "pattern": "agenta.ai/docs/*", "zone_name": "agenta.ai" }
+  ],
   "assets": {
     "directory": "./dist",
     "html_handling": "drop-trailing-slash",


### PR DESCRIPTION
## Summary

- codify the live `agenta.ai/docs*` Cloudflare Worker routes
- remove stale documentation describing the retired Vercel proxy
- add a low-rate production monitor for the sitemap and representative current, versioned, security, and API-reference pages
- verify browser, Googlebot, and Bingbot requests and reject Vercel challenges, invalid content types, non-200 responses, and cacheable errors

## Verification

- `node docs/scripts/monitor-production.mjs` (15 live checks passed)
- `git diff --check`

Closes MAR-129.