### PR TITLE
[fix] Keep the composer dock above the transcript's bottom fade

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -252,7 +252,9 @@ const AgentComposerDock = ({
             {/* The whole composer fades + rises in ONCE on mount (Reveal), so the input joins the
                 empty-state/hero entrance instead of popping. Mount-only: it never remounts across the
                 onboarding→chat transitions, so this never reintroduces layout shift on state changes. */}
-            <Reveal className="px-3" enabled={composer.playComposerEntrance}>
+            {/* `relative z-10`: Reveal's transform traps the `/` panels' own z-index, so without a
+                stacking order here the transcript's `z-[5]` bottom fade washes the docked chrome. */}
+            <Reveal className="relative z-10 px-3" enabled={composer.playComposerEntrance}>
                 {/* Agent empty-chat strip (S6): docked above the composer. Visibility is decided by
                     AgentConversation, which hands the same flag to the empty state so exactly one of
                     the strip and the starter pills renders. */}


### PR DESCRIPTION
## Context

Opening `/permissions` or `/model` above the chat composer draws a dark gradient band across the panel. It is soft at the top, hard edged at the bottom, and it dims whatever rows sit under it.

The panel already asks for `z-[1050]`, so the markup reads as correct. That z-index never applies. `Reveal` always renders `translate-y-0`, and a transform other than `none` turns the composer dock into a stacking context, so the panel's z-index is trapped inside a wrapper that itself sits at 0. The transcript's bottom edge fade is `z-[5]` inside a `relative` root that is *not* a stacking context, so it hoists into the shared parent and sorts at 5. Five beats the whole dock.

## Changes

The `Reveal` wrapper in `AgentComposerDock` now carries `relative z-10`, giving the docked chrome a stacking order of its own above the fade.

Before:

```
transcript root (relative, z auto)  -> bottom fade overlay  z 5
composer dock   (transform)         -> /permissions panel   z 1050, trapped at z 0
```

After:

```
composer dock   (relative, z 10)    -> /permissions panel   z 1050
transcript root (relative, z auto)  -> bottom fade overlay  z 5
```

The fade itself is untouched. It still dissolves transcript content into the composer edge, which is all it was ever meant to do.

## Tests

- Reproduced the layering in an isolated browser page: an `absolute bottom-0 z-[5]` gradient in a non stacking `relative` sibling paints over a `z-[1050]` panel nested in a `translateY(0)` wrapper. Adding `relative z-10` to the wrapper clears it.
- Prettier clean on the changed file.
- No capture from the real app. I could not bring the local stack up while working on this, so a demo on a running branch is still outstanding.

## What to QA

- Open an agent chat, type `/`, choose Permissions. No gradient band across the panel, and every row reads at full contrast.
- Same check with `/model`.
- Regression: scroll a long transcript. Messages still fade out into the composer edge at the bottom.
- Regression: hover a turn sitting near the bottom edge. Its toolbar still renders crisp, since the fade drops on hover.
