### PR TITLE
[fix] Let only the session on screen answer the push-to-talk chord [AGE-4239]

### DIFF
--- a/web/mobile/src/features/chat/Composer.tsx
+++ b/web/mobile/src/features/chat/Composer.tsx
@@ -62,6 +62,8 @@ export const Composer = ({
         // is still in flight; a second pass would re-send the same staged tray.
         if (sending.current) return
         sending.current = true
+        // The message is written; anything still coming in belongs to no draft.
+        voice.endDictation()
         // Close the on-screen keyboard. It covered the transcript while you typed, and the reply
         // to the message you just sent is the thing you want to see next. The helper defers the
         // blur past the editor's own clear, whose reconcile would otherwise re-focus the input and
@@ -109,6 +111,7 @@ export const Composer = ({
         voiceRecorder,
         voiceWillSend,
         startVoiceMessage,
+        dictationStopRef,
         dictating,
         setDictating,
         setDictationError,
@@ -152,6 +155,7 @@ export const Composer = ({
                                 attachmentsFull={attachments.atMax}
                                 onDictationError={setDictationError}
                                 onDictatingChange={setDictating}
+                                stopRef={dictationStopRef}
                                 disabled={disabled}
                             />
                         }

--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -137,6 +137,8 @@ const AgentComposerDock = ({
         voiceRecorder,
         voiceWillSend,
         startVoiceMessage,
+        dictationStopRef,
+        endDictation,
         dictating,
         setDictating,
         setDictationError,
@@ -180,6 +182,17 @@ const AgentComposerDock = ({
             return result
         },
         [onSubmit, richInputRef],
+    )
+
+    // Onboarding: submit = commit the ephemeral — Enter creates the agent (matching the
+    // composer's "↵ Send" hint). Either way the message is written, so anything the mic is still
+    // hearing belongs to no draft.
+    const handleComposerSubmit = useCallback(
+        (text: string) => {
+            endDictation()
+            return onboardingActive ? handleCreateAgent() : submitMessage(text)
+        },
+        [endDictation, handleCreateAgent, onboardingActive, submitMessage],
     )
 
     // Restoring focus can only happen AFTER the picker unmounts: a focus() call in the handler is
@@ -395,9 +408,7 @@ const AgentComposerDock = ({
                         dictating={dictating}
                         className={CHAT_COLUMN}
                         fallback={<ComposerSkeleton className={CHAT_COLUMN} />}
-                        // Onboarding: submit = commit the ephemeral — Enter creates the agent
-                        // (matching the composer's "↵ Send" hint).
-                        onSubmit={onboardingActive ? () => handleCreateAgent() : submitMessage}
+                        onSubmit={handleComposerSubmit}
                         disabled={onboardingActive ? ideHandoffActive : modelBlocked}
                         hideSendButton={onboardingActive}
                         placeholder={
@@ -434,6 +445,7 @@ const AgentComposerDock = ({
                                     attachmentsFull={atMax}
                                     onDictationError={setDictationError}
                                     onDictatingChange={setDictating}
+                                    stopRef={dictationStopRef}
                                     disabled={onboardingActive ? ideHandoffActive : modelBlocked}
                                 />
                                 {/* Context-budget meter temporarily hidden from the UI.

--- a/web/packages/agenta-chat/src/components/VoiceInputButton.tsx
+++ b/web/packages/agenta-chat/src/components/VoiceInputButton.tsx
@@ -69,6 +69,7 @@ const VoiceInputButton = ({
     attachmentsFull,
     onDictationError,
     onDictatingChange,
+    stopRef,
     disabled,
 }: {
     inputRef: RefObject<RichChatInputHandle | null>
@@ -79,6 +80,8 @@ const VoiceInputButton = ({
     onDictationError: (message: string | null) => void
     /** Dictation locks the editor while it runs, which the composer owns. */
     onDictatingChange: (active: boolean) => void
+    /** Where the composer picks up the stopper, so a send can close the mic it opened. */
+    stopRef?: RefObject<() => void>
     /** Tray is at its file limit. A voice message attaches like any file, so recording one now
      * would be rejected on attach — i.e. the take would be destroyed after the fact. */
     attachmentsFull: boolean
@@ -95,6 +98,7 @@ const VoiceInputButton = ({
     // hear. With no explicit choice, lead with whichever the model can actually use.
     const mode: VoiceMode = chosenMode ?? (audioPerceivable === false ? "transcribe" : "audio")
     const transcribe = useVoiceInput()
+    if (stopRef) stopRef.current = transcribe.stop
 
     useEffect(() => {
         onDictationError(transcribe.error)
@@ -120,8 +124,13 @@ const VoiceInputButton = ({
             inputRef.current?.focus()
         }
         wasActive.current = transcribe.active
-        onDictatingChange(transcribe.active)
-    }, [transcribe.active, inputRef, onDictatingChange])
+    }, [transcribe.active, inputRef])
+
+    // Intent, not `active`: the browser's teardown takes seconds, and the editor must not stay
+    // locked across it once the person has released the chord to type or send.
+    useEffect(() => {
+        onDictatingChange(transcribe.recording)
+    }, [transcribe.recording, onDictatingChange])
 
     // Primary action first: a voice message is the default; dictation is the alternative.
     const modes: {key: VoiceMode; supported: boolean}[] = [
@@ -151,8 +160,10 @@ const VoiceInputButton = ({
     useEffect(() => setHoldLabel(pushToTalkLabel()), [])
 
     // Hold ⌃⌥ / Ctrl+Alt to dictate. Same start/stop the button's own click drives.
+    const rootRef = useRef<HTMLDivElement>(null)
     usePushToTalk({
         enabled: effective === "transcribe" && !disabled && !audioPending,
+        rootRef,
         onStart: startDictation,
         onStop: transcribe.stop,
     })
@@ -206,7 +217,7 @@ const VoiceInputButton = ({
     const highlighted = dictating || audioPending
 
     return (
-        <div className="flex items-center">
+        <div ref={rootRef} className="flex items-center">
             <SimpleTooltip title={title}>
                 <Button
                     variant="ghost"

--- a/web/packages/agenta-chat/src/hooks/usePushToTalk.ts
+++ b/web/packages/agenta-chat/src/hooks/usePushToTalk.ts
@@ -1,6 +1,6 @@
-import {useEffect, useRef} from "react"
+import {useEffect, useRef, type RefObject} from "react"
 
-import {isMacPlatform, isOverlayOpen} from "@agenta/shared/utils"
+import {isMacPlatform, isOnScreen, isOverlayOpen} from "@agenta/shared/utils"
 
 /** How long the chord must be held before the mic opens. */
 export const PUSH_TO_TALK_ARM_MS = 300
@@ -10,6 +10,8 @@ const CHORD_KEYS = new Set(["Control", "Alt", "AltGraph"])
 
 export interface UsePushToTalkParams {
     enabled: boolean
+    /** The control's own root — a chat surface keeps visited sessions mounted behind `display: none`. */
+    rootRef: RefObject<HTMLElement | null>
     onStart: () => void
     onStop: () => void
 }
@@ -26,7 +28,7 @@ export interface UsePushToTalkParams {
  * Lives with the mic rather than the app's session shortcuts because dictation state lives here;
  * the app-layer shortcut hook it would otherwise join has no caller since the package carve.
  */
-export function usePushToTalk({enabled, onStart, onStop}: UsePushToTalkParams) {
+export function usePushToTalk({enabled, rootRef, onStart, onStop}: UsePushToTalkParams) {
     // The handlers change every render; keeping them in refs means the listeners register once.
     const onStartRef = useRef(onStart)
     const onStopRef = useRef(onStop)
@@ -64,13 +66,13 @@ export function usePushToTalk({enabled, onStart, onStop}: UsePushToTalkParams) {
             // AltGr is the right-hand Alt everywhere it exists; binding the left one leaves it free.
             if (!macPlatform && e.code === "AltRight") return
             if (armTimer !== null || active) return
-            if (isOverlayOpen()) return
+            // A hidden session hears the chord too, and its recogniser would take the mic.
+            if (!isOnScreen(rootRef.current) || isOverlayOpen()) return
 
             armTimer = setTimeout(() => {
                 armTimer = null
-                // Rechecked: a dialog can open during the arm delay, and the mic must not
-                // open behind it.
-                if (isOverlayOpen()) return
+                // Rechecked: a dialog can open, or the session be switched away, during the delay.
+                if (!isOnScreen(rootRef.current) || isOverlayOpen()) return
                 active = true
                 onStartRef.current()
             }, PUSH_TO_TALK_ARM_MS)
@@ -96,5 +98,5 @@ export function usePushToTalk({enabled, onStart, onStop}: UsePushToTalkParams) {
             window.removeEventListener("blur", release)
             release()
         }
-    }, [enabled])
+    }, [enabled, rootRef])
 }

--- a/web/packages/agenta-chat/src/hooks/useVoiceComposer.ts
+++ b/web/packages/agenta-chat/src/hooks/useVoiceComposer.ts
@@ -1,4 +1,4 @@
-import {type RefObject, useState} from "react"
+import {type RefObject, useCallback, useRef, useState} from "react"
 
 import {type RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 
@@ -45,7 +45,11 @@ export const useVoiceComposer = ({
         voiceRecorder.start()
     }
     // Dictation runs inside the mic button (its transcript changes far too often to lift here), so
-    // it reports failures up for the shared notice.
+    // it reports failures up for the shared notice and leaves its stopper here.
+    const dictationStopRef = useRef<() => void>(() => {})
+    // A send finishes the message, so the mic has nothing left to hear. Stable: the composer's
+    // memoized submit handler depends on it.
+    const endDictation = useCallback(() => dictationStopRef.current(), [])
     const [dictationError, setDictationError] = useState<string | null>(null)
     // Locks the editor while speech is coming in, so typing can't interleave with the transcript.
     const [dictating, setDictating] = useState(false)
@@ -59,6 +63,8 @@ export const useVoiceComposer = ({
         voiceRecorder,
         voiceWillSend,
         startVoiceMessage,
+        dictationStopRef,
+        endDictation,
         dictating,
         setDictating,
         setDictationError,

--- a/web/packages/agenta-chat/tests/unit/components/voiceInputButtonPushToTalk.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/components/voiceInputButtonPushToTalk.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * The mic's push-to-talk chord across the sessions a chat surface keeps mounted.
+ *
+ * A visited session stays in the tree behind `display: none`, so its mic hears the same
+ * document-level chord as the one on screen. Both answering it means two recognisers racing for
+ * the single microphone, and the composer in view is as likely to lose as to win — which reads as
+ * dictation capturing nothing at all.
+ */
+import {act, cleanup, render} from "@testing-library/react"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+import VoiceInputButton from "../../../src/components/VoiceInputButton"
+import {PUSH_TO_TALK_ARM_MS} from "../../../src/hooks/usePushToTalk"
+
+const started: string[] = []
+const stopped: string[] = []
+/** The live session, so a test can hold back `onend` the way a real browser teardown does. */
+let live: FakeRecognition | null = null
+
+class FakeRecognition {
+    continuous = false
+    interimResults = false
+    lang = ""
+    onstart: (() => void) | null = null
+    onresult: ((e: unknown) => void) | null = null
+    onerror: ((e: {error: string}) => void) | null = null
+    onend: (() => void) | null = null
+    start() {
+        started.push("start")
+        live = this
+        this.onstart?.()
+    }
+    /** Stopping only ASKS; the browser closes the session on its own schedule (see `onend`). */
+    stop() {
+        stopped.push("stop")
+    }
+    abort() {
+        this.onend?.()
+    }
+}
+
+const holdChord = () =>
+    document.dispatchEvent(
+        new KeyboardEvent("keydown", {
+            key: "Alt",
+            code: "AltLeft",
+            ctrlKey: true,
+            altKey: true,
+            bubbles: true,
+        }),
+    )
+
+const waitOutArmDelay = () =>
+    act(() => {
+        vi.advanceTimersByTime(PUSH_TO_TALK_ARM_MS)
+    })
+
+const releaseChord = () =>
+    document.dispatchEvent(new KeyboardEvent("keyup", {key: "Alt", bubbles: true}))
+
+const inputRef = {current: null}
+
+const renderMic = (
+    onDictatingChange: (active: boolean) => void = () => {},
+    stopRef?: {current: () => void},
+) =>
+    render(
+        <VoiceInputButton
+            inputRef={inputRef}
+            onStartAudio={() => {}}
+            audioSupported={false}
+            audioPending={false}
+            audioPerceivable={null}
+            attachmentsFull={false}
+            onDictationError={() => {}}
+            onDictatingChange={onDictatingChange}
+            stopRef={stopRef}
+        />,
+    )
+
+beforeEach(() => {
+    started.length = 0
+    stopped.length = 0
+    live = null
+    vi.useFakeTimers()
+    ;(window as unknown as {SpeechRecognition: unknown}).SpeechRecognition = FakeRecognition
+})
+
+afterEach(() => {
+    vi.useRealTimers()
+    cleanup()
+})
+
+describe("VoiceInputButton push-to-talk", () => {
+    it("opens the mic for the session on screen", () => {
+        renderMic()
+        holdChord()
+        waitOutArmDelay()
+        expect(started).toHaveLength(1)
+    })
+
+    it("leaves the chord alone in a session that is mounted but hidden", () => {
+        const {container} = renderMic()
+        ;(container.firstElementChild as HTMLElement).style.display = "none"
+        holdChord()
+        waitOutArmDelay()
+        expect(started).toHaveLength(0)
+    })
+
+    it("opens exactly one mic when a hidden session is mounted alongside the visible one", () => {
+        const hidden = renderMic()
+        ;(hidden.container.firstElementChild as HTMLElement).style.display = "none"
+        renderMic()
+        holdChord()
+        waitOutArmDelay()
+        expect(started).toHaveLength(1)
+    })
+
+    it("unlocks the composer on release, without waiting out the browser's teardown", () => {
+        const onDictatingChange = vi.fn()
+        renderMic(onDictatingChange)
+        holdChord()
+        waitOutArmDelay()
+        expect(onDictatingChange).toHaveBeenLastCalledWith(true)
+
+        // Released, but the recogniser has not closed its session yet — the composer must not
+        // stay read-only across a teardown that can run for seconds.
+        act(() => {
+            releaseChord()
+        })
+        expect(onDictatingChange).toHaveBeenLastCalledWith(false)
+
+        act(() => {
+            live?.onend?.()
+        })
+        expect(onDictatingChange).toHaveBeenLastCalledWith(false)
+    })
+
+    it("hands the composer a stopper, so a send closes the mic it opened", () => {
+        const onDictatingChange = vi.fn()
+        const stopRef = {current: () => {}}
+        renderMic(onDictatingChange, stopRef)
+        holdChord()
+        waitOutArmDelay()
+        expect(onDictatingChange).toHaveBeenLastCalledWith(true)
+
+        // What the composer runs on submit, with the chord still held.
+        act(() => stopRef.current())
+        expect(stopped).toHaveLength(1)
+        expect(onDictatingChange).toHaveBeenLastCalledWith(false)
+    })
+})

--- a/web/packages/agenta-chat/tests/unit/hooks/usePushToTalk.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/usePushToTalk.test.ts
@@ -32,8 +32,13 @@ const waitOutArmDelay = () =>
 const setup = (enabled = true) => {
     const onStart = vi.fn()
     const onStop = vi.fn()
-    const view = renderHook(() => usePushToTalk({enabled, onStart, onStop}))
-    return {onStart, onStop, view}
+    // The mic's own root, as the composer mounts it — the hook reads it to tell a session on
+    // screen from one the chat surface keeps mounted behind `display: none`.
+    const root = document.createElement("div")
+    document.body.append(root)
+    const rootRef = {current: root}
+    const view = renderHook(() => usePushToTalk({enabled, rootRef, onStart, onStop}))
+    return {onStart, onStop, view, root}
 }
 
 beforeEach(() => {
@@ -146,6 +151,25 @@ describe("usePushToTalk", () => {
         const modal = document.createElement("div")
         modal.className = "ant-modal-wrap"
         document.body.append(modal)
+        waitOutArmDelay()
+        expect(onStart).not.toHaveBeenCalled()
+    })
+
+    it("stays out of it for a session that is mounted but off screen", () => {
+        const {onStart, root} = setup()
+        root.style.display = "none"
+        holdChord()
+        waitOutArmDelay()
+        expect(onStart).not.toHaveBeenCalled()
+    })
+
+    it("yields when the session is switched away during the arm delay", () => {
+        const {onStart, root} = setup()
+        holdChord()
+        act(() => {
+            vi.advanceTimersByTime(PUSH_TO_TALK_ARM_MS - 1)
+        })
+        root.style.display = "none"
         waitOutArmDelay()
         expect(onStart).not.toHaveBeenCalled()
     })

--- a/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
+++ b/web/packages/agenta-ui/src/RichChatInput/RichChatInput.tsx
@@ -1,4 +1,12 @@
-import {forwardRef, type ReactNode, useEffect, useImperativeHandle, useRef, useState} from "react"
+import {
+    forwardRef,
+    type ReactNode,
+    useCallback,
+    useEffect,
+    useImperativeHandle,
+    useRef,
+    useState,
+} from "react"
 
 import {modifierKeyLabel} from "@agenta/shared/utils"
 import {CodeHighlightNode, CodeNode} from "@lexical/code"
@@ -179,6 +187,16 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
 
         useEffect(() => setModKey(modifierKeyLabel()), [])
 
+        // A send empties the editor, so the session must go with it: the recogniser flushes a last
+        // final result on its way out, which would otherwise rebuild its nodes in the empty box.
+        const handleSubmit = useCallback(
+            (markdown: string) => {
+                dictationRef.current = null
+                onSubmit(markdown)
+            },
+            [onSubmit],
+        )
+
         // Seed once at mount. EditorRefBridge (a child) binds the editor in its own effect,
         // which runs before this one, so the ref is live here. Mount-only by design — the
         // ref freezes the first value so a re-render can't re-apply it over user edits.
@@ -199,12 +217,15 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                 // focus theft to an overlay that just autofocused itself (it dismisses).
                 blur: () => editorRef.current?.blur(),
                 focus: () => editorRef.current?.focus(),
-                clear: () =>
+                clear: () => {
+                    // Same reason as a send: an emptied editor cannot host a live session.
+                    dictationRef.current = null
                     editorRef.current?.update(() => {
                         const root = $getRoot()
                         root.clear()
                         root.append($createParagraphNode())
-                    }),
+                    })
+                },
                 insertText: (text: string) => {
                     const editor = editorRef.current
                     if (!editor) return
@@ -340,7 +361,7 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                         <div className="ml-auto flex items-center gap-2">
                             {hideSendButton ? null : (
                                 <SendButton
-                                    onSubmit={onSubmit}
+                                    onSubmit={handleSubmit}
                                     forceEnabled={sendForceEnabled}
                                     disabled={disabled || sendDisabled}
                                     disabledReason={sendDisabledReason}
@@ -370,7 +391,7 @@ export const RichChatInput = forwardRef<RichChatInputHandle, RichChatInputProps>
                     {/* Enter on a lone ``` fence opener → code block (runs before SubmitPlugin). */}
                     <CodeFencePlugin />
                     {submitOnEnter ? (
-                        <SubmitPlugin onSubmit={onSubmit} disabled={sendDisabled} />
+                        <SubmitPlugin onSubmit={handleSubmit} disabled={sendDisabled} />
                     ) : null}
                     <FocusStatePlugin onFocusChange={setFocused} />
                     {onChange ? <CharacterCountPlugin onTextChange={onChange} /> : null}

--- a/web/packages/agenta-ui/tests/unit/richChatInputDictationSend.render.test.tsx
+++ b/web/packages/agenta-ui/tests/unit/richChatInputDictationSend.render.test.tsx
@@ -1,0 +1,60 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * A send while dictation is still closing.
+ *
+ * The recogniser flushes a last final result on its way out, and that result arrives after the
+ * send has already emptied the editor. The session's nodes are recreated on demand, so unless the
+ * send retires the session, the words that just left as a message are written straight back into
+ * the composer.
+ */
+import {act, cleanup, render} from "@testing-library/react"
+import {createRef} from "react"
+import {afterEach, describe, expect, it, vi} from "vitest"
+
+import {RichChatInput, type RichChatInputHandle} from "../../src/RichChatInput"
+
+afterEach(cleanup)
+
+const setup = () => {
+    const onSubmit = vi.fn()
+    const ref = createRef<RichChatInputHandle>()
+    const view = render(<RichChatInput ref={ref} onSubmit={onSubmit} />)
+    return {onSubmit, ref, view}
+}
+
+const editorText = (container: HTMLElement) =>
+    container.querySelector('[contenteditable="true"]')?.textContent ?? ""
+
+describe("RichChatInput dictation across a send", () => {
+    it("drops the session on send, so a trailing result cannot refill the composer", async () => {
+        const {onSubmit, ref, view} = setup()
+
+        await act(async () => {
+            ref.current?.beginDictation()
+            ref.current?.updateDictation("hello world", "")
+        })
+        expect(editorText(view.container)).toContain("hello world")
+
+        const send = view.container.querySelector<HTMLButtonElement>('button[aria-label="Send"]')
+        await act(async () => send?.click())
+        expect(onSubmit).toHaveBeenCalledWith("hello world")
+
+        // The recogniser's parting result, arriving after the composer was emptied.
+        await act(async () => ref.current?.updateDictation("hello world", ""))
+        expect(editorText(view.container)).toBe("")
+    })
+
+    it("drops the session on clear too", async () => {
+        const {ref, view} = setup()
+        await act(async () => {
+            ref.current?.beginDictation()
+            ref.current?.updateDictation("hello world", "")
+        })
+        await act(async () => {
+            ref.current?.clear()
+            ref.current?.updateDictation("hello world", "")
+        })
+        expect(editorText(view.container)).toBe("")
+    })
+})


### PR DESCRIPTION
## Context

Holding the push-to-talk chord (⌃⌥ / Ctrl+Alt) in the chat composer captured nothing, and the composer stayed in its recording state after the message was sent.

Three separate causes, all on the dictation path (voice-message mode is still gated off behind `VOICE_MESSAGE_MODE_ENABLED`, so the shortcut only ever drives dictation):

1. `AgentChatPanel` keeps every visited session mounted behind `display: none`, and `usePushToTalk` binds its listener on the `document`. One chord armed every mounted mic at once. Each opened its own `SpeechRecognition`, they fought over the single microphone, and the composer in view was as likely to lose as to win. That reads as dictation hearing nothing.
2. The composer's read-only lock followed the recogniser's `active` flag, which trails `stop()` by hundreds of milliseconds to seconds while the browser closes its speech socket. Releasing the chord left the editor locked across that whole teardown.
3. Sending mid-dictation never told the recogniser. It stayed lit until it was stopped by hand, and every word spoken after the send was discarded in silence.

## Changes

**Only the session on screen answers the chord.** `usePushToTalk` takes the mic's own root and checks `isOnScreen` before it arms, then rechecks when the arm delay elapses so switching sessions mid-hold does not open the mic behind the switch. `isOnScreen` is the helper the repo already uses for exactly this hazard (`ApprovalCard` guards its window-level key handler the same way).

**The editor lock follows intent, not the recogniser.** `onDictatingChange` now reports `transcribe.recording`, which flips the moment the chord is released. The editor's own dictation session still follows `active`, so the recogniser's trailing final result still lands where it belongs.

**A send closes the mic.** The mic leaves its stopper on `useVoiceComposer`, the same shared voice surface it already reports dictation errors and the editor lock through, and both composers call `endDictation()` as they submit. The recogniser itself stays inside the button on purpose: lifting it would re-render the whole composer on every interim word.

**A send also retires the editor's dictation session.** `submitEditorAsMarkdown` empties the root but left `dictationRef` alive, and the session recreates its nodes on demand. A trailing result arriving after the send therefore wrote the sent text straight back into the empty composer. `clear()` gets the same treatment for the same reason.

Everything except the two composer call sites lives in `@agenta/chat` and `@agenta/ui`, so desktop and `/m` are fixed together.

## Tests

Six new unit tests, each confirmed to fail with its fix reverted:

- `voiceInputButtonPushToTalk.test.tsx`: a hidden session ignores the chord; one mic opens when a hidden session is mounted alongside a visible one; the composer unlocks on release without waiting out the teardown; the mic hands the composer a working stopper.
- `usePushToTalk.test.ts`: an off-screen session never arms, and a session switched away during the arm delay does not open the mic.
- `richChatInputDictationSend.render.test.tsx`: a trailing result after a send (and after `clear()`) cannot refill the composer.

Suites: `@agenta/ui` 176/176, `@agenta/chat` 570 passing. The 8 failures in `tests/unit/state/sessionMessages.test.ts` (`localStorage` undefined) predate this branch and are untouched by it.

Verified against the running desktop app with a stubbed recogniser:

- With 3 sessions mounted and 2 hidden, one chord opened **1** recogniser. Revealing the hidden panes made the same chord open **3**, which confirms the on-screen guard is the only thing suppressing them.
- Dictated text landed, the editor was locked during dictation, and `contenteditable` was back to `true` 150ms after release with `onend` still 3 seconds away.
- Sending while dictation was still running: the mic went from "Stop voice input" back to "Hold ⌃⌥ to dictate", `stop()` was called once, the composer emptied, and it stayed empty through the trailing result and the late `onend`.

## What to QA

- Open two or more agent sessions in the playground so both tabs stay mounted. Hold ⌃⌥ in one and speak. The words land in the session you are looking at, and no microphone error appears on the other tabs.
- Hold ⌃⌥, dictate, release. The composer is editable straight away. You do not have to wait before you can edit or send.
- Dictate and press Send without stopping the mic. The message sends, the mic returns to its idle state on its own, and the composer stays empty.
- Regression: click the mic button to start and stop dictation. It still latches on the first press and stops on the second.
- Regression: dictate during agent onboarding (before the agent exists) and press Enter. The agent is created and the mic closes.

Fixes #6452
