### PR TITLE
fix(runner): reject a second turn before touching the sandbox

### DIFF
--- a/api/oss/tests/pytest/unit/sessions/test_heartbeat_is_current_turn.py
+++ b/api/oss/tests/pytest/unit/sessions/test_heartbeat_is_current_turn.py
@@ -200,3 +200,109 @@ async def test_new_turn_on_a_previously_run_session_is_current(lock_engine):
     assert fresh.is_current_turn is True, (
         "a new turn must not be aborted just because the row still named the old one"
     )
+
+
+@pytest.mark.asyncio
+async def test_second_turn_on_a_RUNNING_session_is_refused(lock_engine):
+    """Single-turn admission (#6417, #5539, #5538): the answer the runner's edge now acts on.
+
+    A second user message on a session with a turn in flight reaches the runner as its own turn.
+    Its FIRST beat is the admission request, and this is what must come back: `is_current_turn`
+    False, with the running turn's locks untouched. The API already answered this correctly; the
+    runner used to read it only as "abort later", walk into the keepalive pool, and destroy the
+    running turn's environment on the way. It now stops at the edge, so this answer is the whole
+    gate and it needs its own test.
+    """
+    svc = _service(lock_engine)
+
+    # turn-1 is live: it holds both `alive` and `running`.
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("replica-a", "turn-1"))
+
+    # The second message arrives on the SAME replica as its own turn. Nothing cancelled turn-1,
+    # so `running` still names it — the discriminator that separates this from a handover.
+    second = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("replica-a", "turn-2")
+    )
+
+    assert second.is_current_turn is False, (
+        "a turn that arrives while a DIFFERENT turn holds `running` must be refused"
+    )
+    assert (
+        await get_alive_owner(
+            lock_engine, project_id=str(_PROJECT), session_id=_SESSION
+        )
+        == "turn-1"
+    ), "the refused turn must not take the running turn's alive lock"
+
+    # And the live turn's own next beat is unaffected: it was never displaced.
+    still_live = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("replica-a", "turn-1")
+    )
+    assert still_live.is_current_turn is True
+
+
+@pytest.mark.asyncio
+async def test_a_refused_turns_end_beat_cannot_clear_the_live_turns_running(
+    lock_engine,
+):
+    """The refused turn's watchdog release sends `is_running: false`. That beat must be inert.
+
+    The runner stops a refused turn by releasing its watchdog, which sends one end beat under the
+    REFUSED turn's id. Releasing `running` on behalf of whoever holds it would end the live turn
+    from under itself, which is the failure this whole slice exists to remove. The release is
+    owner-scoped, so it is a no-op here.
+    """
+    svc = _service(lock_engine)
+
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("replica-a", "turn-1"))
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("replica-a", "turn-2"))
+
+    # The refused turn's end beat.
+    await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("replica-a", "turn-2", running=False)
+    )
+
+    live = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("replica-a", "turn-1")
+    )
+    assert live.is_current_turn is True, (
+        "the refused turn's end beat released the LIVE turn's locks"
+    )
+    assert (
+        await get_alive_owner(
+            lock_engine, project_id=str(_PROJECT), session_id=_SESSION
+        )
+        == "turn-1"
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_resume_is_admitted_while_the_previous_turn_is_PARKED(lock_engine):
+    """The case a naive "is anything alive?" gate gets wrong, and the reason `running` exists.
+
+    A turn parked awaiting approval still holds `alive` — that is what makes the session
+    reattachable — but its turn-end beat released `running`. The approval resume arrives as a NEW
+    turn and must be admitted, or every approval in the product stops resuming. `alive` alone
+    cannot tell this apart from the refusal case above; the absent `running` owner is what does.
+    """
+    svc = _service(lock_engine)
+
+    await svc.heartbeat(project_id=_PROJECT, request=_beat("replica-a", "turn-1"))
+    # Park: the turn ends its execution but the session stays alive.
+    await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("replica-a", "turn-1", running=False)
+    )
+
+    resume = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat("replica-a", "turn-2")
+    )
+
+    assert resume.is_current_turn is True, (
+        "an approval resume must be admitted while the previous turn is parked, not running"
+    )
+    assert (
+        await get_alive_owner(
+            lock_engine, project_id=str(_PROJECT), session_id=_SESSION
+        )
+        == "turn-2"
+    ), "the resume takes the nest as a legitimate handover"

--- a/docs/design/session-control-and-live-events/slice-admission.md
+++ b/docs/design/session-control-and-live-events/slice-admission.md
@@ -1,0 +1,324 @@
+# Slice: single-turn admission
+
+Status: built and verified live on 2026-09-02. Branch `feat/session-single-turn-admission`.
+Not pushed, no pull request.
+
+This slice makes one invariant true: **at most one execution runs per session, decided in one
+place.** A second message sent while a turn is running is refused before anything is destroyed.
+That is the `on_busy: reject` policy. Queue and steer are not in this slice.
+
+Closes [#6417](https://github.com/Agenta-AI/agenta/issues/6417),
+[#5539](https://github.com/Agenta-AI/agenta/issues/5539), and
+[#5538](https://github.com/Agenta-AI/agenta/issues/5538).
+
+---
+
+## What happens today, and why
+
+A user sends a second message while the agent is still answering the first. Both turns die and
+the session stays locked for about thirty minutes. Every step below is **verified** in code.
+
+1. A desktop Send does not go through the session coordination endpoint. It goes to the workflow
+   invoke path, `POST /services/agent/v0/invoke`
+   (`web/packages/agenta-playground/src/state/execution/agentRequest.ts:400`). The only caller of
+   `commandSessionStream` in the web tree is Stop.
+2. The runner mints its own turn id for that request
+   (`services/runner/src/server.ts:189`).
+3. The runner starts the turn's alive watchdog **before** it touches any sandbox
+   (`services/runner/src/server.ts:519` versus the run at `:621`). That watchdog's first heartbeat
+   is an atomic `nx` acquire of the session's `alive` lock in the API
+   (`api/oss/src/core/sessions/streams/service.py:513`).
+4. The second turn loses that acquire, because a different turn holds `running`
+   (`api/oss/src/core/sessions/streams/service.py:534`). The API answers `is_current_turn: false`.
+   **The arbiter was already correct.**
+5. The runner read that answer only as "abort this run later"
+   (`services/runner/src/sessions/alive.ts:217`), then carried on into the keepalive pool, found
+   the first turn's environment busy, and **destroyed it**:
+   the `evict (supersede-busy)` branch, now at
+   `services/runner/src/lifecycle/session-coordinator.ts:1343` and no longer reachable by a live
+   turn. The first turn lost its sandbox mid-answer.
+6. The second turn then aborted on its own watchdog signal. Both turns were dead, and the session
+   read as alive under a dead turn's lock until the lease expired.
+
+So the fix is not a new subsystem. It is reading an answer the platform already gives, before
+acting on the session.
+
+---
+
+## What changed
+
+Three commits on `feat/session-single-turn-admission`.
+
+### 1. The runner reads the admission answer (`7675eb0dc7`)
+
+| File | Change |
+|---|---|
+| `services/runner/src/sessions/admission.ts` | New. Holds the stable code `session_turn_in_use` and the one line the user reads. The decision is not made here; this is only how the runner reports it. |
+| `services/runner/src/sessions/alive.ts:190` | `startAliveWatchdog` now returns `admitted`, the FIRST beat's answer. A later `is_current_turn: false` is a Stop or steer and still travels the `onInterrupted` to abort path. |
+| `services/runner/src/server.ts:534` | A refused turn stops at the edge and returns. |
+| `services/runner/src/lifecycle/session-coordinator.ts:1320` | A `busy` pool entry is refused, never evicted. A `destroyed` entry still evicts and cold-starts. |
+| `services/runner/src/engines/sandbox_agent/errors.ts:69` | `session_turn_in_use` added to `RunErrorCode`. |
+
+The refusal in `server.ts` sits above three things it must not do, and this ordering is the
+point:
+
+- `cancelStaleInteractions` (`server.ts:573`) cancels the session's unanswered approval gates. A
+  refused turn running it would cancel the **live** turn's approval card.
+- The persisting emitter (`server.ts:587`) would write the refused message into the durable
+  transcript, so it would come back on reload as a message the user never sent.
+- `run()` (`server.ts:621`) is what reaches the keepalive pool.
+
+The refusal streams as an `error` event carrying the code, then a failed terminal result. That is
+the path every runner failure already takes to the browser, so no new transport is involved.
+
+The coordinator change is a backstop, not the fix. The heartbeat fails open on a network or HTTP
+error, which is deliberate and unchanged: a transient API blip refusing every message would be a
+worse outage than the bug. In that window two turns can be admitted, and a `busy` pool entry is
+the more specific truth on this box, so the coordinator refuses rather than destroying.
+
+### 2. The browser keeps the user's text (`bdd7116520`)
+
+A naive refusal is worse than the bug for the person typing. The composer clears synchronously on
+submit (`web/packages/agenta-ui/src/RichChatInput/assets/submit.ts:31`), so without this change
+their text is simply gone.
+
+| File | Change |
+|---|---|
+| `web/packages/agenta-chat/src/model/error.ts` | The refusal constants, `isSessionBusyRefusal`, and a stable class on the parsed error. |
+| `web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts:98` | Remembers the message handed to `sendQueued` and hands it back once through `takeLastSent`. |
+| `web/oss/src/components/AgentChatSlice/AgentConversation.tsx:433` | Puts that text back in the composer on a refusal. |
+| `web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx:204` | The bubble says "Message not sent" rather than "The agent run failed", and offers no retry. |
+
+The message is **not** re-queued. The queue releases on a settled `"error"` status
+(`useAgentChatQueue.ts:68`, and the release effect below it), which for a refusal would re-send and be refused again in a tight
+loop. The user decides when to send again.
+
+The refusal message text is the contract between the runner and the browser. It is produced once,
+in `services/runner/src/sessions/admission.ts`, and reaches the browser verbatim: the SDK's
+`sanitize_runner_error` passes a clean one-line error through unchanged
+(`sdks/python/agenta/sdk/agents/utils/wire.py:60`) and the Vercel egress puts it on the stream as
+`errorText` with the code beside it
+(`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:954`). The two constants must stay
+byte-identical.
+
+Mobile shares the queue hook and the error model, so it gets the refusal class. It has its own
+composer and its own copy of the error effect, so it does not get the text restore. See the open
+questions.
+
+### 3. API tests only (`8b1a45e5a6`)
+
+No API code changed. Three cases now pin the answers the runner depends on, in
+`api/oss/tests/pytest/unit/sessions/test_heartbeat_is_current_turn.py`.
+
+---
+
+## Approvals still resume
+
+This is the case a naive "is anything alive on this session?" gate breaks, and it was checked
+before the design was chosen.
+
+A turn parked awaiting approval still holds `alive`, which is what makes the session
+reattachable, but its turn-end beat released `running`
+(`api/oss/src/core/sessions/streams/service.py:590`). The approval resume arrives as a new turn.
+The heartbeat sees stale `alive` with **no** `running` owner, treats it as a legitimate handover,
+tombstones the parked turn and admits the resume
+(`api/oss/src/core/sessions/streams/service.py:536-561`).
+
+So `running` is the discriminator, not `alive`. Both cases are now tested, at the API and end to
+end at the runner.
+
+---
+
+## Tests
+
+| Suite | Command | Result |
+|---|---|---|
+| Runner unit | `cd services/runner && pnpm test` | 2636 passed, 4 failed |
+| Chat package | `cd web/packages/agenta-chat && pnpm test` | 626 passed |
+| API sessions unit | `pytest unit/sessions/` | 328 passed, 41 skipped |
+| Web lint | `cd web && pnpm lint-fix` | 25 tasks, 0 errors |
+| Web typecheck | `tsc --noEmit` on `@agenta/oss` and `@agenta/chat` | clean |
+
+The four runner failures are **pre-existing**, all in
+`tests/unit/gateway-run-turn-composition.test.ts`. Confirmed by stashing this slice's changes and
+re-running: the same four fail on the branch tip.
+
+The 11 collection errors in the API run are an artifact of borrowing the live tree's virtual
+environment, which resolves `agenta` from `/home/mahmoud/code/agenta-2/sdks/python` rather than
+from this worktree. They are import errors in unrelated files.
+
+New tests:
+
+- `services/runner/tests/unit/session-admission.test.ts` (7 tests). A real runner HTTP server
+  driven over a socket against a fake platform API. Covers: a refused turn never calls `run()`,
+  the error event carries the code, no interaction sweep or attachment claim happens, the end
+  beat names the refused turn, an admitted turn proceeds, a resume-shaped request is admitted,
+  and an unreachable platform fails open.
+- `services/runner/tests/unit/session-alive-interrupt.test.ts` (+4). `admitted` semantics: first
+  beat only, fail-open, and a later interruption does not un-admit.
+- `services/runner/tests/unit/session-keepalive-dispatch.test.ts` (+1, 1 rewritten). A busy entry
+  refuses with no eviction and no cold acquire; a destroyed entry still evicts.
+- `services/runner/tests/unit/session-steer-mount-loss.test.ts` (3 rewritten). These pinned the
+  old supersede outcome. They now pin the refusal, and one new case asserts the live turn's
+  environment is never torn down.
+- `web/packages/agenta-chat/tests/unit/model/error.test.ts` (+4).
+- `web/packages/agenta-chat/tests/unit/hooks/useAgentChatQueue.test.ts` (+4).
+- `api/oss/tests/pytest/unit/sessions/test_heartbeat_is_current_turn.py` (+3).
+
+---
+
+## Live verification
+
+### The stack
+
+A standalone EE dev stack built from this worktree, at **http://144.76.237.122:8680**.
+
+The brief named `hosting/docker-compose/ee/.env.ee.dev.local` as the base env file. That file is
+from 30 July and is missing `AGENTA_SERVICES_INTERNAL_KEY`, so compose refuses to start. The env
+file was rebased on `.env.ee.dev.toolkit.local` (29 August), which is the one Mahmoud's own stack
+runs, with every port, the project name and the env-file pointer changed. The four
+`agenta-ee-dev-*:latest` images were 15 minutes old, so `--build` was skipped as the brief
+directed; dev mode bind-mounts the source, so the containers run this worktree's code.
+
+Two deployment notes worth keeping. First, the stale env file: compose fails immediately with
+`required variable AGENTA_SERVICES_INTERNAL_KEY is missing a value`, which names the problem
+clearly. Second, the web container 502s indefinitely if you have also run `pnpm install` in this
+worktree's `web/` from the host, as this slice did for lint and tests. The host install runs as
+uid 1000 and the container as uid 10001, so the container's own install and the api-client
+`prepare` build cannot overwrite those paths and the entrypoint retries forever. The log looks
+like a slow install; the real line is `[EACCES] ... .bin/tsc` thousands of lines up. Fix with
+`chmod -R a+rwX web/` in the worktree and restart the container, then poll `/w` rather than `/`,
+because `/` 308-redirects there and the first compile takes a few minutes.
+
+Sandbox provider: `local`. Harness: `pi_core`. Model: `gpt-5.6-luna` on the QA OpenAI key, added
+to the stack's own vault.
+
+### The scenario
+
+Driver: `verify_admission.py`, wire level, asserting on SSE frame types and never on model prose.
+It is kept at
+`/tmp/claude-1000/-home-mahmoud-code-agenta-2/7c724667-82cd-41a6-ba0b-e47bc96b4f67/scratchpad/verify_admission.py`.
+
+1. Turn A starts on a fresh session and runs `sleep 40 && echo DONE_A` as a shell tool.
+2. Fifteen seconds in, turn B sends "What is 2 + 2?" to the same session.
+3. After A settles, turn C sends a third message.
+
+The agent config sets `runner.permissions.default` to `allow`, so the long tool runs instead of
+parking on an approval card. The first attempt without it proved nothing: the tool parked, turn A
+ended after eleven seconds, and the two turns never overlapped.
+
+### Results
+
+| Turn | HTTP | Duration | Outcome |
+|---|---|---|---|
+| A, long turn | 200 | 50.3 s | finished, `finishReason: stop`, reply "Finished.", ran its tool |
+| B, second send | 200 | **0.18 s** | refused, no assistant text, no tool call |
+| C, after | 200 | 2.0 s | ran, reply "READY" |
+
+Turn B's error frames, verbatim:
+
+```json
+{"code": "session_turn_in_use", "errorText": "This session is already running a turn. Your message was not sent. Wait for the reply, or stop the turn, then send again."}
+{"type": "error", "errorText": "This session is already running a turn. Your message was not sent. Wait for the reply, or stop the turn, then send again."}
+```
+
+Runner log for session `081a1fe7-9961-4a0e-bdb1-177a59a8bfd6`, in order:
+
+```
+[sessions] stream sessionOwned=true sessionId=081a1fe7-… turnId=444d272b-… cred=present
+[sessions/alive] heartbeat OK session=081a1fe7-… turn=444d272b-… running=true
+[keepalive] miss key=01a063ea-…:081a1fe7-…; cold
+[keepalive] reserve key=01a063ea-…:081a1fe7-… poolSize=2
+[sessions] stream sessionOwned=true sessionId=081a1fe7-… turnId=0e4a90c0-… cred=present
+[sessions/alive] heartbeat OK session=081a1fe7-… turn=0e4a90c0-… running=true INTERRUPTED
+[sessions] admission REFUSED session=081a1fe7-… turn=0e4a90c0-…; another turn owns this session. No pool resolve, no eviction.
+[sessions/alive] heartbeat OK session=081a1fe7-… turn=0e4a90c0-… running=false
+[sessions/alive] heartbeat OK session=081a1fe7-… turn=444d272b-… running=true
+[sandbox-agent] complete OK session=081a1fe7-… turn=0
+[keepalive] park key=01a063ea-…:081a1fe7-… ttl=60000ms state=idle (re-park) poolSize=1
+[sessions] stream sessionOwned=true sessionId=081a1fe7-… turnId=42fa2fa0-… cred=present
+[keepalive] hit-continue key=01a063ea-…:081a1fe7-…
+[sandbox-agent] complete OK session=081a1fe7-… turn=1
+```
+
+Three things to read from that log:
+
+- There is **no** `evict (supersede-…)` line. The refused turn touched the pool not at all.
+- Turn A ran to `complete OK` and then `park … state=idle`, so it kept its sandbox.
+- Turn C got `hit-continue`, which means it continued the **warm** session A parked. The warm
+  sandbox and the native harness session survived the second send. That is the constraint this
+  slice was bound by, checked rather than assumed.
+
+The stack is left running. Teardown:
+
+```bash
+cd /home/mahmoud/code/agenta-2-worktrees/slice-admission
+bash ./hosting/docker-compose/run.sh --license ee --dev --env-file .env.ee.dev.admission --down
+```
+
+Add `--nuke` to drop the volumes as well. That stack has its own Postgres on port 5441 and shares
+nothing with the other stacks on the box.
+
+### Not verified
+
+The browser behaviour was **not** verified in a browser. The composer restore, the "Message not
+sent" bubble and the mobile path are covered by unit tests and a typecheck only. The web app on
+this stack is serving (`/w` answers 200), so a UI pass is available and is worth doing before
+this ships. Reproducing the refusal by hand needs two browser tabs on one session, or one tab
+plus a curl invoke while a turn runs.
+
+---
+
+## What is left for queue and steer
+
+Refusing needs no storage. Queue and steer both do, and that is the whole reason they are not in
+this slice.
+
+- **Queue** needs a durable pending-input store, because a saved message has to survive the turn
+  it is waiting on and a browser reload. The client-side queue in `useAgentChatQueue` is a
+  per-tab convenience; it is lost on reload and invisible to any other reader of the session.
+- **Steer** needs the same store plus a decision that this slice deliberately does not make: is
+  steer reject-with-message, keeping the turn and the warm session, or interrupt-and-restart? The
+  RFC (`rfc.md:125`) says interrupt-and-restart, which reverses the ruling of 2026-07-22 without
+  saying so, and interrupt-and-restart is the shape that loses warm state today.
+- **The 409 shape.** The API's `_start_turn` already raises `SessionTurnInUse` and the router
+  already maps it to 409 (`api/oss/src/apis/fastapi/sessions/router.py:192`). This slice does not
+  route Send through that endpoint, because the runner's own heartbeat already performs the same
+  atomic acquire one step earlier and the invoke path does not otherwise touch the API. If Send
+  ever moves onto the coordination endpoint, the refusal should become the 409 and the runner's
+  edge check becomes a second line of defence.
+- **The watchdog** is untouched by this slice and remains the highest-value next change. It
+  bounds every hang rather than only the double send.
+
+---
+
+## Open questions for Mahmoud
+
+1. **Should the refused message be queued instead of handed back to the composer?**
+   *Recommendation: keep handing it back for now.* Queueing reads better, but the queue
+   auto-releases on a settled error status, so a refusal would re-send and be refused in a loop
+   until the running turn ends. Fixing that needs a refusal-aware release gate, which is queue
+   work, not admission work.
+
+2. **Should mobile also restore the text?** Today it gets the refusal class but not the restore,
+   because its composer and its error effect are separate files from desktop's.
+   *Recommendation: yes, in a follow-up.* The precedent already exists at
+   `web/mobile/src/features/chat/Composer.tsx:98`, which puts text back and shows a composer-level
+   rejection strip. It is a few lines, but it is a second host to QA and this slice is already
+   wide.
+
+3. **Is the composer-level rejection strip a better home for this than a red transcript bubble?**
+   Mobile already has one. A refusal is a fact about the message the user just typed, not about
+   the conversation. *Recommendation: move it there once someone looks at it in a browser.* The
+   current bubble is honest but it sits in the transcript, which is where run failures live.
+
+4. **Is the fail-open on an unreachable API still the right default?** It is unchanged from
+   today, and the coordinator's busy check backs it up on a single runner.
+   *Recommendation: keep it.* Refusing every message during an API blip would be a worse outage
+   than the bug this closes, and with one runner the local check catches the real overlap.
+
+5. **Should `--build` have been skipped?** The brief said to skip it if the images were under
+   three hours old, and they were fifteen minutes old. The live results therefore depend on dev
+   mode bind-mounting this worktree's source, which the runner log confirms it did (the
+   `admission REFUSED` line only exists in this branch). *Recommendation: no action.* Flagged only
+   so the evidence is auditable.

--- a/docs/design/session-control-and-live-events/slice-admission.md
+++ b/docs/design/session-control-and-live-events/slice-admission.md
@@ -47,7 +47,7 @@ acting on the session.
 
 ## What changed
 
-Five commits on `feat/session-single-turn-admission`.
+Seven commits on `feat/session-single-turn-admission`.
 
 ### 1. The runner reads the admission answer (`7675eb0dc7`)
 
@@ -105,7 +105,7 @@ Mobile shares the queue hook and the error model, so it gets the refusal class. 
 composer and its own copy of the error effect, so it does not get the text restore. See the open
 questions.
 
-### 3. The client learns which execution it is watching (`ce0f1e12da`)
+### 3. The client learns which execution it is watching (`ce0f1e12da`, `ca600cb1e6`)
 
 Added on request from the Stop guard lane, which found that no first-party client can send
 `expected_execution_id` on the public Cancel: the runner mints the turn id per execution
@@ -126,26 +126,37 @@ The earliest frame that can carry it is the one right after:
 |---|---|
 | `services/runner/src/protocol.ts:479` | New `{type: "turn", turnId}` agent event. |
 | `services/runner/src/server.ts:579` | Emitted as the first event of a session-owned run, immediately after admission, through `liveEmit` and never the persisting emitter. It is transport correlation, not conversation, and must not become a session record. |
-| `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:361` and `:653` | Forwarded unchanged as `data-agent-turn`, in both the live and dev-twin projections. |
+| `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:361` and `:663` | Forwarded onto the MESSAGE METADATA, in both the live and dev-twin projections. |
 
-A missing, empty or non-string id emits no part, so a client is never handed a guard value that
+The client reads it as `message.metadata.turnId`, beside the `sessionId` the `start` frame already
+sets and the `traceId` and `usage` the `finish` frame adds, rather than scanning parts for it.
+A `message-metadata` chunk is a first-class chunk in the pinned `ai@6.0.0-beta.150`.
+
+That is safe **because the AI SDK merges metadata rather than replacing it** (`mergeObjects`), so
+the `finish` frame's own metadata lands beside the turn id rather than over it. A test pins that
+the two carry disjoint keys and the turn id is written first. If the SDK ever changed to replace,
+a client would lose the id exactly when a late Stop needs it.
+
+A missing, empty or non-string id emits no frame, so a client is never handed a guard value that
 names nothing. A refused turn emits none either: it runs nothing, so there is nothing to stop.
 
 Verified live on the stack below. The frame arrives third, after `start` and `start-step` and
 before any content:
 
 ```
-["start", "start-step", "data-agent-turn", "data-agent-status"]
+["start", "start-step", "message-metadata", "text-start"]
 ```
 
 and its id is the one holding the session's alive lock, cross-checked against the runner log:
 
 ```
-data-agent-turn  turnId=e741e416-6789-4679-b050-e205d549f73f
-[sessions/alive] heartbeat OK session=be8d2daa-… turn=e741e416-6789-4679-b050-e205d549f73f running=true
+message-metadata  turnId=6a49ff3f-2165-4e4b-bbe8-c9f7192fabb3
+[sessions] stream sessionOwned=true sessionId=2fa74edd-… turnId=6a49ff3f-2165-4e4b-bbe8-c9f7192fabb3
 ```
 
-The Stop guard lane adds the browser half on its own branch. Nothing here consumes the frame yet.
+The first version of this (`ce0f1e12da`) used a `data-agent-turn` part instead. `ca600cb1e6`
+replaced it rather than adding to it: one fact should travel one channel, and nothing consumed the
+part yet. The Stop guard lane adds the browser half on its own branch.
 
 ### 4. API tests only (`8b1a45e5a6`)
 
@@ -209,9 +220,9 @@ New tests:
 - `api/oss/tests/pytest/unit/sessions/test_heartbeat_is_current_turn.py` (+3).
 - `services/runner/tests/unit/session-admission.test.ts` (+3, the turn-id frame): it arrives
   first, it is the id the alive lock was acquired under, and a refused turn emits none.
-- `sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py` (+3): the
-  egress forwards the id verbatim exactly once in both projections, before any content, and a
-  frame with no usable id emits no part.
+- `sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py` (+4): the
+  egress forwards the id verbatim exactly once in both projections, before any content; the
+  `finish` frame's metadata does not displace it; and a frame with no usable id emits nothing.
 
 One rewritten test was found to be passing for the wrong reason. The `destroyed`-entry case in
 `session-keepalive-dispatch.test.ts` called `pool.destroyAll`, which clears the map, so the

--- a/docs/design/session-control-and-live-events/slice-admission.md
+++ b/docs/design/session-control-and-live-events/slice-admission.md
@@ -47,7 +47,7 @@ acting on the session.
 
 ## What changed
 
-Three commits on `feat/session-single-turn-admission`.
+Five commits on `feat/session-single-turn-admission`.
 
 ### 1. The runner reads the admission answer (`7675eb0dc7`)
 
@@ -105,7 +105,49 @@ Mobile shares the queue hook and the error model, so it gets the refusal class. 
 composer and its own copy of the error effect, so it does not get the text restore. See the open
 questions.
 
-### 3. API tests only (`8b1a45e5a6`)
+### 3. The client learns which execution it is watching (`ce0f1e12da`)
+
+Added on request from the Stop guard lane, which found that no first-party client can send
+`expected_execution_id` on the public Cancel: the runner mints the turn id per execution
+(`services/runner/src/server.ts:189`) and never tells anyone, so a Stop can only mean "whatever
+is running now", never "the turn I was watching".
+
+**The `start` frame cannot carry it.** It is built and sent by the SDK's Vercel egress before the
+runner replies at all: the `start` yield is the first statement of the projection
+(`sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:459-464`), and the runner is not
+consulted until the loop below it. Putting the id there would mean moving the mint out of the
+runner and threading a new correlation id through the normalizer, the response models and the
+routing layer for **every** workflow, not just agent ones. That is a much larger change than the
+problem needs.
+
+The earliest frame that can carry it is the one right after:
+
+| File | Change |
+|---|---|
+| `services/runner/src/protocol.ts:479` | New `{type: "turn", turnId}` agent event. |
+| `services/runner/src/server.ts:579` | Emitted as the first event of a session-owned run, immediately after admission, through `liveEmit` and never the persisting emitter. It is transport correlation, not conversation, and must not become a session record. |
+| `sdks/python/agenta/sdk/agents/adapters/vercel/stream.py:361` and `:653` | Forwarded unchanged as `data-agent-turn`, in both the live and dev-twin projections. |
+
+A missing, empty or non-string id emits no part, so a client is never handed a guard value that
+names nothing. A refused turn emits none either: it runs nothing, so there is nothing to stop.
+
+Verified live on the stack below. The frame arrives third, after `start` and `start-step` and
+before any content:
+
+```
+["start", "start-step", "data-agent-turn", "data-agent-status"]
+```
+
+and its id is the one holding the session's alive lock, cross-checked against the runner log:
+
+```
+data-agent-turn  turnId=e741e416-6789-4679-b050-e205d549f73f
+[sessions/alive] heartbeat OK session=be8d2daa-… turn=e741e416-6789-4679-b050-e205d549f73f running=true
+```
+
+The Stop guard lane adds the browser half on its own branch. Nothing here consumes the frame yet.
+
+### 4. API tests only (`8b1a45e5a6`)
 
 No API code changed. Three cases now pin the answers the runner depends on, in
 `api/oss/tests/pytest/unit/sessions/test_heartbeat_is_current_turn.py`.
@@ -133,8 +175,9 @@ end at the runner.
 
 | Suite | Command | Result |
 |---|---|---|
-| Runner unit | `cd services/runner && pnpm test` | 2636 passed, 4 failed |
+| Runner unit | `cd services/runner && pnpm test` | 2639 passed, 4 failed |
 | Chat package | `cd web/packages/agenta-chat && pnpm test` | 626 passed |
+| SDK agents unit | `pytest oss/tests/pytest/unit/agents/` | 1198 passed, 4 skipped |
 | API sessions unit | `pytest unit/sessions/` | 328 passed, 41 skipped |
 | Web lint | `cd web && pnpm lint-fix` | 25 tasks, 0 errors |
 | Web typecheck | `tsc --noEmit` on `@agenta/oss` and `@agenta/chat` | clean |
@@ -164,6 +207,17 @@ New tests:
 - `web/packages/agenta-chat/tests/unit/model/error.test.ts` (+4).
 - `web/packages/agenta-chat/tests/unit/hooks/useAgentChatQueue.test.ts` (+4).
 - `api/oss/tests/pytest/unit/sessions/test_heartbeat_is_current_turn.py` (+3).
+- `services/runner/tests/unit/session-admission.test.ts` (+3, the turn-id frame): it arrives
+  first, it is the id the alive lock was acquired under, and a refused turn emits none.
+- `sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py` (+3): the
+  egress forwards the id verbatim exactly once in both projections, before any content, and a
+  frame with no usable id emits no part.
+
+One rewritten test was found to be passing for the wrong reason. The `destroyed`-entry case in
+`session-keepalive-dispatch.test.ts` called `pool.destroyAll`, which clears the map, so the
+assertion ran against a `miss` rather than a `destroyed` entry. The runner typecheck caught the
+argument-type error that exposed it. It now marks the entry directly, because every public route
+that destroys a session also removes it.
 
 ---
 

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -358,6 +358,15 @@ async def _agent_run_to_vercel_parts_impl(
                     failure_code=_runner_failure_code(data.get("code")),
                 ):
                     yield part
+            elif etype == "turn":
+                # The runner's admitted execution id, forwarded unchanged as the FIRST data part
+                # of the turn. The AI SDK's `start` frame is emitted before the runner replies at
+                # all (see the `start` yield above), so it cannot carry a runner-minted id; this
+                # is the earliest frame that can. A client keeps it to name the execution it means
+                # to Stop (`expected_execution_id`) instead of cancelling "whatever runs now".
+                turn_id = data.get("turnId")
+                if isinstance(turn_id, str) and turn_id:
+                    yield {"type": "data-agent-turn", "data": {"turnId": turn_id}}
             elif etype == "done":
                 # Last non-null stop reason wins; see the routing-layer twin's `done` note.
                 reason = data.get("stopReason")
@@ -641,6 +650,15 @@ async def _agent_stream_to_vercel_stream_impl(
                     failure_code=_runner_failure_code(data.get("code")),
                 ):
                     yield part
+            elif etype == "turn":
+                # The runner's admitted execution id, forwarded unchanged as the FIRST data part
+                # of the turn. The AI SDK's `start` frame is emitted before the runner replies at
+                # all (see the `start` yield above), so it cannot carry a runner-minted id; this
+                # is the earliest frame that can. A client keeps it to name the execution it means
+                # to Stop (`expected_execution_id`) instead of cancelling "whatever runs now".
+                turn_id = data.get("turnId")
+                if isinstance(turn_id, str) and turn_id:
+                    yield {"type": "data-agent-turn", "data": {"turnId": turn_id}}
             elif etype == "done":
                 # Prefer the LAST non-null stop reason. The handler appends a corrective
                 # terminal `done` after the runner's `done` when the authoritative result

--- a/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
+++ b/sdks/python/agenta/sdk/agents/adapters/vercel/stream.py
@@ -359,14 +359,24 @@ async def _agent_run_to_vercel_parts_impl(
                 ):
                     yield part
             elif etype == "turn":
-                # The runner's admitted execution id, forwarded unchanged as the FIRST data part
-                # of the turn. The AI SDK's `start` frame is emitted before the runner replies at
-                # all (see the `start` yield above), so it cannot carry a runner-minted id; this
-                # is the earliest frame that can. A client keeps it to name the execution it means
-                # to Stop (`expected_execution_id`) instead of cancelling "whatever runs now".
+                # The runner's admitted execution id, forwarded onto the MESSAGE METADATA so the
+                # client reads it as `message.metadata.turnId`, beside the `sessionId` the `start`
+                # frame already carries and the `traceId`/`usage` the `finish` frame adds.
+                #
+                # It cannot ride the `start` frame itself: that frame is emitted before the runner
+                # replies at all (see the `start` yield above), so a runner-minted id does not
+                # exist yet. A `message-metadata` chunk is the same channel one frame later, and
+                # the AI SDK MERGES metadata rather than replacing it (`mergeObjects`), so the id
+                # survives the `finish` frame's own metadata to the end of the turn.
+                #
+                # A client keeps it to name the execution it means to Stop
+                # (`expected_execution_id`) instead of cancelling "whatever runs now".
                 turn_id = data.get("turnId")
                 if isinstance(turn_id, str) and turn_id:
-                    yield {"type": "data-agent-turn", "data": {"turnId": turn_id}}
+                    yield {
+                        "type": "message-metadata",
+                        "messageMetadata": {"turnId": turn_id},
+                    }
             elif etype == "done":
                 # Last non-null stop reason wins; see the routing-layer twin's `done` note.
                 reason = data.get("stopReason")
@@ -651,14 +661,24 @@ async def _agent_stream_to_vercel_stream_impl(
                 ):
                     yield part
             elif etype == "turn":
-                # The runner's admitted execution id, forwarded unchanged as the FIRST data part
-                # of the turn. The AI SDK's `start` frame is emitted before the runner replies at
-                # all (see the `start` yield above), so it cannot carry a runner-minted id; this
-                # is the earliest frame that can. A client keeps it to name the execution it means
-                # to Stop (`expected_execution_id`) instead of cancelling "whatever runs now".
+                # The runner's admitted execution id, forwarded onto the MESSAGE METADATA so the
+                # client reads it as `message.metadata.turnId`, beside the `sessionId` the `start`
+                # frame already carries and the `traceId`/`usage` the `finish` frame adds.
+                #
+                # It cannot ride the `start` frame itself: that frame is emitted before the runner
+                # replies at all (see the `start` yield above), so a runner-minted id does not
+                # exist yet. A `message-metadata` chunk is the same channel one frame later, and
+                # the AI SDK MERGES metadata rather than replacing it (`mergeObjects`), so the id
+                # survives the `finish` frame's own metadata to the end of the turn.
+                #
+                # A client keeps it to name the execution it means to Stop
+                # (`expected_execution_id`) instead of cancelling "whatever runs now".
                 turn_id = data.get("turnId")
                 if isinstance(turn_id, str) and turn_id:
-                    yield {"type": "data-agent-turn", "data": {"turnId": turn_id}}
+                    yield {
+                        "type": "message-metadata",
+                        "messageMetadata": {"turnId": turn_id},
+                    }
             elif etype == "done":
                 # Prefer the LAST non-null stop reason. The handler appends a corrective
                 # terminal `done` after the runner's `done` when the authoritative result

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py
@@ -453,9 +453,11 @@ _TURN_EVENTS_RUN: List[Dict[str, Any]] = [
     {"type": "done", "stopReason": "stop"},
 ]
 
+_TURN_METADATA = {"type": "message-metadata", "messageMetadata": {"turnId": _TURN_ID}}
+
 
 @pytest.mark.asyncio
-async def test_live_projection_forwards_the_turn_id_unchanged() -> None:
+async def test_live_projection_puts_the_turn_id_on_message_metadata() -> None:
     parts = [
         part
         async for part in agent_stream_to_vercel_stream(
@@ -465,13 +467,13 @@ async def test_live_projection_forwards_the_turn_id_unchanged() -> None:
     for part in parts:
         assert_conforms(part)
 
-    turn_parts = [p for p in parts if p["type"] == "data-agent-turn"]
-    assert turn_parts == [{"type": "data-agent-turn", "data": {"turnId": _TURN_ID}}], (
-        "the egress must forward the runner's id verbatim, exactly once"
+    metadata_parts = [p for p in parts if p["type"] == "message-metadata"]
+    assert metadata_parts == [_TURN_METADATA], (
+        "the egress must forward the runner's id verbatim, exactly once, as message metadata"
     )
 
     # It must land before any content, so a client that Stops early already holds the id.
-    turn_index = next(i for i, p in enumerate(parts) if p["type"] == "data-agent-turn")
+    turn_index = next(i for i, p in enumerate(parts) if p["type"] == "message-metadata")
     first_text = next(
         (i for i, p in enumerate(parts) if p["type"].startswith("text-")), None
     )
@@ -479,12 +481,37 @@ async def test_live_projection_forwards_the_turn_id_unchanged() -> None:
 
 
 @pytest.mark.asyncio
-async def test_dev_twin_projection_forwards_the_turn_id_unchanged() -> None:
+async def test_the_finish_frames_metadata_does_not_displace_the_turn_id() -> None:
+    """The whole reason `message-metadata` is a safe carrier.
+
+    The AI SDK merges metadata rather than replacing it (`mergeObjects` in ai@6), so the
+    `finish` frame's own `messageMetadata` (traceId, usage) lands BESIDE the turn id rather than
+    over it. If that ever changed, a client would lose the id exactly when a late Stop needs it,
+    so pin that the two carry disjoint keys and the turn id is written first.
+    """
+    parts = [
+        part
+        async for part in agent_stream_to_vercel_stream(
+            _records(_TURN_EVENTS_LIVE), trace_id="t1"
+        )
+    ]
+    turn_index = next(i for i, p in enumerate(parts) if p["type"] == "message-metadata")
+    finish = next(p for p in parts if p["type"] == "finish")
+    finish_index = parts.index(finish)
+
+    assert turn_index < finish_index
+    assert "turnId" not in (finish.get("messageMetadata") or {}), (
+        "the finish frame must not restate the turn id; it merges beside it"
+    )
+
+
+@pytest.mark.asyncio
+async def test_dev_twin_projection_puts_the_turn_id_on_message_metadata() -> None:
     run = _run_with(_TURN_EVENTS_RUN, result={"output": "hello"})
     parts = [part async for part in agent_run_to_vercel_parts(run)]
     for part in parts:
         assert_conforms(part)
-    assert {"type": "data-agent-turn", "data": {"turnId": _TURN_ID}} in parts
+    assert _TURN_METADATA in parts
 
 
 @pytest.mark.asyncio
@@ -499,6 +526,6 @@ async def test_a_turn_event_with_no_usable_id_emits_nothing() -> None:
                 _records([{"type": "turn", "data": bad}]), trace_id="t1"
             )
         ]
-        assert not [p for p in parts if p["type"] == "data-agent-turn"], (
-            f"a turn event with data={bad!r} must emit no part"
+        assert not [p for p in parts if p["type"] == "message-metadata"], (
+            f"a turn event with data={bad!r} must emit no metadata frame"
         )

--- a/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/adapters/test_vercel_stream_conformance.py
@@ -423,3 +423,82 @@ def test_vendored_version_matches_package_pin() -> None:
     # CI-grep-able tripwire: bump this const (and re-audit the shape above) whenever
     # web/oss/package.json's "ai" pin changes.
     assert _AI_PACKAGE_VERSION == "6.0.0-beta.150"
+
+
+# ---------------------------------------------------------------------------
+# The turn id pass-through.
+#
+# The runner mints the turn id per execution and, until this, told no one. The `start` frame is
+# built and emitted before the runner replies at all, so it CANNOT carry a runner-minted id —
+# which is why `expected_execution_id` on the public Cancel had no first-party caller able to fill
+# it. The runner now emits a `turn` event as its first frame and the egress forwards it unchanged
+# as `data-agent-turn`, the earliest part that can carry it.
+# ---------------------------------------------------------------------------
+
+_TURN_ID = "d3b4a1c2-0000-4000-8000-abcdefabcdef"
+
+# The runner's AgentEvent is FLAT (`{type, turnId}`, like `{type, message, code}` for an error),
+# and each path wraps it differently. The live handler yields `{"type", "data"}` where `data` is
+# the whole flat runner event; `AgentStream` (the dev twin) hands the flat record through
+# `Event.from_wire`, which also sets `data` to the whole record. Both fixtures below are the real
+# shapes, not a convenient one — a fixture that reshapes the event tests nothing about the wire.
+_TURN_EVENTS_LIVE: List[Dict[str, Any]] = [
+    {"type": "turn", "data": {"type": "turn", "turnId": _TURN_ID}},
+    {"type": "message", "data": {"text": "hello"}},
+    {"type": "done", "data": {"stopReason": "stop"}},
+]
+_TURN_EVENTS_RUN: List[Dict[str, Any]] = [
+    {"type": "turn", "turnId": _TURN_ID},
+    {"type": "message", "text": "hello"},
+    {"type": "done", "stopReason": "stop"},
+]
+
+
+@pytest.mark.asyncio
+async def test_live_projection_forwards_the_turn_id_unchanged() -> None:
+    parts = [
+        part
+        async for part in agent_stream_to_vercel_stream(
+            _records(_TURN_EVENTS_LIVE), trace_id="t1"
+        )
+    ]
+    for part in parts:
+        assert_conforms(part)
+
+    turn_parts = [p for p in parts if p["type"] == "data-agent-turn"]
+    assert turn_parts == [{"type": "data-agent-turn", "data": {"turnId": _TURN_ID}}], (
+        "the egress must forward the runner's id verbatim, exactly once"
+    )
+
+    # It must land before any content, so a client that Stops early already holds the id.
+    turn_index = next(i for i, p in enumerate(parts) if p["type"] == "data-agent-turn")
+    first_text = next(
+        (i for i, p in enumerate(parts) if p["type"].startswith("text-")), None
+    )
+    assert first_text is None or turn_index < first_text
+
+
+@pytest.mark.asyncio
+async def test_dev_twin_projection_forwards_the_turn_id_unchanged() -> None:
+    run = _run_with(_TURN_EVENTS_RUN, result={"output": "hello"})
+    parts = [part async for part in agent_run_to_vercel_parts(run)]
+    for part in parts:
+        assert_conforms(part)
+    assert {"type": "data-agent-turn", "data": {"turnId": _TURN_ID}} in parts
+
+
+@pytest.mark.asyncio
+async def test_a_turn_event_with_no_usable_id_emits_nothing() -> None:
+    # An older runner, or a malformed frame, must not put an empty id on the stream: a client
+    # would send it as `expected_execution_id` and cancel nothing, or worse, read it as "no
+    # guard". Dropping it leaves the client in the honest "I do not know the id" state.
+    for bad in ({}, {"turnId": None}, {"turnId": ""}, {"turnId": 7}):
+        parts = [
+            part
+            async for part in agent_stream_to_vercel_stream(
+                _records([{"type": "turn", "data": bad}]), trace_id="t1"
+            )
+        ]
+        assert not [p for p in parts if p["type"] == "data-agent-turn"], (
+            f"a turn event with data={bad!r} must emit no part"
+        )

--- a/services/runner/src/engines/sandbox_agent/errors.ts
+++ b/services/runner/src/engines/sandbox_agent/errors.ts
@@ -63,7 +63,12 @@ export type RunErrorCode =
   | "starter_credits_program_paused"
   | "starter_credits_unavailable"
   | "credential_delivery_failed"
-  | "rate_limited";
+  | "rate_limited"
+  // Not a failure: the turn was REFUSED before it started because another turn already owns
+  // this session. Nothing ran, nothing was destroyed, and the user's message was never sent.
+  // Clients render it as a "not sent, try again" state and keep the text, never as a run error.
+  // Produced by `sessions/admission.ts`, not by this module's classifier.
+  | "session_turn_in_use";
 
 /** One failed run, condensed: the line the user reads plus the class a client can act on. */
 export interface ClassifiedRunError {

--- a/services/runner/src/lifecycle/session-coordinator.ts
+++ b/services/runner/src/lifecycle/session-coordinator.ts
@@ -40,6 +40,7 @@ import {
   type SessionEnvironment,
 } from "../engines/sandbox_agent.ts";
 import type { MountCredentials } from "../engines/sandbox_agent/mount.ts";
+import { SESSION_TURN_IN_USE_MESSAGE } from "../sessions/admission.ts";
 import {
   teardownDisposition,
   type TeardownReason,
@@ -1316,12 +1317,29 @@ export async function runWithKeepalive(
       return result;
     }
     // checkout lost a race; fall through to cold.
+  } else if (existing && existing.state === "busy") {
+    // A LIVE turn is streaming on this environment right now, in this process. Refuse; never
+    // destroy it.
+    //
+    // This branch used to `evict` and cold-start ("supersede-busy"), which is the second half of
+    // the double-send bug (#6417, #5539, #5538): a second message on a running session tore the
+    // sandbox out from under the first turn, so both turns died and the session stayed locked
+    // until the 30-minute lease expired. Admission (`sessions/admission.ts`, decided by the API's
+    // atomic `nx` acquire on the turn's first heartbeat) now refuses the second turn at the edge,
+    // so in normal operation nothing reaches here at all.
+    //
+    // What still reaches here is the fail-open window: the heartbeat fails open on a network or
+    // HTTP error, so an API blip can admit two turns. Local state is the more specific truth in
+    // that window — a busy entry means a turn is demonstrably in flight on this box — so this is
+    // the backstop that keeps the invariant true when the arbiter is unreachable. Only a
+    // `checkoutIdle` continuation and a freshly `reserve`d cold turn leave a busy entry;
+    // `checkoutApproval` REMOVES its session, so an in-flight approval resume is never found here.
+    klog(`refuse (busy) key=${key}; another turn owns this session`);
+    return { ok: false, error: SESSION_TURN_IN_USE_MESSAGE };
   } else if (existing) {
-    // Busy / destroyed: two turns racing one session. Only a checkoutIdle continuation leaves a
-    // busy entry in the map (checkoutApproval REMOVES its session, so an in-flight approval
-    // resume can never be found — a duplicate approval misses the pool and runs cold, and its
-    // environment can never be destroyed by this branch). Supersede — destroy the parked one and
-    // cold-start — awaited so its teardown cannot overlap our acquire.
+    // `destroyed`: a dead entry left by a drain (`destroyAll`) or a teardown that has already
+    // run. Nothing is in flight on it, so clearing the key and cold-starting is correct and
+    // costs nothing warm.
     klog(`evict (supersede-${existing.state}) key=${key}; cold`);
     await pool.evict(key, `supersede-${existing.state}`, "failed-turn");
   } else {

--- a/services/runner/src/protocol.ts
+++ b/services/runner/src/protocol.ts
@@ -465,6 +465,18 @@ export type AgentEvent =
       total?: number;
       cost?: number;
     }
+  /**
+   * This turn's ADMITTED execution id, emitted once at the start of a session-owned run.
+   *
+   * The runner mints the turn id per execution (`resolveTurnId`), so before this the browser had
+   * no way to learn it: the client's `start` frame is built and sent before the runner replies at
+   * all. Without the id no first-party client can name the execution it means to act on, which is
+   * why `expected_execution_id` on the public Cancel has never had a caller that could fill it.
+   *
+   * Emitted LIVE only, never through the persisting emitter: it is transport correlation, not
+   * conversation, and it must not become a record in the session's history.
+   */
+  | { type: "turn"; turnId: string }
   | {
       type: "error";
       message: string;

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -566,6 +566,18 @@ async function runAndStreamWithApiBaseResolved(
       return;
     }
 
+    // Admitted. Tell the client which execution it is watching, before anything else streams.
+    //
+    // The runner mints the turn id (`resolveTurnId`), and until now it never told anyone: the
+    // client's `start` frame is built and sent before the runner replies at all, so it cannot
+    // carry a runner-minted id. That is why `expected_execution_id` on the public Cancel has had
+    // no first-party caller able to fill it — a Stop could only mean "whatever is running now",
+    // never "the turn I was watching". This is the earliest frame that can carry it.
+    //
+    // Deliberately on `liveEmit`, not the persisting emitter that replaces it below: this is
+    // transport correlation, not conversation, and it must never become a session record.
+    liveEmit({ type: "turn", turnId });
+
     // A new turn supersedes any prior turn's unanswered gate: cancel stale pending
     // interactions (sparing this turn's own, plus a parked gate this turn answers in-band —
     // the resume resolves that one). Best-effort, never blocks the turn.

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -76,6 +76,10 @@ import {
 import { applyDaytonaSdkEnv } from "./engines/sandbox_agent/daytona-provider.ts";
 import { isEntrypoint } from "./entry.ts";
 import { insecureEgressAllowed } from "./tools/ssrf-guard.ts";
+import {
+  SESSION_TURN_IN_USE_CODE,
+  SESSION_TURN_IN_USE_MESSAGE,
+} from "./sessions/admission.ts";
 import { startAliveWatchdog } from "./sessions/alive.ts";
 import {
   buildWorkflowReferenceList,
@@ -526,6 +530,42 @@ async function runAndStreamWithApiBaseResolved(
     // The heartbeat response already carries the session_streams row id — free, no extra
     // round-trip. Thread it onto the request so the engine's turn-append write has it.
     request.streamId = watchdog.streamId();
+
+    // ADMISSION. That first beat asked the platform's atomic `nx` acquire whether this turn may
+    // run, and `admitted: false` means a DIFFERENT turn already holds the session. Stop here.
+    //
+    // Everything below this point has a side effect that a refused turn must not have:
+    // `cancelStaleInteractions` would cancel the LIVE turn's unanswered approval gate, the
+    // persisting emitter would write this message into the durable transcript, and `run()` would
+    // reach the keepalive pool and destroy the live turn's warm environment. That last one is
+    // the double-send bug (#6417, #5539, #5538): the arbiter's answer was already correct, the
+    // runner simply never read it before acting.
+    //
+    // The refusal travels as an `error` EVENT with a stable code plus a failed terminal result,
+    // which is the path every runner failure already takes to the browser. Nothing is persisted,
+    // so the refused message never appears in the session's history — the client keeps the text.
+    if (!watchdog.admitted) {
+      process.stderr.write(
+        `[sessions] admission REFUSED session=${sessionId} turn=${turnId}; ` +
+          `another turn owns this session. No pool resolve, no eviction.\n`,
+      );
+      // Stops the heartbeat interval and releases the credential lease. Its final
+      // `is_running: false` beat is owner-scoped server-side, so it cannot clear the live
+      // turn's `running` lock or stamp its own turn id on the session row.
+      await watchdog.release().catch(() => {});
+      liveEmit({
+        type: "error",
+        message: SESSION_TURN_IN_USE_MESSAGE,
+        code: SESSION_TURN_IN_USE_CODE,
+      });
+      writeRecord({
+        kind: "result",
+        result: { ok: false, error: SESSION_TURN_IN_USE_MESSAGE, events: [] },
+      });
+      res.end();
+      return;
+    }
+
     // A new turn supersedes any prior turn's unanswered gate: cancel stale pending
     // interactions (sparing this turn's own, plus a parked gate this turn answers in-band —
     // the resume resolves that one). Best-effort, never blocks the turn.

--- a/services/runner/src/sessions/admission.ts
+++ b/services/runner/src/sessions/admission.ts
@@ -1,0 +1,28 @@
+/**
+ * Single-turn admission: at most one execution runs per session, decided in one place.
+ *
+ * The decision is NOT made here. It is made by the platform API's atomic `nx` acquire of the
+ * `alive` Redis lock, which the runner asks for on a turn's first heartbeat
+ * (`sessions/alive.ts` -> `POST /sessions/streams/heartbeat` ->
+ * `api/oss/src/core/sessions/streams/service.py`). This module holds only what the runner needs
+ * to REPORT that decision: the stable code and the one line the user reads.
+ *
+ * Why the runner has to stop rather than continue: before this, a second turn that lost the
+ * acquire still walked into the keepalive pool, found the first turn's environment busy, and
+ * destroyed it (`lifecycle/session-coordinator.ts`, the old `supersede-busy` branch). Both turns
+ * then died and the session stayed locked under a dead turn's lease. Refusing at the edge is what
+ * makes the first turn survive.
+ */
+
+import type { RunErrorCode } from "../engines/sandbox_agent/errors.ts";
+
+/** Stable class for a refused turn. Never a display string. */
+export const SESSION_TURN_IN_USE_CODE: RunErrorCode = "session_turn_in_use";
+
+/**
+ * Product copy. The reader is the person in the chat, so it says what happened to THEIR message
+ * and what to do next, with no lock, turn, or session-id mechanics. It must stay ONE line: the
+ * SDK's `sanitize_runner_error` keeps only the first line of a runner error.
+ */
+export const SESSION_TURN_IN_USE_MESSAGE =
+  "This session is already running a turn. Your message was not sent. Wait for the reply, or stop the turn, then send again.";

--- a/services/runner/src/sessions/alive.ts
+++ b/services/runner/src/sessions/alive.ts
@@ -173,6 +173,17 @@ export async function claimSessionOwnership(
  * the caller MUST await in the run's `finally` so the heartbeat stops and the row is marked
  * `ended`.
  *
+ * That first beat is also this turn's ADMISSION request, and `admitted` reports its answer. The
+ * beat's `nx` acquire of the `alive` lock is the platform's single atomic arbiter of "who runs
+ * this session" (`api/oss/src/core/sessions/streams/service.py`), and it already refuses a turn
+ * that arrives while a different turn holds `running`. Reading that answer BEFORE the caller
+ * touches the sandbox is what makes at-most-one-execution-per-session true: a refused turn stops
+ * at the edge instead of reaching the keepalive pool and destroying the live turn's environment.
+ *
+ * `admitted` is false ONLY on an explicit `is_current_turn: false`. A network or HTTP failure
+ * fails OPEN (`admitted: true`), matching every other use of this beat: a transient API blip must
+ * not refuse a healthy turn. The keepalive pool's own busy check is the backstop for that window.
+ *
  * `proposal` rides EVERY beat rather than only the first. The server fills each field once, so
  * repeating them is a no-op, and one payload for all beats beats a "was this the first?" flag.
  */
@@ -186,6 +197,8 @@ export async function startAliveWatchdog(
   release: () => Promise<void>;
   credential: () => string;
   streamId: () => string | undefined;
+  /** False when the FIRST beat reported `is_current_turn: false` — another turn owns the session. */
+  admitted: boolean;
 }> {
   // Session coordination and standalone turns share this lease. The watchdog owns it here so
   // heartbeat, persistence, and trace export all observe the same current credential.
@@ -238,6 +251,9 @@ export async function startAliveWatchdog(
   }
 
   return {
+    // Read from the FIRST beat only. A later interruption is a cancel, not a failed admission,
+    // and it travels the `onInterrupted` -> abort path instead.
+    admitted: !first.interrupted,
     async release() {
       clearInterval(interval);
       credentialLease.release();

--- a/services/runner/tests/unit/session-admission.test.ts
+++ b/services/runner/tests/unit/session-admission.test.ts
@@ -1,0 +1,375 @@
+/**
+ * Single-turn admission at the runner's edge (#6417, #5539, #5538).
+ *
+ * ============================================================================================
+ * THE BUG THESE PIN
+ * ============================================================================================
+ *
+ * A second user message that reached the runner while a turn was running on the same session
+ * killed BOTH turns and left the session locked until the 30-minute lease expired:
+ *
+ *  1. The runner started the second turn's alive watchdog. Its first heartbeat asked the API's
+ *     atomic `nx` acquire for the session and LOST, so the API answered `is_current_turn: false`.
+ *  2. The runner read that only as "abort this run later" and carried on into the keepalive pool,
+ *     which found the first turn's environment busy and DESTROYED it (`supersede-busy`). Turn one
+ *     lost its sandbox mid-answer.
+ *  3. Turn two then aborted on its own watchdog signal. Both turns were dead, and the session read
+ *     as alive under a dead turn's lock.
+ *
+ * The arbiter was always right. The runner acted before reading its answer. These tests pin that
+ * the runner now stops at the edge: a refused turn resolves no session environment, evicts
+ * nothing, persists nothing, and returns a clear conflict to the caller.
+ *
+ * ============================================================================================
+ * WHAT THE FAKE MODELS
+ * ============================================================================================
+ *
+ * A real runner HTTP server (`createAgentServer`) driven over a real socket, plus a fake platform
+ * API that answers `POST /sessions/streams/heartbeat`. The fake API models exactly one fact: the
+ * `is_current_turn` field, which is the whole admission answer. Every other API call the turn
+ * makes (interaction sweep, attachment claim, credential refresh) is answered 200-and-empty,
+ * because none of them participate in the decision.
+ *
+ * Run: pnpm test (or: pnpm exec vitest run tests/unit/session-admission.test.ts)
+ */
+import { afterEach, beforeEach, describe, it } from "vitest";
+import assert from "node:assert/strict";
+import { createServer, type Server } from "node:http";
+import type { AddressInfo } from "node:net";
+
+import type { AgentRunRequest, AgentRunResult } from "../../src/protocol.ts";
+import { createAgentServer, type RunAgent } from "../../src/server.ts";
+import {
+  SESSION_TURN_IN_USE_CODE,
+  SESSION_TURN_IN_USE_MESSAGE,
+} from "../../src/sessions/admission.ts";
+
+const TEST_TOKEN = "test-runner-token";
+const AUTH = { authorization: `Bearer ${TEST_TOKEN}` };
+const INTERNAL_ENV = "AGENTA_API_INTERNAL_URL";
+
+interface Beat {
+  session_id?: string;
+  turn_id?: string;
+  is_running?: boolean;
+}
+
+/** The fake platform API. `admit` decides what its heartbeat answers for each beat. */
+async function startFakeApi(admit: (beat: Beat) => boolean): Promise<{
+  url: string;
+  beats: Beat[];
+  paths: string[];
+  close: () => Promise<void>;
+}> {
+  const beats: Beat[] = [];
+  const paths: string[] = [];
+  const server = createServer((req, res) => {
+    const chunks: Buffer[] = [];
+    req.on("data", (c) => chunks.push(c as Buffer));
+    req.on("end", () => {
+      const path = (req.url ?? "").split("?")[0];
+      paths.push(path);
+      let body: Record<string, unknown> = {};
+      const raw = Buffer.concat(chunks).toString("utf8");
+      if (raw.trim()) {
+        try {
+          body = JSON.parse(raw) as Record<string, unknown>;
+        } catch {
+          body = {};
+        }
+      }
+      if (path.endsWith("/sessions/streams/heartbeat")) {
+        const beat = body as Beat;
+        beats.push(beat);
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(
+          JSON.stringify({
+            stream: { id: "11111111-1111-1111-1111-111111111111" },
+            replica_id: body.replica_id ?? null,
+            // A turn-end beat (`is_running: false`) is never an admission question.
+            is_current_turn: beat.is_running === false ? true : admit(beat),
+          }),
+        );
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end("{}");
+    });
+  });
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    beats,
+    paths,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+async function startRunner(
+  run: RunAgent,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  process.env.AGENTA_RUNNER_TOKEN = TEST_TOKEN;
+  const server: Server = createAgentServer(run);
+  await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+  const { port } = server.address() as AddressInfo;
+  return {
+    url: `http://127.0.0.1:${port}`,
+    close: () => new Promise<void>((resolve) => server.close(() => resolve())),
+  };
+}
+
+/** A session-owned run request: `sessionId` is the whole gate (`isSessionOwned`). */
+function sessionRequest(
+  overrides: Partial<AgentRunRequest> = {},
+): Record<string, unknown> {
+  return {
+    harness: "claude",
+    model: "m1",
+    sessionId: "session-admission-1",
+    messages: [{ role: "user", content: "hello" }],
+    ...overrides,
+  };
+}
+
+interface StreamRecord {
+  kind: string;
+  event?: { type: string; message?: string; code?: string };
+  result?: { ok: boolean; error?: string };
+}
+
+async function postRun(
+  runnerUrl: string,
+  body: Record<string, unknown>,
+): Promise<{ status: number; records: StreamRecord[] }> {
+  const res = await fetch(`${runnerUrl}/run`, {
+    method: "POST",
+    headers: { accept: "application/x-ndjson", ...AUTH },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  const records = text
+    .split("\n")
+    .filter((line) => line.trim())
+    .map((line) => JSON.parse(line) as StreamRecord);
+  return { status: res.status, records };
+}
+
+const previousInternal = process.env[INTERNAL_ENV];
+const previousToken = process.env.AGENTA_RUNNER_TOKEN;
+
+beforeEach(() => {
+  delete process.env[INTERNAL_ENV];
+});
+
+afterEach(() => {
+  if (previousInternal === undefined) delete process.env[INTERNAL_ENV];
+  else process.env[INTERNAL_ENV] = previousInternal;
+  if (previousToken === undefined) delete process.env.AGENTA_RUNNER_TOKEN;
+  else process.env.AGENTA_RUNNER_TOKEN = previousToken;
+});
+
+describe("runner admission: a refused turn never reaches the session environment", () => {
+  it("does not call run() when the first heartbeat reports is_current_turn: false", async () => {
+    const api = await startFakeApi(() => false);
+    process.env[INTERNAL_ENV] = api.url;
+    const runCalls: AgentRunRequest[] = [];
+    const runner = await startRunner(async (request): Promise<AgentRunResult> => {
+      runCalls.push(request);
+      return { ok: true, output: "should never run", events: [] };
+    });
+    try {
+      const { records } = await postRun(runner.url, sessionRequest());
+
+      assert.equal(
+        runCalls.length,
+        0,
+        "the refused turn must not reach run(), which is what resolves the keepalive pool " +
+          "and is where the live turn's environment used to be destroyed",
+      );
+      const terminal = records.find((r) => r.kind === "result");
+      assert.ok(terminal, "a terminal result record is still written");
+      assert.equal(terminal!.result!.ok, false);
+      assert.equal(terminal!.result!.error, SESSION_TURN_IN_USE_MESSAGE);
+    } finally {
+      await runner.close();
+      await api.close();
+    }
+  });
+
+  it("emits an error event carrying the stable session_turn_in_use code", async () => {
+    // The code is what lets the browser render "not sent, keep your text" instead of the generic
+    // "The agent run failed" bubble. The message is one line, because the SDK's
+    // `sanitize_runner_error` keeps only the first line of a runner error.
+    const api = await startFakeApi(() => false);
+    process.env[INTERNAL_ENV] = api.url;
+    const runner = await startRunner(async () => ({
+      ok: true,
+      output: "",
+      events: [],
+    }));
+    try {
+      const { records } = await postRun(runner.url, sessionRequest());
+
+      const error = records.find(
+        (r) => r.kind === "event" && r.event?.type === "error",
+      );
+      assert.ok(error, "the refusal is streamed as an error event");
+      assert.equal(error!.event!.code, SESSION_TURN_IN_USE_CODE);
+      assert.equal(error!.event!.message, SESSION_TURN_IN_USE_MESSAGE);
+      assert.ok(
+        !SESSION_TURN_IN_USE_MESSAGE.includes("\n"),
+        "the message must stay one line to survive sanitize_runner_error",
+      );
+    } finally {
+      await runner.close();
+      await api.close();
+    }
+  });
+
+  it("makes no interaction-sweep or attachment-claim call for a refused turn", async () => {
+    // `cancelStaleInteractions` cancels the session's unanswered approval gates, sparing only the
+    // CALLING turn's own. Running it for a turn that was refused would cancel the LIVE turn's
+    // pending approval card — a second way the double send broke the running turn.
+    const api = await startFakeApi(() => false);
+    process.env[INTERNAL_ENV] = api.url;
+    const runner = await startRunner(async () => ({
+      ok: true,
+      output: "",
+      events: [],
+    }));
+    try {
+      await postRun(runner.url, sessionRequest());
+      // Give any fire-and-forget call a chance to land before asserting it did not.
+      await new Promise((resolve) => setTimeout(resolve, 50));
+
+      const nonHeartbeat = api.paths.filter(
+        (p) => !p.endsWith("/sessions/streams/heartbeat"),
+      );
+      assert.deepEqual(
+        nonHeartbeat,
+        [],
+        `a refused turn touched the platform beyond its own beats: ${nonHeartbeat.join(", ")}`,
+      );
+    } finally {
+      await runner.close();
+      await api.close();
+    }
+  });
+
+  it("stops the heartbeat with an owner-scoped end beat for its own turn id", async () => {
+    // The end beat is safe to send: the API releases `running` only for the turn that owns it, so
+    // a refused turn's final beat cannot clear the LIVE turn's lock. Sending it is what stops the
+    // heartbeat interval and releases the credential lease.
+    const api = await startFakeApi(() => false);
+    process.env[INTERNAL_ENV] = api.url;
+    const runner = await startRunner(async () => ({
+      ok: true,
+      output: "",
+      events: [],
+    }));
+    try {
+      await postRun(runner.url, sessionRequest());
+
+      assert.equal(api.beats.length, 2, "exactly one start beat and one end beat");
+      assert.equal(api.beats[0].is_running, true);
+      assert.equal(api.beats[1].is_running, false);
+      assert.equal(
+        api.beats[0].turn_id,
+        api.beats[1].turn_id,
+        "the end beat names the REFUSED turn, never the live one",
+      );
+    } finally {
+      await runner.close();
+      await api.close();
+    }
+  });
+});
+
+describe("runner admission: an admitted turn proceeds", () => {
+  it("runs the turn when the first heartbeat admits it", async () => {
+    const api = await startFakeApi(() => true);
+    process.env[INTERNAL_ENV] = api.url;
+    const runCalls: AgentRunRequest[] = [];
+    const runner = await startRunner(async (request): Promise<AgentRunResult> => {
+      runCalls.push(request);
+      return { ok: true, output: "answered", events: [] };
+    });
+    try {
+      const { records } = await postRun(runner.url, sessionRequest());
+
+      assert.equal(runCalls.length, 1, "the admitted turn runs");
+      const terminal = records.find((r) => r.kind === "result");
+      assert.equal(terminal!.result!.ok, true);
+    } finally {
+      await runner.close();
+      await api.close();
+    }
+  });
+
+  it("admits an approval RESUME while the previous turn is parked, not running", async () => {
+    // The park case is the one a naive "is anything alive on this session?" gate gets wrong. A
+    // parked turn still holds `alive` (that is what makes the session reattachable) but has
+    // released `running`. The API's heartbeat distinguishes them: with no `running` owner it
+    // treats the stale `alive` as a legitimate handover, tombstones the parked turn, and admits
+    // the resume. This test pins that the runner honours an ADMIT answer for a resume-shaped
+    // request rather than refusing on the presence of a prior turn.
+    const api = await startFakeApi(() => true);
+    process.env[INTERNAL_ENV] = api.url;
+    const runCalls: AgentRunRequest[] = [];
+    const runner = await startRunner(async (request): Promise<AgentRunResult> => {
+      runCalls.push(request);
+      return { ok: true, output: "resumed", events: [] };
+    });
+    try {
+      const resume = sessionRequest({
+        messages: [
+          { role: "user", content: "edit the file" },
+          {
+            role: "assistant",
+            content: [{ type: "tool_call", toolCallId: "call-1", toolName: "edit" }],
+          },
+          {
+            role: "user",
+            content: [
+              {
+                type: "tool_result",
+                toolCallId: "call-1",
+                output: { approved: true },
+              },
+            ],
+          },
+        ],
+      } as unknown as Partial<AgentRunRequest>);
+      const { records } = await postRun(runner.url, resume);
+
+      assert.equal(runCalls.length, 1, "the resume runs");
+      const terminal = records.find((r) => r.kind === "result");
+      assert.equal(terminal!.result!.ok, true);
+    } finally {
+      await runner.close();
+      await api.close();
+    }
+  });
+
+  it("fails OPEN: an unreachable platform admits the turn rather than refusing it", async () => {
+    // The heartbeat has always failed open, and admission must not change that: a transient API
+    // blip refusing every message would be a worse outage than the bug this slice fixes. The
+    // keepalive pool's busy check is the backstop for the window this leaves.
+    process.env[INTERNAL_ENV] = "http://127.0.0.1:1";
+    const runCalls: AgentRunRequest[] = [];
+    const runner = await startRunner(async (request): Promise<AgentRunResult> => {
+      runCalls.push(request);
+      return { ok: true, output: "answered", events: [] };
+    });
+    try {
+      const { records } = await postRun(runner.url, sessionRequest());
+
+      assert.equal(runCalls.length, 1, "an unreachable arbiter does not refuse the turn");
+      const terminal = records.find((r) => r.kind === "result");
+      assert.equal(terminal!.result!.ok, true);
+    } finally {
+      await runner.close();
+    }
+  });
+});

--- a/services/runner/tests/unit/session-admission.test.ts
+++ b/services/runner/tests/unit/session-admission.test.ts
@@ -134,7 +134,7 @@ function sessionRequest(
 
 interface StreamRecord {
   kind: string;
-  event?: { type: string; message?: string; code?: string };
+  event?: { type: string; message?: string; code?: string; turnId?: string };
   result?: { ok: boolean; error?: string };
 }
 
@@ -370,6 +370,95 @@ describe("runner admission: an admitted turn proceeds", () => {
       assert.equal(terminal!.result!.ok, true);
     } finally {
       await runner.close();
+    }
+  });
+});
+
+describe("runner admission: the admitted turn id reaches the client", () => {
+  // The runner mints the turn id per execution, and until now it told no one. The client's
+  // `start` frame is built and sent before the runner replies at all, so it cannot carry a
+  // runner-minted id — which is why `expected_execution_id` on the public Cancel has never had a
+  // first-party caller able to fill it. A Stop could only mean "whatever is running now", never
+  // "the turn I was watching". The `turn` event is the earliest frame that can carry it.
+
+  it("emits a turn event carrying the admitted turn id, before any other event", async () => {
+    const api = await startFakeApi(() => true);
+    process.env[INTERNAL_ENV] = api.url;
+    const runner = await startRunner(async () => ({
+      ok: true,
+      output: "answered",
+      events: [],
+    }));
+    try {
+      const { records } = await postRun(runner.url, sessionRequest());
+
+      const events = records.filter((r) => r.kind === "event");
+      assert.ok(events.length > 0, "the run streamed at least one event");
+      assert.equal(
+        events[0].event!.type,
+        "turn",
+        "the turn id must arrive FIRST, so a Stop that races the turn's own output can name it",
+      );
+      const turnId = events[0].event!.turnId;
+      assert.ok(turnId, "the turn event carries an id");
+      assert.match(
+        String(turnId),
+        /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/,
+        "the id is the uuid the runner minted",
+      );
+    } finally {
+      await runner.close();
+      await api.close();
+    }
+  });
+
+  it("emits the SAME id the alive lock was acquired under", async () => {
+    // The whole point of handing the id out is that a client can name THIS execution to the
+    // control plane. An id that does not match the one holding the session's locks would name
+    // nothing, so the two must be the same value, not merely both present.
+    const api = await startFakeApi(() => true);
+    process.env[INTERNAL_ENV] = api.url;
+    const runner = await startRunner(async () => ({
+      ok: true,
+      output: "answered",
+      events: [],
+    }));
+    try {
+      const { records } = await postRun(runner.url, sessionRequest());
+
+      const turnEvent = records.find(
+        (r) => r.kind === "event" && r.event?.type === "turn",
+      );
+      assert.ok(turnEvent, "a turn event was emitted");
+      assert.equal(
+        turnEvent!.event!.turnId,
+        api.beats[0].turn_id,
+        "the streamed id must be the id that heartbeat the alive lock",
+      );
+    } finally {
+      await runner.close();
+      await api.close();
+    }
+  });
+
+  it("emits NO turn event for a refused turn, which owns no execution to name", async () => {
+    const api = await startFakeApi(() => false);
+    process.env[INTERNAL_ENV] = api.url;
+    const runner = await startRunner(async () => ({
+      ok: true,
+      output: "",
+      events: [],
+    }));
+    try {
+      const { records } = await postRun(runner.url, sessionRequest());
+
+      assert.ok(
+        !records.some((r) => r.kind === "event" && r.event?.type === "turn"),
+        "a refused turn must not hand out an id: it runs nothing and there is nothing to stop",
+      );
+    } finally {
+      await runner.close();
+      await api.close();
     }
   });
 });

--- a/services/runner/tests/unit/session-alive-interrupt.test.ts
+++ b/services/runner/tests/unit/session-alive-interrupt.test.ts
@@ -12,7 +12,9 @@ import assert from "node:assert/strict";
 const fetchCalls: Array<{ url: string; body: unknown }> = [];
 let nextIsCurrentTurn: boolean | undefined = true;
 
-vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
+/** The default heartbeat fake. Re-stubbed per test, because the fail-open cases replace it and
+ * `vi.restoreAllMocks` does not undo a `vi.stubGlobal`. */
+const recordingFetch = async (url: string, init?: RequestInit) => {
   const body = init?.body ? JSON.parse(init.body as string) : undefined;
   fetchCalls.push({ url, body });
   const payload: Record<string, unknown> = { ok: true };
@@ -20,7 +22,9 @@ vi.stubGlobal("fetch", async (url: string, init?: RequestInit) => {
     payload.is_current_turn = nextIsCurrentTurn;
   }
   return new Response(JSON.stringify(payload), { status: 200 });
-});
+};
+
+vi.stubGlobal("fetch", recordingFetch);
 
 const { startAliveWatchdog } = await import("../../src/sessions/alive.ts");
 
@@ -31,6 +35,7 @@ function flushMicrotasks(): Promise<void> {
 beforeEach(() => {
   fetchCalls.length = 0;
   nextIsCurrentTurn = true;
+  vi.stubGlobal("fetch", recordingFetch);
 });
 
 afterEach(() => {
@@ -136,5 +141,48 @@ describe("startAliveWatchdog onInterrupted", () => {
 
     assert.equal(onInterrupted.mock.calls.length, 0);
     await assert.doesNotReject(() => watchdog.release());
+  });
+});
+
+describe("startAliveWatchdog admitted (single-turn admission)", () => {
+  // The first beat is this turn's ADMISSION request: its `nx` acquire of the `alive` lock is the
+  // platform's single atomic arbiter of who runs a session. `admitted` reports that one answer so
+  // `server.ts` can stop a losing turn at the edge, before it resolves a session environment.
+  // Before this, the same answer only armed `onInterrupted`, and the losing turn still walked into
+  // the keepalive pool and destroyed the winning turn's warm sandbox (#6417, #5539, #5538).
+
+  it("is true when the first beat admits the turn", async () => {
+    const watchdog = await startAliveWatchdog("sess-a", "turn-a", "proj-1");
+    assert.equal(watchdog.admitted, true);
+    await watchdog.release();
+  });
+
+  it("is false when the first beat reports is_current_turn: false", async () => {
+    nextIsCurrentTurn = false;
+    const watchdog = await startAliveWatchdog("sess-b", "turn-b", "proj-1");
+    assert.equal(watchdog.admitted, false);
+    await watchdog.release();
+  });
+
+  it("fails OPEN: an unreachable API admits the turn", async () => {
+    // A transient blip refusing every message would be a worse outage than the bug this closes.
+    // The keepalive pool's busy check is the backstop for the window this leaves open.
+    vi.stubGlobal("fetch", async () => {
+      throw new Error("network down");
+    });
+    const watchdog = await startAliveWatchdog("sess-c", "turn-c", "proj-1");
+    assert.equal(watchdog.admitted, true);
+    await watchdog.release();
+  });
+
+  it("reads the FIRST beat only: a later interruption is a cancel, not a failed admission", async () => {
+    // A mid-turn `is_current_turn: false` is a Stop/steer/kill. That travels the
+    // `onInterrupted` -> abort path and must never retroactively un-admit a turn that already ran.
+    const watchdog = await startAliveWatchdog("sess-d", "turn-d", "proj-1");
+    assert.equal(watchdog.admitted, true);
+    nextIsCurrentTurn = false;
+    await flushMicrotasks();
+    assert.equal(watchdog.admitted, true, "admitted is a fact about the start of the turn");
+    await watchdog.release();
   });
 });

--- a/services/runner/tests/unit/session-keepalive-dispatch.test.ts
+++ b/services/runner/tests/unit/session-keepalive-dispatch.test.ts
@@ -780,7 +780,11 @@ describe("runWithKeepalive: never-park rules", () => {
 });
 
 describe("runWithKeepalive: races and failures", () => {
-  it("a busy session is superseded (destroyed, awaited) and the new turn cold-starts", async () => {
+  it("a busy session REFUSES the racing turn: no eviction, no cold acquire", async () => {
+    // Single-turn admission (#6417, #5539, #5538). This branch used to `evict` the busy entry
+    // and cold-start ("supersede-busy"), which tore the sandbox out from under the turn that was
+    // still streaming on it. Both turns then died and the session stayed locked until the lease
+    // expired. The racing turn is now refused and the live turn's environment is untouched.
     const { engine, calls } = makeEngine();
     const ctx = makeCtx(engine);
     await runWithKeepalive(turn1(), undefined, undefined, ctx);
@@ -790,12 +794,39 @@ describe("runWithKeepalive: races and failures", () => {
     ctx.pool.checkoutIdle(key);
     assert.equal(ctx.pool.get(key)!.state, "busy");
 
-    await runWithKeepalive(turn2(), undefined, undefined, ctx);
-    assert.equal(
-      env1.destroyed,
-      1,
-      "the busy (racing) session is superseded/destroyed (awaited, no flush needed)",
+    const refused = await runWithKeepalive(turn2(), undefined, undefined, ctx);
+
+    assert.equal(refused.ok, false, "the racing turn is refused");
+    assert.match(
+      String(refused.error),
+      /already running a turn/i,
+      "the refusal says a turn is already running, so the client can keep the text",
     );
+    assert.equal(env1.destroyed, 0, "the live turn keeps its warm environment");
+    assert.equal(calls.acquire, 1, "no rival environment is acquired");
+    assert.equal(
+      ctx.pool.get(key)!.state,
+      "busy",
+      "the live turn still owns the pool entry",
+    );
+  });
+
+  it("a DESTROYED pool entry is still evicted and the new turn cold-starts", async () => {
+    // The other half of the old `else if (existing)` branch. A destroyed entry (a drain, or a
+    // teardown that already ran) has nothing in flight on it, so clearing the key and
+    // cold-starting is correct and costs nothing warm. Only `busy` refuses.
+    const { engine, calls } = makeEngine();
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(turn1(), undefined, undefined, ctx);
+    const key = "proj-1:s1";
+    // `destroyAll` is what leaves a `destroyed` entry seated at its key.
+    await ctx.pool.destroyAll("drain");
+    const stale = ctx.pool.get(key);
+    if (stale) assert.equal(stale.state, "destroyed");
+
+    const r = await runWithKeepalive(turn2(), undefined, undefined, ctx);
+
+    assert.equal(r.ok, true, "the new turn runs");
     assert.equal(calls.acquire, 2, "the new turn cold-starts");
   });
 

--- a/services/runner/tests/unit/session-keepalive-dispatch.test.ts
+++ b/services/runner/tests/unit/session-keepalive-dispatch.test.ts
@@ -819,10 +819,12 @@ describe("runWithKeepalive: races and failures", () => {
     const ctx = makeCtx(engine);
     await runWithKeepalive(turn1(), undefined, undefined, ctx);
     const key = "proj-1:s1";
-    // `destroyAll` is what leaves a `destroyed` entry seated at its key.
-    await ctx.pool.destroyAll("drain");
-    const stale = ctx.pool.get(key);
-    if (stale) assert.equal(stale.state, "destroyed");
+    // Marked directly, because every public route that destroys a session also removes it from
+    // the map. A `destroyed` entry SEATED at its key is the residue of a race: `checkoutIdle`
+    // leaves its entry in the map while the turn runs, a teardown marks it destroyed underneath,
+    // and `repark` then refuses to resurrect it (`session-pool.ts`, the `destroyed` guard).
+    // Reproducing that race would test the pool, not this branch.
+    ctx.pool.get(key)!.state = "destroyed";
 
     const r = await runWithKeepalive(turn2(), undefined, undefined, ctx);
 

--- a/services/runner/tests/unit/session-steer-mount-loss.test.ts
+++ b/services/runner/tests/unit/session-steer-mount-loss.test.ts
@@ -307,20 +307,27 @@ function approvalReply(toolCallId: string, toolName: string): AgentRunRequest {
 // --- The scenario the bug report describes ----------------------------------------------- //
 
 describe("steer: a second message while a cold turn is running", () => {
+  // These pinned the OLD outcome: the second turn superseded the first (destroy its environment,
+  // cold-start a rival). Single-turn admission (#6417, #5539, #5538) replaces that with a refusal,
+  // which is a strictly better answer to the SAME hazard the reservation was built for. The
+  // reservation is still what makes the refusal possible: the running cold turn is seated as
+  // `busy` at its key, so the second turn finds it instead of logging `miss` and cold-acquiring a
+  // rival environment onto the shared durable cwd.
+  //
+  // NOTE ON THE HOLD: the second turn no longer acquires anything, so the first turn's hold is
+  // released by the REFUSAL settling, not by `onAcquire(2)`.
+
   it("keeps the session's durable cwd, and the next turn succeeds", async () => {
     const host = makeHost();
     const turn1Running = deferred();
-    const steerAcquired = deferred();
+    const steerSettled = deferred();
 
     const { engine, calls } = makeEngine(host, {
       hold: async (envId, continuation) => {
         if (envId !== 1 || continuation) return;
         turn1Running.resolve();
-        // The long turn runs until the steer's environment exists.
-        await steerAcquired.promise;
-      },
-      onAcquire: (id) => {
-        if (id === 2) steerAcquired.resolve();
+        // The long turn runs until the second message has been answered.
+        await steerSettled.promise;
       },
     });
     const { ctx } = makeCtx(engine);
@@ -332,13 +339,26 @@ describe("steer: a second message while a cold turn is running", () => {
       () => {},
       undefined,
       ctx,
-    );
-    await Promise.all([first, steer]);
+    ).then((r) => {
+      steerSettled.resolve();
+      return r;
+    });
+    const [firstResult, steerResult] = await Promise.all([first, steer]);
 
+    assert.equal(steerResult.ok, false, "the second message is refused");
+    assert.match(
+      String((steerResult as { error?: string }).error),
+      /already running a turn/i,
+    );
+    assert.equal(
+      firstResult.ok,
+      true,
+      `the running turn was killed by the second message: ${(firstResult as { error?: string }).error}`,
+    );
     assert.equal(
       host.dirExists,
       true,
-      `the durable cwd was destroyed by the steer: ${host.trace.join(" | ")}`,
+      `the durable cwd was destroyed by the second message: ${host.trace.join(" | ")}`,
     );
 
     const third = await runWithKeepalive(
@@ -350,30 +370,27 @@ describe("steer: a second message while a cold turn is running", () => {
     assert.equal(
       third.ok,
       true,
-      `the turn after the steer failed: ${(third as { error?: string }).error}`,
+      `the turn after the refusal failed: ${(third as { error?: string }).error}`,
     );
-    // The steer superseded the first environment rather than running beside it, so exactly two
-    // environments existed and the third turn reused one of them warm.
-    assert.equal(calls.acquired.length, 2);
+    // The refused turn acquired nothing, so exactly ONE environment ever existed and the third
+    // turn continued it warm. Before admission this was 2 (supersede plus cold rebuild).
+    assert.equal(calls.acquired.length, 1);
   });
 
-  it("supersedes the running turn instead of acquiring a rival environment", async () => {
+  it("refuses the second turn instead of acquiring a rival environment", async () => {
     const host = makeHost();
     const turn1Running = deferred();
-    const steerAcquired = deferred();
-    // Ordering is the whole fix: the superseded environment's teardown must COMPLETE before the
-    // steer's acquire mounts, or the steer adopts a mount that is about to be pulled.
+    const steerSettled = deferred();
     const order: string[] = [];
 
     const { engine } = makeEngine(host, {
       hold: async (envId, continuation) => {
         if (envId !== 1 || continuation) return;
         turn1Running.resolve();
-        await steerAcquired.promise;
+        await steerSettled.promise;
       },
       onAcquire: (id) => {
         order.push(`acquire:env${id}`);
-        if (id === 2) steerAcquired.resolve();
       },
     });
     const { ctx } = makeCtx(engine);
@@ -385,40 +402,36 @@ describe("steer: a second message while a cold turn is running", () => {
       () => {},
       undefined,
       ctx,
-    );
+    ).then((r) => {
+      steerSettled.resolve();
+      return r;
+    });
     await Promise.all([first, steer]);
 
-    // env1's unmount+rmSync happened, then env2 mounted fresh — never "already mounted (adopted)".
-    assert.deepEqual(order, ["acquire:env1", "acquire:env2"]);
+    // No second acquire at all: nothing to mount, nothing to unmount, nothing to adopt.
+    assert.deepEqual(order, ["acquire:env1"]);
     assert.ok(
       !host.trace.some((line) => line.includes("adopted")),
-      `the steer adopted the running turn's mount: ${host.trace.join(" | ")}`,
+      `the refused turn adopted the running turn's mount: ${host.trace.join(" | ")}`,
     );
     assert.equal(host.mounted, true);
     assert.equal(host.dirExists, true);
   });
 
-  it("survives a displaced turn that aborts (the API-side heartbeat fix)", async () => {
-    // The heartbeat bug means the displaced turn is never told it was superseded, so it runs to
-    // completion beside the steer. Suppose that is fixed and it aborts promptly instead: an
-    // aborted turn still routes to `env.destroy({ reason: "aborted" })`, which unmounts and
-    // deletes the shared cwd. Before the reservation, the abort only narrowed the race window.
+  it("emits no teardown for the refused turn, so the warm session survives", async () => {
+    // The old supersede path called `env.destroy` on the LIVE turn's environment, which unmounted
+    // and `rmSync`ed the shared cwd. That is the destruction half of the double-send bug. A
+    // refusal must touch no environment at all: the running turn keeps its sandbox and its native
+    // harness session, which is the warm-session constraint this whole slice is bound by.
     const host = makeHost();
     const turn1Running = deferred();
-    const steerAcquired = deferred();
+    const steerSettled = deferred();
 
-    const { engine } = makeEngine(host, {
+    const { engine, calls } = makeEngine(host, {
       hold: async (envId, continuation) => {
         if (envId !== 1 || continuation) return;
         turn1Running.resolve();
-        await steerAcquired.promise;
-      },
-      resultFor: (envId, continuation) =>
-        envId === 1 && !continuation
-          ? { ok: false, error: "aborted", stopReason: "aborted" }
-          : undefined,
-      onAcquire: (id) => {
-        if (id === 2) steerAcquired.resolve();
+        await steerSettled.promise;
       },
     });
     const { ctx } = makeCtx(engine);
@@ -430,20 +443,20 @@ describe("steer: a second message while a cold turn is running", () => {
       () => {},
       undefined,
       ctx,
-    );
+    ).then((r) => {
+      steerSettled.resolve();
+      return r;
+    });
     await Promise.all([first, steer]);
 
-    assert.equal(host.dirExists, true, host.trace.join(" | "));
-    const third = await runWithKeepalive(
-      req("still there?"),
-      () => {},
-      undefined,
-      ctx,
-    );
     assert.equal(
-      third.ok,
-      true,
-      `the turn after an aborted steer failed: ${(third as { error?: string }).error}`,
+      calls.acquired[0].destroyed,
+      0,
+      `the running turn's environment was destroyed: ${host.trace.join(" | ")}`,
+    );
+    assert.ok(
+      !host.trace.some((line) => line.includes("teardown")),
+      `a teardown ran during the refusal: ${host.trace.join(" | ")}`,
     );
   });
 });

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -22,7 +22,12 @@ import {
     useVoiceComposer,
 } from "@agenta/chat/hooks"
 import {type SessionRunStatus} from "@agenta/chat/model"
-import {ignoreStreamRejection, isEmptyAssistantTurn, isVisiblePart} from "@agenta/chat/model"
+import {
+    ignoreStreamRejection,
+    isEmptyAssistantTurn,
+    isSessionBusyRefusal,
+    isVisiblePart,
+} from "@agenta/chat/model"
 import {getPendingApprovals} from "@agenta/chat/model"
 import {hasSessionChat, sessionMessagesAtom, setSessionStatusAtom} from "@agenta/chat/state"
 import {clearSessionFresh} from "@agenta/chat/state"
@@ -339,6 +344,7 @@ const AgentConversation = ({
         beginEdit,
         cancelEdit,
         commitEdit,
+        takeLastSent,
     } = useAgentChatQueue({
         status,
         messages,
@@ -421,6 +427,21 @@ const AgentConversation = ({
             }),
         [messages],
     )
+    // Single-turn admission (#6417, #5539, #5538): the backend refuses a message sent while
+    // another turn is already running on this session. Nothing ran and nothing was sent, so the
+    // user's text goes back into the composer instead of vanishing. Without this the refusal is
+    // worse than the bug for the person typing: they lose what they wrote and have no way to get
+    // it back.
+    //
+    // The rAF mirrors the edit-stash restore above it: `submitEditorAsMarkdown` clears the editor
+    // synchronously after `onSubmit` returns, so a restore has to land after that clear.
+    useEffect(() => {
+        if (!error || !isSessionBusyRefusal(error)) return
+        const sent = takeLastSent()
+        if (!sent?.text) return
+        requestAnimationFrame(() => richInputRef.current?.setMarkdown(sent.text))
+    }, [error, takeLastSent])
+
     useEffect(() => {
         const status: SessionRunStatus = error
             ? "error"

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -20,7 +20,7 @@ import {
     StartupActivity,
     TurnFooter,
 } from "@agenta/chat/components"
-import {isToolPart, toolIdentity} from "@agenta/chat/model"
+import {isToolPart, SESSION_TURN_IN_USE_CODE, toolIdentity} from "@agenta/chat/model"
 import {
     errorKey,
     expandedValueAtomFamily,
@@ -159,6 +159,14 @@ const RETRYABLE_CODES = new Set([
     "rate_limited",
 ])
 
+/**
+ * Single-turn admission refused the message because another turn already owns the session
+ * (#6417). Nothing ran and nothing failed, so the failure header would be a lie. The composer
+ * already has the user's text back (see AgentConversation's restore effect), which is why there is
+ * no retry button either: sending again is one keystroke away and only the user knows when.
+ */
+const NOT_SENT_CODES = new Set([SESSION_TURN_IN_USE_CODE])
+
 /** The ONE rule driving both the clamp and the toggle — they can't disagree and hide text (#5350). */
 const isBigError = (text: string) => text.length > 240 || text.split("\n").length > 4
 
@@ -189,13 +197,17 @@ export const RunErrorBody = ({
     const expanded = stored ?? false
     const big = isBigError(text)
     const offerOwnKey = code ? STARTER_CREDIT_CODES.has(code) : false
-    const offerRetry = !!onRetry && (!!transport || (!!code && RETRYABLE_CODES.has(code)))
+    const notSent = !!code && NOT_SENT_CODES.has(code)
+    const offerRetry =
+        !notSent && !!onRetry && (!!transport || (!!code && RETRYABLE_CODES.has(code)))
 
     return (
         <div className="flex items-start gap-2 rounded-xl bg-[var(--ant-color-error-bg)] px-4 py-3">
             <XCircle size={16} weight="fill" className="mt-px shrink-0 text-colorError" />
             <div className="flex min-w-0 flex-col items-start gap-0.5">
-                <span className="text-xs font-medium text-colorError">The agent run failed</span>
+                <span className="text-xs font-medium text-colorError">
+                    {notSent ? "Message not sent" : "The agent run failed"}
+                </span>
                 {big && expanded ? (
                     <pre className="m-0 max-h-60 w-full overflow-auto whitespace-pre-wrap break-words bg-transparent p-0 font-mono text-xs !text-colorErrorText">
                         {text}

--- a/web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts
@@ -83,12 +83,34 @@ export const useAgentChatQueue = ({
         queuedRef.current = queued
     }, [queued])
 
+    /**
+     * The message this mount sent immediately, held until something claims it.
+     *
+     * A QUEUED message survives a failed turn on its own — it is in `queued`, which the dock
+     * renders and the store mirrors. An immediately-sent one had nowhere to live: `submit` handed
+     * it to `sendQueued` and dropped the object, so a send the backend refuses lost the user's
+     * text with no trace. `takeLastSent` is how the host gets it back and puts it in the composer.
+     *
+     * NOT re-queued automatically: the queue releases on a settled `"error"` status, which for a
+     * refusal ("another turn is running") would re-send and be refused again in a tight loop. The
+     * user decides when to send again.
+     */
+    const lastSentRef = useRef<QueuedMessage | undefined>(undefined)
+
+    /** Take back the last immediately-sent message, once. */
+    const takeLastSent = useCallback(() => {
+        const message = lastSentRef.current
+        lastSentRef.current = undefined
+        return message
+    }, [])
+
     // Send now only if idle, unlatched, and the queue is empty; otherwise append (FIFO).
     const submit = useCallback(
         (item: {text: string; fileParts?: FileUIPart[]}) => {
             const message: QueuedMessage = {...item, id: generateId()}
             if (!releasingRef.current && queuedRef.current.length === 0 && canReleaseNow) {
                 releasingRef.current = true
+                lastSentRef.current = message
                 sendQueued(message)
             } else {
                 setQueued((q) => [...q, message])
@@ -187,6 +209,9 @@ export const useAgentChatQueue = ({
         releasingRef.current = true
         const [head, ...rest] = queued
         setQueued(rest)
+        // Reclaimable for the same reason as the immediate path: the release removed it from the
+        // queue, so a refusal would otherwise lose it.
+        lastSentRef.current = head
         sendQueued(head)
     }, [settled, canReleaseNow, queued, sendQueued])
 
@@ -201,5 +226,7 @@ export const useAgentChatQueue = ({
         beginEdit,
         cancelEdit,
         commitEdit,
+        /** Reclaim the last immediately-sent message (e.g. the backend refused it). */
+        takeLastSent,
     }
 }

--- a/web/packages/agenta-chat/src/model/error.ts
+++ b/web/packages/agenta-chat/src/model/error.ts
@@ -1,6 +1,7 @@
 export interface ParsedRunError {
     message: string
-    code?: number
+    /** An HTTP-ish status from a JSON error envelope, or a stable runner failure class string. */
+    code?: number | string
     /** The request never reached Agenta: no server verdict behind it, and retryable as-is. */
     transport?: boolean
 }
@@ -46,6 +47,36 @@ export const isTransportFailure = (raw: string): boolean => {
 }
 
 /**
+ * The runner refuses a message sent while another turn is already running on the same session,
+ * so at most one execution runs per session (#6417, #5539, #5538). Nothing ran, nothing was
+ * destroyed, and the message was never sent — so this is NOT a run failure, and the client keeps
+ * the user's text instead of losing it.
+ *
+ * The message text is the contract with the runner. It is produced in exactly one place,
+ * `services/runner/src/sessions/admission.ts`, and reaches the browser verbatim: the SDK's
+ * `sanitize_runner_error` passes a clean one-line message through unchanged, and the Vercel
+ * egress puts it on the stream as `errorText`. Keep the two constants byte-identical.
+ */
+export const SESSION_TURN_IN_USE_CODE = "session_turn_in_use"
+
+export const SESSION_TURN_IN_USE_MESSAGE =
+    "This session is already running a turn. Your message was not sent. Wait for the reply, or stop the turn, then send again."
+
+/**
+ * True when a `useChat` stream error is the single-turn admission refusal.
+ *
+ * Matched on the message rather than on the stream's `data-agent-error` code because the `error`
+ * object is the only thing available at the moment the client has to decide whether to give the
+ * user their text back. The code still travels on the message part and drives how the bubble
+ * renders (`getMessageRunErrorCode`).
+ */
+export const isSessionBusyRefusal = (err: unknown): boolean =>
+    parseAgentRunError(err).message.trim() === SESSION_TURN_IN_USE_MESSAGE
+
+// Copied verbatim from web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+// (2026-07-25); the OSS original remains authoritative for the desktop chat until the
+// re-plumb PR deletes it. Keep byte-parity if either side changes.
+/**
  * Best-effort human reason from a useChat stream error: a plain string or a `{status:{…}}`
  * envelope. An engine's own wording is translated — "Failed to fetch" under "The agent run
  * failed" read as a fault in the agent.
@@ -71,6 +102,10 @@ export const parseAgentRunError = (err: unknown): ParsedRunError => {
         }
     } catch {
         // raw isn't JSON — it's already the human message.
+    }
+    if (fallback.trim() === SESSION_TURN_IN_USE_MESSAGE) {
+        // Carry the class so the bubble can say "not sent" rather than "the agent run failed".
+        return {message: fallback, code: SESSION_TURN_IN_USE_CODE}
     }
     // After the envelope: a server that reports those words means them, and its code is worth more
     // than this translation. A bare engine string has no envelope to lose.

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentChatQueue.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentChatQueue.test.ts
@@ -362,3 +362,52 @@ describe("useAgentChatQueue", () => {
         expect(result.current.queued.map((m) => m.text)).toEqual(["two"])
     })
 })
+
+describe("useAgentChatQueue: reclaiming a sent message", () => {
+    // Single-turn admission (#6417) refuses a message sent while another turn owns the session.
+    // A QUEUED message survives that on its own — it is still in `queued`. An immediately-sent one
+    // had nowhere to live: `submit` handed it to `sendQueued` and dropped it, so a refused send
+    // lost the user's text with no trace. `takeLastSent` is how the host puts it back in the
+    // composer.
+
+    it("hands back the message that was sent immediately", () => {
+        const {result} = setup(settledEmpty)
+        act(() => {
+            result.current.submit({text: "the refused message"})
+        })
+        expect(result.current.takeLastSent()).toMatchObject({text: "the refused message"})
+    })
+
+    it("hands it back only ONCE, so a re-render cannot re-fill the composer", () => {
+        const {result} = setup(settledEmpty)
+        act(() => {
+            result.current.submit({text: "once"})
+        })
+        expect(result.current.takeLastSent()?.text).toBe("once")
+        expect(result.current.takeLastSent()).toBeUndefined()
+    })
+
+    it("has nothing to hand back for a message that only QUEUED", () => {
+        // A queued message is already safe: it is rendered by the dock and mirrored per session.
+        const {result, sendQueued} = setup({status: "streaming", messages: [], stopped: false})
+        act(() => {
+            result.current.submit({text: "queued, not sent"})
+        })
+        expect(sendQueued).not.toHaveBeenCalled()
+        expect(result.current.queued).toHaveLength(1)
+        expect(result.current.takeLastSent()).toBeUndefined()
+    })
+
+    it("tracks the released queue head too, which the release removed from the queue", () => {
+        const {result, rerender} = setup({status: "streaming", messages: [], stopped: false})
+        act(() => {
+            result.current.submit({text: "held"})
+        })
+        expect(result.current.queued).toHaveLength(1)
+        act(() => {
+            rerender({status: "ready", messages: [], stopped: false})
+        })
+        expect(result.current.queued).toHaveLength(0)
+        expect(result.current.takeLastSent()).toMatchObject({text: "held"})
+    })
+})

--- a/web/packages/agenta-chat/tests/unit/model/error.test.ts
+++ b/web/packages/agenta-chat/tests/unit/model/error.test.ts
@@ -2,7 +2,10 @@ import {describe, expect, it} from "vitest"
 
 import {
     isTransportFailure,
+    isSessionBusyRefusal,
     parseAgentRunError,
+    SESSION_TURN_IN_USE_CODE,
+    SESSION_TURN_IN_USE_MESSAGE,
     TRANSPORT_ERROR_MESSAGE,
 } from "../../../src/model/error"
 
@@ -77,5 +80,34 @@ describe("parseAgentRunError", () => {
         })
         expect(isTransportFailure("")).toBe(false)
         expect(isTransportFailure("The agent run failed.")).toBe(false)
+    })
+})
+
+describe("single-turn admission refusal", () => {
+    // The runner refuses a message sent while another turn owns the session (#6417, #5539, #5538).
+    // Nothing ran and nothing was sent, so the client keeps the user's text instead of losing it.
+    // The message text is the contract with `services/runner/src/sessions/admission.ts`; it reaches
+    // the browser verbatim through the SDK's `sanitize_runner_error` and the Vercel egress.
+
+    it("recognises the refusal and carries its stable class", () => {
+        expect(parseAgentRunError(new Error(SESSION_TURN_IN_USE_MESSAGE))).toEqual({
+            message: SESSION_TURN_IN_USE_MESSAGE,
+            code: SESSION_TURN_IN_USE_CODE,
+        })
+        expect(isSessionBusyRefusal(new Error(SESSION_TURN_IN_USE_MESSAGE))).toBe(true)
+    })
+
+    it("recognises it through surrounding whitespace, as the wire may add", () => {
+        expect(isSessionBusyRefusal(`  ${SESSION_TURN_IN_USE_MESSAGE}\n`)).toBe(true)
+    })
+
+    it("does NOT claim an ordinary run failure, which must keep the failure bubble", () => {
+        expect(isSessionBusyRefusal(new Error("The model provider timed out."))).toBe(false)
+        expect(isSessionBusyRefusal(undefined)).toBe(false)
+        expect(parseAgentRunError("The model provider timed out.").code).toBeUndefined()
+    })
+
+    it("keeps the message one line, or the SDK truncates it at the first newline", () => {
+        expect(SESSION_TURN_IN_USE_MESSAGE).not.toContain("\n")
     })
 })


### PR DESCRIPTION
Sending a second message while a session is running can make both turns terminate and leave the session unusable.

The runner now reads the first heartbeat admission result before resolving or changing the session environment. A rejected turn stops at the boundary. The active turn keeps its sandbox. The browser keeps the rejected text so the user can resend it.

## Issue coverage

Closes the concurrent-send failure described by #6417, #5539, and #5538 for the reject policy. It does not implement Queue or Steer.

## Dependencies

The runtime fix is independent of warm Stop and durable commands. The pull request is based on the RFC branch and will need a clean release base before merge.

## Tests

A live local-provider test refused the second send in 0.18 seconds while the first turn completed and retained its sandbox.

## How to review

1. Review the first-heartbeat admission order.
2. Review keepalive-pool behavior after rejection.
3. Review client conflict handling and text preservation.
4. Review the execution ID passed to the client.