### PR TITLE
[fix] Unblock the v0.114.5 release CI: local-host alias contradiction and a quadratic regex

### DIFF
--- a/services/runner/src/tracing/otel.ts
+++ b/services/runner/src/tracing/otel.ts
@@ -409,8 +409,13 @@ const BRIDGE_REWRITTEN_HOSTS = new Set(["localhost", "0.0.0.0"]);
  * The mirror is deliberately exact: same scheme, port, and path, and only the two hosts the
  * rewrite touches. Three things it deliberately does NOT do:
  *
- *   - `127.0.0.1` earns no alias. Neither copy of `parse_url` rewrites it, so that deployment
- *     already matches its own raw base and the bridge form is a pair the platform cannot produce.
+ *   - `127.0.0.1` earns no alias HERE. Neither copy of `parse_url` rewrites it, so that
+ *     deployment already matches its own raw base and the bridge form is a pair the platform
+ *     cannot produce. It is admitted anyway, one layer up: `isAgentaIngest` folds every
+ *     local-host spelling into one host (#6392), which subsumes this mirror entirely. This
+ *     function is kept because it is the record of WHICH rewrite the platform actually performs,
+ *     and because it names the bridge form in `configuredIngestBases()` so a rejection message
+ *     lists the host the operator will see on the wire.
  *   - A scheme-less base earns no alias, because it cannot help. The SDK's `parse_url` does no
  *     scheme defaulting (unlike the api's), so a scheme-less `AGENTA_API_URL` yields an equally
  *     scheme-less ENDPOINT, which `new URL` reads as an opaque `localhost:`-scheme path. Both

--- a/services/runner/tests/unit/platform-credential-attribution.test.ts
+++ b/services/runner/tests/unit/platform-credential-attribution.test.ts
@@ -290,10 +290,12 @@ describe("bridge-rewritten localhost ingest", () => {
     assert.match(lines[0]!, /collector\.thirdparty\.example/);
   });
 
-  it("leaves a 127.0.0.1 base alone, because the api does not rewrite that host", () => {
-    // `parse_url` rewrites only `localhost` and `0.0.0.0`, so a 127.0.0.1 deployment matches
-    // itself and never sees the bridge form. Admitting it would widen the allowlist past the
-    // platform's own rewrite.
+  it("admits a 127.0.0.1 base under either spelling of the local host", () => {
+    // `bridgeRewrittenBase` mirrors only `localhost`/`0.0.0.0`, so on its own a 127.0.0.1 base
+    // matches itself and nothing else. `isAgentaIngest` then folds every local-host spelling
+    // (#6392), which subsumes that mirror and admits the bridge form here too. The fold is
+    // host-spelling only: port and path still have to match exactly, which the two cases below
+    // this one pin.
     vi.stubEnv("AGENTA_API_URL", "http://127.0.0.1:8480/api");
     const { lines, log } = withLog();
 
@@ -309,6 +311,21 @@ describe("bridge-rewritten localhost ingest", () => {
     resetPlatformCredentialWarnings();
     assert.equal(
       platformCredentialForRequest(request(BRIDGE_ENDPOINT), log),
+      CREDENTIAL,
+    );
+    assert.deepEqual(lines, []);
+  });
+
+  it("still drops a 127.0.0.1 base's credential for a foreign port", () => {
+    // The guard the case above relies on: folding the host name must not fold anything else.
+    vi.stubEnv("AGENTA_API_URL", "http://127.0.0.1:8480/api");
+    const { lines, log } = withLog();
+
+    assert.equal(
+      platformCredentialForRequest(
+        request("http://host.docker.internal:9999/api/otlp/v1/traces"),
+        log,
+      ),
       "",
     );
     assert.equal(lines.length, 1);

--- a/web/packages/agenta-chat/src/model/approvalPreview.ts
+++ b/web/packages/agenta-chat/src/model/approvalPreview.ts
@@ -64,13 +64,25 @@ const pathArgument = (input: unknown): string | undefined => {
     return undefined
 }
 
+/** The articles a generic "<verb> a file" activity can carry. */
+const GENERIC_FILE_ARTICLES = new Set(["a", "an", "the"])
+
 /** "Reading a file" + `notes/a.md` → "reading notes/a.md" (#6349).
  * Singular only: a many-file tool's path is the SCOPE it searches, so naming it would misstate it. */
 const namedFileActivity = (activity: string, input: unknown): string | undefined => {
-    const generic = /^(.*?)\s+(?:an?|the)\s+file$/i.exec(activity)
-    if (!generic?.[1]) return undefined
+    // Split on words rather than matching `/^(.*?)\s+(?:an?|the)\s+file$/`: a lazy prefix
+    // followed by `\s+` can end anywhere inside a whitespace run, so an activity that is mostly
+    // spaces backtracks quadratically (CodeQL js/polynomial-redos). Splitting is linear and the
+    // parse is the same one, read from the end.
+    const words = activity.trim().split(/\s+/)
+    if (words.length < 3) return undefined
+    const article = words[words.length - 2]!
+    if (words[words.length - 1]!.toLowerCase() !== "file") return undefined
+    if (!GENERIC_FILE_ARTICLES.has(article.toLowerCase())) return undefined
+    const prefix = words.slice(0, -2).join(" ")
+    if (!prefix) return undefined
     const path = pathArgument(input)
-    return path ? `${generic[1]} ${fileTarget(path)}` : undefined
+    return path ? `${prefix} ${fileTarget(path)}` : undefined
 }
 
 /**


### PR DESCRIPTION
Two of the four red checks on #6447 are code defects. This fixes both. (The third, `setup / setup`, is the Railway preview gateway failing its healthcheck on an HTTP 308 — infra, not in scope here. `Agent Runner Unit Test Results` is the reporter echoing the same test failure.)

## 1. `run-runner-tests` — two PRs that were green apart went red together

`platform-credential-attribution.test.ts > leaves a 127.0.0.1 base alone` fails: the code hands back the run credential where the test expects it dropped.

Neither PR is at fault on its own. Two mechanisms answer the same question and disagree about `127.0.0.1`:

| | added by | what it aliases |
|---|---|---|
| `bridgeRewrittenBase` | #6407 (merged Aug 31) | `localhost`/`0.0.0.0` → `host.docker.internal`, mirroring the SDK's `parse_url` exactly. Its test pins that a `127.0.0.1` base must **not** admit the bridge form. |
| `LOCAL_HOST_ALIASES` in `isAgentaIngest` | #6392 (merged Sep 1) | every local-host spelling folded to one host, `127.0.0.1` and `[::1]` included. |

#6392's branch was cut before #6407's test existed, so its CI never ran the pair. main has been red on this test since that merge; the release branch inherited it.

**Resolution: keep #6392's fold.** It subsumes the mirror entirely, it is the later deliberate design, and its own `otel-agenta-ingest.test.ts` pins `127.0.0.1` and `[::1]` as aliases of a configured `localhost` — including the internal-hop case (`AGENTA_API_INTERNAL_URL=http://localhost:8000/api` matching an endpoint on `127.0.0.1:8000`). Reverting the fold would break those.

So the contradicting assertion is re-pointed at what ships, and a companion case pins the guard it now leans on: **the fold is host-spelling only** — port and path still have to match exactly, so a foreign port on a `127.0.0.1` base is still refused the credential.

`bridgeRewrittenBase` stays. It is redundant for matching, but it records *which* rewrite the platform actually performs, and it names the bridge host in `configuredIngestBases()` so a rejection message lists the host the operator will see on the wire. Its doc bullet no longer claims `127.0.0.1` is refused.

**Worth a reviewer's eye:** this accepts a slightly wider allowlist than #6407 argued for — a `127.0.0.1`-configured deployment now also admits `host.docker.internal` at the same port and path. That is the same residual width #6407 already accepted for `localhost` ("a third-party collector on the docker host at the exact port of the configured Agenta api, which in practice is that api"). If the team wants the stricter reading instead, the change is in `LOCAL_HOST_ALIASES`, and #6392's test file has to move with it.

## 2. `CodeQL` — 1 new high alert, polynomial ReDoS

`approvalPreview.ts:70` matched `/^(.*?)\s+(?:an?|the)\s+file$/` against a tool's humanized activity. The lazy prefix and the `\s+` after it both match a space, so the prefix can end anywhere inside a whitespace run and the engine retries every split — quadratic on an activity that is mostly spaces.

Read the parse from the end off a word split instead: last word `file`, the one before it an article, the rest is the prefix. Same result on every activity the tool registry produces, linear on anything else.

## Verification

- `platform-credential-attribution.test.ts` + `otel-agenta-ingest.test.ts`: 34 passed, was 1 failed / 32 passed.
- `agenta-chat`: `tsc --noEmit` and `eslint` clean; `approvalPaths.test.ts` (17 cases over this code path) passes; prettier clean.
- `services/runner`: `tsc --noEmit` clean.

Four runner unit files fail on my machine (`workspace-import`, `commit-authorization`, `sandbox-agent-acp-interactions`, `gateway-run-turn-composition`) and one `agenta-chat` file (`sessionMessages`, on `localStorage`). All are green in CI, none reference the changed modules, and one of the changed files is a comment-only edit — local environment, not this diff.
