### PR TITLE
[feat] Show readable tool names in the playground build kit [AGE-4122]

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection.tsx
@@ -27,11 +27,7 @@ export function formatPermissionValue(value: unknown): string {
     }
 }
 
-/**
- * One row of the build kit. `toggle` marks a tool the user may switch off; a row without it is
- * Agenta-owned and always on. They render as ONE list (#6025) — the split between platform tools
- * and embedded tools/skills is an implementation detail the reader has no use for.
- */
+/** One build-kit row. `toggle` marks a tool the user may switch off; without it the row is locked. */
 export interface BuildKitTool {
     /** Stable React key: the `op` for a platform tool, the embed slug or index otherwise. */
     key: string
@@ -68,8 +64,7 @@ export function BuildKitSection({
 }: BuildKitSectionProps) {
     // Per-tool switches only mean anything while the kit as a whole is on.
     const toolsDisabled = Boolean(disabled) || !enabled
-    // Counted over every row, not just the switchable ones: a count that skipped the locked rows
-    // would not add up against the list the reader is looking at.
+    // Counted over every row, so the number adds up against the list on screen.
     const enabledCount = tools.filter((tool) => tool.toggle?.enabled ?? true).length
     const allEnabled = tools.every((tool) => tool.toggle?.enabled ?? true)
     // Nothing to switch means no bulk action — the button would be a dead control.
@@ -131,7 +126,7 @@ export function BuildKitSection({
                             key={`build-kit-tool-${key}`}
                             descriptor={descriptor}
                             locked={!toggle}
-                            inactive={toggle ? !toggle.enabled || !enabled : false}
+                            inactive={!enabled || (toggle ? !toggle.enabled : false)}
                             extra={
                                 toggle ? (
                                     <Switch
@@ -139,8 +134,7 @@ export function BuildKitSection({
                                         checked={toggle.enabled}
                                         disabled={toolsDisabled}
                                         onCheckedChange={(next) => onToggleTool(toggle.op, next)}
-                                        // The readable name, not the wire `op`: a screen reader
-                                        // gets the same words the row shows.
+                                        // The readable name, not the wire `op`.
                                         aria-label={descriptor.name}
                                     />
                                 ) : undefined

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection.tsx
@@ -27,11 +27,16 @@ export function formatPermissionValue(value: unknown): string {
     }
 }
 
-/** One togglable platform tool: its `op` key, its current state, and how the row presents. */
-export interface BuildKitPlatformTool {
-    op: string
-    enabled: boolean
+/**
+ * One row of the build kit. `toggle` marks a tool the user may switch off; a row without it is
+ * Agenta-owned and always on. They render as ONE list (#6025) — the split between platform tools
+ * and embedded tools/skills is an implementation detail the reader has no use for.
+ */
+export interface BuildKitTool {
+    /** Stable React key: the `op` for a platform tool, the embed slug or index otherwise. */
+    key: string
     descriptor: ItemDescriptor
+    toggle?: {op: string; enabled: boolean}
 }
 
 export interface BuildKitSectionProps {
@@ -39,36 +44,36 @@ export interface BuildKitSectionProps {
     enabled: boolean
     onEnabledChange: (value: boolean) => void
     disabled?: boolean
-    platformTools: BuildKitPlatformTool[]
-    /** Switch one platform tool on or off. */
+    tools: BuildKitTool[]
+    /** Switch one tool on or off. */
     onToggleTool: (op: string, next: boolean) => void
-    /** Switch every platform tool on or off at once. */
+    /** Switch every switchable tool on or off at once. */
     onSetAllTools: (next: boolean) => void
-    embeddedTools: ItemDescriptor[]
-    embeddedSkills: ItemDescriptor[]
     /** Sandbox permission overlay, rendered read-only as `key → value` rows. */
     permissions?: Record<string, unknown> | null
     /** Collapsed in the app (it is background information); stories open it. @default false */
     defaultOpen?: boolean
 }
 
-/** The build-kit block. Platform tools get a switch each; embeds and permissions stay read-only. */
+/** The build-kit block. Switchable tools get a switch each; the rest, and permissions, are read-only. */
 export function BuildKitSection({
     enabled,
     onEnabledChange,
     disabled,
-    platformTools,
+    tools,
     onToggleTool,
     onSetAllTools,
-    embeddedTools,
-    embeddedSkills,
     permissions,
     defaultOpen = false,
 }: BuildKitSectionProps) {
     // Per-tool switches only mean anything while the kit as a whole is on.
     const toolsDisabled = Boolean(disabled) || !enabled
-    const enabledCount = platformTools.filter((tool) => tool.enabled).length
-    const allEnabled = enabledCount === platformTools.length
+    // Counted over every row, not just the switchable ones: a count that skipped the locked rows
+    // would not add up against the list the reader is looking at.
+    const enabledCount = tools.filter((tool) => tool.toggle?.enabled ?? true).length
+    const allEnabled = tools.every((tool) => tool.toggle?.enabled ?? true)
+    // Nothing to switch means no bulk action — the button would be a dead control.
+    const hasSwitchableTools = tools.some((tool) => tool.toggle)
     return (
         <ConfigAccordionSection
             size="compact"
@@ -91,70 +96,55 @@ export function BuildKitSection({
             }
         >
             <span className="text-xs leading-snug text-colorTextDescription">
-                These playground-only tools, skills, and permissions help the assistant build and
-                revise this agent. None of this is part of the published agent.
+                These playground-only tools and permissions help the assistant build and revise this
+                agent. None of this is part of the published agent.
             </span>
             {!enabled ? (
                 <div className="rounded border border-solid border-[var(--ant-color-info-border)] bg-[var(--ant-color-info-bg)] px-2.5 py-2 text-xs leading-snug text-[var(--ant-color-info-text)]">
                     The assistant can no longer create files, run code, or edit the agent here.
                 </div>
             ) : null}
-            {platformTools.length > 0 ? (
+            {tools.length > 0 ? (
                 <RailField
                     wide
                     label={
                         <span className="flex flex-col items-start gap-1">
-                            <span>Platform tools</span>
+                            <span>Tools</span>
                             <span className="text-[11px] leading-tight text-colorTextDescription">
-                                {enabledCount} of {platformTools.length} enabled
+                                {enabledCount} of {tools.length} enabled
                             </span>
-                            <button
-                                type="button"
-                                disabled={toolsDisabled}
-                                onClick={() => onSetAllTools(!allEnabled)}
-                                className="cursor-pointer border-0 bg-transparent p-0 text-[11px] underline underline-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                            >
-                                {allEnabled ? "Disable all" : "Enable all"}
-                            </button>
+                            {hasSwitchableTools ? (
+                                <button
+                                    type="button"
+                                    disabled={toolsDisabled}
+                                    onClick={() => onSetAllTools(!allEnabled)}
+                                    className="cursor-pointer border-0 bg-transparent p-0 text-[11px] underline underline-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                                >
+                                    {allEnabled ? "Disable all" : "Enable all"}
+                                </button>
+                            ) : null}
                         </span>
                     }
                 >
-                    {platformTools.map((tool) => (
+                    {tools.map(({key, descriptor, toggle}) => (
                         <ItemRow
-                            key={`build-kit-platform-tool-${tool.op}`}
-                            descriptor={tool.descriptor}
-                            inactive={!tool.enabled || !enabled}
+                            key={`build-kit-tool-${key}`}
+                            descriptor={descriptor}
+                            locked={!toggle}
+                            inactive={toggle ? !toggle.enabled || !enabled : false}
                             extra={
-                                <Switch
-                                    size="sm"
-                                    checked={tool.enabled}
-                                    disabled={toolsDisabled}
-                                    onCheckedChange={(next) => onToggleTool(tool.op, next)}
-                                    aria-label={`Enable the ${tool.op} playground tool`}
-                                />
+                                toggle ? (
+                                    <Switch
+                                        size="sm"
+                                        checked={toggle.enabled}
+                                        disabled={toolsDisabled}
+                                        onCheckedChange={(next) => onToggleTool(toggle.op, next)}
+                                        // The readable name, not the wire `op`: a screen reader
+                                        // gets the same words the row shows.
+                                        aria-label={descriptor.name}
+                                    />
+                                ) : undefined
                             }
-                        />
-                    ))}
-                </RailField>
-            ) : null}
-            {embeddedTools.length > 0 ? (
-                <RailField wide label="Embedded tools">
-                    {embeddedTools.map((descriptor, index) => (
-                        <ItemRow
-                            key={`build-kit-embedded-tool-${index}`}
-                            descriptor={descriptor}
-                            locked
-                        />
-                    ))}
-                </RailField>
-            ) : null}
-            {embeddedSkills.length > 0 ? (
-                <RailField wide label="Embedded skills">
-                    {embeddedSkills.map((descriptor, index) => (
-                        <ItemRow
-                            key={`build-kit-embedded-skill-${index}`}
-                            descriptor={descriptor}
-                            locked
                         />
                     ))}
                 </RailField>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/buildKitDescriptors.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/buildKitDescriptors.tsx
@@ -1,0 +1,148 @@
+/**
+ * Build-kit presentation: the user-facing copy for every row of the playground build kit, and the
+ * `describe*` classifiers that turn an overlay entry into an {@link ItemDescriptor}.
+ *
+ * The overlay is model-facing config — a platform tool arrives as `{type:"platform", op}` and an
+ * embed as an `@ag.embed` reference — so the wire carries no readable name or description and this
+ * table supplies both. Wording follows the chat skin's platform glossary (`PLATFORM_TERMS` in
+ * @agenta/chat) so a tool reads the same in this list as it does in the transcript: a revision is
+ * "changes", a span is a "run", a subscription is a "trigger", a session is "this chat".
+ *
+ * Kept beside itemDescriptors.tsx for the same reason: the table and the classifiers that read it
+ * live together.
+ */
+import {Wrench} from "@phosphor-icons/react"
+
+import {humanizeActionKey, type ItemDescriptor} from "./itemDescriptors"
+
+interface BuildKitCopy {
+    name: string
+    description: string
+}
+
+/** Copy for the platform ops the build kit ships (`build_kit.py`'s `DEFAULT_BUILD_KIT_OPS`). An op
+ * missing from here still renders — it falls back to a humanized `op` — so adding one server-side
+ * costs plain wording, not a broken row. */
+const BUILD_KIT_TOOL_COPY: Record<string, BuildKitCopy> = {
+    discover_tools: {
+        name: "Find tools",
+        description: "Searches Agenta's catalog for apps and actions this agent could use.",
+    },
+    read_config: {
+        name: "Read the agent's setup",
+        description: "Reads how this agent is configured right now.",
+    },
+    commit_revision: {
+        name: "Save changes",
+        description: "Saves an edit to this agent's setup as a new version.",
+    },
+    annotate_trace: {
+        name: "Grade a run",
+        description: "Records evaluation feedback on a run of this agent.",
+    },
+    query_spans: {
+        name: "Look through runs",
+        description: "Searches past runs to check what the agent actually did.",
+    },
+    test_run: {
+        name: "Test the agent",
+        description: "Runs this agent once against test messages and reports the result.",
+    },
+    rename_session: {
+        name: "Rename this chat",
+        description: "Gives this chat a name and a recap so it is easy to find later.",
+    },
+    rename_agent: {
+        name: "Rename the agent",
+        description: "Gives this agent a name and a description.",
+    },
+    discover_triggers: {
+        name: "Find triggers",
+        description: "Searches connected apps for events that could run this agent.",
+    },
+    create_schedule: {
+        name: "Add a schedule",
+        description: "Sets this agent to run on a repeating schedule.",
+    },
+    create_subscription: {
+        name: "Add a trigger",
+        description: "Sets this agent to run when an event happens in a connected app.",
+    },
+    list_schedules: {
+        name: "Check schedules",
+        description: "Lists the schedules set up for this project.",
+    },
+    list_deliveries: {
+        name: "Check trigger history",
+        description: "Lists recent trigger runs and tests.",
+    },
+    test_subscription: {
+        name: "Test a trigger",
+        description: "Waits for one real event to confirm a trigger is wired up correctly.",
+    },
+    remove_schedule: {
+        name: "Remove a schedule",
+        description: "Deletes one of this agent's schedules.",
+    },
+    remove_subscription: {
+        name: "Remove a trigger",
+        description: "Deletes one of this agent's triggers.",
+    },
+}
+
+/** Copy for the Agenta-owned tools and skills the kit embeds, keyed by the referenced slug. */
+const BUILD_KIT_EMBED_COPY: Record<string, BuildKitCopy> = {
+    __ag__request_connection: {
+        name: "Ask you to connect an app",
+        description: "Prompts you to connect an app when the agent needs access to one.",
+    },
+    __ag__request_input: {
+        name: "Ask you a question",
+        description: "Prompts you for details the agent needs before it can continue.",
+    },
+    __ag__build_an_agent: {
+        name: "Guide to building agents",
+        description: "Agenta's instructions for setting up and configuring an agent.",
+    },
+}
+
+/** Every build-kit row wears the same chrome: one list, one kind of thing. */
+const buildKitDescriptor = ({name, description}: BuildKitCopy): ItemDescriptor => ({
+    name,
+    // Prose, never monospace: these are sentences about what a tool does, not identifiers.
+    monoName: false,
+    description,
+    mono: "",
+    color: "#0d9488",
+    icon: <Wrench size={15} weight="fill" />,
+    // No type tag: "platform" and "@ag.embed" are internal vocabulary (#6025). A row that cannot
+    // be switched off says so with ItemRow's "Locked" tag instead.
+    tags: [],
+    typeLabel: "playground tool",
+    subtitle: "Playground-only tool",
+})
+
+/** Row for a `{type:"platform", op}` overlay tool. */
+export function describeBuildKitPlatformTool(op: string): ItemDescriptor {
+    return buildKitDescriptor(
+        BUILD_KIT_TOOL_COPY[op] ?? {
+            name: humanizeActionKey(op),
+            description: "Playground-only tool provided by Agenta.",
+        },
+    )
+}
+
+/** Row for an `@ag.embed` overlay tool or skill. `slug` and `name` come off the wire; the copy
+ * table wins so every row is worded the same way. */
+export function describeBuildKitEmbed(
+    slug: string | undefined,
+    name: string | undefined,
+): ItemDescriptor {
+    const copy = slug ? BUILD_KIT_EMBED_COPY[slug] : undefined
+    return buildKitDescriptor(
+        copy ?? {
+            name: name ?? slug ?? "Playground tool",
+            description: "Playground-only tool provided by Agenta.",
+        },
+    )
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/buildKitDescriptors.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/buildKitDescriptors.tsx
@@ -13,16 +13,28 @@
  */
 import {Wrench} from "@phosphor-icons/react"
 
-import {humanizeActionKey, type ItemDescriptor} from "./itemDescriptors"
+import type {ItemDescriptor} from "./itemDescriptors"
 
 interface BuildKitCopy {
     name: string
     description: string
 }
 
-/** Copy for the platform ops the build kit ships (`build_kit.py`'s `DEFAULT_BUILD_KIT_OPS`). An op
- * missing from here still renders — it falls back to a humanized `op` — so adding one server-side
- * costs plain wording, not a broken row. */
+/** The reserved prefix on an Agenta-owned embed slug, dropped before the slug is read out. */
+const AGENTA_SLUG_PREFIX = "__ag__"
+
+/** Sentence-case a `verb_noun` key: `pause_schedule` -> "Pause schedule". Deliberately not
+ * `humanizeActionKey`, which is for provider action keys and carries their acronym table. */
+function humanizeKey(key: string): string {
+    const words = key
+        .replace(AGENTA_SLUG_PREFIX, "")
+        .split(/[_\s]+/)
+        .filter(Boolean)
+    if (words.length === 0) return key
+    return [words[0][0].toUpperCase() + words[0].slice(1), ...words.slice(1)].join(" ")
+}
+
+/** Copy for the ops the build kit ships. A missing op falls back to a humanized `op`. */
 const BUILD_KIT_TOOL_COPY: Record<string, BuildKitCopy> = {
     discover_tools: {
         name: "Find tools",
@@ -115,8 +127,7 @@ const buildKitDescriptor = ({name, description}: BuildKitCopy): ItemDescriptor =
     mono: "",
     color: "#0d9488",
     icon: <Wrench size={15} weight="fill" />,
-    // No type tag: "platform" and "@ag.embed" are internal vocabulary (#6025). A row that cannot
-    // be switched off says so with ItemRow's "Locked" tag instead.
+    // No type tag: "platform" and "@ag.embed" are internal vocabulary (#6025).
     tags: [],
     typeLabel: "playground tool",
     subtitle: "Playground-only tool",
@@ -126,7 +137,7 @@ const buildKitDescriptor = ({name, description}: BuildKitCopy): ItemDescriptor =
 export function describeBuildKitPlatformTool(op: string): ItemDescriptor {
     return buildKitDescriptor(
         BUILD_KIT_TOOL_COPY[op] ?? {
-            name: humanizeActionKey(op),
+            name: humanizeKey(op),
             description: "Playground-only tool provided by Agenta.",
         },
     )
@@ -141,7 +152,8 @@ export function describeBuildKitEmbed(
     const copy = slug ? BUILD_KIT_EMBED_COPY[slug] : undefined
     return buildKitDescriptor(
         copy ?? {
-            name: name ?? slug ?? "Playground tool",
+            // A bare slug would put `__ag__future` on screen, which is the wire name again.
+            name: name ?? (slug ? humanizeKey(slug) : "Playground tool"),
             description: "Playground-only tool provided by Agenta.",
         },
     )

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
@@ -44,7 +44,7 @@ function isEmbedRefEntry(entry: unknown): entry is Record<string, unknown> {
     )
 }
 
-/** One always-on row for an `@ag.embed` overlay entry; `fallbackKey` covers an embed with no slug. */
+/** One always-on row for an `@ag.embed` overlay entry. */
 function embedRow(entry: Record<string, unknown>, fallbackKey: string): BuildKitTool {
     const slug = staticEmbedSlug(entry)
     return {

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
@@ -7,8 +7,8 @@
  * revision) plus the user's build-kit state — the master on/off and the platform ops switched off
  * individually — and returns:
  *   - `hasBuildKitOverlay`: whether to render the build-kit block / extend the Advanced section,
- *   - `buildKitSection`: the drawer block (platform tools with a switch each, read-only embedded
- *     tools/skills and sandbox permissions) under the master enable/disable switch,
+ *   - `buildKitSection`: the drawer block (one tool list — platform tools with a switch each, the
+ *     Agenta-owned embeds locked on — plus sandbox permissions) under the master enable switch,
  *   - `permissionOverrideHint`: the inline warning to show above SandboxPermissionControl when the
  *     build kit overrides one of the user's permission values.
  *
@@ -23,11 +23,11 @@ import {
     workflowBuildKitEnabledAtomFamily,
     type BuildKitUiState,
 } from "@agenta/entities/workflow"
-import {Wrench} from "@phosphor-icons/react"
 import {useAtom, useAtomValue} from "jotai"
 
-import {BuildKitSection, PermissionOverrideHint} from "./BuildKitSection"
-import {asObj, staticEmbedSlug, type ItemDescriptor} from "./itemDescriptors"
+import {describeBuildKitEmbed, describeBuildKitPlatformTool} from "./buildKitDescriptors"
+import {BuildKitSection, PermissionOverrideHint, type BuildKitTool} from "./BuildKitSection"
+import {asObj, staticEmbedSlug} from "./itemDescriptors"
 
 /** Display name for an `@ag.embed` row: the overlay's sibling `name`, else the referenced
  * workflow's `name`, else undefined (callers fall back to the slug). */
@@ -44,35 +44,12 @@ function isEmbedRefEntry(entry: unknown): entry is Record<string, unknown> {
     )
 }
 
-function describeBuildKitPlatformTool(tool: Record<string, unknown>): ItemDescriptor {
-    const op = typeof tool.op === "string" ? tool.op : "platform tool"
-    return {
-        name: op,
-        description: "Platform-owned playground tool",
-        mono: "",
-        color: "#0d9488",
-        icon: <Wrench size={15} weight="fill" />,
-        tags: ["platform"],
-        typeLabel: "platform",
-        typeColor: "cyan",
-        subtitle: "Platform tool",
-    }
-}
-
-function describeBuildKitEmbed(
-    entry: Record<string, unknown>,
-    kind: "tool" | "skill",
-): ItemDescriptor {
+/** One always-on row for an `@ag.embed` overlay entry; `fallbackKey` covers an embed with no slug. */
+function embedRow(entry: Record<string, unknown>, fallbackKey: string): BuildKitTool {
     const slug = staticEmbedSlug(entry)
     return {
-        name: embedDisplayName(entry) ?? slug ?? `${kind} reference`,
-        description: "Provided by Agenta. This item cannot be edited or removed.",
-        mono: kind === "tool" ? "wf" : "sk",
-        color: kind === "tool" ? "#0d9488" : "#6b7280",
-        tags: ["@ag.embed"],
-        typeLabel: "@ag.embed",
-        typeColor: "blue",
-        subtitle: "Agenta-owned reference",
+        key: slug ?? fallbackKey,
+        descriptor: describeBuildKitEmbed(slug, embedDisplayName(entry)),
     }
 }
 
@@ -167,35 +144,37 @@ export function useBuildKit({
         [buildKitEnabled, sandboxPermissions, overlayPermissions],
     )
 
-    const platformToolRows = useMemo(
-        () =>
-            platformOverlayTools.map((tool) => {
+    // Platform tools first, then the Agenta-owned embeds — one list, no category headings (#6025).
+    const toolRows = useMemo<BuildKitTool[]>(
+        () => [
+            ...platformOverlayTools.map((tool) => {
                 const op = typeof tool.op === "string" ? tool.op : "platform tool"
                 return {
-                    op,
-                    enabled: !disabledOps.includes(op),
-                    descriptor: describeBuildKitPlatformTool(tool),
+                    key: op,
+                    descriptor: describeBuildKitPlatformTool(op),
+                    toggle: {op, enabled: !disabledOps.includes(op)},
                 }
             }),
-        [platformOverlayTools, disabledOps],
+            ...embeddedOverlayTools.map((tool, index) => embedRow(tool, `embed-tool-${index}`)),
+            ...embeddedOverlaySkills.map((skill, index) => embedRow(skill, `embed-skill-${index}`)),
+        ],
+        [platformOverlayTools, disabledOps, embeddedOverlayTools, embeddedOverlaySkills],
     )
     const toggleTool = (op: string, next: boolean) =>
         setDisabledOps(next ? disabledOps.filter((entry) => entry !== op) : [...disabledOps, op])
     const setAllTools = (next: boolean) =>
-        setDisabledOps(next ? [] : platformToolRows.map((tool) => tool.op))
+        setDisabledOps(
+            next ? [] : toolRows.flatMap((tool) => (tool.toggle ? [tool.toggle.op] : [])),
+        )
 
     const buildKitSection = hasBuildKitOverlay ? (
         <BuildKitSection
             enabled={buildKitEnabled}
             onEnabledChange={(next) => write({enabled: next, disabledOps})}
             disabled={disabled}
-            platformTools={platformToolRows}
+            tools={toolRows}
             onToggleTool={toggleTool}
             onSetAllTools={setAllTools}
-            embeddedTools={embeddedOverlayTools.map((tool) => describeBuildKitEmbed(tool, "tool"))}
-            embeddedSkills={embeddedOverlaySkills.map((skill) =>
-                describeBuildKitEmbed(skill, "skill"),
-            )}
             permissions={overlayPermissions}
         />
     ) : null

--- a/web/packages/agenta-entity-ui/tests/unit/buildKitDescriptors.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/buildKitDescriptors.test.ts
@@ -1,0 +1,45 @@
+/** #6025: build-kit rows read as prose, never as the wire `op` or the internal type vocabulary. */
+import {describe, expect, it} from "vitest"
+
+import {
+    describeBuildKitEmbed,
+    describeBuildKitPlatformTool,
+} from "../../src/DrillInView/SchemaControls/agentTemplate/buildKitDescriptors"
+
+describe("describeBuildKitPlatformTool", () => {
+    it("names a shipped op in the product's words, not its wire key", () => {
+        const descriptor = describeBuildKitPlatformTool("commit_revision")
+        expect(descriptor.name).toBe("Save changes")
+        expect(descriptor.description).toBe("Saves an edit to this agent's setup as a new version.")
+    })
+
+    it("describes every row, so no entry is left unexplained", () => {
+        for (const op of ["discover_tools", "test_run", "create_subscription", "list_deliveries"])
+            expect(describeBuildKitPlatformTool(op).description).toBeTruthy()
+    })
+
+    it("humanizes an op the table does not know rather than showing snake_case", () => {
+        const descriptor = describeBuildKitPlatformTool("pause_schedule")
+        expect(descriptor.name).toBe("Pause schedule")
+        expect(descriptor.description).toBeTruthy()
+    })
+
+    it("carries no internal type tag and renders the name as prose", () => {
+        const descriptor = describeBuildKitPlatformTool("query_spans")
+        expect(descriptor.tags).toEqual([])
+        expect(descriptor.monoName).toBe(false)
+    })
+})
+
+describe("describeBuildKitEmbed", () => {
+    it("words a known embed like the rest of the list", () => {
+        expect(describeBuildKitEmbed("__ag__request_input", "Request input").name).toBe(
+            "Ask you a question",
+        )
+    })
+
+    it("falls back to the wire name, then the slug, for an embed it does not know", () => {
+        expect(describeBuildKitEmbed("__ag__future", "Future thing").name).toBe("Future thing")
+        expect(describeBuildKitEmbed("__ag__future", undefined).name).toBe("__ag__future")
+    })
+})

--- a/web/packages/agenta-entity-ui/tests/unit/buildKitDescriptors.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/buildKitDescriptors.test.ts
@@ -38,8 +38,9 @@ describe("describeBuildKitEmbed", () => {
         )
     })
 
-    it("falls back to the wire name, then the slug, for an embed it does not know", () => {
+    it("falls back to the wire name, then a humanized slug, for an embed it does not know", () => {
         expect(describeBuildKitEmbed("__ag__future", "Future thing").name).toBe("Future thing")
-        expect(describeBuildKitEmbed("__ag__future", undefined).name).toBe("__ag__future")
+        // Never the bare slug: `__ag__future_thing` on screen is the wire name again.
+        expect(describeBuildKitEmbed("__ag__future_thing", undefined).name).toBe("Future thing")
     })
 })

--- a/web/storybook/stories/entity-ui/BuildKitSection.stories.tsx
+++ b/web/storybook/stories/entity-ui/BuildKitSection.stories.tsx
@@ -8,8 +8,12 @@ import {Switch as AntSwitch, Tag as AntTag, Tooltip as AntTooltip, Typography} f
 
 // Imported from source: agentTemplate internals are not re-exported from the DrillInView barrel.
 import {
+    describeBuildKitEmbed,
+    describeBuildKitPlatformTool,
+} from "../../../packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/buildKitDescriptors"
+import {
     BuildKitSection,
-    type BuildKitPlatformTool,
+    type BuildKitTool,
     PermissionOverrideHint,
     formatPermissionValue,
 } from "../../../packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection"
@@ -33,7 +37,7 @@ const meta = {
         docs: {
             description: {
                 component:
-                    "The playground-only build-kit overlay (platform tools, embedded tools/skills, sandbox permissions) with its enable switch — read-only, stripped by the backend on commit. `PermissionOverrideHint` is the sibling warning shown above SandboxPermissionControl.",
+                    "The playground-only build-kit overlay — one readable tool list (switchable platform tools plus the locked Agenta-owned embeds) and the sandbox permissions, under its enable switch. Stripped by the backend on commit. `PermissionOverrideHint` is the sibling warning shown above SandboxPermissionControl.",
             },
         },
     },
@@ -42,6 +46,8 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
+// The pre-migration antd half renders the raw ops the rows used to show, so the two columns are
+// comparable as MARKUP; the agenta half runs them through the copy table (#6025).
 const platformDescriptor = (name: string): ItemDescriptor => ({
     name,
     description: "Platform-owned playground tool",
@@ -56,40 +62,22 @@ const platformDescriptor = (name: string): ItemDescriptor => ({
 
 const PLATFORM_OPS = ["discover_tools", "commit_revision", "query_spans", "test_run"]
 
-const platformTools = (disabledOps: string[] = []): BuildKitPlatformTool[] =>
-    PLATFORM_OPS.map((op) => ({
-        op,
-        enabled: !disabledOps.includes(op),
-        descriptor: platformDescriptor(op),
-    }))
+// The locked Agenta-owned embeds, keyed by the slugs the copy table knows.
+const EMBED_SLUGS = ["__ag__request_connection", "__ag__build_an_agent"]
 
-const PLATFORM_TOOLS = platformTools()
-
-const EMBEDDED_TOOLS: ItemDescriptor[] = [
-    {
-        name: "Agent builder",
-        description: "Provided by Agenta. This item cannot be edited or removed.",
-        mono: "wf",
-        color: "#0d9488",
-        tags: ["@ag.embed"],
-        typeLabel: "@ag.embed",
-        typeColor: "blue",
-        subtitle: "Agenta-owned reference",
-    },
+const buildKitTools = (disabledOps: string[] = []): BuildKitTool[] => [
+    ...PLATFORM_OPS.map((op) => ({
+        key: op,
+        descriptor: describeBuildKitPlatformTool(op),
+        toggle: {op, enabled: !disabledOps.includes(op)},
+    })),
+    ...EMBED_SLUGS.map((slug) => ({
+        key: slug,
+        descriptor: describeBuildKitEmbed(slug, undefined),
+    })),
 ]
 
-const EMBEDDED_SKILLS: ItemDescriptor[] = [
-    {
-        name: "write-prompts",
-        description: "Provided by Agenta. This item cannot be edited or removed.",
-        mono: "sk",
-        color: "#6b7280",
-        tags: ["@ag.embed"],
-        typeLabel: "@ag.embed",
-        typeColor: "blue",
-        subtitle: "Agenta-owned reference",
-    },
-]
+const TOOLS = buildKitTools()
 
 const PERMISSIONS: Record<string, unknown> = {
     network: "on",
@@ -98,7 +86,7 @@ const PERMISSIONS: Record<string, unknown> = {
 }
 
 const CAPTION =
-    "These playground-only tools, skills, and permissions help the assistant build and revise this agent. None of this is part of the published agent."
+    "These playground-only tools and permissions help the assistant build and revise this agent. None of this is part of the published agent."
 const DISABLED_NOTE = "The assistant can no longer create files, run code, or edit the agent here."
 const OVERRIDE_KEYS = ["network", "filesystem"]
 
@@ -132,18 +120,8 @@ const AntdBuildKitSection = ({
             </div>
         ) : null}
         <RailField label="Platform tools">
-            {PLATFORM_TOOLS.map((tool, index) => (
-                <ItemRow key={`platform-${index}`} descriptor={tool.descriptor} locked />
-            ))}
-        </RailField>
-        <RailField label="Embedded tools">
-            {EMBEDDED_TOOLS.map((descriptor, index) => (
-                <ItemRow key={`tool-${index}`} descriptor={descriptor} locked />
-            ))}
-        </RailField>
-        <RailField label="Embedded skills">
-            {EMBEDDED_SKILLS.map((descriptor, index) => (
-                <ItemRow key={`skill-${index}`} descriptor={descriptor} locked />
+            {PLATFORM_OPS.map((op) => (
+                <ItemRow key={`platform-${op}`} descriptor={platformDescriptor(op)} locked />
             ))}
         </RailField>
         <RailField label="Sandbox permissions">
@@ -175,11 +153,9 @@ const AntdPermissionOverrideHint = () => (
 )
 
 const BASE = {
-    platformTools: PLATFORM_TOOLS,
+    tools: TOOLS,
     onToggleTool: () => undefined,
     onSetAllTools: () => undefined,
-    embeddedTools: EMBEDDED_TOOLS,
-    embeddedSkills: EMBEDDED_SKILLS,
     permissions: PERMISSIONS,
     // The app renders this collapsed; every story opens it so the body is visible/measured.
     defaultOpen: true,
@@ -203,7 +179,7 @@ const Live = ({
                 enabled={enabled}
                 onEnabledChange={setEnabled}
                 disabled={disabled}
-                platformTools={platformTools(disabledOps)}
+                tools={buildKitTools(disabledOps)}
                 onToggleTool={(op, next) =>
                     setDisabledOps((prev) =>
                         next ? prev.filter((entry) => entry !== op) : [...prev, op],
@@ -239,21 +215,19 @@ export const SomeToolsOff: Story = {
         ...BASE,
         enabled: true,
         onEnabledChange: () => undefined,
-        platformTools: platformTools(["commit_revision", "test_run"]),
+        tools: buildKitTools(["commit_revision", "test_run"]),
     },
     render: () => <Live initialDisabledOps={["commit_revision", "test_run"]} />,
 }
 
-/** A thin overlay: permissions only, no tools or skills. */
+/** A thin overlay: permissions only, no tools. */
 export const PermissionsOnly: Story = {
     args: {
         enabled: true,
         onEnabledChange: () => undefined,
-        platformTools: [],
+        tools: [],
         onToggleTool: () => undefined,
         onSetAllTools: () => undefined,
-        embeddedTools: [],
-        embeddedSkills: [],
         permissions: PERMISSIONS,
         defaultOpen: true,
     },
@@ -263,11 +237,9 @@ export const PermissionsOnly: Story = {
                 enabled
                 defaultOpen
                 onEnabledChange={() => undefined}
-                platformTools={[]}
+                tools={[]}
                 onToggleTool={() => undefined}
                 onSetAllTools={() => undefined}
-                embeddedTools={[]}
-                embeddedSkills={[]}
                 permissions={PERMISSIONS}
             />
         </div>

--- a/web/storybook/stories/entity-ui/BuildKitSection.stories.tsx
+++ b/web/storybook/stories/entity-ui/BuildKitSection.stories.tsx
@@ -46,8 +46,7 @@ const meta = {
 export default meta
 type Story = StoryObj<typeof meta>
 
-// The pre-migration antd half renders the raw ops the rows used to show, so the two columns are
-// comparable as MARKUP; the agenta half runs them through the copy table (#6025).
+// The antd half keeps the raw ops the rows used to show, so the columns compare as markup.
 const platformDescriptor = (name: string): ItemDescriptor => ({
     name,
     description: "Platform-owned playground tool",


### PR DESCRIPTION
## Context

The playground build kit under Advanced listed its entries by wire name. Rows read `commit_revision`, `discover_tools`, `annotate_trace`, split across three headings the reader has no use for (Platform tools, Embedded tools, Embedded skills), each tagged `platform` or `@ag.embed` and described as "Platform-owned playground tool". Nothing on the surface said what any of it did.

That vocabulary is internal. A platform tool is a wrapper over an Agenta endpoint and an `@ag.embed` is a config reference. Both are true, and neither answers the only question the panel raises: what does this switch turn off?

Fixes #6025.

## Changes

The three lists are now one "Tools" list, and every row carries a name and a one-line description in the product's words.

Before:

```
Platform tools    commit_revision     Platform-owned playground tool   [platform]
                  query_spans         Platform-owned playground tool   [platform]
Embedded tools    Request connection  Provided by Agenta. This item…   [@ag.embed]
Embedded skills   build-an-agent      Provided by Agenta. This item…   [@ag.embed]
```

After:

```
Tools   Save changes            Saves an edit to this agent's setup as a new version.
        Look through runs       Searches past runs to check what the agent actually did.
        Ask you to connect…     Prompts you to connect an app when the agent needs access.  [Locked]
        Guide to building…      Agenta's instructions for setting up and configuring an…    [Locked]
```

The overlay the server sends is model-facing config. A platform tool arrives as `{type: "platform", op}` and an embed as an `@ag.embed` reference, so the wire carries no display text and adding some would put presentation into the payload the model reads. The copy therefore lives in a new frontend table keyed by op and embed slug (`buildKitDescriptors.tsx`), beside the existing `itemDescriptors.tsx`. Wording follows the chat skin's platform glossary, so a tool reads the same in this list as it does in the transcript: a revision is "changes", a span is a "run", a subscription is a "trigger". An op the table does not know falls back to a humanized key rather than raw snake_case, so shipping a new op server-side costs plain wording instead of a broken row.

The switches are unchanged in behavior. Agenta-owned embeds still have no switch and keep their Locked tag, the count now covers every row, and the bulk toggle only renders when something is actually switchable.

`BuildKitSection` took three props for the three lists; it now takes one `tools` array where a row without a `toggle` is locked. Only `useBuildKit` and the Storybook story consume it.

## Tests

- Six unit tests in `buildKitDescriptors.test.ts`: a shipped op gets its copy, every default op has a description, an unknown op humanizes, no internal tag survives, an embed resolves by slug, an unknown embed falls back to its wire name and then its slug.
- Storybook story updated to the single-list prop.
- Checked in the running app on `/m`, desktop width and 375px.

## What to QA

- Open any agent, show the configuration panel, Advanced, Playground build kit. One "Tools" list, no Platform tools / Embedded tools / Embedded skills headings, no `platform` or `@ag.embed` tags.
- Every row shows a readable name and a description. Nothing reads as `snake_case`.
- The last three rows (Ask you to connect an app, Ask you a question, Guide to building agents) show Locked and have no switch.
- Toggle one switch off. The counter drops by one and the bulk link flips to "Enable all". Toggle it back and the counter returns.
- Regression: turn the build kit master switch off. The rows dim, the switches disable, and the info note about creating files still appears.
- Regression: commit a revision from the playground. The build kit is still stripped and does not appear in the committed config.
