### PR TITLE
[fix] Say why the first turn is parked when no provider key exists [AGE-4232]

### DIFF
--- a/web/oss/src/components/AgentChatSlice/components/ConnectModelCallout.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ConnectModelCallout.test.tsx
@@ -1,0 +1,24 @@
+/** The parked first turn states why it hasn't run and offers the way out. */
+import {renderToStaticMarkup} from "react-dom/server"
+import {describe, expect, it} from "vitest"
+
+import ConnectModelCallout from "./ConnectModelCallout"
+
+const text = (node: Parameters<typeof renderToStaticMarkup>[0]): string => {
+    const host = document.createElement("div")
+    host.innerHTML = renderToStaticMarkup(node)
+    return (host.textContent ?? "").replace(/\s+/g, " ").trim()
+}
+
+describe("ConnectModelCallout", () => {
+    it("names the missing key as the reason and offers the provider drawer", () => {
+        const rendered = text(<ConnectModelCallout />)
+
+        expect(rendered).toContain("This agent needs a model provider key")
+        expect(rendered).toContain("Set up model providers")
+    })
+
+    it("says the message is held, not lost", () => {
+        expect(text(<ConnectModelCallout />)).toContain("Your message is waiting")
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/components/ConnectModelCallout.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/ConnectModelCallout.tsx
@@ -1,0 +1,43 @@
+import {openProviderDrawerRequestAtom} from "@agenta/shared/state"
+import {Button} from "@agenta/ui/ui"
+import {useSetAtom} from "jotai"
+import {Lock} from "lucide-react"
+
+/**
+ * In-thread callout for a first turn that is parked on the connect-model gate: the message was
+ * accepted and is waiting, but nothing ran and nothing will until the project has a provider key.
+ * It stands in for the assistant's loading bubble (see TranscriptPlaceholder), so the transcript
+ * states the reason instead of spinning forever (#6441). Deliberately NOT the failed-run callout —
+ * no run failed here, because no run started.
+ *
+ * The button reuses the failed-run escape hatch: it writes `openProviderDrawerRequestAtom`, which
+ * `ConnectModelBanner` (always mounted in the composer dock) answers by opening the providers
+ * drawer. Saving a key there clears the gate and the parked seed sends itself.
+ */
+const ConnectModelCallout = () => {
+    const requestProviderDrawer = useSetAtom(openProviderDrawerRequestAtom)
+
+    return (
+        <div className="flex items-start gap-2 rounded-xl bg-[var(--ag-colorWarningBg)] px-4 py-3">
+            <Lock size={16} className="mt-px shrink-0 text-[var(--ag-colorWarningText)]" />
+            <div className="flex min-w-0 flex-col items-start gap-0.5">
+                <span className="text-xs font-medium text-[var(--ag-colorWarningText)]">
+                    This agent needs a model provider key
+                </span>
+                <span className="text-xs text-[var(--ag-colorWarningText)]">
+                    Your message is waiting — it sends as soon as a key is connected.
+                </span>
+                <Button
+                    size="sm"
+                    variant="outline"
+                    className="mt-1"
+                    onClick={() => requestProviderDrawer(true)}
+                >
+                    Set up model providers
+                </Button>
+            </div>
+        </div>
+    )
+}
+
+export default ConnectModelCallout

--- a/web/oss/src/components/AgentChatSlice/components/TranscriptPlaceholder.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/TranscriptPlaceholder.tsx
@@ -8,6 +8,7 @@ import AgentChatEmptyState from "./AgentChatEmptyState"
 import AgentChatHistoryUnavailable from "./AgentChatHistoryUnavailable"
 import {TranscriptSkeleton} from "./AgentChatSkeleton"
 import AgentMessage from "./AgentMessage"
+import ConnectModelCallout from "./ConnectModelCallout"
 import MessageRow from "./MessageRow"
 
 /**
@@ -43,6 +44,7 @@ const TranscriptPlaceholder = ({
     firstRunPrompt: string | null
     /** The composer-docked template strip is rendering — the empty state drops its starter pills. */
     showTemplateStrip: boolean
+    /** The connect-model gate is clear — a turn can actually run (`!modelBlocked`). */
     canStart: boolean
     onStart: (text: string) => void | Promise<void>
     onPrefill: (text: string) => void
@@ -53,6 +55,10 @@ const TranscriptPlaceholder = ({
         // Optimistic first turn: the submitted description as a sent user bubble + an assistant
         // loading placeholder (mirrors a real `status:"submitted"` turn), so the commit reads as
         // one continuous chat, not an empty state.
+        //
+        // Unless the connect-model gate is up — then the seed is parked, no run was ever dispatched,
+        // and a loader would spin forever (#6441). The callout says so in the thread instead, and
+        // reverts to the loader the moment a key lands and the parked seed sends itself.
         return (
             <MessageRow mid="pending-first-turn" enter>
                 <AgentMessage
@@ -62,7 +68,13 @@ const TranscriptPlaceholder = ({
                     onRewind={onRewind}
                     onClientToolOutput={onClientToolOutput}
                 />
-                <ChatBubble placement="start" variant="borderless" loading />
+                <ChatBubble
+                    placement="start"
+                    variant="borderless"
+                    className="min-w-0 max-w-[85%]"
+                    loading={canStart}
+                    content={canStart ? undefined : <ConnectModelCallout />}
+                />
             </MessageRow>
         )
     }

--- a/web/oss/src/components/pages/agent-home/PlaygroundOnboarding/useAgentOnboarding.ts
+++ b/web/oss/src/components/pages/agent-home/PlaygroundOnboarding/useAgentOnboarding.ts
@@ -10,8 +10,13 @@ import {
     useState,
 } from "react"
 
+import {connectModelGate} from "@agenta/chat/hooks"
 import {sessionStatusAtomFamily} from "@agenta/chat/state"
-import {createEphemeralAppFromTemplate} from "@agenta/entities/workflow"
+import {
+    type AgentModelCandidatesState,
+    agentModelCandidatesAtomFamily,
+    createEphemeralAppFromTemplate,
+} from "@agenta/entities/workflow"
 import {
     hasPendingHydrationAtomFamily,
     isAgentModeAtomFamily,
@@ -19,7 +24,7 @@ import {
 } from "@agenta/playground"
 import {extractApiErrorMessage} from "@agenta/shared/utils"
 import {App} from "antd"
-import {useAtomValue, useSetAtom} from "jotai"
+import {atom, useAtomValue, useSetAtom} from "jotai"
 
 import {ONBOARDING_SCOPE_KEY} from "@/oss/components/AgentChatSlice/state/scope"
 import {
@@ -37,6 +42,15 @@ import {useCreateAgent} from "../hooks/useCreateAgent"
 import OnboardingConfigPanel from "./OnboardingConfigPanel"
 import OnboardingConfigSettling from "./OnboardingConfigSettling"
 import {type OnboardingContextValue} from "./OnboardingContext"
+
+/** Stand-in for the query-backed candidate state; reads as "still loading", so the gate stays off. */
+const idleModelCandidatesAtom = atom<AgentModelCandidatesState>({
+    status: "loading",
+    candidates: [],
+    connections: [],
+    capabilities: null,
+    error: null,
+})
 
 export interface AgentOnboardingResult {
     /** True once the ephemeral has been minted (the playground can render it). */
@@ -109,6 +123,25 @@ export function useAgentOnboarding(active: boolean): AgentOnboardingResult {
         sessionStatusAtomFamily(firstRunSettled ? "" : (foundingSessionId ?? "")),
     )
     const sawRunRef = useRef(false)
+    // The connect-model gate parks the seeded run before it ever dispatches, so waiting on a run
+    // status here would keep the lock on forever (#6441). A gated project can't produce a founding
+    // run at all, so it counts as settled — same "never trap the user" rule as "error". Project-wide
+    // and entity-independent, so the candidate list alone decides it (see `useAgentModelKeyStatus`).
+    // Swapped for the inert atom once the lock is out of play, so a plain playground never
+    // subscribes to the (query-backed) candidate sources.
+    const modelCandidates = useAtomValue(
+        useMemo(
+            () =>
+                active && !firstRunSettled
+                    ? agentModelCandidatesAtomFamily(true)
+                    : idleModelCandidatesAtom,
+            [active, firstRunSettled],
+        ),
+    )
+    const modelGateActive = connectModelGate({
+        loading: modelCandidates.status !== "ready",
+        candidateCount: modelCandidates.candidates.length,
+    })
     useEffect(() => {
         if (!realEntityId || firstRunSettled) return
         if (foundingStatus === "running") {
@@ -116,11 +149,17 @@ export function useAgentOnboarding(active: boolean): AgentOnboardingResult {
             return
         }
         // Settled = the seeded run finished (ran, then left "running"), paused on the user
-        // ("awaiting" approval/input IS progress), or failed ("error" — never trap the user).
-        if (sawRunRef.current || foundingStatus === "awaiting" || foundingStatus === "error") {
+        // ("awaiting" approval/input IS progress), failed ("error" — never trap the user), or can
+        // never start because the project has no runnable model.
+        if (
+            sawRunRef.current ||
+            foundingStatus === "awaiting" ||
+            foundingStatus === "error" ||
+            modelGateActive
+        ) {
             setFirstRunSettled(true)
         }
-    }, [realEntityId, foundingStatus, firstRunSettled])
+    }, [realEntityId, foundingStatus, firstRunSettled, modelGateActive])
 
     // Post-commit chrome (session bar / connect-model banner / header mode switch) eases in a beat AFTER
     // the commit, so the send + transcript scroll settle first instead of everything moving at once.


### PR DESCRIPTION
## Context

Sign in to a workspace with no AI provider connected, type a first message into the Home composer, and press Enter. The message appears as a sent bubble, a "..." loader appears under it, and it never stops. No run request is ever sent, so nothing is waiting on the server.

The seed is parked on purpose. `useFirstRunSeed` holds the send while the connect-model gate is active, and releases it the moment a key lands. That part works. What was missing is any sign of it: `TranscriptPlaceholder` rendered the assistant loader unconditionally for a pending first turn, so a parked seed and a running seed looked identical.

The "+ new session" tab stayed locked for the same reason. Onboarding holds it until the founding run settles, and it waits on a run status. A gated project never produces a run, so the lock never lifted and the user could not start a second chat to get out.

## Changes

The pending first turn now branches on the gate. `canStart` was already passed into `TranscriptPlaceholder` (it is `!modelBlocked` at the call site), so no new state was needed.

Before, for a parked seed:

```
[ your message                    ]
                        ( ... )     <- forever
```

After:

```
[ your message                    ]
  This agent needs a model provider key
  Your message is waiting. It sends as soon as a key is connected.
  [ Set up model providers ]
```

The new `ConnectModelCallout` sits in the same borderless `ChatBubble` the loader used, so placement and width are unchanged. Its button writes `openProviderDrawerRequestAtom`, the same hand-off the failed-run callout already uses, and `ConnectModelBanner` opens the drawer as it does today. No new plumbing, and the existing connect, unlock, and auto-send sequence is untouched.

It is deliberately not the failed-run callout. Nothing failed here, because nothing ran.

For the lock, `useAgentOnboarding` now treats an active gate as a settled first run, alongside `error`. Same rule: never trap the user. The candidate atom is swapped for an inert one once the lock is out of play, so a plain playground does not subscribe to the query-backed candidate sources.

## Tests

- `ConnectModelCallout.test.tsx`, static-render, same shape as the existing `AgentMessage.runError.test.tsx`.
- `pnpm lint-fix` and `tsc` clean. The 5 existing `RunErrorBody` tests still pass.
- Not verified in the running app. The dev server did not finish a cold Turbopack compile in the time available, so this is verified by types, lint, and unit tests only. The QA steps below are worth running before merge.

## What to QA

- In a workspace with no provider connected, type a first message on Home and press Enter. The thread shows the callout under your message, not a spinner.
- Click "Set up model providers" on that callout. The providers drawer opens.
- Save a key from that drawer without leaving the page. The callout goes away and your held message sends by itself.
- With the callout up, click "+ new session". It is enabled, and a second session opens.
- Regression: in a workspace that already has a key, send a first message from Home. You still get the loader, and the run starts as before.
- Regression: reloading while the callout is up still loses the typed message and shows "History no longer available". That is unchanged and out of scope here (issue #6441 defers persisting the parked seed).

Closes #6441
