### PR TITLE
[fix] Hide the question form stepper when there is only one question [AGE-4241]

### DIFF
--- a/web/packages/agenta-chat/src/components/ElicitationDock.tsx
+++ b/web/packages/agenta-chat/src/components/ElicitationDock.tsx
@@ -5,9 +5,11 @@
  * point and must survive any edit:
  *
  *  - **The card never moves the composer.** Every state renders into the same `CARD_MIN_H` box, and
- *    every slot holds its space whether or not it has content: the nav renders disabled at one
- *    question, the counter is tabular, and the error line is permanently mounted and merely empty.
- *    A `return null` on any branch, or a slot that only appears when filled, reintroduces the shift.
+ *    every slot holds its space whether or not it has content: the nav renders disabled on the first
+ *    and last question, the counter is tabular, and the error line is permanently mounted and merely
+ *    empty. A `return null` on any branch, or a slot that only appears when filled, reintroduces the
+ *    shift. The stepper cluster is decided by the FORM, not by the state, so a one-question form
+ *    drops it outright without ever moving mid-answer.
  *  - **It docks like its siblings.** It sits between `ApprovalDock` and `ConnectionDock`, in that
  *    order, because that is also the keyboard precedence (approval > elicitation > connect).
  *
@@ -387,7 +389,11 @@ const LiveCard = ({
             tabIndex={-1}
             role="group"
             aria-label={
-                step ? `Question ${stepper.position} of ${stepper.total}` : "Review answers"
+                !step
+                    ? "Review answers"
+                    : stepper.isMultiStep
+                      ? `Question ${stepper.position} of ${stepper.total}`
+                      : "Question"
             }
             onKeyDownCapture={onKeyDown}
             onPointerDownCapture={stepper.cancelHold}
@@ -396,26 +402,31 @@ const LiveCard = ({
         >
             <Eyebrow label={askerLabel}>
                 <div className="ml-auto flex items-center gap-0.5">
-                    <NavButton
-                        label="Previous question"
-                        disabled={!stepper.canGoBack}
-                        onClick={stepper.back}
-                    >
-                        <CaretLeft size={11} />
-                    </NavButton>
-                    <span
-                        aria-live="polite"
-                        className="min-w-[26px] text-center text-[11px] tabular-nums text-colorTextTertiary"
-                    >
-                        {stepper.position}/{stepper.total}
-                    </span>
-                    <NavButton
-                        label="Next question"
-                        disabled={!stepper.canGoForward}
-                        onClick={stepper.forward}
-                    >
-                        <CaretRight size={11} />
-                    </NavButton>
+                    {/* Fixed for the card's life, so hiding it shifts nothing mid-answer. */}
+                    {stepper.isMultiStep ? (
+                        <>
+                            <NavButton
+                                label="Previous question"
+                                disabled={!stepper.canGoBack}
+                                onClick={stepper.back}
+                            >
+                                <CaretLeft size={11} />
+                            </NavButton>
+                            <span
+                                aria-live="polite"
+                                className="min-w-[26px] text-center text-[11px] tabular-nums text-colorTextTertiary"
+                            >
+                                {stepper.position}/{stepper.total}
+                            </span>
+                            <NavButton
+                                label="Next question"
+                                disabled={!stepper.canGoForward}
+                                onClick={stepper.forward}
+                            >
+                                <CaretRight size={11} />
+                            </NavButton>
+                        </>
+                    ) : null}
                     <Button
                         variant="ghost"
                         size="icon-sm"
@@ -431,16 +442,18 @@ const LiveCard = ({
                 </div>
             </Eyebrow>
 
-            <div className="flex gap-1" aria-hidden>
-                {steps.map((candidate, index) => (
-                    <span
-                        key={candidate.name}
-                        className={`h-0.5 flex-1 rounded-full ${
-                            index < stepper.position ? "bg-colorText" : "bg-colorFillTertiary"
-                        }`}
-                    />
-                ))}
-            </div>
+            {stepper.isMultiStep ? (
+                <div className="flex gap-1" aria-hidden>
+                    {steps.map((candidate, index) => (
+                        <span
+                            key={candidate.name}
+                            className={`h-0.5 flex-1 rounded-full ${
+                                index < stepper.position ? "bg-colorText" : "bg-colorFillTertiary"
+                            }`}
+                        />
+                    ))}
+                </div>
+            ) : null}
 
             {/* pb-1 so the control does not sit flush against the actions; the card's own gap
                 alone read as cramped under a field. */}
@@ -450,7 +463,10 @@ const LiveCard = ({
                 ) : step ? (
                     <>
                         <span className="text-[13px] font-medium leading-tight line-clamp-2">
-                            <span className="text-colorText">{stepper.position}.</span> {step.label}
+                            {stepper.isMultiStep ? (
+                                <span className="text-colorText">{stepper.position}. </span>
+                            ) : null}
+                            {step.label}
                             {step.hint ? (
                                 <span className="font-normal text-colorTextQuaternary">
                                     {" "}

--- a/web/packages/agenta-chat/src/hooks/useElicitationStepper.ts
+++ b/web/packages/agenta-chat/src/hooks/useElicitationStepper.ts
@@ -207,6 +207,11 @@ export interface ElicitationStepperState {
      * a summary of a single answer is noise.
      */
     hasReview: boolean
+    /**
+     * Whether the form is a sequence at all. A single question has nothing to step through, so the
+     * card drops the counter, the nav arrows, the progress rail and the question number.
+     */
+    isMultiStep: boolean
     values: Record<string, unknown>
     error: string | null
     hold: string | null
@@ -275,8 +280,10 @@ export const useElicitationStepper = ({
 }: UseElicitationStepperArgs): ElicitationStepperState => {
     const {steps} = form
     const total = steps.length
+    // A single question is not a sequence: nothing to step through, and nothing to compare.
+    const isMultiStep = total > 1
     // A review screen is worth a step of its own only when there is something to compare.
-    const hasReview = total > 1
+    const hasReview = isMultiStep
     const lastIndex = hasReview ? total : Math.max(total - 1, 0)
 
     // Read by the `pick` callback, which must stay identity-stable across steps: closing over
@@ -417,6 +424,7 @@ export const useElicitationStepper = ({
         total,
         isReview,
         hasReview,
+        isMultiStep,
         values: state.values,
         error: state.error,
         hold: state.hold?.label ?? null,

--- a/web/packages/agenta-chat/tests/unit/components/elicitationDockSettle.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/components/elicitationDockSettle.test.tsx
@@ -40,6 +40,14 @@ const TWO_QUESTIONS = {
     },
 }
 
+const ONE_QUESTION = {
+    message: "One detail",
+    requestedSchema: {
+        type: "object",
+        properties: {colour: {type: "string", title: "Colour", enum: ["Red", "Blue"]}},
+    },
+}
+
 // This config sets no `globals`, so RTL never registers its auto-cleanup and mounted cards would
 // otherwise pile up in one document (ApprovalCard.test.tsx unmounts by hand for the same reason).
 afterEach(cleanup)
@@ -105,6 +113,18 @@ describe("chrome", () => {
         for (const label of ["Previous question", "Next question", "Dismiss this request"]) {
             expect(screen.getByLabelText(label).dataset.slot).toBe("button")
         }
+    })
+
+    it("drops the stepper entirely when there is only one question to answer", () => {
+        // Counter, arrows, rail and question number are all inert at one step — dead chrome.
+        const {container} = setup(ONE_QUESTION)
+
+        expect(screen.queryByText("1/1")).toBeNull()
+        expect(screen.queryByLabelText("Previous question")).toBeNull()
+        expect(screen.queryByLabelText("Next question")).toBeNull()
+        expect(container.querySelectorAll("[aria-hidden] > span")).toHaveLength(0)
+        expect(screen.getByText("Colour").textContent).toBe("Colour")
+        expect(screen.getByLabelText("Dismiss this request")).toBeTruthy()
     })
 
     it("titles the card in the primary text colour, not the brand accent or caps", () => {
@@ -263,13 +283,13 @@ describe("automation", () => {
                 properties: {note: {type: "string", title: "Note", format: "multiline"}},
             },
         })
-        const box = screen.getByLabelText("Note")
+        const box = screen.getByLabelText("Note") as HTMLTextAreaElement
 
         fireEvent.change(box, {target: {value: "line one"}})
         fireEvent.keyDown(box, {key: "Enter", shiftKey: true})
 
         expect(onOutput).not.toHaveBeenCalled()
-        expect(screen.getByText("1/1")).toBeTruthy()
+        expect(box.value).toBe("line one")
     })
 
     it("leaves plain Enter alone in a textarea, so the browser inserts the newline", () => {
@@ -287,7 +307,7 @@ describe("automation", () => {
 
         // Nothing intercepts it, so the browser's own newline stands and the step does not move.
         expect(onOutput).not.toHaveBeenCalled()
-        expect(screen.getByText("1/1")).toBeTruthy()
+        expect(field.value).toBe("one")
     })
 
     it("advances immediately on a digit, with no hold", () => {
@@ -353,7 +373,7 @@ describe("multi-select", () => {
         fireEvent.click(screen.getByText("Releases"))
 
         // Still on the one and only question — a checkbox list is not done until you say so.
-        expect(screen.getByText("1/1")).toBeTruthy()
+        expect(screen.getAllByRole("checkbox").length).toBeGreaterThan(0)
         expect(onOutput).not.toHaveBeenCalled()
 
         fireEvent.click(screen.getByText("Send answers"))

--- a/web/packages/agenta-chat/tests/unit/hooks/useElicitationStepper.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useElicitationStepper.test.ts
@@ -73,6 +73,7 @@ describe("navigation", () => {
         expect(result.current.step?.name).toBe("name")
         expect(result.current.position).toBe(1)
         expect(result.current.total).toBe(5)
+        expect(result.current.isMultiStep).toBe(true)
         expect(result.current.canGoBack).toBe(false)
         expect(result.current.primaryLabel).toBe("Next")
     })
@@ -107,6 +108,7 @@ describe("navigation", () => {
         const {result} = setup(formOf({name: {type: "string"}}), onComplete)
 
         expect(result.current.hasReview).toBe(false)
+        expect(result.current.isMultiStep).toBe(false)
         expect(result.current.primaryLabel).toBe("Send answers")
 
         act(() => result.current.setValue("name", "Ada"))


### PR DESCRIPTION
Closes #6456

## Context

When an agent asks for one piece of input, the docked question card still drew a full stepper: a `1/1` counter, two nav arrows that are permanently disabled, a single full-width progress segment, and a `1.` prefix on the question. There is nothing to step through at one question, so all four are inert. They take up the eyebrow row and a rail of vertical space to tell the reader nothing.

The chrome rendered unconditionally in `ElicitationDock`, so form size never entered into it.

## Changes

`useElicitationStepper` now names the predicate once and exposes it:

```ts
const isMultiStep = total > 1
const hasReview = isMultiStep
```

`hasReview` was already a second, independent `total > 1` check with the same meaning ("a summary of a single answer is noise"). It now derives from `isMultiStep`, so the two cannot drift apart.

`ElicitationDock` gates the counter, both arrows, the progress rail and the question number on `isMultiStep`. The header's dismiss button is not stepper chrome and stays put.

Before, one question:

```
? Request input            ‹  1/1  ›  ✕
────────────────────────────────────────
1. Create the issue?
```

After:

```
? Request input                       ✕
Create the issue?
```

Multi-question forms are untouched.

The fix sits in `@agenta/chat`, which both `/m` and the desktop playground render, so it lands on mobile and desktop from one change.

### On the card's layout invariant

`ElicitationDock` carries a rule that the card must never move the composer: every slot holds its space whether or not it has content, and a slot that appears only when filled reintroduces the shift. That rule is about state changing *within* a form. Step count is fixed for a card's life (the card is keyed by `toolCallId`), so a one-question form never grows a second question and dropping the cluster cannot shift anything mid-answer. The header docblock now spells out that distinction, since the old wording read as if the nav had to render at one question.

## Tests

- `pnpm vitest run tests/unit/components/elicitationDockSettle.test.tsx tests/unit/hooks/useElicitationStepper.test.ts` in `web/packages/agenta-chat`. 63 passed.
- Added a render test asserting a one-question form has no counter, no arrows, no rail and no number, and an `isMultiStep` case in the hook tests.
- Three existing tests used `getByText("1/1")` as a proxy for "the form did not advance" on single-question forms. That proxy is gone by design, so they now assert the real state instead (the textarea keeps its value, the checkbox list is still showing).
- Checked the rendered card in the running app at desktop and 375px widths, in both the one-question and two-question cases, with no console errors.

The check above ran against a scratch page that mounts `ElicitationDock` with fixture payloads, not a live agent run, so a capture from a real `request_input` turn is still outstanding. Driving one needs an agent that happens to ask exactly one question, which I could not arrange deterministically. The Playwright elicitation suite that would cover this is `describe.skip`'d on an unrelated seeding blocker (see `web/oss/tests/playwright/acceptance/agent-chat/README.md`).

## What to QA

- Trigger an agent turn that asks for a single value. The card shows the question with no `1/1`, no arrows and no progress bar, and the primary button reads `Send answers`.
- Regression: trigger a turn that asks for two or more values. The counter, arrows and progress rail are all still there, the question is still numbered, and the button reads `Next` until the review screen.
- Regression: on a multi-question form, answer through to the end. The composer must not jump as the card moves between questions and the review list.

