### PR TITLE
[docs] Remove the commit step from the agent guides

### DIFF
--- a/docs/docs/concepts/01-agents.mdx
+++ b/docs/docs/concepts/01-agents.mdx
@@ -40,14 +40,14 @@ You can create an agent in two ways:
 - **Build it through conversation.** Describe the job in the playground. The playground build kit lets the agent update its own configuration as you clarify what you need.
 - **Configure it directly.** Edit the instructions and select the skills, tools, files, permissions, harness, and model yourself.
 
-Both paths create the same configuration. You can also move between them: ask the agent to make a change, then inspect or edit the result before you commit it.
+Both paths create the same configuration. You can also move between them: ask the agent to make a change, then inspect or edit the result.
 
 
 ## How agents improve over time
 
 Improve an agent by turning feedback from real work into configuration changes. Suppose the SEO agent recommends topics that your company has already covered. You can tell it where the content inventory lives and require it to check that inventory before proposing a topic. The agent can update its configuration in the playground, or you can make the change directly.
 
-Agenta saves committed configuration changes as versions. Each version records the agent's instructions, skills, tools, permissions, harness, and model at that point.
+Agenta saves configuration changes as versions. Each version records the agent's instructions, skills, tools, permissions, harness, and model at that point.
 
 ## Learn about each part
 

--- a/docs/docs/concepts/01-agents.mdx
+++ b/docs/docs/concepts/01-agents.mdx
@@ -47,7 +47,7 @@ Both paths create the same configuration. You can also move between them: ask th
 
 Improve an agent by turning feedback from real work into configuration changes. Suppose the SEO agent recommends topics that your company has already covered. You can tell it where the content inventory lives and require it to check that inventory before proposing a topic. The agent can update its configuration in the playground, or you can make the change directly.
 
-Agenta saves configuration changes as versions. Each version records the agent's instructions, skills, tools, permissions, harness, and model at that point.
+Agenta keeps configuration changes as versions. Each version records the agent's instructions, skills, tools, permissions, harness, and model at that point.
 
 ## Learn about each part
 

--- a/docs/docs/concepts/07-automations.mdx
+++ b/docs/docs/concepts/07-automations.mdx
@@ -56,9 +56,9 @@ If later runs should use the result, the agent can also save a copy in its share
 
 ## Each automation runs a version you choose
 
-A schedule or event trigger points to a committed agent version. Draft changes in the playground do not silently change an automation that is already running.
+A schedule or event trigger carries a `Version` field. An automation can follow the agent as you improve it, or stay on one version you choose.
 
-This gives you a clear review point. Improve the agent and test the recurring message in the playground. Then commit the new version and choose when the automation should use it.
+Hold it on one version when a change should not reach a running automation before you have tested it. Improve the agent and test the recurring message in the playground, then move the trigger to the version you want it to run.
 
 ## Continue with the guides
 

--- a/docs/docs/concepts/07-automations.mdx
+++ b/docs/docs/concepts/07-automations.mdx
@@ -54,12 +54,6 @@ That destination might be a channel, an email, a document, a task, or a row in a
 
 If later runs should use the result, the agent can also save a copy in its shared files. Monday's report can then compare itself with the report from the week before.
 
-## Each automation runs a version you choose
-
-A schedule or event trigger carries a `Version` field. An automation can follow the agent as you improve it, or stay on one version you choose.
-
-Hold it on one version when a change should not reach a running automation before you have tested it. Improve the agent and test the recurring message in the playground, then move the trigger to the version you want it to run.
-
 ## Continue with the guides
 
 - [Create an automation](/guides/create-an-automation)

--- a/docs/docs/guides/01-write-your-agents-instructions.mdx
+++ b/docs/docs/guides/01-write-your-agents-instructions.mdx
@@ -43,7 +43,7 @@ question.
 Never publish or send anything. Show me the draft and wait.
 ```
 
-Then click `Save`. The dialog closes and the configuration saves itself as a new version: the state dot in the agent header reads `Saving…`, then `Saved`.
+Then click `Save`. The dialog closes and the agent uses the new instructions from its next message on.
 
 ## Add a correction
 
@@ -59,7 +59,7 @@ question. In social copy: no emoji, and never open with a scene-setting sentence
 Open with the claim.
 ```
 
-Save again. Each save creates a version, and the `vN` chip in the agent header carries the summary of what changed.
+Click `Save` again. The correction applies from the agent's next message on.
 
 ## Ask the agent to edit the instructions
 

--- a/docs/docs/guides/01-write-your-agents-instructions.mdx
+++ b/docs/docs/guides/01-write-your-agents-instructions.mdx
@@ -43,11 +43,7 @@ question.
 Never publish or send anything. Show me the draft and wait.
 ```
 
-Then:
-
-1. Click `Save`. The dialog closes and the playground header state reads `Draft`.
-2. Click `Commit` in the **Configuration** header.
-3. Pick `New version`, keep or edit the commit message, and click `Commit`.
+Then click `Save`. The dialog closes and the configuration saves itself as a new version: the state dot in the agent header reads `Saving…`, then `Saved`.
 
 ## Add a correction
 
@@ -63,7 +59,7 @@ question. In social copy: no emoji, and never open with a scene-setting sentence
 Open with the claim.
 ```
 
-Save and commit again. Each commit creates a version. You can review what changed and when on the **Registry** page.
+Save again. Each save creates a version, and the `vN` chip in the agent header carries the summary of what changed.
 
 ## Ask the agent to edit the instructions
 

--- a/docs/docs/guides/03-manage-skills.mdx
+++ b/docs/docs/guides/03-manage-skills.mdx
@@ -43,7 +43,7 @@ Here is a complete example:
    then the date the money lands.
 ```
 
-Click `Create`, then `Commit` in the **Configuration** header to make the skill part of a version.
+Click `Create`. The configuration saves itself, so the skill becomes part of the agent's next version.
 
 ### Write the description
 
@@ -71,7 +71,7 @@ The dialog fills itself in from what you dropped:
 - Everything after the frontmatter becomes the `SKILL.md` body.
 - Any files sitting beside `SKILL.md` come in as supporting files, keeping their relative paths.
 
-The `SKILL.md` body is plain text, so you can review it before you click `Create`. Then click `Commit` in the **Configuration** header to make the skill part of a version.
+The `SKILL.md` body is plain text, so you can review it before you click `Create`. The configuration saves itself, so the skill becomes part of the agent's next version.
 
 If you have the text but not the folder, paste a whole `SKILL.md`, frontmatter included, anywhere in the dialog. It fills the same fields.
 

--- a/docs/docs/guides/03-manage-skills.mdx
+++ b/docs/docs/guides/03-manage-skills.mdx
@@ -43,7 +43,7 @@ Here is a complete example:
    then the date the money lands.
 ```
 
-Click `Create`. The configuration saves itself, so the skill becomes part of the agent's next version.
+Click `Create`. The skill joins the agent's `Skills` list.
 
 ### Write the description
 
@@ -71,7 +71,7 @@ The dialog fills itself in from what you dropped:
 - Everything after the frontmatter becomes the `SKILL.md` body.
 - Any files sitting beside `SKILL.md` come in as supporting files, keeping their relative paths.
 
-The `SKILL.md` body is plain text, so you can review it before you click `Create`. The configuration saves itself, so the skill becomes part of the agent's next version.
+The `SKILL.md` body is plain text, so you can review it before you click `Create`.
 
 If you have the text but not the folder, paste a whole `SKILL.md`, frontmatter included, anywhere in the dialog. It fills the same fields.
 

--- a/docs/docs/guides/04-add-an-mcp-server.mdx
+++ b/docs/docs/guides/04-add-an-mcp-server.mdx
@@ -31,8 +31,7 @@ The MCP form does not store the key directly. It references a project secret tha
 
 1. In the **Configuration** column, find **MCPs**, between **Tools** and **Skills**. Its summary reads `None` when the agent has no MCP servers yet.
 2. Click the `+` button on that row, labelled `Add MCP server`.
-3. Fill in the fields below, then click `Create`.
-4. Click `Commit` in the **Configuration** header to make the server part of a version.
+3. Fill in the fields below, then click `Create`. The configuration saves itself, so the server becomes part of the agent's next version.
 
 <Stream controls autoplay muted loop src="17ccf3fe16305937aabc23ac8ffe00e9" height="400px" />
 

--- a/docs/docs/guides/04-add-an-mcp-server.mdx
+++ b/docs/docs/guides/04-add-an-mcp-server.mdx
@@ -31,7 +31,7 @@ The MCP form does not store the key directly. It references a project secret tha
 
 1. In the **Configuration** column, find **MCPs**, between **Tools** and **Skills**. Its summary reads `None` when the agent has no MCP servers yet.
 2. Click the `+` button on that row, labelled `Add MCP server`.
-3. Fill in the fields below, then click `Create`. The configuration saves itself, so the server becomes part of the agent's next version.
+3. Fill in the fields below, then click `Create`.
 
 <Stream controls autoplay muted loop src="17ccf3fe16305937aabc23ac8ffe00e9" height="400px" />
 

--- a/docs/docs/guides/06-create-an-automation.mdx
+++ b/docs/docs/guides/06-create-an-automation.mdx
@@ -57,7 +57,7 @@ Triggers live in `Sidebar > Settings > Triggers`, not in the agent's configurati
 - **`Scheduled runs`** runs the agent on a clock. Click `Schedule`. See [Schedule an automation](/guides/schedule-an-automation).
 - **`Event triggers`** runs the agent when an event fires in a connected app. Click `Subscribe`. See [Trigger an automation from an app](/guides/trigger-an-automation-from-an-app).
 
-Both forms carry a `Version` field that sets which version of the agent runs, and a `Run in playground` button that runs the agent with the message you configured. The schedule form saves with `Create schedule`, the trigger form with `Create`.
+Both forms carry a `Run in playground` button that runs the agent with the message you configured. The schedule form saves with `Create schedule`, the trigger form with `Create`.
 
 ## Where automations are listed
 

--- a/docs/docs/guides/06-create-an-automation.mdx
+++ b/docs/docs/guides/06-create-an-automation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Create an automation"
 sidebar_label: "Create an automation"
-description: "Prepare an agent for unattended runs, commit a version, and add a schedule or app trigger."
+description: "Prepare an agent for unattended runs, then add a schedule or app trigger."
 ---
 
 ```mdx-code-block
@@ -46,22 +46,9 @@ Open `Advanced`, then the `Permissions` section, and set `Policy`:
 Under `Ask`, the run waits at the first tool call. Under `Allow reads`, it waits when the agent needs to write. Set permissions that let the automation finish before you attach a trigger.
 :::
 
-There is no separate auto-approve list. When you select `Always allow` on a tool's approval card during a chat, Agenta writes that tool's own `Permission`, or adds a harness built-in to the harness allow list. Either way the grant reaches a trigger only after you commit it.
+There is no separate auto-approve list. When you select `Always allow` on a tool's approval card during a chat, Agenta writes that tool's own `Permission`, or adds a harness built-in to the harness allow list. The agent configuration saves itself, so the grant is part of the next version without any further step.
 
 For the wider set of controls, see [Control what an agent can do](/guides/control-what-an-agent-can-do).
-
-## Commit a version
-
-A trigger runs one pinned variant and revision, so it runs what you committed, not your current draft.
-
-Click `Commit` in the `Configuration` header, keep `New version`, write a commit message, and click `Commit`.
-
-<Image
-  style={{ display: "block", margin: "24px 0" }}
-  img={require("/images/agents/agenta-issue-triage-wide.png")}
-  alt="The commit dialog with What's changing on the left and the New version chooser and commit message on the right"
-  loading="lazy"
-/>
 
 ## Attach the trigger
 
@@ -70,7 +57,7 @@ Triggers live in `Sidebar > Settings > Triggers`, not in the agent's configurati
 - **`Scheduled runs`** runs the agent on a clock. Click `Schedule`. See [Schedule an automation](/guides/schedule-an-automation).
 - **`Event triggers`** runs the agent when an event fires in a connected app. Click `Subscribe`. See [Trigger an automation from an app](/guides/trigger-an-automation-from-an-app).
 
-Both forms carry a `Version` field that pins the variant and revision you choose, and a `Run in playground` button that runs the agent with the message you configured. The schedule form saves with `Create schedule`, the trigger form with `Create`.
+Both forms carry a `Version` field that sets which version of the agent runs, and a `Run in playground` button that runs the agent with the message you configured. The schedule form saves with `Create schedule`, the trigger form with `Create`.
 
 ## Where automations are listed
 

--- a/docs/docs/guides/06-create-an-automation.mdx
+++ b/docs/docs/guides/06-create-an-automation.mdx
@@ -46,7 +46,7 @@ Open `Advanced`, then the `Permissions` section, and set `Policy`:
 Under `Ask`, the run waits at the first tool call. Under `Allow reads`, it waits when the agent needs to write. Set permissions that let the automation finish before you attach a trigger.
 :::
 
-There is no separate auto-approve list. When you select `Always allow` on a tool's approval card during a chat, Agenta writes that tool's own `Permission`, or adds a harness built-in to the harness allow list. The agent configuration saves itself, so the grant is part of the next version without any further step.
+There is no separate auto-approve list. When you select `Always allow` on a tool's approval card during a chat, Agenta writes that tool's own `Permission`, or adds a harness built-in to the harness allow list.
 
 For the wider set of controls, see [Control what an agent can do](/guides/control-what-an-agent-can-do).
 

--- a/docs/docs/guides/07-schedule-an-automation.mdx
+++ b/docs/docs/guides/07-schedule-an-automation.mdx
@@ -46,7 +46,7 @@ If the schedule should only run between two dates, expand `Active window` and se
 
 ### 3. Which version runs?
 
-Choose `Pinned`, then select the variant and revision. Future changes to the agent do not affect this schedule until you update its pinned version.
+`Version` sets which version of the agent this schedule runs: the newest one, or a specific version you choose.
 
 ### 4. What should the agent do?
 

--- a/docs/docs/guides/07-schedule-an-automation.mdx
+++ b/docs/docs/guides/07-schedule-an-automation.mdx
@@ -1,7 +1,7 @@
 ---
 title: "Schedule an automation"
 sidebar_label: "Schedule an automation"
-description: "Run an agent on a recurring schedule by setting its cadence, version, and message."
+description: "Run an agent on a recurring schedule by setting its cadence and message."
 ---
 
 ```mdx-code-block
@@ -44,11 +44,7 @@ A green line under the fields restates the schedule it parsed and the next time 
 
 If the schedule should only run between two dates, expand `Active window` and set the start and end.
 
-### 3. Which version runs?
-
-`Version` sets which version of the agent this schedule runs: the newest one, or a specific version you choose.
-
-### 4. What should the agent do?
+### 3. What should the agent do?
 
 Write the message the agent receives on each run. Name the task and where to send the result. For example: `Summarize support tickets from the previous day and post the digest to #ops.`
 

--- a/docs/docs/guides/07-schedule-an-automation.mdx
+++ b/docs/docs/guides/07-schedule-an-automation.mdx
@@ -10,10 +10,6 @@ import { Stream } from "@cloudflare/stream-react";
 
 A schedule runs an agent at set times without anyone in the chat. First, [prepare the agent for automation](/guides/create-an-automation).
 
-## Commit before you schedule
-
-A schedule runs one pinned variant and revision. Commit the agent first, so the schedule can pin the version you want it to run. In the `Configuration` header, click `Commit`, keep `New version`, and confirm.
-
 ## Open the schedule dialog
 
 Go to `Sidebar > Settings > Triggers`, then click `Schedule` on the `Scheduled runs` section.

--- a/docs/docs/guides/08-trigger-an-automation-from-an-app.mdx
+++ b/docs/docs/guides/08-trigger-an-automation-from-an-app.mdx
@@ -42,7 +42,7 @@ Fill in every field marked with an asterisk.
 
 ### 3. Which version runs?
 
-Choose `Pinned`, then select the variant and revision. Every run uses that version until you update the trigger.
+`Version` sets which version of the agent this trigger runs: the newest one, or a specific version you choose.
 
 ### 4. What the agent gets
 

--- a/docs/docs/guides/08-trigger-an-automation-from-an-app.mdx
+++ b/docs/docs/guides/08-trigger-an-automation-from-an-app.mdx
@@ -40,11 +40,7 @@ Type a `Trigger name`. It is what identifies this trigger in the `Event triggers
 
 Fill in every field marked with an asterisk.
 
-### 3. Which version runs?
-
-`Version` sets which version of the agent this trigger runs: the newest one, or a specific version you choose.
-
-### 4. What the agent gets
+### 3. What the agent gets
 
 Write the message the agent receives when the event fires. `EVENT FIELDS` lists the data the event carries. Click a field to add its live value, such as the issue, branch, or record that started the run.
 

--- a/docs/docs/guides/08-trigger-an-automation-from-an-app.mdx
+++ b/docs/docs/guides/08-trigger-an-automation-from-an-app.mdx
@@ -16,10 +16,6 @@ Go to `Sidebar > Settings > Triggers`, then click `Connect app` on the `Connecti
 
 The trigger picker shows your connections in its left rail, under `YOUR CONNECTIONS`, and each app card has a `+ Connect another account` button for adding a second account.
 
-## Commit before you subscribe
-
-An event trigger runs one pinned variant and revision. Commit the agent first, so the trigger can pin the version you want it to run. In the `Configuration` header, click `Commit`, keep `New version`, and confirm.
-
 ## Pick the app and the event
 
 Go to `Sidebar > Settings > Triggers`, then click `Subscribe` on the `Event triggers` section.

--- a/docs/docs/guides/09-choose-a-harness-and-model.mdx
+++ b/docs/docs/guides/09-choose-a-harness-and-model.mdx
@@ -51,9 +51,3 @@ To manage connections for the whole project instead of from one agent, go to `Si
 />
 
 To run an agent against a Claude or ChatGPT subscription rather than a metered API key, see [Use your own Claude or ChatGPT subscription](/guides/use-your-own-subscription).
-
-## Commit
-
-Picking a model leaves a draft on the agent configuration. To publish it, click `Commit` in the `Configuration` header, keep `New version`, write a message, and click `Commit`.
-
-Deployments and triggers run a pinned revision, so commit before an automation should use the new model or harness.

--- a/docs/docs/guides/10-use-your-own-subscription.mdx
+++ b/docs/docs/guides/10-use-your-own-subscription.mdx
@@ -48,7 +48,3 @@ The login lives in the runner container, so the agent has to run there. Open `Ad
 :::warning
 Every local run can read the files mounted into the runner, including this login. Use a subscription only on a deployment you run for yourself. See [Sandbox isolation and security](/self-host/agent-execution/sandbox-isolation-and-security).
 :::
-
-## 4. Commit
-
-Click `Commit` in the `Configuration` header so deployments and triggers run the version that uses the subscription.


### PR DESCRIPTION
## Context

Nine docs pages walked readers through a `Commit` > `New version` step that no longer exists. The agent playground has no `Commit` button in its Configuration header, and agents have no Registry page in the sidebar, so one guide also sent readers somewhere they cannot go.

The trigger and schedule guides carried a related problem. Both spent a numbered step on which version an automation runs, and the automations concept page devoted a section to the same choice.

## Changes

The commit step is gone. Where a step was only "click Commit", it is removed. Where a step did real work, the commit clause is dropped from it.

Before:

```
1. Click `Save`. The dialog closes and the playground header state reads `Draft`.
2. Click `Commit` in the **Configuration** header.
3. Pick `New version`, keep or edit the commit message, and click `Commit`.
```

After:

```
Then click `Save`. The dialog closes and the agent uses the new instructions
from its next message on.
```

The trailing `## Commit` sections in the harness and subscription guides are removed outright, along with `## Commit before you schedule`, `## Commit before you subscribe`, and `## Commit a version`.

Version selection is gone from the automation pages. The `### 3. Which version runs?` step is removed from both trigger guides and the step that followed is renumbered, the overview sentence in the create guide drops its `Version` clause, and the concept page loses its "Each automation runs a version you choose" section. Picking a version is not a decision the reader makes while filling in the form.

Persistence mechanics are out too. An intermediate draft explained how the configuration saves itself, naming a status indicator and describing when a change becomes a version. Readers do not need that, so the guides now say what they get: click `Save` or `Create`, and the change applies.

## Notes

Every claim was checked against `origin/release/v0.114.5` rather than the local working tree. That mattered: GitButler had an unmerged branch applied locally that adds an agent version-history drawer, and an early draft of these docs described it. It is not on the release branch.

Verified on the release branch:

- The agent config header passes `autoSave`, and `AgentConfigHeader` renders no commit button under it.
- The Registry sidebar item is scoped `workflowCategories: ["app"]`, so agents never show it.

No `What to QA` section. Nothing here is user-visible beyond the docs site.
