### PR TITLE
[fix] Keep sessions and collapsed groups from disappearing off the sidebar

### DIFF
--- a/web/oss/src/components/AgentChatSlice/state/sessions.ts
+++ b/web/oss/src/components/AgentChatSlice/state/sessions.ts
@@ -272,6 +272,15 @@ export const sessionHistoryAtomFamily = atomFamily((key: string) =>
     }),
 )
 
+/** Every scope the local session store holds for this project. Lets a project-wide surface reach
+ * sessions outside the routed playground, which the per-scope families cannot name on their own.
+ * Compared by value: `Object.keys` is a fresh array each read, and its consumer feeds an effect. */
+export const sessionScopeKeysAtom = selectAtom(
+    sessionsByAppAtom,
+    (byScope) => Object.keys(byScope),
+    (a, b) => a.length === b.length && a.every((key, i) => key === b[i]),
+)
+
 /** Archived sessions for a scope, most-recently-active first. Backs the archived view. */
 export const archivedSessionHistoryAtomFamily = atomFamily((key: string) =>
     atom((get) => {

--- a/web/oss/src/components/Sidebar/dynamic/dropMissingAgentSessions.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/dropMissingAgentSessions.test.ts
@@ -1,4 +1,4 @@
-import {dropArchivedAgentSessions, withLocalSessions} from "@agenta/navigation"
+import {dropMissingAgentSessions, withLocalSessions} from "@agenta/navigation"
 import type {SessionSidebarRef} from "@agenta/navigation"
 import {describe, expect, it} from "vitest"
 
@@ -16,40 +16,41 @@ const ref = (over: Partial<SessionSidebarRef> & {id: string}): SessionSidebarRef
     ...over,
 })
 
-const ARCHIVED = new Set(["agent-archived"])
+/** The catalog lists only non-archived agents, so this is every agent still around. */
+const LIVE = new Set(["agent-live"])
 
-describe("dropArchivedAgentSessions", () => {
-    it("drops sessions whose agent is archived", () => {
-        const kept = dropArchivedAgentSessions(
+describe("dropMissingAgentSessions", () => {
+    it("drops sessions whose agent is no longer listed", () => {
+        const kept = dropMissingAgentSessions(
             [ref({id: "a", appId: "agent-archived"}), ref({id: "b", appId: "agent-live"})],
-            ARCHIVED,
+            LIVE,
         )
 
         expect(kept.map((r) => r.id)).toEqual(["b"])
     })
 
     // A pin is an explicit user request, the same exemption it gets from every other list rule.
-    it("keeps a PINNED session even when its agent is archived", () => {
-        const kept = dropArchivedAgentSessions(
+    it("keeps a PINNED session even when its agent is gone", () => {
+        const kept = dropMissingAgentSessions(
             [ref({id: "pinned", appId: "agent-archived", pinned: true})],
-            ARCHIVED,
+            LIVE,
         )
 
         expect(kept.map((r) => r.id)).toEqual(["pinned"])
     })
 
     it("keeps sessions that have no agent at all", () => {
-        const kept = dropArchivedAgentSessions([ref({id: "orphan", appId: null})], ARCHIVED)
+        const kept = dropMissingAgentSessions([ref({id: "orphan", appId: null})], LIVE)
 
         expect(kept.map((r) => r.id)).toEqual(["orphan"])
     })
 
-    // Absence of evidence is not evidence of archival: until the archived-ids query answers there
-    // is no set at all, and a pending query must never blank the group.
-    it("keeps everything until the archived answer arrives (null)", () => {
+    // The dangerous direction: an empty set would read as "every agent is gone" and blank the
+    // whole rail, so a pending or failed catalog fetch has to keep every row.
+    it("keeps everything until the catalog answers (null)", () => {
         const refs = [ref({id: "a", appId: "agent-archived"}), ref({id: "b", appId: "agent-live"})]
 
-        expect(dropArchivedAgentSessions(refs, null).map((r) => r.id)).toEqual(["a", "b"])
+        expect(dropMissingAgentSessions(refs, null).map((r) => r.id)).toEqual(["a", "b"])
     })
 
     // The filter runs before the visible cap, so a live session behind archived ones still lands
@@ -60,7 +61,7 @@ describe("dropArchivedAgentSessions", () => {
             ref({id: "live", appId: "agent-live"}),
         ]
 
-        expect(dropArchivedAgentSessions(refs, ARCHIVED).map((r) => r.id)).toEqual(["live"])
+        expect(dropMissingAgentSessions(refs, LIVE).map((r) => r.id)).toEqual(["live"])
     })
 })
 

--- a/web/oss/src/components/Sidebar/dynamic/dropMissingAgentSessions.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/dropMissingAgentSessions.test.ts
@@ -45,8 +45,7 @@ describe("dropMissingAgentSessions", () => {
         expect(kept.map((r) => r.id)).toEqual(["orphan"])
     })
 
-    // The dangerous direction: an empty set would read as "every agent is gone" and blank the
-    // whole rail, so a pending or failed catalog fetch has to keep every row.
+    // The dangerous direction: an empty set would read as "all gone" and blank the whole rail.
     it("keeps everything until the catalog answers (null)", () => {
         const refs = [ref({id: "a", appId: "agent-archived"}), ref({id: "b", appId: "agent-live"})]
 

--- a/web/oss/src/components/Sidebar/dynamic/localSessionRefs.ts
+++ b/web/oss/src/components/Sidebar/dynamic/localSessionRefs.ts
@@ -16,9 +16,9 @@ import {isValidUUID} from "@/oss/lib/helpers/validators"
 /**
  * OSS binding for `@agenta/navigation`'s local-session seam (#5974).
  *
- * Two playground sessions qualify, and neither is abandoned: the one you are looking at, and any
- * that is RUNNING or awaiting you. Scope is the routed app id, so rows disappear when you leave
- * that playground — a blank chat never lingers.
+ * A playground session qualifies while it is the one you are looking at, while it is running or
+ * awaiting you, or while the server list cannot carry it yet. Scope is the routed app id, so rows
+ * disappear when you leave that playground — a blank chat never lingers.
  *
  * `error` is settled, not live: an errored empty session is as abandoned as an untouched one.
  */
@@ -41,6 +41,19 @@ export const activePlaygroundSessionIdAtom = atom<string | null>((get) => {
     // rail pinning a selection onto a row it does not render, which then fell back to the agent.
     return isSessionHusk(active, get(sessionHasMessagesAtomFamily(active.id))) ? null : active.id
 })
+
+/**
+ * Does this session still need the local seam to be listed at all?
+ *
+ * `serverKnown` is the one signal that survives a tab switch. `isActive` and `isLive` both go false
+ * the moment you look away — `isLive` reads a record only a MOUNTED conversation writes — so a
+ * session whose first turn was still in flight vanished from the rail until the server list caught
+ * up (#6494). An unconfirmed session drops out by itself on the first reconcile.
+ */
+export const qualifiesForLocalRail = (
+    session: AgentChatSession,
+    {isActive, isLive}: {isActive: boolean; isLive: boolean},
+): boolean => isActive || isLive || !session.serverKnown
 
 export const localPlaygroundSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
     const scope = get(defaultScopeKeyAtom)
@@ -67,7 +80,12 @@ export const localPlaygroundSessionRefsAtom = atom<SessionSidebarRef[]>((get) =>
         return at ? new Date(at).toISOString() : null
     }
     return sessions
-        .filter((session) => session.id === active?.id || isLive(session.id))
+        .filter((session) =>
+            qualifiesForLocalRail(session, {
+                isActive: session.id === active?.id,
+                isLive: isLive(session.id),
+            }),
+        )
         .filter((session) => !isHusk(session))
         .map((session) => ({
             id: session.id,

--- a/web/oss/src/components/Sidebar/dynamic/localSessionRefs.ts
+++ b/web/oss/src/components/Sidebar/dynamic/localSessionRefs.ts
@@ -8,6 +8,7 @@ import {
     defaultScopeKeyAtom,
     isSessionHusk,
     sessionHasMessagesAtomFamily,
+    sessionScopeKeysAtom,
     sessionsListAtomFamily,
     type AgentChatSession,
 } from "@/oss/components/AgentChatSlice/state/sessions"
@@ -16,9 +17,9 @@ import {isValidUUID} from "@/oss/lib/helpers/validators"
 /**
  * OSS binding for `@agenta/navigation`'s local-session seam (#5974).
  *
- * A playground session qualifies while it is the one you are looking at, while it is running or
- * awaiting you, or while the server list cannot carry it yet. Scope is the routed app id, so rows
- * disappear when you leave that playground — a blank chat never lingers.
+ * A session qualifies while it is the one you are looking at, while it is running or awaiting you,
+ * or while the server list cannot carry it yet. The last of those spans EVERY playground scope, so
+ * a session survives navigating to another agent; husks never qualify, so a blank chat cannot.
  *
  * `error` is settled, not live: an errored empty session is as abandoned as an untouched one.
  */
@@ -56,12 +57,8 @@ export const qualifiesForLocalRail = (
 ): boolean => isActive || isLive || !session.serverKnown
 
 export const localPlaygroundSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
-    const scope = get(defaultScopeKeyAtom)
-    // The scope key doubles as the app id for the row's link, so it must be a real one.
-    if (!isValidUUID(scope)) return []
-    const sessions = get(sessionsListAtomFamily(scope))
+    const routedScope = get(defaultScopeKeyAtom)
     const activeId = get(activePlaygroundSessionIdAtom)
-    const active = sessions.find((session) => session.id === activeId) ?? null
     const pinned = get(pinnedSessionIdsAtom)
     const statusOf = (id: string) => get(sessionStatusAtomFamily(id))
     const isLive = (id: string) => {
@@ -79,10 +76,24 @@ export const localPlaygroundSessionRefsAtom = atom<SessionSidebarRef[]>((get) =>
         const at = session.lastMessageAt ?? session.createdAt
         return at ? new Date(at).toISOString() : null
     }
+    // EVERY playground scope, not just the routed one: a session you started and then left behind
+    // by opening a different agent is exactly the one the server list cannot show yet (#6494).
+    // A non-UUID scope (`__global__`, `drawer:*`, `onboarding`) never reconciles, so `serverKnown`
+    // is never set there and its sessions would qualify forever — those are skipped.
+    const scopeById = new Map<string, string>()
+    const sessions: AgentChatSession[] = []
+    for (const scope of get(sessionScopeKeysAtom).filter(isValidUUID)) {
+        for (const session of get(sessionsListAtomFamily(scope))) {
+            scopeById.set(session.id, scope)
+            sessions.push(session)
+        }
+    }
+    // The scope key doubles as the app id for the row's link, so it must be a real one.
+    const scopeOf = (id: string) => scopeById.get(id) ?? routedScope
     return sessions
         .filter((session) =>
             qualifiesForLocalRail(session, {
-                isActive: session.id === active?.id,
+                isActive: scopeOf(session.id) === routedScope && session.id === activeId,
                 isLive: isLive(session.id),
             }),
         )
@@ -91,8 +102,8 @@ export const localPlaygroundSessionRefsAtom = atom<SessionSidebarRef[]>((get) =>
             id: session.id,
             sessionId: session.id,
             name: session.title?.trim() || null,
-            appId: scope,
-            agentId: scope,
+            appId: scopeOf(session.id),
+            agentId: scopeOf(session.id),
             pinned: pinned.includes(session.id),
             alive: false,
             activityAt: activityAt(session),

--- a/web/oss/src/components/Sidebar/dynamic/qualifiesForLocalRail.test.ts
+++ b/web/oss/src/components/Sidebar/dynamic/qualifiesForLocalRail.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Which playground sessions the local seam must carry (#5974, #6494).
+ *
+ * The server list cannot show a session until its first turn lands, so until then this rule is the
+ * only thing keeping the row on the rail. It has regressed twice by leaning on signals that go
+ * false as soon as you look away.
+ */
+import {describe, expect, it} from "vitest"
+
+import type {AgentChatSession} from "@/oss/components/AgentChatSlice/state/sessions"
+
+import {qualifiesForLocalRail} from "./localSessionRefs"
+
+const session = (over: Partial<AgentChatSession> = {}): AgentChatSession => ({
+    id: "s1",
+    ...over,
+})
+
+/** Looking elsewhere, with nothing mounted for this session. */
+const lookedAway = {isActive: false, isLive: false}
+
+describe("qualifiesForLocalRail", () => {
+    // The repro: send the first message, switch tabs before the turn lands.
+    it("keeps a session the server has not confirmed yet", () => {
+        expect(qualifiesForLocalRail(session(), lookedAway)).toBe(true)
+    })
+
+    it("drops it once the server list can carry it", () => {
+        expect(qualifiesForLocalRail(session({serverKnown: true}), lookedAway)).toBe(false)
+    })
+
+    it("keeps the session you are looking at", () => {
+        expect(
+            qualifiesForLocalRail(session({serverKnown: true}), {isActive: true, isLive: false}),
+        ).toBe(true)
+    })
+
+    it("keeps a running or awaiting session", () => {
+        expect(
+            qualifiesForLocalRail(session({serverKnown: true}), {isActive: false, isLive: true}),
+        ).toBe(true)
+    })
+})

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -464,6 +464,8 @@ export const appWorkflowsListQueryAtom = atomWithQuery((get) => {
             const response = await queryWorkflows({
                 projectId,
                 flags: {is_evaluator: false},
+                // Non-archived, and UNPAGED: the sidebar reads "absent from this list" as
+                // "archived" to drop that agent's sessions, so a limit here would strand them.
                 lowPriority: true,
             })
             const workflows = response.workflows ?? []

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -464,8 +464,7 @@ export const appWorkflowsListQueryAtom = atomWithQuery((get) => {
             const response = await queryWorkflows({
                 projectId,
                 flags: {is_evaluator: false},
-                // Non-archived, and UNPAGED: the sidebar reads "absent from this list" as
-                // "archived" to drop that agent's sessions, so a limit here would strand them.
+                // Keep UNPAGED: the rail reads "absent from this list" as "archived" (#6457).
                 lowPriority: true,
             })
             const workflows = response.workflows ?? []

--- a/web/packages/agenta-navigation-ui/src/SidebarShell.tsx
+++ b/web/packages/agenta-navigation-ui/src/SidebarShell.tsx
@@ -6,7 +6,6 @@ import {
     sidebarAlwaysOpenGroupsAtomFamily,
     sidebarCollapsedScopeAtomFamily,
     sidebarDefaultOpenGroupsAtomFamily,
-    sidebarRouteOpenGroupsAtomFamily,
     type SidebarConfig,
     type SidebarScope,
     type SidebarSection,
@@ -47,11 +46,8 @@ const findSelectedRoute = (items: SidebarConfig[], currentPath = "") => {
     let matched: SidebarConfig | undefined
     let matchedLength = -1
     let matchedIsExact = false
-    // Full ancestor key chain of the matched item, so every enclosing group auto-opens
-    // (supports arbitrary nesting, not just the immediate parent).
-    let openKeys: string[] = []
 
-    const visit = (nodes: SidebarConfig[], ancestors: string[]) => {
+    const visit = (nodes: SidebarConfig[]) => {
         nodes.forEach((item) => {
             // A row can own more routes than it navigates to; an empty list opts it out.
             const matchLinks = item.matchLinks ?? (item.link ? [item.link] : [])
@@ -73,18 +69,17 @@ const findSelectedRoute = (items: SidebarConfig[], currentPath = "") => {
                     matched = item
                     matchedLength = matchLink.length
                     matchedIsExact = isExact
-                    openKeys = ancestors
                 }
             }
 
             if (item.submenu?.length) {
-                visit(item.submenu, [...ancestors, item.key])
+                visit(item.submenu)
             }
         })
     }
 
-    visit(items, [])
-    return {selectedKey: matched?.key, openKeys}
+    visit(items)
+    return {selectedKey: matched?.key}
 }
 
 /** Whether any row carries this key. */
@@ -106,25 +101,6 @@ export const resolveSelectedKey = (
 ): string | undefined => {
     if (!overrideKey) return routeSelectedKey
     return overrideRendered ? overrideKey : undefined
-}
-
-const findAncestorKeys = (items: SidebarConfig[], selectedKey?: string) => {
-    if (!selectedKey) return []
-
-    const visit = (nodes: SidebarConfig[], ancestors: string[]): string[] | undefined => {
-        for (const item of nodes) {
-            if (item.key === selectedKey) return ancestors
-
-            if (item.submenu?.length) {
-                const match = visit(item.submenu, [...ancestors, item.key])
-                if (match) return match
-            }
-        }
-
-        return undefined
-    }
-
-    return visit(items, []) ?? []
 }
 
 /** Groups that render no collapse control — their key must stay in the open set, or a gated
@@ -199,8 +175,6 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
     const setDefaultOpenGroups = useSetAtom(sidebarDefaultOpenGroupsAtomFamily(scope.id))
     const setAlwaysOpenGroups = useSetAtom(sidebarAlwaysOpenGroupsAtomFamily(scope.id))
     const setCollapsedScope = useSetAtom(sidebarCollapsedScopeAtomFamily(scope.id))
-    const setRouteOpenGroups = useSetAtom(sidebarRouteOpenGroupsAtomFamily(scope.id))
-    const lastSelectedKeyRef = useRef<string | undefined>(undefined)
     const selection = scope.useSelection()
     const sections = scope.useSections()
 
@@ -211,10 +185,8 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
         [visibleSections],
     )
 
-    const {selectedKey, routeOpenKeys, pinned} = useMemo(() => {
-        if (selection.mode === "controlled") {
-            return {selectedKey: selection.selectedKey, routeOpenKeys: [] as string[], pinned: true}
-        }
+    const selectedKey = useMemo(() => {
+        if (selection.mode === "controlled") return selection.selectedKey
 
         const match = findSelectedRoute(allItems, currentPath)
         // A scope may pin the selected key (e.g. onboarding shows Home selected while the route is
@@ -222,24 +194,15 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
         // URL). The override wins over the route match.
         const overrideKey = selection.selectedKeyOverride
         const overrideRendered = overrideKey ? hasItemKey(allItems, overrideKey) : false
-        return {
-            selectedKey: resolveSelectedKey(overrideKey, overrideRendered, match.selectedKey),
-            routeOpenKeys: match.openKeys,
-            pinned: overrideRendered,
-        }
+        return resolveSelectedKey(overrideKey, overrideRendered, match.selectedKey)
     }, [allItems, currentPath, selection])
 
     const selectedKeys = useMemo(() => (selectedKey ? [selectedKey] : []), [selectedKey])
     const defaultOpenKeys = useMemo(() => findDefaultOpenKeys(allItems), [allItems])
     const alwaysOpenKeys = useMemo(() => findAlwaysOpenKeys(allItems), [allItems])
-    // `routeOpenKeys` are the MATCHED row's ancestors, and a pinned key is by definition not the
-    // row the route matched — the session rail pins a row whose group the route never names. Walk
-    // to the pinned row instead, or its group stays folded around the selection.
-    const activeAncestorKeys = useMemo(
-        () => (pinned ? findAncestorKeys(allItems, selectedKey) : routeOpenKeys),
-        [allItems, pinned, routeOpenKeys, selectedKey],
-    )
     const persistedOrDefaultOpenGroups = persistedOpenGroups ?? defaultOpenKeys
+    // The route decides what is SELECTED, never what is open: expanding a matched row's ancestors
+    // persisted over a group the user had collapsed, and creating an agent reopened Agents (#6460).
     const openKeys = useMemo(
         () => uniqueKeys([...persistedOrDefaultOpenGroups, ...alwaysOpenKeys]),
         [alwaysOpenKeys, persistedOrDefaultOpenGroups],
@@ -270,32 +233,6 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
     useEffect(() => {
         setCollapsedScope(collapsed)
     }, [collapsed, setCollapsedScope])
-
-    // Same contract for the route: these ancestors render expanded without touching the persisted
-    // set, so the gate would otherwise hold their queries idle under an already-open group.
-    useEffect(() => {
-        setRouteOpenGroups((current) =>
-            haveSameKeys(current, activeAncestorKeys) ? current : activeAncestorKeys,
-        )
-    }, [activeAncestorKeys, setRouteOpenGroups])
-
-    useEffect(() => {
-        if (selectedKey === lastSelectedKeyRef.current && persistedOpenGroups !== undefined) return
-        lastSelectedKeyRef.current = selectedKey
-
-        if (!activeAncestorKeys.length) return
-
-        const nextOpenKeys = uniqueKeys([...persistedOrDefaultOpenGroups, ...activeAncestorKeys])
-        if (haveSameKeys(nextOpenKeys, persistedOrDefaultOpenGroups)) return
-
-        setPersistedOpenGroups(nextOpenKeys)
-    }, [
-        activeAncestorKeys,
-        persistedOpenGroups,
-        persistedOrDefaultOpenGroups,
-        selectedKey,
-        setPersistedOpenGroups,
-    ])
 
     const handleToggleOpenKey = useCallback(
         (key: string) => {

--- a/web/packages/agenta-navigation-ui/src/SidebarShell.tsx
+++ b/web/packages/agenta-navigation-ui/src/SidebarShell.tsx
@@ -201,8 +201,7 @@ const SidebarShell: React.FC<SidebarShellProps> = ({
     const defaultOpenKeys = useMemo(() => findDefaultOpenKeys(allItems), [allItems])
     const alwaysOpenKeys = useMemo(() => findAlwaysOpenKeys(allItems), [allItems])
     const persistedOrDefaultOpenGroups = persistedOpenGroups ?? defaultOpenKeys
-    // The route decides what is SELECTED, never what is open: expanding a matched row's ancestors
-    // persisted over a group the user had collapsed, and creating an agent reopened Agents (#6460).
+    // The route decides what is SELECTED, never what is open — it reopened collapsed groups (#6460).
     const openKeys = useMemo(
         () => uniqueKeys([...persistedOrDefaultOpenGroups, ...alwaysOpenKeys]),
         [alwaysOpenKeys, persistedOrDefaultOpenGroups],

--- a/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
+++ b/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
@@ -332,14 +332,9 @@ const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRe
 export const localSessionRefsAtom = atom<SessionSidebarRef[]>([])
 
 /**
- * Every agent the catalog still lists, or `null` while it is loading.
- *
- * The catalog excludes archived agents (`include_archived` is off), so "absent here" IS "archived"
- * — which is what lets the rail drop their sessions without paying for the archived rows.
- *
- * REQUIRES an unpaged catalog. `appWorkflowsListQueryAtom` sends no `windowing`, so the query
- * returns every agent in the project; add a limit there and an agent past the cap reads as
- * archived and loses its sessions off the rail.
+ * Every agent the catalog still lists, or `null` while it loads. It excludes archived agents, so
+ * "absent here" IS "archived". Requires an UNPAGED catalog: a limit on `appWorkflowsListQueryAtom`
+ * would make every agent past the cap read as archived and lose its sessions.
  */
 const liveAgentIdsAtom = atom<ReadonlySet<string> | null>((get) => {
     const query = get(appWorkflowsListQueryAtom)
@@ -348,14 +343,12 @@ const liveAgentIdsAtom = atom<ReadonlySet<string> | null>((get) => {
 })
 
 /**
- * Drop sessions whose agent is no longer listed (#5944, #6457) — an archived agent's conversations
- * should not keep occupying the rail. A PIN is an explicit user request and is exempt, the same
- * exemption it gets from every other list rule.
+ * Drop sessions whose agent is no longer listed (#5944, #6457). A PIN is exempt, the same exemption
+ * it gets from every other list rule.
  */
 export const dropMissingAgentSessions = (
     refs: readonly SessionSidebarRef[],
-    // `null` = the catalog has not answered; keep everything rather than blank the rail on a
-    // pending or failed fetch, which an empty set would otherwise do to EVERY row.
+    // `null` = catalog unanswered; an empty set would read as "all gone" and blank the rail.
     liveAgentIds: ReadonlySet<string> | null,
 ): SessionSidebarRef[] =>
     liveAgentIds === null

--- a/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
+++ b/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
@@ -332,36 +332,35 @@ const toSidebarRef = (row: SessionStream, pinned: Set<string>): SessionSidebarRe
 export const localSessionRefsAtom = atom<SessionSidebarRef[]>([])
 
 /**
- * The agents that have been archived, or `null` while the catalog is still loading.
+ * Every agent the catalog still lists, or `null` while it is loading.
  *
- * Archiving is `deleted_at` on the workflow ref, the same field every other "is this agent gone"
- * read uses. `null` rather than an empty set while pending: an empty set would claim NOTHING is
- * archived and let the rows render before being pulled back out.
+ * The catalog excludes archived agents (`include_archived` is off), so "absent here" IS "archived"
+ * — which is what lets the rail drop their sessions without paying for the archived rows.
+ *
+ * REQUIRES an unpaged catalog. `appWorkflowsListQueryAtom` sends no `windowing`, so the query
+ * returns every agent in the project; add a limit there and an agent past the cap reads as
+ * archived and loses its sessions off the rail.
  */
-const archivedAgentIdsAtom = atom<ReadonlySet<string> | null>((get) => {
+const liveAgentIdsAtom = atom<ReadonlySet<string> | null>((get) => {
     const query = get(appWorkflowsListQueryAtom)
     if (!query.data) return null
-    return new Set(
-        (query.data.refs ?? [])
-            .filter((ref: {deleted_at?: string | null}) => Boolean(ref.deleted_at))
-            .map((ref: {id: string}) => ref.id),
-    )
+    return new Set((query.data.refs ?? []).map((ref: {id: string}) => ref.id))
 })
 
 /**
- * Drop sessions whose agent has been archived (#5944) — an archived agent's conversations should
- * not keep occupying the rail. A PIN is an explicit user request and is exempt, the same exemption
- * it gets from every other list rule.
+ * Drop sessions whose agent is no longer listed (#5944, #6457) — an archived agent's conversations
+ * should not keep occupying the rail. A PIN is an explicit user request and is exempt, the same
+ * exemption it gets from every other list rule.
  */
-export const dropArchivedAgentSessions = (
+export const dropMissingAgentSessions = (
     refs: readonly SessionSidebarRef[],
-    // `null` = the archived-agents answer has not arrived; keep everything rather than blink rows
-    // out and back in once it does.
-    archivedAgentIds: ReadonlySet<string> | null,
+    // `null` = the catalog has not answered; keep everything rather than blank the rail on a
+    // pending or failed fetch, which an empty set would otherwise do to EVERY row.
+    liveAgentIds: ReadonlySet<string> | null,
 ): SessionSidebarRef[] =>
-    archivedAgentIds === null
+    liveAgentIds === null
         ? [...refs]
-        : refs.filter((ref) => ref.pinned || !ref.appId || !archivedAgentIds.has(ref.appId))
+        : refs.filter((ref) => ref.pinned || !ref.appId || liveAgentIds.has(ref.appId))
 
 /**
  * The rail's filters, applied to the rows the HOST contributes.
@@ -473,7 +472,7 @@ const sidebarSessionRefsAtomFamily = atomFamily((scopeId: string) =>
         // Archiving an agent has to take its conversations off the rail with it (#5944). Applied
         // to every scope, grouped or not: an archived agent's sessions are stale everywhere the
         // rail renders, not only where headings group them by agent.
-        const merged = dropArchivedAgentSessions(narrowed, get(archivedAgentIdsAtom))
+        const merged = dropMissingAgentSessions(narrowed, get(liveAgentIdsAtom))
 
         // An ungrouped scope needs neither, and the artifactName read would subscribe it to the
         // workflow catalog it never asked for.

--- a/web/packages/agenta-navigation/src/dynamic/source.ts
+++ b/web/packages/agenta-navigation/src/dynamic/source.ts
@@ -8,7 +8,6 @@ import {
     sidebarDefaultOpenGroupsAtomFamily,
     sidebarOpenGroupsAtomFamily,
     sidebarPopupGroupsAtomFamily,
-    sidebarRouteOpenGroupsAtomFamily,
 } from "../state"
 
 import type {SidebarEntityRef, SidebarEntitySource} from "./types"
@@ -38,10 +37,7 @@ export const gatedSidebarSource = <TRef extends SidebarEntityRef>(
         // flyout that is actually open can. Without this an `alwaysOpen` group (Sessions) kept
         // fetching and polling a list with nowhere to render.
         const collapsed = get(sidebarCollapsedScopeAtomFamily(scopeId))
-        // The route opens a group too, without persisting anything — see the atom's note.
-        const routeOpen = get(sidebarRouteOpenGroupsAtomFamily(scopeId)).includes(parentKey)
-        const inlineOpen =
-            !collapsed && (alwaysOpen || routeOpen || effectiveOpen.includes(parentKey))
+        const inlineOpen = !collapsed && (alwaysOpen || effectiveOpen.includes(parentKey))
         const popupOpen = get(sidebarPopupGroupsAtomFamily(scopeId)).includes(parentKey)
 
         if (!inlineOpen && !popupOpen) {

--- a/web/packages/agenta-navigation/src/index.ts
+++ b/web/packages/agenta-navigation/src/index.ts
@@ -14,7 +14,7 @@ export * from "./banners"
 export {useSidebarResize} from "./useSidebarResize"
 
 export {
-    dropArchivedAgentSessions,
+    dropMissingAgentSessions,
     localSessionRefsAtom,
     withLocalSessions,
     type SessionSidebarRef,

--- a/web/packages/agenta-navigation/src/state.ts
+++ b/web/packages/agenta-navigation/src/state.ts
@@ -78,16 +78,6 @@ export const sidebarPopupGroupsAtomFamily = atomFamily((_scopeId: string) => ato
 export const sidebarCollapsedScopeAtomFamily = atomFamily((_scopeId: string) => atom(false))
 
 /**
- * Groups the shell is holding open because the ROUTE lands inside them, published per scope.
- *
- * The fourth way a group can be open, after persisted, `defaultOpen` and `alwaysOpen` — and the
- * gate has to know about every one of them. Navigating to /agents opens the Agents group without
- * writing anything to the persisted set, so a gate reading only that set kept its query idle and
- * the expanded group rendered "Open to load" under a route that was already showing agents.
- */
-export const sidebarRouteOpenGroupsAtomFamily = atomFamily((_scopeId: string) => atom<string[]>([]))
-
-/**
  * The `defaultOpen` keys the shell is currently displaying as expanded, published per scope.
  * Not persisted: it mirrors what the user SEES so the gated entity sources agree with the
  * screen. Seeding the persisted atom instead would clobber it before storage hydrates.

--- a/web/packages/agenta-navigation/src/state.ts
+++ b/web/packages/agenta-navigation/src/state.ts
@@ -124,11 +124,8 @@ const getSidebarOpenGroupsStorageScope = (scopeId: string, projectId: string | n
     projectId ? `${scopeId}:${projectId}` : null
 
 /**
- * Which groups are expanded, per scope and project.
- *
- * Both sides no-op until the project id hydrates. A shared `__global__` bucket stood in for it,
- * which meant a first-paint write landed under a key the real project never reads — the preference
- * was lost, and every project in the browser shared the leftover.
+ * Which groups are expanded, per scope and project. Both sides no-op until the project id hydrates:
+ * the `__global__` bucket that stood in for it was written but never read back.
  */
 export const sidebarOpenGroupsAtomFamily = atomFamily((scopeId: string) =>
     atom(

--- a/web/packages/agenta-navigation/src/state.ts
+++ b/web/packages/agenta-navigation/src/state.ts
@@ -7,7 +7,6 @@ const SIDEBAR_OPEN_GROUPS_STORAGE_KEY = "agenta:sidebar:open-groups"
 const SIDEBAR_COLLAPSED_STORAGE_KEY = "agenta:sidebar:collapsed"
 const SIDEBAR_WIDTH_STORAGE_KEY = "agenta:sidebar:width"
 const LEGACY_SIDEBAR_COLLAPSED_STORAGE_KEY = "sidebarCollapsed"
-const NO_PROJECT_SCOPE = "__global__"
 
 export const SIDEBAR_COLLAPSED_WIDTH = 48
 export const SIDEBAR_DEFAULT_WIDTH = 255
@@ -120,18 +119,28 @@ const sidebarOpenGroupsStorageAtom = atomWithStorage<Record<string, string[]>>(
     {},
 )
 
+/** `null` until a project resolves — there is no bucket to read or write before then. */
 const getSidebarOpenGroupsStorageScope = (scopeId: string, projectId: string | null) =>
-    `${scopeId}:${projectId || NO_PROJECT_SCOPE}`
+    projectId ? `${scopeId}:${projectId}` : null
 
+/**
+ * Which groups are expanded, per scope and project.
+ *
+ * Both sides no-op until the project id hydrates. A shared `__global__` bucket stood in for it,
+ * which meant a first-paint write landed under a key the real project never reads — the preference
+ * was lost, and every project in the browser shared the leftover.
+ */
 export const sidebarOpenGroupsAtomFamily = atomFamily((scopeId: string) =>
     atom(
         (get) => {
             const storageScope = getSidebarOpenGroupsStorageScope(scopeId, get(projectIdAtom))
+            if (!storageScope) return undefined
             const storage = get(sidebarOpenGroupsStorageAtom)
             return storage[storageScope]
         },
         (get, set, nextOpenKeys: string[]) => {
             const storageScope = getSidebarOpenGroupsStorageScope(scopeId, get(projectIdAtom))
+            if (!storageScope) return
             const storage = get(sidebarOpenGroupsStorageAtom)
             set(sidebarOpenGroupsStorageAtom, {...storage, [storageScope]: nextOpenKeys})
         },


### PR DESCRIPTION
## Context

Four sidebar bugs, all in how the rail decides what to show.

**Archived agents kept their sessions on the rail (#6457).** The filter for this already existed. The set it matched against was always empty. `archivedAgentIdsAtom` built that set by taking the app workflows list and keeping rows with a `deleted_at`, but the query sends `include_archived: false`, so the API strips those rows before the frontend sees them. No id could ever land in the set, so the filter dropped nothing.

**Creating an agent reopened a collapsed group (#6460).** `SidebarShell` took the route-matched row's ancestors and wrote them into the persisted open-groups set. Creating an agent lands on its playground, whose row sits under Agents, so a group you had collapsed came back open and stayed open.

**A just-started session vanished from the rail (#6494).** Send the first message, switch to another session before the turn lands, and the new session disappeared until the server list caught up. The local seam that carries a session the server cannot list yet qualified it on `isActive` or `isLive`, and both go false the moment you look away. `isLive` reads a run-state record that only a mounted conversation writes, and switching sessions unmounts it.

**Every project shared one open-groups record.** The storage key fell back to a `__global__` bucket whenever the project id had not hydrated yet, so a first-paint write landed under a key the real project never reads.

## Changes

**#6457.** Invert the test instead of paying for the archived rows. The catalog lists exactly the live agents, so a session whose agent is absent from it is a session whose agent is gone. `dropArchivedAgentSessions(refs, archivedIds)` becomes `dropMissingAgentSessions(refs, liveIds)`.

Before, with an archived agent:

```
archivedAgentIds = new Set([])        // always, the API never returned the row
refs.filter(r => !archivedIds.has(r.appId))   // keeps everything
```

After:

```
liveAgentIds = new Set(["agent-a", "agent-b"])   // what the catalog lists
refs.filter(r => liveAgentIds.has(r.appId))      // drops the archived agent's rows
```

Pins stay exempt, sessions with no `appId` stay, and a pending or failed catalog still keeps every row. That last guard is load-bearing now: an empty set would read as "every agent is gone" and blank the rail.

This couples the rail to an unpaged catalog. `appWorkflowsListQueryAtom` sends no `windowing` today, and adding a limit there would strand the sessions of every agent past the cap. The atom, the filter and the commit all say so.

**#6460.** The route decides what is selected, never what is open. The effect that persisted `activeAncestorKeys` is gone, along with `routeOpenKeys`, `findAncestorKeys`, the `sidebarRouteOpenGroupsAtomFamily` publish, and the gate branch that read it. A group now opens when the user opens it, or when its config declares `defaultOpen` or `alwaysOpen`. A collapsed group no longer keeps its list query subscribed either.

**#6494.** Qualify on `!serverKnown` as well, which is exactly "the server list cannot carry this row yet". It is persisted, so a reload does not flood the rail with every open tab, and the row leaves the seam on the first reconcile. The rule is extracted as `qualifiesForLocalRail` and pinned by a test, because it has now regressed twice on signals scoped to the mount.

**Scope fix.** The storage-scope helper returns `null` when there is no project, and both the getter and setter bail on `null`. Existing `__global__` entries stay in storage and are simply no longer read.

All three land in shared packages, so the desktop rail and the mobile drawer get them together.

## Tests

- `dropMissingAgentSessions.test.ts`: 14 passing, rewritten for the inverted semantics. The null case now documents the blank-rail failure mode explicitly.
- Verified against a local EE stack, both directions: archiving an agent took the rail from 29 rows to 27 and removed exactly its 2 sessions; unarchiving brought all 29 back.
- Verified the collapse survives: seeded a collapsed Agents group, navigated to an agent page, confirmed the persisted record was untouched and the group rendered collapsed. Expanding it still loads its children, which is the regression risk of dropping the route-open gate branch.
- Ran the #6494 repro on a local EE stack: sent a first message, switched tabs, and confirmed the row stayed on the rail while the turn had settled, the session was not active, and `serverKnown` was still false. Exactly one row, no duplicate once the reconcile lands.
- Verified the scope fix by poisoning storage: seeded `main:__global__` with Agents open while the project record said collapsed. The group rendered collapsed, and a later toggle wrote to `main:<projectId>`.

One deliberate behaviour change: nothing in the repo sets `defaultOpen: true`, so with route expansion gone a group only opens when the user opens it. A deep link into a nested group no longer auto-expands it. Adding `defaultOpen` to the Agents item would restore a first-run expansion if the team wants it.

## What to QA

- Archive an agent that has sessions. Its sessions leave the sidebar rail. Unarchive it and they come back.
- Pin a session, then archive its agent. The pinned row stays, since a pin overrides every list rule.
- Collapse the Agents group, then create a new agent. The group stays collapsed and the new agent appears under it.
- Expand Agents after collapsing it. The agent rows load, no "Open to load" placeholder that never resolves.
- Switch between two projects. Each keeps its own expanded groups.
- Same checks on `/m`, which shares the shell and the filter.
- Start a new session, send the first message, and immediately switch to another session of the same agent. The new session stays in the rail instead of disappearing until the reply lands.
- Reload a playground with several open tabs. Only the sessions you would expect are listed, not every tab.
- Regression: with the network throttled or offline, the sessions rail still lists sessions rather than going empty.

Fixes #6457
Fixes #6460
Fixes #6494

