### PR TITLE
[feat] Add agent version history with configuration diffs and revert

### DIFF
--- a/web/mobile/src/features/chat/SessionTopBar.tsx
+++ b/web/mobile/src/features/chat/SessionTopBar.tsx
@@ -64,7 +64,7 @@ export const SessionTopBar = ({
                 entityId ? (
                     <AgentRevisionStatus
                         revisionId={entityId}
-                        pickerWorkflowId={agentId}
+                        historyWorkflowId={agentId}
                         onSelectRevision={pinRevision}
                     />
                 ) : undefined

--- a/web/mobile/src/features/chat/SessionTopBar.tsx
+++ b/web/mobile/src/features/chat/SessionTopBar.tsx
@@ -5,11 +5,9 @@ import {
     AgentPageHeader,
     AgentRevisionStatus,
 } from "@agenta/playground-ui/agent-page-header"
-import {useAtomValue, useSetAtom} from "jotai"
+import {useAtomValue} from "jotai"
 
 import {NavDrawer} from "../nav/NavDrawer"
-
-import {selectedRevisionAtomFamily} from "./selectedRevision"
 
 /**
  * The session workspace's top bar — the desktop playground's header on this surface: which agent
@@ -25,22 +23,17 @@ import {selectedRevisionAtomFamily} from "./selectedRevision"
 export const SessionTopBar = ({
     entityId,
     agentId,
-    sessionId,
     workspaceId,
     projectId,
 }: {
     /** The revision under edit. Absent = a session with no turns yet (nothing committed to show). */
     entityId: string | null
     agentId?: string | null
-    sessionId: string
     workspaceId: string
     projectId: string
 }) => {
     // artifactName resolves from a revision id or a workflow id, so either handle names the agent.
     const name = useAtomValue(workflowMolecule.selectors.artifactName(entityId ?? agentId ?? ""))
-    // Picking a revision pins the whole workspace to it (config AND the conversation's target),
-    // as on the desktop; the pin lives per session and clears on commit.
-    const pinRevision = useSetAtom(selectedRevisionAtomFamily(sessionId))
     // Only override the bar's chip once this agent has an icon; uncustomised, the shared bar draws
     // its own, so /m has no reason to carry a second robot.
     const chrome = useAgentIconChrome(agentId, {size: 15, fallbackGlyph: null})
@@ -62,11 +55,7 @@ export const SessionTopBar = ({
             }
             revision={
                 entityId ? (
-                    <AgentRevisionStatus
-                        revisionId={entityId}
-                        historyWorkflowId={agentId}
-                        onSelectRevision={pinRevision}
-                    />
+                    <AgentRevisionStatus revisionId={entityId} historyWorkflowId={agentId} />
                 ) : undefined
             }
         />

--- a/web/mobile/src/features/chat/SessionWorkspace.tsx
+++ b/web/mobile/src/features/chat/SessionWorkspace.tsx
@@ -130,7 +130,6 @@ export const SessionWorkspace = ({
                     <SessionTopBar
                         entityId={entityId}
                         agentId={agentId}
-                        sessionId={sessionId}
                         workspaceId={workspaceId}
                         projectId={projectId}
                     />

--- a/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
+++ b/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
@@ -77,7 +77,10 @@ const AgentRevisionSelector = ({variantId}: {variantId: string}) => {
                 value={_variantId ?? undefined}
                 borderlessTrigger
             />
-            <AgentRevisionStatus revisionId={variantId} />
+            <AgentRevisionStatus
+                revisionId={variantId}
+                historyWorkflowId={runnableData?.workflow_id}
+            />
         </div>
     )
 }

--- a/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
+++ b/web/oss/src/components/Playground/Components/AgentRevisionSelector/index.tsx
@@ -1,47 +1,29 @@
-import {useCallback, useEffect, useMemo} from "react"
+import {useEffect} from "react"
 
 import {isLocalDraftId} from "@agenta/entities/shared"
 import {workflowMolecule} from "@agenta/entities/workflow"
-import {createWorkflowRevisionAdapter} from "@agenta/entity-ui/selection"
-import {playgroundController} from "@agenta/playground"
 import {registerAgentAutoCommitHandler} from "@agenta/playground/state"
 import {AgentRevisionStatus} from "@agenta/playground-ui/agent-page-header"
-import {useAtomValue, useSetAtom} from "jotai"
-import dynamic from "next/dynamic"
-
-import {routerAppIdAtom} from "@/oss/state/app/atoms/fetcher"
+import {useAtomValue} from "jotai"
 
 import {useCommitHostAdapter} from "../Modals/CommitVariantChangesModal/assets/useCommitHostAdapter"
 
-const SelectVariant = dynamic(() => import("../Menus/SelectVariant"), {ssr: false})
-
 /**
- * The agent playground's revision selector — the borderless "variant ⌄" picker plus a compact
- * `v{n} ● Draft/Saved` status. Lifted out of the config-panel header (PlaygroundVariantConfigHeader)
- * so the page header can host it next to the agent's name. Variant-scoped: it derives everything
- * from `variantId`, so it stays in sync wherever it's rendered.
+ * The agent playground's header control — a `v{n} ⌄ ● Draft/Saved` chip that opens version
+ * history. Variant-scoped: it derives everything from `variantId`, so it stays in sync wherever
+ * it's rendered.
+ *
+ * No variant picker: an agent is edited as one thing, and the picker that used to sit here offered
+ * variant switching the agent surface has no use for. Other workflow kinds keep `SelectVariant` in
+ * the playground header.
+ *
+ * The `vN` chip IS the drawer trigger — a separate "Versions" button beside it said the same
+ * thing twice. Mobile's bar works the same way.
  */
 const AgentRevisionSelector = ({variantId}: {variantId: string}) => {
-    // Project-scoped playground (no app in URL) browses all workflows; app-scoped stays scoped.
-    const appId = useAtomValue(routerAppIdAtom)
-    const isProjectScoped = !appId
-
     const runnableData = useAtomValue(workflowMolecule.selectors.data(variantId || ""))
     const isLocalDraftVariant = variantId ? isLocalDraftId(variantId) : false
-
-    const _variantId = runnableData?.id ?? null
-
-    // App browse picker (project-scoped only) — skip-variant, non-evaluator.
-    const appOnlyAdapter = useMemo(
-        () =>
-            createWorkflowRevisionAdapter({
-                skipVariantLevel: true,
-                excludeRevisionZero: true,
-                flags: {is_evaluator: false, is_feedback: false},
-                parentLabel: "Application",
-            }),
-        [],
-    )
+    const workflowId = runnableData?.workflow_id ?? null
 
     // An auto-commit is still a commit, so it owes this app the same out-of-band work a manual
     // one did: the registry and evaluator tables live outside the entities layer and go stale
@@ -57,32 +39,9 @@ const AgentRevisionSelector = ({variantId}: {variantId: string}) => {
         [onAfterCommit, onCommitted],
     )
 
-    const switchEntity = useSetAtom(playgroundController.actions.switchEntity)
-    const handleSwitchVariant = useCallback(
-        (newVariantId: string) => {
-            switchEntity({currentEntityId: variantId || "", newEntityId: newVariantId})
-        },
-        [switchEntity, variantId],
-    )
-
     if (!variantId || isLocalDraftVariant) return null
 
-    return (
-        <div className="flex min-w-0 items-center gap-2">
-            <SelectVariant
-                mode={isProjectScoped ? "browse" : "scoped"}
-                customBrowseAdapter={isProjectScoped ? appOnlyAdapter : undefined}
-                showCreateNew
-                onChange={(value) => handleSwitchVariant(value)}
-                value={_variantId ?? undefined}
-                borderlessTrigger
-            />
-            <AgentRevisionStatus
-                revisionId={variantId}
-                historyWorkflowId={runnableData?.workflow_id}
-            />
-        </div>
-    )
+    return <AgentRevisionStatus revisionId={variantId} historyWorkflowId={workflowId} />
 }
 
 export default AgentRevisionSelector

--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -86,8 +86,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
           : undefined
     const fnName = fn && typeof fn.name === "string" ? fn.name : undefined
 
-    // A whole integration the agent reaches through the gateway. Named by the app it connects,
-    // not by its discriminator — `gateway_connection` told the reader nothing.
+    // An integration entry: named by the app it connects, not by its discriminator.
     if (raw.type === "gateway_connection") {
         const conn = isObj(raw.connection) ? raw.connection : {}
         const integration = typeof conn.integration === "string" ? conn.integration : ""
@@ -107,9 +106,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
         }
     }
 
-    // One third-party action, canonical encoding (`{type:"gateway", integration, action, …}`).
-    // It has no `function.name`, so without this it fell through to the bare-type fallback below
-    // and every such tool read "Gateway".
+    // Canonical gateway action: no `function.name`, so it must be read before the fallback below.
     if (raw.type === "gateway") {
         const integration = typeof raw.integration === "string" ? raw.integration : ""
         const action = typeof raw.action === "string" ? raw.action : ""
@@ -130,8 +127,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
 
     // Function / gateway tool.
     if (fnName) {
-        // A legacy gateway slug (`tools__provider__integration__ACTION__connection`) reads through
-        // the same helper the config panel uses, so one tool never has two different names.
+        // A legacy gateway slug resolves to the same name as the canonical encoding.
         const slug = parseGatewayToolSlug(fnName)
         const parsed = slug
             ? {
@@ -153,11 +149,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
         }
     }
 
-    // Workflow-reference tool (#4860) — a subagent. Keyed by the slug it targets, but NAMED the
-    // way the config panel names it: the slug is a handle, not what the agent is called. Its
-    // description is the text the calling agent reads to decide when to call it, so it is real
-    // content and has to survive into the diff — hardcoding "" made an edited description a
-    // change with nothing to show.
+    // Subagent (#4860): keyed by slug, but named and described the way the config panel does.
     if (raw.type === "reference") {
         const slug = typeof raw.slug === "string" ? raw.slug : undefined
         const name = typeof raw.name === "string" && raw.name ? raw.name : undefined

--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -67,6 +67,25 @@ function coerceContent(content: unknown): string {
 }
 
 /**
+ * An integration's authored policy — `policy.permissions.{default, tools}`. Read here rather than
+ * through `parseGatewayConnection` (entity-ui) so the classifier stays dependency-light.
+ */
+function readConnectionPolicy(raw: Record<string, unknown>): NormalizedTool["policy"] {
+    const permissions =
+        isObj(raw.policy) && isObj(raw.policy.permissions) ? raw.policy.permissions : undefined
+    const tools: Record<string, string> = {}
+    if (isObj(permissions?.tools)) {
+        for (const [name, value] of Object.entries(permissions.tools)) {
+            if (typeof value === "string") tools[name] = value
+        }
+    }
+    return {
+        default: typeof permissions?.default === "string" ? permissions.default : "inherit",
+        tools,
+    }
+}
+
+/**
  * Normalize one tool entry. Every tool subtype is surfaced (nothing dropped): function/gateway
  * tools keyed by name, workflow-reference tools by slug, builtin/platform tools by type — so a
  * builtin or reference tool added/removed/edited still shows in the Tools diff. Field-level detail
@@ -102,6 +121,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
                 paramsJson: "{}",
                 fingerprint,
                 isFunction: false,
+                policy: readConnectionPolicy(raw),
             }
         }
     }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -28,6 +28,23 @@ export const PARAM_KEYS = [
     "retry_policy",
 ] as const
 
+/** Template keys another section already reports, so `extra` holds only the unclaimed rest. */
+const CLAIMED_KEYS = new Set<string>([
+    "instructions",
+    "llm",
+    "llms",
+    "tools",
+    "mcps",
+    "skills",
+    "harness",
+    "runner",
+    "sandbox",
+    "messages",
+    "prompt",
+    "agent",
+    ...PARAM_KEYS,
+])
+
 function isObj(v: unknown): v is Record<string, unknown> {
     return typeof v === "object" && v !== null && !Array.isArray(v)
 }
@@ -282,6 +299,16 @@ export function readAgentConfig(parameters: unknown): AgentConfigView {
     const mcps = firstArray(agent?.mcps, p.mcps)
     const skills = firstArray(agent?.skills, p.skills)
 
+    // Whatever the template carries that no section above claims. Without this a key the
+    // classifier has not been taught is dropped SILENTLY — the diff reports nothing changed.
+    const template = agent ?? p
+    const extra: Record<string, unknown> = {}
+    for (const [key, value] of Object.entries(template)) {
+        if (CLAIMED_KEYS.has(key)) continue
+        if (key.startsWith("@") || key.startsWith("$")) continue
+        extra[key] = value
+    }
+
     return {
         // The prompt playground shares this classifier but not the agent panel's vocabulary.
         isAgentTemplate:
@@ -299,5 +326,6 @@ export function readAgentConfig(parameters: unknown): AgentConfigView {
         harness: section("harness"),
         runner: section("runner"),
         sandbox: section("sandbox"),
+        extra,
     }
 }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -263,6 +263,11 @@ export function readAgentConfig(parameters: unknown): AgentConfigView {
     const skills = firstArray(agent?.skills, p.skills)
 
     return {
+        // The prompt playground shares this classifier but not the agent panel's vocabulary.
+        isAgentTemplate:
+            !!agent ||
+            agentsMd !== undefined ||
+            ["harness", "runner", "sandbox", "mcps", "skills"].some((k) => p[k] !== undefined),
         instructions,
         tools,
         model,

--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -163,6 +163,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
             paramsJson: "{}",
             fingerprint,
             isFunction: false,
+            isSubagent: true,
         }
     }
 

--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -7,9 +7,9 @@
  *
  * Pure and dependency-free so it can be unit-tested against fixtures for each shape.
  */
-import {humanizeActionKey, parseGatewayToolSlug} from "@agenta/shared/utils"
+import {parseGatewayToolSlug} from "@agenta/shared/utils"
 
-import {parseGatewayToolName, titleCase} from "./gatewayName"
+import {humanizeGatewayAction, parseGatewayToolName, titleCase} from "./gatewayName"
 import {agentItemIdentity} from "./identity"
 import type {AgentConfigView, NormalizedTool} from "./types"
 
@@ -116,7 +116,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
         if (integration && action) {
             return {
                 key,
-                label: humanizeActionKey(action, integration),
+                label: humanizeGatewayAction(action, integration),
                 rawKey: action,
                 source: titleCase(integration),
                 description: typeof raw.description === "string" ? raw.description : "",
@@ -135,7 +135,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
         const slug = parseGatewayToolSlug(fnName)
         const parsed = slug
             ? {
-                  label: humanizeActionKey(slug.action, slug.integration),
+                  label: humanizeGatewayAction(slug.action, slug.integration),
                   source: titleCase(slug.integration),
               }
             : parseGatewayToolName(fnName)
@@ -153,14 +153,20 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
         }
     }
 
-    // Workflow-reference tool (#4860) — keyed by the slug it targets.
+    // Workflow-reference tool (#4860) — a subagent. Keyed by the slug it targets, but NAMED the
+    // way the config panel names it: the slug is a handle, not what the agent is called. Its
+    // description is the text the calling agent reads to decide when to call it, so it is real
+    // content and has to survive into the diff — hardcoding "" made an edited description a
+    // change with nothing to show.
     if (raw.type === "reference") {
         const slug = typeof raw.slug === "string" ? raw.slug : undefined
+        const name = typeof raw.name === "string" && raw.name ? raw.name : undefined
         return {
             key,
-            label: slug || "Workflow tool",
+            label: name || slug || "Subagent",
             rawKey: slug,
-            description: "",
+            source: "Subagent",
+            description: typeof raw.description === "string" ? raw.description : "",
             params: {},
             paramsJson: "{}",
             fingerprint,

--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -7,7 +7,9 @@
  *
  * Pure and dependency-free so it can be unit-tested against fixtures for each shape.
  */
-import {parseGatewayToolName} from "./gatewayName"
+import {humanizeActionKey, parseGatewayToolSlug} from "@agenta/shared/utils"
+
+import {parseGatewayToolName, titleCase} from "./gatewayName"
 import {agentItemIdentity} from "./identity"
 import type {AgentConfigView, NormalizedTool} from "./types"
 
@@ -84,9 +86,59 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
           : undefined
     const fnName = fn && typeof fn.name === "string" ? fn.name : undefined
 
+    // A whole integration the agent reaches through the gateway. Named by the app it connects,
+    // not by its discriminator — `gateway_connection` told the reader nothing.
+    if (raw.type === "gateway_connection") {
+        const conn = isObj(raw.connection) ? raw.connection : {}
+        const integration = typeof conn.integration === "string" ? conn.integration : ""
+        const slug = typeof conn.slug === "string" ? conn.slug : undefined
+        if (integration) {
+            return {
+                key,
+                label: titleCase(integration),
+                rawKey: slug ?? integration,
+                source: "Integration",
+                description: "",
+                params: {},
+                paramsJson: "{}",
+                fingerprint,
+                isFunction: false,
+            }
+        }
+    }
+
+    // One third-party action, canonical encoding (`{type:"gateway", integration, action, …}`).
+    // It has no `function.name`, so without this it fell through to the bare-type fallback below
+    // and every such tool read "Gateway".
+    if (raw.type === "gateway") {
+        const integration = typeof raw.integration === "string" ? raw.integration : ""
+        const action = typeof raw.action === "string" ? raw.action : ""
+        if (integration && action) {
+            return {
+                key,
+                label: humanizeActionKey(action, integration),
+                rawKey: action,
+                source: titleCase(integration),
+                description: typeof raw.description === "string" ? raw.description : "",
+                params: {},
+                paramsJson: "{}",
+                fingerprint,
+                isFunction: false,
+            }
+        }
+    }
+
     // Function / gateway tool.
     if (fnName) {
-        const parsed = parseGatewayToolName(fnName)
+        // A legacy gateway slug (`tools__provider__integration__ACTION__connection`) reads through
+        // the same helper the config panel uses, so one tool never has two different names.
+        const slug = parseGatewayToolSlug(fnName)
+        const parsed = slug
+            ? {
+                  label: humanizeActionKey(slug.action, slug.integration),
+                  source: titleCase(slug.integration),
+              }
+            : parseGatewayToolName(fnName)
         const params = isObj(fn?.parameters) ? (fn?.parameters as Record<string, unknown>) : {}
         return {
             key,

--- a/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/accessors.ts
@@ -112,6 +112,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
     if (!isObj(raw)) return null
     const key = agentItemIdentity("tool", raw, index)
     const fingerprint = stableStringify(raw)
+    const entry = raw
     // Function tool: either the wrapped `{function:{name,...}}` shape or the flat legacy
     // `{name, description, parameters}` shape (guarded so reference/builtin tools, which carry a
     // non-function `type`, don't get misread as flat function tools).
@@ -139,6 +140,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
                 fingerprint,
                 isFunction: false,
                 policy: readConnectionPolicy(raw),
+                raw: entry,
             }
         }
     }
@@ -158,6 +160,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
                 paramsJson: "{}",
                 fingerprint,
                 isFunction: false,
+                raw: entry,
             }
         }
     }
@@ -183,6 +186,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
             paramsJson: stableStringify(params),
             fingerprint,
             isFunction: true,
+            raw: entry,
         }
     }
 
@@ -201,6 +205,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
             fingerprint,
             isFunction: false,
             isSubagent: true,
+            raw: entry,
         }
     }
 
@@ -216,6 +221,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
             paramsJson: "{}",
             fingerprint,
             isFunction: false,
+            raw: entry,
         }
     }
 
@@ -228,6 +234,7 @@ function normalizeTool(raw: unknown, index: number): NormalizedTool | null {
         paramsJson: "{}",
         fingerprint,
         isFunction: false,
+        raw: entry,
     }
 }
 

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -16,6 +16,7 @@ import type {
     ChangeSection,
     NormalizedTool,
     ScalarChange,
+    TextDiff,
     ToolFieldChange,
 } from "./types"
 
@@ -172,27 +173,36 @@ function toolsSection(
     }
 }
 
-function instructionsSection(
-    local: AgentConfigView,
-    remote: AgentConfigView,
-): ChangeSection | null {
-    if (local.instructions === remote.instructions) return null
-    const hunks = computeTextDiffLines(remote.instructions, local.instructions, {
-        enableFolding: true,
-    })
+/** Folded prose diff plus its line counts — the shape both Instructions and skills render. */
+function buildTextDiff(before: string, after: string): TextDiff {
+    const hunks = computeTextDiffLines(before, after, {enableFolding: true})
     let added = 0
     let removed = 0
     for (const line of hunks) {
         if (line.type === "added") added++
         else if (line.type === "removed") removed++
     }
-    const label = added + removed <= 2 ? "Edited" : `+${added} / −${removed}`
+    return {added, removed, before, after, hunks}
+}
+
+function instructionsSection(
+    local: AgentConfigView,
+    remote: AgentConfigView,
+): ChangeSection | null {
+    if (local.instructions === remote.instructions) return null
+    const textDiff = buildTextDiff(remote.instructions, local.instructions)
+    const total = textDiff.added + textDiff.removed
     return {
         id: "instructions",
         title: "Instructions",
-        tags: [{kind: "edited", label}],
+        tags: [
+            {
+                kind: "edited",
+                label: total <= 2 ? "Edited" : `+${textDiff.added} / −${textDiff.removed}`,
+            },
+        ],
         totalCount: 1,
-        textDiff: {added, removed, before: remote.instructions, after: local.instructions, hunks},
+        textDiff,
     }
 }
 
@@ -273,6 +283,31 @@ function advancedBucket(v: AgentConfigView): Record<string, unknown> {
     return out
 }
 
+const entryField = (entry: unknown, field: string): string => {
+    if (!isPlainObj(entry)) return ""
+    const value = entry[field]
+    return typeof value === "string" ? value : ""
+}
+
+/**
+ * What an edited list entry changed. A skill carries prose — its SKILL.md `body` — so it gets the
+ * same hunk view Instructions does rather than a bare "edited" mark.
+ */
+function entryEdit(before: unknown, after: unknown): Pick<ChangeItem, "detail" | "textDiff"> {
+    const parts: string[] = []
+    if (entryField(before, "description") !== entryField(after, "description")) {
+        parts.push("description")
+    }
+    const beforeBody = entryField(before, "body")
+    const afterBody = entryField(after, "body")
+    const bodyChanged = beforeBody !== afterBody
+    if (bodyChanged) parts.push("instructions")
+    return {
+        detail: parts.length ? `${parts.join(" & ")} changed` : undefined,
+        textDiff: bodyChanged ? buildTextDiff(beforeBody, afterBody) : undefined,
+    }
+}
+
 /** Humanize a list entry (mcp/skill) for its summary row. */
 function entryLabel(entry: unknown): string {
     if (!isPlainObj(entry)) return "item"
@@ -313,7 +348,12 @@ function listSection(
     if (total === 0) return null
 
     const rows = (pairs: [string, unknown][], kindTag: ChangeItem["kind"]) =>
-        pairs.map(([key, entry]) => ({id: key, label: entryLabel(entry), kind: kindTag}))
+        pairs.map(([key, entry]) => ({
+            id: key,
+            label: entryLabel(entry),
+            kind: kindTag,
+            ...(kindTag === "edited" ? entryEdit(rMap.get(key), entry) : {}),
+        }))
     const items = [...rows(added, "added"), ...rows(edited, "edited"), ...rows(removed, "removed")]
     const tags = []
     if (added.length) tags.push({kind: "added" as const, label: `${added.length} added`})

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -295,6 +295,7 @@ const entryField = (entry: unknown, field: string): string => {
  */
 function entryEdit(before: unknown, after: unknown): Pick<ChangeItem, "detail" | "textDiff"> {
     const parts: string[] = []
+    if (entryField(before, "name") !== entryField(after, "name")) parts.push("name")
     if (entryField(before, "description") !== entryField(after, "description")) {
         parts.push("description")
     }
@@ -325,6 +326,12 @@ function entryLabel(entry: unknown): string {
  * {@link agentItemIdentity} (collision-free), while the row's display label comes from
  * {@link entryLabel} — so two id-less entries never collapse the way a shared label would.
  */
+interface ListEntry {
+    key: string
+    entry: unknown
+    index: number
+}
+
 function listSection(
     id: "mcps" | "skills",
     title: string,
@@ -332,29 +339,53 @@ function listSection(
     remote: unknown[],
 ): ChangeSection | null {
     const kind: AgentItemKind = id === "mcps" ? "mcp" : "skill"
-    const lMap = new Map(local.map((e, i) => [agentItemIdentity(kind, e, i), e] as const))
-    const rMap = new Map(remote.map((e, i) => [agentItemIdentity(kind, e, i), e] as const))
-    const added: [string, unknown][] = []
-    const removed: [string, unknown][] = []
-    const edited: [string, unknown][] = []
-    for (const [key, entry] of lMap) {
-        const prev = rMap.get(key)
-        if (prev === undefined) added.push([key, entry])
-        else if (stableStringify(prev) !== stableStringify(entry)) edited.push([key, entry])
+    const read = (list: unknown[]): ListEntry[] =>
+        list.map((entry, index) => ({key: agentItemIdentity(kind, entry, index), entry, index}))
+    const lEntries = read(local)
+    const rEntries = read(remote)
+    const lMap = new Map(lEntries.map((e) => [e.key, e]))
+    const rMap = new Map(rEntries.map((e) => [e.key, e]))
+
+    const added: ListEntry[] = []
+    const removed: ListEntry[] = []
+    const edited: {key: string; before: unknown; after: unknown}[] = []
+    for (const entry of lEntries) {
+        const prev = rMap.get(entry.key)
+        if (!prev) added.push(entry)
+        else if (stableStringify(prev.entry) !== stableStringify(entry.entry)) {
+            edited.push({key: entry.key, before: prev.entry, after: entry.entry})
+        }
     }
-    for (const [key, entry] of rMap) if (!lMap.has(key)) removed.push([key, entry])
+    for (const entry of rEntries) if (!lMap.has(entry.key)) removed.push(entry)
+
+    // Identity is the name, so renaming an entry in place would read as a removal plus an
+    // unrelated addition — and the body diff behind it would never be computed. Pair whatever is
+    // left over by the slot it occupies before concluding they are different entries.
+    for (let i = added.length - 1; i >= 0; i -= 1) {
+        const match = removed.findIndex((r) => r.index === added[i].index)
+        if (match === -1) continue
+        edited.push({key: added[i].key, before: removed[match].entry, after: added[i].entry})
+        removed.splice(match, 1)
+        added.splice(i, 1)
+    }
 
     const total = added.length + removed.length + edited.length
     if (total === 0) return null
 
-    const rows = (pairs: [string, unknown][], kindTag: ChangeItem["kind"]) =>
-        pairs.map(([key, entry]) => ({
+    const plain = (entries: ListEntry[], kindTag: ChangeItem["kind"]) =>
+        entries.map(({key, entry}) => ({id: key, label: entryLabel(entry), kind: kindTag}))
+    const editedRows = edited.map(({key, before, after}) => {
+        const beforeLabel = entryLabel(before)
+        const afterLabel = entryLabel(after)
+        return {
             id: key,
-            label: entryLabel(entry),
-            kind: kindTag,
-            ...(kindTag === "edited" ? entryEdit(rMap.get(key), entry) : {}),
-        }))
-    const items = [...rows(added, "added"), ...rows(edited, "edited"), ...rows(removed, "removed")]
+            // A rename is only legible as both names; one of them alone hides what happened.
+            label: beforeLabel === afterLabel ? afterLabel : `${beforeLabel} → ${afterLabel}`,
+            kind: "edited" as const,
+            ...entryEdit(before, after),
+        }
+    })
+    const items = [...plain(added, "added"), ...editedRows, ...plain(removed, "removed")]
     const tags = []
     if (added.length) tags.push({kind: "added" as const, label: `${added.length} added`})
     if (edited.length) tags.push({kind: "edited" as const, label: `${edited.length} edited`})

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -242,6 +242,36 @@ function toolsSection(
     }
 }
 
+/** A whole-body diff has no unchanged region to fold, so cap it before it floods the pane. */
+const ITEM_DIFF_LINES = 12
+
+function capHunks(diff: TextDiff): TextDiff {
+    if (diff.hunks.length <= ITEM_DIFF_LINES) return diff
+    const hidden = diff.hunks.length - ITEM_DIFF_LINES
+    return {
+        ...diff,
+        hunks: [
+            ...diff.hunks.slice(0, ITEM_DIFF_LINES),
+            {type: "fold", content: `… ${hidden} more ${hidden === 1 ? "line" : "lines"}`},
+        ] as TextDiff["hunks"],
+    }
+}
+
+/**
+ * A whole body arriving or leaving. Built directly rather than through the line differ: against an
+ * empty side that reports the empty string as its own removed line.
+ */
+function wholeBodyDiff(body: string, kind: "added" | "removed"): TextDiff {
+    const lines = body.split("\n")
+    return {
+        added: kind === "added" ? lines.length : 0,
+        removed: kind === "removed" ? lines.length : 0,
+        before: kind === "removed" ? body : "",
+        after: kind === "added" ? body : "",
+        hunks: lines.map((content) => ({type: kind, content})) as TextDiff["hunks"],
+    }
+}
+
 /** Folded prose diff plus its line counts — the shape both Instructions and skills render. */
 function buildTextDiff(before: string, after: string): TextDiff {
     const hunks = computeTextDiffLines(before, after, {enableFolding: true})
@@ -393,7 +423,7 @@ function entryEdit(before: unknown, after: unknown): Pick<ChangeItem, "detail" |
 
     return {
         detail: parts.length ? `${parts.join(" & ")} changed` : undefined,
-        textDiff: bodyChanged ? buildTextDiff(beforeBody, afterBody) : undefined,
+        textDiff: bodyChanged ? capHunks(buildTextDiff(beforeBody, afterBody)) : undefined,
     }
 }
 
@@ -460,8 +490,22 @@ function listSection(
     const total = added.length + removed.length + edited.length
     if (total === 0) return null
 
+    // An added skill showed only its name, which says nothing about what the agent gained. Its
+    // body is the skill, so it reads as an all-added diff — and a removal as an all-removed one.
     const plain = (entries: ListEntry[], kindTag: ChangeItem["kind"]) =>
-        entries.map(({key, entry}) => ({id: key, label: entryLabel(entry), kind: kindTag}))
+        entries.map(({key, entry}) => {
+            const body = entryField(entry, "body")
+            const description = entryField(entry, "description")
+            return {
+                id: key,
+                label: entryLabel(entry),
+                kind: kindTag,
+                detail: description || undefined,
+                textDiff: body
+                    ? capHunks(wholeBodyDiff(body, kindTag === "added" ? "added" : "removed"))
+                    : undefined,
+            }
+        })
     const editedRows = edited.map(({key, before, after}) => {
         const beforeLabel = entryLabel(before)
         const afterLabel = entryLabel(after)

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -89,9 +89,18 @@ function toolRowDetail(fields: ToolFieldChange[]): string | undefined {
     return `${parts.join(" & ")} changed`
 }
 
-function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSection | null {
-    const localMap = new Map(local.tools.map((t) => [t.key, t]))
-    const remoteMap = new Map(remote.tools.map((t) => [t.key, t]))
+/**
+ * Diff one slice of the `tools` array. Subagents live in that same array but get their own
+ * section, mirroring the config panel — a `{type:"reference"}` entry is another agent, not a tool.
+ */
+function toolsSection(
+    id: "tools" | "subagents",
+    title: string,
+    localTools: NormalizedTool[],
+    remoteTools: NormalizedTool[],
+): ChangeSection | null {
+    const localMap = new Map(localTools.map((t) => [t.key, t]))
+    const remoteMap = new Map(remoteTools.map((t) => [t.key, t]))
 
     const added: NormalizedTool[] = []
     const removed: NormalizedTool[] = []
@@ -113,11 +122,13 @@ function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSe
     const total = added.length + removed.length + edited.length
     if (total === 0) return null
 
+    // Inside Subagents the source ("Subagent") only repeats the header.
+    const sourceDetail = (t: NormalizedTool) => (id === "subagents" ? undefined : t.source)
     const items = [
         ...added.map((t) => ({
             id: t.key,
             label: t.label,
-            detail: t.source,
+            detail: sourceDetail(t),
             kind: "added" as const,
             rawKey: t.rawKey,
         })),
@@ -138,7 +149,7 @@ function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSe
         ...removed.map((t) => ({
             id: t.key,
             label: t.label,
-            detail: t.source,
+            detail: sourceDetail(t),
             kind: "removed" as const,
             rawKey: t.rawKey,
         })),
@@ -150,8 +161,8 @@ function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSe
     if (removed.length) tags.push({kind: "removed" as const, label: `${removed.length} removed`})
 
     return {
-        id: "tools",
-        title: "Tools",
+        id,
+        title,
         tags,
         totalCount: total,
         defaultCollapsed: total > 20,
@@ -310,11 +321,15 @@ function listSection(
     return {id, title, tags, totalCount: total, defaultCollapsed: total > 20, items}
 }
 
+/** Subagents share the `tools` array with real tools; each section sees only its own kind. */
+const tools = (v: AgentConfigView) => v.tools.filter((t) => !t.isSubagent)
+const subagents = (v: AgentConfigView) => v.tools.filter((t) => t.isSubagent)
+
 export function classifyAgentChanges(localParams: unknown, remoteParams: unknown): ChangeSection[] {
     const local = readAgentConfig(localParams)
     const remote = readAgentConfig(remoteParams)
     // Grouped to mirror the agent-template control sections (Model & harness, Instructions,
-    // Tools, MCP servers, Skills, Advanced) so nothing changed is dropped or split.
+    // Tools, Subagents, MCP servers, Skills, Advanced) so nothing changed is dropped or split.
     return [
         scalarSection(
             "model",
@@ -323,7 +338,8 @@ export function classifyAgentChanges(localParams: unknown, remoteParams: unknown
             modelHarnessBucket(remote),
         ),
         instructionsSection(local, remote),
-        toolsSection(local, remote),
+        toolsSection("tools", "Tools", tools(local), tools(remote)),
+        toolsSection("subagents", "Subagents", subagents(local), subagents(remote)),
         listSection("mcps", "MCPs", local.mcps, remote.mcps),
         listSection("skills", "Skills", local.skills, remote.skills),
         scalarSection("params", "Advanced", advancedBucket(local), advancedBucket(remote)),

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -9,6 +9,7 @@ import {computeTextDiffLines} from "@agenta/ui/diff"
 
 import {PARAM_KEYS, readAgentConfig, stableStringify} from "./accessors"
 import {agentItemIdentity, type AgentItemKind} from "./identity"
+import {scalarKeyLabel, scalarValueLabel} from "./scalarLabels"
 import type {
     AgentConfigView,
     ChangeItem,
@@ -193,10 +194,17 @@ function scalarSection(
     const changes: ScalarChange[] = []
     for (const key of [...new Set([...Object.keys(remoteMap), ...Object.keys(localMap)])].sort()) {
         if (stableStringify(remoteMap[key]) === stableStringify(localMap[key])) continue
+        const before = fmtScalar(remoteMap[key])
+        const after = fmtScalar(localMap[key])
         changes.push({
             key,
-            before: fmtScalar(remoteMap[key]),
-            after: fmtScalar(localMap[key]),
+            label: scalarKeyLabel(key),
+            // Stored values stay untouched: the config panel reads them back to say what a
+            // property was committed as, and a display string there would be a lie.
+            before,
+            after,
+            beforeLabel: scalarValueLabel(key, before),
+            afterLabel: scalarValueLabel(key, after),
             kind: !(key in remoteMap) ? "added" : !(key in localMap) ? "removed" : "changed",
         })
     }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -244,9 +244,9 @@ function prefixed(
 }
 
 /**
- * Model & harness — the model identity (`llm.model`), all of `llm` (provider + connection/auth),
- * and the harness engine (`harness.kind`), mirroring the config panel's "Model & harness" control
- * section, which now owns connection-mode UI too.
+ * Model — the model identity (`llm.model`), all of `llm` (provider + connection/auth), and the
+ * harness engine (`harness.kind`), mirroring the config panel's "Model" section, which owns the
+ * harness and connection-mode UI too.
  */
 function modelHarnessBucket(v: AgentConfigView): Record<string, unknown> {
     const out: Record<string, unknown> = {}
@@ -259,7 +259,7 @@ function modelHarnessBucket(v: AgentConfigView): Record<string, unknown> {
 /**
  * Advanced — everything the config panel *artificially groups* under "Advanced", which lives in
  * several JSON locations: generation params, the runner/sandbox execution sections, and the
- * harness's non-`kind` knobs (e.g. permissions). `llm` in full belongs to Model & harness.
+ * harness's non-`kind` knobs (e.g. permissions). `llm` in full belongs to Model.
  */
 function advancedBucket(v: AgentConfigView): Record<string, unknown> {
     const out: Record<string, unknown> = {}
@@ -333,15 +333,10 @@ export function classifyAgentChanges(localParams: unknown, remoteParams: unknown
     // The agent panel calls them Integrations; the prompt playground has plain tools.
     const asAgent = local.isAgentTemplate || remote.isAgentTemplate
     const [toolsTitle, toolsNoun] = asAgent ? ["Integrations", "integration"] : ["Tools", "tool"]
-    // Grouped to mirror the agent-template control sections (Model & harness, Instructions,
+    // Grouped to mirror the agent-template control sections (Model, Instructions,
     // Tools, Subagents, MCP servers, Skills, Advanced) so nothing changed is dropped or split.
     return [
-        scalarSection(
-            "model",
-            "Model & harness",
-            modelHarnessBucket(local),
-            modelHarnessBucket(remote),
-        ),
+        scalarSection("model", "Model", modelHarnessBucket(local), modelHarnessBucket(remote)),
         instructionsSection(local, remote),
         toolsSection("tools", toolsTitle, toolsNoun, tools(local), tools(remote)),
         toolsSection("subagents", "Subagents", "subagent", subagents(local), subagents(remote)),

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -202,8 +202,8 @@ function scalarSection(
             // property was committed as, and a display string there would be a lie.
             before,
             after,
-            beforeLabel: scalarValueLabel(key, before),
-            afterLabel: scalarValueLabel(key, after),
+            beforeLabel: scalarValueLabel(key, before, remoteMap[key]),
+            afterLabel: scalarValueLabel(key, after, localMap[key]),
             kind: !(key in remoteMap) ? "added" : !(key in localMap) ? "removed" : "changed",
         })
     }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -9,7 +9,7 @@ import {computeTextDiffLines} from "@agenta/ui/diff"
 
 import {PARAM_KEYS, readAgentConfig, stableStringify} from "./accessors"
 import {agentItemIdentity, type AgentItemKind} from "./identity"
-import {scalarKeyLabel, scalarValueLabel} from "./scalarLabels"
+import {gatewayPermissionLabel, scalarKeyLabel, scalarValueLabel} from "./scalarLabels"
 import type {
     AgentConfigView,
     ChangeItem,
@@ -51,8 +51,37 @@ function toolProps(tool: NormalizedTool): Record<string, unknown> {
         : {}
 }
 
-function diffToolFields(before: NormalizedTool, after: NormalizedTool): ToolFieldChange[] {
+/** Permission field paths, so the row can name them instead of counting them as parameters. */
+const PERMISSION_DEFAULT = "permissions.default"
+const PERMISSION_TOOL_PREFIX = "permissions.tools."
+
+/** An integration's policy: its own default, plus whatever it overrides per tool. */
+function diffPolicyFields(before: NormalizedTool, after: NormalizedTool): ToolFieldChange[] {
+    if (!before.policy || !after.policy) return []
     const changes: ToolFieldChange[] = []
+    if (before.policy.default !== after.policy.default) {
+        changes.push({
+            field: PERMISSION_DEFAULT,
+            kind: "changed",
+            detail: `permission ${gatewayPermissionLabel(before.policy.default)} → ${gatewayPermissionLabel(after.policy.default)}`,
+        })
+    }
+    const names = new Set([...Object.keys(before.policy.tools), ...Object.keys(after.policy.tools)])
+    for (const name of [...names].sort()) {
+        const from = before.policy.tools[name]
+        const to = after.policy.tools[name]
+        if (from === to) continue
+        changes.push({
+            field: `${PERMISSION_TOOL_PREFIX}${name}`,
+            kind: !from ? "added" : !to ? "removed" : "changed",
+            detail: `${name}: ${gatewayPermissionLabel(from)} → ${gatewayPermissionLabel(to)}`,
+        })
+    }
+    return changes
+}
+
+function diffToolFields(before: NormalizedTool, after: NormalizedTool): ToolFieldChange[] {
+    const changes: ToolFieldChange[] = [...diffPolicyFields(before, after)]
     if (before.description !== after.description) {
         changes.push({field: "description", kind: "changed", detail: "description changed"})
     }
@@ -78,9 +107,22 @@ function diffToolFields(before: NormalizedTool, after: NormalizedTool): ToolFiel
 }
 
 function toolRowDetail(fields: ToolFieldChange[]): string | undefined {
+    const permissionDefault = fields.find((f) => f.field === PERMISSION_DEFAULT)
+    const perTool = fields.filter((f) => f.field.startsWith(PERMISSION_TOOL_PREFIX))
     const descChanged = fields.some((f) => f.field === "description")
-    const paramCount = fields.filter((f) => f.field !== "description").length
+    const paramCount = fields.filter(
+        (f) =>
+            f.field !== "description" &&
+            f.field !== PERMISSION_DEFAULT &&
+            !f.field.startsWith(PERMISSION_TOOL_PREFIX),
+    ).length
+
+    // A lone policy change is worth spelling out — "permission Ask → Allow" says what a count cannot.
+    if (permissionDefault && !perTool.length && !descChanged && !paramCount) {
+        return permissionDefault.detail
+    }
     const parts: string[] = []
+    if (permissionDefault || perTool.length) parts.push("permissions")
     if (descChanged) parts.push("description")
     if (paramCount) parts.push(paramCount === 1 ? "1 parameter" : `${paramCount} parameters`)
     // Fingerprint-based edit detection can flag a change in a field diffToolFields doesn't inspect

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -322,6 +322,9 @@ function advancedBucket(v: AgentConfigView): Record<string, unknown> {
         const {kind: _kind, ...rest} = v.harness
         Object.assign(out, prefixed("harness", rest))
     }
+    // Only for an agent template: on a prompt shape the unclaimed rest is another schema's
+    // plumbing, not settings a reader authored.
+    if (v.isAgentTemplate) Object.assign(out, flattenScalars(v.extra))
     return out
 }
 
@@ -335,6 +338,9 @@ const entryField = (entry: unknown, field: string): string => {
  * What an edited list entry changed. A skill carries prose — its SKILL.md `body` — so it gets the
  * same hunk view Instructions does rather than a bare "edited" mark.
  */
+/** The prose fields an entry names itself by; everything else is reported as a plain field. */
+const NAMED_ENTRY_FIELDS = new Set(["name", "description", "body"])
+
 function entryEdit(before: unknown, after: unknown): Pick<ChangeItem, "detail" | "textDiff"> {
     const parts: string[] = []
     if (entryField(before, "name") !== entryField(after, "name")) parts.push("name")
@@ -345,6 +351,19 @@ function entryEdit(before: unknown, after: unknown): Pick<ChangeItem, "detail" |
     const afterBody = entryField(after, "body")
     const bodyChanged = beforeBody !== afterBody
     if (bodyChanged) parts.push("instructions")
+
+    // An MCP server has no prose at all — its edit is a url or a command, and naming the field is
+    // the difference between "edited" and knowing what to look at.
+    const beforeRest = isPlainObj(before) ? flattenScalars(before) : {}
+    const afterRest = isPlainObj(after) ? flattenScalars(after) : {}
+    for (const key of [
+        ...new Set([...Object.keys(beforeRest), ...Object.keys(afterRest)]),
+    ].sort()) {
+        if (NAMED_ENTRY_FIELDS.has(key.split(".")[0])) continue
+        if (stableStringify(beforeRest[key]) === stableStringify(afterRest[key])) continue
+        parts.push(scalarKeyLabel(key).toLowerCase())
+    }
+
     return {
         detail: parts.length ? `${parts.join(" & ")} changed` : undefined,
         textDiff: bodyChanged ? buildTextDiff(beforeBody, afterBody) : undefined,

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -102,9 +102,10 @@ function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSe
         if (!prev) {
             added.push(tool)
         } else if (prev.fingerprint !== tool.fingerprint) {
-            // Field-level detail only for function tools; reference/builtin edits register with the
-            // generic "changed" detail (they have no function fields to itemize).
-            edited.push({tool, fields: tool.isFunction ? diffToolFields(prev, tool) : []})
+            // Every tool kind goes through the same field diff. A subagent has no function
+            // parameters, so the params half finds nothing, but its DESCRIPTION is content the
+            // reader needs — skipping non-function tools reported "edited" with nothing to show.
+            edited.push({tool, fields: diffToolFields(prev, tool)})
         }
     }
     for (const [key, tool] of remoteMap) {

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -80,6 +80,30 @@ function diffPolicyFields(before: NormalizedTool, after: NormalizedTool): ToolFi
     return changes
 }
 
+/** Roots another check already reports, so the raw sweep does not double-count them. */
+const COVERED_TOOL_ROOTS = new Set(["description", "function", "policy", "parameters", "name"])
+
+/**
+ * Whatever moved that nothing above inspects — a builtin's option, a reference's version. Without
+ * this the row falls back to a bare "changed" and the reader has no idea where to look.
+ */
+function diffRawToolFields(before: NormalizedTool, after: NormalizedTool): ToolFieldChange[] {
+    if (!before.raw || !after.raw) return []
+    const b = flattenScalars(before.raw)
+    const a = flattenScalars(after.raw)
+    const changes: ToolFieldChange[] = []
+    for (const key of [...new Set([...Object.keys(b), ...Object.keys(a)])].sort()) {
+        if (COVERED_TOOL_ROOTS.has(key.split(".")[0])) continue
+        if (stableStringify(b[key]) === stableStringify(a[key])) continue
+        changes.push({
+            field: key,
+            kind: !(key in b) ? "added" : !(key in a) ? "removed" : "changed",
+            detail: `${scalarKeyLabel(key).toLowerCase()} changed`,
+        })
+    }
+    return changes
+}
+
 function diffToolFields(before: NormalizedTool, after: NormalizedTool): ToolFieldChange[] {
     const changes: ToolFieldChange[] = [...diffPolicyFields(before, after)]
     if (before.description !== after.description) {
@@ -103,19 +127,20 @@ function diffToolFields(before: NormalizedTool, after: NormalizedTool): ToolFiel
             changes.push({field: key, kind: "changed", detail: "changed"})
         }
     }
-    return changes
+    return [...changes, ...diffRawToolFields(before, after)]
 }
 
 function toolRowDetail(fields: ToolFieldChange[]): string | undefined {
     const permissionDefault = fields.find((f) => f.field === PERMISSION_DEFAULT)
     const perTool = fields.filter((f) => f.field.startsWith(PERMISSION_TOOL_PREFIX))
     const descChanged = fields.some((f) => f.field === "description")
-    const paramCount = fields.filter(
+    const others = fields.filter(
         (f) =>
             f.field !== "description" &&
             f.field !== PERMISSION_DEFAULT &&
             !f.field.startsWith(PERMISSION_TOOL_PREFIX),
-    ).length
+    )
+    const paramCount = others.length
 
     // A lone policy change is worth spelling out — "permission Ask → Allow" says what a count cannot.
     if (permissionDefault && !perTool.length && !descChanged && !paramCount) {
@@ -124,7 +149,9 @@ function toolRowDetail(fields: ToolFieldChange[]): string | undefined {
     const parts: string[] = []
     if (permissionDefault || perTool.length) parts.push("permissions")
     if (descChanged) parts.push("description")
-    if (paramCount) parts.push(paramCount === 1 ? "1 parameter" : `${paramCount} parameters`)
+    // One field is worth naming; several are only worth counting.
+    if (paramCount === 1) parts.push(others[0].field)
+    else if (paramCount) parts.push(`${paramCount} parameters`)
     // Fingerprint-based edit detection can flag a change in a field diffToolFields doesn't inspect
     // (or a nameless reference/builtin tool with no fields) — fall back to a generic label so the
     // "edited" badge is never left unexplained.

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -96,6 +96,7 @@ function toolRowDetail(fields: ToolFieldChange[]): string | undefined {
 function toolsSection(
     id: "tools" | "subagents",
     title: string,
+    noun: string,
     localTools: NormalizedTool[],
     remoteTools: NormalizedTool[],
 ): ChangeSection | null {
@@ -163,6 +164,7 @@ function toolsSection(
     return {
         id,
         title,
+        noun,
         tags,
         totalCount: total,
         defaultCollapsed: total > 20,
@@ -328,6 +330,9 @@ const subagents = (v: AgentConfigView) => v.tools.filter((t) => t.isSubagent)
 export function classifyAgentChanges(localParams: unknown, remoteParams: unknown): ChangeSection[] {
     const local = readAgentConfig(localParams)
     const remote = readAgentConfig(remoteParams)
+    // The agent panel calls them Integrations; the prompt playground has plain tools.
+    const asAgent = local.isAgentTemplate || remote.isAgentTemplate
+    const [toolsTitle, toolsNoun] = asAgent ? ["Integrations", "integration"] : ["Tools", "tool"]
     // Grouped to mirror the agent-template control sections (Model & harness, Instructions,
     // Tools, Subagents, MCP servers, Skills, Advanced) so nothing changed is dropped or split.
     return [
@@ -338,8 +343,8 @@ export function classifyAgentChanges(localParams: unknown, remoteParams: unknown
             modelHarnessBucket(remote),
         ),
         instructionsSection(local, remote),
-        toolsSection("tools", "Tools", tools(local), tools(remote)),
-        toolsSection("subagents", "Subagents", subagents(local), subagents(remote)),
+        toolsSection("tools", toolsTitle, toolsNoun, tools(local), tools(remote)),
+        toolsSection("subagents", "Subagents", "subagent", subagents(local), subagents(remote)),
         listSection("mcps", "MCPs", local.mcps, remote.mcps),
         listSection("skills", "Skills", local.skills, remote.skills),
         scalarSection("params", "Advanced", advancedBucket(local), advancedBucket(remote)),

--- a/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/classify.ts
@@ -102,9 +102,7 @@ function toolsSection(local: AgentConfigView, remote: AgentConfigView): ChangeSe
         if (!prev) {
             added.push(tool)
         } else if (prev.fingerprint !== tool.fingerprint) {
-            // Every tool kind goes through the same field diff. A subagent has no function
-            // parameters, so the params half finds nothing, but its DESCRIPTION is content the
-            // reader needs — skipping non-function tools reported "edited" with nothing to show.
+            // Every tool kind: a subagent has no params, but its description still diffs.
             edited.push({tool, fields: diffToolFields(prev, tool)})
         }
     }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/gatewayName.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/gatewayName.ts
@@ -9,7 +9,8 @@ export interface ParsedToolName {
     source?: string
 }
 
-function titleCase(token: string): string {
+/** `gmail` / `GMAIL` / `my_app` → `Gmail` / `My app`. */
+export function titleCase(token: string): string {
     const cleaned = token.replace(/[_-]+/g, " ").trim().toLowerCase()
     if (!cleaned) return token
     return cleaned.charAt(0).toUpperCase() + cleaned.slice(1)

--- a/web/packages/agenta-entities/src/workflow/commitDiff/gatewayName.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/gatewayName.ts
@@ -9,6 +9,49 @@ export interface ParsedToolName {
     source?: string
 }
 
+/** Tokens a humanized action key keeps uppercase. */
+const ACTION_ACRONYMS = new Set([
+    "API",
+    "ID",
+    "URL",
+    "URI",
+    "HTTP",
+    "JSON",
+    "CSV",
+    "PDF",
+    "SDK",
+    "UUID",
+    "OAUTH",
+    "2FA",
+    "MFA",
+])
+
+/**
+ * `GMAIL_ADD_LABEL` + `gmail` → "Add label". Sentence-cased, acronyms kept, and an action key
+ * that repeats its integration loses the prefix — the row names the app separately.
+ *
+ * Deliberately local. `@agenta/entity-ui` has a one-argument version of this and there is a
+ * branch in flight moving a two-argument one into `@agenta/shared`; entities can reach neither
+ * today (entity-ui is the wrong direction, and the shared one has not landed). Converge on the
+ * shared helper once that lands rather than growing a third copy.
+ */
+export function humanizeGatewayAction(key: string, integration?: string): string {
+    const prefix = integration ? `${integration.toUpperCase()}_` : ""
+    const stripped = prefix && key.toUpperCase().startsWith(prefix) ? key.slice(prefix.length) : key
+    const words = stripped
+        .toLowerCase()
+        .split(/[_\s]+/)
+        .filter(Boolean)
+    if (words.length === 0) return key
+    return words
+        .map((word, index) => {
+            const upper = word.toUpperCase()
+            if (ACTION_ACRONYMS.has(upper)) return upper
+            return index === 0 ? word.charAt(0).toUpperCase() + word.slice(1) : word
+        })
+        .join(" ")
+}
+
 /** `gmail` / `GMAIL` / `my_app` → `Gmail` / `My app`. */
 export function titleCase(token: string): string {
     const cleaned = token.replace(/[_-]+/g, " ").trim().toLowerCase()

--- a/web/packages/agenta-entities/src/workflow/commitDiff/identity.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/identity.ts
@@ -44,10 +44,7 @@ export function agentItemIdentity(kind: AgentItemKind, item: unknown, index: num
             const integration = typeof conn?.integration === "string" ? conn.integration : ""
             if (provider && integration) return `integration:${provider}:${integration}`
         }
-        // Canonical gateway tool — keyed by the action it performs. It carries no `function.name`,
-        // so without this it fell to the positional key below: swapping one action for another at
-        // the same index read as a single edited slot rather than an add and a remove, and
-        // reordering tools reported false adds and removes.
+        // Canonical gateway tool — keyed by its action; positional keys mis-report swaps.
         if (rec.type === "gateway") {
             const integration = typeof rec.integration === "string" ? rec.integration : ""
             const action = typeof rec.action === "string" ? rec.action : ""

--- a/web/packages/agenta-entities/src/workflow/commitDiff/identity.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/identity.ts
@@ -44,6 +44,20 @@ export function agentItemIdentity(kind: AgentItemKind, item: unknown, index: num
             const integration = typeof conn?.integration === "string" ? conn.integration : ""
             if (provider && integration) return `integration:${provider}:${integration}`
         }
+        // Canonical gateway tool — keyed by the action it performs. It carries no `function.name`,
+        // so without this it fell to the positional key below: swapping one action for another at
+        // the same index read as a single edited slot rather than an add and a remove, and
+        // reordering tools reported false adds and removes.
+        if (rec.type === "gateway") {
+            const integration = typeof rec.integration === "string" ? rec.integration : ""
+            const action = typeof rec.action === "string" ? rec.action : ""
+            const connection = typeof rec.connection === "string" ? rec.connection : ""
+            if (integration && action) {
+                const provider =
+                    typeof rec.provider === "string" && rec.provider ? rec.provider : "composio"
+                return `gateway:${provider}:${integration}:${action}:${connection}`
+            }
+        }
         // Function / gateway tool — keyed by its function name (wrapped `function.name` or the
         // flat legacy shape `{name, description, parameters}`).
         const fn = isObj(rec.function) ? rec.function : undefined

--- a/web/packages/agenta-entities/src/workflow/commitDiff/index.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/index.ts
@@ -15,7 +15,7 @@ export {
     type RevisionDeltaPreview,
 } from "./revisionDelta"
 export {buildCommitSummaryMessage} from "./summaryMessage"
-export {scalarKeyLabel, scalarValueLabel} from "./scalarLabels"
+export {gatewayPermissionLabel, scalarKeyLabel, scalarValueLabel} from "./scalarLabels"
 export {parseGatewayToolName, type ParsedToolName} from "./gatewayName"
 export type {
     AgentConfigView,

--- a/web/packages/agenta-entities/src/workflow/commitDiff/index.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/index.ts
@@ -15,6 +15,7 @@ export {
     type RevisionDeltaPreview,
 } from "./revisionDelta"
 export {buildCommitSummaryMessage} from "./summaryMessage"
+export {scalarKeyLabel, scalarValueLabel} from "./scalarLabels"
 export {parseGatewayToolName, type ParsedToolName} from "./gatewayName"
 export type {
     AgentConfigView,

--- a/web/packages/agenta-entities/src/workflow/commitDiff/scalarLabels.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/scalarLabels.ts
@@ -1,0 +1,89 @@
+/**
+ * Human names for the scalar config keys a diff reports.
+ *
+ * The diff used to print the storage path and the stored value verbatim —
+ * `runner.permissions.default  allow → allow_reads`. That is the JSON, not the setting: a reader
+ * who has not seen the schema cannot tell what changed or whether it matters.
+ *
+ * Keys are matched by exact path, because the same leaf means different things under different
+ * parents (`harness.permissions.default_mode` is not `runner.permissions.default`). Anything
+ * unmapped falls back to a humanized path rather than being hidden — a new template key should
+ * read imperfectly, never disappear.
+ *
+ * Wording follows the config panel's own controls wherever it has one, so the same setting is not
+ * called two things in two places.
+ */
+import {permissionPolicyLabel} from "@agenta/shared/utils"
+
+const PATH_LABELS: Record<string, string> = {
+    // Generation parameters (PARAM_KEYS).
+    temperature: "Temperature",
+    max_tokens: "Max tokens",
+    top_p: "Top P",
+    frequency_penalty: "Frequency penalty",
+    presence_penalty: "Presence penalty",
+    tool_choice: "Tool choice",
+    response_format: "Response format",
+    stream: "Streaming",
+    template_format: "Template format",
+    fallback_policy: "Fallback policy",
+    retry_policy: "Retry policy",
+
+    // Model & harness. These reach the same renderer, so they had the same problem.
+    "llm.model": "Model",
+    "llm.provider": "Provider",
+    "llm.connection.mode": "Connection mode",
+    "harness.kind": "Harness",
+    "harness.max_iterations": "Max iterations",
+    "harness.permissions.web_search": "Web search",
+
+    // Execution sections. The panel labels the runner policy "Policy" inside its Permissions
+    // group; standalone in a diff row that says too little, so it names the subject too.
+    "runner.permissions.default": "Tool permissions",
+    "harness.permissions.default_mode": "Harness permissions",
+    "sandbox.kind": "Sandbox",
+    "sandbox.permissions": "Sandbox permissions",
+}
+
+/** Per-path value vocabulary — the stored enum is not what the control calls it. */
+const VALUE_LABELS: Record<string, (value: string) => string | undefined> = {
+    "runner.permissions.default": permissionPolicyLabel,
+}
+
+/** Segments a humanized path should not lowercase. */
+const ACRONYMS: Record<string, string> = {llm: "LLM", api: "API", url: "URL", id: "ID"}
+
+const humanizeSegment = (segment: string): string =>
+    ACRONYMS[segment.toLowerCase()] ?? segment.replace(/[_-]+/g, " ").trim().toLowerCase()
+
+/**
+ * `sandbox.permissions.network` → "Sandbox › network". Keeps the parent, because a bare leaf
+ * ("network", "default") is ambiguous across sections.
+ */
+const humanizePath = (path: string): string => {
+    const segments = path.split(".").filter(Boolean)
+    if (segments.length === 0) return path
+    const head = humanizeSegment(segments[0])
+    const label =
+        segments.length === 1
+            ? head
+            : `${head} › ${segments.slice(1).map(humanizeSegment).join(" › ")}`
+    return label.charAt(0).toUpperCase() + label.slice(1)
+}
+
+/** What to call this config key in a diff row. */
+export const scalarKeyLabel = (path: string): string => PATH_LABELS[path] ?? humanizePath(path)
+
+/**
+ * What to call this value. Known enums resolve to the control's own wording; booleans read as
+ * On/Off; everything else is shown as stored, since inventing a name for an arbitrary value
+ * would be a guess.
+ */
+export const scalarValueLabel = (path: string, value: string | undefined): string | undefined => {
+    if (value === undefined) return undefined
+    const mapped = VALUE_LABELS[path]?.(value)
+    if (mapped) return mapped
+    if (value === "true") return "On"
+    if (value === "false") return "Off"
+    return value
+}

--- a/web/packages/agenta-entities/src/workflow/commitDiff/scalarLabels.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/scalarLabels.ts
@@ -41,6 +41,10 @@ const PATH_LABELS: Record<string, string> = {
     // group; standalone in a diff row that says too little, so it names the subject too.
     "runner.permissions.default": "Tool permissions",
     "harness.permissions.default_mode": "Harness permissions",
+    // The Claude permissions control's own field labels.
+    "harness.permissions.allow": "Allow rules",
+    "harness.permissions.ask": "Ask rules",
+    "harness.permissions.deny": "Deny rules",
     "sandbox.kind": "Sandbox",
     "sandbox.permissions": "Sandbox permissions",
 }
@@ -89,5 +93,7 @@ export const scalarValueLabel = (
     if (mapped) return mapped
     // Only a real boolean reads as On/Off; the string "false" is a value, not a flag.
     if (typeof raw === "boolean") return raw ? "On" : "Off"
+    // A rule list is prose, not JSON: `["Bash"]` is punctuation a reader has to decode.
+    if (Array.isArray(raw)) return raw.length ? raw.map(String).join(", ") : "None"
     return value
 }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/scalarLabels.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/scalarLabels.ts
@@ -49,6 +49,18 @@ const PATH_LABELS: Record<string, string> = {
     "sandbox.permissions": "Sandbox permissions",
 }
 
+/** An integration's permission vocabulary, as the tool form spells it. */
+const GATEWAY_PERMISSION_LABELS: Record<string, string> = {
+    allow: "Allow",
+    ask: "Ask",
+    deny: "Deny",
+    inherit: "Inherit",
+}
+
+/** What to call a gateway permission. Unset means the entry inherits the integration default. */
+export const gatewayPermissionLabel = (value: string | undefined): string =>
+    (value && GATEWAY_PERMISSION_LABELS[value]) ?? "Inherit"
+
 /** Per-path value vocabulary — the stored enum is not what the control calls it. */
 const VALUE_LABELS: Record<string, (value: string) => string | undefined> = {
     "runner.permissions.default": permissionPolicyLabel,

--- a/web/packages/agenta-entities/src/workflow/commitDiff/scalarLabels.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/scalarLabels.ts
@@ -40,13 +40,33 @@ const PATH_LABELS: Record<string, string> = {
     // Execution sections. The panel labels the runner policy "Policy" inside its Permissions
     // group; standalone in a diff row that says too little, so it names the subject too.
     "runner.permissions.default": "Tool permissions",
-    "harness.permissions.default_mode": "Harness permissions",
+    "harness.permissions.default_mode": "Permission mode",
     // The Claude permissions control's own field labels.
     "harness.permissions.allow": "Allow rules",
     "harness.permissions.ask": "Ask rules",
     "harness.permissions.deny": "Deny rules",
     "sandbox.kind": "Sandbox",
     "sandbox.permissions": "Sandbox permissions",
+    // The sandbox control's own field labels.
+    "sandbox.permissions.network.mode": "Network egress",
+    "sandbox.permissions.filesystem": "Filesystem",
+    "sandbox.permissions.enforcement": "Enforcement",
+}
+
+/** Enum vocabularies lifted from the controls that author them. */
+const ENUM_LABELS: Record<string, Record<string, string>> = {
+    "harness.permissions.default_mode": {
+        default: "Default",
+        acceptEdits: "Accept edits",
+        plan: "Plan",
+        bypassPermissions: "Bypass",
+    },
+    "sandbox.permissions.network.mode": {
+        on: "Allow all egress",
+        off: "Block all egress",
+        allowlist: "Allowlist",
+    },
+    "sandbox.permissions.filesystem": {on: "Read / write", readonly: "Read-only", off: "No access"},
 }
 
 /** An integration's permission vocabulary, as the tool form spells it. */
@@ -61,16 +81,32 @@ const GATEWAY_PERMISSION_LABELS: Record<string, string> = {
 export const gatewayPermissionLabel = (value: string | undefined): string =>
     (value && GATEWAY_PERMISSION_LABELS[value]) ?? "Inherit"
 
-/** Per-path value vocabulary — the stored enum is not what the control calls it. */
-const VALUE_LABELS: Record<string, (value: string) => string | undefined> = {
-    "runner.permissions.default": permissionPolicyLabel,
-}
-
 /** Segments a humanized path should not lowercase. */
 const ACRONYMS: Record<string, string> = {llm: "LLM", api: "API", url: "URL", id: "ID"}
 
 const humanizeSegment = (segment: string): string =>
     ACRONYMS[segment.toLowerCase()] ?? segment.replace(/[_-]+/g, " ").trim().toLowerCase()
+
+/** Per-path value vocabulary — the stored enum is not what the control calls it. */
+const VALUE_LABELS: Record<string, (value: string) => string | undefined> = {
+    "runner.permissions.default": permissionPolicyLabel,
+    ...Object.fromEntries(
+        Object.entries(ENUM_LABELS).map(([path, map]) => [path, (v: string) => map[v]]),
+    ),
+}
+
+/** `{max_attempts: 3, backoff: "exponential"}` reads as prose; its JSON does not. */
+const objectLabel = (raw: Record<string, unknown>): string | undefined => {
+    const entries = Object.entries(raw)
+    if (!entries.length) return "None"
+    return entries
+        .map(([key, value]) => {
+            const shown =
+                value !== null && typeof value === "object" ? JSON.stringify(value) : String(value)
+            return `${humanizeSegment(key)}: ${shown}`
+        })
+        .join(", ")
+}
 
 /**
  * `sandbox.permissions.network` → "Sandbox › network". Keeps the parent, because a bare leaf
@@ -107,5 +143,6 @@ export const scalarValueLabel = (
     if (typeof raw === "boolean") return raw ? "On" : "Off"
     // A rule list is prose, not JSON: `["Bash"]` is punctuation a reader has to decode.
     if (Array.isArray(raw)) return raw.length ? raw.map(String).join(", ") : "None"
+    if (raw !== null && typeof raw === "object") return objectLabel(raw as Record<string, unknown>)
     return value
 }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/scalarLabels.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/scalarLabels.ts
@@ -79,11 +79,15 @@ export const scalarKeyLabel = (path: string): string => PATH_LABELS[path] ?? hum
  * On/Off; everything else is shown as stored, since inventing a name for an arbitrary value
  * would be a guess.
  */
-export const scalarValueLabel = (path: string, value: string | undefined): string | undefined => {
+export const scalarValueLabel = (
+    path: string,
+    value: string | undefined,
+    raw?: unknown,
+): string | undefined => {
     if (value === undefined) return undefined
     const mapped = VALUE_LABELS[path]?.(value)
     if (mapped) return mapped
-    if (value === "true") return "On"
-    if (value === "false") return "Off"
+    // Only a real boolean reads as On/Off; the string "false" is a value, not a flag.
+    if (typeof raw === "boolean") return raw ? "On" : "Off"
     return value
 }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/summaryMessage.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/summaryMessage.ts
@@ -35,10 +35,8 @@ export function buildCommitSummaryMessage(sections: ChangeSection[]): string {
     for (const section of sections) {
         switch (section.id) {
             case "tools":
-                phrases.push(itemsPhrase(section, "tool"))
-                break
             case "subagents":
-                phrases.push(itemsPhrase(section, "subagent"))
+                phrases.push(itemsPhrase(section, section.noun ?? "tool"))
                 break
             case "instructions":
                 phrases.push("edited the instructions")

--- a/web/packages/agenta-entities/src/workflow/commitDiff/summaryMessage.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/summaryMessage.ts
@@ -46,7 +46,7 @@ export function buildCommitSummaryMessage(sections: ChangeSection[]): string {
                 const to = section.scalarChanges?.find(
                     (c) => c.key === "llm.model" || c.key === "model",
                 )?.after
-                phrases.push(to ? `changed the model to ${to}` : "updated the model & harness")
+                phrases.push(to ? `changed the model to ${to}` : "updated the model")
                 break
             }
             case "mcps":

--- a/web/packages/agenta-entities/src/workflow/commitDiff/summaryMessage.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/summaryMessage.ts
@@ -15,7 +15,7 @@ function joinClauses(parts: string[]): string {
     return `${parts.slice(0, -1).join(", ")}, and ${parts[parts.length - 1]}`
 }
 
-function toolsPhrase(section: ChangeSection): string {
+function itemsPhrase(section: ChangeSection, noun: string): string {
     const items = section.items ?? []
     const counts = {added: 0, edited: 0, removed: 0}
     for (const it of items) {
@@ -24,9 +24,9 @@ function toolsPhrase(section: ChangeSection): string {
         else counts.edited++
     }
     const sub: string[] = []
-    if (counts.added) sub.push(`added ${counts.added} ${plural("tool", counts.added)}`)
-    if (counts.edited) sub.push(`edited ${counts.edited} ${plural("tool", counts.edited)}`)
-    if (counts.removed) sub.push(`removed ${counts.removed} ${plural("tool", counts.removed)}`)
+    if (counts.added) sub.push(`added ${counts.added} ${plural(noun, counts.added)}`)
+    if (counts.edited) sub.push(`edited ${counts.edited} ${plural(noun, counts.edited)}`)
+    if (counts.removed) sub.push(`removed ${counts.removed} ${plural(noun, counts.removed)}`)
     return sub.join(", ")
 }
 
@@ -35,7 +35,10 @@ export function buildCommitSummaryMessage(sections: ChangeSection[]): string {
     for (const section of sections) {
         switch (section.id) {
             case "tools":
-                phrases.push(toolsPhrase(section))
+                phrases.push(itemsPhrase(section, "tool"))
+                break
+            case "subagents":
+                phrases.push(itemsPhrase(section, "subagent"))
                 break
             case "instructions":
                 phrases.push("edited the instructions")

--- a/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
@@ -104,6 +104,8 @@ export interface NormalizedTool {
     fingerprint: string
     /** A function-call tool (`function.name`); only these get field-level diffs. */
     isFunction: boolean
+    /** A `gateway_connection`'s authored policy: the integration default plus per-tool overrides. */
+    policy?: {default: string; tools: Record<string, string>}
     /** A `{type:"reference"}` entry — another agent, sectioned apart from the real tools. */
     isSubagent?: boolean
 }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
@@ -126,4 +126,6 @@ export interface AgentConfigView {
     harness: Record<string, unknown> | undefined
     runner: Record<string, unknown> | undefined
     sandbox: Record<string, unknown> | undefined
+    /** Template keys no section claims, so an untaught key still reports as a change. */
+    extra: Record<string, unknown>
 }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
@@ -106,6 +106,8 @@ export interface NormalizedTool {
     isFunction: boolean
     /** A `gateway_connection`'s authored policy: the integration default plus per-tool overrides. */
     policy?: {default: string; tools: Record<string, string>}
+    /** The entry as authored, so a field no other check inspects can still be named. */
+    raw?: Record<string, unknown>
     /** A `{type:"reference"}` entry — another agent, sectioned apart from the real tools. */
     isSubagent?: boolean
 }

--- a/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
@@ -44,6 +44,8 @@ export interface ChangeItem {
     fieldChanges?: ToolFieldChange[]
     /** description before/after for an edited tool. */
     descriptionDiff?: {before: string; after: string}
+    /** Prose diff of the entry's own body — a skill's SKILL.md, rendered like Instructions. */
+    textDiff?: TextDiff
 }
 
 /** A scalar before→after change (model, temperature, …). */

--- a/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
@@ -9,7 +9,14 @@ import type {ExtendedDiffLine} from "@agenta/ui/diff"
 
 export type ChangeKind = "added" | "removed" | "edited" | "changed"
 
-export type SectionId = "tools" | "instructions" | "model" | "params" | "mcps" | "skills"
+export type SectionId =
+    | "tools"
+    | "subagents"
+    | "instructions"
+    | "model"
+    | "params"
+    | "mcps"
+    | "skills"
 
 export interface ChangeTag {
     kind: ChangeKind
@@ -93,6 +100,8 @@ export interface NormalizedTool {
     fingerprint: string
     /** A function-call tool (`function.name`); only these get field-level diffs. */
     isFunction: boolean
+    /** A `{type:"reference"}` entry — another agent, sectioned apart from the real tools. */
+    isSubagent?: boolean
 }
 
 export interface AgentConfigView {

--- a/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
@@ -41,9 +41,16 @@ export interface ChangeItem {
 
 /** A scalar before→after change (model, temperature, …). */
 export interface ScalarChange {
+    /** Storage path (`runner.permissions.default`) — identity, and the detail/JSON view. */
     key: string
+    /** What to call it on screen ("Tool permissions"). Falls back to a humanized path. */
+    label: string
+    /** Stored values — identity for consumers that recall what a property was committed as. */
     before: string | undefined
     after: string | undefined
+    /** Display forms of the same values ("Allow all", "On"). Absent = show the stored value. */
+    beforeLabel?: string
+    afterLabel?: string
     kind: ChangeKind
 }
 

--- a/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
+++ b/web/packages/agenta-entities/src/workflow/commitDiff/types.ts
@@ -73,6 +73,8 @@ export interface TextDiff {
 export interface ChangeSection {
     id: SectionId
     title: string
+    /** Singular noun for the commit message ("integration"). Defaults to a section-wide fallback. */
+    noun?: string
     tags: ChangeTag[]
     /** Total change count in this section — drives caps / collapse defaults. */
     totalCount: number
@@ -105,6 +107,8 @@ export interface NormalizedTool {
 }
 
 export interface AgentConfigView {
+    /** An agent template, not a prompt variant — the two name the same sections differently. */
+    isAgentTemplate: boolean
     instructions: string
     tools: NormalizedTool[]
     model: string | undefined

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -100,21 +100,39 @@ const workflowRecencyScore = (workflow: Workflow | null | undefined): number => 
     )
 }
 
+/**
+ * Is `a` a later revision than `b`?
+ *
+ * VERSION decides, not the timestamp. `version` is server-assigned and monotonic; `created_at` is
+ * not a reliable ordering — revisions committed by the agent land in bursts that tie to the second,
+ * and a tie used to fall through to array order and pick an arbitrary revision as "latest". That
+ * wrong pick then persisted: it is written to the `latestRevision` key, mirrored to IndexedDB, and
+ * that query is disabled whenever the key is already populated, so nothing ever revalidated it.
+ *
+ * Timestamps stay as the tie-break for revisions that share a version.
+ */
+export const isLaterWorkflowRevision = (
+    a: Workflow | null | undefined,
+    b: Workflow | null | undefined,
+): boolean => {
+    if (!a) return false
+    if (!b) return true
+    const aVersion = Number(a.version ?? 0)
+    const bVersion = Number(b.version ?? 0)
+    if (aVersion !== bVersion) return aVersion > bVersion
+    return workflowRecencyScore(a) > workflowRecencyScore(b)
+}
+
 const pickMostRecentWorkflowRevision = (
     revisions: (Workflow | null | undefined)[],
 ): Workflow | null => {
     let latest: Workflow | null = null
-    let latestScore = -1
 
     for (const revision of revisions) {
         if (!revision) continue
         // Skip v0 revisions (auto-created initial revisions with no useful data)
         if ((revision.version ?? 0) === 0) continue
-        const score = workflowRecencyScore(revision)
-        if (!latest || score > latestScore) {
-            latest = revision
-            latestScore = score
-        }
+        if (isLaterWorkflowRevision(revision, latest)) latest = revision
     }
 
     return latest
@@ -738,11 +756,13 @@ export const workflowRevisionRefsByWorkflowAtomFamily = atomFamily((workflowId: 
     atom<WorkflowRevisionRef[]>((get) => {
         const query = get(workflowRevisionsByWorkflowQueryAtomFamily(workflowId))
         const refs = query.data?.refs ?? []
+        // Version first, timestamp only as a tie-break — see `isLaterWorkflowRevision`.
         return [...refs].sort((a, b) => {
+            const byVersion = (b.version ?? 0) - (a.version ?? 0)
+            if (byVersion !== 0) return byVersion
             const aTime = a.created_at ? new Date(a.created_at).getTime() : 0
             const bTime = b.created_at ? new Date(b.created_at).getTime() : 0
-            if (bTime !== aTime) return bTime - aTime
-            return (b.version ?? 0) - (a.version ?? 0)
+            return bTime - aTime
         })
     }),
 )
@@ -803,10 +823,7 @@ export const workflowRevisionsQueryAtomFamily = atomFamily((variantId: string) =
                             revision.workflow_id,
                             projectId,
                         ])
-                        if (
-                            !cachedLatest ||
-                            workflowRecencyScore(revision) > workflowRecencyScore(cachedLatest)
-                        ) {
+                        if (isLaterWorkflowRevision(revision, cachedLatest)) {
                             queryClient.setQueryData(
                                 ["workflows", "latestRevision", revision.workflow_id, projectId],
                                 revision,

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -196,6 +196,44 @@ describe("an edited skill shows its prose, the way Instructions does", () => {
     })
 })
 
+describe("an integration's permission change says what it became", () => {
+    // Regression: the row read "Composio search · changed" for every policy edit — the fingerprint
+    // caught it, but nothing described it, so the diff carried no information.
+    const connection = (permissions: Record<string, unknown>) => ({
+        type: "gateway_connection",
+        connection: {provider: "composio", integration: "composio_search", slug: "conn-1"},
+        policy: {permissions},
+    })
+    const row = (local: Record<string, unknown>, remote: Record<string, unknown>) =>
+        classifyAgentChanges(
+            {agent: {tools: [connection(local)]}},
+            {agent: {tools: [connection(remote)]}},
+        )?.find((s) => s.id === "tools")?.items?.[0]
+
+    it("spells out a default policy change", () => {
+        const item = row({default: "allow"}, {default: "ask"})
+        expect(item?.kind).toBe("edited")
+        expect(item?.detail).toBe("permission Ask → Allow")
+    })
+
+    it("treats an absent default as Inherit rather than as nothing", () => {
+        expect(row({default: "deny"}, {})?.detail).toBe("permission Inherit → Deny")
+    })
+
+    it("records a per-tool override as its own field change", () => {
+        const item = row({default: "ask", tools: {SEARCH: "allow"}}, {default: "ask"})
+        expect(item?.detail).toBe("permissions changed")
+        expect(item?.fieldChanges).toEqual([
+            {field: "permissions.tools.SEARCH", kind: "added", detail: "SEARCH: Inherit → Allow"},
+        ])
+    })
+
+    it("does not count permissions as parameters", () => {
+        const item = row({default: "allow", tools: {A: "deny", B: "deny"}}, {default: "ask"})
+        expect(item?.detail).toBe("permissions changed")
+    })
+})
+
 describe("renaming a skill in place is an edit, not a swap", () => {
     // Regression: identity is the name, so a rename read as "1 added, 1 removed" and the body
     // diff behind it was never computed — exactly the change you most want to see.

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -90,6 +90,47 @@ describe("readAgentConfig — three schema shapes normalize to one view", () => 
     })
 })
 
+describe("advanced settings read as settings, not as JSON paths", () => {
+    // Regression: the row printed the storage path and the stored enum verbatim —
+    // `runner.permissions.default  allow → allow_reads` — which says nothing to a reader who has
+    // not seen the schema.
+    const advanced = (params: Record<string, unknown>) =>
+        classifyAgentChanges({agent: params}, {agent: {}})?.find((s) => s.id === "params")
+
+    it("names the runner policy and its values the way the config panel does", () => {
+        const section = classifyAgentChanges(
+            {agent: {runner: {permissions: {default: "allow_reads"}}}},
+            {agent: {runner: {permissions: {default: "allow"}}}},
+        ).find((s) => s.id === "params")
+        const [change] = section?.scalarChanges ?? []
+        expect(change.label).toBe("Tool permissions")
+        expect(change.beforeLabel).toBe("Allow all")
+        expect(change.afterLabel).toBe("Allow reads")
+        // Stored values survive for consumers that read them back.
+        expect(change.before).toBe("allow")
+        expect(change.after).toBe("allow_reads")
+        // The storage path survives for the detail/JSON view.
+        expect(change.key).toBe("runner.permissions.default")
+    })
+
+    it("names generation parameters", () => {
+        const [change] = advanced({temperature: 0.7})?.scalarChanges ?? []
+        expect(change.label).toBe("Temperature")
+    })
+
+    it("reads booleans as On/Off", () => {
+        const [change] = advanced({stream: true})?.scalarChanges ?? []
+        expect(change.label).toBe("Streaming")
+        expect(change.afterLabel).toBe("On")
+    })
+
+    it("humanizes an unmapped key instead of dropping it", () => {
+        const [change] = advanced({sandbox: {network_access: "none"}})?.scalarChanges ?? []
+        expect(change.label).toBe("Sandbox › network access")
+        expect(change.afterLabel).toBe("none")
+    })
+})
+
 describe("gateway tools are named by what they DO, not by their discriminator", () => {
     // Regression: canonical gateway tools carry no `function.name`, so they fell through to the
     // bare-type fallback and every one of them rendered as "Gateway" / "Gateway connection" —
@@ -320,8 +361,11 @@ describe("classifyAgentChanges", () => {
         expect(advanced?.title).toBe("Advanced")
         expect(advanced?.scalarChanges).toContainEqual({
             key: "harness.max_iterations",
+            label: "Max iterations",
             before: "10",
             after: "25",
+            beforeLabel: "10",
+            afterLabel: "25",
             kind: "changed",
         })
     })
@@ -332,8 +376,11 @@ describe("classifyAgentChanges", () => {
         const advanced = classifyAgentChanges(local, remote).find((s) => s.id === "params")
         expect(advanced?.scalarChanges).toContainEqual({
             key: "harness.permissions.web_search",
+            label: "Web search",
             before: "false",
             after: "true",
+            beforeLabel: "Off",
+            afterLabel: "On",
             kind: "changed",
         })
     })
@@ -356,8 +403,11 @@ describe("classifyAgentChanges", () => {
         expect(modelHarness?.title).toBe("Model & harness")
         expect(modelHarness?.scalarChanges).toContainEqual({
             key: "llm.connection.mode",
+            label: "Connection mode",
             before: "agenta",
             after: "self_managed",
+            beforeLabel: "agenta",
+            afterLabel: "self_managed",
             kind: "changed",
         })
     })
@@ -370,8 +420,11 @@ describe("classifyAgentChanges", () => {
         const mh = sections.find((s) => s.id === "model")
         expect(mh?.scalarChanges).toContainEqual({
             key: "llm.model",
+            label: "Model",
             before: "opus",
             after: "opus[1m]",
+            beforeLabel: "opus",
+            afterLabel: "opus[1m]",
             kind: "changed",
         })
     })
@@ -391,8 +444,11 @@ describe("classifyAgentChanges", () => {
         expect(mh?.title).toBe("Model & harness")
         expect(mh?.scalarChanges).toContainEqual({
             key: "harness.kind",
+            label: "Harness",
             before: "pi_core",
             after: "claude",
+            beforeLabel: "pi_core",
+            afterLabel: "claude",
             kind: "changed",
         })
         // model + harness are one section, never split into two accordions.

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -161,6 +161,33 @@ describe("subagents get their own section, named the way the config panel names 
     })
 })
 
+describe("permission rules read as rules, not as JSON", () => {
+    // Regression: the row printed `Harness › permissions › allow  —  ["Bash"]`.
+    const row = (local: Record<string, unknown>, remote: Record<string, unknown>) =>
+        classifyAgentChanges({agent: local}, {agent: remote})?.find((s) => s.id === "params")
+            ?.scalarChanges?.[0]
+
+    it("names the rule lists the way the permissions control does", () => {
+        const change = row(
+            {harness: {permissions: {allow: ["Bash"]}}},
+            {harness: {permissions: {allow: []}}},
+        )
+        expect(change?.label).toBe("Allow rules")
+    })
+
+    it("reads a rule list as prose, and an empty one as None", () => {
+        const change = row(
+            {harness: {permissions: {deny: ["Bash", "Write"]}}},
+            {harness: {permissions: {deny: []}}},
+        )
+        expect(change?.label).toBe("Deny rules")
+        expect(change?.beforeLabel).toBe("None")
+        expect(change?.afterLabel).toBe("Bash, Write")
+        // The stored value is untouched for consumers that read it back.
+        expect(change?.after).toBe('["Bash","Write"]')
+    })
+})
+
 describe("the tools section is named the way its own playground names it", () => {
     const one = (params: Record<string, unknown>, before: Record<string, unknown>) =>
         classifyAgentChanges(params, before).find((s) => s.id === "tools")

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -90,7 +90,7 @@ describe("readAgentConfig — three schema shapes normalize to one view", () => 
     })
 })
 
-describe("subagents are named and described like every other tool", () => {
+describe("subagents get their own section, named the way the config panel names them", () => {
     // Regression: named by slug, description dropped, so an edited description showed nothing.
     const ref = (over: Record<string, unknown>) => ({
         type: "reference",
@@ -100,24 +100,50 @@ describe("subagents are named and described like every other tool", () => {
     })
 
     it("uses the subagent's name, and says what kind of thing it is", () => {
-        const tools = classifyAgentChanges(
+        const sections = classifyAgentChanges(
             {agent: {tools: [ref({name: "Article writer"})]}},
             {agent: {tools: []}},
-        ).find((s) => s.id === "tools")
-        expect(tools?.items?.[0]).toMatchObject({
+        )
+        // Its own section — never mixed into Tools.
+        expect(sections.map((s) => s.id)).toEqual(["subagents"])
+        expect(sections[0].items?.[0]).toMatchObject({
             kind: "added",
             label: "Article writer",
-            detail: "Subagent",
+            // No detail: "Subagent" would only repeat the section header.
+            detail: undefined,
             // The slug stays reachable as the technical key.
             rawKey: "dev-to-article-writer",
         })
     })
 
     it("falls back to the slug when the reference carries no name", () => {
-        const tools = classifyAgentChanges({agent: {tools: [ref({})]}}, {agent: {tools: []}}).find(
-            (s) => s.id === "tools",
+        const section = classifyAgentChanges(
+            {agent: {tools: [ref({})]}},
+            {agent: {tools: []}},
+        ).find((s) => s.id === "subagents")
+        expect(section?.items?.[0]).toMatchObject({label: "dev-to-article-writer"})
+    })
+
+    it("keeps real tools and subagents in separate sections", () => {
+        const fn = {function: {name: "send_email", parameters: {}}}
+        const sections = classifyAgentChanges(
+            {agent: {tools: [fn, ref({name: "Writer"})]}},
+            {agent: {tools: []}},
         )
-        expect(tools?.items?.[0]).toMatchObject({label: "dev-to-article-writer"})
+        expect(sections.find((s) => s.id === "tools")?.items?.map((i) => i.label)).toEqual([
+            "Send email",
+        ])
+        expect(sections.find((s) => s.id === "subagents")?.items?.map((i) => i.label)).toEqual([
+            "Writer",
+        ])
+    })
+
+    it("counts subagents as subagents in the commit message", () => {
+        const sections = classifyAgentChanges(
+            {agent: {tools: [ref({name: "Writer"})]}},
+            {agent: {tools: []}},
+        )
+        expect(buildCommitSummaryMessage(sections)).toBe("Added 1 subagent.")
     })
 
     it("shows WHAT changed when a subagent's description is edited", () => {
@@ -125,7 +151,8 @@ describe("subagents are named and described like every other tool", () => {
         const after = {
             agent: {tools: [ref({name: "Writer", description: "Writes and publishes."})]},
         }
-        const item = classifyAgentChanges(after, before).find((s) => s.id === "tools")?.items?.[0]
+        const item = classifyAgentChanges(after, before).find((s) => s.id === "subagents")
+            ?.items?.[0]
         expect(item?.kind).toBe("edited")
         expect(item?.descriptionDiff).toEqual({
             before: "Writes drafts.",
@@ -305,9 +332,9 @@ describe("classifyAgentChanges", () => {
         // "Reference a workflow"; normalizeTool used to drop them → invisible in the Tools diff.
         const remote = {agent: {tools: []}}
         const local = {agent: {tools: [{type: "reference", slug: "sub-workflow"}]}}
-        const tools = classifyAgentChanges(local, remote).find((s) => s.id === "tools")
-        expect(tools?.tags).toContainEqual({kind: "added", label: "1 added"})
-        expect(tools?.items?.[0]).toMatchObject({
+        const section = classifyAgentChanges(local, remote).find((s) => s.id === "subagents")
+        expect(section?.tags).toContainEqual({kind: "added", label: "1 added"})
+        expect(section?.items?.[0]).toMatchObject({
             kind: "added",
             label: "sub-workflow",
             rawKey: "sub-workflow",
@@ -317,8 +344,8 @@ describe("classifyAgentChanges", () => {
     it("agent-template: editing a reference tool (no function fields) still registers", () => {
         const remote = {agent: {tools: [{type: "reference", slug: "wf", version: "1"}]}}
         const local = {agent: {tools: [{type: "reference", slug: "wf", version: "2"}]}}
-        const tools = classifyAgentChanges(local, remote).find((s) => s.id === "tools")
-        expect(tools?.items?.[0]).toMatchObject({kind: "edited", rawKey: "wf"})
+        const section = classifyAgentChanges(local, remote).find((s) => s.id === "subagents")
+        expect(section?.items?.[0]).toMatchObject({kind: "edited", rawKey: "wf"})
     })
 
     it("classifier: nameless builtin tools are diffed too (prompt playground / legacy)", () => {

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -91,9 +91,7 @@ describe("readAgentConfig — three schema shapes normalize to one view", () => 
 })
 
 describe("subagents are named and described like every other tool", () => {
-    // A subagent is stored as a `type:"reference"` tool. The diff named it by its SLUG and threw
-    // its description away, so a reader saw a handle where the config panel shows a name, and an
-    // edited description registered as a change with nothing to show.
+    // Regression: named by slug, description dropped, so an edited description showed nothing.
     const ref = (over: Record<string, unknown>) => ({
         type: "reference",
         ref_by: "variant",
@@ -137,9 +135,7 @@ describe("subagents are named and described like every other tool", () => {
 })
 
 describe("advanced settings read as settings, not as JSON paths", () => {
-    // Regression: the row printed the storage path and the stored enum verbatim —
-    // `runner.permissions.default  allow → allow_reads` — which says nothing to a reader who has
-    // not seen the schema.
+    // Regression: the row printed the storage path and the stored enum verbatim.
     const advanced = (params: Record<string, unknown>) =>
         classifyAgentChanges({agent: params}, {agent: {}})?.find((s) => s.id === "params")
 
@@ -178,9 +174,7 @@ describe("advanced settings read as settings, not as JSON paths", () => {
 })
 
 describe("gateway tools are named by what they DO, not by their discriminator", () => {
-    // Regression: canonical gateway tools carry no `function.name`, so they fell through to the
-    // bare-type fallback and every one of them rendered as "Gateway" / "Gateway connection" —
-    // a diff that told the reader nothing about which tool was added or removed.
+    // Regression: no `function.name`, so every gateway tool rendered as its discriminator.
     const config = (tools: unknown[]) => readAgentConfig({agent: {tools}})
 
     it("names a canonical gateway action, and drops the integration prefix", () => {

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -196,6 +196,43 @@ describe("an edited skill shows its prose, the way Instructions does", () => {
     })
 })
 
+describe("renaming a skill in place is an edit, not a swap", () => {
+    // Regression: identity is the name, so a rename read as "1 added, 1 removed" and the body
+    // diff behind it was never computed — exactly the change you most want to see.
+    const skill = (over: Record<string, unknown>) => ({
+        name: "stop-slop-1",
+        description: "Trims slop",
+        body: "Cut the filler.",
+        ...over,
+    })
+    const item = (local: unknown, remote: unknown) =>
+        classifyAgentChanges({agent: {skills: [local]}}, {agent: {skills: [remote]}})?.find(
+            (s) => s.id === "skills",
+        )
+
+    it("pairs the rename and diffs the body behind it", () => {
+        const section = item(
+            skill({name: "stop-slop-2", body: "Cut every filler word."}),
+            skill({}),
+        )
+
+        expect(section?.tags).toEqual([{kind: "edited", label: "1 edited"}])
+        expect(section?.items?.[0].label).toBe("stop-slop-1 → stop-slop-2")
+        expect(section?.items?.[0].detail).toBe("name & instructions changed")
+        expect(section?.items?.[0].textDiff?.hunks.some((h) => h.type === "added")).toBe(true)
+    })
+
+    it("leaves a genuine add and remove alone when they sit in different slots", () => {
+        const sections = classifyAgentChanges(
+            {agent: {skills: [skill({}), skill({name: "extra", body: "New one."})]}},
+            {agent: {skills: [skill({})]}},
+        ).find((s) => s.id === "skills")
+
+        expect(sections?.tags).toEqual([{kind: "added", label: "1 added"}])
+        expect(sections?.items?.map((i) => i.label)).toEqual(["extra"])
+    })
+})
+
 describe("permission rules read as rules, not as JSON", () => {
     // Regression: the row printed `Harness › permissions › allow  —  ["Bash"]`.
     const row = (local: Record<string, unknown>, remote: Record<string, unknown>) =>

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -196,6 +196,47 @@ describe("an edited skill shows its prose, the way Instructions does", () => {
     })
 })
 
+describe('an edited tool names what moved, never a bare "changed"', () => {
+    const fn = (over: Record<string, unknown>) => ({
+        function: {name: "send_email", description: "Sends mail", parameters: {}, ...over},
+    })
+    const row = (local: unknown, remote: unknown) =>
+        classifyAgentChanges({agent: {tools: [local]}}, {agent: {tools: [remote]}})?.find(
+            (s) => s.id === "tools",
+        )?.items?.[0]
+
+    it("names a single changed parameter instead of counting it", () => {
+        const item = row(
+            fn({parameters: {properties: {to: {type: "string"}}}}),
+            fn({parameters: {properties: {}}}),
+        )
+        expect(item?.detail).toBe("to changed")
+    })
+
+    it("still counts once there are several", () => {
+        const item = row(
+            fn({parameters: {properties: {to: {type: "string"}, cc: {type: "string"}}}}),
+            fn({parameters: {properties: {}}}),
+        )
+        expect(item?.detail).toBe("2 parameters changed")
+    })
+
+    it("names a field on a builtin tool, which has no parameters at all", () => {
+        // Regression: only the whole-entry fingerprint caught these, so the row said "changed".
+        const item = row({type: "web_search", max_uses: 5}, {type: "web_search", max_uses: 2})
+        // The stored key verbatim: it is what the tool form shows, and parameters read the same way.
+        expect(item?.detail).toBe("max_uses changed")
+    })
+
+    it("names a subagent's version, not just that something moved", () => {
+        const item = classifyAgentChanges(
+            {agent: {tools: [{type: "reference", slug: "writer", version: "2"}]}},
+            {agent: {tools: [{type: "reference", slug: "writer", version: "1"}]}},
+        )?.find((s) => s.id === "subagents")?.items?.[0]
+        expect(item?.detail).toBe("version changed")
+    })
+})
+
 describe("an integration's permission change says what it became", () => {
     // Regression: the row read "Composio search · changed" for every policy edit — the fingerprint
     // caught it, but nothing described it, so the diff carried no information.

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -271,6 +271,63 @@ describe("renaming a skill in place is an edit, not a swap", () => {
     })
 })
 
+describe("a sweep of every change kind — the rows that carried no information", () => {
+    const base = {
+        instructions: {agents_md: "Hello."},
+        llm: {model: "gpt-5"},
+        tools: [],
+        mcps: [],
+        skills: [],
+        harness: {kind: "claude"},
+        runner: {permissions: {default: "allow_reads"}},
+        sandbox: {kind: "local"},
+    }
+    const advanced = (over: Record<string, unknown>) =>
+        classifyAgentChanges({agent: {...base, ...over}}, {agent: base})?.find(
+            (s) => s.id === "params",
+        )?.scalarChanges
+
+    it("reports a key the classifier was never taught, rather than dropping it", () => {
+        // The worst failure mode: an unmapped key changed and the diff said nothing at all.
+        const changes = advanced({telemetry: {enabled: true}})
+        expect(changes?.[0].label).toBe("Telemetry › enabled")
+        expect(changes?.[0].afterLabel).toBe("On")
+    })
+
+    it("reads an object setting as prose instead of its JSON", () => {
+        expect(
+            advanced({retry_policy: {max_attempts: 3, backoff: "exponential"}})?.[0].afterLabel,
+        ).toBe("max attempts: 3, backoff: exponential")
+    })
+
+    it("names the sandbox fields and their modes the way the control does", () => {
+        const changes = advanced({
+            sandbox: {kind: "local", permissions: {network: {mode: "off"}, filesystem: "readonly"}},
+        })
+        expect(changes?.map((c) => `${c.label}: ${c.afterLabel}`)).toEqual([
+            "Filesystem: Read-only",
+            "Network egress: Block all egress",
+        ])
+    })
+
+    it("spells out the harness permission mode", () => {
+        const changes = advanced({
+            harness: {kind: "claude", permissions: {default_mode: "acceptEdits"}},
+        })
+        expect(changes?.[0].label).toBe("Permission mode")
+        expect(changes?.[0].afterLabel).toBe("Accept edits")
+    })
+
+    it("names the field an MCP server changed — it has no prose to diff", () => {
+        const mcp = (url: string) => ({name: "linear", url})
+        const item = classifyAgentChanges(
+            {agent: {...base, mcps: [mcp("https://other")]}},
+            {agent: {...base, mcps: [mcp("https://mcp.linear.app")]}},
+        )?.find((s) => s.id === "mcps")?.items?.[0]
+        expect(item?.detail).toBe("url changed")
+    })
+})
+
 describe("permission rules read as rules, not as JSON", () => {
     // Regression: the row printed `Harness › permissions › allow  —  ["Bash"]`.
     const row = (local: Record<string, unknown>, remote: Record<string, unknown>) =>

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -475,8 +475,8 @@ describe("classifyAgentChanges", () => {
         })
     })
 
-    it("agent-template: llm connection-mode change lands in Model & harness, not Advanced", () => {
-        // Connection-mode selection lives in the Model & harness drawer now, so its diff must
+    it("agent-template: llm connection-mode change lands in Model, not Advanced", () => {
+        // Connection-mode selection lives in the Model drawer now, so its diff must
         // classify there — not in Advanced (which would show it under the wrong section).
         const remote = {
             agent: {llm: {model: "opus", provider: "anthropic", connection: {mode: "agenta"}}},
@@ -490,7 +490,7 @@ describe("classifyAgentChanges", () => {
         // No params changed → no Advanced section.
         expect(sections.find((s) => s.id === "params")).toBeUndefined()
         const modelHarness = sections.find((s) => s.id === "model")
-        expect(modelHarness?.title).toBe("Model & harness")
+        expect(modelHarness?.title).toBe("Model")
         expect(modelHarness?.scalarChanges).toContainEqual({
             key: "llm.connection.mode",
             label: "Connection mode",
@@ -502,7 +502,7 @@ describe("classifyAgentChanges", () => {
         })
     })
 
-    it("agent-template: a model-only change stays in Model & harness (no Advanced leak)", () => {
+    it("agent-template: a model-only change stays in Model (no Advanced leak)", () => {
         const remote = {agent: {llm: {model: "opus", provider: "anthropic"}}}
         const local = {agent: {llm: {model: "opus[1m]", provider: "anthropic"}}}
         const sections = classifyAgentChanges(local, remote)
@@ -526,12 +526,12 @@ describe("classifyAgentChanges", () => {
         expect(advanced?.scalarChanges?.map((c) => c.key)).toEqual(["runner.kind", "sandbox.kind"])
     })
 
-    it("agent-template: harness kind change lands in Model & harness", () => {
+    it("agent-template: harness kind change lands in Model", () => {
         const remote = {agent: {harness: {kind: "pi_core"}, llm: {model: "gpt-4o"}}}
         const local = {agent: {harness: {kind: "claude"}, llm: {model: "gpt-4o"}}}
         const sections = classifyAgentChanges(local, remote)
         const mh = sections.find((s) => s.id === "model")
-        expect(mh?.title).toBe("Model & harness")
+        expect(mh?.title).toBe("Model")
         expect(mh?.scalarChanges).toContainEqual({
             key: "harness.kind",
             label: "Harness",
@@ -642,7 +642,7 @@ describe("buildCommitSummaryMessage", () => {
                 llm_config: {model: "claude-opus-4-8", tools: [tool("gmail_send")]},
             },
         }
-        // Ordered to mirror the config panel: Model & harness, Instructions, …, Tools.
+        // Ordered to mirror the config panel: Model, Instructions, …, Tools.
         const msg = buildCommitSummaryMessage(classifyAgentChanges(local, base))
         expect(msg).toBe(
             "Changed the model to claude-opus-4-8, edited the instructions, and added 1 tool.",

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -90,6 +90,77 @@ describe("readAgentConfig — three schema shapes normalize to one view", () => 
     })
 })
 
+describe("gateway tools are named by what they DO, not by their discriminator", () => {
+    // Regression: canonical gateway tools carry no `function.name`, so they fell through to the
+    // bare-type fallback and every one of them rendered as "Gateway" / "Gateway connection" —
+    // a diff that told the reader nothing about which tool was added or removed.
+    const config = (tools: unknown[]) => readAgentConfig({agent: {tools}})
+
+    it("names a canonical gateway action, and drops the integration prefix", () => {
+        const [t] = config([
+            {
+                type: "gateway",
+                provider: "composio",
+                integration: "gmail",
+                action: "GMAIL_ADD_LABEL",
+                connection: "b81",
+            },
+        ]).tools
+        expect(t.label).toBe("Add label")
+        expect(t.source).toBe("Gmail")
+        // The technical key stays reachable for the detail view.
+        expect(t.rawKey).toBe("GMAIL_ADD_LABEL")
+    })
+
+    it("names an integration entry after the app it connects", () => {
+        const [t] = config([
+            {
+                type: "gateway_connection",
+                connection: {provider: "composio", integration: "gmail", slug: "gmail-work"},
+            },
+        ]).tools
+        expect(t.label).toBe("Gmail")
+        expect(t.source).toBe("Integration")
+    })
+
+    it("gives the legacy slug encoding the same name as the canonical one", () => {
+        const [legacy] = config([
+            {function: {name: "tools__composio__gmail__GMAIL_ADD_LABEL__b81"}},
+        ]).tools
+        expect(legacy.label).toBe("Add label")
+        expect(legacy.source).toBe("Gmail")
+    })
+
+    it("reports which tool changed, not just that a tool changed", () => {
+        const before = {
+            agent: {
+                tools: [
+                    {
+                        type: "gateway",
+                        integration: "gmail",
+                        action: "GMAIL_ADD_LABEL",
+                        connection: "b81",
+                    },
+                ],
+            },
+        }
+        const after = {
+            agent: {
+                tools: [
+                    {
+                        type: "gateway",
+                        integration: "gmail",
+                        action: "GMAIL_SEND_EMAIL",
+                        connection: "b81",
+                    },
+                ],
+            },
+        }
+        const tools = classifyAgentChanges(after, before).find((s) => s.id === "tools")
+        expect(tools?.items?.map((i) => i.label).sort()).toEqual(["Add label", "Send email"])
+    })
+})
+
 describe("classifyAgentChanges", () => {
     const base = {
         prompt: {

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -275,6 +275,50 @@ describe("an integration's permission change says what it became", () => {
     })
 })
 
+describe("an added or removed skill shows what it contains", () => {
+    const skill = (over: Record<string, unknown> = {}) => ({
+        name: "stop-slop",
+        description: "Trims filler from replies",
+        body: "Cut the filler.\nBe direct.",
+        ...over,
+    })
+    const section = (local: unknown[], remote: unknown[]) =>
+        classifyAgentChanges({agent: {skills: local}}, {agent: {skills: remote}})?.find(
+            (s) => s.id === "skills",
+        )
+
+    it("renders an added skill's body as an all-added diff, with its description on the row", () => {
+        const item = section([skill()], [])?.items?.[0]
+
+        expect(item?.detail).toBe("Trims filler from replies")
+        expect(item?.textDiff?.hunks.map((h) => h.type)).toEqual(["added", "added"])
+        expect(item?.textDiff?.added).toBe(2)
+    })
+
+    it("renders a removed skill's body as an all-removed diff", () => {
+        const item = section([], [skill()])?.items?.[0]
+        expect(item?.textDiff?.hunks.every((h) => h.type === "removed")).toBe(true)
+    })
+
+    it("caps a long body and says how much it hid", () => {
+        const body = Array.from({length: 30}, (_, i) => `line ${i}`).join("\n")
+        const item = section([skill({body})], [])?.items?.[0]
+
+        expect(item?.textDiff?.hunks).toHaveLength(13)
+        expect(item?.textDiff?.hunks[12]).toEqual({type: "fold", content: "… 18 more lines"})
+        // The counts stay true even though the render is capped.
+        expect(item?.textDiff?.added).toBe(30)
+    })
+
+    it("leaves an entry with no body alone", () => {
+        const item = classifyAgentChanges(
+            {agent: {mcps: [{name: "linear", url: "https://mcp.linear.app"}]}},
+            {agent: {mcps: []}},
+        )?.find((s) => s.id === "mcps")?.items?.[0]
+        expect(item?.textDiff).toBeUndefined()
+    })
+})
+
 describe("renaming a skill in place is an edit, not a swap", () => {
     // Regression: identity is the name, so a rename read as "1 added, 1 removed" and the body
     // diff behind it was never computed — exactly the change you most want to see.

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -90,6 +90,52 @@ describe("readAgentConfig — three schema shapes normalize to one view", () => 
     })
 })
 
+describe("subagents are named and described like every other tool", () => {
+    // A subagent is stored as a `type:"reference"` tool. The diff named it by its SLUG and threw
+    // its description away, so a reader saw a handle where the config panel shows a name, and an
+    // edited description registered as a change with nothing to show.
+    const ref = (over: Record<string, unknown>) => ({
+        type: "reference",
+        ref_by: "variant",
+        slug: "dev-to-article-writer",
+        ...over,
+    })
+
+    it("uses the subagent's name, and says what kind of thing it is", () => {
+        const tools = classifyAgentChanges(
+            {agent: {tools: [ref({name: "Article writer"})]}},
+            {agent: {tools: []}},
+        ).find((s) => s.id === "tools")
+        expect(tools?.items?.[0]).toMatchObject({
+            kind: "added",
+            label: "Article writer",
+            detail: "Subagent",
+            // The slug stays reachable as the technical key.
+            rawKey: "dev-to-article-writer",
+        })
+    })
+
+    it("falls back to the slug when the reference carries no name", () => {
+        const tools = classifyAgentChanges({agent: {tools: [ref({})]}}, {agent: {tools: []}}).find(
+            (s) => s.id === "tools",
+        )
+        expect(tools?.items?.[0]).toMatchObject({label: "dev-to-article-writer"})
+    })
+
+    it("shows WHAT changed when a subagent's description is edited", () => {
+        const before = {agent: {tools: [ref({name: "Writer", description: "Writes drafts."})]}}
+        const after = {
+            agent: {tools: [ref({name: "Writer", description: "Writes and publishes."})]},
+        }
+        const item = classifyAgentChanges(after, before).find((s) => s.id === "tools")?.items?.[0]
+        expect(item?.kind).toBe("edited")
+        expect(item?.descriptionDiff).toEqual({
+            before: "Writes drafts.",
+            after: "Writes and publishes.",
+        })
+    })
+})
+
 describe("advanced settings read as settings, not as JSON paths", () => {
     // Regression: the row printed the storage path and the stored enum verbatim —
     // `runner.permissions.default  allow → allow_reads` — which says nothing to a reader who has

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -161,6 +161,29 @@ describe("subagents get their own section, named the way the config panel names 
     })
 })
 
+describe("the tools section is named the way its own playground names it", () => {
+    const one = (params: Record<string, unknown>, before: Record<string, unknown>) =>
+        classifyAgentChanges(params, before).find((s) => s.id === "tools")
+
+    it("calls them Integrations for an agent template, matching the config panel", () => {
+        const section = one(
+            {agent: {tools: [{function: {name: "send_email", parameters: {}}}]}},
+            {agent: {tools: []}},
+        )
+        expect(section?.title).toBe("Integrations")
+        expect(buildCommitSummaryMessage(section ? [section] : [])).toBe("Added 1 integration.")
+    })
+
+    it("keeps them Tools for a prompt variant, which has no integrations", () => {
+        const section = one(
+            {prompt: {llm_config: {tools: [{type: "web_search"}]}}},
+            {prompt: {llm_config: {tools: []}}},
+        )
+        expect(section?.title).toBe("Tools")
+        expect(buildCommitSummaryMessage(section ? [section] : [])).toBe("Added 1 tool.")
+    })
+})
+
 describe("advanced settings read as settings, not as JSON paths", () => {
     // Regression: the row printed the storage path and the stored enum verbatim.
     const advanced = (params: Record<string, unknown>) =>

--- a/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-commit-diff.test.ts
@@ -161,6 +161,41 @@ describe("subagents get their own section, named the way the config panel names 
     })
 })
 
+describe("an edited skill shows its prose, the way Instructions does", () => {
+    const skill = (over: Record<string, unknown>) => ({
+        name: "build-an-agent",
+        description: "Builds an agent",
+        body: "Step one.\nStep two.",
+        ...over,
+    })
+    const skillsFor = (local: unknown, remote: unknown) =>
+        classifyAgentChanges({agent: {skills: [local]}}, {agent: {skills: [remote]}})?.find(
+            (s) => s.id === "skills",
+        )?.items?.[0]
+
+    it("diffs the body into hunks instead of leaving a bare edited mark", () => {
+        const item = skillsFor(skill({body: "Step one.\nStep two, revised."}), skill({}))
+
+        expect(item?.kind).toBe("edited")
+        expect(item?.detail).toBe("instructions changed")
+        expect(item?.textDiff?.hunks.some((h) => h.type === "added")).toBe(true)
+        expect(item?.textDiff?.hunks.some((h) => h.type === "removed")).toBe(true)
+    })
+
+    it("names a description-only edit without inventing a body diff", () => {
+        const item = skillsFor(skill({description: "Builds agents faster"}), skill({}))
+
+        expect(item?.detail).toBe("description changed")
+        expect(item?.textDiff).toBeUndefined()
+    })
+
+    it("reports both when the description and the body move together", () => {
+        const item = skillsFor(skill({description: "New", body: "Different."}), skill({}))
+        expect(item?.detail).toBe("description & instructions changed")
+        expect(item?.textDiff).toBeDefined()
+    })
+})
+
 describe("permission rules read as rules, not as JSON", () => {
     // Regression: the row printed `Harness › permissions › allow  —  ["Bash"]`.
     const row = (local: Record<string, unknown>, remote: Record<string, unknown>) =>

--- a/web/packages/agenta-entities/tests/unit/latest-workflow-revision.test.ts
+++ b/web/packages/agenta-entities/tests/unit/latest-workflow-revision.test.ts
@@ -1,0 +1,45 @@
+/**
+ * Which revision counts as "latest".
+ *
+ * This used to be decided by `created_at`, with `version` reachable only when every timestamp was
+ * missing. Revisions an agent commits itself land in bursts that tie to the second, and the picker
+ * compared with a strict `>`, so a tie kept whichever revision the API happened to return first —
+ * an arbitrary one. The wrong answer then stuck: it is written to the `latestRevision` query key,
+ * mirrored to IndexedDB, and that query is disabled whenever the key already holds a value, so
+ * nothing ever revalidated it. The playground opened on a stale revision for good.
+ *
+ * `version` is server-assigned and monotonic. It decides; timestamps only break ties within a
+ * version.
+ */
+import {describe, expect, it} from "vitest"
+
+import {isLaterWorkflowRevision} from "../../src/workflow/state/store"
+
+const rev = (version: number, created_at?: string | null) =>
+    ({id: `r${version}`, version, created_at: created_at ?? null}) as never
+
+describe("isLaterWorkflowRevision", () => {
+    it("prefers the higher version even when the older one has a newer timestamp", () => {
+        const v13 = rev(13, "2026-01-01T10:00:00Z")
+        const v10 = rev(10, "2026-01-01T11:00:00Z")
+        expect(isLaterWorkflowRevision(v13, v10)).toBe(true)
+        expect(isLaterWorkflowRevision(v10, v13)).toBe(false)
+    })
+
+    it("does not let a timestamp tie decide by array order", () => {
+        const sameInstant = "2026-01-01T10:00:00Z"
+        expect(isLaterWorkflowRevision(rev(13, sameInstant), rev(12, sameInstant))).toBe(true)
+        expect(isLaterWorkflowRevision(rev(12, sameInstant), rev(13, sameInstant))).toBe(false)
+    })
+
+    it("falls back to recency only when versions match", () => {
+        expect(
+            isLaterWorkflowRevision(rev(7, "2026-01-02T00:00:00Z"), rev(7, "2026-01-01T00:00:00Z")),
+        ).toBe(true)
+    })
+
+    it("treats a missing incumbent as beatable and a missing candidate as not", () => {
+        expect(isLaterWorkflowRevision(rev(1), null)).toBe(true)
+        expect(isLaterWorkflowRevision(null, rev(1))).toBe(false)
+    })
+})

--- a/web/packages/agenta-entity-ui/package.json
+++ b/web/packages/agenta-entity-ui/package.json
@@ -17,6 +17,7 @@
         ".": "./src/index.ts",
         "./adapters": "./src/adapters/index.ts",
         "./agent": "./src/agent/index.ts",
+        "./changes": "./src/changes/index.ts",
         "./drawers/shared": "./src/drawers/shared/index.ts",
         "./drill-in": "./src/DrillInView/index.ts",
         "./gatewayTool": "./src/gatewayTool/index.ts",

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -113,10 +113,6 @@ const INVALID_ITEM_TIP: Record<ItemKind, string> = {
     mcp: "This server is missing its name or URL.",
     skill: "This skill is missing its name.",
 }
-/** The schema field a section's change marks come from. Integrations and Subagents share `tools`. */
-const changeFieldFor = (sectionKey: string): string =>
-    sectionKey === "subagents" ? "tools" : sectionKey
-
 const DRAFT_TIP: Record<string, string> = {
     "model-harness": "Unsaved model or harness changes.",
     instructions: "Unsaved instruction changes.",
@@ -367,8 +363,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
     const agentChangedKeys = sectionChanges.agent?.panelKeys ?? null
     const agentChangeIndicator = useCallback(
         (sectionKey: string) => {
-            if (!agentChangedKeys?.has(changeFieldFor(sectionKey) as PanelSectionKey))
-                return undefined
+            if (!agentChangedKeys?.has(sectionKey as PanelSectionKey)) return undefined
             const version = sectionChanges.agentVersion
             return {
                 tone: "agent" as const,
@@ -821,7 +816,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
         if (invalid) return {tone: "invalid", tooltip: invalid}
         const incomplete = sectionIncompleteTip(key)
         if (incomplete) return {tone: "incomplete", tooltip: incomplete}
-        if (draftSectionKeys.has(changeFieldFor(key) as PanelSectionKey))
+        if (draftSectionKeys.has(key as PanelSectionKey))
             return {
                 tone: "draft",
                 tooltip: DRAFT_TIP[key] ?? "Unsaved changes.",

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/sectionChanges.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/sectionChanges.ts
@@ -38,6 +38,7 @@ export type PanelSectionKey =
     | "model-harness"
     | "instructions"
     | "tools"
+    | "subagents"
     | "mcp"
     | "skills"
     | "advanced"
@@ -51,6 +52,7 @@ export const SECTION_ID_TO_PANEL_KEY: Record<SectionId, PanelSectionKey> = {
     model: "model-harness",
     instructions: "instructions",
     tools: "tools",
+    subagents: "subagents",
     mcps: "mcp",
     skills: "skills",
     params: "advanced",

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/permissionPolicy.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/permissionPolicy.ts
@@ -5,45 +5,16 @@
  * so both offer the same four policies under the same names — the palette is a shortcut to the
  * drawer's control, not a second opinion about what the policies are.
  */
-export type PermissionPolicy = "allow_reads" | "allow" | "ask" | "deny"
+import {permissionPolicyOptionsForEnum, type PermissionPolicyOption} from "@agenta/shared/utils"
 
-export interface PermissionPolicyOption {
-    value: PermissionPolicy
-    label: string
-    help: string
-}
-
-export const PERMISSION_POLICY_OPTIONS: PermissionPolicyOption[] = [
-    {value: "allow_reads", label: "Allow reads", help: "Reads run, writes ask; default"},
-    {value: "allow", label: "Allow all", help: "Every tool runs without asking"},
-    {value: "ask", label: "Ask", help: "A human approves every tool call"},
-    {value: "deny", label: "Deny all", help: "Every tool call is refused"},
-]
-
-/** What the runner applies when the template names no policy. */
-export const DEFAULT_PERMISSION_POLICY: PermissionPolicy = "allow_reads"
-
-const PERMISSION_POLICY_VALUES = new Set<string>(
-    PERMISSION_POLICY_OPTIONS.map((option) => option.value),
-)
-
-export function isPermissionPolicy(value: unknown): value is PermissionPolicy {
-    return typeof value === "string" && PERMISSION_POLICY_VALUES.has(value)
-}
-
-export const permissionPolicyLabel = (value: string | null | undefined): string | undefined =>
-    PERMISSION_POLICY_OPTIONS.find((option) => option.value === value)?.label
-
-/**
- * The options a schema `enum` permits, or all of them when it names none. Every surface offering
- * policies goes through this — one that offered a value the schema forbids would write a draft
- * config the agent's own schema rejects.
- */
-export function permissionPolicyOptionsForEnum(values: unknown): PermissionPolicyOption[] {
-    if (!Array.isArray(values)) return PERMISSION_POLICY_OPTIONS
-    const allowed = new Set(values.filter(isPermissionPolicy))
-    return PERMISSION_POLICY_OPTIONS.filter((option) => allowed.has(option.value))
-}
+export {
+    DEFAULT_PERMISSION_POLICY,
+    PERMISSION_POLICY_OPTIONS,
+    isPermissionPolicy,
+    permissionPolicyLabel,
+    permissionPolicyOptionsForEnum,
+} from "@agenta/shared/utils"
+export type {PermissionPolicy, PermissionPolicyOption} from "@agenta/shared/utils"
 
 const asRecord = (value: unknown): Record<string, unknown> | null =>
     value && typeof value === "object" && !Array.isArray(value)

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -183,7 +183,9 @@ export function HunkRows({
                         className={cn("flex", padX, line.type === "context" && textColors.tertiary)}
                         style={style}
                     >
-                        <span className="w-3.5 shrink-0 opacity-70">
+                        {/* Content can start with its own "-" (a Markdown bullet), so the gutter
+                            needs a visible step or the two read as one doubled marker. */}
+                        <span className="mr-2 w-2 shrink-0 opacity-60">
                             {isAdd ? "+" : isDel ? "−" : " "}
                         </span>
                         <span className="whitespace-pre-wrap break-words">{line.content}</span>

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -205,22 +205,26 @@ function ItemRow({
 }) {
     const clickable = it.kind === "edited" && !!onOpenTool
     return (
-        <Row
-            clickable={clickable}
-            onActivate={clickable ? () => onOpenTool?.(it.id) : undefined}
-            className={cn("flex w-full items-center gap-2.5 py-1.5 text-left", padX)}
-        >
-            <span style={kindStyle(it.kind)} className="flex w-4 shrink-0 justify-center">
-                {kindIcon(it.kind)}
-            </span>
-            <span className="min-w-0 flex-1 truncate text-xs">
-                {it.label}
-                {it.detail ? (
-                    <span className={cn("ml-1", textColors.tertiary)}>· {it.detail}</span>
-                ) : null}
-            </span>
-            {clickable ? <CaretRight className={textColors.tertiary} /> : null}
-        </Row>
+        <>
+            <Row
+                clickable={clickable}
+                onActivate={clickable ? () => onOpenTool?.(it.id) : undefined}
+                className={cn("flex w-full items-center gap-2.5 py-1.5 text-left", padX)}
+            >
+                <span style={kindStyle(it.kind)} className="flex w-4 shrink-0 justify-center">
+                    {kindIcon(it.kind)}
+                </span>
+                <span className="min-w-0 flex-1 truncate text-xs">
+                    {it.label}
+                    {it.detail ? (
+                        <span className={cn("ml-1", textColors.tertiary)}>· {it.detail}</span>
+                    ) : null}
+                </span>
+                {clickable ? <CaretRight className={textColors.tertiary} /> : null}
+            </Row>
+            {/* A skill's body is prose, so it reads as a diff rather than as an "edited" mark. */}
+            {it.textDiff ? <HunkRows hunks={it.textDiff.hunks} padX={padX} /> : null}
+        </>
     )
 }
 

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -38,11 +38,9 @@ import {
 
 /** Inline text-diff rows before the "View full diff" link takes over. */
 export const INLINE_TEXT_DIFF_LINES = 6
-/** Row inset inside a card body. Ghost bleeds instead, so its rows carry the smaller one. */
+/** Row inset inside a card body; ghost sits on a tighter one, its band filling the pane's width. */
 const ROW_PAD = "px-3.5"
 const GHOST_ROW_PAD = "px-2"
-/** How far a ghost band bleeds past the pane's content box, on both sides. */
-const GHOST_BLEED = "-mx-2"
 const SUBGROUP_VISIBLE = 5
 const VIRTUALIZE_AT = 50
 
@@ -320,8 +318,8 @@ export function SectionCard({
     ghost?: boolean
 }) {
     const toolItems = items ?? section.items
-    // Ghost bleeds its band outward, so its rows inset by the same amount to land back on the
-    // pane's content line — one left edge for the heading, the header band and every row.
+    // Ghost bands fill the pane's box and pad inward, so nothing relies on a negative margin —
+    // one bled outward gets clipped by the collapse wrapper's overflow-hidden.
     const rowPad = ghost ? GHOST_ROW_PAD : ROW_PAD
     // Split frame per DetailCard; each header sticks only within its own card wrapper.
     return (
@@ -349,7 +347,6 @@ export function SectionCard({
                         // the heading above it — same left edge, no visible inset.
                         ghost
                             ? cn(
-                                  GHOST_BLEED,
                                   GHOST_ROW_PAD,
                                   "rounded-md border-0 bg-[var(--ag-colorFillQuaternary)] hover:bg-[var(--ag-colorFillTertiary)]",
                                   small ? "gap-2 py-2" : "gap-2.5 py-2.5",
@@ -388,7 +385,7 @@ export function SectionCard({
                     className={cn(
                         "overflow-hidden",
                         ghost
-                            ? cn(GHOST_BLEED, "border-0 bg-transparent")
+                            ? "border-0 bg-transparent"
                             : "rounded-b-[10px] border border-t-0 border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]",
                     )}
                 >

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -130,7 +130,7 @@ export function StatusTags({tags, small}: {tags: ChangeSection["tags"]; small?: 
                     key={i}
                     variant={KIND_COLOR[t.kind] ?? "default"}
                     className={cn(
-                        "rounded-full",
+                        "rounded",
                         small ? "px-1.5 text-[12px] leading-[18px]" : "px-2 text-[12px]",
                     )}
                 >

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -372,7 +372,11 @@ export function SectionCard({
                     <span className={cn("flex-1 leading-none", small ? "text-xs" : "text-[13px]")}>
                         {section.title}
                     </span>
-                    <StatusTags tags={section.tags} small={small} />
+                    {/* A scalar section's rows ARE the list of changes, so "N changed" only
+                        counts what is already visible. Lists earn their added/removed counts. */}
+                    {section.scalarChanges ? null : (
+                        <StatusTags tags={section.tags} small={small} />
+                    )}
                     <span
                         className={cn(
                             "inline-flex shrink-0 items-center leading-none",

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -30,6 +30,7 @@ import {
     PencilSimple,
     PlugsConnected,
     Plus,
+    Robot,
     Sparkle,
     SlidersHorizontal,
     Wrench,
@@ -50,6 +51,9 @@ export const CARD =
 /** Keyboard users need to see where focus lands once these rows are real controls. */
 const FOCUS_RING =
     "outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-focus-ring"
+
+/** Sections whose edited rows carry field-level detail worth opening. */
+const DRILLABLE = new Set<ChangeSection["id"]>(["tools", "subagents"])
 
 /** A row that is a button when it does something, and a plain div when it does not. */
 function Row({
@@ -87,6 +91,7 @@ export const LINK_BTN = cn(
 
 export const SECTION_ICON: Record<ChangeSection["id"], React.ReactNode> = {
     tools: <Wrench />,
+    subagents: <Robot />,
     instructions: <ChatText />,
     model: <Cpu />,
     mcps: <PlugsConnected />,
@@ -361,11 +366,11 @@ export function SectionCard({
                             : "rounded-b-[10px] border border-t-0 border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]",
                     )}
                 >
-                    {/* MCPs and Skills carry rows too; only tools have a detail view to open. */}
+                    {/* MCPs and Skills carry rows too; only the tool kinds drill into a detail view. */}
                     {toolItems?.length ? (
                         <CappedItems
                             items={toolItems}
-                            onOpenTool={section.id === "tools" ? onOpenTool : undefined}
+                            onOpenTool={DRILLABLE.has(section.id) ? onOpenTool : undefined}
                         />
                     ) : null}
                     {section.scalarChanges ? <ScalarRows changes={section.scalarChanges} /> : null}

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -47,6 +47,38 @@ const DEL_BG = "color-mix(in srgb, var(--ag-colorError) 13%, transparent)"
 // carry the structure. Avoids stacking two lightening fills (no "darker body" token in dark mode).
 export const CARD =
     "overflow-hidden rounded-[10px] border border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]"
+/** Keyboard users need to see where focus lands once these rows are real controls. */
+const FOCUS_RING =
+    "outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-[-2px] focus-visible:outline-focus-ring"
+
+/** A row that is a button when it does something, and a plain div when it does not. */
+function Row({
+    clickable,
+    onActivate,
+    className,
+    children,
+}: {
+    clickable: boolean
+    onActivate?: () => void
+    className: string
+    children: React.ReactNode
+}) {
+    if (!clickable) return <div className={className}>{children}</div>
+    return (
+        <button
+            type="button"
+            onClick={onActivate}
+            className={cn(
+                className,
+                "cursor-pointer border-0 bg-transparent hover:bg-[var(--ag-colorFillQuaternary)]",
+                FOCUS_RING,
+            )}
+        >
+            {children}
+        </button>
+    )
+}
+
 export const LINK_BTN = cn(
     "inline-flex cursor-pointer items-center gap-1.5 border-0 bg-transparent p-0 transition-colors",
     textColors.secondary,
@@ -151,12 +183,10 @@ export function HunkRows({hunks, limit}: {hunks: ExtendedDiffLine[]; limit?: num
 function ItemRow({it, onOpenTool}: {it: ChangeItem; onOpenTool?: (itemId: string) => void}) {
     const clickable = it.kind === "edited" && !!onOpenTool
     return (
-        <div
-            className={cn(
-                "flex items-center gap-2.5 px-3.5 py-1.5",
-                clickable && "cursor-pointer hover:bg-[var(--ag-colorFillQuaternary)]",
-            )}
-            onClick={clickable ? () => onOpenTool?.(it.id) : undefined}
+        <Row
+            clickable={clickable}
+            onActivate={clickable ? () => onOpenTool?.(it.id) : undefined}
+            className="flex w-full items-center gap-2.5 px-3.5 py-1.5 text-left"
         >
             <span style={kindStyle(it.kind)} className="flex w-4 shrink-0 justify-center">
                 {kindIcon(it.kind)}
@@ -168,7 +198,7 @@ function ItemRow({it, onOpenTool}: {it: ChangeItem; onOpenTool?: (itemId: string
                 ) : null}
             </span>
             {clickable ? <CaretRight className={textColors.tertiary} /> : null}
-        </div>
+        </Row>
     )
 }
 
@@ -279,9 +309,13 @@ export function SectionCard({
                           ),
                 )}
             >
-                <div
+                <button
+                    type="button"
+                    aria-expanded={open}
+                    onClick={onToggle}
                     className={cn(
-                        "flex cursor-pointer items-center transition-colors",
+                        "flex w-full cursor-pointer items-center border-0 text-left font-[inherit] transition-colors",
+                        FOCUS_RING,
                         // Ghost bleeds its fill outward so the icon column still lines up with
                         // the heading above it — same left edge, no visible inset.
                         ghost
@@ -295,7 +329,6 @@ export function SectionCard({
                                   small ? "gap-2 px-2.5 py-1.5" : "gap-2.5 px-3 py-2.5",
                               ),
                     )}
-                    onClick={onToggle}
                 >
                     <span
                         className={cn(
@@ -317,7 +350,7 @@ export function SectionCard({
                     >
                         {open ? <CaretDown /> : <CaretRight />}
                     </span>
-                </div>
+                </button>
             </div>
             <HeightCollapse open={open}>
                 <div
@@ -378,18 +411,20 @@ export function DetailCard({
         <div>
             {/* Solid underlay so scrolled rows don't ghost through the translucent fill. */}
             <div className="sticky top-0 z-[1] rounded-t-[10px] bg-[var(--ag-colorBgContainer)]">
-                <div
+                <button
+                    type="button"
+                    onClick={onCollapse}
                     className={cn(
-                        "flex cursor-pointer items-center rounded-t-[10px] border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] transition-colors",
+                        "flex w-full cursor-pointer items-center rounded-t-[10px] border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] text-left font-[inherit] transition-colors",
+                        FOCUS_RING,
                         small ? "gap-2 px-2.5 py-1.5" : "gap-2.5 px-3 py-2.5",
                     )}
-                    onClick={onCollapse}
                 >
                     {head}
                     <span className={textColors.tertiary}>
                         <CaretDown />
                     </span>
-                </div>
+                </button>
             </div>
             <div className="overflow-hidden rounded-b-[10px] border border-t-0 border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]">
                 {children}

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -23,17 +23,17 @@ import {
     ArrowRight,
     CaretDown,
     CaretRight,
-    ChatText,
     Cpu,
     DotsThree,
+    FileText,
+    GraduationCap,
     Minus,
     PencilSimple,
-    PlugsConnected,
+    Plugs,
     Plus,
+    PuzzlePiece,
     Robot,
-    Sparkle,
     SlidersHorizontal,
-    Wrench,
 } from "@phosphor-icons/react"
 
 /** Inline text-diff rows before the "View full diff" link takes over. */
@@ -89,13 +89,14 @@ export const LINK_BTN = cn(
     "hover:text-[var(--ag-colorText)]",
 )
 
+/** One per config-panel accordion section, so the diff and the panel read as the same thing. */
 export const SECTION_ICON: Record<ChangeSection["id"], React.ReactNode> = {
-    tools: <Wrench />,
+    tools: <PuzzlePiece />,
     subagents: <Robot />,
-    instructions: <ChatText />,
+    instructions: <FileText />,
     model: <Cpu />,
-    mcps: <PlugsConnected />,
-    skills: <Sparkle />,
+    mcps: <Plugs />,
+    skills: <GraduationCap />,
     params: <SlidersHorizontal />,
 }
 

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -221,12 +221,17 @@ function ScalarRows({changes}: {changes: ScalarChange[]}) {
             {changes.map((c) => (
                 <div
                     key={c.key}
-                    className="flex items-center gap-2 px-3.5 py-1.5 font-mono text-xs"
+                    className="flex flex-wrap items-center gap-2 px-3.5 py-1.5 text-xs"
+                    title={c.key}
                 >
-                    <span className={textColors.secondary}>{c.key}</span>
-                    <span style={{color: "var(--ag-colorError)"}}>{c.before ?? "—"}</span>
+                    <span className={textColors.secondary}>{c.label ?? c.key}</span>
+                    <span className="font-mono" style={{color: "var(--ag-colorError)"}}>
+                        {c.beforeLabel ?? c.before ?? "—"}
+                    </span>
                     <ArrowRight className={textColors.tertiary} />
-                    <span style={{color: "var(--ag-colorSuccess)"}}>{c.after ?? "—"}</span>
+                    <span className="font-mono" style={{color: "var(--ag-colorSuccess)"}}>
+                        {c.afterLabel ?? c.after ?? "—"}
+                    </span>
                 </div>
             ))}
         </div>

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -1,0 +1,448 @@
+/**
+ * ChangeSections — the section-grouped rendering of a commit diff, with no editor in the tree.
+ *
+ * Split out of `AgentChangesSummary` so a surface that only needs "what changed" does not pull
+ * `DiffView` (and the whole Lexical code editor behind it) into its bundle. The commit modal
+ * still gets the JSON view and the master → detail drill-in; it wraps this and adds them back.
+ *
+ * Lives at `@agenta/entity-ui/changes`, its own export subpath, so importing it never reaches
+ * `@agenta/entity-ui/modals`. It cannot live in `@agenta/ui`: the `ChangeSection` types come from
+ * `@agenta/entities`, which already imports `@agenta/ui` — the other direction is a cycle.
+ *
+ * Presentational only. Section open state is the caller's, so a host can persist or seed it.
+ */
+import {useState} from "react"
+
+import type {ChangeItem, ChangeSection, ScalarChange} from "@agenta/entities/workflow/commitDiff"
+import {HeightCollapse} from "@agenta/ui/components"
+import {AdaptiveList} from "@agenta/ui/components/selection"
+import type {ExtendedDiffLine} from "@agenta/ui/diff"
+import {cn, textColors} from "@agenta/ui/styles"
+import {Badge, type BadgeProps} from "@agenta/ui/ui"
+import {
+    ArrowRight,
+    CaretDown,
+    CaretRight,
+    ChatText,
+    Cpu,
+    DotsThree,
+    Minus,
+    PencilSimple,
+    PlugsConnected,
+    Plus,
+    Sparkle,
+    SlidersHorizontal,
+    Wrench,
+} from "@phosphor-icons/react"
+
+/** Inline text-diff rows before the "View full diff" link takes over. */
+export const INLINE_TEXT_DIFF_LINES = 6
+const SUBGROUP_VISIBLE = 5
+const VIRTUALIZE_AT = 50
+
+const ADD_BG = "color-mix(in srgb, var(--ag-colorSuccess) 13%, transparent)"
+const DEL_BG = "color-mix(in srgb, var(--ag-colorError) 13%, transparent)"
+
+// One subtle surface for the whole card; header inherits it, the diff tints + open divider
+// carry the structure. Avoids stacking two lightening fills (no "darker body" token in dark mode).
+export const CARD =
+    "overflow-hidden rounded-[10px] border border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]"
+export const LINK_BTN = cn(
+    "inline-flex cursor-pointer items-center gap-1.5 border-0 bg-transparent p-0 transition-colors",
+    textColors.secondary,
+    "hover:text-[var(--ag-colorText)]",
+)
+
+export const SECTION_ICON: Record<ChangeSection["id"], React.ReactNode> = {
+    tools: <Wrench />,
+    instructions: <ChatText />,
+    model: <Cpu />,
+    mcps: <PlugsConnected />,
+    skills: <Sparkle />,
+    params: <SlidersHorizontal />,
+}
+
+const KIND_COLOR: Record<string, BadgeProps["variant"]> = {
+    added: "green",
+    removed: "red",
+    edited: "gold",
+    changed: "gold",
+}
+
+export const kindIcon = (kind: string) => {
+    if (kind === "added") return <Plus />
+    if (kind === "removed") return <Minus />
+    return <PencilSimple />
+}
+
+export const kindStyle = (kind: string) => {
+    if (kind === "added") return {color: "var(--ag-colorSuccess)"}
+    if (kind === "removed") return {color: "var(--ag-colorError)"}
+    return {color: "var(--ag-colorWarning)"}
+}
+
+export function StatusTags({tags, small}: {tags: ChangeSection["tags"]; small?: boolean}) {
+    return (
+        <>
+            {tags.map((t, i) => (
+                <Badge
+                    key={i}
+                    variant={KIND_COLOR[t.kind] ?? "default"}
+                    className={cn(
+                        "rounded-full",
+                        small ? "px-1.5 text-[12px] leading-[18px]" : "px-2 text-[12px]",
+                    )}
+                >
+                    {t.label}
+                </Badge>
+            ))}
+        </>
+    )
+}
+
+/** Diff surface — tinted +/- rows with a sign gutter; long lines wrap. */
+export function HunkRows({hunks, limit}: {hunks: ExtendedDiffLine[]; limit?: number}) {
+    const shown = limit ? hunks.slice(0, limit) : hunks
+    return (
+        <div className="py-2 font-mono text-xs leading-[1.8]">
+            {shown.map((line, i) => {
+                if (line.type === "fold") {
+                    return (
+                        <div key={i} className={cn("px-3.5 italic", textColors.tertiary)}>
+                            {line.content}
+                        </div>
+                    )
+                }
+                const isAdd = line.type === "added"
+                const isDel = line.type === "removed"
+                const style = isAdd
+                    ? {
+                          background: ADD_BG,
+                          boxShadow: "inset 1px 0 0 var(--ag-colorSuccess)",
+                          color: "var(--ag-colorSuccess)",
+                      }
+                    : isDel
+                      ? {
+                            background: DEL_BG,
+                            boxShadow: "inset 1px 0 0 var(--ag-colorError)",
+                            color: "var(--ag-colorError)",
+                        }
+                      : undefined
+                return (
+                    <div
+                        key={i}
+                        className={cn(
+                            "flex px-3.5",
+                            line.type === "context" && textColors.tertiary,
+                        )}
+                        style={style}
+                    >
+                        <span className="w-3.5 shrink-0 opacity-70">
+                            {isAdd ? "+" : isDel ? "−" : " "}
+                        </span>
+                        <span className="whitespace-pre-wrap break-words">{line.content}</span>
+                    </div>
+                )
+            })}
+        </div>
+    )
+}
+
+function ItemRow({it, onOpenTool}: {it: ChangeItem; onOpenTool?: (itemId: string) => void}) {
+    const clickable = it.kind === "edited" && !!onOpenTool
+    return (
+        <div
+            className={cn(
+                "flex items-center gap-2.5 px-3.5 py-1.5",
+                clickable && "cursor-pointer hover:bg-[var(--ag-colorFillQuaternary)]",
+            )}
+            onClick={clickable ? () => onOpenTool?.(it.id) : undefined}
+        >
+            <span style={kindStyle(it.kind)} className="flex w-4 shrink-0 justify-center">
+                {kindIcon(it.kind)}
+            </span>
+            <span className="min-w-0 flex-1 truncate text-xs">
+                {it.label}
+                {it.detail ? (
+                    <span className={cn("ml-1", textColors.tertiary)}>· {it.detail}</span>
+                ) : null}
+            </span>
+            {clickable ? <CaretRight className={textColors.tertiary} /> : null}
+        </div>
+    )
+}
+
+/** A capped list with "Show N more"; virtualizes only when a huge group is fully expanded. */
+function CappedItems({
+    items,
+    onOpenTool,
+}: {
+    items: ChangeItem[]
+    onOpenTool?: (itemId: string) => void
+}) {
+    const [expanded, setExpanded] = useState(false)
+
+    if (expanded && items.length > VIRTUALIZE_AT) {
+        return (
+            <AdaptiveList
+                items={items}
+                maxHeight={320}
+                estimateSize={30}
+                getItemKey={(it) => it.id}
+                renderItem={(it) => <ItemRow it={it} onOpenTool={onOpenTool} />}
+            />
+        )
+    }
+
+    const visible = expanded ? items : items.slice(0, SUBGROUP_VISIBLE)
+    const hidden = items.length - visible.length
+    return (
+        <div className="py-1">
+            {visible.map((it) => (
+                <ItemRow key={it.id} it={it} onOpenTool={onOpenTool} />
+            ))}
+            {hidden > 0 ? (
+                <button
+                    type="button"
+                    className={cn("px-3.5 py-1.5 text-xs", LINK_BTN)}
+                    onClick={() => setExpanded(true)}
+                >
+                    <DotsThree />
+                    Show {hidden} more
+                </button>
+            ) : null}
+        </div>
+    )
+}
+
+function ScalarRows({changes}: {changes: ScalarChange[]}) {
+    return (
+        <div className="py-1">
+            {changes.map((c) => (
+                <div
+                    key={c.key}
+                    className="flex items-center gap-2 px-3.5 py-1.5 font-mono text-xs"
+                >
+                    <span className={textColors.secondary}>{c.key}</span>
+                    <span style={{color: "var(--ag-colorError)"}}>{c.before ?? "—"}</span>
+                    <ArrowRight className={textColors.tertiary} />
+                    <span style={{color: "var(--ag-colorSuccess)"}}>{c.after ?? "—"}</span>
+                </div>
+            ))}
+        </div>
+    )
+}
+
+export function SectionCard({
+    section,
+    items,
+    open,
+    onToggle,
+    onOpenInstructions,
+    onOpenTool,
+    small,
+    hideTags,
+    ghost,
+}: {
+    section: ChangeSection
+    items?: ChangeItem[]
+    open: boolean
+    onToggle: () => void
+    /** Omit to drop the "View full diff" link — the inline hunks are then all there is. */
+    onOpenInstructions?: () => void
+    /** Omit to make edited tools non-clickable (no detail view to drill into). */
+    onOpenTool?: (itemId: string) => void
+    small?: boolean
+    /** Hide the per-section change tags. The count already sits in the pane header. */
+    hideTags?: boolean
+    /** Drop the card fill and border — flat rows separated by a rule, not stacked cards. */
+    ghost?: boolean
+}) {
+    const toolItems = items ?? section.items
+    // Split frame per DetailCard; each header sticks only within its own card wrapper.
+    return (
+        <div className={cn(ghost ? "mb-1" : small ? "mb-1.5" : "mb-2.5")}>
+            {/* Sticky only with the card chrome behind it — a borderless row pinned over the
+                scrolling diff has nothing separating it from the content it covers. */}
+            <div
+                className={cn(
+                    ghost
+                        ? "rounded-md"
+                        : cn(
+                              "sticky top-0 z-[1] bg-[var(--ag-colorBgContainer)]",
+                              open ? "rounded-t-[10px]" : "rounded-[10px]",
+                          ),
+                )}
+            >
+                <div
+                    className={cn(
+                        "flex cursor-pointer items-center transition-colors",
+                        // Ghost bleeds its fill outward so the icon column still lines up with
+                        // the heading above it — same left edge, no visible inset.
+                        ghost
+                            ? cn(
+                                  "-mx-2 rounded-md border-0 bg-[var(--ag-colorFillQuaternary)] px-2 hover:bg-[var(--ag-colorFillTertiary)]",
+                                  small ? "gap-2 py-2" : "gap-2.5 py-2.5",
+                              )
+                            : cn(
+                                  "border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] hover:bg-[var(--ag-colorFillTertiary)]",
+                                  open ? "rounded-t-[10px]" : "rounded-[10px]",
+                                  small ? "gap-2 px-2.5 py-1.5" : "gap-2.5 px-3 py-2.5",
+                              ),
+                    )}
+                    onClick={onToggle}
+                >
+                    <span
+                        className={cn(
+                            "inline-flex w-[18px] shrink-0 items-center justify-center leading-none",
+                            textColors.secondary,
+                        )}
+                    >
+                        {SECTION_ICON[section.id]}
+                    </span>
+                    <span className={cn("flex-1 leading-none", small ? "text-xs" : "text-[13px]")}>
+                        {section.title}
+                    </span>
+                    {hideTags ? null : <StatusTags tags={section.tags} small={small} />}
+                    <span
+                        className={cn(
+                            "inline-flex shrink-0 items-center leading-none",
+                            textColors.tertiary,
+                        )}
+                    >
+                        {open ? <CaretDown /> : <CaretRight />}
+                    </span>
+                </div>
+            </div>
+            <HeightCollapse open={open}>
+                <div
+                    className={cn(
+                        "overflow-hidden",
+                        ghost
+                            ? "-ml-3.5 border-0 bg-transparent"
+                            : "rounded-b-[10px] border border-t-0 border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]",
+                    )}
+                >
+                    {section.id === "tools" && toolItems ? (
+                        <CappedItems items={toolItems} onOpenTool={onOpenTool} />
+                    ) : null}
+                    {section.scalarChanges ? <ScalarRows changes={section.scalarChanges} /> : null}
+                    {section.textDiff ? (
+                        <div className={cn(ghost && "pl-3.5")}>
+                            <HunkRows
+                                hunks={section.textDiff.hunks}
+                                limit={onOpenInstructions ? INLINE_TEXT_DIFF_LINES : undefined}
+                            />
+                            {onOpenInstructions ? (
+                                <div className="flex items-center border-t border-[var(--ag-colorBorderSecondary)] px-3.5 py-2">
+                                    <button
+                                        type="button"
+                                        className={cn("text-xs", LINK_BTN)}
+                                        onClick={onOpenInstructions}
+                                    >
+                                        <ArrowRight />
+                                        View full diff
+                                        {section.textDiff.added + section.textDiff.removed > 2
+                                            ? ` · ${section.textDiff.added + section.textDiff.removed} lines`
+                                            : ""}
+                                    </button>
+                                </div>
+                            ) : null}
+                        </div>
+                    ) : null}
+                </div>
+            </HeightCollapse>
+        </div>
+    )
+}
+
+/** Detail-view card with a sticky header that collapses back to the summary on click.
+ * Split frame, not CARD: CARD's overflow-hidden clips sticky positioning. */
+export function DetailCard({
+    head,
+    onCollapse,
+    small,
+    children,
+}: {
+    head: React.ReactNode
+    onCollapse: () => void
+    small?: boolean
+    children: React.ReactNode
+}) {
+    return (
+        <div>
+            {/* Solid underlay so scrolled rows don't ghost through the translucent fill. */}
+            <div className="sticky top-0 z-[1] rounded-t-[10px] bg-[var(--ag-colorBgContainer)]">
+                <div
+                    className={cn(
+                        "flex cursor-pointer items-center rounded-t-[10px] border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] transition-colors",
+                        small ? "gap-2 px-2.5 py-1.5" : "gap-2.5 px-3 py-2.5",
+                    )}
+                    onClick={onCollapse}
+                >
+                    {head}
+                    <span className={textColors.tertiary}>
+                        <CaretDown />
+                    </span>
+                </div>
+            </div>
+            <div className="overflow-hidden rounded-b-[10px] border border-t-0 border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]">
+                {children}
+            </div>
+        </div>
+    )
+}
+
+export interface ChangeSectionsProps {
+    sections: ChangeSection[]
+    /** Accordion density: "small" tightens section-card paddings, titles, and tags. */
+    size?: "default" | "small"
+    /** Which sections are expanded. Controlled, so a host can seed or persist it. */
+    openState: Record<string, boolean>
+    onToggleSection: (id: string) => void
+    /** Wired by hosts that own a detail view (the commit modal); omitted, rows stay inline. */
+    onOpenInstructions?: (sectionId: string) => void
+    onOpenTool?: (sectionId: string, itemId: string) => void
+    /** Hide the per-section change tags. The count already sits in the pane header. */
+    hideTags?: boolean
+    /** Drop the card fill and border — flat rows separated by a rule, not stacked cards. */
+    ghost?: boolean
+}
+
+/**
+ * The section list itself. Every host renders this; only the commit modal wraps it with the
+ * JSON view and the drill-in detail cards.
+ */
+export function ChangeSections({
+    sections,
+    size = "default",
+    openState,
+    onToggleSection,
+    onOpenInstructions,
+    onOpenTool,
+    hideTags,
+    ghost,
+}: ChangeSectionsProps) {
+    return (
+        <>
+            {sections.map((section) => (
+                <SectionCard
+                    key={section.id}
+                    section={section}
+                    items={section.items}
+                    open={openState[section.id] ?? false}
+                    small={size === "small"}
+                    hideTags={hideTags}
+                    ghost={ghost}
+                    onToggle={() => onToggleSection(section.id)}
+                    onOpenInstructions={
+                        onOpenInstructions ? () => onOpenInstructions(section.id) : undefined
+                    }
+                    onOpenTool={onOpenTool ? (itemId) => onOpenTool(section.id, itemId) : undefined}
+                />
+            ))}
+        </>
+    )
+}
+
+export default ChangeSections

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -361,8 +361,12 @@ export function SectionCard({
                             : "rounded-b-[10px] border border-t-0 border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]",
                     )}
                 >
-                    {section.id === "tools" && toolItems ? (
-                        <CappedItems items={toolItems} onOpenTool={onOpenTool} />
+                    {/* MCPs and Skills carry rows too; only tools have a detail view to open. */}
+                    {toolItems?.length ? (
+                        <CappedItems
+                            items={toolItems}
+                            onOpenTool={section.id === "tools" ? onOpenTool : undefined}
+                        />
                     ) : null}
                     {section.scalarChanges ? <ScalarRows changes={section.scalarChanges} /> : null}
                     {section.textDiff ? (

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -300,7 +300,6 @@ export function SectionCard({
     onOpenInstructions,
     onOpenTool,
     small,
-    hideTags,
     ghost,
 }: {
     section: ChangeSection
@@ -312,8 +311,6 @@ export function SectionCard({
     /** Omit to make edited tools non-clickable (no detail view to drill into). */
     onOpenTool?: (itemId: string) => void
     small?: boolean
-    /** Hide the per-section change tags. The count already sits in the pane header. */
-    hideTags?: boolean
     /** Drop the card fill and border — flat rows separated by a rule, not stacked cards. */
     ghost?: boolean
 }) {
@@ -369,7 +366,7 @@ export function SectionCard({
                     <span className={cn("flex-1 leading-none", small ? "text-xs" : "text-[13px]")}>
                         {section.title}
                     </span>
-                    {hideTags ? null : <StatusTags tags={section.tags} small={small} />}
+                    <StatusTags tags={section.tags} small={small} />
                     <span
                         className={cn(
                             "inline-flex shrink-0 items-center leading-none",
@@ -484,8 +481,6 @@ export interface ChangeSectionsProps {
     /** Wired by hosts that own a detail view (the commit modal); omitted, rows stay inline. */
     onOpenInstructions?: (sectionId: string) => void
     onOpenTool?: (sectionId: string, itemId: string) => void
-    /** Hide the per-section change tags. The count already sits in the pane header. */
-    hideTags?: boolean
     /** Drop the card fill and border — flat rows separated by a rule, not stacked cards. */
     ghost?: boolean
 }
@@ -501,7 +496,6 @@ export function ChangeSections({
     onToggleSection,
     onOpenInstructions,
     onOpenTool,
-    hideTags,
     ghost,
 }: ChangeSectionsProps) {
     return (
@@ -513,7 +507,6 @@ export function ChangeSections({
                     items={section.items}
                     open={openState[section.id] ?? false}
                     small={size === "small"}
-                    hideTags={hideTags}
                     ghost={ghost}
                     onToggle={() => onToggleSection(section.id)}
                     onOpenInstructions={

--- a/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
+++ b/web/packages/agenta-entity-ui/src/changes/ChangeSections.tsx
@@ -38,6 +38,11 @@ import {
 
 /** Inline text-diff rows before the "View full diff" link takes over. */
 export const INLINE_TEXT_DIFF_LINES = 6
+/** Row inset inside a card body. Ghost bleeds instead, so its rows carry the smaller one. */
+const ROW_PAD = "px-3.5"
+const GHOST_ROW_PAD = "px-2"
+/** How far a ghost band bleeds past the pane's content box, on both sides. */
+const GHOST_BLEED = "-mx-2"
 const SUBGROUP_VISIBLE = 5
 const VIRTUALIZE_AT = 50
 
@@ -139,14 +144,22 @@ export function StatusTags({tags, small}: {tags: ChangeSection["tags"]; small?: 
 }
 
 /** Diff surface — tinted +/- rows with a sign gutter; long lines wrap. */
-export function HunkRows({hunks, limit}: {hunks: ExtendedDiffLine[]; limit?: number}) {
+export function HunkRows({
+    hunks,
+    limit,
+    padX = ROW_PAD,
+}: {
+    hunks: ExtendedDiffLine[]
+    limit?: number
+    padX?: string
+}) {
     const shown = limit ? hunks.slice(0, limit) : hunks
     return (
         <div className="py-2 font-mono text-xs leading-[1.8]">
             {shown.map((line, i) => {
                 if (line.type === "fold") {
                     return (
-                        <div key={i} className={cn("px-3.5 italic", textColors.tertiary)}>
+                        <div key={i} className={cn(padX, "italic", textColors.tertiary)}>
                             {line.content}
                         </div>
                     )
@@ -169,10 +182,7 @@ export function HunkRows({hunks, limit}: {hunks: ExtendedDiffLine[]; limit?: num
                 return (
                     <div
                         key={i}
-                        className={cn(
-                            "flex px-3.5",
-                            line.type === "context" && textColors.tertiary,
-                        )}
+                        className={cn("flex", padX, line.type === "context" && textColors.tertiary)}
                         style={style}
                     >
                         <span className="w-3.5 shrink-0 opacity-70">
@@ -186,13 +196,21 @@ export function HunkRows({hunks, limit}: {hunks: ExtendedDiffLine[]; limit?: num
     )
 }
 
-function ItemRow({it, onOpenTool}: {it: ChangeItem; onOpenTool?: (itemId: string) => void}) {
+function ItemRow({
+    it,
+    onOpenTool,
+    padX = ROW_PAD,
+}: {
+    it: ChangeItem
+    onOpenTool?: (itemId: string) => void
+    padX?: string
+}) {
     const clickable = it.kind === "edited" && !!onOpenTool
     return (
         <Row
             clickable={clickable}
             onActivate={clickable ? () => onOpenTool?.(it.id) : undefined}
-            className="flex w-full items-center gap-2.5 px-3.5 py-1.5 text-left"
+            className={cn("flex w-full items-center gap-2.5 py-1.5 text-left", padX)}
         >
             <span style={kindStyle(it.kind)} className="flex w-4 shrink-0 justify-center">
                 {kindIcon(it.kind)}
@@ -212,9 +230,11 @@ function ItemRow({it, onOpenTool}: {it: ChangeItem; onOpenTool?: (itemId: string
 function CappedItems({
     items,
     onOpenTool,
+    padX = ROW_PAD,
 }: {
     items: ChangeItem[]
     onOpenTool?: (itemId: string) => void
+    padX?: string
 }) {
     const [expanded, setExpanded] = useState(false)
 
@@ -225,7 +245,7 @@ function CappedItems({
                 maxHeight={320}
                 estimateSize={30}
                 getItemKey={(it) => it.id}
-                renderItem={(it) => <ItemRow it={it} onOpenTool={onOpenTool} />}
+                renderItem={(it) => <ItemRow it={it} onOpenTool={onOpenTool} padX={padX} />}
             />
         )
     }
@@ -235,12 +255,12 @@ function CappedItems({
     return (
         <div className="py-1">
             {visible.map((it) => (
-                <ItemRow key={it.id} it={it} onOpenTool={onOpenTool} />
+                <ItemRow key={it.id} it={it} onOpenTool={onOpenTool} padX={padX} />
             ))}
             {hidden > 0 ? (
                 <button
                     type="button"
-                    className={cn("px-3.5 py-1.5 text-xs", LINK_BTN)}
+                    className={cn(padX, "py-1.5 text-xs", LINK_BTN)}
                     onClick={() => setExpanded(true)}
                 >
                     <DotsThree />
@@ -251,13 +271,13 @@ function CappedItems({
     )
 }
 
-function ScalarRows({changes}: {changes: ScalarChange[]}) {
+function ScalarRows({changes, padX = ROW_PAD}: {changes: ScalarChange[]; padX?: string}) {
     return (
         <div className="py-1">
             {changes.map((c) => (
                 <div
                     key={c.key}
-                    className="flex flex-wrap items-center gap-2 px-3.5 py-1.5 text-xs"
+                    className={cn("flex flex-wrap items-center gap-2 py-1.5 text-xs", padX)}
                     title={c.key}
                 >
                     <span className={textColors.secondary}>{c.label ?? c.key}</span>
@@ -300,6 +320,9 @@ export function SectionCard({
     ghost?: boolean
 }) {
     const toolItems = items ?? section.items
+    // Ghost bleeds its band outward, so its rows inset by the same amount to land back on the
+    // pane's content line — one left edge for the heading, the header band and every row.
+    const rowPad = ghost ? GHOST_ROW_PAD : ROW_PAD
     // Split frame per DetailCard; each header sticks only within its own card wrapper.
     return (
         <div className={cn(ghost ? "mb-1" : small ? "mb-1.5" : "mb-2.5")}>
@@ -326,7 +349,9 @@ export function SectionCard({
                         // the heading above it — same left edge, no visible inset.
                         ghost
                             ? cn(
-                                  "-mx-2 rounded-md border-0 bg-[var(--ag-colorFillQuaternary)] px-2 hover:bg-[var(--ag-colorFillTertiary)]",
+                                  GHOST_BLEED,
+                                  GHOST_ROW_PAD,
+                                  "rounded-md border-0 bg-[var(--ag-colorFillQuaternary)] hover:bg-[var(--ag-colorFillTertiary)]",
                                   small ? "gap-2 py-2" : "gap-2.5 py-2.5",
                               )
                             : cn(
@@ -363,7 +388,7 @@ export function SectionCard({
                     className={cn(
                         "overflow-hidden",
                         ghost
-                            ? "-ml-3.5 border-0 bg-transparent"
+                            ? cn(GHOST_BLEED, "border-0 bg-transparent")
                             : "rounded-b-[10px] border border-t-0 border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]",
                     )}
                 >
@@ -372,17 +397,26 @@ export function SectionCard({
                         <CappedItems
                             items={toolItems}
                             onOpenTool={DRILLABLE.has(section.id) ? onOpenTool : undefined}
+                            padX={rowPad}
                         />
                     ) : null}
-                    {section.scalarChanges ? <ScalarRows changes={section.scalarChanges} /> : null}
+                    {section.scalarChanges ? (
+                        <ScalarRows changes={section.scalarChanges} padX={rowPad} />
+                    ) : null}
                     {section.textDiff ? (
-                        <div className={cn(ghost && "pl-3.5")}>
+                        <div>
                             <HunkRows
                                 hunks={section.textDiff.hunks}
                                 limit={onOpenInstructions ? INLINE_TEXT_DIFF_LINES : undefined}
+                                padX={rowPad}
                             />
                             {onOpenInstructions ? (
-                                <div className="flex items-center border-t border-[var(--ag-colorBorderSecondary)] px-3.5 py-2">
+                                <div
+                                    className={cn(
+                                        "flex items-center border-t border-[var(--ag-colorBorderSecondary)] py-2",
+                                        rowPad,
+                                    )}
+                                >
                                     <button
                                         type="button"
                                         className={cn("text-xs", LINK_BTN)}

--- a/web/packages/agenta-entity-ui/src/changes/index.ts
+++ b/web/packages/agenta-entity-ui/src/changes/index.ts
@@ -1,0 +1,20 @@
+/**
+ * Commit-diff section rendering, without an editor in the module graph.
+ *
+ * Its own entry point (`@agenta/entity-ui/changes`) so importing it never reaches
+ * `@agenta/entity-ui/modals`, which pulls `DiffView` and the Lexical editor behind it.
+ */
+export {
+    ChangeSections,
+    SectionCard,
+    DetailCard,
+    StatusTags,
+    HunkRows,
+    SECTION_ICON,
+    INLINE_TEXT_DIFF_LINES,
+    CARD,
+    LINK_BTN,
+    kindIcon,
+    kindStyle,
+} from "./ChangeSections"
+export type {ChangeSectionsProps} from "./ChangeSections"

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/changes/AgentChangesSummary.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/changes/AgentChangesSummary.tsx
@@ -2,359 +2,39 @@
  * AgentChangesSummary
  *
  * Plain-language, section-grouped view of an agent workflow's commit changes.
- * Each change is a self-contained card (header + a real diff/rows surface) so nothing
- * bleeds onto the flat panel. Master → detail navigation inside a fixed frame: the summary
- * list, an edited-tool detail, a full-instructions diff, and the raw JSON diff all render
- * in the same scroll area so the modal never grows. Nothing inline grows unbounded.
+ * Master → detail navigation inside a fixed frame: the summary list, an edited-tool detail, a
+ * full-instructions diff, and the raw JSON diff all render in the same scroll area so the modal
+ * never grows. Nothing inline grows unbounded.
+ *
+ * The section list itself lives in `@agenta/entity-ui/changes` — a surface that only needs
+ * "what changed" renders that directly and keeps `DiffView` (and Lexical) out of its bundle.
+ * What stays here is what needs the editor or a detail stack: the JSON view and the drill-ins.
  */
 import {useMemo, useState} from "react"
 
-import type {ChangeItem, ChangeSection, ScalarChange} from "@agenta/entities/workflow/commitDiff"
-import {HeightCollapse} from "@agenta/ui/components"
-import {AdaptiveList} from "@agenta/ui/components/selection"
-import type {ExtendedDiffLine} from "@agenta/ui/diff"
+import type {ChangeSection} from "@agenta/entities/workflow/commitDiff"
 import {DiffView} from "@agenta/ui/editor"
 import {cn, textColors} from "@agenta/ui/styles"
-import {Badge, type BadgeProps} from "@agenta/ui/ui"
+import {ArrowLeft, ChatText, Code, PencilSimple} from "@phosphor-icons/react"
+
 import {
-    ArrowLeft,
-    ArrowRight,
-    CaretDown,
-    CaretRight,
-    ChatText,
-    Code,
-    Cpu,
-    DotsThree,
-    Minus,
-    PencilSimple,
-    PlugsConnected,
-    Plus,
-    Sparkle,
-    SlidersHorizontal,
-    Wrench,
-} from "@phosphor-icons/react"
+    CARD,
+    ChangeSections,
+    DetailCard,
+    HunkRows,
+    LINK_BTN,
+    StatusTags,
+    kindIcon,
+    kindStyle,
+} from "@agenta/entity-ui/changes"
 
 import {isSectionOpen} from "./sectionOpenState"
-
-const INLINE_TEXT_DIFF_LINES = 6
-const SUBGROUP_VISIBLE = 5
-const VIRTUALIZE_AT = 50
-
-const ADD_BG = "color-mix(in srgb, var(--ag-colorSuccess) 13%, transparent)"
-const DEL_BG = "color-mix(in srgb, var(--ag-colorError) 13%, transparent)"
-
-// One subtle surface for the whole card; header inherits it, the diff tints + open divider
-// carry the structure. Avoids stacking two lightening fills (no "darker body" token in dark mode).
-const CARD =
-    "overflow-hidden rounded-[10px] border border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]"
-const LINK_BTN = cn(
-    "inline-flex cursor-pointer items-center gap-1.5 border-0 bg-transparent p-0 transition-colors",
-    textColors.secondary,
-    "hover:text-[var(--ag-colorText)]",
-)
 
 type View =
     | {kind: "summary"}
     | {kind: "json"}
     | {kind: "instructions"; sectionId: string}
     | {kind: "tool"; sectionId: string; itemId: string}
-
-const SECTION_ICON: Record<ChangeSection["id"], React.ReactNode> = {
-    tools: <Wrench />,
-    instructions: <ChatText />,
-    model: <Cpu />,
-    mcps: <PlugsConnected />,
-    skills: <Sparkle />,
-    params: <SlidersHorizontal />,
-}
-
-const KIND_COLOR: Record<string, BadgeProps["variant"]> = {
-    added: "green",
-    removed: "red",
-    edited: "gold",
-    changed: "gold",
-}
-
-const kindIcon = (kind: string) => {
-    if (kind === "added") return <Plus />
-    if (kind === "removed") return <Minus />
-    return <PencilSimple />
-}
-
-const kindStyle = (kind: string) => {
-    if (kind === "added") return {color: "var(--ag-colorSuccess)"}
-    if (kind === "removed") return {color: "var(--ag-colorError)"}
-    return {color: "var(--ag-colorWarning)"}
-}
-
-function StatusTags({tags, small}: {tags: ChangeSection["tags"]; small?: boolean}) {
-    return (
-        <>
-            {tags.map((t, i) => (
-                <Badge
-                    key={i}
-                    variant={KIND_COLOR[t.kind] ?? "default"}
-                    className={cn(
-                        "rounded-full",
-                        small ? "px-1.5 text-[12px] leading-[18px]" : "px-2 text-[12px]",
-                    )}
-                >
-                    {t.label}
-                </Badge>
-            ))}
-        </>
-    )
-}
-
-/** Diff surface — tinted +/- rows with a sign gutter; long lines wrap. */
-function HunkRows({hunks, limit}: {hunks: ExtendedDiffLine[]; limit?: number}) {
-    const shown = limit ? hunks.slice(0, limit) : hunks
-    return (
-        <div className="py-2 font-mono text-xs leading-[1.8]">
-            {shown.map((line, i) => {
-                if (line.type === "fold") {
-                    return (
-                        <div key={i} className={cn("px-3.5 italic", textColors.tertiary)}>
-                            {line.content}
-                        </div>
-                    )
-                }
-                const isAdd = line.type === "added"
-                const isDel = line.type === "removed"
-                const style = isAdd
-                    ? {
-                          background: ADD_BG,
-                          boxShadow: "inset 2px 0 0 var(--ag-colorSuccess)",
-                          color: "var(--ag-colorSuccess)",
-                      }
-                    : isDel
-                      ? {
-                            background: DEL_BG,
-                            boxShadow: "inset 2px 0 0 var(--ag-colorError)",
-                            color: "var(--ag-colorError)",
-                        }
-                      : undefined
-                return (
-                    <div
-                        key={i}
-                        className={cn(
-                            "flex px-3.5",
-                            line.type === "context" && textColors.tertiary,
-                        )}
-                        style={style}
-                    >
-                        <span className="w-3.5 shrink-0 opacity-70">
-                            {isAdd ? "+" : isDel ? "−" : " "}
-                        </span>
-                        <span className="whitespace-pre-wrap break-words">{line.content}</span>
-                    </div>
-                )
-            })}
-        </div>
-    )
-}
-
-function ItemRow({it, onOpenTool}: {it: ChangeItem; onOpenTool?: (itemId: string) => void}) {
-    const clickable = it.kind === "edited" && !!onOpenTool
-    return (
-        <div
-            className={cn(
-                "flex items-center gap-2.5 px-3.5 py-1.5",
-                clickable && "cursor-pointer hover:bg-[var(--ag-colorFillQuaternary)]",
-            )}
-            onClick={clickable ? () => onOpenTool?.(it.id) : undefined}
-        >
-            <span style={kindStyle(it.kind)} className="flex w-4 shrink-0 justify-center">
-                {kindIcon(it.kind)}
-            </span>
-            <span className="min-w-0 flex-1 truncate text-xs">
-                {it.label}
-                {it.detail ? (
-                    <span className={cn("ml-1", textColors.tertiary)}>· {it.detail}</span>
-                ) : null}
-            </span>
-            {clickable ? <CaretRight className={textColors.tertiary} /> : null}
-        </div>
-    )
-}
-
-/** A capped list with "Show N more"; virtualizes only when a huge group is fully expanded. */
-function CappedItems({
-    items,
-    onOpenTool,
-}: {
-    items: ChangeItem[]
-    onOpenTool?: (itemId: string) => void
-}) {
-    const [expanded, setExpanded] = useState(false)
-
-    if (expanded && items.length > VIRTUALIZE_AT) {
-        return (
-            <AdaptiveList
-                items={items}
-                maxHeight={320}
-                estimateSize={30}
-                getItemKey={(it) => it.id}
-                renderItem={(it) => <ItemRow it={it} onOpenTool={onOpenTool} />}
-            />
-        )
-    }
-
-    const visible = expanded ? items : items.slice(0, SUBGROUP_VISIBLE)
-    const hidden = items.length - visible.length
-    return (
-        <div className="py-1">
-            {visible.map((it) => (
-                <ItemRow key={it.id} it={it} onOpenTool={onOpenTool} />
-            ))}
-            {hidden > 0 ? (
-                <button
-                    type="button"
-                    className={cn("px-3.5 py-1.5 text-xs", LINK_BTN)}
-                    onClick={() => setExpanded(true)}
-                >
-                    <DotsThree />
-                    Show {hidden} more
-                </button>
-            ) : null}
-        </div>
-    )
-}
-
-function ScalarRows({changes}: {changes: ScalarChange[]}) {
-    return (
-        <div className="py-1">
-            {changes.map((c) => (
-                <div
-                    key={c.key}
-                    className="flex items-center gap-2 px-3.5 py-1.5 font-mono text-xs"
-                >
-                    <span className={textColors.secondary}>{c.key}</span>
-                    <span style={{color: "var(--ag-colorError)"}}>{c.before ?? "—"}</span>
-                    <ArrowRight className={textColors.tertiary} />
-                    <span style={{color: "var(--ag-colorSuccess)"}}>{c.after ?? "—"}</span>
-                </div>
-            ))}
-        </div>
-    )
-}
-
-/** Detail-view card with a sticky header that collapses back to the summary on click.
- * Split frame, not CARD: CARD's overflow-hidden clips sticky positioning. */
-function DetailCard({
-    head,
-    onCollapse,
-    small,
-    children,
-}: {
-    head: React.ReactNode
-    onCollapse: () => void
-    small?: boolean
-    children: React.ReactNode
-}) {
-    return (
-        <div>
-            {/* Solid underlay so scrolled rows don't ghost through the translucent fill. */}
-            <div className="sticky top-0 z-[1] rounded-t-[10px] bg-[var(--ag-colorBgContainer)]">
-                <div
-                    className={cn(
-                        "flex cursor-pointer items-center rounded-t-[10px] border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] transition-colors",
-                        small ? "gap-2 px-2.5 py-1.5" : "gap-2.5 px-3 py-2.5",
-                    )}
-                    onClick={onCollapse}
-                >
-                    {head}
-                    <span className={textColors.tertiary}>
-                        <CaretDown />
-                    </span>
-                </div>
-            </div>
-            <div className="overflow-hidden rounded-b-[10px] border border-t-0 border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]">
-                {children}
-            </div>
-        </div>
-    )
-}
-
-function SectionCard({
-    section,
-    items,
-    open,
-    onToggle,
-    onOpenInstructions,
-    onOpenTool,
-    small,
-}: {
-    section: ChangeSection
-    items?: ChangeItem[]
-    open: boolean
-    onToggle: () => void
-    onOpenInstructions: () => void
-    onOpenTool: (itemId: string) => void
-    small?: boolean
-}) {
-    const toolItems = items ?? section.items
-    // Split frame per DetailCard; each header sticks only within its own card wrapper.
-    return (
-        <div className={cn(small ? "mb-1.5" : "mb-2.5")}>
-            <div
-                className={cn(
-                    "sticky top-0 z-[1] bg-[var(--ag-colorBgContainer)]",
-                    open ? "rounded-t-[10px]" : "rounded-[10px]",
-                )}
-            >
-                <div
-                    className={cn(
-                        "flex cursor-pointer items-center border border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)] transition-colors hover:bg-[var(--ag-colorFillTertiary)]",
-                        open ? "rounded-t-[10px]" : "rounded-[10px]",
-                        small ? "gap-2 px-2.5 py-1.5" : "gap-2.5 px-3 py-2.5",
-                    )}
-                    onClick={onToggle}
-                >
-                    <span className={cn("w-[18px] text-center", textColors.secondary)}>
-                        {SECTION_ICON[section.id]}
-                    </span>
-                    <span className={cn("flex-1", small ? "text-xs" : "text-[13px]")}>
-                        {section.title}
-                    </span>
-                    <StatusTags tags={section.tags} small={small} />
-                    <span className={textColors.tertiary}>
-                        {open ? <CaretDown /> : <CaretRight />}
-                    </span>
-                </div>
-            </div>
-            <HeightCollapse open={open}>
-                <div className="overflow-hidden rounded-b-[10px] border border-t-0 border-solid border-[var(--ag-colorBorderSecondary)] bg-[var(--ag-colorFillTertiary)]">
-                    {section.id === "tools" && toolItems ? (
-                        <CappedItems items={toolItems} onOpenTool={onOpenTool} />
-                    ) : null}
-                    {section.scalarChanges ? <ScalarRows changes={section.scalarChanges} /> : null}
-                    {section.textDiff ? (
-                        <>
-                            <HunkRows
-                                hunks={section.textDiff.hunks}
-                                limit={INLINE_TEXT_DIFF_LINES}
-                            />
-                            <div className="flex items-center border-t border-[var(--ag-colorBorderSecondary)] px-3.5 py-2">
-                                <button
-                                    type="button"
-                                    className={cn("text-xs", LINK_BTN)}
-                                    onClick={onOpenInstructions}
-                                >
-                                    <ArrowRight />
-                                    View full diff
-                                    {section.textDiff.added + section.textDiff.removed > 2
-                                        ? ` · ${section.textDiff.added + section.textDiff.removed} lines`
-                                        : ""}
-                                </button>
-                            </div>
-                        </>
-                    ) : null}
-                </div>
-            </HeightCollapse>
-        </div>
-    )
-}
 
 export interface AgentChangesSummaryProps {
     sections: ChangeSection[]
@@ -391,7 +71,14 @@ export default function AgentChangesSummary({
         [sections],
     )
 
-    const isOpen = (id: string) => isSectionOpen(openOverrides, id, defaultOpen)
+    // ChangeSections takes a resolved map; `defaultOpen` is a policy, so resolve it per section.
+    const openState = useMemo(
+        () =>
+            Object.fromEntries(
+                sections.map((s) => [s.id, isSectionOpen(openOverrides, s.id, defaultOpen)]),
+            ),
+        [sections, openOverrides, defaultOpen],
+    )
     const toggleSection = (id: string) =>
         setOpenOverrides((prev) => ({...prev, [id]: !isSectionOpen(prev, id, defaultOpen)}))
 
@@ -458,24 +145,20 @@ export default function AgentChangesSummary({
                     compact ? "max-h-80 rounded-[10px]" : "min-h-0 flex-1 px-4 pb-4",
                 )}
             >
-                {view.kind === "summary"
-                    ? sections.map((section) => (
-                          <SectionCard
-                              key={section.id}
-                              section={section}
-                              items={section.items}
-                              open={isOpen(section.id)}
-                              small={size === "small"}
-                              onToggle={() => toggleSection(section.id)}
-                              onOpenInstructions={() =>
-                                  setView({kind: "instructions", sectionId: section.id})
-                              }
-                              onOpenTool={(itemId) =>
-                                  setView({kind: "tool", sectionId: section.id, itemId})
-                              }
-                          />
-                      ))
-                    : null}
+                {view.kind === "summary" ? (
+                    <ChangeSections
+                        sections={sections}
+                        size={size}
+                        openState={openState}
+                        onToggleSection={toggleSection}
+                        onOpenInstructions={(sectionId) =>
+                            setView({kind: "instructions", sectionId})
+                        }
+                        onOpenTool={(sectionId, itemId) =>
+                            setView({kind: "tool", sectionId, itemId})
+                        }
+                    />
+                ) : null}
 
                 {view.kind === "instructions" && activeSection?.textDiff ? (
                     <DetailCard

--- a/web/packages/agenta-entity-ui/src/modals/commit/components/changes/AgentChangesSummary.tsx
+++ b/web/packages/agenta-entity-ui/src/modals/commit/components/changes/AgentChangesSummary.tsx
@@ -15,7 +15,7 @@ import {useMemo, useState} from "react"
 import type {ChangeSection} from "@agenta/entities/workflow/commitDiff"
 import {DiffView} from "@agenta/ui/editor"
 import {cn, textColors} from "@agenta/ui/styles"
-import {ArrowLeft, ChatText, Code, PencilSimple} from "@phosphor-icons/react"
+import {ArrowLeft, Code, PencilSimple} from "@phosphor-icons/react"
 
 import {
     CARD,
@@ -23,6 +23,7 @@ import {
     DetailCard,
     HunkRows,
     LINK_BTN,
+    SECTION_ICON,
     StatusTags,
     kindIcon,
     kindStyle,
@@ -166,7 +167,9 @@ export default function AgentChangesSummary({
                         onCollapse={collapseDetail}
                         head={
                             <>
-                                <ChatText className={textColors.secondary} />
+                                <span className={textColors.secondary}>
+                                    {SECTION_ICON.instructions}
+                                </span>
                                 <span className={cn("flex-1", small ? "text-xs" : "text-[13px]")}>
                                     Instructions
                                 </span>

--- a/web/packages/agenta-entity-ui/tests/unit/changeSectionRows.render.test.tsx
+++ b/web/packages/agenta-entity-ui/tests/unit/changeSectionRows.render.test.tsx
@@ -30,11 +30,12 @@ describe("ChangeSections", () => {
         ["skills", "Skills", "web-search"],
         ["mcps", "MCPs", "linear"],
         ["tools", "Tools", "send_email"],
+        ["subagents", "Subagents", "hourly-news"],
     ] as const)("renders %s rows when the section is open", (id, title, label) => {
         expect(markup(listSection(id, title, label))).toContain(label)
     })
 
-    it("makes only tool rows clickable — the others have no detail view", () => {
+    it("opens a detail view from tool and subagent rows only", () => {
         // Only an EDITED row has anything to drill into.
         const edited = (id: ChangeSection["id"], title: string): ChangeSection => ({
             ...listSection(id, title, "thing"),
@@ -50,8 +51,10 @@ describe("ChangeSections", () => {
                 />,
             ).match(/<button/g)?.length ?? 0
 
-        // The section header is always a button; only Tools adds a second for the row.
+        // The section header is always a button; a drillable row adds a second.
         expect(buttons(edited("tools", "Tools"))).toBe(2)
+        expect(buttons(edited("subagents", "Subagents"))).toBe(2)
         expect(buttons(edited("skills", "Skills"))).toBe(1)
+        expect(buttons(edited("mcps", "MCPs"))).toBe(1)
     })
 })

--- a/web/packages/agenta-entity-ui/tests/unit/changeSectionRows.render.test.tsx
+++ b/web/packages/agenta-entity-ui/tests/unit/changeSectionRows.render.test.tsx
@@ -1,0 +1,57 @@
+import type {ChangeSection} from "@agenta/entities/workflow/commitDiff"
+import {renderToStaticMarkup} from "react-dom/server"
+import {describe, expect, it} from "vitest"
+
+import {ChangeSections} from "../../src/changes/ChangeSections"
+
+/**
+ * Every list-shaped section renders its rows. The renderer once gated rows on `id === "tools"`,
+ * so an expanded MCPs or Skills section painted a header over nothing.
+ */
+const listSection = (id: ChangeSection["id"], title: string, label: string): ChangeSection => ({
+    id,
+    title,
+    tags: [{kind: "added", label: "1 added"}],
+    totalCount: 1,
+    items: [{id: `${id}-1`, label, kind: "added"}],
+})
+
+const markup = (section: ChangeSection) =>
+    renderToStaticMarkup(
+        <ChangeSections
+            sections={[section]}
+            openState={{[section.id]: true}}
+            onToggleSection={() => undefined}
+        />,
+    )
+
+describe("ChangeSections", () => {
+    it.each([
+        ["skills", "Skills", "web-search"],
+        ["mcps", "MCPs", "linear"],
+        ["tools", "Tools", "send_email"],
+    ] as const)("renders %s rows when the section is open", (id, title, label) => {
+        expect(markup(listSection(id, title, label))).toContain(label)
+    })
+
+    it("makes only tool rows clickable — the others have no detail view", () => {
+        // Only an EDITED row has anything to drill into.
+        const edited = (id: ChangeSection["id"], title: string): ChangeSection => ({
+            ...listSection(id, title, "thing"),
+            items: [{id: `${id}-1`, label: "thing", kind: "edited"}],
+        })
+        const buttons = (section: ChangeSection) =>
+            renderToStaticMarkup(
+                <ChangeSections
+                    sections={[section]}
+                    openState={{[section.id]: true}}
+                    onToggleSection={() => undefined}
+                    onOpenTool={() => undefined}
+                />,
+            ).match(/<button/g)?.length ?? 0
+
+        // The section header is always a button; only Tools adds a second for the row.
+        expect(buttons(edited("tools", "Tools"))).toBe(2)
+        expect(buttons(edited("skills", "Skills"))).toBe(1)
+    })
+})

--- a/web/packages/agenta-entity-ui/tests/unit/changeSectionRows.render.test.tsx
+++ b/web/packages/agenta-entity-ui/tests/unit/changeSectionRows.render.test.tsx
@@ -35,6 +35,38 @@ describe("ChangeSections", () => {
         expect(markup(listSection(id, title, label))).toContain(label)
     })
 
+    // The ghost accordion bleeds its band 8px past the pane's content box on BOTH sides, and its
+    // rows inset by the same 8px to land back on the content line. Header, rows and the drawer
+    // footer then share one left and one right edge; a one-sided bleed is what broke it before.
+    it("bleeds the ghost band symmetrically and insets its rows by the same amount", () => {
+        const html = renderToStaticMarkup(
+            <ChangeSections
+                sections={[listSection("tools", "Tools", "send_email")]}
+                openState={{tools: true}}
+                onToggleSection={() => undefined}
+                ghost
+            />,
+        )
+        // Two bleeding boxes: the header band and the body that hangs under it.
+        expect(html.match(/-mx-2/g)).toHaveLength(2)
+        expect(html).not.toContain("-ml-3.5")
+        // Rows pay the bleed back, so their content sits on the pane's content line.
+        expect(html).toContain("px-2")
+        expect(html).not.toContain("px-3.5")
+    })
+
+    it("leaves the card variant on its own inset — nothing bleeds there", () => {
+        const html = renderToStaticMarkup(
+            <ChangeSections
+                sections={[listSection("tools", "Tools", "send_email")]}
+                openState={{tools: true}}
+                onToggleSection={() => undefined}
+            />,
+        )
+        expect(html).not.toContain("-mx-2")
+        expect(html).toContain("px-3.5")
+    })
+
     it("opens a detail view from tool and subagent rows only", () => {
         // Only an EDITED row has anything to drill into.
         const edited = (id: ChangeSection["id"], title: string): ChangeSection => ({

--- a/web/packages/agenta-entity-ui/tests/unit/changeSectionRows.render.test.tsx
+++ b/web/packages/agenta-entity-ui/tests/unit/changeSectionRows.render.test.tsx
@@ -35,10 +35,11 @@ describe("ChangeSections", () => {
         expect(markup(listSection(id, title, label))).toContain(label)
     })
 
-    // The ghost accordion bleeds its band 8px past the pane's content box on BOTH sides, and its
-    // rows inset by the same 8px to land back on the content line. Header, rows and the drawer
-    // footer then share one left and one right edge; a one-sided bleed is what broke it before.
-    it("bleeds the ghost band symmetrically and insets its rows by the same amount", () => {
+    // Header band, diff rows and the drawer footer have to share one left and one right edge.
+    // Negative margins cannot deliver that: the collapse wrapper around the body sets
+    // overflow-hidden, so a band bled outward is clipped on one side and not the other. The bands
+    // fill the pane's box instead and pad inward.
+    it("keeps the ghost band flush with the pane and pads its rows inward", () => {
         const html = renderToStaticMarkup(
             <ChangeSections
                 sections={[listSection("tools", "Tools", "send_email")]}
@@ -47,15 +48,13 @@ describe("ChangeSections", () => {
                 ghost
             />,
         )
-        // Two bleeding boxes: the header band and the body that hangs under it.
-        expect(html.match(/-mx-2/g)).toHaveLength(2)
-        expect(html).not.toContain("-ml-3.5")
-        // Rows pay the bleed back, so their content sits on the pane's content line.
+        expect(html).not.toMatch(/-m[xl]-/)
+        // One inset, on the header and on every row, so their content lands on one line.
         expect(html).toContain("px-2")
         expect(html).not.toContain("px-3.5")
     })
 
-    it("leaves the card variant on its own inset — nothing bleeds there", () => {
+    it("leaves the card variant on its own wider inset", () => {
         const html = renderToStaticMarkup(
             <ChangeSections
                 sections={[listSection("tools", "Tools", "send_email")]}
@@ -63,7 +62,7 @@ describe("ChangeSections", () => {
                 onToggleSection={() => undefined}
             />,
         )
-        expect(html).not.toContain("-mx-2")
+        expect(html).not.toMatch(/-m[xl]-/)
         expect(html).toContain("px-3.5")
     })
 

--- a/web/packages/agenta-entity-ui/tests/unit/sectionChanges.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/sectionChanges.test.ts
@@ -38,10 +38,35 @@ describe("SECTION_ID_TO_PANEL_KEY", () => {
             model: "model-harness",
             instructions: "instructions",
             tools: "tools",
+            subagents: "subagents",
             mcps: "mcp",
             skills: "skills",
             params: "advanced",
         })
+    })
+})
+
+describe("panel keys", () => {
+    // The panel's Subagents accordion used to borrow the `tools` key, so adding a subagent lit
+    // the Integrations header too (and an integration lit Subagents).
+    it("routes a subagent change to Subagents, leaving Integrations alone", () => {
+        const changes = changesFor(
+            template({tools: [{type: "reference", slug: "hourly-news", name: "News"}]}),
+            template(),
+        )
+
+        expect(changes.panelKeys.has("subagents")).toBe(true)
+        expect(changes.panelKeys.has("tools")).toBe(false)
+    })
+
+    it("routes an integration change to Integrations, leaving Subagents alone", () => {
+        const changes = changesFor(
+            template({tools: [{function: {name: "send_email", parameters: {}}}]}),
+            template(),
+        )
+
+        expect(changes.panelKeys.has("tools")).toBe(true)
+        expect(changes.panelKeys.has("subagents")).toBe(false)
     })
 })
 

--- a/web/packages/agenta-playground-ui/package.json
+++ b/web/packages/agenta-playground-ui/package.json
@@ -34,7 +34,8 @@
         "./commit": "./src/components/CommitVariantChanges/index.ts",
         "./mode-switch": "./src/components/PlaygroundModeSwitch.tsx",
         "./agent-config-header": "./src/components/AgentConfigHeader.tsx",
-        "./agent-page-header": "./src/components/AgentPageHeader/index.ts"
+        "./agent-page-header": "./src/components/AgentPageHeader/index.ts",
+        "./agent-version-history": "./src/components/AgentVersionHistory/index.ts"
     },
     "dependencies": {
         "@agenta/chat": "workspace:../agenta-chat",

--- a/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
@@ -20,6 +20,10 @@ const AgentVersionHistoryDrawer = dynamic(
     {ssr: false},
 )
 
+/** Wraps in a tooltip only when there is something to say beyond the visible label. */
+const StatusWrap = ({tip, children}: {tip: string | null; children: React.ReactElement}) =>
+    tip ? <SimpleTooltip title={tip}>{children}</SimpleTooltip> : <>{children}</>
+
 export interface AgentRevisionStatusProps {
     /** The revision whose version and dirty state this reads. */
     revisionId: string
@@ -28,8 +32,6 @@ export interface AgentRevisionStatusProps {
      * surface has no workflow handle (the chip then just states the version).
      */
     historyWorkflowId?: string | null
-    /** Optional: lets a version's row offer "Open", pinning the surface to that revision. */
-    onSelectRevision?: (revisionId: string) => void
     className?: string
 }
 
@@ -46,7 +48,6 @@ export interface AgentRevisionStatusProps {
 export const AgentRevisionStatus = ({
     revisionId,
     historyWorkflowId,
-    onSelectRevision,
     className,
 }: AgentRevisionStatusProps) => {
     // A commit can land while this surface is closed — the agent commits itself mid-session, or
@@ -116,7 +117,6 @@ export const AgentRevisionStatus = ({
                             <AgentVersionHistoryDrawer
                                 workflowId={historyWorkflowId}
                                 revisionId={revisionId}
-                                onSelectRevision={onSelectRevision}
                             />
                         ) : null}
                     </>
@@ -143,7 +143,9 @@ export const AgentRevisionStatus = ({
                         </span>
                     </SimpleTooltip>
                 ))}
-            <SimpleTooltip title={dot.tip}>
+            {/* Tooltip only on failure: there it carries the error and the retry hint. In every
+                other state it just repeated the word already next to the dot. */}
+            <StatusWrap tip={failed ? dot.tip : null}>
                 <span
                     role={failed ? "button" : undefined}
                     tabIndex={failed ? 0 : undefined}
@@ -171,7 +173,7 @@ export const AgentRevisionStatus = ({
                         tooltip already say it, and the identity beside it needs the room. */}
                     <span className="hidden sm:inline">{dot.label}</span>
                 </span>
-            </SimpleTooltip>
+            </StatusWrap>
         </div>
     )
 }

--- a/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
@@ -123,10 +123,14 @@ export const AgentRevisionStatus = ({
                         type="button"
                         aria-label={`Version ${version}, ${dot.label}. Open version history`}
                         onClick={() => openHistory(historyWorkflowId)}
-                        className="flex cursor-pointer items-center gap-1.5 rounded border-0 bg-colorFillSecondary px-1.5 py-0.5 text-xs text-colorTextSecondary hover:bg-colorFillTertiary hover:text-colorText"
+                        className="group flex cursor-pointer items-center gap-1.5 border-0 bg-transparent p-0 text-xs text-colorTextTertiary"
                     >
-                        {/* A caret would promise a menu; this opens a drawer of history. */}
-                        <ClockCounterClockwise size={11} className="shrink-0" />v{version}
+                        {/* Only the version wears the chip — the save state is a fact about it,
+                            not a second control, so it reads as a label beside it. */}
+                        <span className="flex items-center gap-1 rounded bg-colorFillSecondary px-1.5 py-0.5 text-colorTextSecondary group-hover:bg-colorFillTertiary group-hover:text-colorText">
+                            {/* A caret would promise a menu; this opens a drawer of history. */}
+                            <ClockCounterClockwise size={11} className="shrink-0" />v{version}
+                        </span>
                         <span className="text-colorTextQuaternary">·</span>
                         {statusBody}
                     </button>

--- a/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
@@ -97,30 +97,54 @@ export const AgentRevisionStatus = ({
             ? {tone: "bg-colorWarning", label: "Draft", tip: "Unsaved changes"}
             : {tone: "bg-colorSuccess", label: "Saved", tip: "Saved"}
 
+    // One object for one revision: the version and its save state describe the same thing, and as
+    // two chips they competed. A failed save is the exception — there the status IS the retry
+    // control, so it stays separate rather than sharing a button that opens history.
+    const merged = version !== null && !!historyWorkflowId && !failed
+
+    const statusBody = (
+        <>
+            {failed ? (
+                <WarningCircle size={12} className="shrink-0 text-colorError" />
+            ) : (
+                <span className={`h-[7px] w-[7px] shrink-0 rounded-full ${dot.tone}`} />
+            )}
+            {/* The word is the first thing to go on a narrow bar — the dot and its tooltip
+                already say it, and the identity beside it needs the room. */}
+            <span className="hidden sm:inline">{dot.label}</span>
+        </>
+    )
+
     return (
         <div className={`flex items-center gap-2 ${className ?? ""}`}>
-            {version !== null &&
-                (historyWorkflowId ? (
-                    <>
-                        <SimpleTooltip title="Version history">
-                            <button
-                                type="button"
-                                aria-label="Open version history"
-                                onClick={() => openHistory(historyWorkflowId)}
-                                className="flex cursor-pointer items-center rounded border-0 bg-colorFillSecondary px-1.5 py-0.5 text-xs text-colorTextSecondary hover:text-colorText"
-                            >
-                                v{version}
-                                {/* A caret would promise a menu; this opens a drawer of history. */}
-                                <ClockCounterClockwise size={11} className="ml-1" />
-                            </button>
-                        </SimpleTooltip>
-                        {historyMounted ? (
-                            <AgentVersionHistoryDrawer
-                                workflowId={historyWorkflowId}
-                                revisionId={revisionId}
-                            />
-                        ) : null}
-                    </>
+            {merged ? (
+                <SimpleTooltip title="Version history">
+                    <button
+                        type="button"
+                        aria-label={`Version ${version}, ${dot.label}. Open version history`}
+                        onClick={() => openHistory(historyWorkflowId)}
+                        className="flex cursor-pointer items-center gap-1.5 rounded border-0 bg-colorFillSecondary px-1.5 py-0.5 text-xs text-colorTextSecondary hover:bg-colorFillTertiary hover:text-colorText"
+                    >
+                        {/* A caret would promise a menu; this opens a drawer of history. */}
+                        <ClockCounterClockwise size={11} className="shrink-0" />v{version}
+                        <span className="text-colorTextQuaternary">·</span>
+                        {statusBody}
+                    </button>
+                </SimpleTooltip>
+            ) : null}
+
+            {!merged && version !== null ? (
+                historyWorkflowId ? (
+                    <SimpleTooltip title="Version history">
+                        <button
+                            type="button"
+                            aria-label="Open version history"
+                            onClick={() => openHistory(historyWorkflowId)}
+                            className="flex cursor-pointer items-center gap-1 rounded border-0 bg-colorFillSecondary px-1.5 py-0.5 text-xs text-colorTextSecondary hover:bg-colorFillTertiary hover:text-colorText"
+                        >
+                            <ClockCounterClockwise size={11} className="shrink-0" />v{version}
+                        </button>
+                    </SimpleTooltip>
                 ) : (
                     <SimpleTooltip
                         className="max-w-[360px]"
@@ -143,38 +167,38 @@ export const AgentRevisionStatus = ({
                             v{version}
                         </span>
                     </SimpleTooltip>
-                ))}
-            {/* Tooltip only on failure: there it carries the error and the retry hint. In every
-                other state it just repeated the word already next to the dot. */}
-            <StatusWrap tip={failed ? dot.tip : null}>
-                <span
-                    role={failed ? "button" : undefined}
-                    tabIndex={failed ? 0 : undefined}
-                    aria-label={failed ? "Retry saving changes" : undefined}
-                    onClick={failed ? () => void retrySave({revisionId}) : undefined}
-                    onKeyDown={
-                        failed
-                            ? (event) => {
-                                  if (event.key !== "Enter" && event.key !== " ") return
-                                  event.preventDefault()
-                                  void retrySave({revisionId})
-                              }
-                            : undefined
-                    }
-                    className={`flex items-center gap-1.5 text-xs text-colorTextTertiary ${
-                        failed ? "cursor-pointer" : ""
-                    }`}
-                >
-                    {failed ? (
-                        <WarningCircle size={12} className="shrink-0 text-colorError" />
-                    ) : (
-                        <span className={`h-[7px] w-[7px] shrink-0 rounded-full ${dot.tone}`} />
-                    )}
-                    {/* The word is the first thing to go on a narrow bar — the dot and its
-                        tooltip already say it, and the identity beside it needs the room. */}
-                    <span className="hidden sm:inline">{dot.label}</span>
-                </span>
-            </StatusWrap>
+                )
+            ) : null}
+
+            {historyWorkflowId && historyMounted ? (
+                <AgentVersionHistoryDrawer workflowId={historyWorkflowId} revisionId={revisionId} />
+            ) : null}
+
+            {/* Tooltip only on failure: there it carries the error and the retry hint. */}
+            {merged ? null : (
+                <StatusWrap tip={failed ? dot.tip : null}>
+                    <span
+                        role={failed ? "button" : undefined}
+                        tabIndex={failed ? 0 : undefined}
+                        aria-label={failed ? "Retry saving changes" : undefined}
+                        onClick={failed ? () => void retrySave({revisionId}) : undefined}
+                        onKeyDown={
+                            failed
+                                ? (event) => {
+                                      if (event.key !== "Enter" && event.key !== " ") return
+                                      event.preventDefault()
+                                      void retrySave({revisionId})
+                                  }
+                                : undefined
+                        }
+                        className={`flex items-center gap-1.5 text-xs text-colorTextTertiary ${
+                            failed ? "cursor-pointer" : ""
+                        }`}
+                    >
+                        {statusBody}
+                    </span>
+                </StatusWrap>
+            )}
         </div>
     )
 }

--- a/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
@@ -8,7 +8,7 @@ import {
     flushAgentAutoCommitAtom,
 } from "@agenta/playground/state"
 import {SimpleTooltip} from "@agenta/ui/ui"
-import {CaretDown, WarningCircle} from "@phosphor-icons/react"
+import {ClockCounterClockwise, WarningCircle} from "@phosphor-icons/react"
 import {useAtomValue, useSetAtom} from "jotai"
 import dynamic from "next/dynamic"
 
@@ -110,7 +110,8 @@ export const AgentRevisionStatus = ({
                                 className="flex cursor-pointer items-center rounded border-0 bg-colorFillSecondary px-1.5 py-0.5 text-xs text-colorTextSecondary hover:text-colorText"
                             >
                                 v{version}
-                                <CaretDown size={9} className="ml-1" />
+                                {/* A caret would promise a menu; this opens a drawer of history. */}
+                                <ClockCounterClockwise size={11} className="ml-1" />
                             </button>
                         </SimpleTooltip>
                         {historyMounted ? (

--- a/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
@@ -107,7 +107,7 @@ export const AgentRevisionStatus = ({
             {failed ? (
                 <WarningCircle size={12} className="shrink-0 text-colorError" />
             ) : (
-                <span className={`h-[7px] w-[7px] shrink-0 rounded-full ${dot.tone}`} />
+                <span className={`h-[6px] w-[6px] shrink-0 rounded-full ${dot.tone}`} />
             )}
             {/* The word is the first thing to go on a narrow bar — the dot and its tooltip
                 already say it, and the identity beside it needs the room. */}

--- a/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentPageHeader/AgentRevisionStatus.tsx
@@ -1,107 +1,41 @@
-import {useEffect} from "react"
+import {useEffect, useState} from "react"
 
-import {
-    invalidateAgentCommittedRevisionCache,
-    workflowMolecule,
-    workflowRevisionsByWorkflowListDataAtomFamily,
-    workflowRevisionsByWorkflowQueryAtomFamily,
-} from "@agenta/entities/workflow"
+import {invalidateAgentCommittedRevisionCache, workflowMolecule} from "@agenta/entities/workflow"
 import {
     agentAutoCommitErrorAtomFamily,
     agentAutoCommitScheduledAtomFamily,
     agentAutoCommitStatusAtomFamily,
     flushAgentAutoCommitAtom,
 } from "@agenta/playground/state"
-import {timeAgo} from "@agenta/shared/utils"
-import {
-    DropdownMenu,
-    DropdownMenuContent,
-    DropdownMenuItem,
-    DropdownMenuLabel,
-    DropdownMenuTrigger,
-    SimpleTooltip,
-} from "@agenta/ui/ui"
-import {CaretDown, Check, WarningCircle} from "@phosphor-icons/react"
+import {SimpleTooltip} from "@agenta/ui/ui"
+import {CaretDown, WarningCircle} from "@phosphor-icons/react"
 import {useAtomValue, useSetAtom} from "jotai"
+import dynamic from "next/dynamic"
+
+import {openAgentVersionHistoryAtom, versionHistoryOpenAtomFamily} from "../AgentVersionHistory"
+
+// Mounted only once opened: the drawer pulls the whole revision list and diff machinery.
+const AgentVersionHistoryDrawer = dynamic(
+    () => import("../AgentVersionHistory").then((m) => m.AgentVersionHistoryDrawer),
+    {ssr: false},
+)
 
 export interface AgentRevisionStatusProps {
     /** The revision whose version and dirty state this reads. */
     revisionId: string
     /**
-     * Turn the `vN` chip into a picker over this workflow's revisions. Omit where the surface
-     * already has one (the desktop's variant selector sits beside this).
+     * Turn the `vN` chip into the version-history drawer for this workflow. Omit where the
+     * surface has no workflow handle (the chip then just states the version).
      */
-    pickerWorkflowId?: string | null
-    /** Required with `pickerWorkflowId` — the host decides what selecting a revision means. */
+    historyWorkflowId?: string | null
+    /** Optional: lets a version's row offer "Open", pinning the surface to that revision. */
     onSelectRevision?: (revisionId: string) => void
     className?: string
 }
 
 /**
- * The revision list behind the chip. Its rows carry the commit message, so the picker form drops
- * the chip's message tooltip — the same text, one tap away instead of on hover.
- */
-const RevisionPicker = ({
-    workflowId,
-    revisionId,
-    version,
-    onSelectRevision,
-}: {
-    workflowId: string
-    revisionId: string
-    version: number
-    onSelectRevision: (revisionId: string) => void
-}) => {
-    // Reading the query atom is what fetches; the list atom resolves the refs it primes.
-    useAtomValue(workflowRevisionsByWorkflowQueryAtomFamily(workflowId))
-    const revisions = useAtomValue(workflowRevisionsByWorkflowListDataAtomFamily(workflowId))
-
-    return (
-        <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-                <button
-                    type="button"
-                    aria-label="Select revision"
-                    className="flex cursor-pointer items-center rounded border-0 bg-colorFillSecondary px-1.5 py-0.5 text-xs text-colorTextSecondary hover:text-colorText"
-                >
-                    v{version}
-                    <CaretDown size={9} className="ml-1" />
-                </button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="start" className="w-[280px]">
-                <DropdownMenuLabel>Revisions</DropdownMenuLabel>
-                {revisions.length === 0 ? (
-                    <DropdownMenuItem disabled>Loading…</DropdownMenuItem>
-                ) : null}
-                {revisions.map((revision) => (
-                    <DropdownMenuItem
-                        key={revision.id}
-                        onSelect={() => onSelectRevision(revision.id)}
-                    >
-                        {revision.id === revisionId ? (
-                            <Check size={12} />
-                        ) : (
-                            <span className="inline-block w-[12px]" />
-                        )}
-                        <span className="shrink-0">v{revision.version ?? 0}</span>
-                        <span className="min-w-0 flex-1 truncate text-colorTextSecondary">
-                            {revision.message?.trim() || "No commit message"}
-                        </span>
-                        {revision.created_at ? (
-                            <span className="shrink-0 text-colorTextTertiary">
-                                {timeAgo(Date.parse(revision.created_at))}
-                            </span>
-                        ) : null}
-                    </DropdownMenuItem>
-                ))}
-            </DropdownMenuContent>
-        </DropdownMenu>
-    )
-}
-
-/**
  * A revision's committed identity: the `vN` chip (its commit message on hover) and a save-status
- * dot. With `pickerWorkflowId` the chip becomes a revision picker instead.
+ * dot. With `historyWorkflowId` the chip opens the version-history drawer instead.
  *
  * The dot reports auto-commit; there is no Save button, so a failed save makes the dot the retry.
  *
@@ -111,7 +45,7 @@ const RevisionPicker = ({
  */
 export const AgentRevisionStatus = ({
     revisionId,
-    pickerWorkflowId,
+    historyWorkflowId,
     onSelectRevision,
     className,
 }: AgentRevisionStatusProps) => {
@@ -133,6 +67,14 @@ export const AgentRevisionStatus = ({
     const autoCommitError = useAtomValue(agentAutoCommitErrorAtomFamily(revisionId || ""))
     const autoCommitScheduled = useAtomValue(agentAutoCommitScheduledAtomFamily(revisionId || ""))
     const retrySave = useSetAtom(flushAgentAutoCommitAtom)
+
+    const historyOpen = useAtomValue(versionHistoryOpenAtomFamily(historyWorkflowId || ""))
+    const openHistory = useSetAtom(openAgentVersionHistoryAtom)
+    // Latched, not unmounted on close: tearing the drawer out mid-close skips its slide-out.
+    const [historyMounted, setHistoryMounted] = useState(false)
+    useEffect(() => {
+        if (historyOpen) setHistoryMounted(true)
+    }, [historyOpen])
 
     const version = (data?.version as number | null | undefined) ?? null
     const commitMessage = data?.message?.trim() || null
@@ -157,13 +99,27 @@ export const AgentRevisionStatus = ({
     return (
         <div className={`flex items-center gap-2 ${className ?? ""}`}>
             {version !== null &&
-                (pickerWorkflowId && onSelectRevision ? (
-                    <RevisionPicker
-                        workflowId={pickerWorkflowId}
-                        revisionId={revisionId}
-                        version={version}
-                        onSelectRevision={onSelectRevision}
-                    />
+                (historyWorkflowId ? (
+                    <>
+                        <SimpleTooltip title="Version history">
+                            <button
+                                type="button"
+                                aria-label="Open version history"
+                                onClick={() => openHistory(historyWorkflowId)}
+                                className="flex cursor-pointer items-center rounded border-0 bg-colorFillSecondary px-1.5 py-0.5 text-xs text-colorTextSecondary hover:text-colorText"
+                            >
+                                v{version}
+                                <CaretDown size={9} className="ml-1" />
+                            </button>
+                        </SimpleTooltip>
+                        {historyMounted ? (
+                            <AgentVersionHistoryDrawer
+                                workflowId={historyWorkflowId}
+                                revisionId={revisionId}
+                                onSelectRevision={onSelectRevision}
+                            />
+                        ) : null}
+                    </>
                 ) : (
                     <SimpleTooltip
                         className="max-w-[360px]"

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
@@ -16,7 +16,7 @@ import {
     workflowRevisionsByWorkflowListDataAtomFamily,
     workflowRevisionsByWorkflowQueryAtomFamily,
 } from "@agenta/entities/workflow"
-import {classifyAgentChanges} from "@agenta/entities/workflow/commitDiff"
+import {classifyAgentChanges, stableStringify} from "@agenta/entities/workflow/commitDiff"
 import {buildVersionRows, revertAgentRevisionAtom} from "@agenta/playground/state"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
 import {cn, textColors} from "@agenta/ui/styles"
@@ -121,6 +121,22 @@ export const AgentVersionHistoryDrawer = ({
         [selectedParams, currentParams],
     )
 
+    // An empty `sections` is not proof the configs match — the classifier only surfaces what it
+    // recognises. Compare the stored objects so an unclassified difference stays restorable.
+    const identical = useMemo(
+        () =>
+            !!selectedParams &&
+            !!currentParams &&
+            stableStringify(selectedParams) === stableStringify(currentParams),
+        [selectedParams, currentParams],
+    )
+    const isCurrentRevision = !!selectedId && selectedId === revisionId
+    const emptyText = isCurrentRevision
+        ? "This is the version you are on."
+        : identical
+          ? "Identical to your current configuration — restoring it would change nothing."
+          : "This version differs, but not in anything the summary can describe. Restoring it still applies the stored configuration."
+
     const listLoading = query.isPending && revisions.length === 0
     const isError = query.isError && revisions.length === 0
     // A selected version whose config has not resolved is LOADING, not "identical" — an empty
@@ -147,7 +163,7 @@ export const AgentVersionHistoryDrawer = ({
                     phase={phase}
                     selectedVersion={selectedRow?.version ?? null}
                     currentVersion={latestRow?.version ?? null}
-                    disabled={!selectedRow || diffLoading || !sections.length}
+                    disabled={!selectedRow || diffLoading || identical || isCurrentRevision}
                     onRequestConfirm={() => setPhase("confirm")}
                     onCancel={() => setPhase("idle")}
                     onConfirm={handleConfirm}
@@ -196,6 +212,7 @@ export const AgentVersionHistoryDrawer = ({
                         message={selectedRow?.message}
                         isLoading={diffLoading}
                         placeholder={placeholder}
+                        emptyText={emptyText}
                     />
                 </div>
             </div>

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
@@ -55,13 +55,13 @@ export const AgentVersionHistoryDrawer = ({
     const query = useAtomValue(workflowRevisionsByWorkflowQueryAtomFamily(workflowId))
     const revisions = useAtomValue(workflowRevisionsByWorkflowListDataAtomFamily(workflowId))
 
-    const rows = useMemo(() => buildVersionRows(revisions, revisionId), [revisions, revisionId])
+    const rows = useMemo(() => buildVersionRows(revisions), [revisions])
     const selectedRow = rows.find((row) => row.id === selectedId) ?? null
-    // The footer counts off the LATEST version: a revert mints the next one after it, which is
-    // not `current + 1` when the surface happens to sit on an older revision.
+    // The latest version is the drawer's ONE baseline: what every diff compares against, and what
+    // the footer counts from. A revert mints the version after it, whichever revision is on screen.
     const latestRow = rows.find((row) => row.isLatest) ?? null
 
-    const currentParams = useAtomValue(workflowMolecule.selectors.configuration(revisionId || ""))
+    const latestParams = useAtomValue(workflowMolecule.selectors.configuration(latestRow?.id ?? ""))
     const selectedParams = useAtomValue(
         workflowMolecule.selectors.serverConfiguration(selectedId || ""),
     )
@@ -115,10 +115,10 @@ export const AgentVersionHistoryDrawer = ({
     // restoring this version would bring back — the diff doubles as the revert preview.
     const sections = useMemo(
         () =>
-            selectedParams && currentParams
-                ? classifyAgentChanges(selectedParams, currentParams)
+            selectedParams && latestParams
+                ? classifyAgentChanges(selectedParams, latestParams)
                 : [],
-        [selectedParams, currentParams],
+        [selectedParams, latestParams],
     )
 
     // An empty `sections` is not proof the configs match — the classifier only surfaces what it
@@ -126,22 +126,21 @@ export const AgentVersionHistoryDrawer = ({
     const identical = useMemo(
         () =>
             !!selectedParams &&
-            !!currentParams &&
-            stableStringify(selectedParams) === stableStringify(currentParams),
-        [selectedParams, currentParams],
+            !!latestParams &&
+            stableStringify(selectedParams) === stableStringify(latestParams),
+        [selectedParams, latestParams],
     )
-    const isCurrentRevision = !!selectedId && selectedId === revisionId
-    const emptyText = isCurrentRevision
-        ? "This is the version you are on."
-        : identical
-          ? "Identical to your current configuration — restoring it would change nothing."
-          : "This version differs, but not in anything the summary can describe. Restoring it still applies the stored configuration."
+    const isLatestSelected = !!selectedId && selectedId === latestRow?.id
+    const emptyText =
+        identical || isLatestSelected
+            ? `Identical to v${latestRow?.version ?? "—"} — restoring it would change nothing.`
+            : "This version differs, but not in anything the summary can describe. Restoring it still applies the stored configuration."
 
     const listLoading = query.isPending && revisions.length === 0
     const isError = query.isError && revisions.length === 0
     // A selected version whose config has not resolved is LOADING, not "identical" — an empty
     // `sections` means both, and only this tells them apart.
-    const diffLoading = listLoading || (!!selectedId && (!selectedParams || !currentParams))
+    const diffLoading = listLoading || (!!selectedId && (!selectedParams || !latestParams))
     const placeholder = isError
         ? "The version history could not be loaded. Retry from the list."
         : rows.length <= 1
@@ -162,8 +161,8 @@ export const AgentVersionHistoryDrawer = ({
                 <RevertFooter
                     phase={phase}
                     selectedVersion={selectedRow?.version ?? null}
-                    currentVersion={latestRow?.version ?? null}
-                    disabled={!selectedRow || diffLoading || identical || isCurrentRevision}
+                    latestVersion={latestRow?.version ?? null}
+                    disabled={!selectedRow || diffLoading || identical || isLatestSelected}
                     onRequestConfirm={() => setPhase("confirm")}
                     onCancel={() => setPhase("idle")}
                     onConfirm={handleConfirm}

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
@@ -20,7 +20,6 @@ import {classifyAgentChanges} from "@agenta/entities/workflow/commitDiff"
 import {buildVersionRows, revertAgentRevisionAtom} from "@agenta/playground/state"
 import {EnhancedDrawer} from "@agenta/ui/drawer"
 import {cn, textColors} from "@agenta/ui/styles"
-import {Button} from "@agenta/ui/ui"
 import {ArrowLeft} from "@phosphor-icons/react"
 import {useAtomValue, useSetAtom} from "jotai"
 
@@ -41,14 +40,11 @@ export interface AgentVersionHistoryDrawerProps {
     workflowId: string
     /** The revision under edit — the side every diff compares against, and revert commits from. */
     revisionId: string
-    /** Where the host can pin a revision (mobile). Omitted, rows only select for comparison. */
-    onSelectRevision?: (revisionId: string) => void
 }
 
 export const AgentVersionHistoryDrawer = ({
     workflowId,
     revisionId,
-    onSelectRevision,
 }: AgentVersionHistoryDrawerProps) => {
     const open = useAtomValue(versionHistoryOpenAtomFamily(workflowId))
     const selectedId = useAtomValue(versionHistorySelectedAtomFamily(workflowId))
@@ -66,18 +62,20 @@ export const AgentVersionHistoryDrawer = ({
 
     const rows = useMemo(() => buildVersionRows(revisions, revisionId), [revisions, revisionId])
     const selectedRow = rows.find((row) => row.id === selectedId) ?? null
-    const currentRow = rows.find((row) => row.isCurrent) ?? null
+    // The footer counts off the LATEST version: a revert mints the next one after it, which is
+    // not `current + 1` when the surface happens to sit on an older revision.
+    const latestRow = rows.find((row) => row.isLatest) ?? null
 
     const currentParams = useAtomValue(workflowMolecule.selectors.configuration(revisionId || ""))
     const selectedParams = useAtomValue(
         workflowMolecule.selectors.serverConfiguration(selectedId || ""),
     )
 
-    // Open on the version below the latest — the latest IS the current configuration, so it is
-    // not selectable and would show an empty diff. Set directly, not through `handleSelect`,
-    // so a phone still opens on the list rather than jumping to the diff.
+    // Open on the version below the latest — the latest is the comparison baseline, so it is not
+    // selectable and would show an empty diff. Set directly, not through `handleSelect`, so a
+    // phone still opens on the list rather than jumping to the diff.
     const selectVersionId = useSetAtom(versionHistorySelectedAtomFamily(workflowId))
-    const firstComparableId = rows.find((row) => !row.isCurrent)?.id ?? null
+    const firstComparableId = rows.find((row) => !row.isLatest)?.id ?? null
     useEffect(() => {
         if (open && !selectedId && firstComparableId) selectVersionId(firstComparableId)
     }, [open, selectedId, firstComparableId, selectVersionId])
@@ -139,7 +137,7 @@ export const AgentVersionHistoryDrawer = ({
                 <RevertFooter
                     phase={phase}
                     selectedVersion={selectedRow?.version ?? null}
-                    currentVersion={currentRow?.version ?? null}
+                    currentVersion={latestRow?.version ?? null}
                     revertedFrom={revertedFrom}
                     disabled={!selectedRow || diffLoading || !sections.length}
                     onRequestConfirm={() => setPhase("confirm")}
@@ -163,20 +161,6 @@ export const AgentVersionHistoryDrawer = ({
                         isError={isError}
                         onRetry={() => void query.refetch()}
                         onSelect={handleSelect}
-                        renderRowAction={
-                            onSelectRevision
-                                ? (row) =>
-                                      row.isCurrent ? null : (
-                                          <Button
-                                              variant="link"
-                                              size="sm"
-                                              onClick={() => onSelectRevision(row.id)}
-                                          >
-                                              Open
-                                          </Button>
-                                      )
-                                : undefined
-                        }
                     />
                 </div>
 

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
@@ -140,7 +140,8 @@ export const AgentVersionHistoryDrawer = ({
             onClose={handleClose}
             title={<span className="text-sm font-normal">Version history</span>}
             width={780}
-            classNames={{body: "!p-0"}}
+            // px-3 so the buttons' outer edge lands on the same line as the section bands.
+            classNames={{body: "!p-0", footer: "px-3"}}
             footer={
                 <RevertFooter
                     phase={phase}

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
@@ -9,7 +9,7 @@
  * shared `AgentRevisionStatus`. Below `sm` the two panes become one at a time — a phone has no
  * room for a 250px rail beside a diff.
  */
-import {useCallback, useEffect, useMemo, useState} from "react"
+import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import {
     workflowMolecule,
@@ -78,8 +78,13 @@ export const AgentVersionHistoryDrawer = ({
     // Phone: one pane at a time. Picking a version pushes the diff; a back link returns.
     const [mobileView, setMobileView] = useState<"list" | "diff">("list")
 
+    // Bumped whenever the flow is abandoned, so a revert that resolves afterwards knows its
+    // result is stale. Escape and outside-click dismiss the drawer, so a commit can outlive it.
+    const revertRun = useRef(0)
+
     // The drawer stays mounted so it can animate out, so closing must reset its own state.
     const handleClose = useCallback(() => {
+        revertRun.current += 1
         closeDrawer(workflowId)
         setPhase("idle")
         setMobileView("list")
@@ -87,6 +92,7 @@ export const AgentVersionHistoryDrawer = ({
 
     const handleSelect = useCallback(
         (id: string) => {
+            revertRun.current += 1
             selectVersion({workflowId, revisionId: id})
             setPhase("idle")
             setMobileView("diff")
@@ -96,8 +102,12 @@ export const AgentVersionHistoryDrawer = ({
 
     const handleConfirm = useCallback(async () => {
         if (!selectedRow) return
+        const run = ++revertRun.current
         setPhase("reverting")
         const landed = await revert({revisionId, targetRevisionId: selectedRow.id})
+        // Closed or moved on while the commit was in flight: the outcome is no longer this
+        // drawer's to report. The revision itself still landed either way.
+        if (run !== revertRun.current) return
         setPhase(landed ? "done" : "failed")
     }, [selectedRow, revert, revisionId])
 

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
@@ -56,22 +56,29 @@ export const AgentVersionHistoryDrawer = ({
     const revisions = useAtomValue(workflowRevisionsByWorkflowListDataAtomFamily(workflowId))
 
     const rows = useMemo(() => buildVersionRows(revisions), [revisions])
-    const selectedRow = rows.find((row) => row.id === selectedId) ?? null
-    // The latest version is the drawer's ONE baseline: what every diff compares against, and what
-    // the footer counts from. A revert mints the version after it, whichever revision is on screen.
+    const selectedIndex = rows.findIndex((row) => row.id === selectedId)
+    const selectedRow = selectedIndex >= 0 ? rows[selectedIndex] : null
+    // Rows are newest first, so a version's predecessor is the row under it. That pair is the
+    // diff: what THIS version changed, matching the message the list prints beside it.
+    const previousRow = selectedIndex >= 0 ? (rows[selectedIndex + 1] ?? null) : null
+    // The footer still counts from the latest — a revert mints the version after it.
     const latestRow = rows.find((row) => row.isLatest) ?? null
 
-    const latestParams = useAtomValue(workflowMolecule.selectors.configuration(latestRow?.id ?? ""))
     const selectedParams = useAtomValue(
         workflowMolecule.selectors.serverConfiguration(selectedId || ""),
     )
+    const previousParams = useAtomValue(
+        workflowMolecule.selectors.serverConfiguration(previousRow?.id ?? ""),
+    )
+    // Only the button needs this: reverting to a version identical to the head does nothing.
+    const latestParams = useAtomValue(workflowMolecule.selectors.configuration(latestRow?.id ?? ""))
 
-    // Opens below the latest; set directly so a phone still lands on the list, not the diff.
+    // Opens on the newest version — "what just changed" is the question the drawer is opened with.
     const selectVersionId = useSetAtom(versionHistorySelectedAtomFamily(workflowId))
-    const firstComparableId = rows.find((row) => !row.isLatest)?.id ?? null
+    const newestId = rows[0]?.id ?? null
     useEffect(() => {
-        if (open && !selectedId && firstComparableId) selectVersionId(firstComparableId)
-    }, [open, selectedId, firstComparableId, selectVersionId])
+        if (open && !selectedId && newestId) selectVersionId(newestId)
+    }, [open, selectedId, newestId, selectVersionId])
 
     // Drawer-local: nothing outside reads either.
     const [phase, setPhase] = useState<RevertPhase>("idle")
@@ -111,43 +118,40 @@ export const AgentVersionHistoryDrawer = ({
         setPhase(landed ? "done" : "failed")
     }, [selectedRow, revert, revisionId])
 
-    // `local` is the selected version and `remote` the current one, so "added" reads as what
-    // restoring this version would bring back — the diff doubles as the revert preview.
+    // `local` is the selected version and `remote` its predecessor, so "added" reads as what this
+    // version added — the same tense as the commit message on its row.
     const sections = useMemo(
         () =>
-            selectedParams && latestParams
-                ? classifyAgentChanges(selectedParams, latestParams)
+            selectedParams && previousParams
+                ? classifyAgentChanges(selectedParams, previousParams)
                 : [],
-        [selectedParams, latestParams],
+        [selectedParams, previousParams],
     )
 
-    // An empty `sections` is not proof the configs match — the classifier only surfaces what it
-    // recognises. Compare the stored objects so an unclassified difference stays restorable.
-    const identical = useMemo(
+    // Restoring a version whose configuration already matches the head does nothing, so the
+    // BUTTON still measures against the latest even though the pane shows this version's own change.
+    const matchesLatest = useMemo(
         () =>
             !!selectedParams &&
             !!latestParams &&
             stableStringify(selectedParams) === stableStringify(latestParams),
         [selectedParams, latestParams],
     )
-    const isLatestSelected = !!selectedId && selectedId === latestRow?.id
-    const emptyText =
-        identical || isLatestSelected
-            ? `Identical to v${latestRow?.version ?? "—"} — restoring it would change nothing.`
-            : "This version differs, but not in anything the summary can describe. Restoring it still applies the stored configuration."
+    const emptyText = !previousRow
+        ? "The first version — there is nothing before it to compare."
+        : "No configuration changes recorded in this version."
 
     const listLoading = query.isPending && revisions.length === 0
     const isError = query.isError && revisions.length === 0
-    // A selected version whose config has not resolved is LOADING, not "identical" — an empty
-    // `sections` means both, and only this tells them apart.
-    const diffLoading = listLoading || (!!selectedId && (!selectedParams || !latestParams))
+    // A version whose config has not resolved is LOADING, not "unchanged" — an empty `sections`
+    // means both, and only this tells them apart. The oldest row legitimately has no predecessor.
+    const diffLoading =
+        listLoading || (!!selectedId && !selectedParams) || (!!previousRow && !previousParams)
     const placeholder = isError
         ? "The version history could not be loaded. Retry from the list."
-        : rows.length <= 1
-          ? "Nothing to compare yet — this agent has a single version."
-          : !selectedId
-            ? "Pick a version to see what restoring it would change."
-            : undefined
+        : !selectedId
+          ? "Pick a version to see what changed in it."
+          : undefined
 
     return (
         <EnhancedDrawer
@@ -162,7 +166,7 @@ export const AgentVersionHistoryDrawer = ({
                     phase={phase}
                     selectedVersion={selectedRow?.version ?? null}
                     latestVersion={latestRow?.version ?? null}
-                    disabled={!selectedRow || diffLoading || identical || isLatestSelected}
+                    disabled={!selectedRow || diffLoading || matchesLatest}
                     onRequestConfirm={() => setPhase("confirm")}
                     onCancel={() => setPhase("idle")}
                     onConfirm={handleConfirm}

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
@@ -25,12 +25,11 @@ import {useAtomValue, useSetAtom} from "jotai"
 
 import {ChangesPane} from "./ChangesPane"
 import {RevertFooter} from "./RevertFooter"
+import type {RevertPhase} from "./RevertFooter"
 import {
     closeAgentVersionHistoryAtom,
     selectAgentVersionAtom,
     versionHistoryOpenAtomFamily,
-    versionHistoryPhaseAtomFamily,
-    versionHistoryRevertedFromAtomFamily,
     versionHistorySelectedAtomFamily,
 } from "./store"
 import {VersionList} from "./VersionList"
@@ -48,10 +47,6 @@ export const AgentVersionHistoryDrawer = ({
 }: AgentVersionHistoryDrawerProps) => {
     const open = useAtomValue(versionHistoryOpenAtomFamily(workflowId))
     const selectedId = useAtomValue(versionHistorySelectedAtomFamily(workflowId))
-    const phase = useAtomValue(versionHistoryPhaseAtomFamily(workflowId))
-    const revertedFrom = useAtomValue(versionHistoryRevertedFromAtomFamily(workflowId))
-    const setPhase = useSetAtom(versionHistoryPhaseAtomFamily(workflowId))
-    const setRevertedFrom = useSetAtom(versionHistoryRevertedFromAtomFamily(workflowId))
     const selectVersion = useSetAtom(selectAgentVersionAtom)
     const closeDrawer = useSetAtom(closeAgentVersionHistoryAtom)
     const revert = useSetAtom(revertAgentRevisionAtom)
@@ -78,12 +73,22 @@ export const AgentVersionHistoryDrawer = ({
         if (open && !selectedId && firstComparableId) selectVersionId(firstComparableId)
     }, [open, selectedId, firstComparableId, selectVersionId])
 
+    // Drawer-local: nothing outside reads either.
+    const [phase, setPhase] = useState<RevertPhase>("idle")
     // Phone: one pane at a time. Picking a version pushes the diff; a back link returns.
     const [mobileView, setMobileView] = useState<"list" | "diff">("list")
+
+    // The drawer stays mounted so it can animate out, so closing must reset its own state.
+    const handleClose = useCallback(() => {
+        closeDrawer(workflowId)
+        setPhase("idle")
+        setMobileView("list")
+    }, [closeDrawer, workflowId])
 
     const handleSelect = useCallback(
         (id: string) => {
             selectVersion({workflowId, revisionId: id})
+            setPhase("idle")
             setMobileView("diff")
         },
         [selectVersion, workflowId],
@@ -93,13 +98,8 @@ export const AgentVersionHistoryDrawer = ({
         if (!selectedRow) return
         setPhase("reverting")
         const landed = await revert({revisionId, targetRevisionId: selectedRow.id})
-        if (landed) {
-            setRevertedFrom(selectedRow.version)
-            setPhase("done")
-        } else {
-            setPhase("failed")
-        }
-    }, [selectedRow, revert, revisionId, setPhase, setRevertedFrom])
+        setPhase(landed ? "done" : "failed")
+    }, [selectedRow, revert, revisionId])
 
     // `local` is the selected version and `remote` the current one, so "added" reads as what
     // restoring this version would bring back — the diff doubles as the revert preview.
@@ -115,7 +115,7 @@ export const AgentVersionHistoryDrawer = ({
     const isError = query.isError && revisions.length === 0
     // A selected version whose config has not resolved is LOADING, not "identical" — an empty
     // `sections` means both, and only this tells them apart.
-    const diffLoading = listLoading || (!!selectedId && !selectedParams)
+    const diffLoading = listLoading || (!!selectedId && (!selectedParams || !currentParams))
     const placeholder = isError
         ? "The version history could not be loaded. Retry from the list."
         : rows.length <= 1
@@ -127,7 +127,7 @@ export const AgentVersionHistoryDrawer = ({
     return (
         <EnhancedDrawer
             open={open}
-            onClose={() => closeDrawer(workflowId)}
+            onClose={handleClose}
             title={<span className="text-sm font-normal">Version history</span>}
             width={780}
             classNames={{body: "!p-0"}}
@@ -136,12 +136,11 @@ export const AgentVersionHistoryDrawer = ({
                     phase={phase}
                     selectedVersion={selectedRow?.version ?? null}
                     currentVersion={latestRow?.version ?? null}
-                    revertedFrom={revertedFrom}
                     disabled={!selectedRow || diffLoading || !sections.length}
                     onRequestConfirm={() => setPhase("confirm")}
                     onCancel={() => setPhase("idle")}
                     onConfirm={handleConfirm}
-                    onClose={() => closeDrawer(workflowId)}
+                    onClose={handleClose}
                 />
             }
         >
@@ -159,6 +158,7 @@ export const AgentVersionHistoryDrawer = ({
                         isError={isError}
                         onRetry={() => void query.refetch()}
                         onSelect={handleSelect}
+                        disabled={phase === "reverting"}
                     />
                 </div>
 

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
@@ -1,0 +1,213 @@
+/**
+ * Version history for an agent: browse versions, see what each one would change against the
+ * configuration on screen, and restore one.
+ *
+ * Restoring never rewrites history — it commits a new version holding the old content. The
+ * engine for that lives in `@agenta/playground`; this file is the surface.
+ *
+ * Both hosts render it: the desktop playground header and the mobile session top bar, through the
+ * shared `AgentRevisionStatus`. Below `sm` the two panes become one at a time — a phone has no
+ * room for a 250px rail beside a diff.
+ */
+import {useCallback, useEffect, useMemo, useState} from "react"
+
+import {
+    workflowMolecule,
+    workflowRevisionsByWorkflowListDataAtomFamily,
+    workflowRevisionsByWorkflowQueryAtomFamily,
+} from "@agenta/entities/workflow"
+import {classifyAgentChanges} from "@agenta/entities/workflow/commitDiff"
+import {buildVersionRows, revertAgentRevisionAtom} from "@agenta/playground/state"
+import {EnhancedDrawer} from "@agenta/ui/drawer"
+import {cn, textColors} from "@agenta/ui/styles"
+import {Button} from "@agenta/ui/ui"
+import {ArrowLeft} from "@phosphor-icons/react"
+import {useAtomValue, useSetAtom} from "jotai"
+
+import {ChangesPane} from "./ChangesPane"
+import {RevertFooter} from "./RevertFooter"
+import {
+    closeAgentVersionHistoryAtom,
+    selectAgentVersionAtom,
+    versionHistoryOpenAtomFamily,
+    versionHistoryPhaseAtomFamily,
+    versionHistoryRevertedFromAtomFamily,
+    versionHistorySelectedAtomFamily,
+} from "./store"
+import {VersionList} from "./VersionList"
+
+export interface AgentVersionHistoryDrawerProps {
+    /** The workflow whose revisions are listed. */
+    workflowId: string
+    /** The revision under edit — the side every diff compares against, and revert commits from. */
+    revisionId: string
+    /** Where the host can pin a revision (mobile). Omitted, rows only select for comparison. */
+    onSelectRevision?: (revisionId: string) => void
+}
+
+export const AgentVersionHistoryDrawer = ({
+    workflowId,
+    revisionId,
+    onSelectRevision,
+}: AgentVersionHistoryDrawerProps) => {
+    const open = useAtomValue(versionHistoryOpenAtomFamily(workflowId))
+    const selectedId = useAtomValue(versionHistorySelectedAtomFamily(workflowId))
+    const phase = useAtomValue(versionHistoryPhaseAtomFamily(workflowId))
+    const revertedFrom = useAtomValue(versionHistoryRevertedFromAtomFamily(workflowId))
+    const setPhase = useSetAtom(versionHistoryPhaseAtomFamily(workflowId))
+    const setRevertedFrom = useSetAtom(versionHistoryRevertedFromAtomFamily(workflowId))
+    const selectVersion = useSetAtom(selectAgentVersionAtom)
+    const closeDrawer = useSetAtom(closeAgentVersionHistoryAtom)
+    const revert = useSetAtom(revertAgentRevisionAtom)
+
+    // Reading the query atom is what fetches; the list atom resolves the refs it primes.
+    const query = useAtomValue(workflowRevisionsByWorkflowQueryAtomFamily(workflowId))
+    const revisions = useAtomValue(workflowRevisionsByWorkflowListDataAtomFamily(workflowId))
+
+    const rows = useMemo(() => buildVersionRows(revisions, revisionId), [revisions, revisionId])
+    const selectedRow = rows.find((row) => row.id === selectedId) ?? null
+    const currentRow = rows.find((row) => row.isCurrent) ?? null
+
+    const currentParams = useAtomValue(workflowMolecule.selectors.configuration(revisionId || ""))
+    const selectedParams = useAtomValue(
+        workflowMolecule.selectors.serverConfiguration(selectedId || ""),
+    )
+
+    // Open on the version below the latest — the latest IS the current configuration, so it is
+    // not selectable and would show an empty diff. Set directly, not through `handleSelect`,
+    // so a phone still opens on the list rather than jumping to the diff.
+    const selectVersionId = useSetAtom(versionHistorySelectedAtomFamily(workflowId))
+    const firstComparableId = rows.find((row) => !row.isCurrent)?.id ?? null
+    useEffect(() => {
+        if (open && !selectedId && firstComparableId) selectVersionId(firstComparableId)
+    }, [open, selectedId, firstComparableId, selectVersionId])
+
+    // Phone: one pane at a time. Picking a version pushes the diff; a back link returns.
+    const [mobileView, setMobileView] = useState<"list" | "diff">("list")
+
+    const handleSelect = useCallback(
+        (id: string) => {
+            selectVersion({workflowId, revisionId: id})
+            setMobileView("diff")
+        },
+        [selectVersion, workflowId],
+    )
+
+    const handleConfirm = useCallback(async () => {
+        if (!selectedRow) return
+        setPhase("reverting")
+        const landed = await revert({revisionId, targetRevisionId: selectedRow.id})
+        if (landed) {
+            setRevertedFrom(selectedRow.version)
+            setPhase("done")
+        } else {
+            setPhase("failed")
+        }
+    }, [selectedRow, revert, revisionId, setPhase, setRevertedFrom])
+
+    // `local` is the selected version and `remote` the current one, so "added" reads as what
+    // restoring this version would bring back — the diff doubles as the revert preview.
+    const sections = useMemo(
+        () =>
+            selectedParams && currentParams
+                ? classifyAgentChanges(selectedParams, currentParams)
+                : [],
+        [selectedParams, currentParams],
+    )
+
+    const listLoading = query.isPending && revisions.length === 0
+    const isError = query.isError && revisions.length === 0
+    // A selected version whose config has not resolved is LOADING, not "identical" — an empty
+    // `sections` means both, and only this tells them apart.
+    const diffLoading = listLoading || (!!selectedId && !selectedParams)
+    const placeholder = isError
+        ? "The version history could not be loaded. Retry from the list."
+        : rows.length <= 1
+          ? "Nothing to compare yet — this agent has a single version."
+          : !selectedId
+            ? "Pick a version to see what restoring it would change."
+            : undefined
+
+    return (
+        <EnhancedDrawer
+            open={open}
+            onClose={() => closeDrawer(workflowId)}
+            title={<span className="text-sm font-normal">Version history</span>}
+            width={780}
+            classNames={{body: "!p-0"}}
+            footer={
+                <RevertFooter
+                    phase={phase}
+                    selectedVersion={selectedRow?.version ?? null}
+                    currentVersion={currentRow?.version ?? null}
+                    revertedFrom={revertedFrom}
+                    disabled={!selectedRow || diffLoading || !sections.length}
+                    onRequestConfirm={() => setPhase("confirm")}
+                    onCancel={() => setPhase("idle")}
+                    onConfirm={handleConfirm}
+                    onClose={() => closeDrawer(workflowId)}
+                />
+            }
+        >
+            <div className="flex h-full min-h-0">
+                <div
+                    className={cn(
+                        "flex min-h-0 flex-col py-3 pl-3 pr-2 sm:w-[250px] sm:shrink-0",
+                        mobileView === "list" ? "w-full" : "hidden sm:flex",
+                    )}
+                >
+                    <VersionList
+                        rows={rows}
+                        selectedId={selectedId}
+                        isLoading={listLoading}
+                        isError={isError}
+                        onRetry={() => void query.refetch()}
+                        onSelect={handleSelect}
+                        renderRowAction={
+                            onSelectRevision
+                                ? (row) =>
+                                      row.isCurrent ? null : (
+                                          <Button
+                                              variant="link"
+                                              size="sm"
+                                              onClick={() => onSelectRevision(row.id)}
+                                          >
+                                              Open
+                                          </Button>
+                                      )
+                                : undefined
+                        }
+                    />
+                </div>
+
+                <div
+                    className={cn(
+                        "flex min-w-0 flex-1 flex-col sm:border-0 sm:border-l sm:border-solid sm:border-[var(--ag-colorBorderSecondary)]",
+                        mobileView === "diff" ? "flex" : "hidden sm:flex",
+                    )}
+                >
+                    <button
+                        type="button"
+                        onClick={() => setMobileView("list")}
+                        className={cn(
+                            "flex cursor-pointer items-center gap-1.5 border-0 bg-transparent px-5 pt-3.5 text-xs sm:hidden",
+                            textColors.secondary,
+                        )}
+                    >
+                        <ArrowLeft />
+                        Versions
+                    </button>
+                    <ChangesPane
+                        sections={sections}
+                        version={selectedRow?.version ?? null}
+                        message={selectedRow?.message}
+                        isLoading={diffLoading}
+                        placeholder={placeholder}
+                    />
+                </div>
+            </div>
+        </EnhancedDrawer>
+    )
+}
+
+export default AgentVersionHistoryDrawer

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
@@ -71,9 +71,7 @@ export const AgentVersionHistoryDrawer = ({
         workflowMolecule.selectors.serverConfiguration(selectedId || ""),
     )
 
-    // Open on the version below the latest — the latest is the comparison baseline, so it is not
-    // selectable and would show an empty diff. Set directly, not through `handleSelect`, so a
-    // phone still opens on the list rather than jumping to the diff.
+    // Opens below the latest; set directly so a phone still lands on the list, not the diff.
     const selectVersionId = useSetAtom(versionHistorySelectedAtomFamily(workflowId))
     const firstComparableId = rows.find((row) => !row.isLatest)?.id ?? null
     useEffect(() => {

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
@@ -103,6 +103,12 @@ export const ChangesPane = ({
                         {message}
                     </span>
                 ) : null}
+                {/* Without this the rows read as the version's contents, so a removal reads backwards. */}
+                {sections.length ? (
+                    <span className={cn("mt-1.5 text-[11.5px] leading-snug", textColors.tertiary)}>
+                        What restoring v{version} would change on your agent
+                    </span>
+                ) : null}
             </div>
             {sections.length === 0 ? (
                 <div className={cn("px-6 py-14 text-center text-[12.5px]", textColors.tertiary)}>

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
@@ -1,0 +1,119 @@
+/**
+ * What the selected version would change, against the configuration currently on screen.
+ *
+ * Renders `ChangeSections` (`@agenta/entity-ui/changes`) — the same section list the commit modal
+ * shows — rather than `AgentChangesSummary`, which statically imports `DiffView` and the Lexical
+ * editor behind it. This drawer runs on mobile too, and the design has no JSON view here.
+ *
+ * The sections are computed by the drawer, not here: the footer has to know whether there is
+ * anything to restore before it can enable Revert, and one diff should be computed once.
+ */
+import {useMemo, useState} from "react"
+
+import type {ChangeSection} from "@agenta/entities/workflow/commitDiff"
+import {ChangeSections} from "@agenta/entity-ui/changes"
+import {cn, textColors} from "@agenta/ui/styles"
+
+const SKELETON_SECTIONS = [
+    {title: "112px", tag: "56px", body: "34px"},
+    {title: "78px", tag: "42px", body: "72px"},
+    {title: "88px", tag: "60px", body: "34px"},
+]
+
+const Centered = ({children}: {children: React.ReactNode}) => (
+    <div
+        className={cn(
+            "mx-auto flex max-w-[340px] flex-1 items-center justify-center p-8 text-center text-[12.5px] leading-relaxed",
+            textColors.tertiary,
+        )}
+    >
+        {children}
+    </div>
+)
+
+const Skeleton = () => (
+    <div className="flex-1 overflow-hidden px-5 pb-4 pt-3.5">
+        <div className="mb-4 h-3.5 w-[132px] animate-pulse rounded-[3px] bg-[var(--ag-colorFillSecondary)]" />
+        {SKELETON_SECTIONS.map((section, i) => (
+            <div key={i} className="mb-3.5">
+                <div className="flex items-center gap-2 px-2 py-2">
+                    <div className="size-4 animate-pulse rounded-[3px] bg-[var(--ag-colorFillSecondary)]" />
+                    <div
+                        className="h-3 animate-pulse rounded-[3px] bg-[var(--ag-colorFillSecondary)]"
+                        style={{width: section.title}}
+                    />
+                    <div
+                        className="ml-auto h-2.5 animate-pulse rounded-[3px] bg-[var(--ag-colorFillTertiary)]"
+                        style={{width: section.tag}}
+                    />
+                </div>
+                <div
+                    className="animate-pulse rounded bg-[var(--ag-colorFillQuaternary)]"
+                    style={{height: section.body}}
+                />
+            </div>
+        ))}
+    </div>
+)
+
+export interface ChangesPaneProps {
+    sections: ChangeSection[]
+    /** The selected version, named in the pane heading. */
+    version: number | null
+    /** That version's commit message, under the heading. */
+    message?: string | null
+    /** The version list is still loading, or the selected version's config has not resolved. */
+    isLoading: boolean
+    /** Shown instead of a diff when there is nothing to select yet (empty list, load error). */
+    placeholder?: string
+}
+
+export const ChangesPane = ({
+    sections,
+    version,
+    message,
+    isLoading,
+    placeholder,
+}: ChangesPaneProps) => {
+    const [openOverrides, setOpenOverrides] = useState<Record<string, boolean>>({})
+    // Sections can arrive after the first render, so resolve open state per section rather than
+    // seeding a set once — a late section would otherwise land shut.
+    const openState = useMemo(
+        () => Object.fromEntries(sections.map((s) => [s.id, openOverrides[s.id] ?? true])),
+        [sections, openOverrides],
+    )
+
+    if (isLoading) return <Skeleton />
+    if (placeholder) return <Centered>{placeholder}</Centered>
+
+    return (
+        <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-4 pt-3.5">
+            <div className="mb-3 flex flex-col gap-0.5">
+                <span className="text-[13.5px] font-medium text-colorText">
+                    Version {version ?? "—"}
+                </span>
+                {message ? (
+                    <span className={cn("text-xs leading-snug", textColors.tertiary)}>
+                        {message}
+                    </span>
+                ) : null}
+            </div>
+            {sections.length === 0 ? (
+                <div className={cn("px-6 py-14 text-center text-[12.5px]", textColors.tertiary)}>
+                    This is the current configuration. Nothing to compare.
+                </div>
+            ) : (
+                <ChangeSections
+                    sections={sections}
+                    size="small"
+                    hideTags
+                    ghost
+                    openState={openState}
+                    onToggleSection={(id) =>
+                        setOpenOverrides((prev) => ({...prev, [id]: !(prev[id] ?? true)}))
+                    }
+                />
+            )}
+        </div>
+    )
+}

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
@@ -98,18 +98,13 @@ export const ChangesPane = ({
     return (
         <div className={cn("min-h-0 flex-1 overflow-y-auto pb-4 pt-3.5", PANE_PAD)}>
             <div className={cn("mb-3 flex flex-col gap-0.5", BAND_PAD)}>
+                {/* The title carries the tense: these rows are the version's own change. */}
                 <span className="text-[13.5px] font-medium text-colorText">
-                    Version {version ?? "—"}
+                    What version {version ?? "—"} changed
                 </span>
                 {message ? (
                     <span className={cn("text-xs leading-snug", textColors.tertiary)}>
                         {message}
-                    </span>
-                ) : null}
-                {/* Names the tense: these rows are this version's own change, not its contents. */}
-                {sections.length ? (
-                    <span className={cn("mt-1.5 text-[11.5px] leading-snug", textColors.tertiary)}>
-                        What v{version} changed
                     </span>
                 ) : null}
             </div>

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
@@ -126,7 +126,6 @@ export const ChangesPane = ({
                 <ChangeSections
                     sections={sections}
                     size="small"
-                    hideTags
                     ghost
                     openState={openState}
                     onToggleSection={(id) =>

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
@@ -106,10 +106,10 @@ export const ChangesPane = ({
                         {message}
                     </span>
                 ) : null}
-                {/* Without this the rows read as the version's contents, so a removal reads backwards. */}
+                {/* Names the tense: these rows are this version's own change, not its contents. */}
                 {sections.length ? (
                     <span className={cn("mt-1.5 text-[11.5px] leading-snug", textColors.tertiary)}>
-                        What restoring v{version} would change on your agent
+                        What v{version} changed
                     </span>
                 ) : null}
             </div>

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
@@ -14,6 +14,11 @@ import type {ChangeSection} from "@agenta/entities/workflow/commitDiff"
 import {ChangeSections} from "@agenta/entity-ui/changes"
 import {cn, textColors} from "@agenta/ui/styles"
 
+/** The pane's own inset. Section bands fill it edge to edge and pad their content inward. */
+const PANE_PAD = "px-3"
+/** What a band pads inward, so text sits on one line with the heading above it. */
+const BAND_PAD = "px-2"
+
 const SKELETON_SECTIONS = [
     {title: "112px", tag: "56px", body: "34px"},
     {title: "78px", tag: "42px", body: "72px"},
@@ -32,8 +37,9 @@ const Centered = ({children}: {children: React.ReactNode}) => (
 )
 
 const Skeleton = () => (
-    <div className="flex-1 overflow-hidden px-5 pb-4 pt-3.5">
-        <div className="mb-4 h-3.5 w-[132px] animate-pulse rounded-[3px] bg-[var(--ag-colorFillSecondary)]" />
+    <div className={cn("flex-1 overflow-hidden pb-4 pt-3.5", PANE_PAD)}>
+        {/* ml-2 literal: it mirrors BAND_PAD, but Tailwind only sees classes written out. */}
+        <div className="mb-4 ml-2 h-3.5 w-[132px] animate-pulse rounded-[3px] bg-[var(--ag-colorFillSecondary)]" />
         {SKELETON_SECTIONS.map((section, i) => (
             <div key={i} className="mb-3.5">
                 <div className="flex items-center gap-2 px-2 py-2">
@@ -87,8 +93,8 @@ export const ChangesPane = ({
     if (placeholder) return <Centered>{placeholder}</Centered>
 
     return (
-        <div className="min-h-0 flex-1 overflow-y-auto px-5 pb-4 pt-3.5">
-            <div className="mb-3 flex flex-col gap-0.5">
+        <div className={cn("min-h-0 flex-1 overflow-y-auto pb-4 pt-3.5", PANE_PAD)}>
+            <div className={cn("mb-3 flex flex-col gap-0.5", BAND_PAD)}>
                 <span className="text-[13.5px] font-medium text-colorText">
                     Version {version ?? "—"}
                 </span>

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane.tsx
@@ -72,6 +72,8 @@ export interface ChangesPaneProps {
     isLoading: boolean
     /** Shown instead of a diff when there is nothing to select yet (empty list, load error). */
     placeholder?: string
+    /** Why there are no sections — the caller knows whether the configs actually match. */
+    emptyText?: string
 }
 
 export const ChangesPane = ({
@@ -80,6 +82,7 @@ export const ChangesPane = ({
     message,
     isLoading,
     placeholder,
+    emptyText = "This is the current configuration. Nothing to compare.",
 }: ChangesPaneProps) => {
     const [openOverrides, setOpenOverrides] = useState<Record<string, boolean>>({})
     // Sections can arrive after the first render, so resolve open state per section rather than
@@ -111,8 +114,13 @@ export const ChangesPane = ({
                 ) : null}
             </div>
             {sections.length === 0 ? (
-                <div className={cn("px-6 py-14 text-center text-[12.5px]", textColors.tertiary)}>
-                    This is the current configuration. Nothing to compare.
+                <div
+                    className={cn(
+                        "mx-auto max-w-[340px] px-6 py-14 text-center text-[12.5px] leading-relaxed",
+                        textColors.tertiary,
+                    )}
+                >
+                    {emptyText}
                 </div>
             ) : (
                 <ChangeSections

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter.tsx
@@ -1,0 +1,110 @@
+/**
+ * The drawer's footer, and the whole revert flow.
+ *
+ * Confirmation is inline, not a dialog: a modal over an open drawer stacks two focus traps for
+ * one yes/no, and the sentence explaining what revert does needs the width the footer already has.
+ */
+
+import {cn, textColors} from "@agenta/ui/styles"
+import {Button, Spinner} from "@agenta/ui/ui"
+import {CheckCircle, WarningCircle} from "@phosphor-icons/react"
+
+import type {RevertPhase} from "./store"
+
+export interface RevertFooterProps {
+    phase: RevertPhase
+    /** The selected version's number. Null = nothing selected. */
+    selectedVersion: number | null
+    /** The current version, so the confirm copy can name the range that stays untouched. */
+    currentVersion: number | null
+    /** The version a completed revert restored. */
+    revertedFrom: number | null
+    /** Revert is pointless when the selection is already the current configuration. */
+    disabled: boolean
+    onRequestConfirm: () => void
+    onCancel: () => void
+    onConfirm: () => void
+    onClose: () => void
+}
+
+export const RevertFooter = ({
+    phase,
+    selectedVersion,
+    currentVersion,
+    revertedFrom,
+    disabled,
+    onRequestConfirm,
+    onCancel,
+    onConfirm,
+    onClose,
+}: RevertFooterProps) => {
+    if (phase === "reverting") {
+        return (
+            <div className={cn("flex items-center gap-2 text-xs", textColors.secondary)}>
+                <Spinner className="size-3.5" />
+                Creating v{(currentVersion ?? 0) + 1} from v{selectedVersion}…
+            </div>
+        )
+    }
+
+    if (phase === "done") {
+        return (
+            <div className="flex items-center gap-2 text-xs text-[var(--ag-colorSuccess)]">
+                <CheckCircle size={14} />
+                Reverted. v{currentVersion} now matches v{revertedFrom}.
+            </div>
+        )
+    }
+
+    if (phase === "failed") {
+        return (
+            <div className="flex items-center justify-between gap-4">
+                <span className="text-[11.5px] leading-snug text-[var(--ag-colorError)]">
+                    <strong className="font-semibold">Revert failed.</strong> The commit was
+                    rejected. Your agent is unchanged and no version was created.
+                </span>
+                <span className="flex shrink-0 gap-2">
+                    <Button variant="outline" onClick={onCancel}>
+                        Dismiss
+                    </Button>
+                    <Button onClick={onConfirm}>Try again</Button>
+                </span>
+            </div>
+        )
+    }
+
+    if (phase === "confirm") {
+        return (
+            <div className="flex items-center justify-between gap-4">
+                <span className="flex min-w-0 gap-2">
+                    <WarningCircle
+                        size={15}
+                        className="mt-px shrink-0 text-[var(--ag-colorWarning)]"
+                    />
+                    <span className="text-[11.5px] leading-snug text-colorText">
+                        <strong className="font-semibold">Revert to v{selectedVersion}?</strong>{" "}
+                        This commits v{(currentVersion ?? 0) + 1} with v{selectedVersion}&apos;s
+                        configuration. Versions v1–v{currentVersion} stay exactly as they are.
+                    </span>
+                </span>
+                <span className="flex shrink-0 gap-2">
+                    <Button variant="outline" onClick={onCancel}>
+                        Cancel
+                    </Button>
+                    <Button onClick={onConfirm}>Revert</Button>
+                </span>
+            </div>
+        )
+    }
+
+    return (
+        <div className="flex items-center justify-end gap-2">
+            <Button variant="outline" onClick={onClose}>
+                Cancel
+            </Button>
+            <Button disabled={disabled} onClick={onRequestConfirm}>
+                {selectedVersion === null ? "Revert" : `Revert to v${selectedVersion}`}
+            </Button>
+        </div>
+    )
+}

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter.tsx
@@ -16,8 +16,8 @@ export interface RevertFooterProps {
     phase: RevertPhase
     /** The selected version's number. Null = nothing selected. */
     selectedVersion: number | null
-    /** The current version, so the confirm copy can name the range that stays untouched. */
-    currentVersion: number | null
+    /** The latest version — the drawer's baseline, and what the confirm copy counts from. */
+    latestVersion: number | null
     /** Revert is pointless when the selection is already the current configuration. */
     disabled: boolean
     onRequestConfirm: () => void
@@ -29,7 +29,7 @@ export interface RevertFooterProps {
 export const RevertFooter = ({
     phase,
     selectedVersion,
-    currentVersion,
+    latestVersion,
     disabled,
     onRequestConfirm,
     onCancel,
@@ -40,7 +40,7 @@ export const RevertFooter = ({
         return (
             <div className={cn("flex items-center gap-2 text-xs", textColors.secondary)}>
                 <Spinner className="size-3.5" />
-                Creating v{(currentVersion ?? 0) + 1} from v{selectedVersion}…
+                Creating v{(latestVersion ?? 0) + 1} from v{selectedVersion}…
             </div>
         )
     }
@@ -49,7 +49,7 @@ export const RevertFooter = ({
         return (
             <div className="flex items-center gap-2 text-xs text-[var(--ag-colorSuccess)]">
                 <CheckCircle size={14} />
-                Reverted. v{currentVersion} now matches v{selectedVersion}.
+                Reverted. The latest version now holds v{selectedVersion}&apos;s configuration.
             </div>
         )
     }
@@ -81,8 +81,8 @@ export const RevertFooter = ({
                     />
                     <span className="text-[11.5px] leading-snug text-colorText">
                         <strong className="font-semibold">Revert to v{selectedVersion}?</strong>{" "}
-                        This commits v{(currentVersion ?? 0) + 1} with v{selectedVersion}&apos;s
-                        configuration. Versions v1–v{currentVersion} stay exactly as they are.
+                        This commits v{(latestVersion ?? 0) + 1} with v{selectedVersion}&apos;s
+                        configuration. Versions v1–v{latestVersion} stay exactly as they are.
                     </span>
                 </span>
                 <span className="flex shrink-0 gap-2">

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter.tsx
@@ -9,7 +9,8 @@ import {cn, textColors} from "@agenta/ui/styles"
 import {Button, Spinner} from "@agenta/ui/ui"
 import {CheckCircle, WarningCircle} from "@phosphor-icons/react"
 
-import type {RevertPhase} from "./store"
+/** The footer's machine. `done`/`failed` are terminal until the user acts again. */
+export type RevertPhase = "idle" | "confirm" | "reverting" | "done" | "failed"
 
 export interface RevertFooterProps {
     phase: RevertPhase
@@ -17,8 +18,6 @@ export interface RevertFooterProps {
     selectedVersion: number | null
     /** The current version, so the confirm copy can name the range that stays untouched. */
     currentVersion: number | null
-    /** The version a completed revert restored. */
-    revertedFrom: number | null
     /** Revert is pointless when the selection is already the current configuration. */
     disabled: boolean
     onRequestConfirm: () => void
@@ -31,7 +30,6 @@ export const RevertFooter = ({
     phase,
     selectedVersion,
     currentVersion,
-    revertedFrom,
     disabled,
     onRequestConfirm,
     onCancel,
@@ -51,7 +49,7 @@ export const RevertFooter = ({
         return (
             <div className="flex items-center gap-2 text-xs text-[var(--ag-colorSuccess)]">
                 <CheckCircle size={14} />
-                Reverted. v{currentVersion} now matches v{revertedFrom}.
+                Reverted. v{currentVersion} now matches v{selectedVersion}.
             </div>
         )
     }

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
@@ -1,8 +1,8 @@
 /**
  * The drawer's left rail: every version of the agent, newest first.
  *
- * Four states, all drawn in the design: loading, load error (retryable), a single version
- * (nothing to compare yet), and the list.
+ * Three states: loading, load error (retryable), and the list. A lone first version is a normal
+ * row — it lists like any other, disabled the way the latest always is.
  */
 import type {AgentVersionRow} from "@agenta/playground/state"
 import {timeAgo} from "@agenta/shared/utils"
@@ -80,11 +80,6 @@ export const VersionList = ({
             <Notice
                 title="No versions yet"
                 body="This agent has nothing committed to compare or restore."
-            />
-        ) : rows.length === 1 ? (
-            <Notice
-                title="Only one version"
-                body={`v${rows[0].version} is the first commit, so there is nothing to compare or restore yet.`}
             />
         ) : (
             rows.map((row) => (

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
@@ -43,8 +43,6 @@ export interface VersionListProps {
     isError: boolean
     onRetry: () => void
     onSelect: (revisionId: string) => void
-    /** Rendered per row where the host can pin a revision (mobile). Omitted, rows only select. */
-    renderRowAction?: (row: AgentVersionRow) => React.ReactNode
 }
 
 export const VersionList = ({
@@ -54,7 +52,6 @@ export const VersionList = ({
     isError,
     onRetry,
     onSelect,
-    renderRowAction,
 }: VersionListProps) => (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         {isLoading ? (
@@ -88,40 +85,41 @@ export const VersionList = ({
             />
         ) : (
             rows.map((row) => (
-                // Row action sits beside the select button, never inside it: nested interactive
-                // elements are invalid and swallow the inner click.
                 <div
                     key={row.id}
                     className={cn(
                         "mb-px flex items-center gap-1 rounded-md",
                         row.id === selectedId
                             ? "bg-[var(--ag-colorFillSecondary)]"
-                            : !row.isCurrent && "hover:bg-[var(--ag-colorFillQuaternary)]",
+                            : !row.isLatest && "hover:bg-[var(--ag-colorFillQuaternary)]",
                     )}
                 >
-                    {/* The latest version IS the current configuration, so selecting it could
-                        only ever diff against itself. It stays listed, not selectable. */}
+                    {/* The latest version is what everything else is compared against, so
+                        selecting it could only ever diff against itself. Listed, not selectable. */}
                     <button
                         type="button"
-                        disabled={row.isCurrent}
+                        disabled={row.isLatest}
                         aria-current={row.id === selectedId}
                         onClick={() => onSelect(row.id)}
                         className={cn(
                             "flex min-w-0 flex-1 flex-col gap-1 rounded-md border-0 bg-transparent px-2.5 py-2 text-left font-[inherit]",
                             // Dimmed so the row READS unselectable, not just behaves that way.
-                            row.isCurrent ? "cursor-default opacity-55" : "cursor-pointer",
+                            row.isLatest ? "cursor-default opacity-55" : "cursor-pointer",
                         )}
                     >
                         <span className="flex items-center gap-1.5">
                             <span className="text-xs font-medium text-colorText">
                                 v{row.version}
                             </span>
-                            {row.isCurrent ? (
-                                <span className="rounded px-1.5 py-px text-[10px] font-medium text-[var(--ag-colorInfo)] bg-[var(--ag-colorInfoBg)]">
+                            {/* One tag, one meaning: the newest revision. Whether the surface
+                                happens to sit on it is carried by the row's disabled state, not
+                                by a second competing label. */}
+                            {row.isLatest ? (
+                                <span className="rounded bg-[var(--ag-colorInfoBg)] px-1.5 py-px text-[10px] font-medium text-[var(--ag-colorInfo)]">
                                     Latest
                                 </span>
                             ) : null}
-                            {row.isReverted && !row.isCurrent ? (
+                            {row.isReverted && !row.isLatest ? (
                                 <span
                                     className={cn(
                                         "rounded bg-[var(--ag-colorFillSecondary)] px-1.5 py-px text-[10px] font-medium",
@@ -149,9 +147,6 @@ export const VersionList = ({
                             {row.message || "No commit message"}
                         </span>
                     </button>
-                    {renderRowAction ? (
-                        <span className="shrink-0 pr-1.5">{renderRowAction(row)}</span>
-                    ) : null}
                 </div>
             ))
         )}

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
@@ -43,6 +43,8 @@ export interface VersionListProps {
     isError: boolean
     onRetry: () => void
     onSelect: (revisionId: string) => void
+    /** Freeze selection while a revert is in flight. */
+    disabled?: boolean
 }
 
 export const VersionList = ({
@@ -52,6 +54,7 @@ export const VersionList = ({
     isError,
     onRetry,
     onSelect,
+    disabled,
 }: VersionListProps) => (
     <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
         {isLoading ? (
@@ -98,13 +101,14 @@ export const VersionList = ({
                         selecting it could only ever diff against itself. Listed, not selectable. */}
                     <button
                         type="button"
-                        disabled={row.isLatest}
+                        disabled={row.isLatest || !!disabled}
                         aria-current={row.id === selectedId}
                         onClick={() => onSelect(row.id)}
                         className={cn(
                             "flex min-w-0 flex-1 flex-col gap-1 rounded-md border-0 bg-transparent px-2.5 py-2 text-left font-[inherit]",
                             // Dimmed so the row READS unselectable, not just behaves that way.
-                            row.isLatest ? "cursor-default opacity-55" : "cursor-pointer",
+                            row.isLatest || disabled ? "cursor-default" : "cursor-pointer",
+                            row.isLatest && "opacity-55",
                         )}
                     >
                         <span className="flex items-center gap-1.5">

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
@@ -1,0 +1,159 @@
+/**
+ * The drawer's left rail: every version of the agent, newest first.
+ *
+ * Four states, all drawn in the design: loading, load error (retryable), a single version
+ * (nothing to compare yet), and the list.
+ */
+import type {AgentVersionRow} from "@agenta/playground/state"
+import {timeAgo} from "@agenta/shared/utils"
+import {cn, textColors} from "@agenta/ui/styles"
+import {Button} from "@agenta/ui/ui"
+
+const SKELETON_ROWS = [
+    {title: "38%", body: "88%"},
+    {title: "32%", body: "70%"},
+    {title: "40%", body: "78%"},
+    {title: "30%", body: "56%"},
+]
+
+const Pulse = ({width, tone}: {width: string; tone: "strong" | "faint"}) => (
+    <div
+        className={cn(
+            "h-3 animate-pulse rounded-[3px]",
+            tone === "strong"
+                ? "bg-[var(--ag-colorFillSecondary)]"
+                : "h-2.5 bg-[var(--ag-colorFillTertiary)]",
+        )}
+        style={{width}}
+    />
+)
+
+const Notice = ({title, body, action}: {title: string; body: string; action?: React.ReactNode}) => (
+    <div className="px-3 py-6 text-center">
+        <div className="mb-1 text-xs font-semibold text-colorText">{title}</div>
+        <p className={cn("mb-3 text-[11.5px] leading-relaxed", textColors.tertiary)}>{body}</p>
+        {action}
+    </div>
+)
+
+export interface VersionListProps {
+    rows: AgentVersionRow[]
+    selectedId: string | null
+    isLoading: boolean
+    isError: boolean
+    onRetry: () => void
+    onSelect: (revisionId: string) => void
+    /** Rendered per row where the host can pin a revision (mobile). Omitted, rows only select. */
+    renderRowAction?: (row: AgentVersionRow) => React.ReactNode
+}
+
+export const VersionList = ({
+    rows,
+    selectedId,
+    isLoading,
+    isError,
+    onRetry,
+    onSelect,
+    renderRowAction,
+}: VersionListProps) => (
+    <div className="flex min-h-0 flex-1 flex-col overflow-y-auto">
+        {isLoading ? (
+            <>
+                {SKELETON_ROWS.map((row, i) => (
+                    <div key={i} className="flex flex-col gap-1.5 px-2.5 py-2.5">
+                        <Pulse width={row.title} tone="strong" />
+                        <Pulse width={row.body} tone="faint" />
+                    </div>
+                ))}
+            </>
+        ) : isError ? (
+            <Notice
+                title="Couldn't load versions"
+                body="The request failed. Nothing was changed."
+                action={
+                    <Button variant="outline" size="sm" onClick={onRetry}>
+                        Retry
+                    </Button>
+                }
+            />
+        ) : rows.length === 0 ? (
+            <Notice
+                title="No versions yet"
+                body="This agent has nothing committed to compare or restore."
+            />
+        ) : rows.length === 1 ? (
+            <Notice
+                title="Only one version"
+                body={`v${rows[0].version} is the first commit, so there is nothing to compare or restore yet.`}
+            />
+        ) : (
+            rows.map((row) => (
+                // Row action sits beside the select button, never inside it: nested interactive
+                // elements are invalid and swallow the inner click.
+                <div
+                    key={row.id}
+                    className={cn(
+                        "mb-px flex items-center gap-1 rounded-md",
+                        row.id === selectedId
+                            ? "bg-[var(--ag-colorFillSecondary)]"
+                            : !row.isCurrent && "hover:bg-[var(--ag-colorFillQuaternary)]",
+                    )}
+                >
+                    {/* The latest version IS the current configuration, so selecting it could
+                        only ever diff against itself. It stays listed, not selectable. */}
+                    <button
+                        type="button"
+                        disabled={row.isCurrent}
+                        aria-current={row.id === selectedId}
+                        onClick={() => onSelect(row.id)}
+                        className={cn(
+                            "flex min-w-0 flex-1 flex-col gap-1 rounded-md border-0 bg-transparent px-2.5 py-2 text-left font-[inherit]",
+                            // Dimmed so the row READS unselectable, not just behaves that way.
+                            row.isCurrent ? "cursor-default opacity-55" : "cursor-pointer",
+                        )}
+                    >
+                        <span className="flex items-center gap-1.5">
+                            <span className="text-xs font-medium text-colorText">
+                                v{row.version}
+                            </span>
+                            {row.isCurrent ? (
+                                <span className="rounded px-1.5 py-px text-[10px] font-medium text-[var(--ag-colorInfo)] bg-[var(--ag-colorInfoBg)]">
+                                    Latest
+                                </span>
+                            ) : null}
+                            {row.isReverted && !row.isCurrent ? (
+                                <span
+                                    className={cn(
+                                        "rounded bg-[var(--ag-colorFillSecondary)] px-1.5 py-px text-[10px] font-medium",
+                                        textColors.secondary,
+                                    )}
+                                >
+                                    Reverted
+                                </span>
+                            ) : null}
+                            <span
+                                className={cn(
+                                    "ml-auto whitespace-nowrap text-[10.5px]",
+                                    textColors.tertiary,
+                                )}
+                            >
+                                {row.createdAt ? timeAgo(Date.parse(row.createdAt)) : ""}
+                            </span>
+                        </span>
+                        <span
+                            className={cn(
+                                "line-clamp-2 text-xs leading-snug",
+                                textColors.secondary,
+                            )}
+                        >
+                            {row.message || "No commit message"}
+                        </span>
+                    </button>
+                    {renderRowAction ? (
+                        <span className="shrink-0 pr-1.5">{renderRowAction(row)}</span>
+                    ) : null}
+                </div>
+            ))
+        )}
+    </div>
+)

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
@@ -1,8 +1,8 @@
 /**
  * The drawer's left rail: every version of the agent, newest first.
  *
- * Three states: loading, load error (retryable), and the list. A lone first version is a normal
- * row — it lists like any other, disabled the way the latest always is.
+ * Three states: loading, load error (retryable), and the list. Every version is selectable —
+ * each one is diffed against its predecessor, so the newest has something to show too.
  */
 import type {AgentVersionRow} from "@agenta/playground/state"
 import {timeAgo} from "@agenta/shared/utils"
@@ -89,30 +89,24 @@ export const VersionList = ({
                         "mb-px flex items-center gap-1 rounded-md",
                         row.id === selectedId
                             ? "bg-[var(--ag-colorFillSecondary)]"
-                            : !row.isLatest && "hover:bg-[var(--ag-colorFillQuaternary)]",
+                            : "hover:bg-[var(--ag-colorFillQuaternary)]",
                     )}
                 >
-                    {/* The latest version is what everything else is compared against, so
-                        selecting it could only ever diff against itself. Listed, not selectable. */}
                     <button
                         type="button"
-                        disabled={row.isLatest || !!disabled}
+                        disabled={!!disabled}
                         aria-current={row.id === selectedId}
                         onClick={() => onSelect(row.id)}
                         className={cn(
                             "flex min-w-0 flex-1 flex-col gap-1 rounded-md border-0 bg-transparent px-2.5 py-2 text-left font-[inherit]",
-                            // Dimmed so the row READS unselectable, not just behaves that way.
-                            row.isLatest || disabled ? "cursor-default" : "cursor-pointer",
-                            row.isLatest && "opacity-55",
+                            disabled ? "cursor-default" : "cursor-pointer",
                         )}
                     >
                         <span className="flex items-center gap-1.5">
                             <span className="text-xs font-medium text-colorText">
                                 v{row.version}
                             </span>
-                            {/* One tag, one meaning: the newest revision. Whether the surface
-                                happens to sit on it is carried by the row's disabled state, not
-                                by a second competing label. */}
+                            {/* One tag, one meaning: the newest revision. */}
                             {row.isLatest ? (
                                 <span className="rounded bg-[var(--ag-colorInfoBg)] px-1.5 py-px text-[10px] font-medium text-[var(--ag-colorInfo)]">
                                     Latest

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList.tsx
@@ -123,16 +123,6 @@ export const VersionList = ({
                                     Latest
                                 </span>
                             ) : null}
-                            {row.isReverted && !row.isLatest ? (
-                                <span
-                                    className={cn(
-                                        "rounded bg-[var(--ag-colorFillSecondary)] px-1.5 py-px text-[10px] font-medium",
-                                        textColors.secondary,
-                                    )}
-                                >
-                                    Reverted
-                                </span>
-                            ) : null}
                             <span
                                 className={cn(
                                     "ml-auto whitespace-nowrap text-[10.5px]",

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/index.ts
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/index.ts
@@ -3,6 +3,13 @@
  */
 export {AgentVersionHistoryDrawer} from "./AgentVersionHistoryDrawer"
 export type {AgentVersionHistoryDrawerProps} from "./AgentVersionHistoryDrawer"
+// The three panes, so Storybook can render each state without driving the whole drawer.
+export {ChangesPane} from "./ChangesPane"
+export type {ChangesPaneProps} from "./ChangesPane"
+export {RevertFooter} from "./RevertFooter"
+export type {RevertFooterProps, RevertPhase} from "./RevertFooter"
+export {VersionList} from "./VersionList"
+export type {VersionListProps} from "./VersionList"
 export {
     openAgentVersionHistoryAtom,
     closeAgentVersionHistoryAtom,

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/index.ts
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/index.ts
@@ -1,0 +1,14 @@
+/**
+ * Agent version history — the drawer behind the header's `vN` chip.
+ */
+export {AgentVersionHistoryDrawer} from "./AgentVersionHistoryDrawer"
+export type {AgentVersionHistoryDrawerProps} from "./AgentVersionHistoryDrawer"
+export {
+    openAgentVersionHistoryAtom,
+    closeAgentVersionHistoryAtom,
+    selectAgentVersionAtom,
+    versionHistoryOpenAtomFamily,
+    versionHistorySelectedAtomFamily,
+    versionHistoryPhaseAtomFamily,
+    type RevertPhase,
+} from "./store"

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/index.ts
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/index.ts
@@ -9,6 +9,4 @@ export {
     selectAgentVersionAtom,
     versionHistoryOpenAtomFamily,
     versionHistorySelectedAtomFamily,
-    versionHistoryPhaseAtomFamily,
-    type RevertPhase,
 } from "./store"

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/store.ts
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/store.ts
@@ -1,0 +1,51 @@
+/**
+ * Version-history drawer state.
+ *
+ * Keyed by WORKFLOW, not revision: a revert mints a new revision and the host switches to it, so
+ * revision-keyed state would reset the drawer mid-flow. Workflow-keyed also bounds the
+ * `atomFamily` maps (which never evict) to the handful of agents opened in a session.
+ *
+ * Lives with the drawer, as `WorkflowRevisionDrawer/store.ts` does — the revert engine is the
+ * part that belongs in `@agenta/playground`.
+ */
+import {atom} from "jotai"
+import {atomFamily} from "jotai-family"
+
+/** The footer's machine. `done`/`failed` are terminal until the user acts again. */
+export type RevertPhase = "idle" | "confirm" | "reverting" | "done" | "failed"
+
+export const versionHistoryOpenAtomFamily = atomFamily((_workflowId: string) => atom(false))
+
+/** Which version the diff pane is showing. Null = nothing picked yet. */
+export const versionHistorySelectedAtomFamily = atomFamily((_workflowId: string) =>
+    atom<string | null>(null),
+)
+
+export const versionHistoryPhaseAtomFamily = atomFamily((_workflowId: string) =>
+    atom<RevertPhase>("idle"),
+)
+
+/** The version a completed revert restored, so `done` can name it after the selection moves. */
+export const versionHistoryRevertedFromAtomFamily = atomFamily((_workflowId: string) =>
+    atom<number | null>(null),
+)
+
+/** Pick a version. Any in-progress revert is abandoned — the footer is about the selection. */
+export const selectAgentVersionAtom = atom(
+    null,
+    (_get, set, {workflowId, revisionId}: {workflowId: string; revisionId: string}) => {
+        set(versionHistorySelectedAtomFamily(workflowId), revisionId)
+        set(versionHistoryPhaseAtomFamily(workflowId), "idle")
+    },
+)
+
+export const openAgentVersionHistoryAtom = atom(null, (_get, set, workflowId: string) => {
+    set(versionHistoryOpenAtomFamily(workflowId), true)
+})
+
+export const closeAgentVersionHistoryAtom = atom(null, (_get, set, workflowId: string) => {
+    set(versionHistoryOpenAtomFamily(workflowId), false)
+    set(versionHistorySelectedAtomFamily(workflowId), null)
+    set(versionHistoryPhaseAtomFamily(workflowId), "idle")
+    set(versionHistoryRevertedFromAtomFamily(workflowId), null)
+})

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/store.ts
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/store.ts
@@ -1,18 +1,14 @@
 /**
- * Version-history drawer state.
+ * Version-history state that outlives the drawer: whether it is open, and which version is
+ * picked. The header trigger sets `open`, so those two are genuinely shared.
  *
- * Keyed by WORKFLOW, not revision: a revert mints a new revision and the host switches to it, so
- * revision-keyed state would reset the drawer mid-flow. Workflow-keyed also bounds the
- * `atomFamily` maps (which never evict) to the handful of agents opened in a session.
+ * The revert phase and which pane a phone shows stay local to the drawer — no reader outside it.
  *
- * Lives with the drawer, as `WorkflowRevisionDrawer/store.ts` does — the revert engine is the
- * part that belongs in `@agenta/playground`.
+ * Keyed by WORKFLOW: a revert mints a new revision and the host switches to it, so revision-keyed
+ * state would reset the drawer mid-flow.
  */
 import {atom} from "jotai"
 import {atomFamily} from "jotai-family"
-
-/** The footer's machine. `done`/`failed` are terminal until the user acts again. */
-export type RevertPhase = "idle" | "confirm" | "reverting" | "done" | "failed"
 
 export const versionHistoryOpenAtomFamily = atomFamily((_workflowId: string) => atom(false))
 
@@ -21,21 +17,10 @@ export const versionHistorySelectedAtomFamily = atomFamily((_workflowId: string)
     atom<string | null>(null),
 )
 
-export const versionHistoryPhaseAtomFamily = atomFamily((_workflowId: string) =>
-    atom<RevertPhase>("idle"),
-)
-
-/** The version a completed revert restored, so `done` can name it after the selection moves. */
-export const versionHistoryRevertedFromAtomFamily = atomFamily((_workflowId: string) =>
-    atom<number | null>(null),
-)
-
-/** Pick a version. Any in-progress revert is abandoned — the footer is about the selection. */
 export const selectAgentVersionAtom = atom(
     null,
     (_get, set, {workflowId, revisionId}: {workflowId: string; revisionId: string}) => {
         set(versionHistorySelectedAtomFamily(workflowId), revisionId)
-        set(versionHistoryPhaseAtomFamily(workflowId), "idle")
     },
 )
 
@@ -46,6 +31,4 @@ export const openAgentVersionHistoryAtom = atom(null, (_get, set, workflowId: st
 export const closeAgentVersionHistoryAtom = atom(null, (_get, set, workflowId: string) => {
     set(versionHistoryOpenAtomFamily(workflowId), false)
     set(versionHistorySelectedAtomFamily(workflowId), null)
-    set(versionHistoryPhaseAtomFamily(workflowId), "idle")
-    set(versionHistoryRevertedFromAtomFamily(workflowId), null)
 })

--- a/web/packages/agenta-playground/src/state/execution/agentAutoCommit.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentAutoCommit.ts
@@ -114,14 +114,22 @@ const clearTimer = (store: Store, revisionId: string) => {
     setScheduled(store, revisionId, false)
 }
 
-const schedule = (store: Store, revisionId: string, delay: number, isRetry: boolean) => {
+const schedule = (
+    store: Store,
+    revisionId: string,
+    delay: number,
+    isRetry: boolean,
+    messageOverride?: string,
+) => {
     clearTimer(store, revisionId)
     timers.set(
         revisionId,
         setTimeout(() => {
             timers.delete(revisionId)
             setScheduled(store, revisionId, false)
-            void runFlush(store, revisionId, isRetry)
+            // The override rides the timer: a deferred revert must still commit under its own
+            // message, not the generated summary.
+            void runFlush(store, revisionId, isRetry, messageOverride)
         }, delay),
     )
     setScheduled(store, revisionId, true)
@@ -156,24 +164,29 @@ const forgetRevision = (store: Store, revisionId: string) => {
     agentAutoCommitScheduledAtomFamily.remove(revisionId)
 }
 
-const runFlush = async (store: Store, revisionId: string, isRetry: boolean) => {
+const runFlush = async (
+    store: Store,
+    revisionId: string,
+    isRetry: boolean,
+    messageOverride?: string,
+): Promise<boolean> => {
     const blocker = flushBlocker(store, revisionId)
 
     if (blocker === "skip" || blocker === "clean") {
         settleIdle(store, revisionId, blocker)
-        return
+        return false
     }
 
     if (blocker === "busy") {
-        schedule(store, revisionId, DEBOUNCE_MS, isRetry)
-        return
+        schedule(store, revisionId, DEBOUNCE_MS, isRetry, messageOverride)
+        return false
     }
 
     inFlight.add(revisionId)
     store.set(agentAutoCommitStatusAtomFamily(revisionId), "saving")
 
     try {
-        const commitMessage = buildMessage(store, revisionId)
+        const commitMessage = messageOverride ?? buildMessage(store, revisionId)
         const result = await store.set(commitWorkflowRevisionAtom, {revisionId, commitMessage})
 
         if (result.success) {
@@ -189,14 +202,14 @@ const runFlush = async (store: Store, revisionId: string, isRetry: boolean) => {
                 // finish first. Safe: it is superseded.
                 setTimeout(() => forgetRevision(store, revisionId), 0)
             }
-            return
+            return true
         }
 
         if (!isRetry) {
             // Still working, so the header keeps saying so rather than flashing a failure the
             // retry is about to clear.
-            schedule(store, revisionId, RETRY_MS, true)
-            return
+            schedule(store, revisionId, RETRY_MS, true, messageOverride)
+            return false
         }
 
         store.set(agentAutoCommitStatusAtomFamily(revisionId), "error")
@@ -204,6 +217,7 @@ const runFlush = async (store: Store, revisionId: string, isRetry: boolean) => {
             agentAutoCommitErrorAtomFamily(revisionId),
             result.error?.message ?? "Couldn't save changes",
         )
+        return false
     } finally {
         inFlight.delete(revisionId)
     }
@@ -228,13 +242,20 @@ const scheduleAgentAutoCommit = (revisionId: string) => {
 /**
  * Save now, skipping the debounce. The header's failure notice uses it to retry; the timer path
  * needs nothing else.
+ *
+ * `commitMessage` overrides the generated summary — a revert names what it did. Returns whether
+ * the commit landed, so a caller that shows its own outcome (the version-history drawer) can.
  */
 export const flushAgentAutoCommitAtom = atom(
     null,
-    async (_get, _set, {revisionId}: {revisionId: string}) => {
+    async (
+        _get,
+        _set,
+        {revisionId, commitMessage}: {revisionId: string; commitMessage?: string},
+    ): Promise<boolean> => {
         clearTimer(getDefaultStore(), revisionId)
         // A manual retry is the user's second attempt; don't spend the automatic one on it.
-        await runFlush(getDefaultStore(), revisionId, true)
+        return runFlush(getDefaultStore(), revisionId, true, commitMessage)
     },
 )
 

--- a/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
@@ -13,6 +13,7 @@
 import {
     discardWorkflowDraftAtom,
     updateWorkflowDraftAtom,
+    workflowDraftAtomFamily,
     workflowMolecule,
     type Workflow,
 } from "@agenta/entities/workflow"
@@ -92,10 +93,9 @@ export interface RevertAgentRevisionParams {
  * was never committed. Schemas ride along — the commit sends `data.schemas`, so leaving them
  * behind would restore a configuration the old version never had.
  *
- * All-or-nothing: if the commit does not land, the staged draft is rolled back, so "no version
- * was created" also means the agent on screen is the one the user started with. The rollback is
- * skipped when the revision was ALREADY dirty — discarding then would throw away edits this
- * revert never owned, and a stranded draft is recoverable where a discarded one is not.
+ * All-or-nothing: if the commit does not land, the draft goes back exactly as it was. Staging
+ * OVERWRITES an existing draft, so a pre-existing one is snapshotted and restored rather than
+ * discarded, or a failed revert would eat edits it never owned.
  *
  * Resolves to whether a new version landed.
  */
@@ -108,13 +108,17 @@ export const revertAgentRevisionAtom = atom(
         if (!parameters) return false
         const schemas = get(workflowMolecule.selectors.serverData(targetRevisionId))?.data?.schemas
 
-        const wasDirty = get(workflowMolecule.selectors.isDirty(revisionId))
+        // Staging overwrites whatever is there, so keep the original to put back on failure.
+        const priorDraft = get(workflowDraftAtomFamily(revisionId))
         set(updateWorkflowDraftAtom, revisionId, {
             data: {parameters, ...(schemas ? {schemas} : {})},
         } as Partial<Workflow>)
 
         // Nothing staged means the target already matches the current configuration.
-        if (!get(workflowMolecule.selectors.isDirty(revisionId))) return false
+        if (!get(workflowMolecule.selectors.isDirty(revisionId))) {
+            if (priorDraft) set(workflowDraftAtomFamily(revisionId), priorDraft)
+            return false
+        }
 
         const target = get(workflowMolecule.selectors.data(targetRevisionId)) as Workflow | null
         const commitMessage = buildRevertMessage({
@@ -123,7 +127,10 @@ export const revertAgentRevisionAtom = atom(
         })
 
         const landed = await set(flushAgentAutoCommitAtom, {revisionId, commitMessage})
-        if (!landed && !wasDirty) set(discardWorkflowDraftAtom, revisionId)
+        if (!landed) {
+            if (priorDraft) set(workflowDraftAtomFamily(revisionId), priorDraft)
+            else set(discardWorkflowDraftAtom, revisionId)
+        }
         return landed
     },
 )

--- a/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
@@ -29,9 +29,7 @@ export interface AgentVersionRow {
     version: number
     message: string | null
     createdAt: string | null
-    /** The revision the header is on — the side every diff compares against. */
-    isCurrent: boolean
-    /** The newest version. Usually also `isCurrent`, but not when the surface sits on an older one. */
+    /** The newest version — the one baseline every diff and every footer count is measured from. */
     isLatest: boolean
 }
 
@@ -41,10 +39,7 @@ export interface AgentVersionRow {
  * Drops the `version: 0` seed every workflow carries: it holds no configuration, so it can be
  * neither compared nor restored. The revision pickers filter it the same way.
  */
-export const buildVersionRows = (
-    revisions: Workflow[],
-    currentRevisionId: string | null,
-): AgentVersionRow[] =>
+export const buildVersionRows = (revisions: Workflow[]): AgentVersionRow[] =>
     revisions
         .filter((revision) => (revision.version as number | null | undefined) !== 0)
         // Version first, timestamp only as a tie-break — `created_at` can disagree with the order.
@@ -64,7 +59,6 @@ export const buildVersionRows = (
                 version: (revision.version as number | null | undefined) ?? 0,
                 message,
                 createdAt: revision.created_at ?? null,
-                isCurrent: revision.id === currentRevisionId,
                 isLatest: index === 0,
             }
         })

--- a/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
@@ -1,0 +1,130 @@
+/**
+ * Agent version history: the rows the drawer lists, and the revert that restores one.
+ *
+ * Revert is not a new kind of write — it is a normal commit whose content happens to be old.
+ * History is therefore never rewritten: the selected version's configuration is staged onto the
+ * current revision's draft and committed, minting a new head above everything that came before.
+ *
+ * It commits through {@link flushAgentAutoCommitAtom} rather than calling the commit atom
+ * directly. Staging a draft arms the auto-commit debounce; a second, independent commit would
+ * race it and could mint two versions from one click. The flush owns that timer and its
+ * in-flight guard, so going through it means exactly one new version.
+ */
+import {
+    discardWorkflowDraftAtom,
+    updateWorkflowDraftAtom,
+    workflowMolecule,
+    type Workflow,
+} from "@agenta/entities/workflow"
+import {atom, getDefaultStore} from "jotai"
+
+import {flushAgentAutoCommitAtom} from "./agentAutoCommit"
+
+/** Prefix of a revert's commit message — also how a row is recognised as one. */
+export const REVERT_MESSAGE_PREFIX = "Revert to v"
+
+export interface AgentVersionRow {
+    id: string
+    version: number
+    message: string | null
+    createdAt: string | null
+    /** The revision the header is on — the side every diff compares against. */
+    isCurrent: boolean
+    /** Committed by a revert. Derived from the message; no field records it. */
+    isReverted: boolean
+}
+
+/**
+ * Rows for the version list, newest first.
+ *
+ * Drops the `version: 0` seed every workflow carries: it holds no configuration, so it can be
+ * neither compared nor restored. The revision pickers filter it the same way.
+ */
+export const buildVersionRows = (
+    revisions: Workflow[],
+    currentRevisionId: string | null,
+): AgentVersionRow[] =>
+    revisions
+        .filter((revision) => (revision.version as number | null | undefined) !== 0)
+        // Sorted here rather than trusted from the caller: not every revisions atom is
+        // recency-ordered, and the list's whole shape assumes newest first.
+        .slice()
+        .sort((a, b) => {
+            const at = Date.parse(a.created_at ?? "")
+            const bt = Date.parse(b.created_at ?? "")
+            const byTime = (Number.isNaN(bt) ? 0 : bt) - (Number.isNaN(at) ? 0 : at)
+            if (byTime !== 0) return byTime
+            return (((b.version as number) ?? 0) - ((a.version as number) ?? 0)) as number
+        })
+        .map((revision) => {
+            const message = revision.message?.trim() || null
+            return {
+                id: revision.id,
+                version: (revision.version as number | null | undefined) ?? 0,
+                message,
+                createdAt: revision.created_at ?? null,
+                isCurrent: revision.id === currentRevisionId,
+                isReverted: !!message?.startsWith(REVERT_MESSAGE_PREFIX),
+            }
+        })
+
+/** `Revert to v3 — "Switch to Opus"`, or just `Revert to v3` when that version had no message. */
+export const buildRevertMessage = (row: Pick<AgentVersionRow, "version" | "message">): string =>
+    row.message
+        ? `${REVERT_MESSAGE_PREFIX}${row.version} — "${row.message}"`
+        : `${REVERT_MESSAGE_PREFIX}${row.version}`
+
+export interface RevertAgentRevisionParams {
+    /** The revision under edit — the one the new version is committed from. */
+    revisionId: string
+    /** The historical revision whose configuration is being restored. */
+    targetRevisionId: string
+}
+
+/**
+ * Stage a historical revision's configuration onto the current one and commit it.
+ *
+ * Reads the target through `serverConfiguration`, NOT `configuration`: the latter overlays that
+ * revision's local draft, so an older revision someone once edited would restore content that
+ * was never committed. Schemas ride along — the commit sends `data.schemas`, so leaving them
+ * behind would restore a configuration the old version never had.
+ *
+ * All-or-nothing: if the commit does not land, the staged draft is rolled back, so "no version
+ * was created" also means the agent on screen is the one the user started with. The rollback is
+ * skipped when the revision was ALREADY dirty — discarding then would throw away edits this
+ * revert never owned, and a stranded draft is recoverable where a discarded one is not.
+ *
+ * Resolves to whether a new version landed.
+ */
+export const revertAgentRevisionAtom = atom(
+    null,
+    async (get, set, {revisionId, targetRevisionId}: RevertAgentRevisionParams) => {
+        if (!revisionId || !targetRevisionId || revisionId === targetRevisionId) return false
+
+        const parameters = get(workflowMolecule.selectors.serverConfiguration(targetRevisionId))
+        if (!parameters) return false
+        const schemas = get(workflowMolecule.selectors.serverData(targetRevisionId))?.data?.schemas
+
+        const wasDirty = get(workflowMolecule.selectors.isDirty(revisionId))
+        set(updateWorkflowDraftAtom, revisionId, {
+            data: {parameters, ...(schemas ? {schemas} : {})},
+        } as Partial<Workflow>)
+
+        // Nothing staged means the target already matches the current configuration.
+        if (!get(workflowMolecule.selectors.isDirty(revisionId))) return false
+
+        const target = get(workflowMolecule.selectors.data(targetRevisionId)) as Workflow | null
+        const commitMessage = buildRevertMessage({
+            version: (target?.version as number | null | undefined) ?? 0,
+            message: target?.message?.trim() || null,
+        })
+
+        const landed = await set(flushAgentAutoCommitAtom, {revisionId, commitMessage})
+        if (!landed && !wasDirty) set(discardWorkflowDraftAtom, revisionId)
+        return landed
+    },
+)
+
+/** Imperative form, for hosts outside a Jotai render tree. */
+export const revertAgentRevision = (params: RevertAgentRevisionParams) =>
+    getDefaultStore().set(revertAgentRevisionAtom, params)

--- a/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
@@ -21,7 +21,7 @@ import {atom, getDefaultStore} from "jotai"
 
 import {flushAgentAutoCommitAtom} from "./agentAutoCommit"
 
-/** Prefix of a revert's commit message — also how a row is recognised as one. */
+/** Prefix of a revert's commit message. */
 export const REVERT_MESSAGE_PREFIX = "Revert to v"
 
 export interface AgentVersionRow {
@@ -33,8 +33,6 @@ export interface AgentVersionRow {
     isCurrent: boolean
     /** The newest version. Usually also `isCurrent`, but not when the surface sits on an older one. */
     isLatest: boolean
-    /** Committed by a revert. Derived from the message; no field records it. */
-    isReverted: boolean
 }
 
 /**
@@ -68,7 +66,6 @@ export const buildVersionRows = (
                 createdAt: revision.created_at ?? null,
                 isCurrent: revision.id === currentRevisionId,
                 isLatest: index === 0,
-                isReverted: !!message?.startsWith(REVERT_MESSAGE_PREFIX),
             }
         })
 

--- a/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
@@ -48,9 +48,7 @@ export const buildVersionRows = (
 ): AgentVersionRow[] =>
     revisions
         .filter((revision) => (revision.version as number | null | undefined) !== 0)
-        // Version number first, timestamp only as a tie-break: `created_at` can disagree with
-        // the real order (a revision committed by the agent carries its own clock), and the
-        // highest version must always sit on top.
+        // Version first, timestamp only as a tie-break — `created_at` can disagree with the order.
         .slice()
         .sort((a, b) => {
             const byVersion = (((b.version as number) ?? 0) -

--- a/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
@@ -30,6 +30,8 @@ export interface AgentVersionRow {
     createdAt: string | null
     /** The revision the header is on — the side every diff compares against. */
     isCurrent: boolean
+    /** The newest version. Usually also `isCurrent`, but not when the surface sits on an older one. */
+    isLatest: boolean
     /** Committed by a revert. Derived from the message; no field records it. */
     isReverted: boolean
 }
@@ -46,17 +48,19 @@ export const buildVersionRows = (
 ): AgentVersionRow[] =>
     revisions
         .filter((revision) => (revision.version as number | null | undefined) !== 0)
-        // Sorted here rather than trusted from the caller: not every revisions atom is
-        // recency-ordered, and the list's whole shape assumes newest first.
+        // Version number first, timestamp only as a tie-break: `created_at` can disagree with
+        // the real order (a revision committed by the agent carries its own clock), and the
+        // highest version must always sit on top.
         .slice()
         .sort((a, b) => {
+            const byVersion = (((b.version as number) ?? 0) -
+                ((a.version as number) ?? 0)) as number
+            if (byVersion !== 0) return byVersion
             const at = Date.parse(a.created_at ?? "")
             const bt = Date.parse(b.created_at ?? "")
-            const byTime = (Number.isNaN(bt) ? 0 : bt) - (Number.isNaN(at) ? 0 : at)
-            if (byTime !== 0) return byTime
-            return (((b.version as number) ?? 0) - ((a.version as number) ?? 0)) as number
+            return (Number.isNaN(bt) ? 0 : bt) - (Number.isNaN(at) ? 0 : at)
         })
-        .map((revision) => {
+        .map((revision, index) => {
             const message = revision.message?.trim() || null
             return {
                 id: revision.id,
@@ -64,6 +68,7 @@ export const buildVersionRows = (
                 message,
                 createdAt: revision.created_at ?? null,
                 isCurrent: revision.id === currentRevisionId,
+                isLatest: index === 0,
                 isReverted: !!message?.startsWith(REVERT_MESSAGE_PREFIX),
             }
         })

--- a/web/packages/agenta-playground/src/state/execution/index.ts
+++ b/web/packages/agenta-playground/src/state/execution/index.ts
@@ -392,3 +392,13 @@ export {
     flushAgentAutoCommitAtom,
     registerAgentAutoCommitHandler,
 } from "./agentAutoCommit"
+// Agent version history: the drawer's rows, and the revert that commits an old config as a new one.
+export {
+    buildVersionRows,
+    buildRevertMessage,
+    revertAgentRevisionAtom,
+    revertAgentRevision,
+    REVERT_MESSAGE_PREFIX,
+    type AgentVersionRow,
+    type RevertAgentRevisionParams,
+} from "./agentVersionHistory"

--- a/web/packages/agenta-playground/src/state/index.ts
+++ b/web/packages/agenta-playground/src/state/index.ts
@@ -465,4 +465,10 @@ export {
     agentAutoCommitScheduledAtomFamily,
     flushAgentAutoCommitAtom,
     registerAgentAutoCommitHandler,
+    buildVersionRows,
+    buildRevertMessage,
+    revertAgentRevisionAtom,
+    revertAgentRevision,
+    REVERT_MESSAGE_PREFIX,
 } from "./execution"
+export type {AgentVersionRow, RevertAgentRevisionParams} from "./execution"

--- a/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
@@ -187,17 +187,6 @@ describe("buildVersionRows", () => {
         ])
     })
 
-    it("recognises a revert by its commit message", () => {
-        const rows = buildVersionRows(
-            [
-                revision({id: "a", version: 3, message: 'Revert to v1 — "Initial commit"'}),
-                revision({id: "b", version: 2, message: "Add the Linear MCP server"}),
-            ],
-            "a",
-        )
-        expect(rows.map((r) => r.isReverted)).toEqual([true, false])
-    })
-
     it("normalises a blank commit message to null", () => {
         expect(buildVersionRows([revision({message: "   "})], null)[0].message).toBeNull()
     })

--- a/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
@@ -32,6 +32,7 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
         }
     }
     const isDirty = mk<boolean>(true)
+    const draft = mk<unknown>(null)
     return {
         ...actual,
         workflowMolecule: {
@@ -48,6 +49,7 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
             },
         },
         registerWorkflowDraftCallbacks: () => undefined,
+        workflowDraftAtomFamily: draft,
         updateWorkflowDraftAtom: atom(
             null,
             (
@@ -57,6 +59,7 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
                 updates: any,
             ) => {
                 draftWrites.push({revisionId, updates})
+                set(draft(revisionId), updates)
                 set(isDirty(revisionId), true)
             },
         ),
@@ -64,6 +67,7 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
             null,
             (_g: unknown, set: (a: unknown, v: unknown) => void, revisionId: string) => {
                 discards.push(revisionId)
+                set(draft(revisionId), null)
                 set(isDirty(revisionId), false)
             },
         ),
@@ -82,7 +86,7 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
     }
 })
 
-import {workflowMolecule} from "@agenta/entities/workflow"
+import {workflowDraftAtomFamily, workflowMolecule} from "@agenta/entities/workflow"
 import {projectIdAtom} from "@agenta/shared/state"
 
 import {__resetAgentAutoCommit} from "../../src/state/execution/agentAutoCommit"
@@ -98,6 +102,7 @@ const nextId = () => `rev-${++seq}`
 
 const put = (sel: any, id: string, value: unknown) =>
     store.set(sel(id) as PrimitiveAtom<unknown>, value)
+const draftOf = (id: string) => workflowDraftAtomFamily(id) as unknown as PrimitiveAtom<unknown>
 
 /** A committed revision: what the drawer reads and what a revert restores from. */
 function seedRevision(
@@ -287,15 +292,20 @@ describe("revertAgentRevisionAtom", () => {
         expect(discards).toEqual([current])
     })
 
-    it("keeps a pre-existing draft when the commit fails, rather than discarding the user's edits", async () => {
+    it("restores the user's own draft when the commit fails, rather than leaving ours staged", async () => {
+        // Staging overwrites the draft, so "your agent is unchanged" is only true if the edits
+        // this revert never owned are put back. Discarding is not enough.
         commitOutcome = {success: false, error: new Error("rejected")}
         const target = seedRevision(nextId(), {version: 2, params: OLD})
         const current = seedRevision(nextId(), {version: 4, params: NEW})
+        const mine = {data: {parameters: {agent: {llm: {model: "my-edit"}}}}}
+        store.set(draftOf(current), mine)
         put((workflowMolecule as any).selectors.isDirty, current, true)
 
         await store.set(revertAgentRevisionAtom, {revisionId: current, targetRevisionId: target})
 
         expect(discards).toEqual([])
+        expect(store.get(draftOf(current))).toEqual(mine)
     })
 
     it("cancelling is simply never calling it — no draft is staged and nothing commits", () => {

--- a/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
@@ -159,6 +159,29 @@ describe("buildVersionRows", () => {
         expect(rows.map((r) => r.isCurrent)).toEqual([false, true])
     })
 
+    it("puts the highest version on top even when created_at disagrees", () => {
+        const rows = buildVersionRows(
+            [
+                revision({id: "old", version: 1, created_at: "2026-01-09T00:00:00Z"}),
+                revision({id: "new", version: 3, created_at: "2026-01-01T00:00:00Z"}),
+                revision({id: "mid", version: 2, created_at: "2026-01-05T00:00:00Z"}),
+            ],
+            "old",
+        )
+        expect(rows.map((r) => r.version)).toEqual([3, 2, 1])
+    })
+
+    it("separates latest from current — the surface can sit on an older revision", () => {
+        const rows = buildVersionRows(
+            [revision({id: "a", version: 3}), revision({id: "b", version: 1})],
+            "b",
+        )
+        expect(rows.map((r) => [r.version, r.isLatest, r.isCurrent])).toEqual([
+            [3, true, false],
+            [1, false, true],
+        ])
+    })
+
     it("recognises a revert by its commit message", () => {
         const rows = buildVersionRows(
             [

--- a/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
@@ -149,46 +149,35 @@ describe("buildVersionRows", () => {
         ({id: "r", version: 1, message: null, created_at: null, ...over}) as any
 
     it("drops the v0 seed — it holds no configuration to compare or restore", () => {
-        const rows = buildVersionRows(
-            [revision({id: "a", version: 2}), revision({id: "b", version: 0})],
-            "a",
-        )
+        const rows = buildVersionRows([
+            revision({id: "a", version: 2}),
+            revision({id: "b", version: 0}),
+        ])
         expect(rows.map((r) => r.id)).toEqual(["a"])
     })
 
-    it("marks the revision under edit as current", () => {
-        const rows = buildVersionRows(
-            [revision({id: "a", version: 2}), revision({id: "b", version: 1})],
-            "b",
-        )
-        expect(rows.map((r) => r.isCurrent)).toEqual([false, true])
-    })
-
     it("puts the highest version on top even when created_at disagrees", () => {
-        const rows = buildVersionRows(
-            [
-                revision({id: "old", version: 1, created_at: "2026-01-09T00:00:00Z"}),
-                revision({id: "new", version: 3, created_at: "2026-01-01T00:00:00Z"}),
-                revision({id: "mid", version: 2, created_at: "2026-01-05T00:00:00Z"}),
-            ],
-            "old",
-        )
+        const rows = buildVersionRows([
+            revision({id: "old", version: 1, created_at: "2026-01-09T00:00:00Z"}),
+            revision({id: "new", version: 3, created_at: "2026-01-01T00:00:00Z"}),
+            revision({id: "mid", version: 2, created_at: "2026-01-05T00:00:00Z"}),
+        ])
         expect(rows.map((r) => r.version)).toEqual([3, 2, 1])
     })
 
-    it("separates latest from current — the surface can sit on an older revision", () => {
-        const rows = buildVersionRows(
-            [revision({id: "a", version: 3}), revision({id: "b", version: 1})],
-            "b",
-        )
-        expect(rows.map((r) => [r.version, r.isLatest, r.isCurrent])).toEqual([
-            [3, true, false],
-            [1, false, true],
+    it("marks only the highest version as latest — the drawer's single baseline", () => {
+        const rows = buildVersionRows([
+            revision({id: "a", version: 3}),
+            revision({id: "b", version: 1}),
+        ])
+        expect(rows.map((r) => [r.version, r.isLatest])).toEqual([
+            [3, true],
+            [1, false],
         ])
     })
 
     it("normalises a blank commit message to null", () => {
-        expect(buildVersionRows([revision({message: "   "})], null)[0].message).toBeNull()
+        expect(buildVersionRows([revision({message: "   "})])[0].message).toBeNull()
     })
 })
 

--- a/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
@@ -1,0 +1,285 @@
+/**
+ * Unit tests for agent version history — the rows the drawer lists, and the revert behind them.
+ *
+ * The property that matters most is what revert must NEVER do: rewrite history. It is a plain
+ * commit whose content is old, so the assertions here are about what reaches the commit call —
+ * the historical parameters, once, under a message that names the version restored.
+ *
+ * The mock mirrors `agentAutoCommit.test.ts`: revert goes through the same flush, so it inherits
+ * that engine's guards and has to be driven the same way.
+ */
+import {getDefaultStore, type PrimitiveAtom} from "jotai"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+const commitCalls: {revisionId: string; commitMessage?: string}[] = []
+let commitOutcome: {success: boolean; newRevisionId?: string; error?: Error} = {
+    success: true,
+    newRevisionId: "new-rev",
+}
+/** Draft writes the revert makes, so a test can assert what it staged. */
+const draftWrites: {revisionId: string; updates: any}[] = []
+/** Revisions whose draft was rolled back. */
+const discards: string[] = []
+
+vi.mock("@agenta/entities/workflow", async (importOriginal) => {
+    const actual = (await importOriginal()) as any
+    const {atom} = await import("jotai")
+    const mk = <T>(init: T) => {
+        const m = new Map<string, unknown>()
+        return (id: string) => {
+            if (!m.has(id)) m.set(id, atom<T>(init))
+            return m.get(id)
+        }
+    }
+    const isDirty = mk<boolean>(true)
+    return {
+        ...actual,
+        workflowMolecule: {
+            ...actual.workflowMolecule,
+            selectors: {
+                ...actual.workflowMolecule.selectors,
+                data: mk<Record<string, unknown> | null>(null),
+                isAgent: mk<boolean>(true),
+                isDirty,
+                isEphemeral: mk<boolean>(false),
+                configuration: mk<Record<string, unknown> | null>(null),
+                serverConfiguration: mk<Record<string, unknown> | null>(null),
+                serverData: mk<Record<string, unknown> | null>(null),
+            },
+        },
+        registerWorkflowDraftCallbacks: () => undefined,
+        updateWorkflowDraftAtom: atom(
+            null,
+            (
+                _g: unknown,
+                set: (a: unknown, v: unknown) => void,
+                revisionId: string,
+                updates: any,
+            ) => {
+                draftWrites.push({revisionId, updates})
+                set(isDirty(revisionId), true)
+            },
+        ),
+        discardWorkflowDraftAtom: atom(
+            null,
+            (_g: unknown, set: (a: unknown, v: unknown) => void, revisionId: string) => {
+                discards.push(revisionId)
+                set(isDirty(revisionId), false)
+            },
+        ),
+        commitWorkflowRevisionAtom: atom(
+            null,
+            async (
+                _g: unknown,
+                set: (a: unknown, v: unknown) => void,
+                params: {revisionId: string; commitMessage?: string},
+            ) => {
+                commitCalls.push(params)
+                if (commitOutcome.success) set(isDirty(params.revisionId), false)
+                return commitOutcome
+            },
+        ),
+    }
+})
+
+import {workflowMolecule} from "@agenta/entities/workflow"
+import {projectIdAtom} from "@agenta/shared/state"
+
+import {__resetAgentAutoCommit} from "../../src/state/execution/agentAutoCommit"
+import {
+    buildRevertMessage,
+    buildVersionRows,
+    revertAgentRevisionAtom,
+} from "../../src/state/execution/agentVersionHistory"
+
+let store: ReturnType<typeof getDefaultStore>
+let seq = 0
+const nextId = () => `rev-${++seq}`
+
+const put = (sel: any, id: string, value: unknown) =>
+    store.set(sel(id) as PrimitiveAtom<unknown>, value)
+
+/** A committed revision: what the drawer reads and what a revert restores from. */
+function seedRevision(
+    id: string,
+    {
+        version,
+        message = null,
+        params,
+        schemas,
+    }: {
+        version: number
+        message?: string | null
+        params: Record<string, unknown>
+        schemas?: Record<string, unknown>
+    },
+) {
+    const {selectors} = workflowMolecule as any
+    put(selectors.data, id, {id, version, message, workflow_id: "wf-1"})
+    put(selectors.serverConfiguration, id, params)
+    put(selectors.configuration, id, params)
+    put(selectors.serverData, id, {data: {parameters: params, ...(schemas ? {schemas} : {})}})
+    put(selectors.isAgent, id, true)
+    put(selectors.isEphemeral, id, false)
+    put(selectors.isDirty, id, false)
+    return id
+}
+
+beforeEach(() => {
+    commitCalls.length = 0
+    draftWrites.length = 0
+    discards.length = 0
+    commitOutcome = {success: true, newRevisionId: "new-rev"}
+    __resetAgentAutoCommit()
+    store = getDefaultStore()
+    store.set(projectIdAtom, "proj-1")
+})
+
+afterEach(() => {
+    vi.clearAllTimers()
+})
+
+describe("buildVersionRows", () => {
+    const revision = (over: Record<string, unknown>) =>
+        ({id: "r", version: 1, message: null, created_at: null, ...over}) as any
+
+    it("drops the v0 seed — it holds no configuration to compare or restore", () => {
+        const rows = buildVersionRows(
+            [revision({id: "a", version: 2}), revision({id: "b", version: 0})],
+            "a",
+        )
+        expect(rows.map((r) => r.id)).toEqual(["a"])
+    })
+
+    it("marks the revision under edit as current", () => {
+        const rows = buildVersionRows(
+            [revision({id: "a", version: 2}), revision({id: "b", version: 1})],
+            "b",
+        )
+        expect(rows.map((r) => r.isCurrent)).toEqual([false, true])
+    })
+
+    it("recognises a revert by its commit message", () => {
+        const rows = buildVersionRows(
+            [
+                revision({id: "a", version: 3, message: 'Revert to v1 — "Initial commit"'}),
+                revision({id: "b", version: 2, message: "Add the Linear MCP server"}),
+            ],
+            "a",
+        )
+        expect(rows.map((r) => r.isReverted)).toEqual([true, false])
+    })
+
+    it("normalises a blank commit message to null", () => {
+        expect(buildVersionRows([revision({message: "   "})], null)[0].message).toBeNull()
+    })
+})
+
+describe("buildRevertMessage", () => {
+    it("quotes the restored version's own message", () => {
+        expect(buildRevertMessage({version: 2, message: "Add the Linear MCP server"})).toBe(
+            'Revert to v2 — "Add the Linear MCP server"',
+        )
+    })
+
+    it("falls back to the version alone when it had no message", () => {
+        expect(buildRevertMessage({version: 2, message: null})).toBe("Revert to v2")
+    })
+})
+
+describe("revertAgentRevisionAtom", () => {
+    const OLD = {agent: {llm: {model: "gpt-4"}}}
+    const NEW = {agent: {llm: {model: "claude-opus-4-8"}}}
+
+    it("commits the historical configuration once, naming the version it restored", async () => {
+        const target = seedRevision(nextId(), {version: 2, message: "Add tools", params: OLD})
+        const current = seedRevision(nextId(), {version: 4, params: NEW})
+
+        const landed = await store.set(revertAgentRevisionAtom, {
+            revisionId: current,
+            targetRevisionId: target,
+        })
+
+        expect(landed).toBe(true)
+        expect(commitCalls).toEqual([
+            {revisionId: current, commitMessage: 'Revert to v2 — "Add tools"'},
+        ])
+        // History is untouched: the only write is a draft staged on the CURRENT revision.
+        expect(draftWrites).toHaveLength(1)
+        expect(draftWrites[0].revisionId).toBe(current)
+        expect(draftWrites[0].updates.data.parameters).toEqual(OLD)
+    })
+
+    it("carries the historical schemas, not just the parameters", async () => {
+        const schemas = {parameters: {type: "object"}}
+        const target = seedRevision(nextId(), {version: 2, params: OLD, schemas})
+        const current = seedRevision(nextId(), {version: 4, params: NEW})
+
+        await store.set(revertAgentRevisionAtom, {revisionId: current, targetRevisionId: target})
+
+        expect(draftWrites[0].updates.data.schemas).toEqual(schemas)
+    })
+
+    it("reads the target's SERVER config, so a draft left on an old revision cannot leak in", async () => {
+        const target = seedRevision(nextId(), {version: 2, params: OLD})
+        // Someone once edited that old revision; the draft must not be what gets restored.
+        put((workflowMolecule as any).selectors.configuration, target, {
+            agent: {llm: {model: "scratch"}},
+        })
+        const current = seedRevision(nextId(), {version: 4, params: NEW})
+
+        await store.set(revertAgentRevisionAtom, {revisionId: current, targetRevisionId: target})
+
+        expect(draftWrites[0].updates.data.parameters).toEqual(OLD)
+    })
+
+    it("does nothing when the target is the current revision", async () => {
+        const current = seedRevision(nextId(), {version: 4, params: NEW})
+
+        const landed = await store.set(revertAgentRevisionAtom, {
+            revisionId: current,
+            targetRevisionId: current,
+        })
+
+        expect(landed).toBe(false)
+        expect(commitCalls).toEqual([])
+        expect(draftWrites).toEqual([])
+    })
+
+    it("reports failure and leaves the agent unchanged when the commit is rejected", async () => {
+        commitOutcome = {success: false, error: new Error("rejected")}
+        const target = seedRevision(nextId(), {version: 2, params: OLD})
+        const current = seedRevision(nextId(), {version: 4, params: NEW})
+
+        const landed = await store.set(revertAgentRevisionAtom, {
+            revisionId: current,
+            targetRevisionId: target,
+        })
+
+        expect(landed).toBe(false)
+        // One attempt, not a silent retry: the drawer's "Try again" is the user's retry.
+        expect(commitCalls).toHaveLength(1)
+        // "Your agent is unchanged" has to be true: the staged config is rolled back, so no
+        // later auto-commit can land it under a generated message.
+        expect(discards).toEqual([current])
+    })
+
+    it("keeps a pre-existing draft when the commit fails, rather than discarding the user's edits", async () => {
+        commitOutcome = {success: false, error: new Error("rejected")}
+        const target = seedRevision(nextId(), {version: 2, params: OLD})
+        const current = seedRevision(nextId(), {version: 4, params: NEW})
+        put((workflowMolecule as any).selectors.isDirty, current, true)
+
+        await store.set(revertAgentRevisionAtom, {revisionId: current, targetRevisionId: target})
+
+        expect(discards).toEqual([])
+    })
+
+    it("cancelling is simply never calling it — no draft is staged and nothing commits", () => {
+        seedRevision(nextId(), {version: 2, params: OLD})
+        seedRevision(nextId(), {version: 4, params: NEW})
+
+        expect(commitCalls).toEqual([])
+        expect(draftWrites).toEqual([])
+    })
+})

--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -237,6 +237,18 @@ export {
     parseGatewayToolSlug,
 } from "./toolSlug"
 
+// Agent tool-permission policy vocabulary (shared by the config drawer, the /permissions
+// palette, and the commit diff).
+export {
+    DEFAULT_PERMISSION_POLICY,
+    PERMISSION_POLICY_OPTIONS,
+    isPermissionPolicy,
+    permissionPolicyLabel,
+    permissionPolicyOptionsForEnum,
+    type PermissionPolicy,
+    type PermissionPolicyOption,
+} from "./permissionPolicy"
+
 // Gateway Tool JSON-Schema → form-field descriptor utilities
 export {
     buildFormFieldsFromData,

--- a/web/packages/agenta-shared/src/utils/index.ts
+++ b/web/packages/agenta-shared/src/utils/index.ts
@@ -237,8 +237,7 @@ export {
     parseGatewayToolSlug,
 } from "./toolSlug"
 
-// Agent tool-permission policy vocabulary (shared by the config drawer, the /permissions
-// palette, and the commit diff).
+// Agent tool-permission policy vocabulary.
 export {
     DEFAULT_PERMISSION_POLICY,
     PERMISSION_POLICY_OPTIONS,

--- a/web/packages/agenta-shared/src/utils/permissionPolicy.ts
+++ b/web/packages/agenta-shared/src/utils/permissionPolicy.ts
@@ -1,10 +1,4 @@
-/**
- * The agent's default tool-permission policy: the values, and what a human calls them.
- *
- * Lives in `shared` because three layers need the same four names — the config drawer's
- * Permissions group, the chat composer's `/permissions` palette, and the commit diff, which
- * would otherwise print the raw enum (`allow_reads`) at the reader.
- */
+/** The agent's default tool-permission policy, and what a human calls each value. */
 export type PermissionPolicy = "allow_reads" | "allow" | "ask" | "deny"
 
 export interface PermissionPolicyOption {
@@ -34,11 +28,7 @@ export function isPermissionPolicy(value: unknown): value is PermissionPolicy {
 export const permissionPolicyLabel = (value: string | null | undefined): string | undefined =>
     PERMISSION_POLICY_OPTIONS.find((option) => option.value === value)?.label
 
-/**
- * The options a schema `enum` permits, or all of them when it names none. Every surface offering
- * policies goes through this — one that offered a value the schema forbids would write a draft
- * config the agent's own schema rejects.
- */
+/** The options a schema `enum` permits, or all of them when it names none. */
 export function permissionPolicyOptionsForEnum(values: unknown): PermissionPolicyOption[] {
     if (!Array.isArray(values)) return PERMISSION_POLICY_OPTIONS
     const allowed = new Set(values.filter(isPermissionPolicy))

--- a/web/packages/agenta-shared/src/utils/permissionPolicy.ts
+++ b/web/packages/agenta-shared/src/utils/permissionPolicy.ts
@@ -1,0 +1,46 @@
+/**
+ * The agent's default tool-permission policy: the values, and what a human calls them.
+ *
+ * Lives in `shared` because three layers need the same four names — the config drawer's
+ * Permissions group, the chat composer's `/permissions` palette, and the commit diff, which
+ * would otherwise print the raw enum (`allow_reads`) at the reader.
+ */
+export type PermissionPolicy = "allow_reads" | "allow" | "ask" | "deny"
+
+export interface PermissionPolicyOption {
+    value: PermissionPolicy
+    label: string
+    help: string
+}
+
+export const PERMISSION_POLICY_OPTIONS: PermissionPolicyOption[] = [
+    {value: "allow_reads", label: "Allow reads", help: "Reads run, writes ask; default"},
+    {value: "allow", label: "Allow all", help: "Every tool runs without asking"},
+    {value: "ask", label: "Ask", help: "A human approves every tool call"},
+    {value: "deny", label: "Deny all", help: "Every tool call is refused"},
+]
+
+/** What the runner applies when the template names no policy. */
+export const DEFAULT_PERMISSION_POLICY: PermissionPolicy = "allow_reads"
+
+const PERMISSION_POLICY_VALUES = new Set<string>(
+    PERMISSION_POLICY_OPTIONS.map((option) => option.value),
+)
+
+export function isPermissionPolicy(value: unknown): value is PermissionPolicy {
+    return typeof value === "string" && PERMISSION_POLICY_VALUES.has(value)
+}
+
+export const permissionPolicyLabel = (value: string | null | undefined): string | undefined =>
+    PERMISSION_POLICY_OPTIONS.find((option) => option.value === value)?.label
+
+/**
+ * The options a schema `enum` permits, or all of them when it names none. Every surface offering
+ * policies goes through this — one that offered a value the schema forbids would write a draft
+ * config the agent's own schema rejects.
+ */
+export function permissionPolicyOptionsForEnum(values: unknown): PermissionPolicyOption[] {
+    if (!Array.isArray(values)) return PERMISSION_POLICY_OPTIONS
+    const allowed = new Set(values.filter(isPermissionPolicy))
+    return PERMISSION_POLICY_OPTIONS.filter((option) => allowed.has(option.value))
+}

--- a/web/pnpm-lock.yaml
+++ b/web/pnpm-lock.yaml
@@ -2421,6 +2421,12 @@ importers:
       '@agenta/oss':
         specifier: workspace:*
         version: link:../oss
+      '@agenta/playground':
+        specifier: workspace:*
+        version: link:../packages/agenta-playground
+      '@agenta/playground-ui':
+        specifier: workspace:*
+        version: link:../packages/agenta-playground-ui
       '@agenta/shared':
         specifier: workspace:*
         version: link:../packages/agenta-shared

--- a/web/storybook/package.json
+++ b/web/storybook/package.json
@@ -15,6 +15,8 @@
         "@agenta/entities": "workspace:*",
         "@agenta/entity-ui": "workspace:*",
         "@agenta/oss": "workspace:*",
+        "@agenta/playground": "workspace:*",
+        "@agenta/playground-ui": "workspace:*",
         "@agenta/shared": "workspace:*",
         "@agenta/ui": "workspace:*",
         "@phosphor-icons/react": "^2.1.10",

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -32,6 +32,7 @@ const rows: AgentVersionRow[] = [
         message: "Tighten refusal wording and add the Write tool",
         createdAt: new Date(now - 2 * HOUR).toISOString(),
         isCurrent: true,
+        isLatest: true,
         isReverted: false,
     },
     {
@@ -40,6 +41,7 @@ const rows: AgentVersionRow[] = [
         message: 'Revert to v1 — "Initial commit"',
         createdAt: new Date(now - 72 * HOUR).toISOString(),
         isCurrent: false,
+        isLatest: false,
         isReverted: true,
     },
     {
@@ -48,6 +50,7 @@ const rows: AgentVersionRow[] = [
         message: "Add the Linear MCP server",
         createdAt: new Date(now - 144 * HOUR).toISOString(),
         isCurrent: false,
+        isLatest: false,
         isReverted: false,
     },
     {
@@ -56,6 +59,7 @@ const rows: AgentVersionRow[] = [
         message: null,
         createdAt: new Date(now - 336 * HOUR).toISOString(),
         isCurrent: false,
+        isLatest: false,
         isReverted: false,
     },
 ]
@@ -75,7 +79,7 @@ const listArgs = {
 
 type ListStory = StoryObj<typeof VersionList>
 
-/** v2 is selected. v4 is Latest — it IS the current configuration, so its row is disabled. */
+/** v2 is selected. v4 is Current — it IS the configuration on screen, so its row is disabled. */
 export const List: ListStory = {
     render: (args) => (
         <Rail>

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -1,10 +1,7 @@
 import type {ChangeSection} from "@agenta/entities/workflow/commitDiff"
 import type {AgentVersionRow} from "@agenta/playground/state"
+import {ChangesPane, RevertFooter, VersionList} from "@agenta/playground-ui/agent-version-history"
 import type {Meta, StoryObj} from "@storybook/nextjs"
-
-import {ChangesPane} from "../../../packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane"
-import {RevertFooter} from "../../../packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter"
-import {VersionList} from "../../../packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList"
 
 // The version-history drawer's three panes (#6405), in the states a reviewer cannot click to.
 // Widths match the real drawer (780px, 250px rail) so rows wrap as they do in situ.

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -23,7 +23,6 @@ const rows: AgentVersionRow[] = [
         version: 4,
         message: "Tighten refusal wording and add the Write tool",
         createdAt: new Date(now - 2 * HOUR).toISOString(),
-        isCurrent: true,
         isLatest: true,
     },
     {
@@ -31,7 +30,6 @@ const rows: AgentVersionRow[] = [
         version: 3,
         message: 'Revert to v1 — "Initial commit"',
         createdAt: new Date(now - 72 * HOUR).toISOString(),
-        isCurrent: false,
         isLatest: false,
     },
     {
@@ -39,7 +37,6 @@ const rows: AgentVersionRow[] = [
         version: 2,
         message: "Add the Linear MCP server",
         createdAt: new Date(now - 144 * HOUR).toISOString(),
-        isCurrent: false,
         isLatest: false,
     },
     {
@@ -47,7 +44,6 @@ const rows: AgentVersionRow[] = [
         version: 1,
         message: null,
         createdAt: new Date(now - 336 * HOUR).toISOString(),
-        isCurrent: false,
         isLatest: false,
     },
 ]
@@ -92,7 +88,7 @@ export const ListSingleVersion: ListStory = {
     ...List,
     args: {
         ...listArgs,
-        rows: [{...rows[3], isCurrent: true, isLatest: true}],
+        rows: [{...rows[3], isLatest: true}],
         selectedId: null,
     },
 }
@@ -199,7 +195,7 @@ export const ChangesNoSelection: PaneStory = {
 
 const footerArgs = {
     selectedVersion: 2,
-    currentVersion: 4,
+    latestVersion: 4,
     revertedFrom: 2,
     disabled: false,
     onRequestConfirm: () => undefined,
@@ -243,7 +239,7 @@ export const FooterReverting: FooterStory = {
 
 export const FooterDone: FooterStory = {
     ...FooterIdle,
-    args: {...footerArgs, phase: "done", currentVersion: 5},
+    args: {...footerArgs, phase: "done", latestVersion: 5},
 }
 
 export const FooterFailed: FooterStory = {

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -105,7 +105,7 @@ export const ListEmpty: ListStory = {
 const sections: ChangeSection[] = [
     {
         id: "model",
-        title: "Model & harness",
+        title: "Model",
         tags: [{kind: "changed", label: "1 changed"}],
         totalCount: 1,
         scalarChanges: [

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -25,7 +25,6 @@ const rows: AgentVersionRow[] = [
         createdAt: new Date(now - 2 * HOUR).toISOString(),
         isCurrent: true,
         isLatest: true,
-        isReverted: false,
     },
     {
         id: "r3",
@@ -34,7 +33,6 @@ const rows: AgentVersionRow[] = [
         createdAt: new Date(now - 72 * HOUR).toISOString(),
         isCurrent: false,
         isLatest: false,
-        isReverted: true,
     },
     {
         id: "r2",
@@ -43,7 +41,6 @@ const rows: AgentVersionRow[] = [
         createdAt: new Date(now - 144 * HOUR).toISOString(),
         isCurrent: false,
         isLatest: false,
-        isReverted: false,
     },
     {
         id: "r1",
@@ -52,7 +49,6 @@ const rows: AgentVersionRow[] = [
         createdAt: new Date(now - 336 * HOUR).toISOString(),
         isCurrent: false,
         isLatest: false,
-        isReverted: false,
     },
 ]
 

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -158,19 +158,19 @@ export const ChangesLoading: PaneStory = {
     args: {sections: [], version: 2, message: "Add the Linear MCP server", isLoading: true},
 }
 
-/** Selected version's configuration is byte-identical to the current one. */
-export const ChangesIdentical: PaneStory = {
+/** The oldest version: no predecessor, so there is no change of its own to show. */
+export const ChangesFirstVersion: PaneStory = {
     ...Changes,
     args: {
         sections: [],
-        version: 2,
-        message: "Add the Linear MCP server",
+        version: 1,
+        message: null,
         isLoading: false,
-        emptyText: "Identical to your current configuration — restoring it would change nothing.",
+        emptyText: "The first version — there is nothing before it to compare.",
     },
 }
 
-/** The configs differ, but only in fields the classifier does not surface — still restorable. */
+/** A commit whose only changes are in fields the classifier does not surface. */
 export const ChangesUnclassified: PaneStory = {
     ...Changes,
     args: {
@@ -178,8 +178,7 @@ export const ChangesUnclassified: PaneStory = {
         version: 2,
         message: "Add the Linear MCP server",
         isLoading: false,
-        emptyText:
-            "This version differs, but not in anything the summary can describe. Restoring it still applies the stored configuration.",
+        emptyText: "No configuration changes recorded in this version.",
     },
 }
 
@@ -189,7 +188,7 @@ export const ChangesNoSelection: PaneStory = {
         sections: [],
         version: null,
         isLoading: false,
-        placeholder: "Pick a version to see what restoring it would change.",
+        placeholder: "Pick a version to see what changed in it.",
     },
 }
 

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -87,10 +87,14 @@ export const ListError: ListStory = {
     args: {...listArgs, isError: true},
 }
 
-/** A brand-new agent: one commit, so there is nothing to compare or restore. */
+/** A brand-new agent: v1 lists as a normal row, disabled the way the latest always is. */
 export const ListSingleVersion: ListStory = {
     ...List,
-    args: {...listArgs, rows: [rows[0]], selectedId: null},
+    args: {
+        ...listArgs,
+        rows: [{...rows[3], isCurrent: true, isLatest: true}],
+        selectedId: null,
+    },
 }
 
 export const ListEmpty: ListStory = {

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -122,7 +122,8 @@ const sections: ChangeSection[] = [
     },
     {
         id: "tools",
-        title: "Tools",
+        title: "Integrations",
+        noun: "integration",
         tags: [
             {kind: "added", label: "1 added"},
             {kind: "removed", label: "2 removed"},
@@ -133,6 +134,14 @@ const sections: ChangeSection[] = [
             {id: "t2", label: "Write", kind: "removed"},
             {id: "t3", label: "Fetch", kind: "removed"},
         ],
+    },
+    {
+        id: "subagents",
+        title: "Subagents",
+        noun: "subagent",
+        tags: [{kind: "added", label: "1 added"}],
+        totalCount: 1,
+        items: [{id: "s1", label: "hourly-news", kind: "added"}],
     },
 ]
 

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -6,13 +6,8 @@ import {ChangesPane} from "../../../packages/agenta-playground-ui/src/components
 import {RevertFooter} from "../../../packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter"
 import {VersionList} from "../../../packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList"
 
-// The three panes of the agent version-history drawer (#6405), each in the states a reviewer
-// cannot reach by clicking: a failed version fetch, a single-version agent, a revert mid-flight,
-// and a rejected revert. The drawer itself is jotai + react-query connected; these are its pure
-// presentational pieces, which is where the design contract actually lives.
-//
-// Layout note: the real drawer is 780px with a 250px rail. The list stories fix that rail width
-// so the rows wrap exactly as they do in the drawer.
+// The version-history drawer's three panes (#6405), in the states a reviewer cannot click to.
+// Widths match the real drawer (780px, 250px rail) so rows wrap as they do in situ.
 
 const meta = {
     title: "@agenta/playground-ui/AgentVersionHistory",

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -165,7 +165,26 @@ export const ChangesLoading: PaneStory = {
 /** Selected version's configuration is byte-identical to the current one. */
 export const ChangesIdentical: PaneStory = {
     ...Changes,
-    args: {sections: [], version: 2, message: "Add the Linear MCP server", isLoading: false},
+    args: {
+        sections: [],
+        version: 2,
+        message: "Add the Linear MCP server",
+        isLoading: false,
+        emptyText: "Identical to your current configuration — restoring it would change nothing.",
+    },
+}
+
+/** The configs differ, but only in fields the classifier does not surface — still restorable. */
+export const ChangesUnclassified: PaneStory = {
+    ...Changes,
+    args: {
+        sections: [],
+        version: 2,
+        message: "Add the Linear MCP server",
+        isLoading: false,
+        emptyText:
+            "This version differs, but not in anything the summary can describe. Restoring it still applies the stored configuration.",
+    },
 }
 
 export const ChangesNoSelection: PaneStory = {

--- a/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentVersionHistory.stories.tsx
@@ -1,0 +1,228 @@
+import type {ChangeSection} from "@agenta/entities/workflow/commitDiff"
+import type {AgentVersionRow} from "@agenta/playground/state"
+import type {Meta, StoryObj} from "@storybook/nextjs"
+
+import {ChangesPane} from "../../../packages/agenta-playground-ui/src/components/AgentVersionHistory/ChangesPane"
+import {RevertFooter} from "../../../packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter"
+import {VersionList} from "../../../packages/agenta-playground-ui/src/components/AgentVersionHistory/VersionList"
+
+// The three panes of the agent version-history drawer (#6405), each in the states a reviewer
+// cannot reach by clicking: a failed version fetch, a single-version agent, a revert mid-flight,
+// and a rejected revert. The drawer itself is jotai + react-query connected; these are its pure
+// presentational pieces, which is where the design contract actually lives.
+//
+// Layout note: the real drawer is 780px with a 250px rail. The list stories fix that rail width
+// so the rows wrap exactly as they do in the drawer.
+
+const meta = {
+    title: "@agenta/playground-ui/AgentVersionHistory",
+    parameters: {layout: "padded"},
+} satisfies Meta
+
+export default meta
+
+const HOUR = 3_600_000
+// Relative to load time so the rows read "2 hours ago", not "281d ago".
+const now = Date.now()
+
+const rows: AgentVersionRow[] = [
+    {
+        id: "r4",
+        version: 4,
+        message: "Tighten refusal wording and add the Write tool",
+        createdAt: new Date(now - 2 * HOUR).toISOString(),
+        isCurrent: true,
+        isReverted: false,
+    },
+    {
+        id: "r3",
+        version: 3,
+        message: 'Revert to v1 — "Initial commit"',
+        createdAt: new Date(now - 72 * HOUR).toISOString(),
+        isCurrent: false,
+        isReverted: true,
+    },
+    {
+        id: "r2",
+        version: 2,
+        message: "Add the Linear MCP server",
+        createdAt: new Date(now - 144 * HOUR).toISOString(),
+        isCurrent: false,
+        isReverted: false,
+    },
+    {
+        id: "r1",
+        version: 1,
+        message: null,
+        createdAt: new Date(now - 336 * HOUR).toISOString(),
+        isCurrent: false,
+        isReverted: false,
+    },
+]
+
+const Rail = ({children}: {children: React.ReactNode}) => (
+    <div className="flex h-[420px] w-[250px] flex-col">{children}</div>
+)
+
+const listArgs = {
+    rows,
+    selectedId: "r2",
+    isLoading: false,
+    isError: false,
+    onRetry: () => undefined,
+    onSelect: () => undefined,
+}
+
+type ListStory = StoryObj<typeof VersionList>
+
+/** v2 is selected. v4 is Latest — it IS the current configuration, so its row is disabled. */
+export const List: ListStory = {
+    render: (args) => (
+        <Rail>
+            <VersionList {...args} />
+        </Rail>
+    ),
+    args: listArgs,
+}
+
+export const ListLoading: ListStory = {
+    ...List,
+    args: {...listArgs, isLoading: true},
+}
+
+export const ListError: ListStory = {
+    ...List,
+    args: {...listArgs, isError: true},
+}
+
+/** A brand-new agent: one commit, so there is nothing to compare or restore. */
+export const ListSingleVersion: ListStory = {
+    ...List,
+    args: {...listArgs, rows: [rows[0]], selectedId: null},
+}
+
+export const ListEmpty: ListStory = {
+    ...List,
+    args: {...listArgs, rows: [], selectedId: null},
+}
+
+const sections: ChangeSection[] = [
+    {
+        id: "model",
+        title: "Model & harness",
+        tags: [{kind: "changed", label: "1 changed"}],
+        totalCount: 1,
+        scalarChanges: [
+            {
+                key: "agent.model",
+                before: "claude-opus-4-1",
+                after: "claude-sonnet-4-5",
+                kind: "changed",
+            },
+        ],
+    },
+    {
+        id: "tools",
+        title: "Tools",
+        tags: [
+            {kind: "added", label: "1 added"},
+            {kind: "removed", label: "2 removed"},
+        ],
+        totalCount: 3,
+        items: [
+            {id: "t1", label: "Search", kind: "added"},
+            {id: "t2", label: "Write", kind: "removed"},
+            {id: "t3", label: "Fetch", kind: "removed"},
+        ],
+    },
+]
+
+const Pane = ({children}: {children: React.ReactNode}) => (
+    <div className="flex h-[420px] w-[520px] flex-col">{children}</div>
+)
+
+type PaneStory = StoryObj<typeof ChangesPane>
+
+export const Changes: PaneStory = {
+    render: (args) => (
+        <Pane>
+            <ChangesPane {...args} />
+        </Pane>
+    ),
+    args: {sections, version: 2, message: "Add the Linear MCP server", isLoading: false},
+}
+
+export const ChangesLoading: PaneStory = {
+    ...Changes,
+    args: {sections: [], version: 2, message: "Add the Linear MCP server", isLoading: true},
+}
+
+/** Selected version's configuration is byte-identical to the current one. */
+export const ChangesIdentical: PaneStory = {
+    ...Changes,
+    args: {sections: [], version: 2, message: "Add the Linear MCP server", isLoading: false},
+}
+
+export const ChangesNoSelection: PaneStory = {
+    ...Changes,
+    args: {
+        sections: [],
+        version: null,
+        isLoading: false,
+        placeholder: "Pick a version to see what restoring it would change.",
+    },
+}
+
+const footerArgs = {
+    selectedVersion: 2,
+    currentVersion: 4,
+    revertedFrom: 2,
+    disabled: false,
+    onRequestConfirm: () => undefined,
+    onCancel: () => undefined,
+    onConfirm: () => undefined,
+    onClose: () => undefined,
+}
+
+type FooterStory = StoryObj<typeof RevertFooter>
+
+const Footer = ({children}: {children: React.ReactNode}) => (
+    <div className="w-[780px] border-0 border-t border-solid border-[var(--ag-colorBorderSecondary)] px-4 py-3">
+        {children}
+    </div>
+)
+
+export const FooterIdle: FooterStory = {
+    render: (args) => (
+        <Footer>
+            <RevertFooter {...args} />
+        </Footer>
+    ),
+    args: {...footerArgs, phase: "idle"},
+}
+
+/** Nothing to restore — the selection is the current configuration. */
+export const FooterDisabled: FooterStory = {
+    ...FooterIdle,
+    args: {...footerArgs, phase: "idle", disabled: true},
+}
+
+export const FooterConfirm: FooterStory = {
+    ...FooterIdle,
+    args: {...footerArgs, phase: "confirm"},
+}
+
+export const FooterReverting: FooterStory = {
+    ...FooterIdle,
+    args: {...footerArgs, phase: "reverting"},
+}
+
+export const FooterDone: FooterStory = {
+    ...FooterIdle,
+    args: {...footerArgs, phase: "done", currentVersion: 5},
+}
+
+export const FooterFailed: FooterStory = {
+    ...FooterIdle,
+    args: {...footerArgs, phase: "failed"},
+}


### PR DESCRIPTION
Closes #6405

## Context

Inspecting an agent's versions went through a dropdown that listed version numbers and nothing else. You could not see what a version contained, compare it against what you have now, or go back to it.

Building that surfaced four defects underneath it, each one the same shape: the identifying data was present in the object and the code read past it.

## What this adds

The `vN` chip opens a version history drawer. It lists every version with its commit message, shows what a selected version would change against the configuration on screen, and restores one behind a confirmation.

Revert is not a new kind of write. It is a normal commit whose content happens to be old, so history is never rewritten: the selected version's parameters and schemas are staged onto the current revision and committed as a new version on top. It goes through the auto-commit flush rather than committing directly, because staging a draft arms that debounce and a second independent commit would race it and could mint two versions from one click. If the commit does not land, the staged draft is rolled back, unless the revision was already dirty, so a failed revert never discards your own unsaved edits.

Desktop and mobile share one implementation through `AgentRevisionStatus`, so the desktop playground gets version history for the first time. The agent header loses its variant picker: an agent is edited as one thing, and the `vN` chip is now the single control. Other workflow kinds keep `SelectVariant`.

## The four defects

**The playground could open on a stale revision and stay there.** "Latest" was scored by `created_at`, with `version` reachable only when every timestamp was missing, and the picker compared with a strict `>`. Revisions an agent commits itself land in bursts that tie to the second, so a tie let array order decide. The wrong pick then stuck: it is written to the `latestRevision` key, mirrored to IndexedDB, and that query is disabled whenever the key already holds a value, so nothing revalidated it. `version` is server-assigned and monotonic, so it decides now; timestamps only break ties. One shared `isLaterWorkflowRevision` replaces three sites that each had the bug. Opening the drawer re-primes the key through the same picker, so a poisoned cache repairs itself.

**Gateway tools were labelled with their type.** Canonical gateway tools carry no `function.name`, so `normalizeTool` fell into its bare-type fallback and title-cased the discriminator.

```
Before:  + Gateway        + Gateway        − Gateway connection
After:   + Add label      + Send email     − Gmail
```

They also had no stable identity, so replacing one action with another at the same index read as a single edited slot instead of an add and a remove.

**Advanced settings printed their storage paths.**

```
Before:  runner.permissions.default  allow → allow_reads
After:   Tool permissions            Allow all → Allow reads
```

Wording follows the config panel's own controls, so one setting is not called two things in two places. Unmapped keys humanize (`sandbox.network_access` becomes "Sandbox › network access") rather than disappearing.

**Subagents were named by their slug and lost their description.** A subagent is a `type: "reference"` tool. The diff showed the slug where the config panel shows the name, and `normalizeTool` hardcoded `description: ""`, so editing the text the calling agent reads to decide when to call it registered as "edited" with nothing to show.

## Notes

`AgentChangesSummary` statically imports `DiffView` and the Lexical editor behind it, and mobile bans Lexical outright. Its section list is extracted to `@agenta/entity-ui/changes` as `ChangeSections`; `AgentChangesSummary` now wraps it and keeps the JSON view and drill-ins, so the commit modal is unchanged.

The permission-policy names moved from `@agenta/entity-ui` to `@agenta/shared` so `@agenta/entities` can reach them. The entity-ui module re-exports them, so no call site moved.

## Tests

- 45 tests in `agent-commit-diff.test.ts`, 13 in `agentVersionHistory.test.ts`, 4 in `latest-workflow-revision.test.ts`. Full suites pass: 1479 entities, 598 entity-ui, 280 playground, 459 shared.
- 15 Storybook stories under `@agenta/playground-ui/AgentVersionHistory` cover the states a reviewer cannot reach by clicking: load error, single-version agent, revert in flight, revert rejected.
- One regression the tests caught: labelling `before`/`after` in place broke `sectionChanges.changeFor()`, which reads them back to tell the config panel what a property was committed as. Labels are additive now.

**Demo outstanding.** The list, diff and revert flow were checked in the running app during development, but I could not capture a recording: my dev server's API calls are CORS-blocked against the local stack.

## What to QA

- Open an agent playground, click the `vN` chip. The drawer lists every version newest first, the latest is tagged and not selectable, and the version below it is selected by default.
- Select an older version. The right pane names it and shows what restoring it would change. Tools read as "Add label", not "Gateway"; advanced settings read as "Tool permissions", not `runner.permissions.default`.
- Revert to it and confirm. A new version appears at the top with a `Revert to vN` message, and the older versions are unchanged.
- Cancel a revert. Nothing commits and the agent is untouched.
- Same flow on `/m` at phone width: the drawer shows one pane at a time, list then diff.
- Regression: open the commit modal on a prompt workflow. Its changes summary, "View as JSON" and tool drill-ins all still work.
- Regression: an agent that self-commits during a session. The header follows to the new version rather than sticking on an older one.


## Preview

<img width="600" alt="image" src="https://github.com/user-attachments/assets/6289e29f-ee3e-46e1-be5c-2a0734ef93cf" />
