### PR TITLE
[fix] Open an agent on its overview from the sidebar [AGE-4216]

### DIFF
--- a/web/mobile/src/features/agents/AgentOverviewScreen.tsx
+++ b/web/mobile/src/features/agents/AgentOverviewScreen.tsx
@@ -13,6 +13,7 @@ import {useAtomValue} from "jotai"
 
 import {PageTitle} from "@/components/PageTitle"
 import {ScreenScaffold} from "@/components/ScreenScaffold"
+import {Skeleton} from "@/components/ui/skeleton"
 import {FOCUS_RING} from "@/lib/interactive"
 
 import {useBindProjectContext} from "../context/useBindProjectContext"
@@ -99,9 +100,15 @@ export const AgentOverviewScreen = ({
                                 {/* The heading-3 rung (24px/1.3333) every other title in this app
                                     gets — Sessions, Agents, Templates. At `text-sm` the agent's
                                     name read as a breadcrumb, so the page had no title at all. */}
-                                <h1 className="text-colorText m-0 min-w-0 truncate text-[24px] font-semibold leading-[1.3333333333333333]">
-                                    {name}
-                                </h1>
+                                {/* The "Agent" fallback is for an agent that never resolves; while
+                                    the roster is still in flight it read as a real name. */}
+                                {agentsQuery.isPending && !agent ? (
+                                    <Skeleton className="h-8 w-40 shrink-0" />
+                                ) : (
+                                    <h1 className="text-colorText m-0 min-w-0 truncate text-[24px] font-semibold leading-[1.3333333333333333]">
+                                        {name}
+                                    </h1>
+                                )}
                                 {/* The same verbs the desktop header offers; rename and delete
                                     fall through to the shared implementations here, since /m has
                                     no app-management modals of its own.
@@ -122,13 +129,12 @@ export const AgentOverviewScreen = ({
                     {/* THE shared overview body — the same cards, order and chrome the desktop
                         page renders. Read-only host: configuration is edited in the desktop
                         playground, so no `onEditConfig`. */}
-                    {/* `flex flex-col` is load-bearing: the body's columns size off `flex-1` +
-                        `h-full`, so a plain block here leaves them with no definite height and
-                        the left column scrolls inside a stunted box. */}
                     {/* The shared page column (`pageContentWidthClass`), same as Sessions and
                         Agents: this page used to opt out of the cap at `lg` and stretched ~300px
                         wider than every other screen, which also inflated the body's right rail
                         past the width its rows are designed for. */}
+                    {/* `min-h-0 flex-1` is load-bearing: the body IS the scroller, so it needs a
+                        definite height to scroll within. */}
                     <div
                         className={`${pageContentWidthClass} flex min-h-0 flex-1 flex-col px-2 pb-4 pt-2 lg:px-16 lg:pb-6 lg:pt-5`}
                     >

--- a/web/oss/src/components/Sidebar/scopes/mainScope.tsx
+++ b/web/oss/src/components/Sidebar/scopes/mainScope.tsx
@@ -8,9 +8,10 @@ import type {
 } from "@agenta/navigation"
 import {HOME_SIDEBAR_KEY, MAIN_SIDEBAR_SCOPE_ID, SESSIONS_SIDEBAR_KEY} from "@agenta/navigation"
 import {SidebarLogo} from "@agenta/navigation-ui"
-import {useAtomValue} from "jotai"
+import {atom, useAtomValue} from "jotai"
 
 import SidePanelSubscriptionInfo from "@/oss/components/SidePanel/Subscription"
+import {appStateSnapshotAtom} from "@/oss/state/appState"
 import {homeNavHighlightedAtom} from "@/oss/state/onboarding"
 
 import ProjectOrgSwitcher from "../components/ProjectOrgSwitcher"
@@ -35,6 +36,10 @@ const MainSidebarAfterBottom = ({collapsed}: SidebarSlotContext) => (
     <ProjectOrgSwitcher collapsed={collapsed} />
 )
 
+// The open session is a fact about the playground, not about where you are: the tab list is
+// persisted per agent, so off that route the pin outranked the row the route itself selects (#6389).
+const playgroundRouteAtom = atom((get) => get(appStateSnapshotAtom).restPath[0] === "playground")
+
 // During onboarding the route is the ephemeral playground, but Home IS the surface — pin it selected.
 const useMainSidebarSelection = (): SidebarSelection => {
     const highlightHome = useAtomValue(homeNavHighlightedAtom)
@@ -42,16 +47,17 @@ const useMainSidebarSelection = (): SidebarSelection => {
     // the agent row won every tie. Pin the open session instead; when that row is not rendered
     // (its group collapsed, or filtered out) the shell selects nothing rather than the agent.
     const activeSessionId = useAtomValue(activePlaygroundSessionIdAtom)
+    const onPlaygroundRoute = useAtomValue(playgroundRouteAtom)
     return useMemo(() => {
         if (highlightHome) return {mode: "route", selectedKeyOverride: HOME_SIDEBAR_KEY}
-        if (activeSessionId) {
+        if (onPlaygroundRoute && activeSessionId) {
             return {
                 mode: "route",
                 selectedKeyOverride: `${SESSIONS_SIDEBAR_KEY}-${activeSessionId}`,
             }
         }
         return {mode: "route"}
-    }, [activeSessionId, highlightHome])
+    }, [activeSessionId, highlightHome, onPlaygroundRoute])
 }
 
 const useMainSidebarSections = (): SidebarSection[] => {

--- a/web/oss/src/components/pages/overview/agent/AgentOverview.tsx
+++ b/web/oss/src/components/pages/overview/agent/AgentOverview.tsx
@@ -1,8 +1,7 @@
-import {useCallback, useEffect} from "react"
+import {useCallback} from "react"
 
 import {AgentOverviewBody} from "@agenta/entity-ui/agent"
 import {RichChatInput} from "@agenta/ui/rich-chat-input"
-import {useSetAtom} from "jotai"
 
 import {useStartAgentSession} from "@/oss/components/AgentChatSlice/hooks/useStartAgentSession"
 import {sessionRouteModes} from "@/oss/components/pages/sessions/assets/sessionRouteScope"
@@ -15,7 +14,6 @@ import {
 import UsageSummary from "@/oss/components/UsageSummary"
 import {usePlaygroundNavigation} from "@/oss/hooks/usePlaygroundNavigation"
 import useURL from "@/oss/hooks/useURL"
-import {layoutFullHeightRequestAtom} from "@/oss/state/layout/fullHeight"
 
 interface Props {
     appId: string
@@ -35,21 +33,12 @@ interface Props {
  * it in the main column a waiting session sat below six rows of settings. The rail is also the
  * width the config rows were designed for — they come from the playground's panel, which is narrow.
  *
- * Columns scroll independently, as Home's do. They did not when this page held one list; with
- * Sessions and Automation runs both in the main column it outgrew the rail, and a whole-page
- * scroll meant losing the configuration while reading the sessions. The full-height frame is
- * requested rather than matched on the path, because this route also serves the prompt and
- * evaluator overviews, which still flow.
+ * The page scrolls as one. The columns used to scroll independently inside a bounded frame,
+ * which put two scrollbars on one page and left the rail and the reading column disagreeing
+ * about where the top was.
  */
 const AgentOverview = ({appId, agentName}: Props) => {
     const startSession = useStartAgentSession()
-    // The layout can't tell an agent overview from a prompt one by its path, so this branch asks
-    // for the bounded frame and releases it on the way out.
-    const requestFullHeight = useSetAtom(layoutFullHeightRequestAtom)
-    useEffect(() => {
-        requestFullHeight(true)
-        return () => requestFullHeight(false)
-    }, [requestFullHeight])
 
     // "View all" stays on this agent's rail rather than dropping you on the project list with a
     // filter you then have to trust.

--- a/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/overview/index.tsx
+++ b/web/oss/src/pages/w/[workspace_id]/p/[project_id]/apps/[app_id]/overview/index.tsx
@@ -1,8 +1,9 @@
-import {memo, useState} from "react"
+import {memo, useEffect, useState} from "react"
 
-import {AgentActionsMenu} from "@agenta/entity-ui/agent"
+import {AgentActionsMenu, AgentOverviewSkeleton} from "@agenta/entity-ui/agent"
 import {PageLayout} from "@agenta/ui"
 import {pageContentWidthClass} from "@agenta/ui/components/page-width"
+import {SkeletonBlock} from "@agenta/ui/ui"
 import {Space, Typography} from "antd"
 import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
@@ -19,7 +20,8 @@ import WorkflowPageTitle from "@/oss/components/PageTitle/WorkflowPageTitle"
 import RequireWorkflowKind from "@/oss/components/RequireWorkflowKind"
 import {useAppId} from "@/oss/hooks/useAppId"
 import {useAppsData} from "@/oss/state/app"
-import {currentWorkflowAtom} from "@/oss/state/workflow"
+import {layoutFullHeightRequestAtom} from "@/oss/state/layout/fullHeight"
+import {currentWorkflowAtom, playgroundEarlyAgentStateAtom} from "@/oss/state/workflow"
 
 const CustomWorkflowHistory: any = dynamic(
     () => import("@/oss/components/pages/app-management/drawers/CustomWorkflowHistory"),
@@ -51,9 +53,14 @@ const AppDetailsSection = memo(() => {
     return (
         <>
             <Space className="flex items-center gap-3">
-                <Title level={3} className="!m-0">
-                    {workflowName}
-                </Title>
+                {/* An empty <h3> is a title-shaped hole; hold the line's height until the name lands. */}
+                {workflowName ? (
+                    <Title level={3} className="!m-0">
+                        {workflowName}
+                    </Title>
+                ) : (
+                    <SkeletonBlock active className="h-7 w-48" />
+                )}
 
                 <AgentActionsMenu
                     agent={{
@@ -98,6 +105,21 @@ const OverviewContent = () => {
     const agents = useAtomValue(agentsWorkflowsAtom)
     const agentsLoading = useAtomValue(agentsWorkflowsLoadingAtom)
     const isAgent = Boolean(appId) && agents.some((agent) => agent.workflowId === appId)
+    // Which SKELETON to hold the page with while the list above resolves — never which branch
+    // renders. Revision-derived like the list, but answered by the lightweight latest-revision
+    // query (with a persisted fallback), so it lands first. A prompt app must not be shown an
+    // agent's surface, so only a workflow this does not rule out gets the agent placeholder.
+    const earlyAgentState = useAtomValue(playgroundEarlyAgentStateAtom)
+    const skeletonIsAgentShaped = agentsLoading && earlyAgentState !== "non-agent"
+    // The agent layout scrolls INSIDE itself, so it needs the bounded frame. Requested here
+    // rather than inside `AgentOverview` so the placeholder gets the same frame as the body it
+    // stands in for — asking only once the body mounted made the page reflow at the handoff.
+    const needsFullHeight = isAgent || skeletonIsAgentShaped
+    const requestFullHeight = useSetAtom(layoutFullHeightRequestAtom)
+    useEffect(() => {
+        requestFullHeight(needsFullHeight)
+        return () => requestFullHeight(false)
+    }, [needsFullHeight, requestFullHeight])
     // An agent's overview is about its work, not its prompt revisions or evaluation runs.
     // Held while the list resolves so those sections never flash in and then vanish.
     const showWorkflowSections = !isAgent && !agentsLoading
@@ -107,12 +129,12 @@ const OverviewContent = () => {
     return (
         <>
             <WorkflowPageTitle title="Overview" />
-            {/* The agent branch runs inside the layout's bounded frame (it asks for it), so the
-                page column must be allowed to shrink or its children can't take a definite
-                height and the per-column scrolls collapse back into one page scroll. It also
-                takes the shared centred column, like Home — the prompt-app/evaluator branch
-                below stays full width for its charts and evaluation tables. */}
-            <PageLayout className={clsx("gap-8", isAgent && [pageContentWidthClass, "min-h-0"])}>
+            {/* The agent branch takes the shared centred column, like Home; the prompt-app and
+                evaluator branch below stays full width for its charts and evaluation tables. The
+                placeholder claims the same column so the page does not change width under it. */}
+            <PageLayout
+                className={clsx("gap-8", needsFullHeight && [pageContentWidthClass, "min-h-0"])}
+            >
                 <AppDetailsSection />
 
                 {/* An agent's overview is its own surface. Charts move into that layout's usage
@@ -122,6 +144,10 @@ const OverviewContent = () => {
                     so neither flashes in and vanishes. */}
                 {isAgent && appId ? (
                     <AgentOverview appId={appId} agentName={currentWorkflow?.name ?? undefined} />
+                ) : skeletonIsAgentShaped ? (
+                    // Waiting is not nothing: this branch rendered null, so the page sat blank
+                    // under its own title for the whole classification.
+                    <AgentOverviewSkeleton />
                 ) : agentsLoading ? null : (
                     <>
                         <ObservabilityOverview />

--- a/web/packages/agenta-entity-ui/src/agent/AgentOverviewBody.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentOverviewBody.tsx
@@ -1,7 +1,7 @@
 import type {ReactNode} from "react"
 
 import {SessionListCard, type SessionListCardProps} from "@agenta/sessions-ui"
-import {PanelScroll, PanelSurface} from "@agenta/ui/components/presentational"
+import {PanelSurface} from "@agenta/ui/components/presentational"
 
 import {AgentConfigSummaryCard} from "./AgentConfigSummaryCard"
 import {AgentFilesCard} from "./AgentFilesCard"
@@ -55,7 +55,6 @@ export const AgentOverviewBody = ({
     agentNames,
 }: AgentOverviewBodyProps) => (
     <AgentOverviewLayout
-        scroll
         main={
             <>
                 {composer}
@@ -94,15 +93,13 @@ export const AgentOverviewBody = ({
             </>
         }
         rail={
-            <PanelSurface className="flex max-h-full min-h-0 flex-col">
-                <PanelScroll>
-                    <AgentConfigSummaryCard appId={agentId} onEdit={onEditConfig} />
-                    <AgentFilesCard appId={agentId} />
-                    {/* Scoped to this agent. Automation RUNS say what already happened; an agent
-                        whose schedule quietly stopped looks identical there. */}
-                    <NextTriggersSection agentId={agentId} agentNames={agentNames} />
-                    {usage}
-                </PanelScroll>
+            <PanelSurface className="flex flex-col gap-3">
+                <AgentConfigSummaryCard appId={agentId} onEdit={onEditConfig} />
+                <AgentFilesCard appId={agentId} />
+                {/* Scoped to this agent. Automation RUNS say what already happened; an agent
+                    whose schedule quietly stopped looks identical there. */}
+                <NextTriggersSection agentId={agentId} agentNames={agentNames} />
+                {usage}
             </PanelSurface>
         }
     />

--- a/web/packages/agenta-entity-ui/src/agent/AgentOverviewLayout.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentOverviewLayout.tsx
@@ -8,13 +8,6 @@ export interface AgentOverviewLayoutProps {
     /** The rail: what the agent IS — configuration, files, triggers, usage. Each host brings the
      * cards it can serve; the layout only places them. */
     rail: ReactNode
-    /**
-     * The frame owns the height and each column scrolls on its own (the desktop page, which is a
-     * full-height frame). Default: both columns are plain blocks and the host's page scrolls —
-     * nesting a scroller inside an already-scrolling screen strands the rail, which is the bug
-     * `ScreenScaffold`'s `fill` exists to avoid on mobile.
-     */
-    scroll?: boolean
     /** Host spacing — the stacked gap below lg is content rhythm, not layout. */
     className?: string
 }
@@ -25,34 +18,24 @@ export interface AgentOverviewLayoutProps {
  * and the two stack below lg. One definition so the two surfaces cannot drift — the components
  * inside the slots are already shared (`AgentConfigSummaryCard`, `NextTriggersSection`,
  * `SessionCardList`); this is the composition that was still being written twice.
+ *
+ * ONE scroller, and it is this frame — not the host's page, and not one per column. The columns
+ * used to scroll independently, which put two scrollbars side by side and left them disagreeing
+ * about where the top was; letting the page scroll instead pushed the whole surface, header and
+ * all, off the screen. So the frame takes the height its host gives it and both columns move
+ * together inside it. The host must therefore bound this: give it a parent with a definite
+ * height (the desktop page asks the layout for its full-height frame, mobile's `ScreenScaffold`
+ * takes `fill`), or `flex-1` has no space to resolve against.
  */
-export const AgentOverviewLayout = ({
-    main,
-    rail,
-    scroll = false,
-    className,
-}: AgentOverviewLayoutProps) => (
+export const AgentOverviewLayout = ({main, rail, className}: AgentOverviewLayoutProps) => (
     <div
         className={clsx(
-            "flex w-full flex-col items-start gap-10 lg:flex-row",
-            scroll && "min-h-0 flex-1 overflow-y-auto lg:overflow-hidden",
+            "flex min-h-0 w-full flex-1 flex-col items-start gap-10 overflow-y-auto lg:flex-row",
             className,
         )}
     >
-        <div
-            className={clsx(
-                "flex w-full min-w-0 flex-col gap-6 lg:flex-1",
-                scroll && "lg:h-full lg:overflow-y-auto lg:pr-4",
-            )}
-        >
-            {main}
-        </div>
-        <div
-            className={clsx(
-                "flex w-full shrink-0 grow-0 flex-col lg:w-1/3 lg:min-w-[340px] lg:max-w-[520px]",
-                scroll && "min-h-0 lg:h-full lg:pr-1",
-            )}
-        >
+        <div className="flex w-full min-w-0 flex-col gap-6 lg:flex-1">{main}</div>
+        <div className="flex w-full shrink-0 grow-0 flex-col lg:w-1/3 lg:min-w-[340px] lg:max-w-[520px]">
             {rail}
         </div>
     </div>

--- a/web/packages/agenta-entity-ui/src/agent/AgentOverviewSkeleton.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentOverviewSkeleton.tsx
@@ -1,0 +1,80 @@
+import {PanelSection, PanelSurface} from "@agenta/ui/components/presentational"
+import {SkeletonBlock} from "@agenta/ui/ui"
+
+import {AgentOverviewLayout} from "./AgentOverviewLayout"
+
+/** `SessionCardList`'s own placeholder: four bars, whatever the card's row limit is. */
+const ListRows = () => (
+    <div className="flex flex-col gap-2 px-2 py-2">
+        {[0, 1, 2, 3].map((i) => (
+            <SkeletonBlock key={i} active className="h-6 w-full" />
+        ))}
+    </div>
+)
+
+/** The rail cards' placeholder: text-height bars at the widths each card draws. */
+const TextRows = ({widths}: {widths: string[]}) => (
+    <div className="flex flex-col gap-2 px-2 py-2">
+        {widths.map((width, i) => (
+            <SkeletonBlock key={i} active className={`h-4 ${width}`} />
+        ))}
+    </div>
+)
+
+/**
+ * The overview's placeholder for the window before a host knows it is rendering an agent at all.
+ *
+ * Every card inside {@link AgentOverviewBody} already skeletons itself, so this exists only for
+ * the step above them: a host that must classify the workflow first cannot mount those cards
+ * yet — mounting them would fire an agent's queries for what may turn out to be a prompt app —
+ * and rendering nothing leaves the page blank under its own title.
+ *
+ * Every section copies the placeholder the card it stands in for draws, NOT that card's eventual
+ * row count: this hands off to those placeholders, not to loaded content, so a section that
+ * guessed at the row limit would snap to a different height the moment the real card mounted.
+ */
+export const AgentOverviewSkeleton = () => (
+    <AgentOverviewLayout
+        main={
+            <>
+                <SkeletonBlock active className="h-[92px] w-full rounded-xl" />
+                <div className="flex flex-col gap-10">
+                    <PanelSection variant="page" title="Sessions">
+                        <ListRows />
+                    </PanelSection>
+                    <PanelSection
+                        variant="page"
+                        title="Automation runs"
+                        minHeightClassName="min-h-[100px]"
+                    >
+                        <ListRows />
+                    </PanelSection>
+                </div>
+            </>
+        }
+        rail={
+            <PanelSurface className="flex flex-col gap-3">
+                {/* Six rows, one per config section — the one card whose placeholder is a fixed
+                    count rather than a shape. */}
+                <PanelSection title="Configuration" bodyClassName="flex flex-col px-4 pb-3">
+                    <div className="flex flex-col gap-2 py-1">
+                        {[0, 1, 2, 3, 4, 5].map((i) => (
+                            <SkeletonBlock key={i} active className="h-6 w-full" />
+                        ))}
+                    </div>
+                </PanelSection>
+                <PanelSection title="Files">
+                    <TextRows widths={["w-full", "w-5/6", "w-2/3"]} />
+                </PanelSection>
+                <PanelSection title="Next triggers">
+                    <TextRows widths={["w-3/4", "w-1/2"]} />
+                </PanelSection>
+                {/* Usage has no placeholder of its own — it renders its real rows with em-dashes
+                    until the figures land, so two bars stand in for that pair. */}
+                <PanelSection title="Usage" bodyClassName="flex flex-col gap-3 px-4 pb-4">
+                    <TextRows widths={["w-1/2", "w-1/3"]} />
+                </PanelSection>
+            </PanelSurface>
+        }
+    />
+)

--- a/web/packages/agenta-entity-ui/src/agent/index.ts
+++ b/web/packages/agenta-entity-ui/src/agent/index.ts
@@ -21,6 +21,7 @@ export {AgentRosterGrid, type AgentRosterEntry, type AgentRosterGridProps} from 
 export {AgentOverviewLayout, type AgentOverviewLayoutProps} from "./AgentOverviewLayout"
 export {AgentFilesCard} from "./AgentFilesCard"
 export {AgentOverviewBody, type AgentOverviewBodyProps} from "./AgentOverviewBody"
+export {AgentOverviewSkeleton} from "./AgentOverviewSkeleton"
 export {AgentActionsMenu, type AgentActionsMenuProps} from "./AgentActionsMenu"
 export {useAgentActions, type AgentActionTarget} from "./useAgentActions"
 export {AgentIntroCard, capabilityLabel} from "./AgentIntroCard"

--- a/web/packages/agenta-navigation/src/dynamic/registry.ts
+++ b/web/packages/agenta-navigation/src/dynamic/registry.ts
@@ -161,7 +161,8 @@ const ENTITIES: SidebarEntity[] = [
         icon: createElement(RobotIcon, {size: 14}),
         listAtom: agentWorkflowsListQueryStateAtom,
         getLabel: (workflow) => workflow.name || workflow.slug || "Untitled agent",
-        childPath: (workflow) => `/apps/${workflow.id}/playground`,
+        // An agent's surface is its overview — its config, sessions and runs live there (#6389).
+        childPath: (workflow) => `/apps/${workflow.id}/overview`,
         // Busiest agent first, by session count — stable session to session, unlike recency,
         // which reshuffled on every turn. Frozen per page load. Same rule the mobile rail applies.
         ranksAtom: sidebarAgentRanksAtomFamily(MAIN_SIDEBAR_SCOPE_ID),

--- a/web/packages/agenta-navigation/tests/unit/sidebarChildren.test.ts
+++ b/web/packages/agenta-navigation/tests/unit/sidebarChildren.test.ts
@@ -4,6 +4,9 @@ import {atom} from "jotai"
 import {describe, expect, it} from "vitest"
 
 import {
+    AGENTS_SIDEBAR_KEY,
+    PROMPTS_SIDEBAR_KEY,
+    SIDEBAR_ENTITIES,
     defineSidebarEntity,
     livePollInterval,
     agentSessionCounts,
@@ -538,5 +541,22 @@ describe("agentSessionCounts", () => {
         >[0][number]
 
         expect(agentSessionCounts([orphan]).size).toBe(0)
+    })
+})
+
+// The registry is the single source for where a row opens, so assert the destinations here.
+describe("registered entity destinations", () => {
+    const workflow = ref("01a03ed2-c322-7493-b2a2-29b8ae273530", "Ops Assistant")
+
+    it("opens an agent on its overview, not the playground", () => {
+        expect(SIDEBAR_ENTITIES[AGENTS_SIDEBAR_KEY].childLink(workflow, "/w/w1/p/p1")).toBe(
+            "/w/w1/p/p1/apps/01a03ed2-c322-7493-b2a2-29b8ae273530/overview",
+        )
+    })
+
+    it("still opens a prompt on the playground", () => {
+        expect(SIDEBAR_ENTITIES[PROMPTS_SIDEBAR_KEY].childLink(workflow, "/w/w1/p/p1")).toBe(
+            "/w/w1/p/p1/apps/01a03ed2-c322-7493-b2a2-29b8ae273530/playground",
+        )
     })
 })

--- a/web/packages/agenta-sessions-ui/src/SessionListCard.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionListCard.tsx
@@ -95,7 +95,6 @@ export const SessionListCard = ({
 
     return (
         <PanelSection
-            sticky
             variant="page"
             title={title}
             minHeightClassName={minHeightClassName}

--- a/web/storybook/stories/entity-ui/AgentOverviewSkeleton.stories.tsx
+++ b/web/storybook/stories/entity-ui/AgentOverviewSkeleton.stories.tsx
@@ -1,0 +1,40 @@
+import {AgentOverviewSkeleton} from "@agenta/entity-ui/agent"
+import type {Meta, StoryObj} from "@storybook/nextjs"
+
+// The agent overview's placeholder for the window before the host knows the workflow IS an agent.
+// Every card inside the real body skeletons itself, so this covers only the step above
+// them: the page cannot mount those cards until it has classified the workflow, and it used to
+// render nothing at all in the meantime — a blank page under its own title.
+//
+// Real headings, placeholder bodies, and the real `AgentOverviewLayout`/`PanelSection` chrome.
+// Each section copies the placeholder the card it stands in for draws — not that card's row
+// limit — so the handoff to the real body does not move anything.
+const meta = {
+    title: "@agenta/entity-ui/Agent/AgentOverviewSkeleton",
+    component: AgentOverviewSkeleton,
+    parameters: {
+        layout: "padded",
+        docs: {
+            description: {
+                component:
+                    "Two-column overview placeholder: composer, Sessions and Automation runs in the reading column; Configuration, Files, Next triggers and Usage in the rail.",
+            },
+        },
+    },
+} satisfies Meta<typeof AgentOverviewSkeleton>
+
+export default meta
+type Story = StoryObj<typeof AgentOverviewSkeleton>
+
+// The frame scrolls inside itself, so it needs a host that bounds its height — the desktop page
+// asks the layout for its full-height frame, mobile's `ScreenScaffold` takes `fill`. The
+// decorator stands in for that here.
+export const Default: Story = {
+    decorators: [
+        (Story) => (
+            <div className="flex h-[720px] flex-col">
+                <Story />
+            </div>
+        ),
+    ],
+}


### PR DESCRIPTION
## Context

Clicking an agent in the sidebar opened its playground instead of the agent's page. Every other way into an agent already lands on its overview: the Agents list page routes there, and so does the mobile rail. The overview is also the page that holds the agent's configuration, files and triggers, so the sidebar was the odd one out.

The shared sidebar entity registry was the single caller that disagreed. Fixing it exposed two more problems on the page it now lands on.

## Changes

**The destination.** The Agents entity in the navigation registry pointed at `/apps/<id>/playground`. It now points at `/apps/<id>/overview`, with a test pinning both that and the Prompts entity, which still opens its playground because a prompt has nothing else.

**The selected row.** `mainScope` pinned the open playground session over whatever the route selected. That pin reads a per-agent tab list persisted in localStorage and never looked at the route, so on the overview it outranked the agent row you had just clicked. It is now gated on actually being on a playground route.

**The blank page.** The overview rendered `null` while it worked out whether the workflow was an agent, so it sat empty under its own title for the whole wait:

```
Agent Builder  ⋮
(nothing)
```

Every card inside the page already draws its own skeleton. None of them got the chance, because nothing rendered them yet. `AgentOverviewSkeleton` fills that window. It is built on the real `AgentOverviewLayout` and `PanelSection`, so its geometry cannot drift from the body it stands in for, and each section copies the placeholder the card it replaces actually draws rather than that card's row limit. `SessionCardList`, for example, always draws four bars whatever its `limit` is, so the skeleton draws four too and the handoff moves nothing.

Which placeholder appears is gated on `playgroundEarlyAgentStateAtom`. That is revision-derived like the agents list, but answered by the lightweight latest-revision query, so it lands first. A workflow already known to be a prompt app is never shown an agent's surface. It steers the placeholder only. The agents list still decides what actually renders.

**The scrollbars.** The two columns each owned a scroller, which put two scrollbars side by side and left them disagreeing about where the top was. The layout now owns one scroller, and it is the overview frame rather than the page. The bounded frame is requested by the page instead of by `AgentOverview`, so the placeholder and the real body share it and nothing reflows when one replaces the other.

`SessionListCard` drops `sticky`, which only made sense pinning inside the per-column scroller that is now gone. `AgentOverviewBody` is its only consumer.

## Tests

- `pnpm test:unit` in `@agenta/navigation`: 45 pass, including the two new destination assertions.
- `tsc --noEmit` clean across `web/oss`, `web/mobile`, `@agenta/entity-ui` and `@agenta/sessions-ui`. eslint and prettier clean on every touched file. Storybook lints at `--max-warnings 0` and builds.
- Verified the skeleton in Storybook in light and dark, at desktop and stacked widths. Confirmed by measurement that exactly one scroll container exists inside the overview (714px visible against 1244px of content) and that none of the rail cards clip.
- Not verified against the running app. That needs the docker stack and an account with agents, so the demo below is outstanding.

## What to QA

- Open a project with at least one agent. Click an agent under Agents in the sidebar. You land on that agent's overview, not its playground, and that agent's row is the highlighted one.
- Watch the moment the overview opens on a cold load. You see the placeholder page (composer, Sessions, Automation runs, and the rail cards) rather than a blank page under the title, and nothing jumps when the real content arrives.
- Scroll the overview. There is one scrollbar, inside the page frame, and both columns move together. The page itself does not scroll.
- Open an agent's playground and send a message, then click that agent in the sidebar again. You still land on the overview, and the agent row stays selected rather than a session row taking the highlight.
- Regression: open a prompt app's overview. It still shows the charts, deployment and evaluation tables at full width, and never flashes an agent-shaped placeholder on the way in.
- Regression: click a session under Sessions in the sidebar. It still opens that session in its agent's playground, and the session row is the one highlighted.
- Regression on `/m`: open an agent from the mobile drawer. The screen still scrolls as before, and the title shows a placeholder rather than the word "Agent" while the roster loads.
