### PR TITLE
[AGE-4249] fix(runner): let the credential preflight judge providers that do not echo the key

### DIFF
--- a/services/runner/src/engines/sandbox_agent/credential-preflight.ts
+++ b/services/runner/src/engines/sandbox_agent/credential-preflight.ts
@@ -11,12 +11,12 @@
  * fresh sandboxes (target eu); production showed ~3% over an earlier window, so the rate
  * varies. Waiting therefore cannot help; only a fresh sandbox can.
  *
- * THE MECHANISM. Right after the sandbox is created, probe the credential's own endpoint from
- * INSIDE the sandbox: POST the provider's auth-first path with the key env var as the
- * credential. Several consecutive placeholder answers convict the sandbox as STUCK; any other
- * response means the header was substituted (a 400 for the junk body, a real 401 for a
- * genuinely bad key) and the run may proceed. The preflight runs CONCURRENTLY with the rest of
- * acquire (mounts, workspace, session open, ~10s), so a healthy sandbox pays nothing.
+ * THE MECHANISM. Right after the sandbox is created, call the credential's own endpoint from
+ * INSIDE the sandbox with the key env var as the credential. Several consecutive placeholder
+ * readings convict the sandbox as STUCK; anything else means the header was substituted, or
+ * means nothing this module can judge, and the run proceeds. The preflight runs CONCURRENTLY
+ * with the rest of acquire (mounts, workspace, session open, ~10s), so a healthy sandbox pays
+ * nothing.
  *
  * TWO INSTRUMENTS READ THAT PROBE, BECAUSE ONE OF THEM IS BLIND ON HALF THE PROVIDERS.
  *
@@ -32,18 +32,34 @@
  * placeholder really went out. This is the same correction that invalidated the first probe
  * run; see the "CORRECTED" section of `docs/design/daytona-secret-propagation/README.md`.
  *
- * 2. THE CONTROL CALL, for a provider that echoes nothing. OpenRouter answers a bad bearer with
- * a plain 401 that never names the key, and so do Anthropic and Gemini. Instrument 1 sees
- * nothing there and fails open, so every stuck sandbox on those connections became a failed
- * first turn: 10 user-visible failures on the direct OpenRouter connection in production over
- * 2026-09-01..02 (AGE-4249). The runner itself holds the real key at this point, because it
- * created the Secret from it. So it makes ONE call of its own, from the runner process, to the
- * same URL with the same body, concurrently with the sandbox probe. The two answers together
- * are the reading: sandbox 401 plus control accepted means the sandbox sent something the
- * provider refused while the real key works, and the only other thing the sandbox can send is
- * the raw placeholder. Control refused (401 or 403) means the key itself is bad, which is not
- * this fault. The control call is body-independent, so no provider wording can hide the fault
- * from it.
+ * 2. THE DIFFERENTIAL, for a provider that echoes nothing. OpenRouter answers a bad bearer with
+ * a plain 401 that never names the key, and so do Anthropic and OpenAI on their auth endpoints.
+ * Instrument 1 sees nothing there and fails open, so every stuck sandbox on those connections
+ * became a failed first turn: 10 user-visible failures on the direct OpenRouter connection in
+ * production over 2026-09-01..02 (AGE-4249). The runner itself holds the real key at this
+ * point, because it created the Secret from it. So it calls the SAME auth endpoint itself,
+ * concurrently with the sandbox probe, and the pair of answers is the reading.
+ *
+ * WHAT THE DIFFERENTIAL ACTUALLY MEASURES, STATED PLAINLY. It is a difference between two
+ * REQUEST CONTEXTS — one request from inside the sandbox, one from the runner process — and it
+ * attributes that difference to the credential. That attribution is an assumption, not a proof.
+ * Any other environment difference between the two contexts would convict a healthy sandbox:
+ * an IP allowlist on the provider account, a WAF or bot rule that treats the sandbox's egress
+ * range differently, a regional block, a provider-side per-source throttle. Three things bound
+ * the damage. Only a positive, documented auth answer counts as accepted (HTTP 200 from a
+ * non-generation auth endpoint), so an environment difference that produces anything else is
+ * unknown and fails open. A wrong verdict costs a rebuild, not a failed run, because acquire
+ * retries with a fresh sandbox and the retry ladder is bounded. And the rule applies only to
+ * the three direct providers whose auth endpoint is documented and pinned below; every other
+ * connection, custom gateways included, keeps masked-echo-only conviction.
+ *
+ * ONLY A NON-GENERATION AUTH ENDPOINT, READ BY STATUS ALONE. Each differential provider has a
+ * documented endpoint whose entire job is to answer whether a key is good: OpenRouter's
+ * `GET /key`, Anthropic's `GET /v1/models`, OpenAI's `GET /models`. 200 means accepted, 401
+ * means the key is refused, and every other status — 403, 3xx, 404, 405, 429, 5xx, a timeout —
+ * is unknown and fails open. Reading the status of a purpose-built endpoint, rather than
+ * inferring acceptance from "not a refusal" on a generation endpoint, is what keeps a
+ * misrouted or rate-limited call from being read as proof that a key works.
  *
  * WHAT A "STUCK" VERDICT DOES. The acquire path destroys the environment and retries ONCE
  * with a brand-new sandbox, because the twin experiment proved a new sandbox on the same
@@ -57,27 +73,30 @@
  * 10s and rebuild rather than hold every stuck user turn another 20s for a recovery nobody
  * has observed. Decided by the product owner 2026-08-31; revisit only if a late recovery
  * ever shows up in the preflight logs (it would log "substitution confirmed after N
- * probes" with N > 1).
+ * probes" with N > 1). It is ONE deadline: every sandbox probe timeout and the runner's own
+ * call are capped by what is left of it, so a slow probe cannot spend more than the grace.
  *
  * SCOPE. Only a freshly created Daytona sandbox whose MODEL credential rides a Daytona Secret
- * and whose connection declares an endpoint base URL. That covers the OpenAI-compatible shape
- * (the LiteLLM credits proxy, OpenAI, OpenRouter and any custom gateway) and the Anthropic
- * shape, which are the two request shapes below. A provider outside those two stays on the
- * OpenAI-compatible shape and therefore fails open on anything it cannot judge, exactly as an
- * unknown response body does. Gemini is not covered: its auth rides a query parameter rather
- * than a header, so it needs its own shape and its own evidence. A plaintext-env run has no
- * placeholder; a reconnected sandbox already proved itself.
+ * and whose connection declares an endpoint base URL. Within that, the differential covers
+ * exactly three direct providers (openrouter, anthropic, openai). Every other connection —
+ * a custom gateway such as the LiteLLM credits proxy, and any direct provider not named above
+ * — keeps the OpenAI-compatible chat probe and masked-echo-only conviction, which is what has
+ * been convicting stuck sandboxes on the credits proxy since this module shipped. Gemini is
+ * not covered at all: its auth rides a query parameter rather than a header, so it needs its
+ * own shape. A plaintext-env run has no placeholder; a reconnected sandbox already proved
+ * itself.
  *
  * THE KEY VALUE NEVER LEAVES THIS MODULE. The sandbox command carries the env var name, which
- * the sandbox shell expands, and the control call carries the value in a request header only.
- * Every log line goes through a redactor, so no future message can leak it either.
+ * the sandbox shell expands, and the runner's own call carries the value in a request header
+ * only. Every log line goes through a redactor, so no future message can leak it either.
  *
  * AMBIGUITY FAILS OPEN. Any of these returns "ok" and the run proceeds: a probe that errors, a
  * body with nothing judgeable in it, an UNMASKED placeholder-shaped echo, a sandbox status that
- * is not 401, a control call that was refused, and a control call that errored, timed out, or
- * gave no status. The worst outcome is the pre-existing behavior, classified honestly by
- * `classifyRunError`. Only consecutive, unambiguous readings convict: a masked raw-placeholder
- * echo, or a sandbox 401 beside a control call that accepted the same key.
+ * is not 401, a sandbox 401 on a connection without a differential shape, and a runner call
+ * that was refused, errored, timed out, or answered any status but 200. The worst outcome is
+ * the pre-existing behavior, classified honestly by `classifyRunError`. Only consecutive,
+ * unambiguous readings convict: a masked raw-placeholder echo, or a sandbox 401 beside a
+ * runner call that the provider's own auth endpoint answered with 200.
  */
 
 /**
@@ -114,15 +133,18 @@ export interface PreflightSandbox {
   }): Promise<{ exitCode?: number | null; stdout: string } | undefined>;
 }
 
-/** One control call the runner makes itself, with the real key. */
+/** One call the runner makes itself, with the real key, to the provider's auth endpoint. */
 export interface ControlProbeRequest {
+  method: "GET" | "POST";
   url: string;
   headers: Record<string, string>;
-  body: string;
+  body?: string;
   timeoutMs: number;
+  /** Aborted as soon as the preflight stops needing the answer. */
+  signal: AbortSignal;
 }
 
-/** What the control call answered. `status` is absent when nothing could be read. */
+/** What that call answered. `status` is absent when nothing could be read. */
 export interface ControlProbeResponse {
   status?: number;
 }
@@ -138,8 +160,9 @@ export type CredentialPreflightVerdict = "ok" | "stuck";
 export class SubstitutionStuckError extends Error {
   constructor() {
     super(
-      "This sandbox never received its credential-substitution wiring (raw placeholder " +
-        "echoed on every probe); a fresh sandbox is required.",
+      "This sandbox never received its credential-substitution wiring: every probe from " +
+        "inside it either echoed the raw placeholder back or was refused by the provider " +
+        "while the same key succeeded from the runner. A fresh sandbox is required.",
     );
     this.name = "SubstitutionStuckError";
   }
@@ -150,17 +173,19 @@ export const STUCK_ACQUIRE_ATTEMPTS = 2;
 
 export interface CredentialPreflightInput {
   sandbox: PreflightSandbox;
-  /** The custom connection's endpoint base URL (`modelConnection.endpoint.baseUrl`). */
+  /** The connection's endpoint base URL (`modelConnection.endpoint.baseUrl`). */
   baseUrl: string;
   /** The env var name holding the key in the sandbox (the Secret's placeholder). */
   apiKeyVar: string;
-  /** The connection's provider family, which selects the request shape. */
+  /** The connection's provider family (`modelConnection.provider`). */
   provider?: string;
+  /** How that provider is reached (`modelConnection.deployment`): `direct`, `custom`, ... */
+  deployment?: string;
   /**
-   * The real key value, used ONLY as the control call's credential header.
+   * The real key value, used ONLY as the runner call's credential header.
    *
-   * Without it the control instrument is unavailable and a bare 401 fails open, which is the
-   * behavior that shipped before the control call existed.
+   * Without it the differential is unavailable and a bare 401 fails open, which is the
+   * behavior that shipped before the differential existed.
    */
   controlKey?: string;
   log: (message: string) => void;
@@ -168,21 +193,24 @@ export interface CredentialPreflightInput {
   budgetMs?: number;
   /** Delay between probes. */
   pollMs?: number;
-  /** Injectable clock/sleep/control call for tests. */
+  /** The acquire's cancellation signal; aborts the runner's own call with the run. */
+  signal?: AbortSignal;
+  /** Injectable clock/sleep/transport for tests. */
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
   controlProbe?: ControlProbe;
+  fetchImpl?: typeof fetch;
 }
 
 /** See the module doc: 10s, deliberately below Daytona's ~30s keep-or-recreate bound. */
 const DEFAULT_BUDGET_MS = 10_000;
 const DEFAULT_POLL_MS = 2_000;
-const CURL_TIMEOUT_S = 8;
+const PROBE_TIMEOUT_S = 8;
 const CONTROL_TIMEOUT_MS = 8_000;
-/** Pinned by Anthropic's API, which refuses a `/v1/messages` call without it. */
+/** Pinned by Anthropic's API, which refuses a versionless call. */
 const ANTHROPIC_VERSION = "2023-06-01";
-/** Where the credential goes in a header template, for the sandbox and the control call alike. */
-const KEY_SLOT = "%KEY%";
+/** A shell would expand anything else in the command string. */
+const SHELL_SAFE_ENV_VAR = /^[A-Za-z_][A-Za-z0-9_]*$/;
 
 /**
  * The only echo that proves the raw placeholder went out: one the provider MASKED.
@@ -203,67 +231,122 @@ const MASKED_PLACEHOLDER_ECHO =
   /dtn_[A-Za-z0-9_-]*\*|virtual key expected.*received=\s*dtn_/i;
 
 /**
- * The auth-first request this preflight sends, in the shape the provider understands.
+ * The request this preflight sends, in the shape the provider understands.
  *
- * Both shapes post an empty JSON body on purpose: an auth-first endpoint answers it without
- * running a model, so the probe costs nothing and returns quickly. The credential sits in
- * `KEY_SLOT` so the same shape builds the sandbox command (which gets a shell expansion) and
- * the control request (which gets the real value).
+ * `buildHeaders` takes the credential and returns the headers, so the same shape builds the
+ * sandbox command (which gets a shell expansion of the env var) and the runner's own request
+ * (which gets the real value). `differential` says whether a bare 401 from the sandbox may be
+ * judged against the runner's answer; see the module doc for why only three providers set it.
  */
 interface ProbeShape {
+  method: "GET" | "POST";
   url: string;
-  headers: [string, string][];
-  body: string;
+  buildHeaders: (credential: string) => Record<string, string>;
+  body?: string;
+  differential: boolean;
 }
 
-function probeShapeFor(baseUrl: string, provider?: string): ProbeShape {
-  const base = baseUrl.replace(/\/+$/, "");
-  if (provider?.trim().toLowerCase() === "anthropic") {
-    return {
-      url: `${base}/v1/messages`,
-      headers: [
-        ["Content-Type", "application/json"],
-        ["x-api-key", KEY_SLOT],
-        ["anthropic-version", ANTHROPIC_VERSION],
-      ],
-      body: "{}",
-    };
-  }
-  // The OpenAI-compatible shape, and the fallback for a provider whose shape is unknown. It
-  // covers the LiteLLM credits proxy, OpenAI, OpenRouter, and any custom gateway. An unknown
-  // provider that does not speak it simply answers something unjudgeable, which fails open.
+/**
+ * The chat probe: a POST of an empty JSON body to the OpenAI-compatible chat path.
+ *
+ * The default for every connection without a documented auth endpoint here. An auth-first
+ * gateway answers it without running a model, and the LiteLLM credits proxy answers it with the
+ * masked refusal that has been convicting stuck sandboxes since this module shipped. It carries
+ * no differential: a 401 from a generation endpoint has too many causes to attribute.
+ */
+function chatProbeShape(base: string): ProbeShape {
   return {
+    method: "POST",
     url: `${base}/chat/completions`,
-    headers: [
-      ["Content-Type", "application/json"],
-      ["Authorization", `Bearer ${KEY_SLOT}`],
-    ],
+    buildHeaders: (credential) => ({
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${credential}`,
+    }),
     body: "{}",
+    differential: false,
   };
 }
 
 /**
- * The curl the sandbox runs. `-w` appends the HTTP status on its own line, which is the second
- * instrument's whole input: the body alone cannot tell a refusal from a substituted call on a
+ * Pick the request shape from the connection's provider family and how it is reached.
+ *
+ * Only a DIRECT connection to one of the three providers below gets a differential shape, and
+ * each one is that provider's own documented endpoint for checking a key. `deployment` matters
+ * as much as `provider`: a custom gateway can carry any provider name while speaking its own
+ * dialect at its own host, so the auth endpoint below would not exist there.
+ */
+function probeShapeFor(
+  baseUrl: string,
+  provider?: string,
+  deployment?: string,
+): ProbeShape {
+  const base = baseUrl.replace(/\/+$/, "");
+  if (deployment?.trim().toLowerCase() !== "direct")
+    return chatProbeShape(base);
+  switch (provider?.trim().toLowerCase()) {
+    case "openrouter":
+      // OpenRouter's documented "get current key" endpoint.
+      return {
+        method: "GET",
+        url: `${base}/key`,
+        buildHeaders: (credential) => ({
+          Authorization: `Bearer ${credential}`,
+        }),
+        differential: true,
+      };
+    case "anthropic":
+      // `limit=1` so the answer stays small; the status is all this reads.
+      return {
+        method: "GET",
+        url: `${base}/v1/models?limit=1`,
+        buildHeaders: (credential) => ({
+          "x-api-key": credential,
+          "anthropic-version": ANTHROPIC_VERSION,
+        }),
+        differential: true,
+      };
+    case "openai":
+      return {
+        method: "GET",
+        url: `${base}/models`,
+        buildHeaders: (credential) => ({
+          Authorization: `Bearer ${credential}`,
+        }),
+        differential: true,
+      };
+    default:
+      return chatProbeShape(base);
+  }
+}
+
+/**
+ * The curl the sandbox runs. `-w` appends the HTTP status on its own line, which is the
+ * differential's whole input: the body alone cannot tell a refusal from a substituted call on a
  * provider that echoes nothing. The env var is expanded by the sandbox shell, so the key value
  * never appears in any runner-side string.
  */
-function sandboxProbeScript(shape: ProbeShape, apiKeyVar: string): string {
-  const headers = shape.headers
-    .map(
-      ([name, value]) =>
-        `-H "${name}: ${value.split(KEY_SLOT).join(`$${apiKeyVar}`)}" `,
-    )
+function sandboxProbeScript(
+  shape: ProbeShape,
+  apiKeyVar: string,
+  timeoutSeconds: number,
+): string {
+  const headers = Object.entries(shape.buildHeaders(`$${apiKeyVar}`))
+    .map(([name, value]) => `-H "${name}: ${value}" `)
     .join("");
+  const method = shape.method === "POST" ? "-X POST " : "";
+  const body =
+    shape.body === undefined ? "" : `-d ${JSON.stringify(shape.body)} `;
   return (
-    `curl -s -m ${CURL_TIMEOUT_S} -w '\\n%{http_code}' -X POST ` +
+    `curl -s -m ${timeoutSeconds} -w '\\n%{http_code}' ` +
+    method +
     headers +
-    `-d ${JSON.stringify(shape.body)} ${JSON.stringify(shape.url)}`
+    body +
+    JSON.stringify(shape.url)
   );
 }
 
 /** Split curl's output into the response body and the status `-w` appended. */
-export function splitProbeOutput(stdout: string | undefined): {
+export function parseCurlProbeOutput(stdout: string | undefined): {
   body: string;
   status?: number;
 } {
@@ -278,28 +361,44 @@ export function splitProbeOutput(stdout: string | undefined): {
   return { body: stdout.slice(0, lastNewline), status };
 }
 
-/** What the runner's own call to the same endpoint said about the key. */
-type ControlReading =
+/** What the runner's own call to the provider's auth endpoint said about the key. */
+type RunnerAuthProbeResult =
   | { kind: "accepted"; status: number }
   | { kind: "refused"; status: number }
   | { kind: "unknown"; detail: string };
 
-async function fetchControlProbe(
-  request: ControlProbeRequest,
-): Promise<ControlProbeResponse> {
-  const controller = new AbortController();
-  const timer = setTimeout(() => controller.abort(), request.timeoutMs);
-  try {
-    const response = await fetch(request.url, {
-      method: "POST",
+/**
+ * Read the auth endpoint's answer. Only a 200 is acceptance and only a 401 is refusal; every
+ * other status is a different fact about the request, not about the key. See the module doc.
+ */
+function readRunnerAuthStatus(
+  status: number | undefined,
+): RunnerAuthProbeResult {
+  if (status === undefined) return { kind: "unknown", detail: "no status" };
+  if (status === 200) return { kind: "accepted", status };
+  if (status === 401) return { kind: "refused", status };
+  return { kind: "unknown", detail: `HTTP ${status}` };
+}
+
+/**
+ * The runner's own call, over `fetch`.
+ *
+ * `redirect: "error"` so a 3xx is never followed: the auth endpoint is pinned, and a redirect
+ * would send the real key to whatever host the response named. The body is cancelled once the
+ * status is read, because nothing here reads it and an unread body holds the connection.
+ */
+function createFetchControlProbe(fetchImpl: typeof fetch): ControlProbe {
+  return async (request) => {
+    const response = await fetchImpl(request.url, {
+      method: request.method,
       headers: request.headers,
-      body: request.body,
-      signal: controller.signal,
+      ...(request.body === undefined ? {} : { body: request.body }),
+      redirect: "error",
+      signal: request.signal,
     });
+    await response.body?.cancel().catch(() => {});
     return { status: response.status };
-  } finally {
-    clearTimeout(timer);
-  }
+  };
 }
 
 /**
@@ -315,175 +414,202 @@ export async function awaitCredentialSubstitution(
     ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const budgetMs = input.budgetMs ?? DEFAULT_BUDGET_MS;
   const pollMs = input.pollMs ?? DEFAULT_POLL_MS;
-  const shape = probeShapeFor(input.baseUrl, input.provider);
-  const script = sandboxProbeScript(shape, input.apiKeyVar);
   // Last line of defence: no message this module writes may carry the key, whatever a future
-  // edit or a provider error string puts in it.
+  // edit or a provider error string puts in it. Any non-empty value is redacted.
   const controlKey = input.controlKey;
   const log = (message: string) =>
     input.log(
-      controlKey && controlKey.length >= 8
-        ? message.split(controlKey).join("[redacted]")
-        : message,
+      controlKey ? message.split(controlKey).join("[redacted]") : message,
     );
 
-  // Started HERE so it runs concurrently with probe 1, and awaited only when a bare 401 makes
-  // it the deciding evidence. One call per preflight. It never rejects, so an unawaited
-  // rejection cannot escape when the sandbox answers cleanly.
-  const control: Promise<ControlReading> | undefined = controlKey
-    ? (input.controlProbe ?? fetchControlProbe)({
-        url: shape.url,
-        headers: Object.fromEntries(
-          shape.headers.map(([name, value]) => [
-            name,
-            value.split(KEY_SLOT).join(controlKey),
-          ]),
-        ),
-        body: shape.body,
-        timeoutMs: CONTROL_TIMEOUT_MS,
-      }).then(
-        (response): ControlReading => {
-          if (response.status === undefined)
-            return { kind: "unknown", detail: "no status" };
-          // 401 and 403 are the provider refusing the key itself. Everything else — a 400 for
-          // the junk body, a 200, a 429 — means the provider read the key and accepted it.
-          return response.status === 401 || response.status === 403
-            ? { kind: "refused", status: response.status }
-            : { kind: "accepted", status: response.status };
-        },
-        (error): ControlReading => ({
-          kind: "unknown",
-          detail: String(error instanceof Error ? error.message : error).slice(
-            0,
-            120,
-          ),
-        }),
-      )
-    : undefined;
+  // The env var name is interpolated into a shell command, so it must be a name and nothing
+  // else. A value that is not one is a programming error upstream, not a stuck sandbox.
+  if (!SHELL_SAFE_ENV_VAR.test(input.apiKeyVar)) {
+    log(
+      `[credential-preflight] refusing to probe: the credential's binding name is not a ` +
+        `shell-safe environment variable name; proceeding`,
+    );
+    return "ok";
+  }
 
+  const shape = probeShapeFor(input.baseUrl, input.provider, input.deployment);
   const startedAt = now();
-  for (let attempt = 1; ; attempt++) {
-    let stdout: string | undefined;
-    try {
-      const result = await input.sandbox.runProcess({
-        command: "sh",
-        args: ["-c", script],
-        timeoutMs: (CURL_TIMEOUT_S + 4) * 1000,
-      });
-      stdout = result?.stdout;
-    } catch (error) {
-      // The exec channel itself failed (sandbox tearing down, daemon hiccup): fail open.
-      log(
-        `[credential-preflight] probe errored, proceeding: ${String(
-          error instanceof Error ? error.message : error,
-        ).slice(0, 120)}`,
-      );
-      return "ok";
-    }
-    const { body, status } = splitProbeOutput(stdout);
-    const masked = MASKED_PLACEHOLDER_ECHO.test(body);
-    // Awaited BEFORE the clock is read, so a slow control call spends the same budget every
-    // other step of the preflight spends. Otherwise a control call that took most of the grace
-    // would leave the loop thinking it still had time for several more probes.
-    const reading =
-      !masked && status === 401 && control ? await control : undefined;
-    const elapsedMs = now() - startedAt;
-    const elapsed = (elapsedMs / 1000).toFixed(1);
+  const deadlineAt = startedAt + budgetMs;
+  const remainingMs = () => Math.max(0, deadlineAt - now());
 
-    // Evidence that the raw placeholder went out. Each instrument words its own two lines: the
-    // per-probe line while the grace still runs, and the conviction line at the end.
-    let evidence: { probeLine: string; stuckLine: string } | undefined;
-    if (masked) {
-      evidence = {
-        probeLine: `raw placeholder echoed (probe ${attempt}, +${elapsed}s)`,
-        stuckLine: `STUCK: raw placeholder on all ${attempt} probes (${elapsed}s)`,
-      };
-    } else if (status === 401) {
-      // The provider refused without naming what it received. Only the control call can say
-      // whether the sandbox sent a bad key or the raw placeholder.
-      if (!reading) {
-        log(
-          `[credential-preflight] sandbox answered 401 with no echo (probe ${attempt}, ` +
-            `+${elapsed}s) and the runner holds no key for a control call; proceeding`,
-        );
-        return "ok";
-      }
-      if (reading.kind === "refused") {
-        log(
-          `[credential-preflight] sandbox answered 401 with no echo (probe ${attempt}, ` +
-            `+${elapsed}s), and the runner's own control call with the same key was ` +
-            `refused (HTTP ${reading.status}): the key itself is being rejected, not its ` +
-            `delivery; proceeding`,
-        );
-        return "ok";
-      }
-      if (reading.kind === "unknown") {
-        log(
-          `[credential-preflight] sandbox answered 401 with no echo (probe ${attempt}, ` +
-            `+${elapsed}s), but the control call gave no verdict (${reading.detail}); ` +
-            `proceeding`,
-        );
-        return "ok";
-      }
-      evidence = {
-        probeLine:
-          `bare 401 with no echo (probe ${attempt}, +${elapsed}s); the runner's own ` +
-          `control call accepted the same key (HTTP ${reading.status})`,
-        stuckLine:
-          `STUCK: bare 401 with no echo on all ${attempt} probes (${elapsed}s) while ` +
-          `the runner's own control call accepted the same key (HTTP ${reading.status})`,
-      };
-    }
+  // ONE controller for the runner's call, aborted in the `finally` below so every exit path
+  // (verdict, throw, caller cancellation) releases it. Composed with the acquire's own signal
+  // so a cancelled run does not leave a request in flight.
+  const controlAbort = new AbortController();
+  const controlSignal = input.signal
+    ? AbortSignal.any([input.signal, controlAbort.signal])
+    : controlAbort.signal;
 
-    if (!evidence) {
-      // Substituted, or the endpoint gave nothing this preflight can judge by — fail open
-      // either way. An unmasked placeholder shape lands here on purpose: scrubbing produces
-      // it from a healthy key too, so it is not evidence. Log it, because a stuck sandbox
-      // behind an echoing endpoint now passes the preflight and surfaces as the 401 instead.
-      if (body.includes("dtn_")) {
-        log(
-          `[credential-preflight] unmasked placeholder-shaped echo (probe ${attempt}, ` +
-            `+${elapsed}s): scrubbing produces this from a REAL key ` +
-            `too, so it convicts nothing; proceeding`,
-        );
-      } else if (attempt > 1) {
-        log(
-          `[credential-preflight] substitution confirmed after ${attempt} probes ` +
-            `(${elapsed}s)`,
-        );
-      }
-      return "ok";
-    }
-    if (elapsedMs + pollMs > budgetMs) {
-      log(
-        `[credential-preflight] ${evidence.stuckLine}; this sandbox will never substitute`,
+  // Started HERE so it runs concurrently with probe 1, and awaited only when a bare 401 makes
+  // it the deciding evidence. One call per preflight, and none at all on a connection whose
+  // shape carries no differential. It never rejects, so an unawaited rejection cannot escape
+  // when the sandbox answers cleanly.
+  const control: Promise<RunnerAuthProbeResult> | undefined =
+    controlKey && shape.differential
+      ? (
+          input.controlProbe ??
+          createFetchControlProbe(input.fetchImpl ?? fetch)
+        )({
+          method: shape.method,
+          url: shape.url,
+          headers: shape.buildHeaders(controlKey),
+          ...(shape.body === undefined ? {} : { body: shape.body }),
+          timeoutMs: Math.max(1_000, Math.min(CONTROL_TIMEOUT_MS, budgetMs)),
+          signal: controlSignal,
+        }).then(
+          (response) => readRunnerAuthStatus(response.status),
+          (error): RunnerAuthProbeResult => ({
+            kind: "unknown",
+            detail: String(
+              error instanceof Error ? error.message : error,
+            ).slice(0, 120),
+          }),
+        )
+      : undefined;
+
+  try {
+    for (let attempt = 1; ; attempt++) {
+      // Every probe is capped by what is left of the one deadline, so a slow sandbox cannot
+      // spend more than the grace no matter how long its exec channel takes to answer.
+      const probeSeconds = Math.max(
+        1,
+        Math.min(PROBE_TIMEOUT_S, Math.ceil(remainingMs() / 1000)),
       );
-      return "stuck";
+      const script = sandboxProbeScript(shape, input.apiKeyVar, probeSeconds);
+      let stdout: string | undefined;
+      try {
+        const result = await input.sandbox.runProcess({
+          command: "sh",
+          args: ["-c", script],
+          timeoutMs: (probeSeconds + 4) * 1000,
+        });
+        stdout = result?.stdout;
+      } catch (error) {
+        // The exec channel itself failed (sandbox tearing down, daemon hiccup): fail open.
+        log(
+          `[credential-preflight] probe errored, proceeding: ${String(
+            error instanceof Error ? error.message : error,
+          ).slice(0, 120)}`,
+        );
+        return "ok";
+      }
+      const { body, status } = parseCurlProbeOutput(stdout);
+      const masked = MASKED_PLACEHOLDER_ECHO.test(body);
+      // Awaited BEFORE the clock is read, so a slow runner call spends the same budget every
+      // other step spends. Otherwise a call that took most of the grace would leave the loop
+      // thinking it still had time for several more probes.
+      const reading =
+        !masked && status === 401 && control ? await control : undefined;
+      const elapsedMs = now() - startedAt;
+      const elapsed = (elapsedMs / 1000).toFixed(1);
+
+      // Evidence that the raw placeholder went out. Each instrument words its own two lines:
+      // the per-probe line while the grace still runs, and the conviction line at the end.
+      let evidence: { probeLine: string; stuckLine: string } | undefined;
+      if (masked) {
+        evidence = {
+          probeLine: `raw placeholder echoed (probe ${attempt}, +${elapsed}s)`,
+          stuckLine: `STUCK: raw placeholder on all ${attempt} probes (${elapsed}s)`,
+        };
+      } else if (status === 401 && shape.differential) {
+        // The provider refused without naming what it received. Only the runner's own call to
+        // the same auth endpoint can say whether the key is bad or the delivery is.
+        if (!reading) {
+          log(
+            `[credential-preflight] sandbox answered 401 with no echo (probe ${attempt}, ` +
+              `+${elapsed}s) and the runner holds no key to check it against; proceeding`,
+          );
+          return "ok";
+        }
+        if (reading.kind === "refused") {
+          log(
+            `[credential-preflight] sandbox answered 401 with no echo (probe ${attempt}, ` +
+              `+${elapsed}s), and the provider's auth endpoint refused the same key from ` +
+              `the runner (HTTP ${reading.status}): the key itself is being rejected, not ` +
+              `its delivery; proceeding`,
+          );
+          return "ok";
+        }
+        if (reading.kind === "unknown") {
+          log(
+            `[credential-preflight] sandbox answered 401 with no echo (probe ${attempt}, ` +
+              `+${elapsed}s), but the runner's own call to the auth endpoint gave no ` +
+              `verdict (${reading.detail}); proceeding`,
+          );
+          return "ok";
+        }
+        evidence = {
+          probeLine:
+            `bare 401 with no echo (probe ${attempt}, +${elapsed}s); the provider's auth ` +
+            `endpoint accepted the same key from the runner (HTTP ${reading.status})`,
+          stuckLine:
+            `STUCK: bare 401 with no echo on all ${attempt} probes (${elapsed}s) while ` +
+            `the provider's auth endpoint accepted the same key from the runner ` +
+            `(HTTP ${reading.status})`,
+        };
+      }
+
+      if (!evidence) {
+        // Substituted, or the endpoint gave nothing this preflight can judge by — fail open
+        // either way. An unmasked placeholder shape lands here on purpose: scrubbing produces
+        // it from a healthy key too, so it is not evidence. Log it, because a stuck sandbox
+        // behind an echoing endpoint now passes the preflight and surfaces as the 401 instead.
+        if (body.includes("dtn_")) {
+          log(
+            `[credential-preflight] unmasked placeholder-shaped echo (probe ${attempt}, ` +
+              `+${elapsed}s): scrubbing produces this from a REAL key ` +
+              `too, so it convicts nothing; proceeding`,
+          );
+        } else if (attempt > 1) {
+          log(
+            `[credential-preflight] substitution confirmed after ${attempt} probes ` +
+              `(${elapsed}s)`,
+          );
+        }
+        return "ok";
+      }
+      if (elapsedMs + pollMs > budgetMs) {
+        log(
+          `[credential-preflight] ${evidence.stuckLine}; this sandbox will never substitute`,
+        );
+        return "stuck";
+      }
+      log(`[credential-preflight] ${evidence.probeLine}`);
+      await sleep(pollMs);
     }
-    log(`[credential-preflight] ${evidence.probeLine}`);
-    await sleep(pollMs);
+  } finally {
+    // Nothing reads the runner's call after this point, on any exit path.
+    controlAbort.abort();
   }
 }
 
 /**
- * Build the preflight's request from the acquire path's pieces.
+ * Build the preflight's input from the acquire path's pieces.
  *
  * It exists so the kickoff's wiring is testable: `acquireEnvironment` cannot be driven without a
  * live provider, and the one property worth pinning is that the candidate's real value has
- * exactly one destination, the control call. Everything the sandbox sees is a variable name.
+ * exactly one destination, the runner's own call. Everything the sandbox sees is a variable
+ * name.
  */
-export function credentialPreflightRequest(input: {
+export function buildCredentialPreflightInput(input: {
   baseUrl: string;
   candidate: { binding: { name: string }; value: string };
   provider?: string;
+  deployment?: string;
 }): Pick<
   CredentialPreflightInput,
-  "baseUrl" | "apiKeyVar" | "provider" | "controlKey"
+  "baseUrl" | "apiKeyVar" | "provider" | "deployment" | "controlKey"
 > {
   return {
     baseUrl: input.baseUrl.trim(),
     apiKeyVar: input.candidate.binding.name,
     ...(input.provider ? { provider: input.provider } : {}),
+    ...(input.deployment ? { deployment: input.deployment } : {}),
     controlKey: input.candidate.value,
   };
 }

--- a/services/runner/src/engines/sandbox_agent/credential-preflight.ts
+++ b/services/runner/src/engines/sandbox_agent/credential-preflight.ts
@@ -11,27 +11,39 @@
  * fresh sandboxes (target eu); production showed ~3% over an earlier window, so the rate
  * varies. Waiting therefore cannot help; only a fresh sandbox can.
  *
- * THE MECHANISM. Right after the sandbox is created, probe the credential's own endpoint
- * from INSIDE the sandbox: POST `${baseUrl}/chat/completions` with the key env var as the
- * bearer. Several consecutive raw-placeholder echoes convict the sandbox as STUCK; any other
+ * THE MECHANISM. Right after the sandbox is created, probe the credential's own endpoint from
+ * INSIDE the sandbox: POST the provider's auth-first path with the key env var as the
+ * credential. Several consecutive placeholder answers convict the sandbox as STUCK; any other
  * response means the header was substituted (a 400 for the junk body, a real 401 for a
- * genuinely bad key) and the run may proceed. The preflight runs CONCURRENTLY with the rest
- * of acquire (mounts, workspace, session open, ~10s), so a healthy sandbox pays nothing.
+ * genuinely bad key) and the run may proceed. The preflight runs CONCURRENTLY with the rest of
+ * acquire (mounts, workspace, session open, ~10s), so a healthy sandbox pays nothing.
  *
- * ONLY A MASKED ECHO CONVICTS, AND THAT DISTINCTION IS THE WHOLE INSTRUMENT. A bare `dtn_`
- * in the body proves nothing: Daytona's egress proxy also SCRUBS responses, rewriting real
- * credential values back into `dtn_secret_<id>` before they reach the sandbox. So an endpoint
- * that echoes the Authorization header verbatim returns the full placeholder shape on a
- * perfectly HEALTHY sandbox, and convicting on that would destroy both acquire attempts and
- * fail a first turn whose real model call would have worked. What scrubbing cannot forge is a
- * MASKED placeholder: a provider masks the key it received (LiteLLM's
- * "Virtual Key expected. Received=dtn_****", OpenAI's "Incorrect API key provided:
- * dtn_secr*****"), and a masked string no longer contains the real value for the scrubber to
- * match — so a masked `dtn_` can only mean the raw placeholder really went out. This is the
- * same correction that invalidated the first probe run; see the "CORRECTED" section of
- * `docs/design/daytona-secret-propagation/README.md`. Every incident observed in production
- * and in the 20-sandbox probe carried a masked echo, so the narrower signature costs no
- * detection.
+ * TWO INSTRUMENTS READ THAT PROBE, BECAUSE ONE OF THEM IS BLIND ON HALF THE PROVIDERS.
+ *
+ * 1. THE MASKED ECHO, for a provider that quotes back what it received. A bare `dtn_` in the
+ * body proves nothing: Daytona's egress proxy also SCRUBS responses, rewriting real credential
+ * values back into `dtn_secret_<id>` before they reach the sandbox. So an endpoint that echoes
+ * the Authorization header verbatim returns the full placeholder shape on a perfectly HEALTHY
+ * sandbox, and convicting on that would destroy both acquire attempts and fail a first turn
+ * whose real model call would have worked. What scrubbing cannot forge is a MASKED placeholder:
+ * a provider masks the key it received (LiteLLM's "Virtual Key expected. Received=dtn_****",
+ * OpenAI's "Incorrect API key provided: dtn_secr*****"), and a masked string no longer contains
+ * the real value for the scrubber to match — so a masked `dtn_` can only mean the raw
+ * placeholder really went out. This is the same correction that invalidated the first probe
+ * run; see the "CORRECTED" section of `docs/design/daytona-secret-propagation/README.md`.
+ *
+ * 2. THE CONTROL CALL, for a provider that echoes nothing. OpenRouter answers a bad bearer with
+ * a plain 401 that never names the key, and so do Anthropic and Gemini. Instrument 1 sees
+ * nothing there and fails open, so every stuck sandbox on those connections became a failed
+ * first turn: 10 user-visible failures on the direct OpenRouter connection in production over
+ * 2026-09-01..02 (AGE-4249). The runner itself holds the real key at this point, because it
+ * created the Secret from it. So it makes ONE call of its own, from the runner process, to the
+ * same URL with the same body, concurrently with the sandbox probe. The two answers together
+ * are the reading: sandbox 401 plus control accepted means the sandbox sent something the
+ * provider refused while the real key works, and the only other thing the sandbox can send is
+ * the raw placeholder. Control refused (401 or 403) means the key itself is bad, which is not
+ * this fault. The control call is body-independent, so no provider wording can hide the fault
+ * from it.
  *
  * WHAT A "STUCK" VERDICT DOES. The acquire path destroys the environment and retries ONCE
  * with a brand-new sandbox, because the twin experiment proved a new sandbox on the same
@@ -47,15 +59,25 @@
  * ever shows up in the preflight logs (it would log "substitution confirmed after N
  * probes" with N > 1).
  *
- * SCOPE. Only a freshly created Daytona sandbox whose MODEL credential rides a Daytona
- * Secret and whose connection declares an endpoint base URL (the custom OpenAI-compatible
- * shape — every observed incident). A plaintext-env run has no placeholder; a reconnected
- * sandbox already proved itself.
+ * SCOPE. Only a freshly created Daytona sandbox whose MODEL credential rides a Daytona Secret
+ * and whose connection declares an endpoint base URL. That covers the OpenAI-compatible shape
+ * (the LiteLLM credits proxy, OpenAI, OpenRouter and any custom gateway) and the Anthropic
+ * shape, which are the two request shapes below. A provider outside those two stays on the
+ * OpenAI-compatible shape and therefore fails open on anything it cannot judge, exactly as an
+ * unknown response body does. Gemini is not covered: its auth rides a query parameter rather
+ * than a header, so it needs its own shape and its own evidence. A plaintext-env run has no
+ * placeholder; a reconnected sandbox already proved itself.
  *
- * AMBIGUITY FAILS OPEN. A probe that errors, returns nothing judgeable, or returns an
- * UNMASKED placeholder-shaped echo returns "ok" and the run proceeds: the worst outcome is
- * the pre-existing behavior, classified honestly by `classifyRunError`. Only consecutive,
- * unambiguous masked raw-placeholder echoes convict.
+ * THE KEY VALUE NEVER LEAVES THIS MODULE. The sandbox command carries the env var name, which
+ * the sandbox shell expands, and the control call carries the value in a request header only.
+ * Every log line goes through a redactor, so no future message can leak it either.
+ *
+ * AMBIGUITY FAILS OPEN. Any of these returns "ok" and the run proceeds: a probe that errors, a
+ * body with nothing judgeable in it, an UNMASKED placeholder-shaped echo, a sandbox status that
+ * is not 401, a control call that was refused, and a control call that errored, timed out, or
+ * gave no status. The worst outcome is the pre-existing behavior, classified honestly by
+ * `classifyRunError`. Only consecutive, unambiguous readings convict: a masked raw-placeholder
+ * echo, or a sandbox 401 beside a control call that accepted the same key.
  */
 
 /**
@@ -63,8 +85,8 @@
  *
  * The condition the preflight gates on, minus the endpoint — and the condition that arms the
  * classifier's credential-race reading. Those two must not drift: the preflight can only SEE the
- * race where the provider echoes what it received, but the race EXISTS wherever a model key rides
- * a Secret on a fresh sandbox. Naming it once keeps that difference deliberate instead of
+ * race on a provider whose shape it knows, but the race EXISTS wherever a model key rides a
+ * Secret on a fresh sandbox. Naming it once keeps that difference deliberate instead of
  * accidental.
  *
  * A reconnect is excluded because the sandbox already proved itself, a local run because there is
@@ -92,6 +114,23 @@ export interface PreflightSandbox {
   }): Promise<{ exitCode?: number | null; stdout: string } | undefined>;
 }
 
+/** One control call the runner makes itself, with the real key. */
+export interface ControlProbeRequest {
+  url: string;
+  headers: Record<string, string>;
+  body: string;
+  timeoutMs: number;
+}
+
+/** What the control call answered. `status` is absent when nothing could be read. */
+export interface ControlProbeResponse {
+  status?: number;
+}
+
+export type ControlProbe = (
+  request: ControlProbeRequest,
+) => Promise<ControlProbeResponse>;
+
 /** The preflight's answer: proceed, or this sandbox will never substitute. */
 export type CredentialPreflightVerdict = "ok" | "stuck";
 
@@ -115,20 +154,35 @@ export interface CredentialPreflightInput {
   baseUrl: string;
   /** The env var name holding the key in the sandbox (the Secret's placeholder). */
   apiKeyVar: string;
+  /** The connection's provider family, which selects the request shape. */
+  provider?: string;
+  /**
+   * The real key value, used ONLY as the control call's credential header.
+   *
+   * Without it the control instrument is unavailable and a bare 401 fails open, which is the
+   * behavior that shipped before the control call existed.
+   */
+  controlKey?: string;
   log: (message: string) => void;
   /** Total budget from first probe to giving up (fail open). */
   budgetMs?: number;
   /** Delay between probes. */
   pollMs?: number;
-  /** Injectable clock/sleep for tests. */
+  /** Injectable clock/sleep/control call for tests. */
   now?: () => number;
   sleep?: (ms: number) => Promise<void>;
+  controlProbe?: ControlProbe;
 }
 
 /** See the module doc: 10s, deliberately below Daytona's ~30s keep-or-recreate bound. */
 const DEFAULT_BUDGET_MS = 10_000;
 const DEFAULT_POLL_MS = 2_000;
 const CURL_TIMEOUT_S = 8;
+const CONTROL_TIMEOUT_MS = 8_000;
+/** Pinned by Anthropic's API, which refuses a `/v1/messages` call without it. */
+const ANTHROPIC_VERSION = "2023-06-01";
+/** Where the credential goes in a header template, for the sandbox and the control call alike. */
+const KEY_SLOT = "%KEY%";
 
 /**
  * The only echo that proves the raw placeholder went out: one the provider MASKED.
@@ -149,9 +203,108 @@ const MASKED_PLACEHOLDER_ECHO =
   /dtn_[A-Za-z0-9_-]*\*|virtual key expected.*received=\s*dtn_/i;
 
 /**
+ * The auth-first request this preflight sends, in the shape the provider understands.
+ *
+ * Both shapes post an empty JSON body on purpose: an auth-first endpoint answers it without
+ * running a model, so the probe costs nothing and returns quickly. The credential sits in
+ * `KEY_SLOT` so the same shape builds the sandbox command (which gets a shell expansion) and
+ * the control request (which gets the real value).
+ */
+interface ProbeShape {
+  url: string;
+  headers: [string, string][];
+  body: string;
+}
+
+function probeShapeFor(baseUrl: string, provider?: string): ProbeShape {
+  const base = baseUrl.replace(/\/+$/, "");
+  if (provider?.trim().toLowerCase() === "anthropic") {
+    return {
+      url: `${base}/v1/messages`,
+      headers: [
+        ["Content-Type", "application/json"],
+        ["x-api-key", KEY_SLOT],
+        ["anthropic-version", ANTHROPIC_VERSION],
+      ],
+      body: "{}",
+    };
+  }
+  // The OpenAI-compatible shape, and the fallback for a provider whose shape is unknown. It
+  // covers the LiteLLM credits proxy, OpenAI, OpenRouter, and any custom gateway. An unknown
+  // provider that does not speak it simply answers something unjudgeable, which fails open.
+  return {
+    url: `${base}/chat/completions`,
+    headers: [
+      ["Content-Type", "application/json"],
+      ["Authorization", `Bearer ${KEY_SLOT}`],
+    ],
+    body: "{}",
+  };
+}
+
+/**
+ * The curl the sandbox runs. `-w` appends the HTTP status on its own line, which is the second
+ * instrument's whole input: the body alone cannot tell a refusal from a substituted call on a
+ * provider that echoes nothing. The env var is expanded by the sandbox shell, so the key value
+ * never appears in any runner-side string.
+ */
+function sandboxProbeScript(shape: ProbeShape, apiKeyVar: string): string {
+  const headers = shape.headers
+    .map(
+      ([name, value]) =>
+        `-H "${name}: ${value.split(KEY_SLOT).join(`$${apiKeyVar}`)}" `,
+    )
+    .join("");
+  return (
+    `curl -s -m ${CURL_TIMEOUT_S} -w '\\n%{http_code}' -X POST ` +
+    headers +
+    `-d ${JSON.stringify(shape.body)} ${JSON.stringify(shape.url)}`
+  );
+}
+
+/** Split curl's output into the response body and the status `-w` appended. */
+export function splitProbeOutput(stdout: string | undefined): {
+  body: string;
+  status?: number;
+} {
+  if (!stdout) return { body: "" };
+  const lastNewline = stdout.lastIndexOf("\n");
+  if (lastNewline < 0) return { body: stdout };
+  const tail = stdout.slice(lastNewline + 1).trim();
+  if (!/^\d{3}$/.test(tail)) return { body: stdout };
+  const status = Number(tail);
+  // curl writes 000 when the request never completed. That is not a provider answer.
+  if (status === 0) return { body: stdout.slice(0, lastNewline) };
+  return { body: stdout.slice(0, lastNewline), status };
+}
+
+/** What the runner's own call to the same endpoint said about the key. */
+type ControlReading =
+  | { kind: "accepted"; status: number }
+  | { kind: "refused"; status: number }
+  | { kind: "unknown"; detail: string };
+
+async function fetchControlProbe(
+  request: ControlProbeRequest,
+): Promise<ControlProbeResponse> {
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), request.timeoutMs);
+  try {
+    const response = await fetch(request.url, {
+      method: "POST",
+      headers: request.headers,
+      body: request.body,
+      signal: controller.signal,
+    });
+    return { status: response.status };
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+/**
  * Resolve "ok" when the sandbox's model credential substitutes on the wire (or nothing can be
- * judged — fail open), and "stuck" after enough consecutive raw-placeholder echoes. Never
- * throws.
+ * judged — fail open), and "stuck" after enough consecutive placeholder readings. Never throws.
  */
 export async function awaitCredentialSubstitution(
   input: CredentialPreflightInput,
@@ -162,65 +315,175 @@ export async function awaitCredentialSubstitution(
     ((ms: number) => new Promise<void>((resolve) => setTimeout(resolve, ms)));
   const budgetMs = input.budgetMs ?? DEFAULT_BUDGET_MS;
   const pollMs = input.pollMs ?? DEFAULT_POLL_MS;
-  const url = `${input.baseUrl.replace(/\/+$/, "")}/chat/completions`;
-  // The env var is expanded by the sandbox shell, so the placeholder value never appears in
-  // any runner-side string. `-d "{}"` makes an auth-first endpoint answer without a model call.
-  const script =
-    `curl -s -m ${CURL_TIMEOUT_S} -X POST ` +
-    `-H "Content-Type: application/json" ` +
-    `-H "Authorization: Bearer $${input.apiKeyVar}" ` +
-    `-d "{}" ${JSON.stringify(url)}`;
+  const shape = probeShapeFor(input.baseUrl, input.provider);
+  const script = sandboxProbeScript(shape, input.apiKeyVar);
+  // Last line of defence: no message this module writes may carry the key, whatever a future
+  // edit or a provider error string puts in it.
+  const controlKey = input.controlKey;
+  const log = (message: string) =>
+    input.log(
+      controlKey && controlKey.length >= 8
+        ? message.split(controlKey).join("[redacted]")
+        : message,
+    );
+
+  // Started HERE so it runs concurrently with probe 1, and awaited only when a bare 401 makes
+  // it the deciding evidence. One call per preflight. It never rejects, so an unawaited
+  // rejection cannot escape when the sandbox answers cleanly.
+  const control: Promise<ControlReading> | undefined = controlKey
+    ? (input.controlProbe ?? fetchControlProbe)({
+        url: shape.url,
+        headers: Object.fromEntries(
+          shape.headers.map(([name, value]) => [
+            name,
+            value.split(KEY_SLOT).join(controlKey),
+          ]),
+        ),
+        body: shape.body,
+        timeoutMs: CONTROL_TIMEOUT_MS,
+      }).then(
+        (response): ControlReading => {
+          if (response.status === undefined)
+            return { kind: "unknown", detail: "no status" };
+          // 401 and 403 are the provider refusing the key itself. Everything else — a 400 for
+          // the junk body, a 200, a 429 — means the provider read the key and accepted it.
+          return response.status === 401 || response.status === 403
+            ? { kind: "refused", status: response.status }
+            : { kind: "accepted", status: response.status };
+        },
+        (error): ControlReading => ({
+          kind: "unknown",
+          detail: String(error instanceof Error ? error.message : error).slice(
+            0,
+            120,
+          ),
+        }),
+      )
+    : undefined;
 
   const startedAt = now();
   for (let attempt = 1; ; attempt++) {
-    let body: string | undefined;
+    let stdout: string | undefined;
     try {
       const result = await input.sandbox.runProcess({
         command: "sh",
         args: ["-c", script],
         timeoutMs: (CURL_TIMEOUT_S + 4) * 1000,
       });
-      body = result?.stdout;
+      stdout = result?.stdout;
     } catch (error) {
       // The exec channel itself failed (sandbox tearing down, daemon hiccup): fail open.
-      input.log(
+      log(
         `[credential-preflight] probe errored, proceeding: ${String(
           error instanceof Error ? error.message : error,
         ).slice(0, 120)}`,
       );
       return "ok";
     }
+    const { body, status } = splitProbeOutput(stdout);
+    const masked = MASKED_PLACEHOLDER_ECHO.test(body);
+    // Awaited BEFORE the clock is read, so a slow control call spends the same budget every
+    // other step of the preflight spends. Otherwise a control call that took most of the grace
+    // would leave the loop thinking it still had time for several more probes.
+    const reading =
+      !masked && status === 401 && control ? await control : undefined;
     const elapsedMs = now() - startedAt;
-    if (!body || !MASKED_PLACEHOLDER_ECHO.test(body)) {
+    const elapsed = (elapsedMs / 1000).toFixed(1);
+
+    // Evidence that the raw placeholder went out. Each instrument words its own two lines: the
+    // per-probe line while the grace still runs, and the conviction line at the end.
+    let evidence: { probeLine: string; stuckLine: string } | undefined;
+    if (masked) {
+      evidence = {
+        probeLine: `raw placeholder echoed (probe ${attempt}, +${elapsed}s)`,
+        stuckLine: `STUCK: raw placeholder on all ${attempt} probes (${elapsed}s)`,
+      };
+    } else if (status === 401) {
+      // The provider refused without naming what it received. Only the control call can say
+      // whether the sandbox sent a bad key or the raw placeholder.
+      if (!reading) {
+        log(
+          `[credential-preflight] sandbox answered 401 with no echo (probe ${attempt}, ` +
+            `+${elapsed}s) and the runner holds no key for a control call; proceeding`,
+        );
+        return "ok";
+      }
+      if (reading.kind === "refused") {
+        log(
+          `[credential-preflight] sandbox answered 401 with no echo (probe ${attempt}, ` +
+            `+${elapsed}s), and the runner's own control call with the same key was ` +
+            `refused (HTTP ${reading.status}): the key itself is being rejected, not its ` +
+            `delivery; proceeding`,
+        );
+        return "ok";
+      }
+      if (reading.kind === "unknown") {
+        log(
+          `[credential-preflight] sandbox answered 401 with no echo (probe ${attempt}, ` +
+            `+${elapsed}s), but the control call gave no verdict (${reading.detail}); ` +
+            `proceeding`,
+        );
+        return "ok";
+      }
+      evidence = {
+        probeLine:
+          `bare 401 with no echo (probe ${attempt}, +${elapsed}s); the runner's own ` +
+          `control call accepted the same key (HTTP ${reading.status})`,
+        stuckLine:
+          `STUCK: bare 401 with no echo on all ${attempt} probes (${elapsed}s) while ` +
+          `the runner's own control call accepted the same key (HTTP ${reading.status})`,
+      };
+    }
+
+    if (!evidence) {
       // Substituted, or the endpoint gave nothing this preflight can judge by — fail open
       // either way. An unmasked placeholder shape lands here on purpose: scrubbing produces
       // it from a healthy key too, so it is not evidence. Log it, because a stuck sandbox
       // behind an echoing endpoint now passes the preflight and surfaces as the 401 instead.
-      if (body?.includes("dtn_")) {
-        input.log(
+      if (body.includes("dtn_")) {
+        log(
           `[credential-preflight] unmasked placeholder-shaped echo (probe ${attempt}, ` +
-            `+${(elapsedMs / 1000).toFixed(1)}s): scrubbing produces this from a REAL key ` +
+            `+${elapsed}s): scrubbing produces this from a REAL key ` +
             `too, so it convicts nothing; proceeding`,
         );
       } else if (attempt > 1) {
-        input.log(
+        log(
           `[credential-preflight] substitution confirmed after ${attempt} probes ` +
-            `(${(elapsedMs / 1000).toFixed(1)}s)`,
+            `(${elapsed}s)`,
         );
       }
       return "ok";
     }
     if (elapsedMs + pollMs > budgetMs) {
-      input.log(
-        `[credential-preflight] STUCK: raw placeholder on all ${attempt} probes ` +
-          `(${(elapsedMs / 1000).toFixed(1)}s); this sandbox will never substitute`,
+      log(
+        `[credential-preflight] ${evidence.stuckLine}; this sandbox will never substitute`,
       );
       return "stuck";
     }
-    input.log(
-      `[credential-preflight] raw placeholder echoed (probe ${attempt}, ` +
-        `+${(elapsedMs / 1000).toFixed(1)}s)`,
-    );
+    log(`[credential-preflight] ${evidence.probeLine}`);
     await sleep(pollMs);
   }
+}
+
+/**
+ * Build the preflight's request from the acquire path's pieces.
+ *
+ * It exists so the kickoff's wiring is testable: `acquireEnvironment` cannot be driven without a
+ * live provider, and the one property worth pinning is that the candidate's real value has
+ * exactly one destination, the control call. Everything the sandbox sees is a variable name.
+ */
+export function credentialPreflightRequest(input: {
+  baseUrl: string;
+  candidate: { binding: { name: string }; value: string };
+  provider?: string;
+}): Pick<
+  CredentialPreflightInput,
+  "baseUrl" | "apiKeyVar" | "provider" | "controlKey"
+> {
+  return {
+    baseUrl: input.baseUrl.trim(),
+    apiKeyVar: input.candidate.binding.name,
+    ...(input.provider ? { provider: input.provider } : {}),
+    controlKey: input.candidate.value,
+  };
 }

--- a/services/runner/src/engines/sandbox_agent/credential-preflight.ts
+++ b/services/runner/src/engines/sandbox_agent/credential-preflight.ts
@@ -330,19 +330,36 @@ function sandboxProbeScript(
   apiKeyVar: string,
   timeoutSeconds: number,
 ): string {
+  // Headers stay DOUBLE-quoted on purpose: `$VAR` has to reach the shell unquoted enough to
+  // expand, because expanding it is how the key stays out of this string. Their names and
+  // values are this module's own constants plus a binding name already checked against
+  // `SHELL_SAFE_ENV_VAR`, so nothing here is caller-shaped.
   const headers = Object.entries(shape.buildHeaders(`$${apiKeyVar}`))
     .map(([name, value]) => `-H "${name}: ${value}" `)
     .join("");
   const method = shape.method === "POST" ? "-X POST " : "";
-  const body =
-    shape.body === undefined ? "" : `-d ${JSON.stringify(shape.body)} `;
+  const body = shape.body === undefined ? "" : `-d ${shellQuote(shape.body)} `;
   return (
     `curl -s -m ${timeoutSeconds} -w '\\n%{http_code}' ` +
     method +
     headers +
     body +
-    JSON.stringify(shape.url)
+    shellQuote(shape.url)
   );
+}
+
+/**
+ * Quote one operand for `sh -c`.
+ *
+ * `JSON.stringify` is not shell quoting. Inside double quotes a shell still expands `$VAR`,
+ * `$(...)` and a backtick, and the URL is built from a base URL the request supplies. A base
+ * URL carrying any of those would be rewritten before curl ever saw it, so the probe would
+ * call some other host and this instrument would go silently blind while still reporting a
+ * verdict. Single quotes suppress every expansion; a single quote inside the value is closed,
+ * escaped, and reopened.
+ */
+function shellQuote(value: string): string {
+  return `'${value.split("'").join(`'\\''`)}'`;
 }
 
 /** Split curl's output into the response body and the status `-w` appended. */

--- a/services/runner/src/engines/sandbox_agent/credential-preflight.ts
+++ b/services/runner/src/engines/sandbox_agent/credential-preflight.ts
@@ -73,18 +73,26 @@
  * 10s and rebuild rather than hold every stuck user turn another 20s for a recovery nobody
  * has observed. Decided by the product owner 2026-08-31; revisit only if a late recovery
  * ever shows up in the preflight logs (it would log "substitution confirmed after N
- * probes" with N > 1). It is ONE deadline: every sandbox probe timeout and the runner's own
- * call are capped by what is left of it, so a slow probe cannot spend more than the grace.
+ * probes" with N > 1).
+ *
+ * AND IT IS ONE HARD DEADLINE. Every curl timeout, every exec timeout, every poll, and the
+ * runner's own call are capped by what is left of the grace; a probe is never started once the
+ * grace is gone; and a poll that would land exactly on the deadline convicts instead of
+ * sleeping. The runner's call carries its own timer as well, because its abort signal alone
+ * fires only when the preflight has already stopped waiting, and a provider that never answers
+ * would otherwise hold the whole acquire open.
  *
  * SCOPE. Only a freshly created Daytona sandbox whose MODEL credential rides a Daytona Secret
  * and whose connection declares an endpoint base URL. Within that, the differential covers
- * exactly three direct providers (openrouter, anthropic, openai). Every other connection —
- * a custom gateway such as the LiteLLM credits proxy, and any direct provider not named above
- * — keeps the OpenAI-compatible chat probe and masked-echo-only conviction, which is what has
- * been convicting stuck sandboxes on the credits proxy since this module shipped. Gemini is
- * not covered at all: its auth rides a query parameter rather than a header, so it needs its
- * own shape. A plaintext-env run has no placeholder; a reconnected sandbox already proved
- * itself.
+ * exactly three direct providers (openrouter, anthropic, openai) AT THEIR CANONICAL BASE URL —
+ * `deployment: "direct"` does not by itself say which host the connection points at, so the
+ * base URL is compared against a pinned table (`CANONICAL_DIRECT_BASE_URLS`). Every other
+ * connection — a custom gateway such as the LiteLLM credits proxy, a self-hosted gateway
+ * labelled with a known provider family, and any direct provider not named above — keeps the
+ * OpenAI-compatible chat probe and masked-echo-only conviction, which is what has been
+ * convicting stuck sandboxes on the credits proxy since this module shipped. Gemini is not
+ * covered at all: its auth rides a query parameter rather than a header, so it needs its own
+ * shape. A plaintext-env run has no placeholder; a reconnected sandbox already proved itself.
  *
  * THE KEY VALUE NEVER LEAVES THIS MODULE. The sandbox command carries the env var name, which
  * the sandbox shell expands, and the runner's own call carries the value in a request header
@@ -268,27 +276,69 @@ function chatProbeShape(base: string): ProbeShape {
 }
 
 /**
- * Pick the request shape from the connection's provider family and how it is reached.
+ * The one base URL each differential provider is reached at.
  *
- * Only a DIRECT connection to one of the three providers below gets a differential shape, and
- * each one is that provider's own documented endpoint for checking a key. `deployment` matters
- * as much as `provider`: a custom gateway can carry any provider name while speaking its own
- * dialect at its own host, so the auth endpoint below would not exist there.
+ * `deployment: "direct"` is NOT enough on its own to know the host. A vault custom-provider
+ * record naming a known provider family is labelled `direct` by the resolver while keeping its
+ * own configured URL (`sdks/python/agenta/sdk/agents/platform/connections.py`, pinned by
+ * `test_known_direct_custom_provider_uses_direct_deployment`), and an explicit endpoint always
+ * overrides the family default (`endpoints.py`). Without this table the preflight would send
+ * the real key to a tenant gateway's `/models` and read whatever it answered as a verdict.
+ */
+const CANONICAL_DIRECT_BASE_URLS: Record<string, string> = {
+  openrouter: "https://openrouter.ai/api/v1",
+  anthropic: "https://api.anthropic.com",
+  openai: "https://api.openai.com/v1",
+};
+
+/**
+ * Reduce a base URL to scheme, host and path for an exact comparison, or return undefined.
+ *
+ * Undefined for anything unparseable, and for a URL carrying a query, a fragment, or embedded
+ * credentials: those parts would be lost by the comparison while still being part of the real
+ * request, so a URL that has them is simply not one of the canonical bases.
+ */
+function normalizeBaseUrl(baseUrl: string): string | undefined {
+  let url: URL;
+  try {
+    url = new URL(baseUrl.trim());
+  } catch {
+    return undefined;
+  }
+  if (url.search || url.hash || url.username || url.password) return undefined;
+  const path = url.pathname.replace(/\/+$/, "");
+  return `${url.protocol.toLowerCase()}//${url.host.toLowerCase()}${path}`;
+}
+
+/**
+ * Pick the request shape from the connection's provider family, how it is reached, and its host.
+ *
+ * A differential shape needs all three to agree: a known provider, a `direct` deployment, and a
+ * base URL that IS that provider's canonical one. The URL check is the load-bearing part, for
+ * the reason spelled out on `CANONICAL_DIRECT_BASE_URLS`. When it matches, the probe URL is
+ * built from the canonical base rather than the request's spelling, so the two are the same
+ * request by construction.
  */
 function probeShapeFor(
   baseUrl: string,
   provider?: string,
   deployment?: string,
 ): ProbeShape {
-  const base = baseUrl.replace(/\/+$/, "");
-  if (deployment?.trim().toLowerCase() !== "direct")
-    return chatProbeShape(base);
-  switch (provider?.trim().toLowerCase()) {
+  const family = provider?.trim().toLowerCase() ?? "";
+  const canonical = CANONICAL_DIRECT_BASE_URLS[family];
+  if (
+    deployment?.trim().toLowerCase() !== "direct" ||
+    !canonical ||
+    normalizeBaseUrl(baseUrl) !== canonical
+  ) {
+    return chatProbeShape(baseUrl.replace(/\/+$/, ""));
+  }
+  switch (family) {
     case "openrouter":
       // OpenRouter's documented "get current key" endpoint.
       return {
         method: "GET",
-        url: `${base}/key`,
+        url: `${canonical}/key`,
         buildHeaders: (credential) => ({
           Authorization: `Bearer ${credential}`,
         }),
@@ -298,24 +348,22 @@ function probeShapeFor(
       // `limit=1` so the answer stays small; the status is all this reads.
       return {
         method: "GET",
-        url: `${base}/v1/models?limit=1`,
+        url: `${canonical}/v1/models?limit=1`,
         buildHeaders: (credential) => ({
           "x-api-key": credential,
           "anthropic-version": ANTHROPIC_VERSION,
         }),
         differential: true,
       };
-    case "openai":
+    default:
       return {
         method: "GET",
-        url: `${base}/models`,
+        url: `${canonical}/models`,
         buildHeaders: (credential) => ({
           Authorization: `Bearer ${credential}`,
         }),
         differential: true,
       };
-    default:
-      return chatProbeShape(base);
   }
 }
 
@@ -406,15 +454,27 @@ function readRunnerAuthStatus(
  */
 function createFetchControlProbe(fetchImpl: typeof fetch): ControlProbe {
   return async (request) => {
-    const response = await fetchImpl(request.url, {
-      method: request.method,
-      headers: request.headers,
-      ...(request.body === undefined ? {} : { body: request.body }),
-      redirect: "error",
-      signal: request.signal,
-    });
-    await response.body?.cancel().catch(() => {});
-    return { status: response.status };
+    // `request.signal` alone cannot end a call the provider never answers: nothing fires it
+    // until the preflight is already done waiting. Without this timer an unanswered fetch
+    // holds `await control` open past the grace and past the preflight's own cleanup.
+    const timeout = new AbortController();
+    const timer = setTimeout(
+      () => timeout.abort(new Error("runner auth call timed out")),
+      request.timeoutMs,
+    );
+    try {
+      const response = await fetchImpl(request.url, {
+        method: request.method,
+        headers: request.headers,
+        ...(request.body === undefined ? {} : { body: request.body }),
+        redirect: "error",
+        signal: AbortSignal.any([request.signal, timeout.signal]),
+      });
+      await response.body?.cancel().catch(() => {});
+      return { status: response.status };
+    } finally {
+      clearTimeout(timer);
+    }
   };
 }
 
@@ -476,7 +536,9 @@ export async function awaitCredentialSubstitution(
           url: shape.url,
           headers: shape.buildHeaders(controlKey),
           ...(shape.body === undefined ? {} : { body: shape.body }),
-          timeoutMs: Math.max(1_000, Math.min(CONTROL_TIMEOUT_MS, budgetMs)),
+          // The same one deadline the sandbox probes answer to. No floor: a caller who gives
+          // the preflight almost no budget gets almost no wait, not a fixed second of one.
+          timeoutMs: Math.min(CONTROL_TIMEOUT_MS, remainingMs()),
           signal: controlSignal,
         }).then(
           (response) => readRunnerAuthStatus(response.status),
@@ -491,11 +553,22 @@ export async function awaitCredentialSubstitution(
 
   try {
     for (let attempt = 1; ; attempt++) {
+      const leftMs = remainingMs();
+      if (leftMs <= 0) {
+        // The grace is gone and nothing has convicted. Starting another probe would spend
+        // time the caller did not give, so the answer is the fail-open one.
+        log(
+          `[credential-preflight] grace spent after ${attempt - 1} probes with no verdict; ` +
+            `proceeding`,
+        );
+        return "ok";
+      }
       // Every probe is capped by what is left of the one deadline, so a slow sandbox cannot
-      // spend more than the grace no matter how long its exec channel takes to answer.
+      // spend more than the grace no matter how long its exec channel takes to answer. The
+      // floor is one second because `curl -m 0` means no timeout at all, not an instant one.
       const probeSeconds = Math.max(
         1,
-        Math.min(PROBE_TIMEOUT_S, Math.ceil(remainingMs() / 1000)),
+        Math.min(PROBE_TIMEOUT_S, Math.floor(leftMs / 1000)),
       );
       const script = sandboxProbeScript(shape, input.apiKeyVar, probeSeconds);
       let stdout: string | undefined;
@@ -503,7 +576,9 @@ export async function awaitCredentialSubstitution(
         const result = await input.sandbox.runProcess({
           command: "sh",
           args: ["-c", script],
-          timeoutMs: (probeSeconds + 4) * 1000,
+          // Capped by the same deadline. The exec channel gets its usual slack over curl's
+          // own ceiling only while the grace can pay for it.
+          timeoutMs: Math.max(1, Math.min((probeSeconds + 4) * 1000, leftMs)),
         });
         stdout = result?.stdout;
       } catch (error) {
@@ -590,14 +665,16 @@ export async function awaitCredentialSubstitution(
         }
         return "ok";
       }
-      if (elapsedMs + pollMs > budgetMs) {
+      // `>=`, not `>`: sleeping exactly onto the deadline and then starting another probe
+      // spends time the grace does not have. A poll that would land on the deadline convicts.
+      if (elapsedMs + pollMs >= budgetMs) {
         log(
           `[credential-preflight] ${evidence.stuckLine}; this sandbox will never substitute`,
         );
         return "stuck";
       }
       log(`[credential-preflight] ${evidence.probeLine}`);
-      await sleep(pollMs);
+      await sleep(Math.min(pollMs, remainingMs()));
     }
   } finally {
     // Nothing reads the runner's call after this point, on any exit path.

--- a/services/runner/src/engines/sandbox_agent/credential-preflight.ts
+++ b/services/runner/src/engines/sandbox_agent/credential-preflight.ts
@@ -297,15 +297,22 @@ const CANONICAL_DIRECT_BASE_URLS: Record<string, string> = {
  * Undefined for anything unparseable, and for a URL carrying a query, a fragment, or embedded
  * credentials: those parts would be lost by the comparison while still being part of the real
  * request, so a URL that has them is simply not one of the canonical bases.
+ *
+ * The query and fragment are rejected on the RAW string, not on `url.search` and `url.hash`.
+ * Those two are empty strings for a URL ending in a bare `?` or `#`, so reading them would let
+ * `https://api.openai.com/v1?` through as canonical while the connection's real requests carry
+ * that character. A `?` or a `#` anywhere in the input is enough to disqualify it.
  */
 function normalizeBaseUrl(baseUrl: string): string | undefined {
+  const trimmed = baseUrl.trim();
+  if (trimmed.includes("?") || trimmed.includes("#")) return undefined;
   let url: URL;
   try {
-    url = new URL(baseUrl.trim());
+    url = new URL(trimmed);
   } catch {
     return undefined;
   }
-  if (url.search || url.hash || url.username || url.password) return undefined;
+  if (url.username || url.password) return undefined;
   const path = url.pathname.replace(/\/+$/, "");
   return `${url.protocol.toLowerCase()}//${url.host.toLowerCase()}${path}`;
 }
@@ -526,8 +533,12 @@ export async function awaitCredentialSubstitution(
   // it the deciding evidence. One call per preflight, and none at all on a connection whose
   // shape carries no differential. It never rejects, so an unawaited rejection cannot escape
   // when the sandbox answers cleanly.
+  //
+  // The remaining-time check is part of the gate, not an optimization. This runs BEFORE the
+  // loop's own deadline check, so without it a preflight with no grace left would still send
+  // the real key to the provider for an answer nothing would ever read.
   const control: Promise<RunnerAuthProbeResult> | undefined =
-    controlKey && shape.differential
+    controlKey && shape.differential && remainingMs() > 0
       ? (
           input.controlProbe ??
           createFetchControlProbe(input.fetchImpl ?? fetch)

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -378,6 +378,11 @@ async function acquireEnvironmentOnce(
   } = setup;
   let runAgentDir = setup.runAgentDir;
 
+  // The credential preflight is kicked off mid-acquire and awaited at the very end, so an
+  // acquire that fails in between would leave it running with nothing observing it. This is
+  // how the failure path ends it; see the kickoff and the catch below.
+  const preflightAbort = new AbortController();
+
   // ---- MountLifecycle ------------------------------------------------------------------ //
   // The six mount helpers moved to `environment/mount-lifecycle.ts`. They used to be mutually
   // recursive closures over this scope; they now take `ctx` and capture nothing. `ctx` is the
@@ -665,9 +670,21 @@ async function acquireEnvironmentOnce(
                 ? { deployment: request.modelConnection.deployment }
                 : {}),
             }),
-            // Cancel the runner's own auth call with the run, not just with the preflight.
-            ...(signal ? { signal } : {}),
+            // Cancel the runner's own auth call with the run, and with an acquire that fails
+            // before the await below ever runs.
+            signal: signal
+              ? AbortSignal.any([signal, preflightAbort.signal])
+              : preflightAbort.signal,
             log: logger,
+          }).catch((error: unknown) => {
+            // `awaitCredentialSubstitution` is written not to throw. If it ever does, the
+            // acquire must not inherit the rejection from a promise nobody is awaiting yet.
+            // The error's name only: nothing from a credential path is interpolated here.
+            logger(
+              `[credential-preflight] preflight itself failed (` +
+                `${error instanceof Error ? error.name : "unknown"}); proceeding`,
+            );
+            return "ok" as const;
           })
         : undefined;
 
@@ -1218,6 +1235,10 @@ async function acquireEnvironmentOnce(
     });
     return { ok: true, env: environment };
   } catch (err) {
+    // End the preflight first. Acquire failed somewhere between its kickoff and its await, so
+    // nothing downstream will ever read it, and its runner-side auth call must not outlive the
+    // acquire that started it.
+    preflightAbort.abort();
     // DELIBERATELY WITHOUT `daytonaCredentialFresh`, unlike the two call sites in `run-turn.ts`.
     // Acquire INSTALLS the model credential but never exercises it: the first model call belongs
     // to the turn. The one credential-shaped failure this path can raise is the preflight's

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -64,7 +64,7 @@ import { applyCodexMode, resolveCodexMode } from "./codex-mode.ts";
 import { conciseError } from "./errors.ts";
 import {
   awaitCredentialSubstitution,
-  credentialPreflightRequest,
+  buildCredentialPreflightInput,
   deliversModelSecretOnCreate,
   STUCK_ACQUIRE_ATTEMPTS,
   SubstitutionStuckError,
@@ -653,15 +653,20 @@ async function acquireEnvironmentOnce(
       preflightBaseUrl
         ? (deps.awaitCredentialSubstitution ?? awaitCredentialSubstitution)({
             sandbox: environment.sandbox,
-            // The candidate's real value rides in as the control call's credential and
-            // nowhere else. See `credentialPreflightRequest`.
-            ...credentialPreflightRequest({
+            // The candidate's real value rides in as the credential for the runner's own
+            // auth call and nowhere else. See `buildCredentialPreflightInput`.
+            ...buildCredentialPreflightInput({
               baseUrl: preflightBaseUrl,
               candidate: modelSecretCandidate,
               ...(request.modelConnection?.provider
                 ? { provider: request.modelConnection.provider }
                 : {}),
+              ...(request.modelConnection?.deployment
+                ? { deployment: request.modelConnection.deployment }
+                : {}),
             }),
+            // Cancel the runner's own auth call with the run, not just with the preflight.
+            ...(signal ? { signal } : {}),
             log: logger,
           })
         : undefined;

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -64,6 +64,7 @@ import { applyCodexMode, resolveCodexMode } from "./codex-mode.ts";
 import { conciseError } from "./errors.ts";
 import {
   awaitCredentialSubstitution,
+  credentialPreflightRequest,
   deliversModelSecretOnCreate,
   STUCK_ACQUIRE_ATTEMPTS,
   SubstitutionStuckError,
@@ -634,8 +635,8 @@ async function acquireEnvironmentOnce(
     const preflightBaseUrl = request.modelConnection?.endpoint?.baseUrl?.trim();
     // Record the delivery moment for the 401 classifier. Same condition as the preflight below,
     // minus the endpoint: the race exists wherever a model key rides a Secret on a fresh sandbox,
-    // but the preflight can only SEE it where the provider echoes what it received. A direct
-    // Anthropic endpoint echoes nothing, so on that path the classifier is the only guard.
+    // but the preflight can only SEE it on a provider whose request shape it knows. Gemini is
+    // not one of those, so on that path the classifier is still the only guard.
     if (
       deliversModelSecretOnCreate({
         isDaytona: plan.isDaytona,
@@ -652,8 +653,15 @@ async function acquireEnvironmentOnce(
       preflightBaseUrl
         ? (deps.awaitCredentialSubstitution ?? awaitCredentialSubstitution)({
             sandbox: environment.sandbox,
-            baseUrl: preflightBaseUrl,
-            apiKeyVar: modelSecretCandidate.binding.name,
+            // The candidate's real value rides in as the control call's credential and
+            // nowhere else. See `credentialPreflightRequest`.
+            ...credentialPreflightRequest({
+              baseUrl: preflightBaseUrl,
+              candidate: modelSecretCandidate,
+              ...(request.modelConnection?.provider
+                ? { provider: request.modelConnection.provider }
+                : {}),
+            }),
             log: logger,
           })
         : undefined;

--- a/services/runner/tests/unit/credential-preflight.test.ts
+++ b/services/runner/tests/unit/credential-preflight.test.ts
@@ -8,65 +8,71 @@ import assert from "node:assert/strict";
 
 import {
   awaitCredentialSubstitution,
-  credentialPreflightRequest,
+  buildCredentialPreflightInput,
   deliversModelSecretOnCreate,
   type ControlProbeRequest,
   type ControlProbeResponse,
-  type PreflightSandbox,
 } from "../../src/engines/sandbox_agent/credential-preflight.ts";
 
-/** A sandbox whose probe responses play back in order (the last repeats forever). */
-function sandboxAnswering(bodies: (string | Error)[]): {
-  sandbox: PreflightSandbox;
-  commands: string[];
-} {
+interface HarnessOptions {
+  /** The model connection's provider and how it is reached; together they pick the shape. */
+  provider?: string;
+  deployment?: string;
+  /** The real key value the runner holds, used only by its own auth call. */
+  controlKey?: string;
+  /** What that call answers, an error it throws, or "pending" for one that never settles. */
+  control?: ControlProbeResponse | Error | "pending";
+  baseUrl?: string;
+  apiKeyVar?: string;
+  /** Clock milliseconds each sandbox probe consumes, for deadline tests. */
+  probeCostMs?: number;
+  /** Drive the real fetch-backed probe instead of an injected one. */
+  fetchImpl?: typeof fetch;
+  signal?: AbortSignal;
+}
+
+/**
+ * Drive one preflight against a scripted sandbox (the last body repeats forever) and a
+ * scripted runner call, on a fake clock that only moves when the code sleeps or probes.
+ */
+function harness(
+  bodies: (string | Error)[],
+  budgetMs = 25_000,
+  options: HarnessOptions = {},
+) {
   const commands: string[] = [];
+  const logs: string[] = [];
+  const controlRequests: ControlProbeRequest[] = [];
   let index = 0;
-  return {
-    commands,
+  let clock = 0;
+  const run = awaitCredentialSubstitution({
     sandbox: {
       async runProcess(request) {
         commands.push(request.args?.[1] ?? request.command);
+        clock += options.probeCostMs ?? 0;
         const body = bodies[Math.min(index, bodies.length - 1)];
         index += 1;
         if (body instanceof Error) throw body;
         return { exitCode: 0, stdout: body };
       },
     },
-  };
-}
-
-interface HarnessOptions {
-  /** The model connection's provider, which selects the probe shape. */
-  provider?: string;
-  /** The real key value the runner holds, used only by the control call. */
-  controlKey?: string;
-  /** What the runner's own control call answers, or an error it throws. */
-  control?: ControlProbeResponse | Error;
-  baseUrl?: string;
-  apiKeyVar?: string;
-}
-
-function harness(
-  bodies: (string | Error)[],
-  budgetMs = 25_000,
-  options: HarnessOptions = {},
-) {
-  const { sandbox, commands } = sandboxAnswering(bodies);
-  const logs: string[] = [];
-  const controlRequests: ControlProbeRequest[] = [];
-  let clock = 0;
-  const run = awaitCredentialSubstitution({
-    sandbox,
     baseUrl: options.baseUrl ?? "https://gateway.example/",
     apiKeyVar: options.apiKeyVar ?? "OPENAI_API_KEY",
     ...(options.provider ? { provider: options.provider } : {}),
+    ...(options.deployment ? { deployment: options.deployment } : {}),
     ...(options.controlKey ? { controlKey: options.controlKey } : {}),
-    controlProbe: async (request) => {
-      controlRequests.push(request);
-      if (options.control instanceof Error) throw options.control;
-      return options.control ?? { status: 400 };
-    },
+    ...(options.signal ? { signal: options.signal } : {}),
+    ...(options.fetchImpl
+      ? { fetchImpl: options.fetchImpl }
+      : {
+          controlProbe: async (request) => {
+            controlRequests.push(request);
+            if (options.control instanceof Error) throw options.control;
+            if (options.control === "pending")
+              return new Promise<ControlProbeResponse>(() => {});
+            return options.control ?? { status: 200 };
+          },
+        }),
     log: (m) => logs.push(m),
     budgetMs,
     pollMs: 2_000,
@@ -81,6 +87,15 @@ function harness(
 /** The OpenRouter body observed in production: a 401 that never names the key. */
 const BARE_401 =
   '{"error":{"message":"No auth credentials found","code":401}}\n401';
+
+/** A direct OpenRouter connection, the one the production defect was reported on. */
+const OPENROUTER: HarnessOptions = {
+  provider: "openrouter",
+  deployment: "direct",
+  baseUrl: "https://openrouter.ai/api/v1",
+  apiKeyVar: "OPENROUTER_API_KEY",
+  controlKey: "sk-or-real-key-value",
+};
 
 describe("awaitCredentialSubstitution", () => {
   it("returns ok immediately when the first probe substitutes", async () => {
@@ -170,6 +185,369 @@ describe("awaitCredentialSubstitution", () => {
   });
 });
 
+describe("the differential: judging a provider that does not echo the key", () => {
+  // The production defect (AGE-4249): on the direct OpenRouter connection a bad bearer comes
+  // back as a 401 that never names the key, so the masked-echo instrument is blind and the
+  // preflight fails open on probe 1. The second instrument compares that answer against the
+  // runner's own call to the provider's documented auth endpoint.
+
+  it("convicts a bare 401 when the auth endpoint accepted the same key", async () => {
+    const { run, logs, commands, controlRequests } = harness(
+      [BARE_401],
+      3_000,
+      { ...OPENROUTER, control: { status: 200 } },
+    );
+    assert.equal(await run, "stuck");
+    assert.ok(commands.length >= 1);
+    assert.equal(
+      controlRequests.length,
+      1,
+      "exactly one runner call per preflight",
+    );
+    const stuck = logs[logs.length - 1];
+    assert.match(stuck, /STUCK/);
+    assert.match(stuck, /auth endpoint accepted the same key/);
+  });
+
+  it("fails open when the auth endpoint refused the key too", async () => {
+    const { run, logs, commands } = harness([BARE_401], 3_000, {
+      ...OPENROUTER,
+      control: { status: 401 },
+    });
+    assert.equal(await run, "ok");
+    assert.equal(commands.length, 1, "a refused key must not be re-probed");
+    assert.match(logs[0], /refused the same key/);
+    assert.match(logs[0], /the key itself is being rejected/);
+  });
+
+  it("fails open on every status that is neither 200 nor 401, naming it", async () => {
+    // Only a positive answer from a purpose-built auth endpoint is acceptance. A 403, a
+    // missing route, a throttle, or a provider outage says something about the request, not
+    // about the key, and reading any of them as proof would convict a healthy sandbox.
+    for (const status of [403, 404, 405, 429, 500, 502]) {
+      const { run, logs, commands } = harness([BARE_401], 3_000, {
+        ...OPENROUTER,
+        control: { status },
+      });
+      assert.equal(await run, "ok", `status ${status}`);
+      assert.equal(commands.length, 1, `status ${status}`);
+      assert.match(logs[0], /gave no verdict/, `status ${status}`);
+      assert.match(logs[0], new RegExp(`HTTP ${status}`), `status ${status}`);
+    }
+  });
+
+  it("fails open when the runner's own call throws or times out", async () => {
+    const { run, logs } = harness([BARE_401], 3_000, {
+      ...OPENROUTER,
+      control: new Error("control timed out"),
+    });
+    assert.equal(await run, "ok");
+    assert.match(logs[0], /gave no verdict \(control timed out\)/);
+  });
+
+  it("fails open when the runner's own call returns no status", async () => {
+    const { run, logs } = harness([BARE_401], 3_000, {
+      ...OPENROUTER,
+      control: {},
+    });
+    assert.equal(await run, "ok");
+    assert.match(logs[0], /gave no verdict \(no status\)/);
+  });
+
+  it("makes no runner call and fails open when the runner holds no key", async () => {
+    const { run, logs, controlRequests } = harness([BARE_401], 3_000, {
+      ...OPENROUTER,
+      controlKey: undefined,
+    });
+    assert.equal(await run, "ok");
+    assert.equal(controlRequests.length, 0);
+    assert.match(logs[0], /no key to check it against/);
+  });
+
+  it("fails open on a sandbox status that is not 401", async () => {
+    const { run } = harness(['{"data":[{"id":"gpt-5.5"}]}\n200'], 3_000, {
+      ...OPENROUTER,
+      control: { status: 200 },
+    });
+    assert.equal(await run, "ok");
+  });
+
+  it("aborts the runner's call as soon as the preflight stops needing it", async () => {
+    // A healthy sandbox returns on probe 1 while the runner's call is still in flight.
+    // Nothing reads it after that, so it must not be left running.
+    const { run, controlRequests } = harness(
+      ['{"data":[{"id":"gpt-5.5"}]}\n200'],
+      3_000,
+      { ...OPENROUTER, control: "pending" },
+    );
+    assert.equal(await run, "ok");
+    assert.equal(controlRequests.length, 1);
+    assert.equal(controlRequests[0].signal.aborted, true);
+  });
+
+  it("aborts the runner's call after a conviction too", async () => {
+    const { run, controlRequests } = harness([BARE_401], 3_000, {
+      ...OPENROUTER,
+      control: { status: 200 },
+    });
+    assert.equal(await run, "stuck");
+    assert.equal(controlRequests[0].signal.aborted, true);
+  });
+
+  it("never puts the real key in a log line or in the sandbox command", async () => {
+    const secret = "sk-or-real-key-value-0123456789";
+    const { run, logs, commands } = harness([BARE_401], 3_000, {
+      ...OPENROUTER,
+      controlKey: secret,
+      control: { status: 200 },
+    });
+    await run;
+    for (const line of [...logs, ...commands]) {
+      assert.ok(!line.includes(secret), `key leaked into: ${line}`);
+    }
+  });
+
+  it("redacts even a very short key value", async () => {
+    // The redactor takes no view on what a key looks like. A three-character value is still
+    // the run's credential, and a length rule would be the one hole a leak walks through.
+    const secret = "abc";
+    const { run, logs } = harness(
+      [`{"error":{"message":"bad key abc, sorry"}}\n401`],
+      3_000,
+      { ...OPENROUTER, controlKey: secret, control: { status: 401 } },
+    );
+    assert.equal(await run, "ok");
+    assert.ok(logs.length > 0);
+    for (const line of logs) {
+      assert.ok(!/abc/.test(line), `key leaked into: ${line}`);
+    }
+  });
+});
+
+describe("the one deadline", () => {
+  it("caps each probe by what is left of the grace", async () => {
+    // Probe 1 starts with the full 10s, so curl gets its own 8s ceiling. Probe 2 starts at
+    // 5s spent and gets 5s. Probe 3 starts with the grace gone and gets the 1s floor, so a
+    // probe the loop has already committed to cannot run for another eight seconds.
+    const { run, commands } = harness(["Received=dtn_****9maz"], 10_000, {
+      probeCostMs: 3_000,
+    });
+    assert.equal(await run, "stuck");
+    assert.equal(commands.length, 3);
+    assert.match(commands[0], /curl -s -m 8 /);
+    assert.match(commands[1], /curl -s -m 5 /);
+    assert.match(commands[2], /curl -s -m 1 /);
+  });
+
+  it("a slow probe cannot push the total past the budget", async () => {
+    const { run, commands } = harness(["Received=dtn_****9maz"], 10_000, {
+      probeCostMs: 9_000,
+    });
+    assert.equal(await run, "stuck");
+    assert.equal(commands.length, 1, "one 9s probe already spends the grace");
+  });
+});
+
+describe("provider shapes", () => {
+  it("uses the OpenAI-compatible chat probe when the deployment is not direct", async () => {
+    const { run, commands } = harness([BARE_401], 3_000, {
+      deployment: "custom",
+      controlKey: "sk-real-key-value",
+    });
+    await run;
+    assert.match(commands[0], /-X POST /);
+    assert.match(commands[0], /https:\/\/gateway\.example\/chat\/completions/);
+    assert.match(commands[0], /Authorization: Bearer \$OPENAI_API_KEY/);
+  });
+
+  it("uses OpenRouter's documented key endpoint on a direct connection", async () => {
+    const { run, commands, controlRequests } = harness([BARE_401], 3_000, {
+      ...OPENROUTER,
+      control: { status: 200 },
+    });
+    await run;
+    assert.match(commands[0], /"https:\/\/openrouter\.ai\/api\/v1\/key"/);
+    assert.ok(!commands[0].includes("-X POST"), "the auth probe is a GET");
+    assert.match(commands[0], /Authorization: Bearer \$OPENROUTER_API_KEY/);
+    assert.equal(controlRequests[0].method, "GET");
+    assert.equal(controlRequests[0].url, "https://openrouter.ai/api/v1/key");
+    assert.equal(controlRequests[0].body, undefined);
+    assert.equal(
+      controlRequests[0].headers.Authorization,
+      `Bearer ${OPENROUTER.controlKey}`,
+    );
+  });
+
+  it("uses Anthropic's model list on a direct connection", async () => {
+    const secret = "sk-ant-real-key-value";
+    const { run, commands, controlRequests } = harness([BARE_401], 3_000, {
+      provider: "anthropic",
+      deployment: "direct",
+      baseUrl: "https://api.anthropic.com",
+      apiKeyVar: "ANTHROPIC_API_KEY",
+      controlKey: secret,
+      control: { status: 200 },
+    });
+    await run;
+    assert.match(
+      commands[0],
+      /"https:\/\/api\.anthropic\.com\/v1\/models\?limit=1"/,
+    );
+    assert.match(commands[0], /x-api-key: \$ANTHROPIC_API_KEY/);
+    assert.match(commands[0], /anthropic-version: 2023-06-01/);
+    assert.ok(
+      !commands[0].includes(secret),
+      "the key never enters the sandbox command",
+    );
+    assert.equal(
+      controlRequests[0].url,
+      "https://api.anthropic.com/v1/models?limit=1",
+    );
+    assert.equal(controlRequests[0].headers["x-api-key"], secret);
+    assert.equal(controlRequests[0].headers["anthropic-version"], "2023-06-01");
+    assert.equal(controlRequests[0].headers.Authorization, undefined);
+  });
+
+  it("uses OpenAI's model list on a direct connection", async () => {
+    const { run, commands, controlRequests } = harness([BARE_401], 3_000, {
+      provider: "openai",
+      deployment: "direct",
+      baseUrl: "https://api.openai.com/v1",
+      controlKey: "sk-real-key-value",
+      control: { status: 200 },
+    });
+    assert.equal(await run, "stuck");
+    assert.match(commands[0], /"https:\/\/api\.openai\.com\/v1\/models"/);
+    assert.equal(controlRequests[0].url, "https://api.openai.com/v1/models");
+  });
+
+  it("never applies the differential to a custom gateway, even on a 200", async () => {
+    // The LiteLLM credits proxy lands here. Its masked 401 is what convicts a stuck sandbox,
+    // and a 401 from its chat endpoint has too many other causes to attribute.
+    const { run, controlRequests } = harness([BARE_401], 3_000, {
+      provider: "openai",
+      deployment: "custom",
+      controlKey: "sk-real-key-value",
+      control: { status: 200 },
+    });
+    assert.equal(await run, "ok");
+    assert.equal(controlRequests.length, 0, "no runner call is made at all");
+  });
+
+  it("keeps a direct provider outside the three on the chat probe", async () => {
+    const { run, commands, controlRequests } = harness([BARE_401], 3_000, {
+      provider: "gemini",
+      deployment: "direct",
+      controlKey: "sk-real-key-value",
+      control: { status: 200 },
+    });
+    assert.equal(await run, "ok");
+    assert.match(commands[0], /chat\/completions/);
+    assert.equal(controlRequests.length, 0);
+  });
+
+  it("asks the sandbox probe for the HTTP status", async () => {
+    const { run, commands } = harness([BARE_401], 3_000, OPENROUTER);
+    await run;
+    assert.match(commands[0], /http_code/);
+  });
+
+  it("fails open when the binding name is not a shell-safe variable name", async () => {
+    // The name is interpolated into a shell command. Anything but a variable name is an
+    // upstream programming error, and the preflight refuses rather than building the string.
+    const { run, logs, commands } = harness([BARE_401], 3_000, {
+      ...OPENROUTER,
+      apiKeyVar: "KEY; curl evil.example",
+    });
+    assert.equal(await run, "ok");
+    assert.equal(commands.length, 0, "nothing is ever run in the sandbox");
+    assert.match(logs[0], /not a shell-safe environment variable name/);
+  });
+});
+
+describe("the runner's own request", () => {
+  it("refuses to follow a redirect, so the key cannot be sent to another host", async () => {
+    const seen: { url: string; init: RequestInit }[] = [];
+    const fetchImpl = (async (
+      url: string | URL | Request,
+      init: RequestInit,
+    ) => {
+      seen.push({ url: String(url), init });
+      return new Response("{}", { status: 401 });
+    }) as unknown as typeof fetch;
+    const { run } = harness([BARE_401], 3_000, { ...OPENROUTER, fetchImpl });
+    assert.equal(await run, "ok");
+    assert.equal(seen.length, 1);
+    assert.equal(seen[0].url, "https://openrouter.ai/api/v1/key");
+    assert.equal(seen[0].init.redirect, "error");
+    assert.equal(seen[0].init.method, "GET");
+    assert.equal(seen[0].init.body, undefined);
+    assert.ok(seen[0].init.signal, "the request carries an abort signal");
+  });
+});
+
+describe("buildCredentialPreflightInput: what the acquire path hands the preflight", () => {
+  // `acquireEnvironment` cannot be driven without a live provider, so this builder is where
+  // the kickoff's wiring is pinned. The key value has exactly one destination.
+  const candidate = {
+    binding: { name: "OPENROUTER_API_KEY" },
+    value: "sk-or-real-key-value",
+  };
+
+  it("routes the candidate value only into the runner call's credential", () => {
+    const input = buildCredentialPreflightInput({
+      baseUrl: " https://openrouter.ai/api/v1 ",
+      candidate,
+      provider: "openrouter",
+      deployment: "direct",
+    });
+    assert.equal(input.baseUrl, "https://openrouter.ai/api/v1");
+    assert.equal(input.apiKeyVar, "OPENROUTER_API_KEY");
+    assert.equal(input.provider, "openrouter");
+    assert.equal(input.deployment, "direct");
+    assert.equal(input.controlKey, candidate.value);
+    const serialized = JSON.stringify(input);
+    assert.equal(
+      serialized.split(candidate.value).length - 1,
+      1,
+      "the value appears once, as the runner call's credential",
+    );
+  });
+
+  it("keeps the key out of every log line the preflight then writes", async () => {
+    const input = buildCredentialPreflightInput({
+      baseUrl: "https://openrouter.ai/api/v1",
+      candidate,
+      provider: "openrouter",
+      deployment: "direct",
+    });
+    const logs: string[] = [];
+    const commands: string[] = [];
+    let clock = 0;
+    const verdict = await awaitCredentialSubstitution({
+      ...input,
+      sandbox: {
+        async runProcess(req) {
+          commands.push(req.args?.[1] ?? req.command);
+          return { exitCode: 0, stdout: BARE_401 };
+        },
+      },
+      controlProbe: async () => ({ status: 200 }),
+      log: (m) => logs.push(m),
+      budgetMs: 3_000,
+      pollMs: 2_000,
+      now: () => clock,
+      sleep: async (ms) => {
+        clock += ms;
+      },
+    });
+    assert.equal(verdict, "stuck");
+    for (const line of [...logs, ...commands]) {
+      assert.ok(!line.includes(candidate.value), `key leaked into: ${line}`);
+    }
+  });
+});
+
 describe("deliversModelSecretOnCreate: what arms the race guards", () => {
   // The preflight gates on this AND a declared endpoint; the 401 classifier arms its
   // credential-race reading on this alone. `acquireEnvironment` cannot be driven without a live
@@ -203,227 +581,5 @@ describe("deliversModelSecretOnCreate: what arms the race guards", () => {
       deliversModelSecretOnCreate({ ...base, hasModelSecretCandidate: false }),
       false,
     );
-  });
-});
-
-describe("the control call: judging a provider that does not echo the key", () => {
-  // The production defect (AGE-4249): on the direct OpenRouter connection a bad bearer comes
-  // back as a 401 that never names the key, so the masked-echo instrument is blind and the
-  // preflight fails open on probe 1. The second instrument is body-independent: the runner
-  // holds the real key, so it calls the same URL itself and compares the two answers.
-
-  it("convicts a bare 401 when the runner's own control call was accepted", async () => {
-    const { run, logs, commands, controlRequests } = harness(
-      [BARE_401],
-      3_000,
-      {
-        controlKey: "sk-real-key-value",
-        control: { status: 400 },
-      },
-    );
-    assert.equal(await run, "stuck");
-    assert.ok(commands.length >= 1);
-    assert.equal(
-      controlRequests.length,
-      1,
-      "exactly one control call per preflight",
-    );
-    const stuck = logs[logs.length - 1];
-    assert.match(stuck, /STUCK/);
-    assert.match(stuck, /control call/i);
-    assert.match(stuck, /accepted/i);
-  });
-
-  it("fails open when the control call is refused too: the key itself is bad", async () => {
-    const { run, logs, commands } = harness([BARE_401], 3_000, {
-      controlKey: "sk-real-key-value",
-      control: { status: 401 },
-    });
-    assert.equal(await run, "ok");
-    assert.equal(
-      commands.length,
-      1,
-      "a refused control call must not be re-probed",
-    );
-    assert.match(logs[0], /control call/i);
-    assert.match(logs[0], /refused|the key itself/i);
-  });
-
-  it("fails open when the control call is forbidden (403)", async () => {
-    const { run } = harness([BARE_401], 3_000, {
-      controlKey: "sk-real-key-value",
-      control: { status: 403 },
-    });
-    assert.equal(await run, "ok");
-  });
-
-  it("fails open when the control call throws or times out", async () => {
-    const { run, logs } = harness([BARE_401], 3_000, {
-      controlKey: "sk-real-key-value",
-      control: new Error("control timed out"),
-    });
-    assert.equal(await run, "ok");
-    assert.match(logs[0], /control call/i);
-    assert.match(logs[0], /no verdict|proceeding/i);
-  });
-
-  it("fails open when the control call returns no status", async () => {
-    const { run } = harness([BARE_401], 3_000, {
-      controlKey: "sk-real-key-value",
-      control: {},
-    });
-    assert.equal(await run, "ok");
-  });
-
-  it("makes no control call and fails open when the runner holds no key", async () => {
-    const { run, controlRequests } = harness([BARE_401], 3_000, {});
-    assert.equal(await run, "ok");
-    assert.equal(controlRequests.length, 0);
-  });
-
-  it("fails open on a non-401 status, whatever the control call says", async () => {
-    // A 400 from the sandbox means the endpoint read the header and rejected the junk body.
-    const { run } = harness(
-      ['{"error":{"message":"model is required"}}\n400'],
-      3_000,
-      { controlKey: "sk-real-key-value", control: { status: 400 } },
-    );
-    assert.equal(await run, "ok");
-  });
-
-  it("never puts the real key in a log line or in the sandbox command", async () => {
-    const secret = "sk-real-key-value-0123456789";
-    const { run, logs, commands } = harness([BARE_401], 3_000, {
-      controlKey: secret,
-      control: { status: 400 },
-    });
-    await run;
-    for (const line of [...logs, ...commands]) {
-      assert.ok(!line.includes(secret), `key leaked into: ${line}`);
-    }
-  });
-});
-
-describe("provider shapes", () => {
-  it("uses the OpenAI-compatible shape by default", async () => {
-    const { run, commands, controlRequests } = harness([BARE_401], 3_000, {
-      controlKey: "sk-real-key-value",
-      control: { status: 400 },
-    });
-    await run;
-    assert.match(commands[0], /https:\/\/gateway\.example\/chat\/completions/);
-    assert.match(commands[0], /Authorization: Bearer \$OPENAI_API_KEY/);
-    assert.equal(
-      controlRequests[0].url,
-      "https://gateway.example/chat/completions",
-    );
-    assert.equal(
-      controlRequests[0].headers.Authorization,
-      "Bearer sk-real-key-value",
-    );
-  });
-
-  it("uses the Anthropic shape for a direct Anthropic connection", async () => {
-    const secret = "sk-ant-real-key-value";
-    const { run, commands, controlRequests } = harness([BARE_401], 3_000, {
-      provider: "anthropic",
-      baseUrl: "https://api.anthropic.com",
-      apiKeyVar: "ANTHROPIC_API_KEY",
-      controlKey: secret,
-      control: { status: 400 },
-    });
-    await run;
-    assert.match(commands[0], /https:\/\/api\.anthropic\.com\/v1\/messages/);
-    assert.match(commands[0], /x-api-key: \$ANTHROPIC_API_KEY/);
-    assert.match(commands[0], /anthropic-version: 2023-06-01/);
-    assert.ok(
-      !commands[0].includes(secret),
-      "the key never enters the sandbox command",
-    );
-    assert.equal(
-      controlRequests[0].url,
-      "https://api.anthropic.com/v1/messages",
-    );
-    assert.equal(controlRequests[0].headers["x-api-key"], secret);
-    assert.equal(controlRequests[0].headers["anthropic-version"], "2023-06-01");
-    assert.equal(controlRequests[0].headers.Authorization, undefined);
-  });
-
-  it("asks the sandbox probe for the HTTP status", async () => {
-    const { run, commands } = harness([BARE_401], 3_000, {
-      controlKey: "sk-real-key-value",
-      control: { status: 400 },
-    });
-    await run;
-    assert.match(commands[0], /http_code/);
-  });
-
-  it("keeps an unknown provider on the default shape", async () => {
-    const { run, commands } = harness([BARE_401], 3_000, {
-      provider: "some-new-gateway",
-      controlKey: "sk-real-key-value",
-      control: { status: 401 },
-    });
-    assert.equal(await run, "ok");
-    assert.match(commands[0], /chat\/completions/);
-  });
-});
-
-describe("credentialPreflightRequest: what the acquire path hands the preflight", () => {
-  // `acquireEnvironment` cannot be driven without a live provider, so this builder is where
-  // the kickoff's wiring is pinned. The key value has exactly one destination.
-  const candidate = {
-    binding: { name: "OPENROUTER_API_KEY" },
-    value: "sk-or-real-key-value",
-  };
-
-  it("routes the candidate value only into the control-call input", () => {
-    const request = credentialPreflightRequest({
-      baseUrl: " https://openrouter.ai/api/v1 ",
-      candidate,
-      provider: "openrouter",
-    });
-    assert.equal(request.baseUrl, "https://openrouter.ai/api/v1");
-    assert.equal(request.apiKeyVar, "OPENROUTER_API_KEY");
-    assert.equal(request.provider, "openrouter");
-    assert.equal(request.controlKey, candidate.value);
-    const serialized = JSON.stringify(request);
-    assert.equal(
-      serialized.split(candidate.value).length - 1,
-      1,
-      "the value appears once, as the control key",
-    );
-  });
-
-  it("keeps the key out of every log line the preflight then writes", async () => {
-    const request = credentialPreflightRequest({
-      baseUrl: "https://openrouter.ai/api/v1",
-      candidate,
-      provider: "openrouter",
-    });
-    const logs: string[] = [];
-    const commands: string[] = [];
-    let clock = 0;
-    const verdict = await awaitCredentialSubstitution({
-      ...request,
-      sandbox: {
-        async runProcess(req) {
-          commands.push(req.args?.[1] ?? req.command);
-          return { exitCode: 0, stdout: BARE_401 };
-        },
-      },
-      controlProbe: async () => ({ status: 400 }),
-      log: (m) => logs.push(m),
-      budgetMs: 3_000,
-      pollMs: 2_000,
-      now: () => clock,
-      sleep: async (ms) => {
-        clock += ms;
-      },
-    });
-    assert.equal(verdict, "stuck");
-    for (const line of [...logs, ...commands]) {
-      assert.ok(!line.includes(candidate.value), `key leaked into: ${line}`);
-    }
   });
 });

--- a/services/runner/tests/unit/credential-preflight.test.ts
+++ b/services/runner/tests/unit/credential-preflight.test.ts
@@ -350,6 +350,20 @@ describe("the one deadline", () => {
     assert.match(logs[0], /grace spent after 0 probes/);
   });
 
+  it("sends no key to the provider when there is no grace to spend", async () => {
+    // The runner's call is started before the loop's own deadline check, so it needs the
+    // same gate. Otherwise a preflight with no time left would still put the real key on the
+    // wire for an answer nothing would read.
+    const { run, commands, controlRequests } = harness(
+      ["Received=dtn_****9maz"],
+      0,
+      { ...OPENROUTER, control: { status: 200 } },
+    );
+    assert.equal(await run, "ok");
+    assert.equal(controlRequests.length, 0, "no key leaves the runner");
+    assert.equal(commands.length, 0);
+  });
+
   it("a slow probe cannot push the total past the budget", async () => {
     const { run, commands } = harness(["Received=dtn_****9maz"], 10_000, {
       probeCostMs: 9_000,
@@ -496,8 +510,13 @@ describe("provider shapes", () => {
   });
 
   it("does not match a canonical base carrying a query or credentials", async () => {
+    // The bare `?` and `#` cases matter because `url.search` and `url.hash` are both empty
+    // strings for them, so a check that read those two properties would let them through.
     for (const baseUrl of [
       "https://api.openai.com/v1?tenant=acme",
+      "https://api.openai.com/v1?",
+      "https://api.openai.com/v1#",
+      "https://api.openai.com/v1#frag",
       "https://user:pass@api.openai.com/v1",
     ]) {
       const { run, controlRequests } = harness([BARE_401], 3_000, {

--- a/services/runner/tests/unit/credential-preflight.test.ts
+++ b/services/runner/tests/unit/credential-preflight.test.ts
@@ -8,7 +8,10 @@ import assert from "node:assert/strict";
 
 import {
   awaitCredentialSubstitution,
+  credentialPreflightRequest,
   deliversModelSecretOnCreate,
+  type ControlProbeRequest,
+  type ControlProbeResponse,
   type PreflightSandbox,
 } from "../../src/engines/sandbox_agent/credential-preflight.ts";
 
@@ -33,14 +36,37 @@ function sandboxAnswering(bodies: (string | Error)[]): {
   };
 }
 
-function harness(bodies: (string | Error)[], budgetMs = 25_000) {
+interface HarnessOptions {
+  /** The model connection's provider, which selects the probe shape. */
+  provider?: string;
+  /** The real key value the runner holds, used only by the control call. */
+  controlKey?: string;
+  /** What the runner's own control call answers, or an error it throws. */
+  control?: ControlProbeResponse | Error;
+  baseUrl?: string;
+  apiKeyVar?: string;
+}
+
+function harness(
+  bodies: (string | Error)[],
+  budgetMs = 25_000,
+  options: HarnessOptions = {},
+) {
   const { sandbox, commands } = sandboxAnswering(bodies);
   const logs: string[] = [];
+  const controlRequests: ControlProbeRequest[] = [];
   let clock = 0;
   const run = awaitCredentialSubstitution({
     sandbox,
-    baseUrl: "https://gateway.example/",
-    apiKeyVar: "OPENAI_API_KEY",
+    baseUrl: options.baseUrl ?? "https://gateway.example/",
+    apiKeyVar: options.apiKeyVar ?? "OPENAI_API_KEY",
+    ...(options.provider ? { provider: options.provider } : {}),
+    ...(options.controlKey ? { controlKey: options.controlKey } : {}),
+    controlProbe: async (request) => {
+      controlRequests.push(request);
+      if (options.control instanceof Error) throw options.control;
+      return options.control ?? { status: 400 };
+    },
     log: (m) => logs.push(m),
     budgetMs,
     pollMs: 2_000,
@@ -49,8 +75,12 @@ function harness(bodies: (string | Error)[], budgetMs = 25_000) {
       clock += ms;
     },
   });
-  return { run, logs, commands };
+  return { run, logs, commands, controlRequests };
 }
+
+/** The OpenRouter body observed in production: a 401 that never names the key. */
+const BARE_401 =
+  '{"error":{"message":"No auth credentials found","code":401}}\n401';
 
 describe("awaitCredentialSubstitution", () => {
   it("returns ok immediately when the first probe substitutes", async () => {
@@ -173,5 +203,227 @@ describe("deliversModelSecretOnCreate: what arms the race guards", () => {
       deliversModelSecretOnCreate({ ...base, hasModelSecretCandidate: false }),
       false,
     );
+  });
+});
+
+describe("the control call: judging a provider that does not echo the key", () => {
+  // The production defect (AGE-4249): on the direct OpenRouter connection a bad bearer comes
+  // back as a 401 that never names the key, so the masked-echo instrument is blind and the
+  // preflight fails open on probe 1. The second instrument is body-independent: the runner
+  // holds the real key, so it calls the same URL itself and compares the two answers.
+
+  it("convicts a bare 401 when the runner's own control call was accepted", async () => {
+    const { run, logs, commands, controlRequests } = harness(
+      [BARE_401],
+      3_000,
+      {
+        controlKey: "sk-real-key-value",
+        control: { status: 400 },
+      },
+    );
+    assert.equal(await run, "stuck");
+    assert.ok(commands.length >= 1);
+    assert.equal(
+      controlRequests.length,
+      1,
+      "exactly one control call per preflight",
+    );
+    const stuck = logs[logs.length - 1];
+    assert.match(stuck, /STUCK/);
+    assert.match(stuck, /control call/i);
+    assert.match(stuck, /accepted/i);
+  });
+
+  it("fails open when the control call is refused too: the key itself is bad", async () => {
+    const { run, logs, commands } = harness([BARE_401], 3_000, {
+      controlKey: "sk-real-key-value",
+      control: { status: 401 },
+    });
+    assert.equal(await run, "ok");
+    assert.equal(
+      commands.length,
+      1,
+      "a refused control call must not be re-probed",
+    );
+    assert.match(logs[0], /control call/i);
+    assert.match(logs[0], /refused|the key itself/i);
+  });
+
+  it("fails open when the control call is forbidden (403)", async () => {
+    const { run } = harness([BARE_401], 3_000, {
+      controlKey: "sk-real-key-value",
+      control: { status: 403 },
+    });
+    assert.equal(await run, "ok");
+  });
+
+  it("fails open when the control call throws or times out", async () => {
+    const { run, logs } = harness([BARE_401], 3_000, {
+      controlKey: "sk-real-key-value",
+      control: new Error("control timed out"),
+    });
+    assert.equal(await run, "ok");
+    assert.match(logs[0], /control call/i);
+    assert.match(logs[0], /no verdict|proceeding/i);
+  });
+
+  it("fails open when the control call returns no status", async () => {
+    const { run } = harness([BARE_401], 3_000, {
+      controlKey: "sk-real-key-value",
+      control: {},
+    });
+    assert.equal(await run, "ok");
+  });
+
+  it("makes no control call and fails open when the runner holds no key", async () => {
+    const { run, controlRequests } = harness([BARE_401], 3_000, {});
+    assert.equal(await run, "ok");
+    assert.equal(controlRequests.length, 0);
+  });
+
+  it("fails open on a non-401 status, whatever the control call says", async () => {
+    // A 400 from the sandbox means the endpoint read the header and rejected the junk body.
+    const { run } = harness(
+      ['{"error":{"message":"model is required"}}\n400'],
+      3_000,
+      { controlKey: "sk-real-key-value", control: { status: 400 } },
+    );
+    assert.equal(await run, "ok");
+  });
+
+  it("never puts the real key in a log line or in the sandbox command", async () => {
+    const secret = "sk-real-key-value-0123456789";
+    const { run, logs, commands } = harness([BARE_401], 3_000, {
+      controlKey: secret,
+      control: { status: 400 },
+    });
+    await run;
+    for (const line of [...logs, ...commands]) {
+      assert.ok(!line.includes(secret), `key leaked into: ${line}`);
+    }
+  });
+});
+
+describe("provider shapes", () => {
+  it("uses the OpenAI-compatible shape by default", async () => {
+    const { run, commands, controlRequests } = harness([BARE_401], 3_000, {
+      controlKey: "sk-real-key-value",
+      control: { status: 400 },
+    });
+    await run;
+    assert.match(commands[0], /https:\/\/gateway\.example\/chat\/completions/);
+    assert.match(commands[0], /Authorization: Bearer \$OPENAI_API_KEY/);
+    assert.equal(
+      controlRequests[0].url,
+      "https://gateway.example/chat/completions",
+    );
+    assert.equal(
+      controlRequests[0].headers.Authorization,
+      "Bearer sk-real-key-value",
+    );
+  });
+
+  it("uses the Anthropic shape for a direct Anthropic connection", async () => {
+    const secret = "sk-ant-real-key-value";
+    const { run, commands, controlRequests } = harness([BARE_401], 3_000, {
+      provider: "anthropic",
+      baseUrl: "https://api.anthropic.com",
+      apiKeyVar: "ANTHROPIC_API_KEY",
+      controlKey: secret,
+      control: { status: 400 },
+    });
+    await run;
+    assert.match(commands[0], /https:\/\/api\.anthropic\.com\/v1\/messages/);
+    assert.match(commands[0], /x-api-key: \$ANTHROPIC_API_KEY/);
+    assert.match(commands[0], /anthropic-version: 2023-06-01/);
+    assert.ok(
+      !commands[0].includes(secret),
+      "the key never enters the sandbox command",
+    );
+    assert.equal(
+      controlRequests[0].url,
+      "https://api.anthropic.com/v1/messages",
+    );
+    assert.equal(controlRequests[0].headers["x-api-key"], secret);
+    assert.equal(controlRequests[0].headers["anthropic-version"], "2023-06-01");
+    assert.equal(controlRequests[0].headers.Authorization, undefined);
+  });
+
+  it("asks the sandbox probe for the HTTP status", async () => {
+    const { run, commands } = harness([BARE_401], 3_000, {
+      controlKey: "sk-real-key-value",
+      control: { status: 400 },
+    });
+    await run;
+    assert.match(commands[0], /http_code/);
+  });
+
+  it("keeps an unknown provider on the default shape", async () => {
+    const { run, commands } = harness([BARE_401], 3_000, {
+      provider: "some-new-gateway",
+      controlKey: "sk-real-key-value",
+      control: { status: 401 },
+    });
+    assert.equal(await run, "ok");
+    assert.match(commands[0], /chat\/completions/);
+  });
+});
+
+describe("credentialPreflightRequest: what the acquire path hands the preflight", () => {
+  // `acquireEnvironment` cannot be driven without a live provider, so this builder is where
+  // the kickoff's wiring is pinned. The key value has exactly one destination.
+  const candidate = {
+    binding: { name: "OPENROUTER_API_KEY" },
+    value: "sk-or-real-key-value",
+  };
+
+  it("routes the candidate value only into the control-call input", () => {
+    const request = credentialPreflightRequest({
+      baseUrl: " https://openrouter.ai/api/v1 ",
+      candidate,
+      provider: "openrouter",
+    });
+    assert.equal(request.baseUrl, "https://openrouter.ai/api/v1");
+    assert.equal(request.apiKeyVar, "OPENROUTER_API_KEY");
+    assert.equal(request.provider, "openrouter");
+    assert.equal(request.controlKey, candidate.value);
+    const serialized = JSON.stringify(request);
+    assert.equal(
+      serialized.split(candidate.value).length - 1,
+      1,
+      "the value appears once, as the control key",
+    );
+  });
+
+  it("keeps the key out of every log line the preflight then writes", async () => {
+    const request = credentialPreflightRequest({
+      baseUrl: "https://openrouter.ai/api/v1",
+      candidate,
+      provider: "openrouter",
+    });
+    const logs: string[] = [];
+    const commands: string[] = [];
+    let clock = 0;
+    const verdict = await awaitCredentialSubstitution({
+      ...request,
+      sandbox: {
+        async runProcess(req) {
+          commands.push(req.args?.[1] ?? req.command);
+          return { exitCode: 0, stdout: BARE_401 };
+        },
+      },
+      controlProbe: async () => ({ status: 400 }),
+      log: (m) => logs.push(m),
+      budgetMs: 3_000,
+      pollMs: 2_000,
+      now: () => clock,
+      sleep: async (ms) => {
+        clock += ms;
+      },
+    });
+    assert.equal(verdict, "stuck");
+    for (const line of [...logs, ...commands]) {
+      assert.ok(!line.includes(candidate.value), `key leaked into: ${line}`);
+    }
   });
 });

--- a/services/runner/tests/unit/credential-preflight.test.ts
+++ b/services/runner/tests/unit/credential-preflight.test.ts
@@ -81,7 +81,7 @@ function harness(
       clock += ms;
     },
   });
-  return { run, logs, commands, controlRequests };
+  return { run, logs, commands, controlRequests, elapsed: () => clock };
 }
 
 /** The OpenRouter body observed in production: a 401 that never names the key. */
@@ -325,18 +325,29 @@ describe("the differential: judging a provider that does not echo the key", () =
 });
 
 describe("the one deadline", () => {
-  it("caps each probe by what is left of the grace", async () => {
-    // Probe 1 starts with the full 10s, so curl gets its own 8s ceiling. Probe 2 starts at
-    // 5s spent and gets 5s. Probe 3 starts with the grace gone and gets the 1s floor, so a
-    // probe the loop has already committed to cannot run for another eight seconds.
-    const { run, commands } = harness(["Received=dtn_****9maz"], 10_000, {
-      probeCostMs: 3_000,
-    });
+  it("caps each probe by what is left of the grace and never runs past it", async () => {
+    // Probe 1 starts with the full 10s, so curl gets its own 8s ceiling. Probe 2 starts at 5s
+    // spent and gets 5s. A third probe would have to run past the deadline, so the loop
+    // convicts instead of sleeping onto it.
+    const { run, commands, elapsed } = harness(
+      ["Received=dtn_****9maz"],
+      10_000,
+      { probeCostMs: 3_000 },
+    );
     assert.equal(await run, "stuck");
-    assert.equal(commands.length, 3);
+    assert.equal(commands.length, 2);
     assert.match(commands[0], /curl -s -m 8 /);
     assert.match(commands[1], /curl -s -m 5 /);
-    assert.match(commands[2], /curl -s -m 1 /);
+    assert.ok(elapsed() <= 10_000, `finished at ${elapsed()}ms`);
+  });
+
+  it("starts no probe at all when there is no grace to spend", async () => {
+    // The body would convict if it were ever read. Reaching the fail-open answer with zero
+    // commands proves the deadline is checked before a probe is started, not after.
+    const { run, logs, commands } = harness(["Received=dtn_****9maz"], 0);
+    assert.equal(await run, "ok");
+    assert.equal(commands.length, 0);
+    assert.match(logs[0], /grace spent after 0 probes/);
   });
 
   it("a slow probe cannot push the total past the budget", async () => {
@@ -434,6 +445,73 @@ describe("provider shapes", () => {
     assert.equal(controlRequests.length, 0, "no runner call is made at all");
   });
 
+  it("never applies the differential to a tenant gateway labelled direct", async () => {
+    // A vault custom-provider record for a known family is labelled `direct` by the resolver
+    // while keeping its own URL. Without the canonical-base check the runner would send the
+    // real key to that gateway's /models and read the answer as a verdict about our sandbox.
+    const { run, commands, controlRequests } = harness([BARE_401], 3_000, {
+      provider: "openai",
+      deployment: "direct",
+      baseUrl: "https://tenant-gateway.example/v1",
+      controlKey: "sk-real-key-value",
+      control: { status: 200 },
+    });
+    assert.equal(await run, "ok");
+    assert.equal(controlRequests.length, 0, "no key leaves the runner");
+    assert.match(commands[0], /chat\/completions/);
+  });
+
+  it("matches the canonical base through a trailing slash and an uppercase host", async () => {
+    for (const baseUrl of [
+      "https://api.openai.com/v1/",
+      "https://API.OpenAI.COM/v1",
+      "  https://api.openai.com/v1  ",
+    ]) {
+      const { run, controlRequests } = harness([BARE_401], 3_000, {
+        provider: "openai",
+        deployment: "direct",
+        baseUrl,
+        controlKey: "sk-real-key-value",
+        control: { status: 200 },
+      });
+      assert.equal(await run, "stuck", baseUrl);
+      assert.equal(
+        controlRequests[0].url,
+        "https://api.openai.com/v1/models",
+        baseUrl,
+      );
+    }
+  });
+
+  it("does not match a canonical host reached over plain http", async () => {
+    const { run, controlRequests } = harness([BARE_401], 3_000, {
+      provider: "openai",
+      deployment: "direct",
+      baseUrl: "http://api.openai.com/v1",
+      controlKey: "sk-real-key-value",
+      control: { status: 200 },
+    });
+    assert.equal(await run, "ok");
+    assert.equal(controlRequests.length, 0);
+  });
+
+  it("does not match a canonical base carrying a query or credentials", async () => {
+    for (const baseUrl of [
+      "https://api.openai.com/v1?tenant=acme",
+      "https://user:pass@api.openai.com/v1",
+    ]) {
+      const { run, controlRequests } = harness([BARE_401], 3_000, {
+        provider: "openai",
+        deployment: "direct",
+        baseUrl,
+        controlKey: "sk-real-key-value",
+        control: { status: 200 },
+      });
+      assert.equal(await run, "ok", baseUrl);
+      assert.equal(controlRequests.length, 0, baseUrl);
+    }
+  });
+
   it("keeps a direct provider outside the three on the chat probe", async () => {
     const { run, commands, controlRequests } = harness([BARE_401], 3_000, {
       provider: "gemini",
@@ -513,6 +591,34 @@ describe("the runner's own request", () => {
     assert.equal(seen[0].init.method, "GET");
     assert.equal(seen[0].init.body, undefined);
     assert.ok(seen[0].init.signal, "the request carries an abort signal");
+  });
+
+  it("gives up on a provider that never answers, instead of waiting forever", async () => {
+    // The preflight's own abort signal cannot end this call: nothing fires it until the
+    // preflight has already stopped waiting. Only a timer inside the request can. Before it
+    // existed, a fetch that never settles held `await control` open for the whole run.
+    let requestSignal: AbortSignal | undefined;
+    const fetchImpl = (async (
+      _url: string | URL | Request,
+      init: RequestInit,
+    ) => {
+      requestSignal = init.signal ?? undefined;
+      // Never resolves on its own; only the abort ends it, exactly like a hung provider.
+      return new Promise<Response>((_resolve, reject) => {
+        init.signal?.addEventListener("abort", () =>
+          reject(new Error("aborted")),
+        );
+      });
+    }) as unknown as typeof fetch;
+    // A tiny budget makes the request's own deadline tiny too, so this finishes in
+    // milliseconds of real time rather than the eight second default.
+    const { run, logs } = harness([BARE_401], 20, {
+      ...OPENROUTER,
+      fetchImpl,
+    });
+    assert.equal(await run, "ok");
+    assert.match(logs[0], /gave no verdict/);
+    assert.equal(requestSignal?.aborted, true);
   });
 });
 

--- a/services/runner/tests/unit/credential-preflight.test.ts
+++ b/services/runner/tests/unit/credential-preflight.test.ts
@@ -366,7 +366,7 @@ describe("provider shapes", () => {
       control: { status: 200 },
     });
     await run;
-    assert.match(commands[0], /"https:\/\/openrouter\.ai\/api\/v1\/key"/);
+    assert.match(commands[0], /'https:\/\/openrouter\.ai\/api\/v1\/key'/);
     assert.ok(!commands[0].includes("-X POST"), "the auth probe is a GET");
     assert.match(commands[0], /Authorization: Bearer \$OPENROUTER_API_KEY/);
     assert.equal(controlRequests[0].method, "GET");
@@ -391,7 +391,7 @@ describe("provider shapes", () => {
     await run;
     assert.match(
       commands[0],
-      /"https:\/\/api\.anthropic\.com\/v1\/models\?limit=1"/,
+      /'https:\/\/api\.anthropic\.com\/v1\/models\?limit=1'/,
     );
     assert.match(commands[0], /x-api-key: \$ANTHROPIC_API_KEY/);
     assert.match(commands[0], /anthropic-version: 2023-06-01/);
@@ -417,7 +417,7 @@ describe("provider shapes", () => {
       control: { status: 200 },
     });
     assert.equal(await run, "stuck");
-    assert.match(commands[0], /"https:\/\/api\.openai\.com\/v1\/models"/);
+    assert.match(commands[0], /'https:\/\/api\.openai\.com\/v1\/models'/);
     assert.equal(controlRequests[0].url, "https://api.openai.com/v1/models");
   });
 
@@ -450,6 +450,36 @@ describe("provider shapes", () => {
     const { run, commands } = harness([BARE_401], 3_000, OPENROUTER);
     await run;
     assert.match(commands[0], /http_code/);
+  });
+
+  it("single-quotes the URL, so the sandbox shell cannot rewrite it", async () => {
+    // Double quotes would let the shell expand `$USER` and run the backtick command before
+    // curl saw the URL. The probe would then call some other host and this instrument would
+    // report a verdict about a request it never made.
+    const { run, commands } = harness([BARE_401], 3_000, {
+      baseUrl: "https://gateway.example/$USER/`id`/v1",
+    });
+    await run;
+    assert.ok(
+      commands[0].includes(
+        "'https://gateway.example/$USER/`id`/v1/chat/completions'",
+      ),
+      commands[0],
+    );
+    assert.ok(commands[0].includes("-d '{}' "), commands[0]);
+  });
+
+  it("escapes a single quote inside the URL rather than closing the string", async () => {
+    const { run, commands } = harness([BARE_401], 3_000, {
+      baseUrl: "https://gateway.example/o'brien/v1",
+    });
+    await run;
+    assert.ok(
+      commands[0].includes(
+        "'https://gateway.example/o'\\''brien/v1/chat/completions'",
+      ),
+      commands[0],
+    );
   });
 
   it("fails open when the binding name is not a shell-safe variable name", async () => {


### PR DESCRIPTION
## Context

Targets `release/v0.114.6`. Linear [AGE-4249](https://linear.app/agenta/issue/AGE-4249) / GitHub #6485: about 1 in 5 first messages to an agent in production fails with "A temporary issue kept this run's credentials from reaching the model."

On Daytona the model key never enters the sandbox. The runner creates a Daytona Secret, and the sandbox holds a `dtn_secret_<id>` placeholder that Daytona substitutes on egress. Some fresh sandboxes never get that wiring. The credential preflight (#6370) detects a stuck sandbox in about 10 seconds, but only when the provider echoes a masked placeholder back. OpenRouter, Anthropic, and Gemini answer a bad key with a bare 401 and no echo. On those providers the preflight fails open on probe 1, the run proceeds, the first model call gets a 401, and the once-per-session race branch in `errors.ts` (#6408) reports it as `credential_delivery_failed`.

Production runner logs over 2026-09-01 and 2026-09-02:

| Path | User-visible failures |
| --- | --- |
| Direct OpenRouter connection, preflight blind, race classification at model-call time | 10 |
| Starter-credits proxy, preflight convicted, retry stuck again | 4 |

All 10 failures on the first row came from the same OpenRouter connection, which worked on the other runs. The keys are fine. The preflight simply had nothing to judge on.

## Change

The preflight gains a second, body-independent instrument for the three direct providers that do not echo the key: OpenRouter, Anthropic, and OpenAI. The runner holds the real key when it creates the Secret, so it makes one call of its own to the provider's documented non-generation auth endpoint, and the sandbox probes the same endpoint. Both are read by status alone.

| Provider (direct) | Endpoint probed from the sandbox and from the runner |
| --- | --- |
| OpenRouter | `GET /key` |
| Anthropic | `GET /v1/models?limit=1` with `x-api-key` and `anthropic-version` |
| OpenAI | `GET /models` |

- A sandbox 401 on every probe, beside a runner call that answered 200, convicts the sandbox under the same consecutive-probe rule and the same 10 second budget as the masked echo.
- A runner call that answered 401 means the key itself is refused. The preflight fails open, and the turn's classifier gives the add-a-key advice, which is the right answer there.
- Any other runner status (403, 404, 405, 429, 5xx), a timeout, or an error is unknown and fails open with one log line naming the status.
- The differential applies only when the connection is direct AND its normalized base URL equals the provider's canonical base (`https://openrouter.ai/api/v1`, `https://api.anthropic.com`, `https://api.openai.com/v1`; scheme, host, and path compared, trailing slash and host case ignored, a query, fragment, or embedded credentials never match). The probe URL is built from the canonical base, so the runner never sends the key anywhere but the provider's own host. A vault custom-provider record for a known family is labelled direct but keeps its configured URL, so this check is what excludes tenant gateways. Custom gateways (the LiteLLM credits proxy included) and any other provider keep the existing `POST {}` to `/chat/completions` with masked-echo-only conviction, and make no runner call at all.

This rule is a differential between two request contexts. An IP allowlist, a WAF rule, or a per-source throttle that answers the sandbox differently from the runner would convict a healthy sandbox. Three things bound that: only a positive 200 counts as accepted, a wrong verdict costs a rebuild rather than a failed run, and the rule reaches only the three pinned direct providers. The module doc says this plainly.

Safety of the key: the value reaches the preflight only as the runner call's credential and lands only in that request header, with `redirect: "error"` so it can never be forwarded to another origin. The sandbox command carries the env var name for the shell to expand, the name is validated as a shell identifier first, and the shell operands are single-quoted. Every log line passes through a redactor that covers any non-empty key value.

One deadline caps every sandbox probe and the runner call by what is left of the 10 second grace. No probe starts once the grace is gone, and the budget check convicts on a poll that would land on the deadline. The runner call has its own timer composed with the preflight signal, so a provider that never answers cannot hold the preflight past the deadline. The acquire path aborts the preflight on any failure between kickoff and await, and the kickoff observes the promise so nothing is left dangling.

## Tests

`tests/unit/credential-preflight.test.ts` goes from 18 to 45 cases. The first eight new cases fail on `release/v0.114.5` and pass here: bare 401 plus an accepted runner call convicts; a refused runner call fails open; a runner call that throws fails open; the per-provider request shapes; the status capture; the kickoff routes the candidate value only into the runner call; no log line holds the key. The second commit adds the review-driven cases: 403, 404, 405, 429, 500, and 502 from the runner each fail open; the redirect option is present; a three-character key is redacted; an invalid binding name fails open; a slow probe cannot push the total past the budget; an early healthy return aborts the runner call; a custom deployment and a direct Gemini connection never make a runner call.

Full runner unit suite: 158 files, 2661 tests, green. `pnpm run typecheck` clean.

Review history: Codex (xhigh) asked for changes twice. First pass: the acceptance rule and the redirect policy. Second pass: the runner call had no effective timeout, a custom gateway labelled direct could receive the key, and the sandbox deadline was not hard. The follow-up commits address every item, plus CodeRabbit's shell-quoting nitpick; the third round adds tests for a never-answering provider, a tenant gateway labelled direct, canonical-URL normalization, and a zero budget. Codex's third pass confirmed the runner timeout and the canonical-host gate and left one blocker, the zero-budget runner call, which the fifth commit closes together with a bare `?` or `#` at the end of a URL (CodeRabbit raised the same zero-budget point).

## Live verification, before and after

Dev-box stack `agenta-ee-dev-age4249` on port 8180, Daytona Secrets mode on, driver from #6488 with `--only burst --only crosstalk --burst-size 16`. Before = `release/v0.114.5`. After = #6487 plus #6486 merged, hot-reloaded into the same runner.

| Cell | Before burst | Before crosstalk | After burst | After crosstalk |
| --- | --- | --- | --- | --- |
| C2 claude on Anthropic, Daytona | 2 of 16 failed, misfiled as "add your key" | 2 of 5 failed | 0 of 16 | 0 of 5 |
| C4 pi_core on OpenAI, Daytona | 1 of 16 failed, raw internal message | 0 of 5 | 0 of 16 | 0 of 5 |

During the after run the runner log shows about a dozen stuck convictions (masked echo on OpenAI, the bare-401 differential on Anthropic), twelve rebuilds on the same Secret, two third attempts, and no user-visible failure. One earlier after attempt was invalid because the Daytona organization hit its 300 GiB disk quota from the day's parked burst sandboxes; it was rerun after cleanup. The full run directories live in the evidence folder on the dev box (`~/agenta-qa-evidence/2026-09-02-age-4249/`), not in the repo; gate runs are gitignored by design.

A second clean sample with the reviewed gate (default burst 16, driver at the fourth commit of #6488) gave the same result: 0 of 16 and 0 of 5 on both cells. During that run the runner convicted 12 of 42 cold sandboxes (7 by the masked echo on OpenAI, 5 by the bare-401 differential on Anthropic), rebuilt 9 on the same Secret, and 3 of those 9 were stuck again and recovered on the third attempt. Fixed-runner total: 84 runs, 0 user-visible failures. Same-Secret retries were stuck 3 of 9 times, down from 4 of 7 with a fresh Secret in production, so the third attempt is earning its place. A third sample on the final commits of both PRs gave the same result on both cells (0 of 16 and 0 of 5), with 7 stuck sandboxes rebuilt on the same Secret. Fixed-runner total: 126 runs, 0 user-visible failures. The full runner suite on the merged tree of both PRs is green (2683 tests).


## Left out

Gemini. Its auth rides a query parameter, so it needs its own request shape and its own reading of a refusal. It stays on the default shape and fails open, so the race classifier remains the only guard there.

The companion fix for the second row of the table (retry a stuck sandbox on the same Secret) is a separate PR.

https://claude.ai/code/session_01197QHDuiZnt3iCEydn3ybF
