### PR TITLE
[fix] Open an archived session in the playground [AGE-4247]

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/SessionHistoryMenu.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionHistoryMenu.tsx
@@ -255,7 +255,10 @@ const SessionHistoryList = ({onPicked}: {onPicked: () => void}) => {
                                 session={session}
                                 label={labelOf(session)}
                                 archived
-                                onOpen={() => undefined}
+                                onOpen={() => {
+                                    openSession(session.id)
+                                    onPicked()
+                                }}
                                 onDelete={() => deleteSession(session.id)}
                                 onArchive={() => archiveSession(session.id)}
                                 onUnarchive={() => unarchiveSession(session.id)}

--- a/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionRail.tsx
@@ -52,10 +52,6 @@ const TRASH_ICON = <Trash size={12} />
 const ARCHIVE_ICON = <Archive size={12} />
 const RESTORE_ICON = <ArrowCounterClockwise size={12} />
 
-// Stable no-op for an archived row's `onSelect` (archived rows aren't openable) — keeps the
-// id-taking setter identity stable so the memoized row doesn't re-render.
-const NOOP = () => {}
-
 interface SessionRailRowProps {
     session: AgentChatSession
     label: string
@@ -468,9 +464,9 @@ const SessionRail = ({activeId, addDisabled = false, className}: SessionRailProp
                                             key={session.id}
                                             session={session}
                                             label={label}
-                                            active={false}
+                                            active={session.id === currentActiveId}
                                             archived
-                                            onSelect={NOOP}
+                                            onSelect={openSession}
                                             onDelete={deleteSession}
                                             onRename={handleRename}
                                             onArchive={archiveSession}

--- a/web/oss/src/components/AgentChatSlice/state/sessions.archivedTabs.test.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.archivedTabs.test.ts
@@ -1,0 +1,119 @@
+/**
+ * Opening an archived session (#6468).
+ *
+ * Archiving closes the tab at the write site — locally, and on the next reconcile when it happened
+ * on another device. The tab list itself must therefore NOT re-filter archived sessions, or a
+ * session the user deliberately opened from the sessions page is adopted and then dropped before
+ * it can render.
+ */
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {projectIdAtom} from "@/oss/state/project"
+
+const {
+    adoptSessionAtomFamily,
+    addSessionAtomFamily,
+    archiveSessionAtomFamily,
+    reconcileServerSessionsAtomFamily,
+    sessionsListAtomFamily,
+    activeSessionIdAtomFamily,
+    unarchiveSessionAtomFamily,
+} = await import("./sessions")
+
+const SCOPE = "app-archived-tabs"
+
+const newStore = () => {
+    const store = createStore()
+    store.set(projectIdAtom, "project-1")
+    return store
+}
+
+const tabIds = (store: ReturnType<typeof createStore>) =>
+    store.get(sessionsListAtomFamily(SCOPE)).map((s) => s.id)
+
+/** The archived row as the sessions page's server list reports it. */
+const archivedOnServer = (id: string) => ({
+    id,
+    title: `session ${id}`,
+    lastMessageAt: 1,
+    archived: true,
+})
+
+describe("an archived session opened on purpose", () => {
+    it("becomes a tab, and stays one as the server confirms it is archived", () => {
+        const store = newStore()
+        // What "open in playground" does once the panel mounts: adopt by id, sight unseen.
+        store.set(adoptSessionAtomFamily(SCOPE), {id: "old", title: "session old"})
+        expect(tabIds(store)).toEqual(["old"])
+        expect(store.get(activeSessionIdAtomFamily(SCOPE))).toBe("old")
+
+        store.set(reconcileServerSessionsAtomFamily(SCOPE), [archivedOnServer("old")])
+        expect(tabIds(store)).toEqual(["old"])
+        store.set(reconcileServerSessionsAtomFamily(SCOPE), [
+            {...archivedOnServer("old"), lastMessageAt: 2},
+        ])
+        expect(tabIds(store)).toEqual(["old"])
+    })
+
+    it("stays a tab when it was already known to be archived", () => {
+        const store = newStore()
+        store.set(reconcileServerSessionsAtomFamily(SCOPE), [archivedOnServer("old")])
+        expect(tabIds(store)).toEqual([])
+
+        store.set(adoptSessionAtomFamily(SCOPE), {id: "old"})
+        expect(tabIds(store)).toEqual(["old"])
+        store.set(reconcileServerSessionsAtomFamily(SCOPE), [
+            {...archivedOnServer("old"), lastMessageAt: 2},
+        ])
+        expect(tabIds(store)).toEqual(["old"])
+    })
+})
+
+describe("archiving still closes the tab", () => {
+    it("closes it when archived here", () => {
+        const store = newStore()
+        store.set(addSessionAtomFamily(SCOPE), {id: "mine"})
+        store.set(addSessionAtomFamily(SCOPE), {id: "other"})
+        store.set(archiveSessionAtomFamily(SCOPE), "mine")
+        expect(tabIds(store)).toEqual(["other"])
+    })
+
+    it("closes it when archived on another device, and re-points the active tab", () => {
+        const store = newStore()
+        store.set(addSessionAtomFamily(SCOPE), {id: "mine"})
+        store.set(addSessionAtomFamily(SCOPE), {id: "other"})
+        // The server has to have answered first: that is what makes a later `archived: true` a
+        // change of the server's mind rather than the first thing we ever learned about it.
+        store.set(reconcileServerSessionsAtomFamily(SCOPE), [
+            {id: "mine", lastMessageAt: 1},
+            {id: "other", lastMessageAt: 1},
+        ])
+        store.set(reconcileServerSessionsAtomFamily(SCOPE), [
+            {id: "mine", lastMessageAt: 2, archived: true},
+            {id: "other", lastMessageAt: 1},
+        ])
+        expect(tabIds(store)).toEqual(["other"])
+        expect(store.get(activeSessionIdAtomFamily(SCOPE))).toBe("other")
+    })
+
+    /**
+     * The reconcile query (`internal-reconciliation`) is not among the keys the session verbs
+     * invalidate, so an unarchive never supersedes a poll already in flight. That poll answers
+     * with the pre-unarchive row, and a guard reading the LOCAL flag would read the disagreement
+     * as a remote archive and close the tab the user just restored.
+     */
+    it("keeps the tab when a stale poll contradicts a local unarchive", () => {
+        const store = newStore()
+        store.set(adoptSessionAtomFamily(SCOPE), {id: "old"})
+        store.set(reconcileServerSessionsAtomFamily(SCOPE), [archivedOnServer("old")])
+        expect(tabIds(store)).toEqual(["old"])
+
+        store.set(unarchiveSessionAtomFamily(SCOPE), "old")
+        // In flight before the unarchive landed, so it still reports the session as archived.
+        store.set(reconcileServerSessionsAtomFamily(SCOPE), [
+            {...archivedOnServer("old"), lastMessageAt: 2},
+        ])
+        expect(tabIds(store)).toEqual(["old"])
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -94,6 +94,11 @@ export interface AgentChatSession {
     /** Hidden-but-recoverable (server `archived_at`). Filtered out of the main history/tabs and
      * shown only in the archived view; unarchive clears it. Distinct from `ended` (kill). */
     archived?: boolean
+    /** The server's own last answer for `archived`, written only by the reconciler. `archived`
+     * alone cannot say who moved it: a local archive/unarchive writes it optimistically, so a
+     * stale or failed write makes local and remote disagree for reasons that are not a remote
+     * archive. Undefined until the server has answered once. */
+    remoteArchived?: boolean
 }
 
 export const GLOBAL_APP_KEY = "__global__"
@@ -280,8 +285,8 @@ export const archivedSessionHistoryAtomFamily = atomFamily((key: string) =>
     }),
 )
 
-/** Sessions shown as tabs for a scope, in tab order. Archived sessions are hidden even if a stale
- * open-tab id lingers (e.g. archived on another device — the reconciler flips the flag).
+/** Sessions shown as tabs for a scope: the open list, nothing else — archiving closes tabs where
+ * it is written, so filtering archived here too only hid deliberate opens (#6468).
  *
  * Pinned sessions lead (same project-wide pin the rail and sessions page use); a drag that lands
  * an unpinned tab among the pins is re-sorted back. */
@@ -291,7 +296,7 @@ export const sessionsListAtomFamily = atomFamily((key: string) =>
         const pinned = new Set(get(pinnedSessionIdsAtom))
         const open = currentOpenIds(get, key)
             .map((id) => byId.get(id))
-            .filter((s): s is AgentChatSession => Boolean(s) && !s!.archived)
+            .filter((s): s is AgentChatSession => Boolean(s))
         return open.sort((a, b) => Number(pinned.has(b.id)) - Number(pinned.has(a.id)))
     }),
 )
@@ -637,13 +642,14 @@ export const reconcileServerSessionsAtomFamily = atomFamily((key: string) =>
         for (const s of existing) {
             const remote = serverById.get(s.id)
             if (remote) {
-                // Archived on another device: the tab list hides it from here on, so this is its
-                // only teardown signal — mirror the local archive exactly, tab and active pointer
-                // included, or the pane keeps rendering an archived session as the active one.
-                if (remote.archived && !s.archived) retireArchivedSession(get, set, key, s.id)
+                // Archived elsewhere, per the SERVER's answer changing (#6468).
+                if (s.remoteArchived === false && remote.archived) {
+                    retireArchivedSession(get, set, key, s.id)
+                }
                 merged.push({
                     ...s,
                     serverKnown: true,
+                    remoteArchived: Boolean(remote.archived),
                     title: remote.title?.trim() ? remote.title : s.title,
                     createdAt: s.createdAt ?? remote.createdAt,
                     // Keep the freshest activity time: a local turn just settled may lead the
@@ -671,6 +677,7 @@ export const reconcileServerSessionsAtomFamily = atomFamily((key: string) =>
                 serverKnown: true,
                 ended: s.ended,
                 archived: s.archived,
+                remoteArchived: Boolean(s.archived),
             })
         }
 
@@ -686,7 +693,8 @@ export const reconcileServerSessionsAtomFamily = atomFamily((key: string) =>
                     e.lastMessageAt !== m.lastMessageAt ||
                     e.serverKnown !== m.serverKnown ||
                     e.ended !== m.ended ||
-                    e.archived !== m.archived
+                    e.archived !== m.archived ||
+                    e.remoteArchived !== m.remoteArchived
                 )
             })
         if (!changed) return

--- a/web/oss/src/components/Sidebar/dynamic/localSessionRefs.ts
+++ b/web/oss/src/components/Sidebar/dynamic/localSessionRefs.ts
@@ -78,8 +78,8 @@ export const localPlaygroundSessionRefsAtom = atom<SessionSidebarRef[]>((get) =>
             pinned: pinned.includes(session.id),
             alive: false,
             activityAt: activityAt(session),
-            // A client-created session has no server row yet, so it cannot be archived.
-            archived: false,
+            // The server source excludes archived rows, so this ref is their only way in (#6468).
+            archived: Boolean(session.archived),
             // A playground chat is never a trigger run.
             isAutomation: false,
             // Running and awaiting are DIFFERENT signals — one spins, the other goes amber — so


### PR DESCRIPTION
Fixes #6468 (AGE-4247).

## Context

Turn on archived sessions on the Sessions page, pick an archived one, and use "Open in playground". The playground opened for the right agent and showed a blank new chat instead of the session you picked.

The open path was fine. `useOpenAgentSession` queued the target, `AgentChatPanel` adopted it on arrival, and the session id landed in that scope's open-tab list. Then `sessionsListAtomFamily`, which derives the tab strip from that list, filtered archived sessions back out. The strip ended up empty, so the panel's "always keep one tab" rule seeded a fresh blank session in its place.

That filter was a second rule for an invariant the write path already enforces. Archiving closes the tab where it is written, and that is what actually keeps archived sessions out of the strip.

## Changes

`sessionsListAtomFamily` no longer filters on `archived`. The open list is the only thing that decides what is a tab.

`07240dee1a` on this release branch already taught the reconciler to close the tab on a remote archive, through `retireArchivedSession`. Its condition reads the local flag, which is not safe once an archived session can be an open tab:

```
-  if (remote.archived && !s.archived) retireArchivedSession(get, set, key, s.id)
+  if (s.remoteArchived === false && remote.archived) {
+      retireArchivedSession(get, set, key, s.id)
+  }
```

`archived` alone cannot say who moved it. A local archive or unarchive writes it optimistically, so local and remote also disagree when a local write is still in flight or has failed. The reconcile query is keyed `["internal-reconciliation", ...]` and the session verbs only invalidate `sessions-page`, `session-list` and `sidebar-sessions*`, so an unarchive never supersedes a poll already running, and a failed unarchive leaves the two disagreeing until the next 60s poll. Either way the old condition reads it as a remote archive and closes the tab.

The new `remoteArchived` field records the server's own last answer and is written only by the reconciler, so the guard asks the question it always meant to ask: did the server change its mind? A session adopted by an explicit open has no `remoteArchived` yet, so the first reconcile that reveals it is archived cannot close the tab the user opened a tick earlier.

Archived rows in the playground's own rail and history picker open too. They were inert before (`onSelect={NOOP}`, `onOpen={() => undefined}`), which left the playground claiming archived sessions could not be opened while the Sessions page offered exactly that.

`localPlaygroundSessionRefsAtom` reported `archived: false` unconditionally, on the reasoning that a client-created session has no server row to archive. Once an archived session can be the active tab that is no longer true, and the sidebar's server source asks for `includeArchived: false`, so this local ref is the only way an archived session reaches the sidebar. It now reports the real flag and the row renders dimmed like every other archived row.

Opening an archived session does not unarchive it. Mobile needed no change: it opens a session at `/sessions/[session_id]`, with no tab model and no archived filter anywhere in that path.

`remoteArchived` is persisted, so sessions already in localStorage start undefined. A cross-device archive that happened before this ships takes one extra poll to close its tab, then self-corrects. No migration needed.

## Tests

- New `sessions.archivedTabs.test.ts`: an adopted archived session becomes a tab and stays one across repeated reconciles, whether or not its archived state was already known; a stale poll contradicting a local unarchive leaves the tab alone; a remote archive closes the tab and re-points the active one; a local archive still closes it.
- Verified by hand against a local EE stack. Archived a session on the Sessions page, opened it in the playground, and it came up as the active tab with its transcript loaded.

## What to QA

- Sessions page, Archived toggle on, right-click an archived row, "Open in playground". The playground opens with that session as the active tab and its transcript loaded.
- Right-click that tab. The menu offers Unarchive, and no Rename or Pin. The session is still archived; opening it did not change that.
- Unarchive it from that menu. The tab stays open and stays open a minute later, once the next reconcile poll has been through.
- The sidebar row for an archived open tab is dimmed, like archived rows elsewhere.
- Open the session rail (maximize the chat), expand Archived, click a row. It opens as a tab.
- Regression: archive a session from its tab's context menu. The tab closes and the active tab moves to a neighbour.
- Regression: a normal, unarchived session still opens from the Sessions page exactly as before.
