### PR TITLE
test(sessions): characterize record IDs before immutable history

### DIFF
--- a/api/oss/tests/pytest/unit/sessions/test_records_upsert_semantics.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_upsert_semantics.py
@@ -1,0 +1,374 @@
+"""Characterization tests for what the records upsert keeps and what it discards (spike D).
+
+The DAO writes every batch with ``ON CONFLICT (project_id, record_id) DO UPDATE``
+(``api/oss/src/dbs/postgres/sessions/records/dao.py:123-136``). A repeated ``record_id``
+therefore means two different things today: an exact delivery retry, and a progressive
+update that carries a later payload for the same object. Immutable history
+(``ON CONFLICT DO NOTHING``) is correct for the first and lossy for the second.
+
+These tests pin the current end state, and each one says what must change when inserts
+become immutable. The companion runner tests are in
+``services/runner/tests/unit/record-id-semantics.test.ts``. The written analysis is
+``docs/design/session-control-and-live-events/spike-d-stable-record-ids.md``.
+"""
+
+from datetime import datetime, timedelta, timezone
+from typing import Any, Dict, List
+from uuid import NAMESPACE_DNS, UUID, uuid4, uuid5
+
+from oss.src.core.sessions.records.dtos import SessionRecord, SessionRecordEvent
+from oss.src.dbs.postgres.sessions.records.dao import RecordsDAO
+from oss.src.dbs.postgres.sessions.records.mappings import map_record_event_to_dbe
+from oss.src.tasks.asyncio.sessions.interactions_dispatcher import build_wire_messages
+
+
+_RECORDS_NS = uuid5(uuid5(NAMESPACE_DNS, "agenta"), "records")
+_PROJECT = UUID("00000000-0000-0000-0000-0000000000aa")
+_T0 = datetime(2026, 9, 2, 12, 0, 0, tzinfo=timezone.utc)
+
+
+def _stable_id(session_id: str, call_id: str, record_type: str, turn_id: str) -> UUID:
+    """The runner's uuid5 key (``services/runner/src/sessions/record-id.ts:41-50``)."""
+    return uuid5(_RECORDS_NS, f"{session_id}:{call_id}:{record_type}:{turn_id}")
+
+
+def _event(**over: Any) -> SessionRecordEvent:
+    base: Dict[str, Any] = {
+        "session_id": "sess-1",
+        "project_id": _PROJECT,
+        "record_index": 0,
+        "timestamp": _T0,
+        "record_type": "tool_call",
+        "record_source": "agent",
+        "attributes": {"type": "tool_call", "id": "call_a", "input": {}},
+        "turn_id": "turn-1",
+    }
+    base.update(over)
+    return SessionRecordEvent(**base)
+
+
+def _values(events: List[SessionRecordEvent]) -> List[dict]:
+    return [RecordsDAO._values(event=e) for e in events]
+
+
+def _insert_only(values_list: List[dict]) -> List[dict]:
+    """The immutable-history counterfactual: ``ON CONFLICT DO NOTHING``.
+
+    First write per ``(project_id, record_id)`` wins and is never touched again.
+    """
+    kept: Dict[Any, dict] = {}
+    for values in values_list:
+        key = (values["project_id"], values["record_id"])
+        kept.setdefault(key, values)
+    return list(kept.values())
+
+
+def _read_order(rows: List[dict]) -> List[dict]:
+    """The order ``get_records`` returns (``dao.py:157-161``): timestamp, then ingest order."""
+    ordered = sorted(enumerate(rows), key=lambda pair: (pair[1]["timestamp"], pair[0]))
+    return [row for _, row in ordered]
+
+
+def _as_records(rows: List[dict]) -> List[SessionRecord]:
+    return [
+        SessionRecord(
+            record_id=row["record_id"],
+            session_id=row["session_id"],
+            project_id=row["project_id"],
+            record_index=row.get("record_index"),
+            timestamp=row.get("timestamp"),
+            record_type=row.get("record_type"),
+            record_source=row.get("record_source"),
+            attributes=row.get("attributes"),
+            turn_id=row.get("turn_id"),
+        )
+        for row in rows
+    ]
+
+
+# --------------------------------------------------------------------------------------
+# What the upsert overwrites, and what it keeps
+# --------------------------------------------------------------------------------------
+
+
+def test_upsert_overwrites_exactly_six_columns():
+    """The overwrite set is the contract every other test here depends on."""
+    assert RecordsDAO._UPSERT_UPDATED_COLUMNS == (
+        "record_type",
+        "record_source",
+        "timestamp",
+        "attributes",
+        "turn_id",
+        "span_id",
+    )
+    # record_index, created_at and updated_at are absent on purpose: a repeat keeps the
+    # first write's ordinal and ingest time, and leaves no audit trace at all.
+    #
+    # WHEN INSERTS BECOME IMMUTABLE: this tuple should disappear with the DO UPDATE clause.
+    # If it survives as a narrower set, this test must be updated to the new set and the
+    # reason recorded next to it.
+
+
+def test_a_progressive_tool_call_repeat_repairs_the_arguments_but_moves_the_row():
+    """The interleaved / TTL case from the runner: empty args, then the real args."""
+    stable = _stable_id("sess-1", "call_a", "tool_call", "turn-1")
+    other = _stable_id("sess-1", "call_b", "tool_call", "turn-1")
+    values = _values(
+        [
+            _event(record_id=stable, record_index=0, timestamp=_T0),
+            _event(
+                record_id=other,
+                record_index=1,
+                timestamp=_T0 + timedelta(milliseconds=5),
+                attributes={
+                    "type": "tool_call",
+                    "id": "call_b",
+                    "input": {"path": "/y"},
+                },
+            ),
+            _event(
+                record_id=stable,
+                record_index=2,
+                timestamp=_T0 + timedelta(milliseconds=9),
+                attributes={
+                    "type": "tool_call",
+                    "id": "call_a",
+                    "input": {"command": "ls -la"},
+                },
+            ),
+        ]
+    )
+
+    upserted = _read_order(RecordsDAO._dedupe_values(values_list=values))
+    assert len(upserted) == 2
+    by_id = {row["record_id"]: row for row in upserted}
+    # The arguments are repaired.
+    assert by_id[stable]["attributes"]["input"] == {"command": "ls -la"}
+    # The ordinal is NOT: it keeps the first write's index, which now disagrees with the
+    # timestamp the same repeat moved forward.
+    assert by_id[stable]["record_index"] == 0
+    assert by_id[stable]["timestamp"] == _T0 + timedelta(milliseconds=9)
+    # Consequence: the repaired row sorts after the call that flushed it. The transcript
+    # shows call_b before call_a even though call_a was announced first.
+    assert [row["attributes"]["id"] for row in upserted] == ["call_b", "call_a"]
+
+    insert_only = _read_order(_insert_only(values))
+    # Immutable insert keeps the right order and the WRONG payload: an empty input for a
+    # command that really ran.
+    assert [row["attributes"]["id"] for row in insert_only] == ["call_a", "call_b"]
+    assert insert_only[0]["attributes"]["input"] == {}
+
+    # WHEN INSERTS BECOME IMMUTABLE: the producer must stop sending this repeat (hold the
+    # open tool slot until the call closes), or send the later snapshot as its own event id
+    # that readers fold by ``attributes.id``. Update the ``insert_only`` assertion to the
+    # repaired arguments once that lands. The upsert's timestamp move is a separate live
+    # defect that immutability fixes for free.
+
+
+def test_a_repeated_tool_result_keeps_the_last_output_today():
+    stable = _stable_id("sess-1", "call_a", "tool_result", "turn-1")
+    values = _values(
+        [
+            _event(
+                record_id=stable,
+                record_type="tool_result",
+                record_index=1,
+                timestamp=_T0,
+                attributes={"type": "tool_result", "id": "call_a", "output": ""},
+            ),
+            _event(
+                record_id=stable,
+                record_type="tool_result",
+                record_index=2,
+                timestamp=_T0 + timedelta(milliseconds=4),
+                attributes={
+                    "type": "tool_result",
+                    "id": "call_a",
+                    "output": "exit 0\n42 files",
+                },
+            ),
+        ]
+    )
+
+    upserted = RecordsDAO._dedupe_values(values_list=values)
+    assert len(upserted) == 1
+    assert upserted[0]["attributes"]["output"] == "exit 0\n42 files"
+
+    insert_only = _insert_only(values)
+    assert len(insert_only) == 1
+    # Immutable insert pins the result to the empty first snapshot.
+    assert insert_only[0]["attributes"]["output"] == ""
+
+    # WHEN INSERTS BECOME IMMUTABLE: the runner must emit exactly one durable tool_result
+    # per call per turn. Change the ``insert_only`` expectation to the final output then.
+
+
+def test_a_resume_in_a_later_turn_appends_instead_of_overwriting():
+    """The turn id is part of the uuid5 key, so a resume can never overwrite history."""
+    turn_one = _stable_id("sess-1", "gate-9", "interaction_response", "turn-1")
+    turn_two = _stable_id("sess-1", "gate-9", "interaction_response", "turn-2")
+    assert turn_one != turn_two
+
+    answer = {
+        "type": "interaction_response",
+        "id": "gate-9",
+        "kind": "user_approval",
+        "payload": {"toolCallId": "call_9", "approved": True},
+    }
+    values = _values(
+        [
+            _event(
+                record_id=turn_one,
+                record_type="interaction_response",
+                turn_id="turn-1",
+                timestamp=_T0,
+                attributes=answer,
+            ),
+            _event(
+                record_id=turn_two,
+                record_type="interaction_response",
+                turn_id="turn-2",
+                timestamp=_T0 + timedelta(seconds=30),
+                attributes=answer,
+            ),
+        ]
+    )
+
+    # Both policies store two rows for one logical answer. Immutability neither creates nor
+    # removes this duplicate.
+    assert len(RecordsDAO._dedupe_values(values_list=values)) == 2
+    assert len(_insert_only(values)) == 2
+
+    # WHEN INSERTS BECOME IMMUTABLE: unchanged. The duplicate becomes visible in a replay
+    # cursor, so a reader must fold interaction answers by ``attributes.id``.
+
+
+def test_a_terminal_event_carries_no_stable_id_so_a_retry_duplicates_it():
+    """`done` sends no record_id, so the API mints a fresh uuid4 per ingest."""
+    first = map_record_event_to_dbe(
+        event=_event(
+            record_id=None,
+            record_type="done",
+            attributes={"type": "done", "stopReason": "end_turn"},
+        )
+    )
+    second = map_record_event_to_dbe(
+        event=_event(
+            record_id=None,
+            record_type="done",
+            attributes={"type": "done", "stopReason": "end_turn"},
+        )
+    )
+    assert first.record_id != second.record_id
+    assert first.record_id.version == 4
+
+    # WHEN INSERTS BECOME IMMUTABLE: this is the gap immutability alone does not close. A
+    # lost ingest response still duplicates the terminal fact, because the producer never
+    # gave it an id to deduplicate on. Give every durable event a producer-generated stable
+    # id before its first send, then assert equality here instead.
+
+
+# --------------------------------------------------------------------------------------
+# What the reconstructed conversation looks like after each policy
+# --------------------------------------------------------------------------------------
+
+
+def test_wire_message_reconstruction_loses_the_tool_arguments_under_immutable_insert():
+    """`build_wire_messages` is what an out-of-band approval resume sends to the harness."""
+    call_id = _stable_id("sess-1", "call_a", "tool_call", "turn-1")
+    result_id = _stable_id("sess-1", "call_a", "tool_result", "turn-1")
+    values = _values(
+        [
+            _event(
+                record_id=None,
+                record_type="message",
+                record_source="user",
+                record_index=0,
+                timestamp=_T0,
+                attributes={"type": "message", "text": "list the files"},
+            ),
+            _event(
+                record_id=call_id,
+                record_index=1,
+                timestamp=_T0 + timedelta(milliseconds=2),
+            ),
+            _event(
+                record_id=call_id,
+                record_index=2,
+                timestamp=_T0 + timedelta(milliseconds=6),
+                attributes={
+                    "type": "tool_call",
+                    "id": "call_a",
+                    "name": "bash",
+                    "input": {"command": "ls -la"},
+                },
+            ),
+            _event(
+                record_id=result_id,
+                record_type="tool_result",
+                record_index=3,
+                timestamp=_T0 + timedelta(milliseconds=9),
+                attributes={
+                    "type": "tool_result",
+                    "id": "call_a",
+                    "output": "42 files",
+                },
+            ),
+        ]
+    )
+
+    upserted = build_wire_messages(
+        _as_records(_read_order(RecordsDAO._dedupe_values(values_list=values)))
+    )
+    assert upserted[0] == {"role": "user", "content": "list the files"}
+    call_block = next(
+        block for block in upserted[1]["content"] if block["type"] == "tool_call"
+    )
+    assert call_block["input"] == {"command": "ls -la"}
+
+    immutable = build_wire_messages(_as_records(_read_order(_insert_only(values))))
+    call_block = next(
+        block for block in immutable[1]["content"] if block["type"] == "tool_call"
+    )
+    # The harness would be told the agent called bash with no arguments.
+    assert call_block["input"] == {}
+
+    # WHEN INSERTS BECOME IMMUTABLE: both branches must produce the real arguments. This
+    # test is the acceptance check for the producer fix.
+
+
+def test_dedupe_preserves_the_row_the_first_write_created():
+    """A repeat must not resurrect a row identity, only its payload."""
+    stable = _stable_id("sess-1", "call_a", "tool_call", "turn-1")
+    values = _values(
+        [
+            _event(record_id=stable, record_index=7, session_id="sess-1"),
+            _event(record_id=stable, record_index=9, session_id="sess-1"),
+        ]
+    )
+    deduped = RecordsDAO._dedupe_values(values_list=values)
+    assert len(deduped) == 1
+    assert deduped[0]["record_id"] == stable
+    assert deduped[0]["record_index"] == 7
+    assert deduped[0]["session_id"] == "sess-1"
+
+    # WHEN INSERTS BECOME IMMUTABLE: ``_dedupe_values`` can collapse to "keep the first
+    # occurrence" and drop the merge of the overwrite columns entirely. Update the payload
+    # expectations here at the same time.
+
+
+def test_a_record_id_is_unrelated_to_time_so_it_cannot_be_a_replay_cursor():
+    """Both id families in use are unordered; only `timestamp` orders a read."""
+    minted = map_record_event_to_dbe(event=_event(record_id=None)).record_id
+    assert minted.version == 4
+    stable = _stable_id("sess-1", "call_a", "tool_call", "turn-1")
+    assert stable.version == 5
+    # A uuid4 and a uuid5 sort by their random or hashed bytes, never by production order.
+    # This is why the query orders by (timestamp, created_at, record_index) and why the
+    # frontend comments claiming a "uuid7 id" order are wrong
+    # (``web/packages/agenta-chat/src/assets/transcriptToMessages.ts:30``,
+    # ``web/packages/agenta-entities/src/session/api/api.ts:61``).
+    assert uuid4().version == 4
+
+    # WHEN INSERTS BECOME IMMUTABLE: a cursor column has to be added. record_id cannot
+    # become one without rewriting every existing row.

--- a/docs/design/session-control-and-live-events/spike-d-stable-record-ids.md
+++ b/docs/design/session-control-and-live-events/spike-d-stable-record-ids.md
@@ -1,0 +1,297 @@
+# Spike D: stable record-ID semantics
+
+> AGENT-GENERATED, low weight. Draft for discussion. Mahmoud makes final decisions.
+
+This spike is the gate `records-invariants.md` requires before any immutable-history work. It
+answers one question: what breaks today if the records table changes from
+`ON CONFLICT DO UPDATE` to `ON CONFLICT DO NOTHING`.
+
+Every claim marked **verified** was read in code at the cited `path:line` or proven by a test in
+this branch. Every claim marked **reported** comes from an earlier document and was not re-checked.
+
+## The answer
+
+One case breaks, and it is a producer bug, not a storage requirement.
+
+Three kinds of repeated `record_id` exist. Two of them are already correct under an immutable
+insert:
+
+- An exact delivery retry sends the same payload twice. An immutable insert is the right handling.
+- A resume re-emission never collides at all, because the turn id is part of the id and every
+  resume mints a new turn.
+
+The third kind, a progressive update inside one turn, loses data under an immutable insert. It
+happens when a tool call is written to storage before its arguments have arrived, and a later
+snapshot repairs the row. Under `DO NOTHING` the durable tool call keeps empty arguments forever,
+and the harness is later told the agent ran a command with no arguments.
+
+That early write has two causes, both in `services/runner/src/sessions/persist.ts`, and both are
+fixable in the producer without touching storage:
+
+1. The emitter keeps one open tool slot for the whole turn, so a second tool call flushes the
+   first one early (`persist.ts:304-321`).
+2. A three second idle timer flushes an open tool call that is still streaming its arguments
+   (`persist.ts:233`, `:278-294`).
+
+Fixing the producer also removes a defect that is live today. The upsert overwrites `timestamp`
+(`api/oss/src/dbs/postgres/sessions/records/dao.py:131`), which is the primary read-order key
+(`dao.py:157-161`). A repaired tool call therefore re-sorts after the call that flushed it, and the
+transcript shows two parallel tool calls in the wrong order.
+
+Recommendation, in one line: land the producer fix first as its own change, then Option A.
+Section 5 gives the evidence.
+
+## 1. Inventory of durable record producers
+
+The runner is the only producer. Verified: the only non-test caller of
+`POST /sessions/records/ingest` is `services/runner/src/sessions/persist.ts:91`. Nothing in
+`sdks/python` or `services/` writes records; the SDK only carries a `turnId` onto the `/run`
+request (`sdks/python/agenta/sdk/agents/utils/wire.py:173-174`).
+
+The stable id is `uuid5(RECORD_NAMESPACE, "<sessionId>:<toolCallId>:<recordType>:<turnId>")`
+(`services/runner/src/sessions/record-id.ts:41-50`). Verified. Everything else sends no id and the
+API mints a fresh uuid4 per ingest
+(`api/oss/src/dbs/postgres/sessions/records/mappings.py:20`). Verified.
+
+| Producer | Record types | How the id is built | When the same id is sent again | Payload difference between sends |
+| --- | --- | --- | --- | --- |
+| Open tool slot, flushed by `flushOpenTool` (`persist.ts:278-294`) | `tool_call` | uuid5, includes `turnId` | A different tool id flushes the slot and the first id returns; or the idle timer fires and later snapshots arrive | **Different.** The first send often carries `input: {}`; the later send carries the real arguments |
+| Tool and interaction branch (`persist.ts:390-408`) | `tool_result`, `interaction_request`, `interaction_response` | uuid5, includes `turnId` | The emitter sees the same event twice inside one turn | **Same** for a re-emitted approval answer (`run-turn.ts:736-751`). **Different** when a placeholder result precedes the real one (`tracing/otel.ts:1979-1993`) |
+| Catch-all branch (`persist.ts:411-421`) | `message`, `thought`, `done`, `usage`, `error`, `data`, `file`, `attachment_delivery` | None. API mints uuid4 | Never collides. A duplicate emit or a lost HTTP response creates a second row | Not applicable; no dedup is possible |
+| Coalesced text (`persist.ts:338-386`) | `message`, `thought` | None | One send per `*_end` marker | Not applicable |
+| Out-of-band user turn (`persist.ts:424-438`, called from `server.ts:559-563`) | `message` with source `user` | None | Guarded by `tailIsFreshUserMessage`, so a resume does not re-send the prompt | Not applicable |
+| Ingest endpoint (`api/oss/src/apis/fastapi/sessions/router.py:743-770`) | Pass-through | Does not mint or change ids | Not applicable | Truncates `attributes` at 64 KB before Redis (`core/sessions/records/streaming.py:23`) |
+| Records worker (`tasks/asyncio/sessions/records_worker.py:238`) | All | Not applicable | Collapses in-batch duplicates first (`dao.py:99-121`), then upserts | The collapse keeps the last payload, matching what sequential upserts would produce |
+
+Three readers consume records. All three were verified.
+
+| Reader | Path | What it uses records for |
+| --- | --- | --- |
+| Runner harness reconstruction | `services/runner/src/sessions/reconstruct.ts` | Rebuilds `ChatMessage[]` so a client can send only the newest message |
+| API approval resume | `tasks/asyncio/sessions/interactions_dispatcher.py:70` | Rebuilds wire messages for an out-of-band approval reply |
+| Browser transcript | `web/packages/agenta-chat/src/assets/transcriptToMessages.ts` | Rebuilds `UIMessage[]` for replay rendering |
+
+`RecordsDAO.append`, the single-row upsert, has no production caller. Verified: every ingest goes
+through Redis and `append_many`. It is reachable only from tests.
+
+## 2. Classification of every repeated id
+
+| Case | Class | Does the id repeat? | What an immutable insert breaks |
+| --- | --- | --- | --- |
+| One tool call, three argument snapshots, then a result | Not a repeat. Coalescing sends one final `tool_call` | No | Nothing |
+| Two tool calls in flight, the first announced with empty arguments | **Progressive update** | Yes, same turn | **The arguments.** The durable row keeps `input: {}` and the rebuilt conversation tells the model the agent called the tool with nothing |
+| One tool call whose arguments stream past the three second idle window | **Progressive update** | Yes, same turn | Same as above |
+| A placeholder `tool_result` followed by the real output | **Progressive update** | Yes, same turn | **The output.** The durable result keeps `""` |
+| The same `interaction_response` re-emitted for a token already resolved in this turn | **Exact retry** | Yes, same turn | Nothing. This is the case immutability handles correctly |
+| An approval answer re-emitted in a later turn after a resume | **Resume re-emission** | No. The turn id is part of the id, so it is a new row | Nothing. It is already append-only, but the duplicate becomes visible in a replay cursor |
+| A `tool_call` in turn one paired with its `tool_result` in turn two | Not a repeat | No | Nothing, provided readers keep binding by `attributes.id` rather than by turn |
+| A `done` terminal event sent twice | Neither. It carries no id | No | Nothing today, but immutability cannot deduplicate it either, so a lost ingest response still duplicates a terminal fact |
+
+Two facts make the progressive-update class small and fixable.
+
+**Every resume mints a new turn id.** `_start_turn` generates a fresh uuid7 for send, steer and
+resume (`api/oss/src/core/sessions/streams/service.py:947`), and the runner uses the request's turn
+id when present (`services/runner/src/server.ts:186-190`). Verified. So an upsert can only ever
+fire inside one turn. There is no cross-turn overwrite path.
+
+**The progressive updates all come from one design choice.** The emitter holds at most one open
+tool call and flushes it whenever anything else happens (`persist.ts:271-276`, `:304-324`). Both
+progressive-update paths disappear if the slot becomes one entry per tool id with no early flush.
+The idle timer must stay, because a harness may never close a streaming call
+(`persist.ts:228-232`), but it only needs to fire at turn end rather than after three seconds of
+silence.
+
+## 3. Defect findings
+
+### Confirmed: a dropped record never marks the session incomplete
+
+Verified in code and pinned by a test.
+
+`flush()` calls `takePersistFailures`, which reads **and clears** the per-session drop counter
+(`persist.ts:448`, `:203-207`). The run handler then calls `takePersistFailures` again in its
+`finally` block to decide whether to call `noteRecordsIncomplete` (`server.ts:608-616`). Both exit
+paths await `flush()` first: the success path at `server.ts:588` and the throw path at
+`server.ts:602`. The count at `server.ts:609` is therefore always zero.
+
+`noteRecordsIncomplete` is unreachable in practice. The guard it feeds,
+`recordsIncomplete()` at `engines/sandbox_agent/reconstruct-history.ts:85`, is meant to fail a turn
+rather than rebuild model context from a log with a hole in it. Today a dropped record writes a
+warning line and the next turn reconstructs from the incomplete log.
+
+**Proposed fix, not applied.** Make `flush()` return the count and let the run handler act on it:
+
+```ts
+// persist.ts — flush()
+const dropped = takePersistFailures(sessionId);
+if (dropped > 0) log(`WARN ...`);
+return dropped;
+
+// server.ts — replace the finally-block re-read
+if (sessionOwned && sessionId && droppedThisTurn > 0) {
+  noteRecordsIncomplete(sessionId);
+}
+```
+
+I did not apply it, because it is not obviously safe. Enabling the guard turns a silent context
+hole into a hard turn failure, and `incompleteSessions` is a process-lifetime `Set` that is never
+cleared (`persist.ts:210-225`). One dropped record would disable a session for the life of the
+runner process. That is a product decision, not a spike decision. See the open questions.
+
+### Confirmed: comments claim an id-based order that never existed
+
+Four comments were wrong. I corrected all four in a separate commit. The change is comment-only.
+
+| File | What it said | What is true |
+| --- | --- | --- |
+| `web/packages/agenta-chat/src/assets/transcriptToMessages.ts:30` | rows arrive ordered by a uuid7 `id` | Ordered on `(timestamp, created_at, record_index)` (`dao.py:157-161`) |
+| `web/packages/agenta-entities/src/session/api/api.ts:61` | events ordered by a uuid7 `id` | Same |
+| `services/runner/src/sessions/records-query.ts:33` | ordered by ingest time, then `record_index` | Producer `timestamp` leads, then `created_at`, then `record_index` |
+| `services/runner/src/sessions/reconstruct.ts:7` and `:86` | ordered by ingest time / `created_at`, then `record_index` | Same |
+
+No uuid7 is minted anywhere on this path. Verified: `record_id` is a uuid5 for tool-family records
+and a uuid4 otherwise, and neither is time ordered.
+
+### Also found, outside the brief
+
+**The records worker acknowledges records it never wrote.** `processed_ids.append(msg_id)` runs
+during deserialization (`records_worker.py:177`), before the Postgres write is attempted. A failed
+`append_many` logs and continues (`:242-248`) without removing those ids, and the consumer loop
+then acknowledges and deletes them from Redis (`shared/consumer.py:193`, `:144-155`). Verified.
+This is an acknowledgement bookkeeping defect, not a Redis Streams limitation. It matters for
+immutability because an immutable history has no repair path: a lost row stays lost.
+
+**Enterprise record retention has never worked.** `api/ee/src/dbs/postgres/sessions/records/dao.py:105`
+and `:119` reference `RecordDBE.id`. That attribute does not exist; the key is
+`(project_id, record_id)`. Verified by importing the model:
+`hasattr(RecordDBE, "id")` is `False`. Any call to the retention flush raises before it deletes
+anything. This is a migration input, not a records-model defect. See section 5.
+
+## 4. Tests added
+
+Both files pass on current behavior. Each test carries a comment that names what must change when
+inserts become immutable.
+
+`services/runner/tests/unit/record-id-semantics.test.ts` — 9 tests. The file includes a small
+store simulator that applies either the current upsert rule or `ON CONFLICT DO NOTHING` to the
+POST bodies the runner actually sends, then feeds the resulting rows to the real
+`reconstructMessages`. Each scenario is asserted under both policies, so the loss is visible rather
+than argued.
+
+| Test | What it pins |
+| --- | --- |
+| Re-emitting one `interaction_response` inside a turn | Exact retry. Both policies agree |
+| Three argument snapshots then a result | Coalescing sends no repeat. Both policies agree |
+| Interleaved tool calls re-open a flushed id | The same id is sent with `{}` then with real arguments. Upsert repairs the arguments but re-sorts the row after the call that flushed it. Immutable insert keeps the order and loses the arguments |
+| The idle timer flushes early arguments | Same class, single tool call |
+| A `tool_result` sent twice in one turn | Upsert keeps the real output; immutable insert pins it to `""`. Asserted through `reconstructMessages` |
+| A resume re-emits the answer under a new turn | No cross-turn id collision. Reconstruction identical under both policies |
+| The same gate re-raised in a later turn | Two durable rows for one logical answer, under both policies |
+| A `done` event sent twice | Two rows under both policies, because no stable id is sent |
+| `flush()` clears the drop count | The defect above, pinned |
+
+`api/oss/tests/pytest/unit/sessions/test_records_upsert_semantics.py` — 8 tests, against the real
+`RecordsDAO._dedupe_values`, `RecordsDAO._UPSERT_UPDATED_COLUMNS`, `map_record_event_to_dbe` and
+`build_wire_messages`.
+
+| Test | What it pins |
+| --- | --- |
+| The upsert overwrites exactly six columns | The contract the rest of the file depends on |
+| A progressive tool-call repeat | Arguments repaired, ordinal kept, timestamp moved, row re-sorted |
+| A repeated `tool_result` | Last output wins today, empty output wins under immutable insert |
+| A resume in a later turn | Two distinct uuid5 ids, so both policies append |
+| A terminal event | Two distinct uuid4 ids; no dedup is possible at any storage policy |
+| Wire-message reconstruction | The out-of-band approval resume loses the tool arguments under immutable insert |
+| Dedupe keeps the first row identity | `record_index` and `session_id` come from the first write |
+| `record_id` is unrelated to time | Neither uuid4 nor uuid5 can serve as a replay cursor |
+
+## 5. Option A versus Option B, on this spike's evidence
+
+Recommendation: **Option A**, repair records, with the producer fix landing first as its own change.
+
+The evidence that points to A:
+
+- **There is one producer and three readers.** Verified. A second permanent log would have to be
+  kept consistent with the first, and this spike found no fan-in problem that a second log solves.
+- **Only one repeated-id class breaks, and it is producer-side.** Two of the three classes are
+  already correct under an immutable insert. The third disappears when the emitter keeps one open
+  slot per tool id instead of one for the whole turn.
+- **The fix pays for itself immediately.** The same change removes the live transcript-ordering
+  defect caused by the upsert moving `timestamp`. That defect exists today, independently of the
+  RFC.
+- **Records already carry turn and span columns** (`dbes.py`, migration `oss000000004`), so
+  execution lifecycle facts have a home without new schema.
+
+The evidence that argues for B, and why it does not decide the question:
+
+- **Records live in the tracing database, not the core database.** Verified: the DAO uses
+  `AnalyticsEngine` (`dao.py:20,26`). If session history must outlive tracing retention, records
+  cannot hold it as they stand. That argues for **moving** the table, not for adding a second
+  permanent log next to it.
+- **Attributes are truncated at 64 KB before Redis** (`streaming.py:23`). An immutable event that
+  was truncated has no repair path. A separate event table would face the same limit unless it
+  stores lifecycle facts only, which are small. This is a real point for B, but it applies to
+  payload-carrying events, not to the lifecycle events the RFC needs.
+
+### Migration risk for old rows
+
+- **Volume.** About 208,000 rows in the shared dev database, with zero carrying an `updated_at`
+  (reported, from the earlier records-model report; not re-measured here).
+- **No cursor column exists.** Adding a monotonic cursor means backfilling every existing row. The
+  only order available for a backfill is the composite the reader already uses,
+  `(timestamp, created_at, record_index)`. That order is good enough for a backfill: old rows only
+  need to be readable and correctly ordered, never replayable from a live cursor. Once written the
+  backfilled value is stable.
+- **Old rows carry mixed id families.** uuid5 for tool-family rows, uuid4 for everything else, and
+  504 legacy rows with `record_source: runner` from early July 2026 (reported). A cursor column
+  sidesteps all of this, because the id stays what it is.
+- **Retention has never run.** Because the Enterprise retention flush raises on `RecordDBE.id`
+  (verified), no records have ever been aged out. Two consequences. The current table is a full
+  history rather than a retained window, which makes a backfill larger but simpler. And fixing
+  retention later would start deleting session history, so the retention question in the open
+  questions must be answered before that fix ships.
+- **An upsert leaves no trace.** `updated_at` is never written (it is absent from the update set at
+  `dao.py:128-134`). Verified. So there is no way to identify, in existing data, which rows were
+  ever rewritten. A migration cannot distinguish a repaired row from a first write. It does not
+  need to: the stored payload is the end state either way.
+
+## Open questions for Mahmoud
+
+1. **Must durable session history outlive tracing-record retention?**
+   Recommendation: answer this before any storage change. If yes, move the records table to the
+   core database rather than adding a second permanent log. Reason: a second log buys a separate
+   retention policy at the price of a consistency invariant between two histories, and this spike
+   found no other reason to pay it.
+
+2. **Should the open-tool-slot fix land now, as its own change, ahead of the RFC work?**
+   Recommendation: yes. One slot per tool id, no flush on a different id, timer only at turn end.
+   Reason: it removes both progressive-update paths and it fixes a transcript-ordering defect that
+   is live today. It is small, it is testable with the tests in this branch, and the immutability
+   decision then has nothing left to break.
+
+3. **When the drop counter is fixed, should `recordsIncomplete` stay set for the life of the runner
+   process?**
+   Recommendation: no. Scope it to the turn, or clear it once a later records read succeeds.
+   Reason: as written, one dropped record disables reconstruction for that session until the runner
+   restarts, which is a larger outage than the hole it protects against.
+
+4. **Should the records worker acknowledge only after the Postgres write commits?**
+   Recommendation: yes, and before immutability, not after. Reason: an immutable history has no
+   repair path, so a silently acknowledged unwritten record becomes a permanent gap rather than a
+   row a later write would have fixed.
+
+5. **Do terminal and message records need producer-generated stable ids in version one?**
+   Recommendation: yes for `done` and `error`, no for `usage` and `thought`. Reason: a lost ingest
+   response on a terminal event duplicates it, and the browser closes an assistant message on every
+   `done` (`transcriptToMessages.ts:567-587`), so a duplicate splits one turn into two bubbles. The
+   change is one more `stableRecordId` call in `persist.ts`.
+
+## What this spike did not do
+
+- It did not change any behavior. The only source edits are four comment corrections.
+- It did not select Option A or Option B. Section 5 is evidence and a recommendation.
+- It did not measure the shared dev database. Row counts are quoted from the earlier report and
+  marked reported.
+- It did not test against a live Postgres. The DAO tests exercise the real statement builder and
+  the real dedupe function, not a real database. Forty-one tests in
+  `api/oss/tests/pytest/unit/sessions/` skip without a reachable Postgres, all of them in
+  `test_wp5_dao_fanout.py`. They were already skipping before this branch.

--- a/services/runner/src/sessions/reconstruct.ts
+++ b/services/runner/src/sessions/reconstruct.ts
@@ -4,10 +4,11 @@
  * send only the newest user message: the runner rebuilds prior turns from records instead of
  * trusting a full inbound history.
  *
- * The fold is chronological (records already arrive ordered by ingest time, then per-turn
- * `record_index`) and keyed on `record_source`: a "user" record flushes the assistant turn in
- * progress and starts a user turn; "agent" records accumulate into the current assistant turn as
- * ACP content blocks. The output matches the vercel adapter's `ChatMessage`/`ContentBlock` shape
+ * The fold is chronological (records already arrive ordered by producer `timestamp`, then
+ * ingest `created_at`, then per-turn `record_index`) and keyed on `record_source`: a "user"
+ * record flushes the assistant turn in progress and starts a user turn; "agent" records
+ * accumulate into the current assistant turn as ACP content blocks. The output matches the
+ * vercel adapter's `ChatMessage`/`ContentBlock` shape
  * exactly (`sdks/python/agenta/sdk/agents/adapters/vercel/messages.py`), so `buildTurnText`,
  * `priorMessages`, and the responder's tool_call↔tool_result binding consume it unchanged.
  *
@@ -83,8 +84,8 @@ function finalizeAssistant(blocks: ContentBlock[]): ChatMessage {
 
 /**
  * Fold ordered session records into the conversation's `ChatMessage[]`. Pure; no I/O. Records
- * MUST be in conversation order (the query endpoint returns them by `created_at`, then
- * `record_index`) — this fold preserves that order and does not re-sort.
+ * MUST be in conversation order (the query endpoint returns them by `timestamp`, then
+ * `created_at`, then `record_index`) — this fold preserves that order and does not re-sort.
  */
 export function reconstructMessages(
   records: readonly SessionRecordRow[],

--- a/services/runner/src/sessions/records-query.ts
+++ b/services/runner/src/sessions/records-query.ts
@@ -30,8 +30,9 @@ function queryTimeoutMs(): number {
 
 /**
  * Fetch a session's durable record log, ordered for reconstruction (the endpoint returns records
- * by ingest time, then per-turn `record_index`). Returns `null` on failure so the caller can fall
- * back to the inbound history rather than run with an empty context.
+ * by producer `timestamp`, then ingest `created_at`, then per-turn `record_index`). Returns
+ * `null` on failure so the caller can fall back to the inbound history rather than run with an
+ * empty context.
  */
 export async function fetchSessionRecords(
   sessionId: string,

--- a/services/runner/tests/unit/record-id-semantics.test.ts
+++ b/services/runner/tests/unit/record-id-semantics.test.ts
@@ -1,0 +1,567 @@
+/**
+ * Characterization tests for stable `record_id` semantics (spike D).
+ *
+ * These tests pin what the runner PRODUCES today and what the durable store then HOLDS,
+ * under the two candidate storage policies:
+ *
+ *   - "upsert"      — today: `ON CONFLICT (project_id, record_id) DO UPDATE`, which
+ *                     overwrites record_type, record_source, timestamp, attributes,
+ *                     turn_id and span_id, and keeps record_index and created_at
+ *                     (`api/oss/src/dbs/postgres/sessions/records/dao.py:123-136`).
+ *   - "insert-only" — the immutable-history proposal: `ON CONFLICT DO NOTHING`.
+ *
+ * Every test states, in a comment, what must change when inserts become immutable.
+ * A test that fails after that change is the signal, not a nuisance.
+ *
+ * See `docs/design/session-control-and-live-events/spike-d-stable-record-ids.md`.
+ */
+import { describe, it, beforeEach, vi } from "vitest";
+import assert from "node:assert/strict";
+
+interface IngestBody {
+  session_id: string;
+  record_id?: string;
+  record_index: number;
+  timestamp: string;
+  record_source: string;
+  record_type: string;
+  attributes: Record<string, unknown>;
+  turn_id?: string;
+}
+
+const postedBodies: IngestBody[] = [];
+
+// Two milliseconds per POST so consecutive records get distinct `timestamp` values, the
+// way a real HTTP round trip does. The store simulator below reads that ordering key, so
+// an upsert that moves a row's timestamp forward is visible as a re-sort.
+vi.stubGlobal("fetch", async (_url: string, init?: RequestInit) => {
+  await new Promise((r) => setTimeout(r, 2));
+  postedBodies.push(JSON.parse(init?.body as string) as IngestBody);
+  return new Response(JSON.stringify({ ok: true }), { status: 200 });
+});
+
+const { buildPersistingEmitter } = await import("../../src/sessions/persist.ts");
+const { reconstructMessages } = await import("../../src/sessions/reconstruct.ts");
+import type { SessionRecordRow } from "../../src/sessions/reconstruct.ts";
+
+type StorePolicy = "upsert" | "insert-only";
+
+/**
+ * Apply one ingest batch to a simulated `records` table and return the rows in the order
+ * `get_records` returns them (`ORDER BY timestamp, created_at, record_index`).
+ *
+ * A body with no `record_id` gets a fresh uuid4 server-side
+ * (`api/oss/src/dbs/postgres/sessions/records/mappings.py:20`), so it can never conflict.
+ */
+function applyStore(
+  bodies: readonly IngestBody[],
+  policy: StorePolicy,
+): SessionRecordRow[] {
+  interface Row {
+    seq: number;
+    recordIndex: number;
+    body: IngestBody;
+  }
+  const rows: Row[] = [];
+  const byId = new Map<string, Row>();
+  let minted = 0;
+
+  for (const body of bodies) {
+    const key = body.record_id ?? `minted-uuid4-${minted++}`;
+    const existing = byId.get(key);
+    if (!existing) {
+      const row: Row = {
+        seq: rows.length,
+        recordIndex: body.record_index,
+        body: { ...body },
+      };
+      rows.push(row);
+      byId.set(key, row);
+      continue;
+    }
+    // ON CONFLICT DO NOTHING: the first write wins, forever.
+    if (policy === "insert-only") continue;
+    // ON CONFLICT DO UPDATE: the payload columns take the new value; record_index and
+    // created_at keep the first write's value.
+    existing.body = { ...body, record_index: existing.recordIndex };
+  }
+
+  return [...rows]
+    .sort((a, b) =>
+      a.body.timestamp === b.body.timestamp
+        ? a.seq - b.seq
+        : a.body.timestamp < b.body.timestamp
+          ? -1
+          : 1,
+    )
+    .map((row) => ({
+      record_source: row.body.record_source,
+      record_type: row.body.record_type,
+      attributes: row.body.attributes,
+      turn_id: row.body.turn_id ?? null,
+      record_index: row.body.record_index,
+    }));
+}
+
+/** The `attributes.input` of every stored `tool_call` row, in read order. */
+function toolCallInputs(rows: SessionRecordRow[]): unknown[] {
+  return rows
+    .filter((row) => row.record_type === "tool_call")
+    .map((row) => (row.attributes as Record<string, unknown>).input);
+}
+
+/** The `attributes.id` of every stored row of one type, in read order. */
+function idsOfType(rows: SessionRecordRow[], type: string): unknown[] {
+  return rows
+    .filter((row) => row.record_type === type)
+    .map((row) => (row.attributes as Record<string, unknown>).id);
+}
+
+beforeEach(() => {
+  postedBodies.length = 0;
+});
+
+describe("stable record_id: exact delivery retry", () => {
+  it("re-emitting one interaction_response inside a turn is an idempotent no-op", async () => {
+    // Shape: `resolveInteractionToken` re-emits the same answer for an already-resolved
+    // token, same id and same payload (`run-turn.ts:736-751`).
+    const { emit, flush } = buildPersistingEmitter(
+      "sess-retry",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-1",
+    );
+    const answer = {
+      type: "interaction_response" as const,
+      id: "approval-1",
+      kind: "user_approval" as const,
+      payload: { toolCallId: "tool-1", approved: true },
+    };
+    emit({ type: "interaction_request", id: "approval-1", kind: "user_approval" });
+    emit(answer);
+    emit(answer);
+    await flush();
+
+    assert.equal(postedBodies.length, 3);
+    // The two answers carry one id; the request carries a different one (record type is
+    // part of the uuid5 key).
+    assert.equal(postedBodies[1].record_id, postedBodies[2].record_id);
+    assert.notEqual(postedBodies[0].record_id, postedBodies[1].record_id);
+
+    // Both policies store two rows and the payloads are identical, so nothing is lost.
+    for (const policy of ["upsert", "insert-only"] as StorePolicy[]) {
+      const rows = applyStore(postedBodies, policy);
+      assert.equal(rows.length, 2, policy);
+      assert.deepEqual(idsOfType(rows, "interaction_response"), ["approval-1"], policy);
+    }
+
+    // WHEN INSERTS BECOME IMMUTABLE: this test must keep passing unchanged. It is the one
+    // repeated-id case that an immutable insert already handles correctly.
+  });
+});
+
+describe("stable record_id: progressive update inside one turn", () => {
+  it("three argument snapshots then a result coalesce into two records", async () => {
+    // The happy path: one open tool slot absorbs every snapshot, so only the final
+    // arguments are ever POSTed. No id repeats.
+    const { emit, flush } = buildPersistingEmitter(
+      "sess-coalesce",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-1",
+    );
+    emit({ type: "tool_call", id: "call_1", name: "bash", input: {} });
+    emit({ type: "tool_call", id: "call_1", name: "bash", input: { command: "fi" } });
+    emit({ type: "tool_call", id: "call_1", name: "bash", input: { command: "find ." } });
+    emit({ type: "tool_result", id: "call_1", output: "found" });
+    await flush();
+
+    assert.equal(postedBodies.length, 2);
+    assert.notEqual(postedBodies[0].record_id, postedBodies[1].record_id);
+    const ids = postedBodies.map((body) => body.record_id);
+    assert.equal(new Set(ids).size, 2, "no id is sent twice");
+
+    // Identical under both policies: coalescing already produced one final fact per object.
+    for (const policy of ["upsert", "insert-only"] as StorePolicy[]) {
+      const rows = applyStore(postedBodies, policy);
+      assert.deepEqual(toolCallInputs(rows), [{ command: "find ." }], policy);
+      assert.deepEqual(
+        reconstructMessages(rows),
+        [
+          {
+            role: "assistant",
+            content: [
+              {
+                type: "tool_call",
+                toolCallId: "call_1",
+                toolName: "bash",
+                input: { command: "find ." },
+              },
+              {
+                type: "tool_result",
+                toolCallId: "call_1",
+                toolName: "bash",
+                output: "found",
+                isError: undefined,
+              },
+            ],
+          },
+        ],
+        policy,
+      );
+    }
+
+    // WHEN INSERTS BECOME IMMUTABLE: this test must keep passing unchanged.
+  });
+
+  it("interleaved tool calls re-open a flushed id and send it twice", async () => {
+    // Reachable in production: a harness announces a call with empty arguments and fills
+    // them on a later `tool_call_update` (`tracing/otel.ts:1872-1876`, and the refresh at
+    // :1911-1922). With two calls in flight the second announcement flushes the first slot
+    // with EMPTY arguments, and the first call's later update re-opens the same id.
+    const { emit, flush } = buildPersistingEmitter(
+      "sess-interleave",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-1",
+    );
+    emit({ type: "tool_call", id: "call_a", name: "bash", input: {} });
+    emit({ type: "tool_call", id: "call_b", name: "read", input: { path: "/y" } });
+    emit({ type: "tool_call", id: "call_a", name: "bash", input: { command: "ls -la" } });
+    await flush();
+
+    assert.equal(postedBodies.length, 3);
+    // The same record_id is sent twice with DIFFERENT payloads. This is a progressive
+    // update, not a delivery retry.
+    assert.equal(postedBodies[0].record_id, postedBodies[2].record_id);
+    assert.deepEqual(postedBodies[0].attributes.input, {});
+    assert.deepEqual(postedBodies[2].attributes.input, { command: "ls -la" });
+    // The re-opened slot claims a NEW record_index that the upsert then discards.
+    assert.deepEqual(
+      postedBodies.map((body) => body.record_index),
+      [0, 1, 2],
+    );
+
+    const upserted = applyStore(postedBodies, "upsert");
+    // Today the arguments are repaired...
+    assert.deepEqual(toolCallInputs(upserted), [
+      { path: "/y" },
+      { command: "ls -la" },
+    ]);
+    // ...but the repaired row also took the retry's timestamp, so it now sorts AFTER the
+    // call that flushed it. The transcript shows call_b before call_a even though call_a
+    // was announced first. That is a live ordering defect of the upsert, not of the
+    // proposal.
+    assert.deepEqual(idsOfType(upserted, "tool_call"), ["call_b", "call_a"]);
+
+    const insertOnly = applyStore(postedBodies, "insert-only");
+    // Under immutable insert the order is right but the arguments are lost forever: the
+    // durable tool call records an EMPTY input for a command that really ran.
+    assert.deepEqual(idsOfType(insertOnly, "tool_call"), ["call_a", "call_b"]);
+    assert.deepEqual(toolCallInputs(insertOnly), [{}, { path: "/y" }]);
+
+    // Harness reconstruction inherits the loss: the rebuilt conversation tells the model
+    // the agent called bash with no arguments.
+    const rebuilt = reconstructMessages(insertOnly);
+    const blocks = rebuilt[0].content as Array<Record<string, unknown>>;
+    const callA = blocks.find((block) => block.toolCallId === "call_a");
+    assert.deepEqual(callA?.input, {});
+
+    // WHEN INSERTS BECOME IMMUTABLE: this case must stop reaching storage as a repeat.
+    // Either the runner holds every open tool slot until the call closes (no early flush
+    // on a different id), or the later snapshot is appended as its own event with its own
+    // event id and the reader folds by `attributes.id`. A plain `ON CONFLICT DO NOTHING`
+    // over today's producer loses the arguments. Then update the `insert-only` assertions
+    // above to the new expected end state.
+  });
+
+  it("the open-tool TTL flushes early arguments and the next snapshot repeats the id", async () => {
+    // A tool call that streams its arguments slowly crosses the 3 s idle window
+    // (`persist.ts:233`), so the slot flushes with a partial payload and the next
+    // snapshot re-opens the same id.
+    vi.stubEnv("AGENTA_RECORD_TOOL_TTL_MS", "10");
+    const persist = await import("../../src/sessions/persist.ts?ttl-reload");
+    const { emit, flush } = persist.buildPersistingEmitter(
+      "sess-ttl",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-1",
+    );
+    emit({ type: "tool_call", id: "call_slow", name: "bash", input: {} });
+    await new Promise((r) => setTimeout(r, 60));
+    emit({
+      type: "tool_call",
+      id: "call_slow",
+      name: "bash",
+      input: { command: "rg pattern" },
+    });
+    await flush();
+    vi.unstubAllEnvs();
+
+    assert.equal(postedBodies.length, 2);
+    assert.equal(postedBodies[0].record_id, postedBodies[1].record_id);
+    assert.deepEqual(postedBodies[0].attributes.input, {});
+
+    assert.deepEqual(toolCallInputs(applyStore(postedBodies, "upsert")), [
+      { command: "rg pattern" },
+    ]);
+    assert.deepEqual(toolCallInputs(applyStore(postedBodies, "insert-only")), [{}]);
+
+    // WHEN INSERTS BECOME IMMUTABLE: same fix as the interleaved case. The TTL exists
+    // because a harness may never close a streaming call, so it cannot simply be removed.
+  });
+
+  it("a tool_result sent twice in one turn keeps only the last payload today", async () => {
+    // Shape: a settle path emits a placeholder result for a still-open call and the real
+    // result lands afterwards (`tracing/otel.ts:1979-1993` settleOpenToolCalls, then
+    // maybeCloseTool for the same id in a later update).
+    const { emit, flush } = buildPersistingEmitter(
+      "sess-result-twice",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-1",
+    );
+    emit({ type: "tool_call", id: "call_1", name: "bash", input: { command: "sleep 1" } });
+    emit({ type: "tool_result", id: "call_1", output: "" });
+    emit({ type: "tool_result", id: "call_1", output: "exit 0\n42 files" });
+    await flush();
+
+    assert.equal(postedBodies.length, 3);
+    assert.equal(postedBodies[1].record_id, postedBodies[2].record_id);
+
+    const upserted = applyStore(postedBodies, "upsert");
+    const upsertBlocks = reconstructMessages(upserted)[0].content as Array<
+      Record<string, unknown>
+    >;
+    assert.equal(
+      upsertBlocks.find((block) => block.type === "tool_result")?.output,
+      "exit 0\n42 files",
+    );
+
+    const insertOnly = applyStore(postedBodies, "insert-only");
+    const insertOnlyBlocks = reconstructMessages(insertOnly)[0].content as Array<
+      Record<string, unknown>
+    >;
+    // The first snapshot has an empty output, so immutable insert pins the tool result to
+    // "" and the model is told the command produced nothing.
+    assert.equal(
+      insertOnlyBlocks.find((block) => block.type === "tool_result")?.output,
+      "",
+    );
+
+    // WHEN INSERTS BECOME IMMUTABLE: the runner must send exactly one durable
+    // `tool_result` per call per turn, or send the second snapshot as a distinct event id
+    // that the reader folds by `attributes.id` (last one wins). Update the `insert-only`
+    // expectation to the final output once that lands.
+  });
+});
+
+describe("stable record_id: resume re-emission across turns", () => {
+  it("a resume re-emits the answer under a new turn, so it becomes a second row", async () => {
+    // Every send, steer and approval resume mints a fresh turn id
+    // (`api/oss/src/core/sessions/streams/service.py:947`), and `turnId` is part of the
+    // uuid5 key (`sessions/record-id.ts:41-50`). A resume therefore never upserts the
+    // original turn's rows: it appends.
+    const first = buildPersistingEmitter(
+      "sess-resume",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-1",
+    );
+    first.persist({ type: "message", text: "delete the file" }, "user");
+    first.emit({ type: "tool_call", id: "call_rm", name: "bash", input: { command: "rm x" } });
+    first.emit({ type: "interaction_request", id: "gate-1", kind: "user_approval" });
+    first.emit({ type: "done", stopReason: "paused" });
+    await first.flush();
+
+    const second = buildPersistingEmitter(
+      "sess-resume",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-2",
+    );
+    second.emit({
+      type: "interaction_response",
+      id: "gate-1",
+      kind: "user_approval",
+      payload: { toolCallId: "call_rm", approved: true },
+    });
+    second.emit({ type: "tool_result", id: "call_rm", output: "removed" });
+    second.emit({ type: "done" });
+    await second.flush();
+
+    const turn1 = postedBodies.filter((body) => body.turn_id === "turn-1");
+    const turn2 = postedBodies.filter((body) => body.turn_id === "turn-2");
+    assert.equal(turn1.length, 4);
+    assert.equal(turn2.length, 3);
+    // No id is shared across the two turns, so no cross-turn conflict exists.
+    const turn1Ids = new Set(turn1.map((body) => body.record_id).filter(Boolean));
+    for (const body of turn2) {
+      if (body.record_id) assert.ok(!turn1Ids.has(body.record_id));
+    }
+
+    // Both policies store all seven rows, and reconstruction is identical.
+    for (const policy of ["upsert", "insert-only"] as StorePolicy[]) {
+      const rows = applyStore(postedBodies, policy);
+      assert.equal(rows.length, 7, policy);
+      const rebuilt = reconstructMessages(rows);
+      assert.deepEqual(rebuilt[0], { role: "user", content: "delete the file" }, policy);
+      const blocks = rebuilt[1].content as Array<Record<string, unknown>>;
+      assert.deepEqual(
+        blocks.map((block) => block.type),
+        ["tool_call", "tool_result"],
+        policy,
+      );
+      assert.equal(
+        blocks.find((block) => block.type === "tool_result")?.output,
+        "removed",
+        policy,
+      );
+    }
+
+    // WHEN INSERTS BECOME IMMUTABLE: this test must keep passing unchanged. Resume is
+    // already append-only. Note that the paired `tool_call` (turn-1) and `tool_result`
+    // (turn-2) are separate rows in separate turns; any migration that scopes an event id
+    // to a turn must keep them paired by `attributes.id`, which is how both readers bind
+    // them (`sessions/reconstruct.ts:60-68`, `interactions_dispatcher.py:123-149`).
+  });
+
+  it("the same gate re-raised in a later turn appends rather than overwriting", async () => {
+    // `resolveInteractionToken` re-emits an answer for a token claimed in an EARLIER turn
+    // (`run-turn.ts:745-751`: "a client can see it twice for the same id").
+    const answer = {
+      type: "interaction_response" as const,
+      id: "gate-9",
+      kind: "user_approval" as const,
+      payload: { toolCallId: "call_9", approved: true },
+    };
+    const first = buildPersistingEmitter(
+      "sess-regate",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-1",
+    );
+    first.emit(answer);
+    await first.flush();
+    const second = buildPersistingEmitter(
+      "sess-regate",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-2",
+    );
+    second.emit(answer);
+    await second.flush();
+
+    assert.equal(postedBodies.length, 2);
+    assert.notEqual(postedBodies[0].record_id, postedBodies[1].record_id);
+    // Two durable rows carry one logical answer under both policies. Immutability does not
+    // create this duplicate and cannot remove it.
+    for (const policy of ["upsert", "insert-only"] as StorePolicy[]) {
+      assert.deepEqual(
+        idsOfType(applyStore(postedBodies, policy), "interaction_response"),
+        ["gate-9", "gate-9"],
+        policy,
+      );
+    }
+
+    // WHEN INSERTS BECOME IMMUTABLE: unchanged, but the duplicate becomes visible in a
+    // replay cursor. A reader that folds interaction answers by `attributes.id` must treat
+    // the second as idempotent, which the frontend already does
+    // (`transcriptToMessages.ts` splices the duplicate approval part).
+  });
+});
+
+describe("stable record_id: terminal events", () => {
+  it("a done event sent twice becomes two rows because it carries no stable id", async () => {
+    const { emit, flush } = buildPersistingEmitter(
+      "sess-done",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-1",
+    );
+    emit({ type: "message", text: "finished" });
+    emit({ type: "done", stopReason: "end_turn" });
+    emit({ type: "done", stopReason: "end_turn" });
+    await flush();
+
+    // No record_id is sent for a terminal event, so the API mints a fresh uuid4 each time
+    // (`mappings.py:20`) and dedup is impossible at any storage policy.
+    assert.equal(postedBodies.length, 3);
+    for (const body of postedBodies) {
+      assert.equal(body.record_id, undefined);
+    }
+    for (const policy of ["upsert", "insert-only"] as StorePolicy[]) {
+      const rows = applyStore(postedBodies, policy);
+      assert.equal(rows.length, 3, policy);
+      assert.equal(
+        rows.filter((row) => row.record_type === "done").length,
+        2,
+        policy,
+      );
+      // The runner's reconstruction drops `done`, so the rebuilt conversation is unharmed.
+      assert.deepEqual(
+        reconstructMessages(rows),
+        [{ role: "assistant", content: "finished" }],
+        policy,
+      );
+    }
+
+    // WHEN INSERTS BECOME IMMUTABLE: this is the gap immutability alone does not close.
+    // A terminal event needs a producer-generated stable event id before its first send,
+    // or a lost ingest response turns into a duplicate terminal fact in the replay cursor.
+    // The frontend closes an assistant message on every `done`
+    // (`transcriptToMessages.ts:567-587`), so a duplicate terminal event can split one
+    // turn into two bubbles. Replace the `rows.length === 3` expectation with 2 when every
+    // durable event carries a stable id.
+  });
+});
+
+describe("detectable incompleteness: the drop counter is consumed twice", () => {
+  it("flush() clears the per-session drop count, so the caller always reads zero", async () => {
+    // `server.ts:588` (success) and `:602` (throw) both await `flush()`, which calls
+    // `takePersistFailures` at `persist.ts:448` — a READ AND CLEAR. The `finally` block at
+    // `server.ts:608-616` then calls `takePersistFailures` again to decide whether to call
+    // `noteRecordsIncomplete`. It can only ever see zero, so `recordsIncomplete()` at
+    // `engines/sandbox_agent/reconstruct-history.ts:85` never fires and a turn rebuilds
+    // model context from a log with a hole in it.
+    //
+    // This test pins the defect. The proposed fix is in
+    // `docs/design/session-control-and-live-events/spike-d-stable-record-ids.md`.
+    const persist = await import("../../src/sessions/persist.ts?drop-counter");
+    vi.stubEnv("AGENTA_RECORDS_INGEST_MAX_RETRIES", "1");
+    const failing = vi.fn(async () => new Response("boom", { status: 500 }));
+    vi.stubGlobal("fetch", failing);
+
+    const { emit, flush } = persist.buildPersistingEmitter(
+      "sess-drop-counter",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-1",
+    );
+    emit({ type: "message", text: "this record never lands" });
+    await flush();
+
+    assert.ok(failing.mock.calls.length > 0, "the POST was attempted and failed");
+    // The record was dropped, but the count the run handler reads is already gone.
+    assert.equal(persist.takePersistFailures("sess-drop-counter"), 0);
+    assert.equal(persist.recordsIncomplete("sess-drop-counter"), false);
+
+    vi.unstubAllEnvs();
+
+    // WHEN THE DEFECT IS FIXED: `recordsIncomplete("sess-drop-counter")` must be true here,
+    // or `flush()` must return the dropped count for the caller to act on. Flip both
+    // assertions then. This test is unrelated to immutability; it is the delivery-loss
+    // signal immutable history depends on.
+  });
+});

--- a/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
+++ b/web/packages/agenta-chat/src/assets/transcriptToMessages.ts
@@ -27,10 +27,13 @@ import type {UIMessage} from "ai"
  * `UIMessage[]`; this rebuilds the assembled messages directly so replayed history renders
  * identically to a turn this browser streamed live.
  *
- * Grouping: rows arrive ordered (uuid7 `id`). A contiguous run of non-user rows folds into
- * one assistant message; each user row opens a user message. Within an assistant message,
- * tool parts are keyed by `toolCallId` so a later `tool_result` settles the earlier
- * `tool_call`, and a `interaction_request` (permission) marks it awaiting approval.
+ * Grouping: rows arrive ordered by the backend on (timestamp, created_at, record_index) —
+ * NOT by `id`, which is a uuid5 for tool-family rows and a uuid4 otherwise and carries no
+ * time order (`api/oss/src/dbs/postgres/sessions/records/dao.py:151-161`). A contiguous run
+ * of non-user rows folds into one assistant message; each user row opens a user message.
+ * Within an assistant message, tool parts are keyed by `toolCallId` so a later `tool_result`
+ * settles the earlier `tool_call`, and a `interaction_request` (permission) marks it awaiting
+ * approval.
  */
 
 type Part = Record<string, unknown>

--- a/web/packages/agenta-entities/src/session/api/api.ts
+++ b/web/packages/agenta-entities/src/session/api/api.ts
@@ -58,8 +58,9 @@ export interface QueryRecordsParams {
 
 /**
  * Fetch a session's durable, append-only record log — the replay source for rendering a
- * conversation. Returns events ordered by the backend (uuid7 `id`); `null` on failure or
- * when the project scope is missing.
+ * conversation. Returns events ordered by the backend on (timestamp, created_at,
+ * record_index) — `id` carries no time order; `null` on failure or when the project scope is
+ * missing.
  */
 export async function querySessionRecords({
     sessionId,


### PR DESCRIPTION
Session records currently use the same ID for both exact delivery retries and progressive tool updates. Changing the table to immutable inserts without understanding those cases can lose tool arguments or output.

This change inventories repeated record IDs and adds characterization tests for the runner and Postgres data-access layer. It finds that exact retries already fit immutable inserts, while progressive tool calls and tool results need a producer change first. It also finds that terminal records need stable producer IDs.

## Issue coverage

This supports #5496 and #5594 but does not fix their runtime failures. The acknowledgement fix is in #6502.

## Dependencies and limits

Independent tests and documentation on the RFC branch. Before changing storage, confirm the inventory includes every intentional progressive update.

## How to review

1. Review the repeated-ID classification.
2. Review the tool-call and tool-result counterexamples.
3. Review terminal-event retry behavior.
4. Review the recommendation to keep partial frames temporary and commit one complete durable checkpoint.