### PR TITLE
[fix] Show a subagent's current name instead of a copy from when it was added [AGE-4235]

### DIFF
--- a/sdks/python/agenta/sdk/agents/platform/workflow.py
+++ b/sdks/python/agenta/sdk/agents/platform/workflow.py
@@ -64,7 +64,7 @@ class AgentaWorkflowToolResolver:
         authorization = self._connection.authorization()
 
         # Resolve every model-visible name up front. Sanitizing can merge two distinct children
-        # onto one name ("Support Router" and "Support/Router" both become `Support_Router`), and
+        # onto one name ("support router" and "support/router" both become `support_router`), and
         # a duplicate name silently shadows the earlier tool instead of erroring — so the second
         # subagent would simply never be callable. This is the only place that sees siblings.
         names_by_call_ref = disambiguate_tool_names(
@@ -103,12 +103,10 @@ class AgentaWorkflowToolResolver:
             tool_specs.append(
                 CallbackToolSpec(
                     name=resolved_name,
-                    # The DESCRIPTION keeps the authored display name when there is one: that is
-                    # what the model reads to decide whether to call this subagent, and the
-                    # sanitized wire name may have lost the spacing that made it readable.
-                    description=tool_config.description
-                    or tool_config.name
-                    or resolved_name,
+                    # The DESCRIPTION is what the model reads to decide whether to call this
+                    # subagent, so it never falls back to the stored `name`: that copy goes stale
+                    # the moment the target is renamed (#6444).
+                    description=tool_config.description or resolved_name,
                     # Expand Agenta catalog pointers (``x-ag-type-ref``, e.g. ``messages``) into
                     # concrete JSON Schema so the harness sees a real shape (an array WITH items,
                     # not a bare ``x-ag-type-ref``) and can construct the call. Reference tools are

--- a/sdks/python/agenta/sdk/agents/tools/models.py
+++ b/sdks/python/agenta/sdk/agents/tools/models.py
@@ -378,7 +378,15 @@ class ReferenceToolConfig(ToolConfigBase):
         default=None,
         description="Pin a workflow revision (ref_by='variant' only); absent = latest.",
     )
-    name: Optional[str] = Field(default=None, min_length=1)
+    name: Optional[str] = Field(
+        default=None,
+        min_length=1,
+        description=(
+            "Legacy: a copy of the target's display name, taken when the subagent was added. "
+            "Renaming the target never reached it, so nothing reads it any more (#6444). Kept "
+            "only so configurations saved before then still parse."
+        ),
+    )
     description: Optional[str] = None
     input_schema: Dict[str, Any] = Field(default_factory=_empty_object_schema)
 
@@ -403,15 +411,18 @@ class ReferenceToolConfig(ToolConfigBase):
 
     @property
     def tool_name(self) -> str:
-        """The model-visible name; defaults to the workflow slug when none is authored.
+        """The model-visible name: the workflow SLUG, never the stored display name.
 
-        Sanitized to the provider's tool-name pattern, because the authored `name` is a DISPLAY
-        name a person typed and may contain spaces or punctuation the provider refuses. The
-        display name itself is never rewritten — only this wire value. Collisions between two
-        children that sanitize alike are resolved by the caller building the tool list, which is
-        the only place that can see siblings.
+        The slug is the reference's only identity and a rename never touches it, so this is
+        stable inside a conversation AND correct after the target is renamed — the stored `name`
+        was neither, because it was a copy taken at add time (#6444).
+
+        Still sanitized to the provider's tool-name pattern: a slug authored through the API
+        rather than the UI need not match it, and a name the provider refuses fails the whole
+        tool list. Collisions between two slugs that sanitize alike are resolved by the caller
+        building the tool list, which is the only place that can see siblings.
         """
-        return sanitize_tool_name(self.name, fallback=self.slug)
+        return sanitize_tool_name(self.slug, fallback=self.slug)
 
     @property
     def call_ref(self) -> str:

--- a/sdks/python/agenta/sdk/agents/tools/models.py
+++ b/sdks/python/agenta/sdk/agents/tools/models.py
@@ -383,8 +383,9 @@ class ReferenceToolConfig(ToolConfigBase):
         min_length=1,
         description=(
             "Legacy: a copy of the target's display name, taken when the subagent was added. "
-            "Renaming the target never reached it, so nothing reads it any more (#6444). Kept "
-            "only so configurations saved before then still parse."
+            "Renaming the target never reached it, so no wire value derives from it any more "
+            "(#6444); the browser still reads it as a placeholder on a reference saved before "
+            "then. Kept so those configurations still parse."
         ),
     )
     description: Optional[str] = None

--- a/sdks/python/agenta/sdk/agents/tools/models.py
+++ b/sdks/python/agenta/sdk/agents/tools/models.py
@@ -28,19 +28,19 @@ def _empty_object_schema() -> Dict[str, Any]:
 _TOOL_NAME_ALLOWED = re.compile(r"[^a-zA-Z0-9_.-]+")
 
 
-def sanitize_tool_name(raw: Optional[str], *, fallback: str) -> str:
-    """Coerce an authored name into the provider's tool-name pattern.
+def sanitize_tool_name(raw: Optional[str], *, fallback: str = "") -> str:
+    """Coerce a name into the provider's tool-name pattern.
 
-    A subagent's model-visible name is a DISPLAY name the user typed, so it can carry spaces,
-    slashes, or anything else a person writes. Sending it unchanged made the provider refuse the
-    entire tool list with `Invalid 'tools[N].name'`, which bricks every run of the parent agent
-    until the child is renamed. Names like "Support Router" are an ordinary thing to type.
+    Every major provider requires `^[a-zA-Z0-9_.-]+$` and refuses the WHOLE tool list when any
+    entry violates it, which bricks every run of the parent agent. A subagent's name comes from
+    its workflow slug, and a slug saved through the platform already matches; this guards the
+    one that did not, because `ReferenceToolConfig.slug` is an unvalidated string a hand-authored
+    configuration can fill with anything.
 
     The mapping is deterministic and stable, because the model sees this name and a name that
     changed between turns would strand a conversation mid-tool-call: every disallowed run of
     characters becomes one `_`, leading and trailing separators are trimmed, and an input that
-    survives none of that falls back to `fallback` (itself sanitized). Only the WIRE name is
-    touched; the display name is never rewritten.
+    survives none of that falls back to `fallback` (itself sanitized), then to "tool".
     """
     collapsed = _TOOL_NAME_ALLOWED.sub("_", (raw or "").strip())
     # Trim separators the collapse may have produced at either end. `.` and `-` are legal
@@ -382,10 +382,8 @@ class ReferenceToolConfig(ToolConfigBase):
         default=None,
         min_length=1,
         description=(
-            "Legacy: a copy of the target's display name, taken when the subagent was added. "
-            "Renaming the target never reached it, so no wire value derives from it any more "
-            "(#6444); the browser still reads it as a placeholder on a reference saved before "
-            "then. Kept so those configurations still parse."
+            "Legacy: a stale copy of the target's display name (#6444). No wire value derives "
+            "from it; kept so references saved before then still parse."
         ),
     )
     description: Optional[str] = None
@@ -423,7 +421,7 @@ class ReferenceToolConfig(ToolConfigBase):
         tool list. Collisions between two slugs that sanitize alike are resolved by the caller
         building the tool list, which is the only place that can see siblings.
         """
-        return sanitize_tool_name(self.slug, fallback=self.slug)
+        return sanitize_tool_name(self.slug)
 
     @property
     def call_ref(self) -> str:

--- a/sdks/python/agenta/sdk/agents/tools/resolver.py
+++ b/sdks/python/agenta/sdk/agents/tools/resolver.py
@@ -138,12 +138,11 @@ def _validate_declared_config_names(tool_configs: Sequence[ToolConfig]) -> None:
             continue
         if isinstance(tool_config, ReferenceToolConfig):
             # A reference tool's model-visible name is DERIVED: its workflow slug, sanitized to
-            # the provider's tool-name pattern. Two distinct children can therefore arrive here
-            # sharing one name ("support router" and "support/router" both sanitize to
-            # `support_router`) without either being a mistake. The workflow adapter gives
-            # them distinct names before they reach the wire, and `_validate_unique_names` still
-            # checks the result, so rejecting them here would refuse a valid configuration. The
-            # reserved-name check still applies — that one is about shadowing a built-in.
+            # the provider's tool-name pattern. Two slugs can therefore arrive here sharing one
+            # name, and the workflow adapter gives them distinct names before they reach the wire
+            # while `_validate_unique_names` still checks the result. Rejecting here would refuse
+            # a pair the adapter handles. The reserved-name check still applies — that one is
+            # about shadowing a built-in.
             _reject_reserved_tool_name(name)
             continue
         _check_tool_name(name, seen)

--- a/sdks/python/agenta/sdk/agents/tools/resolver.py
+++ b/sdks/python/agenta/sdk/agents/tools/resolver.py
@@ -137,10 +137,10 @@ def _validate_declared_config_names(tool_configs: Sequence[ToolConfig]) -> None:
         if name is None:
             continue
         if isinstance(tool_config, ReferenceToolConfig):
-            # A reference tool's model-visible name is DERIVED: an authored display name,
-            # sanitized to the provider's tool-name pattern. Two distinct children can therefore
-            # arrive here sharing one name ("Support Router" and "Support/Router" both sanitize
-            # to `Support_Router`) without either being a mistake. The workflow adapter gives
+            # A reference tool's model-visible name is DERIVED: its workflow slug, sanitized to
+            # the provider's tool-name pattern. Two distinct children can therefore arrive here
+            # sharing one name ("support router" and "support/router" both sanitize to
+            # `support_router`) without either being a mistake. The workflow adapter gives
             # them distinct names before they reach the wire, and `_validate_unique_names` still
             # checks the result, so rejecting them here would refuse a valid configuration. The
             # reserved-name check still applies — that one is about shadowing a built-in.

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_models.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_models.py
@@ -22,9 +22,9 @@ def test_reference_tool_variant_call_ref_grammar():
     )
     # ref_by defaults to "variant".
     assert ReferenceToolConfig(slug="wf").ref_by == "variant"
-    # The model-visible name defaults to the slug when none is authored.
+    # The model-visible name IS the slug; a stored display name never reaches it (#6444).
     assert ReferenceToolConfig(slug="wf").tool_name == "wf"
-    assert ReferenceToolConfig(slug="wf", name="run").tool_name == "run"
+    assert ReferenceToolConfig(slug="wf", name="run").tool_name == "wf"
 
 
 def test_reference_tool_environment_call_ref_grammar():

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_subagent_tool_name.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_subagent_tool_name.py
@@ -1,20 +1,25 @@
-"""Subagent tool names must satisfy the provider's tool-name pattern (E4).
+"""A subagent's model-visible tool name is its workflow SLUG (E4, #6444).
 
-THE BUG. A subagent's model-visible name is a DISPLAY name the user typed in the Subagents UI, and
-it reached the provider verbatim. Every major provider requires `^[a-zA-Z0-9_.-]+$` for a tool
-name and refuses the WHOLE `tools` array when any entry violates it, so adding a child called
-"QA-v0.114.4 Helper" made every run of the parent fail with `Invalid 'tools[23].name'` until the
-child was renamed. "Support Router" is an ordinary thing to type.
+TWO BUGS, ONE DERIVATION. `ReferenceToolConfig.tool_name` used to return the display name the
+author typed in the Subagents UI, and that name was wrong in two different ways.
 
-The derivation itself is old — `ReferenceToolConfig.tool_name` has returned `self.name or
-self.slug` since 2026-06-26 — but nothing put an authored display name in front of it until the
-Subagents UI shipped, so the latent break became reachable.
+  IT WAS INVALID. Every major provider requires `^[a-zA-Z0-9_.-]+$` for a tool name and refuses
+  the WHOLE `tools` array when any entry violates it, so a child called "QA-v0.114.4 Helper" made
+  every run of the parent fail with `Invalid 'tools[23].name'`.
+
+  IT WAS STALE. The name was a COPY, taken when the subagent was added, and renaming the child
+  never reached it. The model was told about an agent that no longer went by that name, and the
+  only cure was to remove the subagent and add it again.
+
+The slug fixes both at once: it already matches the provider pattern, and a rename never touches
+it. Sanitizing stays, because a slug authored through the API rather than the UI need not match.
 
 Two properties are load-bearing beyond "it is valid now":
 
   STABILITY. The model sees this name. A name that changed between turns would strand a
   conversation mid-tool-call, so the mapping is deterministic and the collision discriminator is
-  derived from the tool's own identity rather than its position in the list.
+  derived from the tool's own identity rather than its position in the list. A rename during an
+  open conversation must not move it.
 
   DISTINCTNESS. Sanitizing can merge two different children onto one name, and a duplicate tool
   name silently SHADOWS the earlier tool rather than erroring — the second subagent would simply
@@ -37,70 +42,74 @@ from agenta.sdk.agents.tools import (
 PROVIDER_TOOL_NAME = re.compile(r"^[a-zA-Z0-9_.-]+$")
 
 
-@pytest.mark.parametrize(
-    "display_name",
-    [
-        "QA-v0.114.4 Helper",  # the live repro
-        "Support Router",  # the ordinary case that bricks a parent
-        "Café Assistant",  # non-ASCII
-        "billing/refunds",  # a slash
-        "deploy (staging)",  # brackets
-        "  padded  ",  # leading and trailing space
-        "emoji 🚀 agent",  # astral plane
-        "tabs\tand\nnewlines",
-        "a" * 200,  # long, but every character legal
-    ],
-)
-def test_every_authored_display_name_produces_a_valid_tool_name(display_name):
-    name = ReferenceToolConfig(slug="wf", name=display_name).tool_name
-    assert PROVIDER_TOOL_NAME.match(name), f"{display_name!r} -> {name!r}"
-
-
-def test_a_clean_name_passes_through_unchanged():
-    # The common case must not be disfigured: a name already matching the pattern is the name.
-    for clean in ["summarizer", "Support_Router", "billing-v2", "agent.v1", "A1"]:
-        assert ReferenceToolConfig(slug="wf", name=clean).tool_name == clean
-
-
-def test_the_spaced_repro_becomes_the_obvious_thing():
-    assert (
-        ReferenceToolConfig(slug="wf", name="QA-v0.114.4 Helper").tool_name
-        == "QA-v0.114.4_Helper"
-    )
-    assert (
-        ReferenceToolConfig(slug="wf", name="Support Router").tool_name
-        == "Support_Router"
-    )
-
-
-def test_runs_of_disallowed_characters_collapse_to_one_separator():
-    # "a___b" from "a   b" would be noise; the model reads this name.
-    assert sanitize_tool_name("a   b", fallback="wf") == "a_b"
-    assert sanitize_tool_name("a // b", fallback="wf") == "a_b"
-
-
-def test_separators_are_trimmed_from_both_ends():
-    assert sanitize_tool_name("  spaced  ", fallback="wf") == "spaced"
-    assert sanitize_tool_name("...dots...", fallback="wf") == "dots"
-    assert sanitize_tool_name("---", fallback="wf") == "wf"
-
-
-class TestFallback:
-    """A name that survives sanitization empty must still produce something callable."""
-
-    def test_a_symbol_only_name_falls_back_to_the_slug(self):
-        assert ReferenceToolConfig(slug="my-workflow", name="🚀🚀🚀").tool_name == (
-            "my-workflow"
-        )
-        assert ReferenceToolConfig(slug="my-workflow", name="///").tool_name == (
-            "my-workflow"
+class TestTheWireNameIsTheSlug:
+    def test_the_slug_is_the_tool_name(self):
+        assert ReferenceToolConfig(slug="support-router-k3f9").tool_name == (
+            "support-router-k3f9"
         )
 
-    def test_no_authored_name_uses_the_slug_as_before(self):
-        assert ReferenceToolConfig(slug="summarizer").tool_name == "summarizer"
+    @pytest.mark.parametrize(
+        "display_name",
+        [
+            "QA-v0.114.4 Helper",  # the live repro
+            "Support Router",  # the ordinary case that bricked a parent
+            "Café Assistant",  # non-ASCII
+            "billing/refunds",  # a slash
+            "deploy (staging)",  # brackets
+            "emoji 🚀 agent",  # astral plane
+            "tabs\tand\nnewlines",
+        ],
+    )
+    def test_a_stored_display_name_cannot_reach_the_wire(self, display_name):
+        # Whatever a legacy configuration carries, the provider only ever sees the slug — so no
+        # authored name can produce `Invalid 'tools[N].name'` again.
+        config = ReferenceToolConfig(slug="wf", name=display_name)
+        assert config.tool_name == "wf"
+        assert PROVIDER_TOOL_NAME.match(config.tool_name)
 
-    def test_a_slug_needing_sanitizing_is_sanitized_too(self):
-        assert sanitize_tool_name(None, fallback="my workflow") == "my_workflow"
+    def test_renaming_the_child_does_not_move_the_name(self):
+        # The staleness bug and the stability property have the same answer: the slug. Two
+        # configs for the same child, saved either side of a rename, agree on the wire name.
+        before = ReferenceToolConfig(slug="helper-9f21", name="Helper One")
+        after = ReferenceToolConfig(slug="helper-9f21", name="Helper Two")
+        assert before.tool_name == after.tool_name == "helper-9f21"
+
+    def test_a_slug_needing_sanitizing_is_sanitized(self):
+        # UI-made slugs already match the pattern; one authored through the API need not.
+        assert ReferenceToolConfig(slug="my workflow").tool_name == "my_workflow"
+
+    def test_the_stored_name_itself_is_never_rewritten(self):
+        # Only the wire name is derived. Anything still reading `name` off a legacy config sees
+        # exactly what was saved.
+        config = ReferenceToolConfig(slug="wf", name="Support Router")
+        assert config.name == "Support Router"
+
+
+class TestSanitizing:
+    """The pattern guard, exercised directly — `tool_name` is only its most important caller."""
+
+    def test_a_clean_name_passes_through_unchanged(self):
+        for clean in ["summarizer", "Support_Router", "billing-v2", "agent.v1", "A1"]:
+            assert sanitize_tool_name(clean, fallback="wf") == clean
+
+    def test_the_spaced_repro_becomes_the_obvious_thing(self):
+        assert sanitize_tool_name("QA-v0.114.4 Helper", fallback="wf") == (
+            "QA-v0.114.4_Helper"
+        )
+
+    def test_runs_of_disallowed_characters_collapse_to_one_separator(self):
+        # "a___b" from "a   b" would be noise; the model reads this name.
+        assert sanitize_tool_name("a   b", fallback="wf") == "a_b"
+        assert sanitize_tool_name("a // b", fallback="wf") == "a_b"
+
+    def test_separators_are_trimmed_from_both_ends(self):
+        assert sanitize_tool_name("  spaced  ", fallback="wf") == "spaced"
+        assert sanitize_tool_name("...dots...", fallback="wf") == "dots"
+        assert sanitize_tool_name("---", fallback="wf") == "wf"
+
+    def test_a_symbol_only_input_falls_back(self):
+        assert sanitize_tool_name("🚀🚀🚀", fallback="my-workflow") == "my-workflow"
+        assert sanitize_tool_name("///", fallback="my-workflow") == "my-workflow"
 
     def test_a_last_resort_name_when_everything_sanitizes_empty(self):
         # Not reachable through the model today (`slug` has min_length=1 and is a slug), but the
@@ -112,17 +121,17 @@ class TestFallback:
 class TestCollisions:
     def test_two_names_that_sanitize_alike_stay_distinct(self):
         pairs = [
-            ("workflow.variant.a", "Support_Router"),
-            ("workflow.variant.b", "Support_Router"),
+            ("workflow.variant.a", "support_router"),
+            ("workflow.variant.b", "support_router"),
         ]
         resolved = disambiguate_tool_names(pairs)
         assert resolved["workflow.variant.a"] != resolved["workflow.variant.b"]
         for name in resolved.values():
             assert PROVIDER_TOOL_NAME.match(name)
-            assert name.startswith("Support_Router")
+            assert name.startswith("support_router")
 
     def test_a_name_with_no_collision_is_left_alone(self):
-        # Only the colliding names are decorated, so the common case keeps the name the user
+        # Only the colliding names are decorated, so the common case keeps the slug the user
         # recognizes from the UI.
         pairs = [
             ("workflow.variant.a", "summarizer"),
@@ -160,40 +169,30 @@ class TestCollisions:
         assert resolved["workflow.variant.c"] == "unique"
 
 
-def test_the_display_name_itself_is_never_rewritten():
-    # Only the wire name changes. The UI, the config, and anything else reading `name` must still
-    # see exactly what the user typed.
-    config = ReferenceToolConfig(slug="wf", name="Support Router")
-    assert config.name == "Support Router"
-    assert config.tool_name == "Support_Router"
-
-
 class TestResolverInteraction:
-    """Sanitizing must not make the resolver reject a configuration that is actually fine."""
+    """The declared-name pass must not reject a configuration that is actually fine."""
 
-    def test_two_display_names_that_sanitize_alike_are_not_a_duplicate_error(self):
+    def test_two_slugs_that_sanitize_alike_are_not_a_duplicate_error(self):
         # The early declared-name pass runs BEFORE the adapter disambiguates, so it would see two
-        # `Support_Router` entries. Rejecting there would turn the fix into a different outage:
+        # `support_router` entries. Rejecting there would turn the fix into a different outage:
         # the user could no longer save the pair at all.
         from agenta.sdk.agents.tools.resolver import _validate_declared_config_names
 
         _validate_declared_config_names(
             [
-                ReferenceToolConfig(slug="a", name="Support Router"),
-                ReferenceToolConfig(slug="b", name="Support/Router"),
+                ReferenceToolConfig(slug="support router"),
+                ReferenceToolConfig(slug="support/router"),
             ]
         )
 
     def test_a_reference_tool_may_still_not_shadow_a_builtin(self):
         # The other half of that pass is about a custom tool silently replacing a harness
-        # built-in, which sanitizing does nothing to excuse.
+        # built-in, which deriving from the slug does nothing to excuse.
         from agenta.sdk.agents.tools.errors import ReservedToolNameError
         from agenta.sdk.agents.tools.resolver import _validate_declared_config_names
 
         with pytest.raises(ReservedToolNameError):
-            _validate_declared_config_names(
-                [ReferenceToolConfig(slug="wf", name="read")]
-            )
+            _validate_declared_config_names([ReferenceToolConfig(slug="read")])
 
     def test_a_genuine_duplicate_among_other_tool_kinds_still_raises(self):
         from agenta.sdk.agents.tools import ClientToolConfig

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -78,7 +78,11 @@ import {
     ConnectedSubagentList,
     SubagentDrawerContainer,
 } from "./agentTemplate/SubagentDrawerContainer"
-import {SubagentHeaderIcon, SubagentOpenAgentButton} from "./agentTemplate/SubagentHeader"
+import {
+    SubagentHeaderIcon,
+    SubagentHeaderTitle,
+    SubagentOpenAgentButton,
+} from "./agentTemplate/SubagentHeader"
 import {
     selectSubagentTools,
     SubagentList,
@@ -1100,7 +1104,17 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
                                         ? subagentHeaderIcon
                                         : def.icon
                               }
-                              title={def.drawerTitle(draft)}
+                              title={
+                                  isSubagent && workflowReference ? (
+                                      <SubagentHeaderTitle
+                                          bridge={workflowReference}
+                                          slug={editingSubagentSlug}
+                                          fallback={def.drawerTitle(draft)}
+                                      />
+                                  ) : (
+                                      def.drawerTitle(draft)
+                                  )
+                              }
                               badge={
                                   bareChrome || isSubagent
                                       ? undefined

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/SubagentDrawerContainer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/SubagentDrawerContainer.tsx
@@ -19,6 +19,7 @@ import {toolReferenceSlug} from "./itemDescriptors"
 import {SubagentList, type SubagentListProps} from "./ToolManagementList"
 
 const iconFamily = (id: string) => agentIconAtomFamily(id)
+const artifactNameFamily = (id: string) => workflowMolecule.selectors.artifactName(id)
 
 export interface SubagentDrawerContainerProps {
     open: boolean
@@ -154,8 +155,8 @@ export function ConnectedSubagentList({
     )
     const {bySlug} = bridge.useWorkflowReferenceCatalog(savedSlugs)
 
-    // Each saved subagent's icon, from the agent it points at. The list stays presentational.
-    const iconIdsKey = useMemo(
+    // The agent each saved subagent points at. Its icon and its name both key off this id.
+    const workflowIdsKey = useMemo(
         () =>
             savedSlugs
                 .map((slug) => bySlug[slug]?.workflowId)
@@ -163,7 +164,21 @@ export function ConnectedSubagentList({
                 .join("\n"),
         [savedSlugs, bySlug],
     )
-    const iconById = useFamilyMap(iconIdsKey, iconFamily)
+    const iconById = useFamilyMap(workflowIdsKey, iconFamily)
+
+    // The CURRENT name, off the workflow ARTIFACT. The reference stores no name of its own, so a
+    // rename reaches every parent without re-adding the subagent (#6444).
+    const nameById = useFamilyMap(workflowIdsKey, artifactNameFamily)
+    const nameBySlug = useMemo(() => {
+        const map = new Map<string, string>()
+        for (const slug of savedSlugs) {
+            const workflowId = bySlug[slug]?.workflowId
+            const name = workflowId ? nameById.get(workflowId) : null
+            if (name) map.set(slug, name)
+        }
+        return map
+    }, [savedSlugs, bySlug, nameById])
+
     const chromeBySlug = useMemo(() => {
         const map = new Map<
             string,
@@ -192,5 +207,12 @@ export function ConnectedSubagentList({
         return slugs
     }, [savedSlugs, bySlug])
 
-    return <SubagentList {...listProps} nonAgentSlugs={nonAgentSlugs} chromeBySlug={chromeBySlug} />
+    return (
+        <SubagentList
+            {...listProps}
+            nonAgentSlugs={nonAgentSlugs}
+            chromeBySlug={chromeBySlug}
+            nameBySlug={nameBySlug}
+        />
+    )
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/SubagentHeader.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/SubagentHeader.tsx
@@ -1,6 +1,6 @@
-/** The subagent drawer header's two resolved parts. Both take the bridge as a required prop and
- *  mount only when the host supplies one, so neither calls a hook conditionally. */
-import {agentIconAtomFamily} from "@agenta/entities/workflow"
+/** The subagent drawer header's resolved parts. Each takes the bridge as a required prop and
+ *  mounts only when the host supplies one, so none of them calls a hook conditionally. */
+import {agentIconAtomFamily, workflowMolecule} from "@agenta/entities/workflow"
 import {agentIconChrome} from "@agenta/ui/agent-icon"
 import type {WorkflowReferenceBridge} from "@agenta/ui/drill-in"
 import {cn} from "@agenta/ui/styles"
@@ -30,6 +30,21 @@ export function SubagentHeaderIcon({
             {chrome.glyph}
         </span>
     )
+}
+
+/** The agent's CURRENT name, off its artifact. `fallback` covers the moment before it resolves. */
+export function SubagentHeaderTitle({
+    bridge,
+    slug,
+    fallback,
+}: {
+    bridge: WorkflowReferenceBridge
+    slug: string
+    fallback: string
+}) {
+    const {detail} = bridge.useSubagentDetail(slug)
+    const name = useAtomValue(workflowMolecule.selectors.artifactName(detail?.workflowId ?? ""))
+    return <>{name || fallback}</>
 }
 
 export function SubagentOpenAgentButton({

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
@@ -228,14 +228,15 @@ function markNonAgent(
 }
 
 /** Stable per-entry keys: the saved reference's own slug, never its array position. A config
- *  hand-authored to repeat a slug (or to omit one) falls back to position rather than colliding. */
+ *  hand-authored to repeat a slug (or to omit one) falls back to position. The two are namespaced
+ *  apart so a slug that reads like a position cannot collide with one. */
 function subagentKeys(entries: IndexedTool[]): string[] {
     const seen = new Set<string>()
     return entries.map(({item, index}) => {
         const slug = toolReferenceSlug(item)
-        if (!slug || seen.has(slug)) return `subagent-${index}`
+        if (!slug || seen.has(slug)) return `subagent-index-${index}`
         seen.add(slug)
-        return slug
+        return `subagent-slug-${slug}`
     })
 }
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
@@ -203,6 +203,8 @@ export interface SubagentListProps {
     nonAgentSlugs?: Set<string>
     /** Each subagent's icon chrome by slug. Only the caller can reach the icon record. */
     chromeBySlug?: Map<string, {glyph: ReactNode; className: string; style?: CSSProperties}>
+    /** Each subagent's CURRENT agent name by slug. Only the caller can resolve the artifact. */
+    nameBySlug?: Map<string, string>
     openEdit: (kind: "tool", index: number, item: unknown, view: ConfigItemView) => void
     removeItem: (kind: "tool", index: number) => void
     closeEditor: () => void
@@ -227,17 +229,15 @@ function markNonAgent(
 
 /** Stable per-entry key: the saved reference's own identity, never its array position. */
 function subagentKey(item: unknown, index: number): string {
-    const t = (item ?? {}) as Record<string, unknown>
-    const name = typeof t.name === "string" ? t.name : ""
-    const identity = [toolReferenceSlug(item) ?? "", name].filter(Boolean).join("|")
-    // A reference with no identity falls back to its position, rather than colliding.
-    return identity || `subagent-${index}`
+    // A reference with no slug falls back to its position, rather than colliding.
+    return toolReferenceSlug(item) || `subagent-${index}`
 }
 
 export function SubagentList({
     entries,
     nonAgentSlugs,
     chromeBySlug,
+    nameBySlug,
     openEdit,
     removeItem,
     closeEditor,
@@ -256,7 +256,11 @@ export function SubagentList({
                 <ItemRow
                     key={subagentKey(item, index)}
                     descriptor={markNonAgent(
-                        describeSubagent(item, chromeBySlug?.get(toolReferenceSlug(item) ?? "")),
+                        describeSubagent(
+                            item,
+                            chromeBySlug?.get(toolReferenceSlug(item) ?? ""),
+                            nameBySlug?.get(toolReferenceSlug(item) ?? ""),
+                        ),
                         item,
                         nonAgentSlugs,
                     )}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ToolManagementList.tsx
@@ -227,10 +227,16 @@ function markNonAgent(
     return {...descriptor, tags: [...(descriptor.tags ?? []), "not an agent"]}
 }
 
-/** Stable per-entry key: the saved reference's own identity, never its array position. */
-function subagentKey(item: unknown, index: number): string {
-    // A reference with no slug falls back to its position, rather than colliding.
-    return toolReferenceSlug(item) || `subagent-${index}`
+/** Stable per-entry keys: the saved reference's own slug, never its array position. A config
+ *  hand-authored to repeat a slug (or to omit one) falls back to position rather than colliding. */
+function subagentKeys(entries: IndexedTool[]): string[] {
+    const seen = new Set<string>()
+    return entries.map(({item, index}) => {
+        const slug = toolReferenceSlug(item)
+        if (!slug || seen.has(slug)) return `subagent-${index}`
+        seen.add(slug)
+        return slug
+    })
 }
 
 export function SubagentList({
@@ -245,6 +251,8 @@ export function SubagentList({
     emptyAdd,
     statusFor,
 }: SubagentListProps) {
+    const keys = subagentKeys(entries)
+
     if (entries.length === 0) {
         if (disabled) return null
         return <EmptyLine label="No subagents yet" add={emptyAdd} />
@@ -252,9 +260,9 @@ export function SubagentList({
 
     return (
         <div className="flex flex-col gap-2">
-            {entries.map(({item, index}) => (
+            {entries.map(({item, index}, position) => (
                 <ItemRow
-                    key={subagentKey(item, index)}
+                    key={keys[position]}
                     descriptor={markNonAgent(
                         describeSubagent(
                             item,

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/itemDescriptors.tsx
@@ -100,10 +100,14 @@ function capitalizeFirst(value: string): string {
 export function describeSubagent(
     tool: unknown,
     chrome?: {glyph: React.ReactNode; className: string; style?: React.CSSProperties},
+    currentName?: string,
 ): ItemDescriptor {
     const t = (tool ?? {}) as Record<string, unknown>
     const slug = typeof t.slug === "string" ? t.slug : undefined
-    const name = typeof t.name === "string" && t.name ? t.name : slug
+    // The target's CURRENT name wins: a reference saved before #6444 still carries a copy that a
+    // rename never reached, and that copy is only a placeholder until the artifact resolves.
+    const stored = typeof t.name === "string" && t.name ? t.name : undefined
+    const name = currentName || stored || slug
     return {
         name: name ?? "Subagent",
         // Prose, never monospace: this is an agent's name, not an identifier.

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/subagentReference.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/subagentReference.ts
@@ -1,11 +1,14 @@
 /** The one shape a saved subagent may take. A subagent always runs the target agent's latest
  *  revision, so a legacy pin (`version`, `environment`) or a forbidden `variant_id` is dropped
- *  on every write rather than left where no surface can show or clear it. */
+ *  on every write rather than left where no surface can show or clear it. `name` goes with them:
+ *  a copy of the target's name went stale on a rename (#6444), so the slug is the only identity
+ *  stored and every surface reads the current name off the agent it points at. */
 export function normalizeSubagentReference(tool: Record<string, unknown>): Record<string, unknown> {
     const {
         variant_id: _variantId,
         version: _version,
         environment: _environment,
+        name: _name,
         ref_by: _refBy,
         type: _type,
         ...rest

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/subagentReference.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/subagentReference.ts
@@ -1,8 +1,9 @@
 /** The one shape a saved subagent may take. A subagent always runs the target agent's latest
  *  revision, so a legacy pin (`version`, `environment`) or a forbidden `variant_id` is dropped
  *  on every write rather than left where no surface can show or clear it. `name` goes with them:
- *  a copy of the target's name went stale on a rename (#6444), so the slug is the only identity
- *  stored and every surface reads the current name off the agent it points at. */
+ *  a copy of the target's name went stale on a rename (#6444), so the slug is the only identity a
+ *  new write stores. A reference saved before this keeps its copy until the next write, and the
+ *  row shows it only as a placeholder until the target's current name resolves. */
 export function normalizeSubagentReference(tool: Record<string, unknown>): Record<string, unknown> {
     const {
         variant_id: _variantId,

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
@@ -68,10 +68,11 @@ export function useAgentTools({
             const latest = configRef.current
             const latestTools = Array.isArray(latest.tools) ? (latest.tools as unknown[]) : []
             if (latestTools.some((t) => toolReferenceSlug(t) === payload.slug)) return
+            // No `name`: a copy of the target's name goes stale on a rename (#6444). The
+            // description IS authored here, and seeds from the target's own description only.
             const referenceTool = normalizeSubagentReference({
                 slug: payload.slug,
-                name: wf?.name || payload.slug,
-                description: payload.description ?? wf?.description ?? wf?.name ?? "",
+                description: payload.description ?? wf?.description ?? "",
                 input_schema: inputSchema ?? {type: "object", properties: {}},
             })
             onChange({...latest, tools: [...latestTools, referenceTool]})

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useAgentTools.ts
@@ -68,8 +68,8 @@ export function useAgentTools({
             const latest = configRef.current
             const latestTools = Array.isArray(latest.tools) ? (latest.tools as unknown[]) : []
             if (latestTools.some((t) => toolReferenceSlug(t) === payload.slug)) return
-            // No `name`: a copy of the target's name goes stale on a rename (#6444). The
-            // description IS authored here, and seeds from the target's own description only.
+            // No `name`: that copy went stale on a rename (#6444). The description is authored
+            // here, so it stays, seeded from the target's own description alone.
             const referenceTool = normalizeSubagentReference({
                 slug: payload.slug,
                 description: payload.description ?? wf?.description ?? "",

--- a/web/packages/agenta-entity-ui/tests/unit/subagentName.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/subagentName.test.ts
@@ -1,0 +1,52 @@
+/** A renamed agent must not keep its old name in the parents that call it (#6444).
+ *
+ * The stored reference used to carry a COPY of the target's name, taken when the subagent was
+ * added. A rename never reached it, so the row, the drawer header and the tool the model sees all
+ * kept the dead name until the subagent was removed and added again. The slug is now the only
+ * identity stored, and the name is read live off the agent it points at. */
+import {describe, expect, it} from "vitest"
+
+import {describeSubagent} from "../../src/DrillInView/SchemaControls/agentTemplate/itemDescriptors"
+import {normalizeSubagentReference} from "../../src/DrillInView/SchemaControls/agentTemplate/subagentReference"
+
+const legacy = {
+    type: "reference",
+    ref_by: "variant",
+    slug: "helper-9f21",
+    name: "Helper One",
+    description: "Helps.",
+}
+
+describe("normalizeSubagentReference", () => {
+    it("drops the name copy, so no write can reintroduce the staleness", () => {
+        const saved = normalizeSubagentReference(legacy)
+        expect(saved).not.toHaveProperty("name")
+        expect(saved).toMatchObject({type: "reference", ref_by: "variant", slug: "helper-9f21"})
+    })
+
+    it("keeps the description, which is authored on the reference itself", () => {
+        expect(normalizeSubagentReference(legacy).description).toBe("Helps.")
+    })
+
+    it("still drops the legacy pins it always dropped", () => {
+        const saved = normalizeSubagentReference({...legacy, version: "2", variant_id: "v1"})
+        expect(saved).not.toHaveProperty("version")
+        expect(saved).not.toHaveProperty("variant_id")
+    })
+})
+
+describe("describeSubagent", () => {
+    it("shows the target's current name, not the copy saved beside it", () => {
+        expect(describeSubagent(legacy, undefined, "Helper Two").name).toBe("Helper Two")
+    })
+
+    it("falls back to the stored copy while the artifact is still resolving", () => {
+        // A raw slug would be a worse placeholder than the name the row showed a moment ago.
+        expect(describeSubagent(legacy).name).toBe("Helper One")
+    })
+
+    it("falls back to the slug for a reference saved without a name", () => {
+        const saved = normalizeSubagentReference(legacy)
+        expect(describeSubagent(saved).name).toBe("helper-9f21")
+    })
+})

--- a/web/packages/agenta-entity-ui/tests/unit/subagentName.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/subagentName.test.ts
@@ -2,8 +2,9 @@
  *
  * The stored reference used to carry a COPY of the target's name, taken when the subagent was
  * added. A rename never reached it, so the row, the drawer header and the tool the model sees all
- * kept the dead name until the subagent was removed and added again. The slug is now the only
- * identity stored, and the name is read live off the agent it points at. */
+ * kept the dead name until the subagent was removed and added again. A new write now stores the
+ * slug alone, and the current name is passed in from the agent the slug points at; a reference
+ * saved before this still shows its copy as a placeholder while that name resolves. */
 import {describe, expect, it} from "vitest"
 
 import {describeSubagent} from "../../src/DrillInView/SchemaControls/agentTemplate/itemDescriptors"


### PR DESCRIPTION
## Context

Rename an agent that another agent calls as a subagent, and every parent keeps showing the old name. Reloads do not clear it, new chat sessions do not clear it, and the only cure is to remove the subagent and add it again.

The name was a copy. When you added a subagent, the picker wrote the target's name onto the saved reference, and a rename never went back to touch that copy. Resolution was never affected: identity is carried by the slug, which a rename does not change.

The stale copy was not only cosmetic. It became the tool name the model sees, and the copied description is what the model reads to decide whether to call the subagent, so the model was told about an agent that no longer went by that name.

## Changes

The slug is now the only identity stored. `normalizeSubagentReference` drops `name` on every write, beside the legacy pins it already dropped, and the picker stops writing it.

Before:

```json
{"type": "reference", "ref_by": "variant", "slug": "helper-9f21",
 "name": "Helper One", "description": "Helper One", "input_schema": {}}
```

After:

```json
{"type": "reference", "ref_by": "variant", "slug": "helper-9f21",
 "description": "", "input_schema": {}}
```

Both display surfaces now read the target's current name off its workflow artifact through `workflowMolecule.selectors.artifactName`, the sanctioned selector for entity display names. The saved list keys it by the workflow id its catalog already resolves for each row's icon, so this adds no request: that artifact query is batched, and renaming invalidates it. The drawer header gets a `SubagentHeaderTitle` component that matches the icon and "Open agent" components already sitting beside it.

On the wire, `ReferenceToolConfig.tool_name` derives from the slug instead of the stored display name. A slug never moves under a rename, so the name the model sees is stable inside a conversation and correct after a rename, which the copied name was neither. The tool description no longer falls back to that copy either. The field stays on the model so configurations saved before this still parse.

The description remains stored, because it is authored on the reference itself. Its default no longer falls back to the target's name, which is what produced a row that read the same name twice.

## Tests

- New `subagentName.test.ts` covers the write path dropping `name` and the row preferring the live name, with the stored copy kept as the placeholder while the artifact resolves.
- `test_subagent_tool_name.py` now pins the new contract: whatever a legacy config carries, the wire name is the slug, and two configs saved either side of a rename agree on it.
- Suites run: 486 SDK, 610 `@agenta/entity-ui`, 1475 `@agenta/entities`, 144 `@agenta/mobile`.
- Verified against a local EE stack. Added `teach-me` as a subagent of `technical-writer`, renamed it to "Teach Me Renamed", reloaded the parent, and confirmed both the row and the drawer header follow. The saved revision carries no `name`, so the name on screen can only be coming from the artifact.
- Not smoke-tested on `/m`: the mobile service is not running in my stack and has no built image, and on a spare port it is refused by the API's CORS allowlist. The mobile app does compile and boot this package code with no module errors, and its unit tests pass. Every changed file is package code that mobile renders through the same component tree.

## Reviewer notes

Two consequences worth a look rather than a surprise later:

- The version history diff labels subagents by slug now. `classifyAgentChanges` is a pure function over two config snapshots with no store access, so it cannot resolve a live name. Its fallback to the slug already existed and is already tested. Fixing it properly belongs in the version history drawer, which is in flight on another branch.
- A workflow slug equal to a Pi built-in (`read`, `find`, `edit`, ...) now raises `ReservedToolNameError` where an authored display name used to mask it. The rejection is correct, since that slug genuinely would shadow the built-in on the wire. UI-created slugs carry a random four-character suffix and cannot collide, so only an API or SDK authored slug can reach it.

## What to QA

- Create two agents. Add the second to the first under Subagents, then rename the second one. The parent's Subagents row shows the new name without a reload.
- Open that subagent's drawer. The header shows the new name too.
- Add a subagent that has no description of its own. The row shows its name once, not twice.
- Regression: a subagent added before this change still runs, and its row still shows a name rather than a bare slug.

Fixes #6444
