### PR TITLE
fix(sessions): settle executions after runner or sandbox loss

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -283,8 +283,15 @@ async def lifespan(*args, **kwargs):
         except Exception as e:  # noqa: BLE001
             log.warning("Store bucket ensure failed at startup: %s", e)
 
+    # The execution watchdog. It needs the records plane to write the terminal outcome a
+    # dead runner owed, and the watch publisher so an open browser sees the turn close.
     _orphan_sweep_task = asyncio.create_task(
-        orphan_sweep_loop(_transactions_engine, _lock_engine)
+        orphan_sweep_loop(
+            _transactions_engine,
+            _lock_engine,
+            records_service=records_service,
+            watch_publisher=_sessions_watch_publisher,
+        )
     )
 
     _attachment_sweep_task = asyncio.create_task(

--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -292,6 +292,7 @@ async def lifespan(*args, **kwargs):
             _lock_engine,
             records_service=records_service,
             watch_publisher=_sessions_watch_publisher,
+            commands_service=session_commands_service,
         )
     )
 

--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -184,6 +184,7 @@ from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
 from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.dbs.postgres.sessions.commands.dbes import SessionCommandDBE  # noqa: F401
 from oss.src.dbs.postgres.sessions.commands.dao import SessionCommandsDAO
+from oss.src.dbs.postgres.sessions.executions.dao import SessionExecutionsDAO
 from oss.src.core.sessions.commands.service import SessionCommandsService
 from oss.src.dbs.http.sessions.control_delivery_direct import DirectControlDelivery
 from oss.src.tasks.asyncio.sessions.orphan_sweep import orphan_sweep_loop
@@ -598,6 +599,8 @@ evaluations_dao = EvaluationsDAO(engine=_transactions_engine)
 folders_dao = FoldersDAO(engine=_transactions_engine)
 session_streams_dao = SessionStreamsDAO(engine=_transactions_engine)
 session_turns_dao = SessionTurnsDAO(engine=_transactions_engine)
+session_commands_dao = SessionCommandsDAO(engine=_transactions_engine)
+session_executions_dao = SessionExecutionsDAO(engine=_transactions_engine)
 
 connections_dao = ConnectionsDAO(engine=_transactions_engine)
 mounts_dao = MountsDAO(engine=_transactions_engine)
@@ -632,6 +635,7 @@ events_service = EventsService(
 
 records_service = RecordsService(
     records_dao=records_dao,
+    executions_dao=session_executions_dao,
 )
 
 
@@ -1138,13 +1142,13 @@ if _control_adapter != "direct":
         "Only 'direct' is implemented; the long-poll adapter is a later change."
     )
 
-session_commands_dao = SessionCommandsDAO()
 session_commands_service = SessionCommandsService(
     commands_dao=session_commands_dao,
     streams_service=session_streams_service,
     interactions_service=interactions_service,
     lock_engine=_lock_engine,
     delivery=DirectControlDelivery(),
+    executions_dao=session_executions_dao,
 )
 
 sessions = SessionsRouter(

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000023_add_session_executions.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000023_add_session_executions.py
@@ -1,0 +1,44 @@
+"""add authoritative session execution terminal outcomes
+
+Revision ID: oss000000023
+Revises: oss000000022
+Create Date: 2026-09-03 22:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "oss000000023"
+down_revision: Union[str, None] = "oss000000022"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "session_executions",
+        sa.Column("project_id", sa.UUID(as_uuid=True), nullable=False),
+        sa.Column("session_id", sa.String(), nullable=False),
+        sa.Column("execution_id", sa.String(), nullable=False),
+        sa.Column("terminal_outcome", sa.String(), nullable=False),
+        sa.Column("settled_by", sa.String(), nullable=False),
+        sa.Column("settled_at", sa.TIMESTAMP(timezone=True), nullable=False),
+        sa.Column("records_closed_at", sa.TIMESTAMP(timezone=True), nullable=True),
+        sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("project_id", "session_id", "execution_id"),
+    )
+    op.create_index(
+        "ix_session_executions_project_session",
+        "session_executions",
+        ["project_id", "session_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_session_executions_project_session", table_name="session_executions"
+    )
+    op.drop_table("session_executions")

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000023_add_session_executions.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000023_add_session_executions.py
@@ -26,7 +26,6 @@ def upgrade() -> None:
         sa.Column("terminal_outcome", sa.String(), nullable=False),
         sa.Column("settled_by", sa.String(), nullable=False),
         sa.Column("settled_at", sa.TIMESTAMP(timezone=True), nullable=False),
-        sa.Column("records_closed_at", sa.TIMESTAMP(timezone=True), nullable=True),
         sa.ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
         sa.PrimaryKeyConstraint("project_id", "session_id", "execution_id"),
     )

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000024_add_execution_redis_reconciliation.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000024_add_execution_redis_reconciliation.py
@@ -1,0 +1,41 @@
+"""track execution Redis reconciliation
+
+Revision ID: oss000000024
+Revises: oss000000023
+Create Date: 2026-09-03 22:30:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "oss000000024"
+down_revision: Union[str, None] = "oss000000023"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "session_executions",
+        sa.Column("redis_reconciled_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_session_executions_redis_unreconciled",
+        "session_executions",
+        ["settled_at"],
+        postgresql_where=sa.text(
+            "settled_by = 'runner' AND terminal_outcome = 'stopped' "
+            "AND redis_reconciled_at IS NULL"
+        ),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_session_executions_redis_unreconciled",
+        table_name="session_executions",
+    )
+    op.drop_column("session_executions", "redis_reconciled_at")

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000025_add_execution_ending_marker.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000025_add_execution_ending_marker.py
@@ -1,0 +1,38 @@
+"""add session execution ending marker
+
+Revision ID: oss000000025
+Revises: oss000000024
+Create Date: 2026-09-04 12:00:00.000000
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision: str = "oss000000025"
+down_revision: Union[str, None] = "oss000000024"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "session_executions",
+        sa.Column("ending_written_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_session_executions_ending_unwritten",
+        "session_executions",
+        ["settled_at"],
+        postgresql_where=sa.text("ending_written_at IS NULL"),
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_session_executions_ending_unwritten",
+        table_name="session_executions",
+    )
+    op.drop_column("session_executions", "ending_written_at")

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000026_add_execution_ending_marker.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000026_add_execution_ending_marker.py
@@ -1,6 +1,6 @@
 """add session execution ending marker
 
-Revision ID: oss000000025
+Revision ID: oss000000026
 Revises: oss000000024
 Create Date: 2026-09-04 12:00:00.000000
 """
@@ -11,7 +11,7 @@ from alembic import op
 import sqlalchemy as sa
 
 
-revision: str = "oss000000025"
+revision: str = "oss000000026"
 down_revision: Union[str, None] = "oss000000024"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/api/oss/databases/postgres/migrations/tracing_oss/versions/oss000000005_add_records_quarantined_at.py
+++ b/api/oss/databases/postgres/migrations/tracing_oss/versions/oss000000005_add_records_quarantined_at.py
@@ -1,0 +1,35 @@
+"""add_records_quarantined_at
+
+Revision ID: oss000000005
+Revises: oss000000004
+Create Date: 2026-09-03 12:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = "oss000000005"
+down_revision: Union[str, None] = "oss000000004"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # A record that reached ingest for a turn the execution watchdog had already ended.
+    # Nullable and forward-fill only, like every other column on this table: the tracing DB
+    # is never backfilled, and no existing row can be classified retroactively anyway.
+    #
+    # No index. Every read that filters on it is already scoped to one project and one
+    # session by an existing index, and the column is null on all but a handful of rows.
+    op.add_column(
+        "records",
+        sa.Column("quarantined_at", sa.TIMESTAMP(timezone=True), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("records", "quarantined_at")

--- a/api/oss/src/apis/fastapi/sessions/models.py
+++ b/api/oss/src/apis/fastapi/sessions/models.py
@@ -360,7 +360,13 @@ class SessionCancelRequest(BaseModel):
     # refuses the request if another one is running. When absent, it cancels whichever
     # execution is active when the request is applied. A person never types this: the browser
     # fills it from the session's own state, and a first-party client always sends it.
-    expected_execution_id: Optional[str] = None
+    expected_execution_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional stale-request guard honored only in cancel mode; ignored for send, "
+            "steer, and attach."
+        ),
+    )
 
 
 class SessionCommandRef(BaseModel):

--- a/api/oss/src/core/sessions/commands/interfaces.py
+++ b/api/oss/src/core/sessions/commands/interfaces.py
@@ -7,7 +7,7 @@ state machine and terminal settlement live in the service and must not move into
 
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import List, NamedTuple, Optional
+from typing import Any, AsyncContextManager, List, NamedTuple, Optional
 from uuid import UUID
 
 from pydantic import BaseModel
@@ -69,6 +69,10 @@ class ControlDeliveryPort(ABC):
 
 
 class SessionCommandsDAOInterface(ABC):
+    @abstractmethod
+    def transaction(self) -> AsyncContextManager[Any]:
+        """Open a transaction that sibling session DAOs can share."""
+
     @abstractmethod
     async def create_command(
         self,
@@ -163,6 +167,7 @@ class SessionCommandsDAOInterface(ABC):
         self,
         *,
         settle: SessionCommandSettle,
+        transaction: Optional[Any] = None,
     ) -> Optional[SessionCommand]:
         """Terminal transition, guarded on `state='claimed' AND claimed_by=:replica_id`.
         None means the claim had expired or somebody else settled it first."""

--- a/api/oss/src/core/sessions/commands/interfaces.py
+++ b/api/oss/src/core/sessions/commands/interfaces.py
@@ -148,6 +148,17 @@ class SessionCommandsDAOInterface(ABC):
         `claim_commands`; both exist so the outcome route's guard reads the same either way."""
 
     @abstractmethod
+    async def record_delivery_attempt(
+        self,
+        *,
+        project_id: UUID,
+        command_id: UUID,
+        now: datetime,
+        max_deliveries: int,
+    ) -> Optional[SessionCommand]:
+        """Reserve one bounded delivery attempt and return the updated command."""
+
+    @abstractmethod
     async def settle_command(
         self,
         *,
@@ -173,6 +184,6 @@ class SessionCommandsDAOInterface(ABC):
         *,
         now: datetime,
         max_deliveries: int,
+        pending_before: Optional[datetime] = None,
     ) -> List[SessionCommand]:
-        """Commands whose claim lease has passed. The settlement sweep reads this. Not called
-        in this slice; the execution watchdog owns settlement (see the slice document)."""
+        """Pending or claimed commands old enough for recovery."""

--- a/api/oss/src/core/sessions/commands/service.py
+++ b/api/oss/src/core/sessions/commands/service.py
@@ -31,7 +31,7 @@ THE LATE-STOP GUARDS. A Stop that arrives after its turn ended must not kill the
     which is exact.
 """
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from typing import List, Optional, Tuple
 from uuid import UUID
 
@@ -354,6 +354,15 @@ class SessionCommandsService:
 
         Never raises. The user's request has already succeeded by the time this runs.
         """
+        command = await self._dao.record_delivery_attempt(
+            project_id=command.project_id,
+            command_id=command.id,
+            now=datetime.now(timezone.utc),
+            max_deliveries=env.agenta.sessions.commands.max_deliveries,
+        )
+        if command is None:
+            return
+
         try:
             receipt = await self._delivery.deliver(command=command)
         except Exception as e:  # noqa: BLE001 — transport failure is never a request failure
@@ -457,6 +466,40 @@ class SessionCommandsService:
             updated_at = updated_at.replace(tzinfo=timezone.utc)
         age = (datetime.now(timezone.utc) - updated_at).total_seconds()
         return age < HEARTBEAT_INTERVAL_SECONDS * 2
+
+    async def settle_abandoned_commands(self, *, now: datetime) -> int:
+        max_deliveries = env.agenta.sessions.commands.max_deliveries
+        abandoned = await self._dao.expire_claims(
+            now=now,
+            max_deliveries=max_deliveries,
+            pending_before=now
+            - timedelta(seconds=env.agenta.sessions.commands.admission_timeout_seconds),
+        )
+        settled = 0
+        for command in abandoned:
+            beating = await self._session_is_beating(
+                project_id=command.project_id,
+                session_id=command.session_id,
+            )
+            if beating and command.claim_count < max_deliveries:
+                await self._deliver(command)
+                continue
+
+            result = await self.settle(
+                command_id=command.id,
+                project_id=command.project_id,
+                replica_id=None,
+                expected_states=[
+                    SessionCommandState.pending,
+                    SessionCommandState.claimed,
+                ],
+                state=SessionCommandState.obsolete,
+                outcome=SessionCommandOutcome.lost,
+                execution_id=command.target_turn_id,
+            )
+            if result is not None:
+                settled += 1
+        return settled
 
     # -- settlement --------------------------------------------------------- #
 

--- a/api/oss/src/core/sessions/commands/service.py
+++ b/api/oss/src/core/sessions/commands/service.py
@@ -54,6 +54,7 @@ from oss.src.core.sessions.commands.types import (
     SessionCommandNotClaimable,
     SessionCommandNotFound,
 )
+from oss.src.core.sessions.executions.interfaces import SessionExecutionsDAOInterface
 from oss.src.core.sessions.interactions.service import SessionInteractionsService
 from oss.src.core.sessions.streams.dtos import (
     SessionStreamCommandRequest,
@@ -106,12 +107,14 @@ class SessionCommandsService:
         interactions_service: SessionInteractionsService,
         lock_engine: LockEngine,
         delivery: ControlDeliveryPort,
+        executions_dao: Optional[SessionExecutionsDAOInterface] = None,
     ) -> None:
         self._dao = commands_dao
         self._streams = streams_service
         self._interactions = interactions_service
         self._lock = lock_engine
         self._delivery = delivery
+        self._executions = executions_dao
 
     # -- admission ---------------------------------------------------------- #
 
@@ -503,6 +506,26 @@ class SessionCommandsService:
 
     # -- settlement --------------------------------------------------------- #
 
+    async def settle_execution_lost(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        execution_id: str,
+        settled_at: datetime,
+    ) -> bool:
+        if self._executions is None:
+            return True
+        result = await self._executions.settle(
+            project_id=project_id,
+            session_id=session_id,
+            execution_id=execution_id,
+            terminal_outcome=SessionCommandOutcome.lost.value,
+            settled_by="watchdog",
+            settled_at=settled_at,
+        )
+        return result.won
+
     async def report_outcome(
         self,
         *,
@@ -577,6 +600,31 @@ class SessionCommandsService:
         The guard is what makes this idempotent: a second report finds a terminal row, changes
         nothing, and the side effects below do not run twice.
         """
+        if (
+            self._executions is not None
+            and execution_id is not None
+            and outcome in (SessionCommandOutcome.stopped, SessionCommandOutcome.lost)
+        ):
+            settled_by = (
+                "watchdog" if outcome == SessionCommandOutcome.lost else "runner"
+            )
+            stored_command = await self._dao.fetch_command(command_id=command_id)
+            if stored_command is None:
+                return None
+            execution = await self._executions.settle(
+                project_id=project_id,
+                session_id=stored_command.session_id,
+                execution_id=execution_id,
+                terminal_outcome=outcome.value,
+                settled_by=settled_by,
+            )
+            winner = execution.settlement
+            if not execution.won and (
+                winner.terminal_outcome != outcome.value
+                or winner.settled_by != settled_by
+            ):
+                return None
+
         settled = await self._dao.settle_command(
             settle=SessionCommandSettle(
                 project_id=project_id,

--- a/api/oss/src/core/sessions/commands/service.py
+++ b/api/oss/src/core/sessions/commands/service.py
@@ -524,7 +524,51 @@ class SessionCommandsService:
             settled_by="watchdog",
             settled_at=settled_at,
         )
-        return result.won
+        winner = result.settlement
+        return result.won or (
+            winner.terminal_outcome == SessionCommandOutcome.lost.value
+            and winner.settled_by == "watchdog"
+        )
+
+    async def repair_terminal_redis(self) -> int:
+        if self._executions is None:
+            return 0
+        pending = await self._executions.list_redis_unreconciled(limit=200)
+        repaired = 0
+        for execution in pending:
+            await self._reconcile_stopped_redis(
+                project_id=execution.project_id,
+                session_id=execution.session_id,
+                execution_id=execution.execution_id,
+            )
+            repaired += 1
+        return repaired
+
+    async def _reconcile_stopped_redis(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        execution_id: str,
+    ) -> None:
+        await mark_turn_superseded(
+            self._lock,
+            project_id=str(project_id),
+            session_id=session_id,
+            turn_id=execution_id,
+        )
+        await release_running(
+            self._lock,
+            project_id=str(project_id),
+            session_id=session_id,
+            turn_id=execution_id,
+        )
+        if self._executions is not None:
+            await self._executions.mark_redis_reconciled(
+                project_id=project_id,
+                session_id=session_id,
+                execution_id=execution_id,
+            )
 
     async def report_outcome(
         self,
@@ -600,69 +644,66 @@ class SessionCommandsService:
         The guard is what makes this idempotent: a second report finds a terminal row, changes
         nothing, and the side effects below do not run twice.
         """
-        if (
-            self._executions is not None
-            and execution_id is not None
-            and outcome in (SessionCommandOutcome.stopped, SessionCommandOutcome.lost)
-        ):
-            settled_by = (
-                "watchdog" if outcome == SessionCommandOutcome.lost else "runner"
-            )
+        transition = SessionCommandSettle(
+            project_id=project_id,
+            command_id=command_id,
+            state=state,
+            outcome=outcome,
+            expected_states=expected_states,
+            replica_id=replica_id,
+        )
+        atomic_core_settlement = self._executions is not None
+        if atomic_core_settlement:
             stored_command = await self._dao.fetch_command(command_id=command_id)
             if stored_command is None:
                 return None
-            execution = await self._executions.settle(
-                project_id=project_id,
+            terminal = outcome in (
+                SessionCommandOutcome.stopped,
+                SessionCommandOutcome.lost,
+            )
+            settled = await self._executions.settle_command_execution(
+                settle=transition,
                 session_id=stored_command.session_id,
                 execution_id=execution_id,
-                terminal_outcome=outcome.value,
-                settled_by=settled_by,
+                terminal_outcome=outcome.value if terminal else None,
+                settled_by=(
+                    "watchdog"
+                    if outcome == SessionCommandOutcome.lost
+                    else "runner"
+                    if terminal
+                    else None
+                ),
+                mirror_stopped=outcome == SessionCommandOutcome.stopped,
+                cancel_interactions=outcome
+                in (
+                    SessionCommandOutcome.stopped,
+                    SessionCommandOutcome.not_running,
+                    SessionCommandOutcome.lost,
+                ),
             )
-            winner = execution.settlement
-            if not execution.won and (
-                winner.terminal_outcome != outcome.value
-                or winner.settled_by != settled_by
-            ):
-                return None
-
-        settled = await self._dao.settle_command(
-            settle=SessionCommandSettle(
-                project_id=project_id,
-                command_id=command_id,
-                state=state,
-                outcome=outcome,
-                expected_states=expected_states,
-                replica_id=replica_id,
-            )
-        )
+        else:
+            settled = await self._dao.settle_command(settle=transition)
         if settled is None:
             return None
 
         session_id = settled.session_id
         target = settled.target_turn_id
 
-        await self._dao.clear_stopping_turn(
-            project_id=project_id,
-            session_id=session_id,
-            turn_id=target,
-        )
+        if not atomic_core_settlement:
+            await self._dao.clear_stopping_turn(
+                project_id=project_id,
+                session_id=session_id,
+                turn_id=target,
+            )
 
         if outcome == SessionCommandOutcome.stopped and target:
             # Order matters. Tombstone first, so a late beat from the stopped execution cannot
             # re-arm the locks it is about to lose; that beat would otherwise find `alive` free
             # and take it straight back under the same turn id.
-            await mark_turn_superseded(
-                self._lock,
-                project_id=str(project_id),
+            await self._reconcile_stopped_redis(
+                project_id=project_id,
                 session_id=session_id,
-                turn_id=target,
-            )
-            # Owner-checked, so it can only release its OWN execution's key.
-            await release_running(
-                self._lock,
-                project_id=str(project_id),
-                session_id=session_id,
-                turn_id=target,
+                execution_id=target,
             )
             # `alive` is deliberately left to its own time to live, exactly as the end of a
             # normal turn leaves it. Warm resume is the required outcome of Stop, so the session
@@ -674,17 +715,18 @@ class SessionCommandsService:
             # (`query_streams`) reads Postgres and never Redis. Skipping this leaves the row
             # saying `is_running: true` until the orphan sweep collapses it, so the tab that
             # pressed Stop shows a "running somewhere else" strip over its own session.
-            await self._streams.mirror_liveness(
-                project_id=project_id,
-                session_id=session_id,
-            )
+            if not atomic_core_settlement:
+                await self._streams.mirror_liveness(
+                    project_id=project_id,
+                    session_id=session_id,
+                )
 
         if outcome in (
             SessionCommandOutcome.stopped,
             SessionCommandOutcome.not_running,
             SessionCommandOutcome.lost,
         ):
-            if target:
+            if target and not atomic_core_settlement:
                 # An approval card whose execution was stopped is a card whose buttons do
                 # nothing. Scoped to this execution, so a newer turn's gates survive.
                 await self._interactions.cancel_session_pending(

--- a/api/oss/src/core/sessions/commands/service.py
+++ b/api/oss/src/core/sessions/commands/service.py
@@ -657,6 +657,7 @@ class SessionCommandsService:
             replica_id=replica_id,
         )
         atomic_core_settlement = self._executions is not None
+        cancelled_interactions = 0
         if atomic_core_settlement:
             stored_command = await self._dao.fetch_command(command_id=command_id)
             if stored_command is None:
@@ -709,12 +710,14 @@ class SessionCommandsService:
                         SessionCommandOutcome.not_running,
                         SessionCommandOutcome.lost,
                     ):
-                        await self._interactions.cancel_session_pending(
-                            project_id=project_id,
-                            session_id=stored_command.session_id,
-                            only_turn_id=execution_id,
-                            transaction=transaction,
-                            publish=False,
+                        cancelled_interactions = (
+                            await self._interactions.cancel_session_pending(
+                                project_id=project_id,
+                                session_id=stored_command.session_id,
+                                only_turn_id=execution_id,
+                                transaction=transaction,
+                                publish=False,
+                            )
                         )
             except _SettlementRejected:
                 return None
@@ -725,6 +728,12 @@ class SessionCommandsService:
 
         session_id = settled.session_id
         target = settled.target_turn_id
+
+        if cancelled_interactions:
+            await self._interactions.publish_session_pending_cancelled(
+                project_id=project_id,
+                session_id=session_id,
+            )
 
         if not atomic_core_settlement:
             await self._dao.clear_stopping_turn(

--- a/api/oss/src/core/sessions/commands/service.py
+++ b/api/oss/src/core/sessions/commands/service.py
@@ -98,6 +98,10 @@ class CancelAdmission:
         self.accepted = accepted
 
 
+class _SettlementRejected(Exception):
+    pass
+
+
 class SessionCommandsService:
     def __init__(
         self,
@@ -661,26 +665,59 @@ class SessionCommandsService:
                 SessionCommandOutcome.stopped,
                 SessionCommandOutcome.lost,
             )
-            settled = await self._executions.settle_command_execution(
-                settle=transition,
-                session_id=stored_command.session_id,
-                execution_id=execution_id,
-                terminal_outcome=outcome.value if terminal else None,
-                settled_by=(
-                    "watchdog"
-                    if outcome == SessionCommandOutcome.lost
-                    else "runner"
-                    if terminal
-                    else None
-                ),
-                mirror_stopped=outcome == SessionCommandOutcome.stopped,
-                cancel_interactions=outcome
-                in (
-                    SessionCommandOutcome.stopped,
-                    SessionCommandOutcome.not_running,
-                    SessionCommandOutcome.lost,
-                ),
+            settled_by = (
+                "watchdog"
+                if outcome == SessionCommandOutcome.lost
+                else "runner"
+                if terminal
+                else None
             )
+            try:
+                async with self._dao.transaction() as transaction:
+                    settled = await self._dao.settle_command(
+                        settle=transition,
+                        transaction=transaction,
+                    )
+                    if settled is None:
+                        raise _SettlementRejected
+
+                    if execution_id and terminal and settled_by:
+                        result = await self._executions.settle(
+                            project_id=project_id,
+                            session_id=stored_command.session_id,
+                            execution_id=execution_id,
+                            terminal_outcome=outcome.value,
+                            settled_by=settled_by,
+                            transaction=transaction,
+                        )
+                        winner = result.settlement
+                        if not result.won and (
+                            winner.terminal_outcome != outcome.value
+                            or winner.settled_by != settled_by
+                        ):
+                            raise _SettlementRejected
+
+                    await self._streams.settle_command(
+                        project_id=project_id,
+                        session_id=stored_command.session_id,
+                        turn_id=execution_id,
+                        mirror_stopped=outcome == SessionCommandOutcome.stopped,
+                        transaction=transaction,
+                    )
+                    if execution_id and outcome in (
+                        SessionCommandOutcome.stopped,
+                        SessionCommandOutcome.not_running,
+                        SessionCommandOutcome.lost,
+                    ):
+                        await self._interactions.cancel_session_pending(
+                            project_id=project_id,
+                            session_id=stored_command.session_id,
+                            only_turn_id=execution_id,
+                            transaction=transaction,
+                            publish=False,
+                        )
+            except _SettlementRejected:
+                return None
         else:
             settled = await self._dao.settle_command(settle=transition)
         if settled is None:

--- a/api/oss/src/core/sessions/commands/service.py
+++ b/api/oss/src/core/sessions/commands/service.py
@@ -32,7 +32,7 @@ THE LATE-STOP GUARDS. A Stop that arrives after its turn ended must not kill the
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional, Tuple
+from typing import Any, List, Optional, Tuple
 from uuid import UUID
 
 from oss.src.core.sessions.commands.dtos import (
@@ -517,6 +517,7 @@ class SessionCommandsService:
         session_id: str,
         execution_id: str,
         settled_at: datetime,
+        transaction: Optional[Any] = None,
     ) -> bool:
         if self._executions is None:
             return True
@@ -527,6 +528,7 @@ class SessionCommandsService:
             terminal_outcome=SessionCommandOutcome.lost.value,
             settled_by="watchdog",
             settled_at=settled_at,
+            transaction=transaction,
         )
         winner = result.settlement
         return result.won or (

--- a/api/oss/src/core/sessions/commands/service.py
+++ b/api/oss/src/core/sessions/commands/service.py
@@ -537,9 +537,9 @@ class SessionCommandsService:
     async def repair_terminal_redis(self) -> int:
         if self._executions is None:
             return 0
-        pending = await self._executions.list_redis_unreconciled(limit=200)
+        misses = await self._executions.list_redis_unreconciled(limit=200)
         repaired = 0
-        for execution in pending:
+        for execution in misses:
             await self._reconcile_stopped_redis(
                 project_id=execution.project_id,
                 session_id=execution.session_id,

--- a/api/oss/src/core/sessions/executions/__init__.py
+++ b/api/oss/src/core/sessions/executions/__init__.py
@@ -1,0 +1,1 @@
+"""Execution terminal-state contracts."""

--- a/api/oss/src/core/sessions/executions/dtos.py
+++ b/api/oss/src/core/sessions/executions/dtos.py
@@ -13,6 +13,7 @@ class SessionExecutionSettlement(BaseModel):
     settled_by: str
     settled_at: datetime
     records_closed_at: Optional[datetime] = None
+    redis_reconciled_at: Optional[datetime] = None
 
 
 class SessionExecutionSettlementResult(BaseModel):

--- a/api/oss/src/core/sessions/executions/dtos.py
+++ b/api/oss/src/core/sessions/executions/dtos.py
@@ -12,6 +12,7 @@ class SessionExecutionSettlement(BaseModel):
     terminal_outcome: str
     settled_by: str
     settled_at: datetime
+    ending_written_at: Optional[datetime] = None
     redis_reconciled_at: Optional[datetime] = None
 
 

--- a/api/oss/src/core/sessions/executions/dtos.py
+++ b/api/oss/src/core/sessions/executions/dtos.py
@@ -12,7 +12,6 @@ class SessionExecutionSettlement(BaseModel):
     terminal_outcome: str
     settled_by: str
     settled_at: datetime
-    records_closed_at: Optional[datetime] = None
     redis_reconciled_at: Optional[datetime] = None
 
 

--- a/api/oss/src/core/sessions/executions/dtos.py
+++ b/api/oss/src/core/sessions/executions/dtos.py
@@ -1,0 +1,20 @@
+from datetime import datetime
+from typing import Optional
+from uuid import UUID
+
+from pydantic import BaseModel
+
+
+class SessionExecutionSettlement(BaseModel):
+    project_id: UUID
+    session_id: str
+    execution_id: str
+    terminal_outcome: str
+    settled_by: str
+    settled_at: datetime
+    records_closed_at: Optional[datetime] = None
+
+
+class SessionExecutionSettlementResult(BaseModel):
+    settlement: SessionExecutionSettlement
+    won: bool

--- a/api/oss/src/core/sessions/executions/interfaces.py
+++ b/api/oss/src/core/sessions/executions/interfaces.py
@@ -34,6 +34,16 @@ class SessionExecutionsDAOInterface(ABC):
         """Fetch terminal state for `(session_id, execution_id)` keys."""
 
     @abstractmethod
+    async def mark_endings_written(
+        self,
+        *,
+        project_id: UUID,
+        keys: Sequence[Tuple[str, str]],
+        written_at: Optional[datetime] = None,
+    ) -> None:
+        """Mark terminal executions whose transcript ending has been written."""
+
+    @abstractmethod
     async def list_redis_unreconciled(
         self,
         *,

--- a/api/oss/src/core/sessions/executions/interfaces.py
+++ b/api/oss/src/core/sessions/executions/interfaces.py
@@ -1,12 +1,13 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Dict, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 
 from oss.src.core.sessions.executions.dtos import (
     SessionExecutionSettlement,
     SessionExecutionSettlementResult,
 )
+from oss.src.core.sessions.commands.dtos import SessionCommand, SessionCommandSettle
 
 
 class SessionExecutionsDAOInterface(ABC):
@@ -41,3 +42,35 @@ class SessionExecutionsDAOInterface(ABC):
         settled_by: str,
     ) -> None:
         """Close the winner's record stream after its terminal batch commits."""
+
+    @abstractmethod
+    async def settle_command_execution(
+        self,
+        *,
+        settle: SessionCommandSettle,
+        session_id: str,
+        execution_id: Optional[str],
+        terminal_outcome: Optional[str],
+        settled_by: Optional[str],
+        mirror_stopped: bool,
+        cancel_interactions: bool,
+    ) -> Optional[SessionCommand]:
+        """Commit the terminal core facts in one transaction."""
+
+    @abstractmethod
+    async def list_redis_unreconciled(
+        self,
+        *,
+        limit: int,
+    ) -> List[SessionExecutionSettlement]:
+        """Runner settlements whose post-commit Redis projection is incomplete."""
+
+    @abstractmethod
+    async def mark_redis_reconciled(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        execution_id: str,
+    ) -> None:
+        """Record completion of the idempotent post-commit Redis projection."""

--- a/api/oss/src/core/sessions/executions/interfaces.py
+++ b/api/oss/src/core/sessions/executions/interfaces.py
@@ -1,0 +1,43 @@
+from abc import ABC, abstractmethod
+from datetime import datetime
+from typing import Dict, Optional, Sequence, Tuple
+from uuid import UUID
+
+from oss.src.core.sessions.executions.dtos import (
+    SessionExecutionSettlement,
+    SessionExecutionSettlementResult,
+)
+
+
+class SessionExecutionsDAOInterface(ABC):
+    @abstractmethod
+    async def settle(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        execution_id: str,
+        terminal_outcome: str,
+        settled_by: str,
+        settled_at: Optional[datetime] = None,
+    ) -> SessionExecutionSettlementResult:
+        """Compare-and-set one terminal outcome and return the stored winner."""
+
+    @abstractmethod
+    async def query_settled(
+        self,
+        *,
+        project_id: UUID,
+        keys: Sequence[Tuple[str, str]],
+    ) -> Dict[Tuple[str, str], SessionExecutionSettlement]:
+        """Fetch terminal state for `(session_id, execution_id)` keys."""
+
+    @abstractmethod
+    async def close_records(
+        self,
+        *,
+        project_id: UUID,
+        keys: Sequence[Tuple[str, str]],
+        settled_by: str,
+    ) -> None:
+        """Close the winner's record stream after its terminal batch commits."""

--- a/api/oss/src/core/sessions/executions/interfaces.py
+++ b/api/oss/src/core/sessions/executions/interfaces.py
@@ -1,13 +1,12 @@
 from abc import ABC, abstractmethod
 from datetime import datetime
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 
 from oss.src.core.sessions.executions.dtos import (
     SessionExecutionSettlement,
     SessionExecutionSettlementResult,
 )
-from oss.src.core.sessions.commands.dtos import SessionCommand, SessionCommandSettle
 
 
 class SessionExecutionsDAOInterface(ABC):
@@ -21,6 +20,7 @@ class SessionExecutionsDAOInterface(ABC):
         terminal_outcome: str,
         settled_by: str,
         settled_at: Optional[datetime] = None,
+        transaction: Optional[Any] = None,
     ) -> SessionExecutionSettlementResult:
         """Compare-and-set one terminal outcome and return the stored winner."""
 
@@ -32,30 +32,6 @@ class SessionExecutionsDAOInterface(ABC):
         keys: Sequence[Tuple[str, str]],
     ) -> Dict[Tuple[str, str], SessionExecutionSettlement]:
         """Fetch terminal state for `(session_id, execution_id)` keys."""
-
-    @abstractmethod
-    async def close_records(
-        self,
-        *,
-        project_id: UUID,
-        keys: Sequence[Tuple[str, str]],
-        settled_by: str,
-    ) -> None:
-        """Close the winner's record stream after its terminal batch commits."""
-
-    @abstractmethod
-    async def settle_command_execution(
-        self,
-        *,
-        settle: SessionCommandSettle,
-        session_id: str,
-        execution_id: Optional[str],
-        terminal_outcome: Optional[str],
-        settled_by: Optional[str],
-        mirror_stopped: bool,
-        cancel_interactions: bool,
-    ) -> Optional[SessionCommand]:
-        """Commit the terminal core facts in one transaction."""
 
     @abstractmethod
     async def list_redis_unreconciled(

--- a/api/oss/src/core/sessions/interactions/interfaces.py
+++ b/api/oss/src/core/sessions/interactions/interfaces.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Any, List, Optional
 from uuid import UUID
 
 from oss.src.core.sessions.interactions.dtos import (
@@ -47,6 +47,7 @@ class SessionInteractionsDAOInterface(ABC):
         except_turn_id: Optional[str] = None,
         except_tokens: Optional[List[str]] = None,
         only_turn_id: Optional[str] = None,
+        transaction: Optional[Any] = None,
     ) -> List[SessionInteraction]: ...
 
     @abstractmethod

--- a/api/oss/src/core/sessions/interactions/service.py
+++ b/api/oss/src/core/sessions/interactions/service.py
@@ -1,4 +1,4 @@
-from typing import List, Optional
+from typing import Any, List, Optional
 from uuid import NAMESPACE_DNS, UUID, uuid5
 
 from oss.src.core.sessions.interactions.dtos import (
@@ -112,6 +112,8 @@ class SessionInteractionsService:
         except_tokens: Optional[List[str]] = None,
         only_turn_id: Optional[str] = None,
         command_id: Optional[UUID] = None,
+        transaction: Optional[Any] = None,
+        publish: bool = True,
     ) -> int:
         cancelled = await self.interactions_dao.cancel_session_pending(
             project_id=project_id,
@@ -119,6 +121,7 @@ class SessionInteractionsService:
             except_turn_id=except_turn_id,
             except_tokens=except_tokens,
             only_turn_id=only_turn_id,
+            transaction=transaction,
         )
         if cancelled and command_id is not None and self._records is not None:
             try:
@@ -156,7 +159,7 @@ class SessionInteractionsService:
                     command_id,
                     exc_info=True,
                 )
-        if cancelled:
+        if cancelled and publish:
             await self._publish_interaction(
                 project_id=project_id,
                 session_id=session_id,

--- a/api/oss/src/core/sessions/interactions/service.py
+++ b/api/oss/src/core/sessions/interactions/service.py
@@ -160,12 +160,19 @@ class SessionInteractionsService:
                     exc_info=True,
                 )
         if cancelled and publish:
-            await self._publish_interaction(
-                project_id=project_id,
-                session_id=session_id,
-                status=WATCH_INTERACTION_RESOLVED,
+            await self.publish_session_pending_cancelled(
+                project_id=project_id, session_id=session_id
             )
         return len(cancelled)
+
+    async def publish_session_pending_cancelled(
+        self, *, project_id: UUID, session_id: str
+    ) -> None:
+        await self._publish_interaction(
+            project_id=project_id,
+            session_id=session_id,
+            status=WATCH_INTERACTION_RESOLVED,
+        )
 
     async def query_interactions(
         self,

--- a/api/oss/src/core/sessions/records/dtos.py
+++ b/api/oss/src/core/sessions/records/dtos.py
@@ -10,6 +10,21 @@ from oss.src.core.shared.dtos import Lifecycle, OTelSpanId
 # just keeps the DTO honest about that contract for any other producer.
 SESSION_MESSAGE_PREVIEW_TEXT_LIMIT = 240
 
+# The runner's terminal per-turn record type, mirrored from
+# services/runner/src/protocol.ts (`{ type: "done" }`). Also spelled in the records DAO and
+# the ingest worker, which read the same marker off their own layers.
+TERMINAL_RECORD_TYPE = "done"
+
+# Who wrote a terminal record, stamped into `attributes` by the writer.
+#
+# Only the platform ever sets it: the ingest route builds `SessionRecordEvent` field by field
+# from the request body and has no path to this key, so a runner cannot claim to be the
+# watchdog. It exists because the two endings are otherwise identical — the watchdog copies
+# the runner's `{"type": "done"}` deliberately, so one outcome never reaches a user in two
+# wordings — and the late-record guard has to tell them apart.
+RECORD_SETTLED_BY_ATTRIBUTE = "settled_by"
+SETTLED_BY_WATCHDOG = "watchdog"
+
 
 class SessionRecordEvent(BaseModel):
     project_id: UUID
@@ -26,6 +41,12 @@ class SessionRecordEvent(BaseModel):
     turn_id: Optional[str] = None
     span_id: Optional[OTelSpanId] = None
 
+    # Set ONLY by the ingest guard in `RecordsService.append_many`, never by a producer: the
+    # ingest route builds this DTO field by field and never reads this one off the wire. A
+    # non-null value means the record arrived for a turn the watchdog had already ended, so it
+    # is kept as evidence and left out of the transcript. See `RecordsService.append_many`.
+    quarantined_at: Optional[datetime] = None
+
 
 class SessionRecord(Lifecycle):
     record_id: UUID
@@ -41,6 +62,11 @@ class SessionRecord(Lifecycle):
 
     turn_id: Optional[str] = None
     span_id: Optional[OTelSpanId] = None
+
+    # Non-null when this record was written for an already-settled turn. Reads that rebuild a
+    # transcript filter these out at the DAO; the column is exposed so support and billing can
+    # still see the work the agent did after the platform closed the turn.
+    quarantined_at: Optional[datetime] = None
 
 
 class SessionMessagePreview(BaseModel):

--- a/api/oss/src/core/sessions/records/interfaces.py
+++ b/api/oss/src/core/sessions/records/interfaces.py
@@ -53,7 +53,11 @@ class RecordsDAOInterface:
         *,
         project_id: UUID,
         keys: Sequence[Tuple[str, str]],
+        settled_by: Optional[str] = None,
     ) -> Set[Tuple[str, str]]:
-        """Which of these `(session_id, turn_id)` pairs already carry a terminal record."""
+        """Which of these `(session_id, turn_id)` pairs already carry a terminal record.
+
+        `settled_by` narrows the answer to endings that one writer wrote; see the DAO.
+        """
 
         raise NotImplementedError

--- a/api/oss/src/core/sessions/records/interfaces.py
+++ b/api/oss/src/core/sessions/records/interfaces.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 from uuid import UUID
 
 from oss.src.core.sessions.records.dtos import (
@@ -46,4 +46,14 @@ class RecordsDAOInterface:
         project_id: UUID,
         session_ids: List[str],
     ) -> Dict[str, SessionMessagePreview]:
+        raise NotImplementedError
+
+    async def settled_turns(
+        self,
+        *,
+        project_id: UUID,
+        keys: Sequence[Tuple[str, str]],
+    ) -> Set[Tuple[str, str]]:
+        """Which of these `(session_id, turn_id)` pairs already carry a terminal record."""
+
         raise NotImplementedError

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -75,7 +75,42 @@ class RecordsService:
             return []
 
         guarded = await self._handle_late_events(events=events)
-        return await self.records_dao.append_many(events=guarded)
+        appended = await self.records_dao.append_many(events=guarded)
+        await self._mark_endings_written(events=guarded)
+        return appended
+
+    async def _mark_endings_written(
+        self,
+        *,
+        events: List[SessionRecordEvent],
+    ) -> None:
+        if self.executions_dao is None or not env.agenta.sessions.durable_stop:
+            return
+
+        endings: Dict[UUID, Set[Tuple[str, str]]] = {}
+        for event in events:
+            if (
+                event.record_type != TERMINAL_RECORD_TYPE
+                or not event.turn_id
+                or event.quarantined_at is not None
+            ):
+                continue
+            endings.setdefault(event.project_id, set()).add(
+                (event.session_id, event.turn_id)
+            )
+
+        for project_id, keys in endings.items():
+            try:
+                await self.executions_dao.mark_endings_written(
+                    project_id=project_id,
+                    keys=sorted(keys),
+                )
+            except Exception:
+                log.warning(
+                    "[RECORDS] Execution ending marker update failed; record remains appended",
+                    project_id=str(project_id),
+                    exc_info=True,
+                )
 
     async def _handle_late_events(
         self,

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -11,6 +11,7 @@ from oss.src.core.sessions.records.dtos import (
     SessionRecordEvent,
 )
 from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
+from oss.src.utils.env import env
 from oss.src.utils.logging import get_module_logger
 
 log = get_module_logger(__name__)
@@ -67,10 +68,10 @@ class RecordsService:
             return []
 
         return await self.records_dao.append_many(
-            events=await self._quarantine_late_events(events=events)
+            events=await self._handle_late_events(events=events)
         )
 
-    async def _quarantine_late_events(
+    async def _handle_late_events(
         self,
         *,
         events: List[SessionRecordEvent],
@@ -147,14 +148,18 @@ class RecordsService:
                 guarded.append(event)
                 continue
 
+            action = env.agenta.sessions.late_output
             log.warning(
-                "[RECORDS] Quarantined a record for a turn the watchdog had already ended",
+                "[RECORDS] %s a record for a turn the watchdog had already ended",
+                "Rejected" if action == "reject" else "Quarantined",
                 project_id=str(event.project_id),
                 session_id=event.session_id,
                 turn_id=event.turn_id,
                 record_type=event.record_type,
                 record_id=str(event.record_id) if event.record_id else None,
             )
+            if action == "reject":
+                continue
             guarded.append(event.model_copy(update={"quarantined_at": now}))
 
         return guarded

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -10,6 +10,7 @@ from oss.src.core.sessions.records.dtos import (
     SessionRecord,
     SessionRecordEvent,
 )
+from oss.src.core.sessions.executions.interfaces import SessionExecutionsDAOInterface
 from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
 from oss.src.utils.env import env
 from oss.src.utils.logging import get_module_logger
@@ -30,8 +31,13 @@ def _written_by_watchdog(event: SessionRecordEvent) -> bool:
 
 
 class RecordsService:
-    def __init__(self, records_dao: RecordsDAOInterface):
+    def __init__(
+        self,
+        records_dao: RecordsDAOInterface,
+        executions_dao: Optional[SessionExecutionsDAOInterface] = None,
+    ):
         self.records_dao = records_dao
+        self.executions_dao = executions_dao
 
     async def append(
         self,
@@ -67,16 +73,34 @@ class RecordsService:
         if not events:
             return []
 
-        return await self.records_dao.append_many(
-            events=await self._handle_late_events(events=events)
-        )
+        guarded = await self._handle_late_events(events=events)
+        records = await self.records_dao.append_many(events=guarded)
+        if self.executions_dao is not None and env.agenta.sessions.durable_stop:
+            terminal: Dict[UUID, Set[Tuple[str, str]]] = {}
+            for event in guarded:
+                if (
+                    event.record_type == TERMINAL_RECORD_TYPE
+                    and event.turn_id
+                    and not _written_by_watchdog(event)
+                    and event.quarantined_at is None
+                ):
+                    terminal.setdefault(event.project_id, set()).add(
+                        (event.session_id, event.turn_id)
+                    )
+            for project_id, keys in terminal.items():
+                await self.executions_dao.close_records(
+                    project_id=project_id,
+                    keys=sorted(keys),
+                    settled_by="runner",
+                )
+        return records
 
     async def _handle_late_events(
         self,
         *,
         events: List[SessionRecordEvent],
     ) -> List[SessionRecordEvent]:
-        """Stamp `quarantined_at` on every event belonging to a watchdog-settled turn.
+        """Stamp `quarantined_at` on every event belonging to a settled turn.
 
         Scoped as narrowly as the invariant allows, in three ways.
 
@@ -98,6 +122,9 @@ class RecordsService:
         A failed lookup quarantines nothing and appends everything. Losing a record is worse
         than showing one that should have been hidden, and the next delivery gets another go.
         """
+        if self.executions_dao is not None and env.agenta.sessions.durable_stop:
+            return await self._handle_by_execution_state(events=events)
+
         candidates: Dict[UUID, Set[Tuple[str, str]]] = {}
         for event in events:
             if not event.turn_id or _written_by_watchdog(event):
@@ -161,6 +188,86 @@ class RecordsService:
             if action == "reject":
                 continue
             guarded.append(event.model_copy(update={"quarantined_at": now}))
+
+        return guarded
+
+    async def _handle_by_execution_state(
+        self,
+        *,
+        events: List[SessionRecordEvent],
+    ) -> List[SessionRecordEvent]:
+        candidates: Dict[UUID, Set[Tuple[str, str]]] = {}
+        for event in events:
+            if event.turn_id:
+                candidates.setdefault(event.project_id, set()).add(
+                    (event.session_id, event.turn_id)
+                )
+
+        if not candidates:
+            return events
+
+        for event in events:
+            if event.record_type != TERMINAL_RECORD_TYPE or not event.turn_id:
+                continue
+            settled_by = "watchdog" if _written_by_watchdog(event) else "runner"
+            attributes = event.attributes or {}
+            stop_reason = str(attributes.get("stopReason") or "").lower()
+            outcome = (
+                "lost"
+                if settled_by == "watchdog"
+                else "stopped"
+                if stop_reason in {"cancelled", "canceled"}
+                else "completed"
+            )
+            await self.executions_dao.settle(
+                project_id=event.project_id,
+                session_id=event.session_id,
+                execution_id=event.turn_id,
+                terminal_outcome=outcome,
+                settled_by=settled_by,
+                settled_at=event.timestamp,
+            )
+
+        settled = {}
+        for project_id, keys in candidates.items():
+            settled[project_id] = await self.executions_dao.query_settled(
+                project_id=project_id,
+                keys=sorted(keys),
+            )
+
+        now = datetime.now(timezone.utc)
+        guarded: List[SessionRecordEvent] = []
+        for event in events:
+            if not event.turn_id:
+                guarded.append(event)
+                continue
+            terminal = settled.get(event.project_id, {}).get(
+                (event.session_id, event.turn_id)
+            )
+            if terminal is None:
+                guarded.append(event)
+                continue
+
+            writer = "watchdog" if _written_by_watchdog(event) else "runner"
+            is_late = terminal.settled_by != writer or (
+                writer == "runner" and terminal.records_closed_at is not None
+            )
+            if not is_late:
+                guarded.append(event)
+                continue
+
+            action = env.agenta.sessions.late_output
+            log.warning(
+                "[RECORDS] %s a record for an execution that is already terminal",
+                "Rejected" if action == "reject" else "Quarantined",
+                project_id=str(event.project_id),
+                session_id=event.session_id,
+                turn_id=event.turn_id,
+                record_type=event.record_type,
+                record_id=str(event.record_id) if event.record_id else None,
+            )
+            if action == "quarantine":
+                guarded.append(event.model_copy(update={"quarantined_at": now}))
 
         return guarded
 

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -10,6 +10,7 @@ from oss.src.core.sessions.records.dtos import (
     SessionRecord,
     SessionRecordEvent,
 )
+from oss.src.core.sessions.executions.dtos import SessionExecutionSettlement
 from oss.src.core.sessions.executions.interfaces import SessionExecutionsDAOInterface
 from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
 from oss.src.utils.env import env
@@ -74,26 +75,7 @@ class RecordsService:
             return []
 
         guarded = await self._handle_late_events(events=events)
-        records = await self.records_dao.append_many(events=guarded)
-        if self.executions_dao is not None and env.agenta.sessions.durable_stop:
-            terminal: Dict[UUID, Set[Tuple[str, str]]] = {}
-            for event in guarded:
-                if (
-                    event.record_type == TERMINAL_RECORD_TYPE
-                    and event.turn_id
-                    and not _written_by_watchdog(event)
-                    and event.quarantined_at is None
-                ):
-                    terminal.setdefault(event.project_id, set()).add(
-                        (event.session_id, event.turn_id)
-                    )
-            for project_id, keys in terminal.items():
-                await self.executions_dao.close_records(
-                    project_id=project_id,
-                    keys=sorted(keys),
-                    settled_by="runner",
-                )
-        return records
+        return await self.records_dao.append_many(events=guarded)
 
     async def _handle_late_events(
         self,
@@ -206,34 +188,20 @@ class RecordsService:
         if not candidates:
             return events
 
-        for event in events:
-            if event.record_type != TERMINAL_RECORD_TYPE or not event.turn_id:
-                continue
-            settled_by = "watchdog" if _written_by_watchdog(event) else "runner"
-            attributes = event.attributes or {}
-            stop_reason = str(attributes.get("stopReason") or "").lower()
-            outcome = (
-                "lost"
-                if settled_by == "watchdog"
-                else "stopped"
-                if stop_reason in {"cancelled", "canceled"}
-                else "completed"
-            )
-            await self.executions_dao.settle(
-                project_id=event.project_id,
-                session_id=event.session_id,
-                execution_id=event.turn_id,
-                terminal_outcome=outcome,
-                settled_by=settled_by,
-                settled_at=event.timestamp,
-            )
-
-        settled = {}
+        settled: Dict[UUID, Dict[Tuple[str, str], SessionExecutionSettlement]] = {}
         for project_id, keys in candidates.items():
-            settled[project_id] = await self.executions_dao.query_settled(
-                project_id=project_id,
-                keys=sorted(keys),
-            )
+            try:
+                settled[project_id] = await self.executions_dao.query_settled(
+                    project_id=project_id,
+                    keys=sorted(keys),
+                )
+            except Exception:
+                log.warning(
+                    "[RECORDS] Terminal execution lookup failed; appending the batch unguarded",
+                    project_id=str(project_id),
+                    exc_info=True,
+                )
+                settled[project_id] = {}
 
         now = datetime.now(timezone.utc)
         guarded: List[SessionRecordEvent] = []
@@ -249,8 +217,9 @@ class RecordsService:
                 continue
 
             writer = "watchdog" if _written_by_watchdog(event) else "runner"
-            is_late = terminal.settled_by != writer or (
-                writer == "runner" and terminal.records_closed_at is not None
+            is_late = terminal.settled_by != writer and terminal.terminal_outcome in (
+                "lost",
+                "stopped",
             )
             if not is_late:
                 guarded.append(event)

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 from uuid import UUID
 
 from oss.src.core.sessions.records.dtos import (
@@ -63,4 +63,19 @@ class RecordsService:
         return await self.records_dao.latest_message_per_session(
             project_id=project_id,
             session_ids=session_ids,
+        )
+
+    async def settled_turns(
+        self,
+        *,
+        project_id: UUID,
+        keys: Sequence[Tuple[str, str]],
+    ) -> Set[Tuple[str, str]]:
+        """One batched lookup for a whole watchdog pass — never one call per candidate."""
+        if not keys:
+            return set()
+
+        return await self.records_dao.settled_turns(
+            project_id=project_id,
+            keys=keys,
         )

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -1,12 +1,31 @@
+from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
 from uuid import UUID
 
 from oss.src.core.sessions.records.dtos import (
+    RECORD_SETTLED_BY_ATTRIBUTE,
+    SETTLED_BY_WATCHDOG,
+    TERMINAL_RECORD_TYPE,
     SessionMessagePreview,
     SessionRecord,
     SessionRecordEvent,
 )
 from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
+from oss.src.utils.logging import get_module_logger
+
+log = get_module_logger(__name__)
+
+
+def _written_by_watchdog(event: SessionRecordEvent) -> bool:
+    """Did the platform write this record, rather than a runner?
+
+    Only the watchdog stamps the marker, and only the platform can: the ingest route builds
+    `SessionRecordEvent` field by field out of the request body and never reads this key off
+    the wire, so a runner cannot present itself as the watchdog to get past the guard below.
+    """
+    return (event.attributes or {}).get(
+        RECORD_SETTLED_BY_ATTRIBUTE
+    ) == SETTLED_BY_WATCHDOG
 
 
 class RecordsService:
@@ -26,7 +45,119 @@ class RecordsService:
         *,
         events: List[SessionRecordEvent],
     ) -> List[SessionRecord]:
-        return await self.records_dao.append_many(events=events)
+        """Append a batch, quarantining anything that arrives after the platform ended its turn.
+
+        RFC "Required behavior / Execution" item 3: after an execution reaches its terminal
+        outcome, later non-terminal output for it is rejected or quarantined. This is where
+        that happens, because ingest is the only place both writers meet.
+
+        The case is real and was caught live. A runner wedges, the watchdog writes the turn's
+        `error` and `done` on its behalf, and the runner then THAWS and submits everything it
+        had buffered — a tool call, its result, a `usage`, and a second `done`. Nothing
+        downstream could refuse it: the runner-side gate in `server.ts` knows only about
+        endings that request wrote itself, and the reader was left with a failure notice
+        followed by the work the agent went on to do.
+
+        Quarantine rather than reject, deliberately. The tail is real work: a late `usage`
+        carries token accounting that is real money, and the tool result is the first thing a
+        support engineer asks for. A dropped record cannot be looked at later; a marked one
+        can, and it is already invisible to every read that rebuilds a transcript.
+        """
+        if not events:
+            return []
+
+        return await self.records_dao.append_many(
+            events=await self._quarantine_late_events(events=events)
+        )
+
+    async def _quarantine_late_events(
+        self,
+        *,
+        events: List[SessionRecordEvent],
+    ) -> List[SessionRecordEvent]:
+        """Stamp `quarantined_at` on every event belonging to a watchdog-settled turn.
+
+        Scoped as narrowly as the invariant allows, in three ways.
+
+        * Only turns the WATCHDOG ended. A turn that reached its own honest ending — an
+          ordinary Stop, a normal completion — is untouched, so the runner's single ending
+          always lands and a `usage` that trails its own `done` through the stream is still
+          ordinary history.
+        * Only records the watchdog did not write. Its own `error` is not a terminal record,
+          so a redelivery of it after its `done` had landed would otherwise quarantine the
+          very ending it belongs to.
+        * Terminal records included. A late `done` is quarantined like the rest of the tail,
+          which is what keeps ONE effective ending: folding it into the watchdog's would
+          rewrite the record the user has already read, and hide that two writers disagreed.
+
+        A batch that carries the watchdog's own `done` settles that turn for the rest of the
+        same batch. Ingest batches up to fifty messages, and the thawed runner's tail can
+        share one with the ending that beat it by a second.
+
+        A failed lookup quarantines nothing and appends everything. Losing a record is worse
+        than showing one that should have been hidden, and the next delivery gets another go.
+        """
+        candidates: Dict[UUID, Set[Tuple[str, str]]] = {}
+        for event in events:
+            if not event.turn_id or _written_by_watchdog(event):
+                continue
+            candidates.setdefault(event.project_id, set()).add(
+                (event.session_id, event.turn_id)
+            )
+
+        if not candidates:
+            return events
+
+        settled: Dict[UUID, Set[Tuple[str, str]]] = {}
+        for project_id, keys in candidates.items():
+            try:
+                settled[project_id] = await self.records_dao.settled_turns(
+                    project_id=project_id,
+                    keys=sorted(keys),
+                    settled_by=SETTLED_BY_WATCHDOG,
+                )
+            except Exception:
+                log.warning(
+                    "[RECORDS] Late-record lookup failed; appending the batch unguarded",
+                    project_id=str(project_id),
+                    exc_info=True,
+                )
+                settled[project_id] = set()
+
+        for event in events:
+            if (
+                _written_by_watchdog(event)
+                and event.record_type == TERMINAL_RECORD_TYPE
+                and event.turn_id
+            ):
+                settled.setdefault(event.project_id, set()).add(
+                    (event.session_id, event.turn_id)
+                )
+
+        now = datetime.now(timezone.utc)
+        guarded: List[SessionRecordEvent] = []
+        for event in events:
+            is_late = (
+                event.turn_id is not None
+                and not _written_by_watchdog(event)
+                and (event.session_id, event.turn_id)
+                in settled.get(event.project_id, set())
+            )
+            if not is_late:
+                guarded.append(event)
+                continue
+
+            log.warning(
+                "[RECORDS] Quarantined a record for a turn the watchdog had already ended",
+                project_id=str(event.project_id),
+                session_id=event.session_id,
+                turn_id=event.turn_id,
+                record_type=event.record_type,
+                record_id=str(event.record_id) if event.record_id else None,
+            )
+            guarded.append(event.model_copy(update={"quarantined_at": now}))
+
+        return guarded
 
     async def get_records(
         self,
@@ -70,6 +201,7 @@ class RecordsService:
         *,
         project_id: UUID,
         keys: Sequence[Tuple[str, str]],
+        settled_by: Optional[str] = None,
     ) -> Set[Tuple[str, str]]:
         """One batched lookup for a whole watchdog pass — never one call per candidate."""
         if not keys:
@@ -78,4 +210,5 @@ class RecordsService:
         return await self.records_dao.settled_turns(
             project_id=project_id,
             keys=keys,
+            settled_by=settled_by,
         )

--- a/api/oss/src/core/sessions/streams/dtos.py
+++ b/api/oss/src/core/sessions/streams/dtos.py
@@ -80,6 +80,10 @@ class SessionStreamEdit(Header):
     tags: Optional[Dict[str, Any]] = None
     meta: Optional[Dict[str, Any]] = None
     turn_id: Optional[str] = None
+    # Internal heartbeat fence. When present, the DAO updates only this still-current,
+    # non-terminal execution generation. Excluded from serialization because it is a write
+    # precondition, not stream state.
+    expected_turn_id: Optional[str] = Field(default=None, exclude=True)
 
 
 class SessionStreamHeaderEdit(Header):

--- a/api/oss/src/core/sessions/streams/dtos.py
+++ b/api/oss/src/core/sessions/streams/dtos.py
@@ -148,7 +148,14 @@ class SessionStreamCommandRequest(BaseModel):
     data: Optional[WorkflowServiceRequestData] = None
     force: bool = False
     detached: bool = False  # fire-and-forget mode
-    expected_execution_id: Optional[str] = None
+    # A stale-request guard for cancel mode only; send, steer, and attach ignore it.
+    expected_execution_id: Optional[str] = Field(
+        default=None,
+        description=(
+            "Optional stale-request guard honored only in cancel mode; ignored for send, "
+            "steer, and attach."
+        ),
+    )
 
     @field_validator("expected_execution_id")
     @classmethod

--- a/api/oss/src/core/sessions/streams/interfaces.py
+++ b/api/oss/src/core/sessions/streams/interfaces.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import List, Optional
+from typing import Any, List, Optional
 from uuid import UUID
 
 from oss.src.core.sessions.streams.dtos import (
@@ -16,6 +16,18 @@ from oss.src.core.shared.dtos import Windowing
 
 
 class SessionStreamsDAOInterface(ABC):
+    @abstractmethod
+    async def settle_command(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        turn_id: Optional[str],
+        mirror_stopped: bool,
+        transaction: Optional[Any] = None,
+    ) -> None:
+        """Clear this command's marker and project its stopped state."""
+
     @abstractmethod
     async def create(
         self,

--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -504,6 +504,85 @@ class SessionStreamsService:
             session_id=session_id,
         )
 
+    async def _reclaim_affinity_from_a_departed_replica(
+        self,
+        *,
+        project_id: UUID,
+        request: SessionHeartbeatRequest,
+        incumbent: str,
+    ) -> str:
+        """Take `owner:session:<id>` from a replica that holds no running turn on it.
+
+        `owner` exists to say which box is SERVING the session, and only an in-flight turn's
+        heartbeat ever refreshes it. So a claim held by a replica with no running turn is not
+        protecting anything: it is the residue of a runner that stopped beating. A runner that
+        dies without a graceful shutdown (SIGKILL, OOM, a crashed node, `docker restart -t 0`)
+        always leaves exactly that, because nothing releases the key on its way out and
+        `claim_owner` never steals. The replacement replica then loses every beat for the rest
+        of OWNER_TTL_SECONDS, and the runner reads that refusal as "another turn owns this
+        session" and refuses the user's next message for two minutes.
+
+        `running` is the discriminator, the same one the alive-lock handover below uses. A live
+        turn holds it under its own id for the whole turn and re-arms it every beat, so a
+        replica that is genuinely serving the session can never be mistaken for a departed one.
+        A `running` lock held by the CALLER's own turn is not an obstacle: `_start_turn` arms
+        alive and running before the runner's first beat, so an API-minted turn legitimately
+        arrives here with its own lock already in place.
+
+        Only the beat of a real, running turn may reclaim. A turn-end beat asserts nothing
+        about who should serve the session next, and a beat with no turn id proves no work.
+
+        KNOWN LIMIT. A turn parked awaiting an approval also holds `alive` with no `running`,
+        so on a MULTI-replica deployment a second replica can take affinity from a live first
+        one and the handover below then tombstones the parked turn, killing the pending
+        approval. That outcome is not new: nothing refreshes `owner` on a parked session, so the
+        key expires after OWNER_TTL_SECONDS and the same handover follows. This only makes it up
+        to that TTL sooner, and only on a topology the direct control adapter cannot route to
+        anyway (`core/sessions/commands/service.py`). On a single replica the caller already
+        equals the owner and this method is never entered.
+
+        Returns the owner after the attempt: the caller when the reclaim landed, otherwise
+        whoever holds the key, which is what the refusal above must report.
+        """
+        if not (request.turn_id and request.is_running):
+            return incumbent
+
+        running_owner = await get_running_owner(
+            self._lock,
+            project_id=str(project_id),
+            session_id=request.session_id,
+        )
+        if running_owner is not None and running_owner != request.turn_id:
+            return incumbent
+
+        # Release-if-owner, then the ordinary non-stealing claim. Two atomic steps rather than
+        # one so no new script is needed, and the gap is safe in both directions: a concurrent
+        # claim by a third replica makes the release a no-op and the claim below returns that
+        # replica, so this path can never hand the session to the wrong caller.
+        await clear_owner(
+            self._lock,
+            project_id=str(project_id),
+            session_id=request.session_id,
+            replica_id=incumbent,
+        )
+        owner = await claim_owner(
+            self._lock,
+            project_id=str(project_id),
+            session_id=request.session_id,
+            replica_id=request.replica_id,
+        )
+        if owner == request.replica_id:
+            log.info(
+                "sessions: reclaimed session affinity from a replica with no running turn",
+                extra={
+                    "session_id": request.session_id,
+                    "departed_replica_id": incumbent,
+                    "replica_id": request.replica_id,
+                    "turn_id": request.turn_id,
+                },
+            )
+        return owner
+
     async def heartbeat(
         self,
         *,
@@ -605,6 +684,15 @@ class SessionStreamsService:
             session_id=request.session_id,
             replica_id=request.replica_id,
         )
+        # A different replica holds affinity. That claim is worth honouring only while it
+        # protects a turn, so before refusing, check whether it still protects one.
+        if owner != request.replica_id:
+            owner = await self._reclaim_affinity_from_a_departed_replica(
+                project_id=project_id,
+                request=request,
+                incumbent=owner,
+            )
+
         # A replica that lost the claim owns nothing here: mutating the nest would let it
         # overwrite the winner's turn locks and stream row. Report the true owner and stop.
         if owner != request.replica_id:

--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -570,6 +570,7 @@ class SessionStreamsService:
             project_id=str(project_id),
             session_id=request.session_id,
             replica_id=request.replica_id,
+            turn_id=request.turn_id,
         )
         if owner == request.replica_id:
             log.info(
@@ -683,6 +684,7 @@ class SessionStreamsService:
             project_id=str(project_id),
             session_id=request.session_id,
             replica_id=request.replica_id,
+            turn_id=request.turn_id,
         )
         # A different replica holds affinity. That claim is worth honouring only while it
         # protects a turn, so before refusing, check whether it still protects one.

--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -920,8 +920,21 @@ class SessionStreamsService:
                 project_id=project_id,
                 user_id=None,
                 session_id=request.session_id,
-                stream=SessionStreamEdit(flags=flags, turn_id=durable_turn_id),
+                stream=SessionStreamEdit(
+                    flags=flags,
+                    turn_id=durable_turn_id,
+                    expected_turn_id=request.turn_id if turn_was_established else None,
+                ),
             )
+            if stream is None and turn_was_established:
+                # The guarded row write lost to settlement or to a new generation. Redis may
+                # already have been refreshed, but this beat no longer owns durable state and
+                # must tell the runner to stop.
+                is_current_turn = False
+                stream = await self._dao.get_by_session_id(
+                    project_id=project_id,
+                    session_id=request.session_id,
+                )
 
         # `running` lifecycle for the path that actually runs turns. `_start_turn` publishes it
         # for send/steer, but the runner mints its own turn id and only ever heartbeats, so

--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -295,12 +295,30 @@ class SessionStreamsService:
                 entity="session",
                 id=session_id,
             )
+
         except Exception:
             log.warning(
                 "[WATCH] session change publish failed",
                 project_id=str(project_id),
                 session_id=session_id,
             )
+
+    async def settle_command(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        turn_id: Optional[str],
+        mirror_stopped: bool,
+        transaction: Optional[Any] = None,
+    ) -> None:
+        await self._dao.settle_command(
+            project_id=project_id,
+            session_id=session_id,
+            turn_id=turn_id,
+            mirror_stopped=mirror_stopped,
+            transaction=transaction,
+        )
 
     async def command(
         self,

--- a/api/oss/src/core/sessions/streams/service.py
+++ b/api/oss/src/core/sessions/streams/service.py
@@ -23,6 +23,7 @@ from oss.src.dbs.redis.sessions.contract import (
     CONCURRENCY_LIMIT,
     WATCH_LIFECYCLE_ENDED,
     WATCH_LIFECYCLE_RUNNING,
+    owner_replica_id,
     validate_session_id as _validate_session_id_fn,
 )
 from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterface
@@ -30,6 +31,7 @@ from oss.src.dbs.redis.sessions.locks import (
     acquire_alive,
     acquire_running,
     claim_owner,
+    claim_owner_value,
     clear_owner,
     clear_running,
     release_running,
@@ -45,6 +47,7 @@ from oss.src.dbs.redis.sessions.locks import (
     refresh_running,
     release_alive,
     release_attached,
+    release_owner_value,
     steal_attached,
 )
 
@@ -509,7 +512,7 @@ class SessionStreamsService:
         *,
         project_id: UUID,
         request: SessionHeartbeatRequest,
-        incumbent: str,
+        incumbent_value: str,
     ) -> str:
         """Take `owner:session:<id>` from a replica that holds no running turn on it.
 
@@ -544,6 +547,7 @@ class SessionStreamsService:
         Returns the owner after the attempt: the caller when the reclaim landed, otherwise
         whoever holds the key, which is what the refusal above must report.
         """
+        incumbent = owner_replica_id(incumbent_value)
         if not (request.turn_id and request.is_running):
             return incumbent
 
@@ -559,11 +563,11 @@ class SessionStreamsService:
         # one so no new script is needed, and the gap is safe in both directions: a concurrent
         # claim by a third replica makes the release a no-op and the claim below returns that
         # replica, so this path can never hand the session to the wrong caller.
-        await clear_owner(
+        await release_owner_value(
             self._lock,
             project_id=str(project_id),
             session_id=request.session_id,
-            replica_id=incumbent,
+            owner_value=incumbent_value,
         )
         owner = await claim_owner(
             self._lock,
@@ -679,20 +683,21 @@ class SessionStreamsService:
         # replica_id claims affinity without stealing from a live different owner; turn_id
         # separately refreshes the alive/running TTLs. `owner` is the actual winner (this
         # replica if it won or already held it, another replica otherwise).
-        owner = await claim_owner(
+        owner_value = await claim_owner_value(
             self._lock,
             project_id=str(project_id),
             session_id=request.session_id,
             replica_id=request.replica_id,
             turn_id=request.turn_id,
         )
+        owner = owner_replica_id(owner_value)
         # A different replica holds affinity. That claim is worth honouring only while it
         # protects a turn, so before refusing, check whether it still protects one.
         if owner != request.replica_id:
             owner = await self._reclaim_affinity_from_a_departed_replica(
                 project_id=project_id,
                 request=request,
-                incumbent=owner,
+                incumbent_value=owner_value,
             )
 
         # A replica that lost the claim owns nothing here: mutating the nest would let it

--- a/api/oss/src/dbs/postgres/sessions/commands/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/commands/dao.py
@@ -275,6 +275,9 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
 
         None means somebody else already took or settled it, which is not an error: the runner
         that answered will still report, and the outcome route decides on the stored state.
+        The delivery budget was already consumed by `record_delivery_attempt`; incrementing it
+        again here would charge one direct delivery twice. Long-poll claims use `claim_commands`,
+        which performs its own increment.
         """
         async with self.engine.session() as session:
             now = datetime.now(timezone.utc)

--- a/api/oss/src/dbs/postgres/sessions/commands/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/commands/dao.py
@@ -286,11 +286,45 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
                     state=SessionCommandState.claimed.value,
                     claimed_by=replica_id,
                     claim_expires_at=now + timedelta(seconds=lease_seconds),
-                    claim_count=SessionCommandDBE.claim_count + 1,
                     updated_at=now,
                 )
                 .returning(SessionCommandDBE)
             )
+            result = await session.execute(stmt)
+            dbe = result.scalar_one_or_none()
+            await session.commit()
+        return map_command_dbe_to_dto(dbe) if dbe is not None else None
+
+    async def record_delivery_attempt(
+        self,
+        *,
+        project_id: UUID,
+        command_id: UUID,
+        now: datetime,
+        max_deliveries: int,
+    ) -> Optional[SessionCommand]:
+        stmt = (
+            sa_update(SessionCommandDBE)
+            .where(
+                SessionCommandDBE.project_id == project_id,
+                SessionCommandDBE.id == command_id,
+                SessionCommandDBE.state.in_(_OPEN_STATES),
+                SessionCommandDBE.claim_count < max_deliveries,
+                or_(
+                    SessionCommandDBE.state == SessionCommandState.pending.value,
+                    SessionCommandDBE.claim_expires_at < now,
+                ),
+            )
+            .values(
+                state=SessionCommandState.pending.value,
+                claimed_by=None,
+                claim_expires_at=None,
+                claim_count=SessionCommandDBE.claim_count + 1,
+                updated_at=now,
+            )
+            .returning(SessionCommandDBE)
+        )
+        async with self.engine.session() as session:
             result = await session.execute(stmt)
             dbe = result.scalar_one_or_none()
             await session.commit()
@@ -367,17 +401,38 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
         *,
         now: datetime,
         max_deliveries: int,
+        pending_before: Optional[datetime] = None,
     ) -> List[SessionCommand]:
         async with self.engine.session() as session:
+            abandoned = and_(
+                SessionCommandDBE.state == SessionCommandState.claimed.value,
+                SessionCommandDBE.claim_expires_at < now,
+            )
+            if pending_before is not None:
+                abandoned = or_(
+                    abandoned,
+                    and_(
+                        SessionCommandDBE.state == SessionCommandState.pending.value,
+                        func.coalesce(
+                            SessionCommandDBE.updated_at,
+                            SessionCommandDBE.created_at,
+                        )
+                        < pending_before,
+                    ),
+                )
             stmt = (
                 select(SessionCommandDBE)
                 .where(
-                    SessionCommandDBE.state == SessionCommandState.claimed.value,
                     SessionCommandDBE.deleted_at.is_(None),
-                    SessionCommandDBE.claim_expires_at < now,
-                    SessionCommandDBE.claim_count < max_deliveries,
+                    abandoned,
                 )
-                .order_by(SessionCommandDBE.claim_expires_at)
+                .order_by(
+                    func.coalesce(
+                        SessionCommandDBE.claim_expires_at,
+                        SessionCommandDBE.updated_at,
+                        SessionCommandDBE.created_at,
+                    )
+                )
                 .limit(200)
             )
             result = await session.execute(stmt)

--- a/api/oss/src/dbs/postgres/sessions/commands/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/commands/dao.py
@@ -7,11 +7,13 @@ write a terminal outcome, and it is the same pattern
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import Any, List, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 
 from sqlalchemy import and_, func, or_, select, update as sa_update
 from sqlalchemy.exc import IntegrityError
+
+from oss.src.utils.logging import get_module_logger
 
 from oss.src.core.sessions.commands.dtos import (
     SessionCommand,
@@ -36,7 +38,40 @@ from oss.src.dbs.postgres.shared.engine import (
     get_transactions_engine,
 )
 
+log = get_module_logger(__name__)
+
 _OPEN_STATES = (SessionCommandState.pending.value, SessionCommandState.claimed.value)
+
+
+def _map_settle_candidates(rows: List[SessionCommandDBE]) -> List[SessionCommand]:
+    """Map an abandoned-command batch to DTOs, skipping any row this API cannot map.
+
+    A newer API replica can write a command `kind` (or state, or outcome) an older replica's
+    enums do not know; `map_command_dbe_to_dto` then raises `ValueError` on that row. The
+    watchdog reads the whole abandoned batch before it settles any of it, so one such row used
+    to poison the entire pass -- the ValueError escaped the list comprehension and no command
+    was ever settled. Skip the rows this API cannot act on, warn once per pass with their kinds
+    and count, and settle the rest. The unknown row is left untouched for a replica that knows
+    its kind; this never changes the enum or the write path.
+    """
+    mapped: List[SessionCommand] = []
+    skipped: Dict[str, int] = {}
+    for dbe in rows:
+        try:
+            mapped.append(map_command_dbe_to_dto(dbe))
+        except ValueError:
+            kind = str(dbe.kind)
+            skipped[kind] = skipped.get(kind, 0) + 1
+    if skipped:
+        by_kind = ", ".join(
+            f"{kind}={count}" for kind, count in sorted(skipped.items())
+        )
+        log.warning(
+            "commands: skipped %d abandoned row(s) this API cannot map (by kind: %s)",
+            sum(skipped.values()),
+            by_kind,
+        )
+    return mapped
 
 
 class SessionCommandsDAO(SessionCommandsDAOInterface):
@@ -449,7 +484,7 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
             )
             result = await session.execute(stmt)
             rows = result.scalars().all()
-        return [map_command_dbe_to_dto(dbe) for dbe in rows]
+        return _map_settle_candidates(rows)
 
     async def count_open(self, *, project_id: UUID, session_id: str) -> int:
         """Open commands for a session. Diagnostics and tests only."""

--- a/api/oss/src/dbs/postgres/sessions/commands/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/commands/dao.py
@@ -43,16 +43,21 @@ log = get_module_logger(__name__)
 _OPEN_STATES = (SessionCommandState.pending.value, SessionCommandState.claimed.value)
 
 
-def _map_settle_candidates(rows: List[SessionCommandDBE]) -> List[SessionCommand]:
-    """Map an abandoned-command batch to DTOs, skipping any row this API cannot map.
+def _map_commands_skipping_unmappable(
+    rows: List[SessionCommandDBE],
+    *,
+    context: str,
+) -> List[SessionCommand]:
+    """Map a batch of command rows to DTOs, skipping any row this API cannot map.
 
     A newer API replica can write a command `kind` (or state, or outcome) an older replica's
-    enums do not know; `map_command_dbe_to_dto` then raises `ValueError` on that row. The
-    watchdog reads the whole abandoned batch before it settles any of it, so one such row used
-    to poison the entire pass -- the ValueError escaped the list comprehension and no command
-    was ever settled. Skip the rows this API cannot act on, warn once per pass with their kinds
-    and count, and settle the rest. The unknown row is left untouched for a replica that knows
-    its kind; this never changes the enum or the write path.
+    enums do not know; `map_command_dbe_to_dto` then raises `ValueError` on that row. Both the
+    abandoned-command sweep and a runner's claim read a whole batch before acting on any of it,
+    so one such row used to poison the entire batch -- the ValueError escaped the list
+    comprehension and nothing was settled or claimed. Skip the rows this API cannot act on,
+    warn once per batch with their kinds and count, and return the rest. The unknown row is
+    left untouched for a replica that knows its kind; this never changes the enum or the write
+    path. `context` names the batch in the warning (for example "abandoned" or "claimed").
     """
     mapped: List[SessionCommand] = []
     skipped: Dict[str, int] = {}
@@ -67,8 +72,9 @@ def _map_settle_candidates(rows: List[SessionCommandDBE]) -> List[SessionCommand
             f"{kind}={count}" for kind, count in sorted(skipped.items())
         )
         log.warning(
-            "commands: skipped %d abandoned row(s) this API cannot map (by kind: %s)",
+            "commands: skipped %d %s row(s) this API cannot map (by kind: %s)",
             sum(skipped.values()),
+            context,
             by_kind,
         )
     return mapped
@@ -296,7 +302,7 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
             )
             claimed = (await session.execute(stmt)).scalars().all()
             await session.commit()
-        return [map_command_dbe_to_dto(dbe) for dbe in claimed]
+        return _map_commands_skipping_unmappable(claimed, context="claimed")
 
     async def claim_for_delivery(
         self,
@@ -484,7 +490,7 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
             )
             result = await session.execute(stmt)
             rows = result.scalars().all()
-        return _map_settle_candidates(rows)
+        return _map_commands_skipping_unmappable(rows, context="abandoned")
 
     async def count_open(self, *, project_id: UUID, session_id: str) -> int:
         """Open commands for a session. Diagnostics and tests only."""

--- a/api/oss/src/dbs/postgres/sessions/commands/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/commands/dao.py
@@ -7,7 +7,7 @@ write a terminal outcome, and it is the same pattern
 """
 
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import Any, List, Optional
 from uuid import UUID
 
 from sqlalchemy import and_, func, or_, select, update as sa_update
@@ -44,6 +44,9 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
         if engine is None:
             engine = get_transactions_engine()
         self.engine = engine
+
+    def transaction(self):
+        return self.engine.session()
 
     async def create_command(
         self,
@@ -334,6 +337,7 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
         self,
         *,
         settle: SessionCommandSettle,
+        transaction: Optional[Any] = None,
     ) -> Optional[SessionCommand]:
         """Terminal transition. None means the command was in none of the states the caller
         expected, so the caller reads the stored row and answers 409 instead of letting a runner
@@ -343,7 +347,8 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
         first and updating after would reopen the very race this exists to close: the claim can
         commit between the read and the write.
         """
-        async with self.engine.session() as session:
+
+        async def execute(session: Any) -> Optional[SessionCommand]:
             now = datetime.now(timezone.utc)
             stmt = sa_update(SessionCommandDBE).where(
                 SessionCommandDBE.project_id == settle.project_id,
@@ -370,8 +375,12 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
             ).returning(SessionCommandDBE)
             result = await session.execute(stmt)
             dbe = result.scalar_one_or_none()
-            await session.commit()
-        return map_command_dbe_to_dto(dbe) if dbe is not None else None
+            return map_command_dbe_to_dto(dbe) if dbe is not None else None
+
+        if transaction is not None:
+            return await execute(transaction)
+        async with self.engine.session() as session:
+            return await execute(session)
 
     async def clear_stopping_turn(
         self,

--- a/api/oss/src/dbs/postgres/sessions/executions/__init__.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/__init__.py
@@ -1,0 +1,1 @@
+"""Postgres execution terminal-state storage."""

--- a/api/oss/src/dbs/postgres/sessions/executions/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/dao.py
@@ -2,7 +2,7 @@ from datetime import datetime, timezone
 from typing import Any, Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 
-from sqlalchemy import and_, literal_column, or_, select, update as sa_update
+from sqlalchemy import and_, literal_column, or_, select, tuple_, update as sa_update
 from sqlalchemy.dialects.postgresql import insert
 
 from oss.src.core.sessions.executions.dtos import (
@@ -25,6 +25,7 @@ def _to_dto(row: SessionExecutionDBE) -> SessionExecutionSettlement:
         terminal_outcome=row.terminal_outcome,
         settled_by=row.settled_by,
         settled_at=row.settled_at,
+        ending_written_at=row.ending_written_at,
         redis_reconciled_at=row.redis_reconciled_at,
     )
 
@@ -101,6 +102,29 @@ class SessionExecutionsDAO(SessionExecutionsDAOInterface):
                 )
             ).scalars()
             return {(row.session_id, row.execution_id): _to_dto(row) for row in rows}
+
+    async def mark_endings_written(
+        self,
+        *,
+        project_id: UUID,
+        keys: Sequence[Tuple[str, str]],
+        written_at: Optional[datetime] = None,
+    ) -> None:
+        if not keys:
+            return
+        async with self.engine.session() as session:
+            await session.execute(
+                sa_update(SessionExecutionDBE)
+                .where(
+                    SessionExecutionDBE.project_id == project_id,
+                    tuple_(
+                        SessionExecutionDBE.session_id,
+                        SessionExecutionDBE.execution_id,
+                    ).in_(keys),
+                    SessionExecutionDBE.ending_written_at.is_(None),
+                )
+                .values(ending_written_at=written_at or datetime.now(timezone.utc))
+            )
 
     async def list_redis_unreconciled(
         self,

--- a/api/oss/src/dbs/postgres/sessions/executions/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/dao.py
@@ -1,0 +1,137 @@
+from datetime import datetime, timezone
+from typing import Dict, Optional, Sequence, Tuple
+from uuid import UUID
+
+from sqlalchemy import and_, or_, select, update as sa_update
+from sqlalchemy.dialects.postgresql import insert
+
+from oss.src.core.sessions.executions.dtos import (
+    SessionExecutionSettlement,
+    SessionExecutionSettlementResult,
+)
+from oss.src.core.sessions.executions.interfaces import SessionExecutionsDAOInterface
+from oss.src.dbs.postgres.sessions.executions.dbes import SessionExecutionDBE
+from oss.src.dbs.postgres.shared.engine import (
+    TransactionsEngine,
+    get_transactions_engine,
+)
+
+
+def _to_dto(row: SessionExecutionDBE) -> SessionExecutionSettlement:
+    return SessionExecutionSettlement(
+        project_id=row.project_id,
+        session_id=row.session_id,
+        execution_id=row.execution_id,
+        terminal_outcome=row.terminal_outcome,
+        settled_by=row.settled_by,
+        settled_at=row.settled_at,
+        records_closed_at=row.records_closed_at,
+    )
+
+
+class SessionExecutionsDAO(SessionExecutionsDAOInterface):
+    def __init__(self, engine: Optional[TransactionsEngine] = None):
+        self.engine = engine or get_transactions_engine()
+
+    async def settle(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        execution_id: str,
+        terminal_outcome: str,
+        settled_by: str,
+        settled_at: Optional[datetime] = None,
+    ) -> SessionExecutionSettlementResult:
+        settled_at = settled_at or datetime.now(timezone.utc)
+        stmt = (
+            insert(SessionExecutionDBE)
+            .values(
+                project_id=project_id,
+                session_id=session_id,
+                execution_id=execution_id,
+                terminal_outcome=terminal_outcome,
+                settled_by=settled_by,
+                settled_at=settled_at,
+            )
+            .on_conflict_do_nothing(
+                index_elements=["project_id", "session_id", "execution_id"]
+            )
+            .returning(SessionExecutionDBE)
+        )
+        async with self.engine.session() as session:
+            inserted = (await session.execute(stmt)).scalar_one_or_none()
+            if inserted is not None:
+                return SessionExecutionSettlementResult(
+                    settlement=_to_dto(inserted), won=True
+                )
+            stored = (
+                await session.execute(
+                    select(SessionExecutionDBE).where(
+                        SessionExecutionDBE.project_id == project_id,
+                        SessionExecutionDBE.session_id == session_id,
+                        SessionExecutionDBE.execution_id == execution_id,
+                    )
+                )
+            ).scalar_one()
+            return SessionExecutionSettlementResult(
+                settlement=_to_dto(stored), won=False
+            )
+
+    async def query_settled(
+        self,
+        *,
+        project_id: UUID,
+        keys: Sequence[Tuple[str, str]],
+    ) -> Dict[Tuple[str, str], SessionExecutionSettlement]:
+        if not keys:
+            return {}
+        key_filter = or_(
+            *[
+                and_(
+                    SessionExecutionDBE.session_id == session_id,
+                    SessionExecutionDBE.execution_id == execution_id,
+                )
+                for session_id, execution_id in keys
+            ]
+        )
+        async with self.engine.session() as session:
+            rows = (
+                await session.execute(
+                    select(SessionExecutionDBE).where(
+                        SessionExecutionDBE.project_id == project_id,
+                        key_filter,
+                    )
+                )
+            ).scalars()
+            return {(row.session_id, row.execution_id): _to_dto(row) for row in rows}
+
+    async def close_records(
+        self,
+        *,
+        project_id: UUID,
+        keys: Sequence[Tuple[str, str]],
+        settled_by: str,
+    ) -> None:
+        if not keys:
+            return
+        key_filter = or_(
+            *[
+                and_(
+                    SessionExecutionDBE.session_id == session_id,
+                    SessionExecutionDBE.execution_id == execution_id,
+                )
+                for session_id, execution_id in keys
+            ]
+        )
+        async with self.engine.session() as session:
+            await session.execute(
+                sa_update(SessionExecutionDBE)
+                .where(
+                    SessionExecutionDBE.project_id == project_id,
+                    SessionExecutionDBE.settled_by == settled_by,
+                    SessionExecutionDBE.records_closed_at.is_(None),
+                    key_filter,
+                )
+                .values(records_closed_at=datetime.now(timezone.utc))
+            )

--- a/api/oss/src/dbs/postgres/sessions/executions/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/dao.py
@@ -1,16 +1,21 @@
 from datetime import datetime, timezone
-from typing import Dict, Optional, Sequence, Tuple
+from typing import Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 
-from sqlalchemy import and_, or_, select, update as sa_update
-from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy import and_, cast, func, or_, select, update as sa_update
+from sqlalchemy.dialects.postgresql import JSONB, insert
 
+from oss.src.core.sessions.commands.dtos import SessionCommand, SessionCommandSettle
 from oss.src.core.sessions.executions.dtos import (
     SessionExecutionSettlement,
     SessionExecutionSettlementResult,
 )
 from oss.src.core.sessions.executions.interfaces import SessionExecutionsDAOInterface
+from oss.src.dbs.postgres.sessions.commands.dbes import SessionCommandDBE
+from oss.src.dbs.postgres.sessions.commands.mappings import map_command_dbe_to_dto
 from oss.src.dbs.postgres.sessions.executions.dbes import SessionExecutionDBE
+from oss.src.dbs.postgres.sessions.interactions.dbes import SessionInteractionDBE
+from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.dbs.postgres.shared.engine import (
     TransactionsEngine,
     get_transactions_engine,
@@ -26,6 +31,7 @@ def _to_dto(row: SessionExecutionDBE) -> SessionExecutionSettlement:
         settled_by=row.settled_by,
         settled_at=row.settled_at,
         records_closed_at=row.records_closed_at,
+        redis_reconciled_at=row.redis_reconciled_at,
     )
 
 
@@ -134,4 +140,148 @@ class SessionExecutionsDAO(SessionExecutionsDAOInterface):
                     key_filter,
                 )
                 .values(records_closed_at=datetime.now(timezone.utc))
+            )
+
+    async def settle_command_execution(
+        self,
+        *,
+        settle: SessionCommandSettle,
+        session_id: str,
+        execution_id: Optional[str],
+        terminal_outcome: Optional[str],
+        settled_by: Optional[str],
+        mirror_stopped: bool,
+        cancel_interactions: bool,
+    ) -> Optional[SessionCommand]:
+        now = datetime.now(timezone.utc)
+        async with self.engine.session() as session:
+            if execution_id and terminal_outcome and settled_by:
+                execution_stmt = (
+                    insert(SessionExecutionDBE)
+                    .values(
+                        project_id=settle.project_id,
+                        session_id=session_id,
+                        execution_id=execution_id,
+                        terminal_outcome=terminal_outcome,
+                        settled_by=settled_by,
+                        settled_at=now,
+                    )
+                    .on_conflict_do_nothing(
+                        index_elements=["project_id", "session_id", "execution_id"]
+                    )
+                    .returning(SessionExecutionDBE)
+                )
+                inserted = (await session.execute(execution_stmt)).scalar_one_or_none()
+                if inserted is None:
+                    stored = (
+                        await session.execute(
+                            select(SessionExecutionDBE).where(
+                                SessionExecutionDBE.project_id == settle.project_id,
+                                SessionExecutionDBE.session_id == session_id,
+                                SessionExecutionDBE.execution_id == execution_id,
+                            )
+                        )
+                    ).scalar_one()
+                    if (
+                        stored.terminal_outcome != terminal_outcome
+                        or stored.settled_by != settled_by
+                    ):
+                        await session.rollback()
+                        return None
+
+            command_stmt = sa_update(SessionCommandDBE).where(
+                SessionCommandDBE.project_id == settle.project_id,
+                SessionCommandDBE.id == settle.command_id,
+                SessionCommandDBE.state.in_(
+                    [state.value for state in settle.expected_states]
+                ),
+            )
+            if settle.replica_id is not None:
+                command_stmt = command_stmt.where(
+                    or_(
+                        SessionCommandDBE.claimed_by.is_(None),
+                        SessionCommandDBE.claimed_by == settle.replica_id,
+                    )
+                )
+            command_stmt = command_stmt.values(
+                state=settle.state.value,
+                outcome=settle.outcome.value,
+                settled_at=now,
+                updated_at=now,
+            ).returning(SessionCommandDBE)
+            command = (await session.execute(command_stmt)).scalar_one_or_none()
+            if command is None:
+                await session.rollback()
+                return None
+
+            stream_values = {"stopping_turn_id": None, "updated_at": now}
+            if mirror_stopped:
+                stream_values["flags"] = func.coalesce(
+                    SessionStreamDBE.flags, cast({}, JSONB)
+                ).op("||")(cast({"is_running": False, "is_attached": False}, JSONB))
+            stream_stmt = sa_update(SessionStreamDBE).where(
+                SessionStreamDBE.project_id == settle.project_id,
+                SessionStreamDBE.session_id == session_id,
+            )
+            if execution_id is not None:
+                stream_stmt = stream_stmt.where(
+                    or_(
+                        SessionStreamDBE.stopping_turn_id == execution_id,
+                        SessionStreamDBE.stopping_turn_id.is_(None),
+                    )
+                )
+            await session.execute(stream_stmt.values(**stream_values))
+
+            if cancel_interactions and execution_id is not None:
+                await session.execute(
+                    sa_update(SessionInteractionDBE)
+                    .where(
+                        SessionInteractionDBE.project_id == settle.project_id,
+                        SessionInteractionDBE.session_id == session_id,
+                        SessionInteractionDBE.turn_id == execution_id,
+                        SessionInteractionDBE.status == "pending",
+                    )
+                    .values(status="cancelled", updated_at=now)
+                )
+
+            await session.commit()
+            return map_command_dbe_to_dto(command)
+
+    async def list_redis_unreconciled(
+        self,
+        *,
+        limit: int,
+    ) -> List[SessionExecutionSettlement]:
+        async with self.engine.session() as session:
+            rows = (
+                await session.execute(
+                    select(SessionExecutionDBE)
+                    .where(
+                        SessionExecutionDBE.settled_by == "runner",
+                        SessionExecutionDBE.terminal_outcome == "stopped",
+                        SessionExecutionDBE.redis_reconciled_at.is_(None),
+                    )
+                    .order_by(SessionExecutionDBE.settled_at)
+                    .limit(limit)
+                )
+            ).scalars()
+            return [_to_dto(row) for row in rows]
+
+    async def mark_redis_reconciled(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        execution_id: str,
+    ) -> None:
+        async with self.engine.session() as session:
+            await session.execute(
+                sa_update(SessionExecutionDBE)
+                .where(
+                    SessionExecutionDBE.project_id == project_id,
+                    SessionExecutionDBE.session_id == session_id,
+                    SessionExecutionDBE.execution_id == execution_id,
+                    SessionExecutionDBE.redis_reconciled_at.is_(None),
+                )
+                .values(redis_reconciled_at=datetime.now(timezone.utc))
             )

--- a/api/oss/src/dbs/postgres/sessions/executions/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/dao.py
@@ -25,7 +25,6 @@ def _to_dto(row: SessionExecutionDBE) -> SessionExecutionSettlement:
         terminal_outcome=row.terminal_outcome,
         settled_by=row.settled_by,
         settled_at=row.settled_at,
-        records_closed_at=row.records_closed_at,
         redis_reconciled_at=row.redis_reconciled_at,
     )
 

--- a/api/oss/src/dbs/postgres/sessions/executions/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/dao.py
@@ -1,21 +1,16 @@
 from datetime import datetime, timezone
-from typing import Dict, List, Optional, Sequence, Tuple
+from typing import Any, Dict, List, Optional, Sequence, Tuple
 from uuid import UUID
 
-from sqlalchemy import and_, cast, func, or_, select, update as sa_update
-from sqlalchemy.dialects.postgresql import JSONB, insert
+from sqlalchemy import and_, literal_column, or_, select, update as sa_update
+from sqlalchemy.dialects.postgresql import insert
 
-from oss.src.core.sessions.commands.dtos import SessionCommand, SessionCommandSettle
 from oss.src.core.sessions.executions.dtos import (
     SessionExecutionSettlement,
     SessionExecutionSettlementResult,
 )
 from oss.src.core.sessions.executions.interfaces import SessionExecutionsDAOInterface
-from oss.src.dbs.postgres.sessions.commands.dbes import SessionCommandDBE
-from oss.src.dbs.postgres.sessions.commands.mappings import map_command_dbe_to_dto
 from oss.src.dbs.postgres.sessions.executions.dbes import SessionExecutionDBE
-from oss.src.dbs.postgres.sessions.interactions.dbes import SessionInteractionDBE
-from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.dbs.postgres.shared.engine import (
     TransactionsEngine,
     get_transactions_engine,
@@ -48,6 +43,7 @@ class SessionExecutionsDAO(SessionExecutionsDAOInterface):
         terminal_outcome: str,
         settled_by: str,
         settled_at: Optional[datetime] = None,
+        transaction: Optional[Any] = None,
     ) -> SessionExecutionSettlementResult:
         settled_at = settled_at or datetime.now(timezone.utc)
         stmt = (
@@ -60,29 +56,24 @@ class SessionExecutionsDAO(SessionExecutionsDAOInterface):
                 settled_by=settled_by,
                 settled_at=settled_at,
             )
-            .on_conflict_do_nothing(
-                index_elements=["project_id", "session_id", "execution_id"]
+            .on_conflict_do_update(
+                index_elements=["project_id", "session_id", "execution_id"],
+                set_={"terminal_outcome": SessionExecutionDBE.terminal_outcome},
             )
-            .returning(SessionExecutionDBE)
+            .returning(
+                SessionExecutionDBE,
+                literal_column("xmax = 0").label("won"),
+            )
         )
+
+        async def execute(session: Any) -> SessionExecutionSettlementResult:
+            stored, won = (await session.execute(stmt)).one()
+            return SessionExecutionSettlementResult(settlement=_to_dto(stored), won=won)
+
+        if transaction is not None:
+            return await execute(transaction)
         async with self.engine.session() as session:
-            inserted = (await session.execute(stmt)).scalar_one_or_none()
-            if inserted is not None:
-                return SessionExecutionSettlementResult(
-                    settlement=_to_dto(inserted), won=True
-                )
-            stored = (
-                await session.execute(
-                    select(SessionExecutionDBE).where(
-                        SessionExecutionDBE.project_id == project_id,
-                        SessionExecutionDBE.session_id == session_id,
-                        SessionExecutionDBE.execution_id == execution_id,
-                    )
-                )
-            ).scalar_one()
-            return SessionExecutionSettlementResult(
-                settlement=_to_dto(stored), won=False
-            )
+            return await execute(session)
 
     async def query_settled(
         self,
@@ -111,141 +102,6 @@ class SessionExecutionsDAO(SessionExecutionsDAOInterface):
                 )
             ).scalars()
             return {(row.session_id, row.execution_id): _to_dto(row) for row in rows}
-
-    async def close_records(
-        self,
-        *,
-        project_id: UUID,
-        keys: Sequence[Tuple[str, str]],
-        settled_by: str,
-    ) -> None:
-        if not keys:
-            return
-        key_filter = or_(
-            *[
-                and_(
-                    SessionExecutionDBE.session_id == session_id,
-                    SessionExecutionDBE.execution_id == execution_id,
-                )
-                for session_id, execution_id in keys
-            ]
-        )
-        async with self.engine.session() as session:
-            await session.execute(
-                sa_update(SessionExecutionDBE)
-                .where(
-                    SessionExecutionDBE.project_id == project_id,
-                    SessionExecutionDBE.settled_by == settled_by,
-                    SessionExecutionDBE.records_closed_at.is_(None),
-                    key_filter,
-                )
-                .values(records_closed_at=datetime.now(timezone.utc))
-            )
-
-    async def settle_command_execution(
-        self,
-        *,
-        settle: SessionCommandSettle,
-        session_id: str,
-        execution_id: Optional[str],
-        terminal_outcome: Optional[str],
-        settled_by: Optional[str],
-        mirror_stopped: bool,
-        cancel_interactions: bool,
-    ) -> Optional[SessionCommand]:
-        now = datetime.now(timezone.utc)
-        async with self.engine.session() as session:
-            if execution_id and terminal_outcome and settled_by:
-                execution_stmt = (
-                    insert(SessionExecutionDBE)
-                    .values(
-                        project_id=settle.project_id,
-                        session_id=session_id,
-                        execution_id=execution_id,
-                        terminal_outcome=terminal_outcome,
-                        settled_by=settled_by,
-                        settled_at=now,
-                    )
-                    .on_conflict_do_nothing(
-                        index_elements=["project_id", "session_id", "execution_id"]
-                    )
-                    .returning(SessionExecutionDBE)
-                )
-                inserted = (await session.execute(execution_stmt)).scalar_one_or_none()
-                if inserted is None:
-                    stored = (
-                        await session.execute(
-                            select(SessionExecutionDBE).where(
-                                SessionExecutionDBE.project_id == settle.project_id,
-                                SessionExecutionDBE.session_id == session_id,
-                                SessionExecutionDBE.execution_id == execution_id,
-                            )
-                        )
-                    ).scalar_one()
-                    if (
-                        stored.terminal_outcome != terminal_outcome
-                        or stored.settled_by != settled_by
-                    ):
-                        await session.rollback()
-                        return None
-
-            command_stmt = sa_update(SessionCommandDBE).where(
-                SessionCommandDBE.project_id == settle.project_id,
-                SessionCommandDBE.id == settle.command_id,
-                SessionCommandDBE.state.in_(
-                    [state.value for state in settle.expected_states]
-                ),
-            )
-            if settle.replica_id is not None:
-                command_stmt = command_stmt.where(
-                    or_(
-                        SessionCommandDBE.claimed_by.is_(None),
-                        SessionCommandDBE.claimed_by == settle.replica_id,
-                    )
-                )
-            command_stmt = command_stmt.values(
-                state=settle.state.value,
-                outcome=settle.outcome.value,
-                settled_at=now,
-                updated_at=now,
-            ).returning(SessionCommandDBE)
-            command = (await session.execute(command_stmt)).scalar_one_or_none()
-            if command is None:
-                await session.rollback()
-                return None
-
-            stream_values = {"stopping_turn_id": None, "updated_at": now}
-            if mirror_stopped:
-                stream_values["flags"] = func.coalesce(
-                    SessionStreamDBE.flags, cast({}, JSONB)
-                ).op("||")(cast({"is_running": False, "is_attached": False}, JSONB))
-            stream_stmt = sa_update(SessionStreamDBE).where(
-                SessionStreamDBE.project_id == settle.project_id,
-                SessionStreamDBE.session_id == session_id,
-            )
-            if execution_id is not None:
-                stream_stmt = stream_stmt.where(
-                    or_(
-                        SessionStreamDBE.stopping_turn_id == execution_id,
-                        SessionStreamDBE.stopping_turn_id.is_(None),
-                    )
-                )
-            await session.execute(stream_stmt.values(**stream_values))
-
-            if cancel_interactions and execution_id is not None:
-                await session.execute(
-                    sa_update(SessionInteractionDBE)
-                    .where(
-                        SessionInteractionDBE.project_id == settle.project_id,
-                        SessionInteractionDBE.session_id == session_id,
-                        SessionInteractionDBE.turn_id == execution_id,
-                        SessionInteractionDBE.status == "pending",
-                    )
-                    .values(status="cancelled", updated_at=now)
-                )
-
-            await session.commit()
-            return map_command_dbe_to_dto(command)
 
     async def list_redis_unreconciled(
         self,

--- a/api/oss/src/dbs/postgres/sessions/executions/dbes.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/dbes.py
@@ -21,6 +21,7 @@ class SessionExecutionDBE(Base):
     terminal_outcome = Column(String, nullable=False)
     settled_by = Column(String, nullable=False)
     settled_at = Column(TIMESTAMP(timezone=True), nullable=False)
+    ending_written_at = Column(TIMESTAMP(timezone=True), nullable=True)
     redis_reconciled_at = Column(TIMESTAMP(timezone=True), nullable=True)
 
     __table_args__ = (
@@ -30,6 +31,11 @@ class SessionExecutionDBE(Base):
             "ix_session_executions_project_session",
             "project_id",
             "session_id",
+        ),
+        Index(
+            "ix_session_executions_ending_unwritten",
+            "settled_at",
+            postgresql_where=text("ending_written_at IS NULL"),
         ),
         Index(
             "ix_session_executions_redis_unreconciled",

--- a/api/oss/src/dbs/postgres/sessions/executions/dbes.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/dbes.py
@@ -1,4 +1,11 @@
-from sqlalchemy import Column, ForeignKeyConstraint, Index, PrimaryKeyConstraint, String
+from sqlalchemy import (
+    Column,
+    ForeignKeyConstraint,
+    Index,
+    PrimaryKeyConstraint,
+    String,
+    text,
+)
 from sqlalchemy import TIMESTAMP
 from sqlalchemy.dialects.postgresql import UUID
 
@@ -15,6 +22,7 @@ class SessionExecutionDBE(Base):
     settled_by = Column(String, nullable=False)
     settled_at = Column(TIMESTAMP(timezone=True), nullable=False)
     records_closed_at = Column(TIMESTAMP(timezone=True), nullable=True)
+    redis_reconciled_at = Column(TIMESTAMP(timezone=True), nullable=True)
 
     __table_args__ = (
         ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
@@ -23,5 +31,13 @@ class SessionExecutionDBE(Base):
             "ix_session_executions_project_session",
             "project_id",
             "session_id",
+        ),
+        Index(
+            "ix_session_executions_redis_unreconciled",
+            "settled_at",
+            postgresql_where=text(
+                "settled_by = 'runner' AND terminal_outcome = 'stopped' "
+                "AND redis_reconciled_at IS NULL"
+            ),
         ),
     )

--- a/api/oss/src/dbs/postgres/sessions/executions/dbes.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/dbes.py
@@ -1,0 +1,27 @@
+from sqlalchemy import Column, ForeignKeyConstraint, Index, PrimaryKeyConstraint, String
+from sqlalchemy import TIMESTAMP
+from sqlalchemy.dialects.postgresql import UUID
+
+from oss.src.dbs.postgres.shared.base import Base
+
+
+class SessionExecutionDBE(Base):
+    __tablename__ = "session_executions"
+
+    project_id = Column(UUID(as_uuid=True), nullable=False)
+    session_id = Column(String, nullable=False)
+    execution_id = Column(String, nullable=False)
+    terminal_outcome = Column(String, nullable=False)
+    settled_by = Column(String, nullable=False)
+    settled_at = Column(TIMESTAMP(timezone=True), nullable=False)
+    records_closed_at = Column(TIMESTAMP(timezone=True), nullable=True)
+
+    __table_args__ = (
+        ForeignKeyConstraint(["project_id"], ["projects.id"], ondelete="CASCADE"),
+        PrimaryKeyConstraint("project_id", "session_id", "execution_id"),
+        Index(
+            "ix_session_executions_project_session",
+            "project_id",
+            "session_id",
+        ),
+    )

--- a/api/oss/src/dbs/postgres/sessions/executions/dbes.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/dbes.py
@@ -21,7 +21,6 @@ class SessionExecutionDBE(Base):
     terminal_outcome = Column(String, nullable=False)
     settled_by = Column(String, nullable=False)
     settled_at = Column(TIMESTAMP(timezone=True), nullable=False)
-    records_closed_at = Column(TIMESTAMP(timezone=True), nullable=True)
     redis_reconciled_at = Column(TIMESTAMP(timezone=True), nullable=True)
 
     __table_args__ = (

--- a/api/oss/src/dbs/postgres/sessions/interactions/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/interactions/dao.py
@@ -171,9 +171,7 @@ class SessionInteractionsDAO(SessionInteractionsDAOInterface):
             if except_tokens:
                 stmt = stmt.where(SessionInteractionDBE.token.notin_(except_tokens))
             result = await session.execute(stmt)
-            return [
-                map_interaction_dbe_to_dto(dbe) for dbe in result.scalars().all()
-            ]
+            return [map_interaction_dbe_to_dto(dbe) for dbe in result.scalars().all()]
 
         if transaction is not None:
             return await execute(transaction)

--- a/api/oss/src/dbs/postgres/sessions/interactions/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/interactions/dao.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timedelta, timezone
-from typing import List, Optional
+from typing import Any, List, Optional
 from uuid import UUID
 
 from sqlalchemy import cast, delete as sa_delete, func, select, update as sa_update
@@ -142,13 +142,15 @@ class SessionInteractionsDAO(SessionInteractionsDAOInterface):
         except_turn_id: Optional[str] = None,
         except_tokens: Optional[List[str]] = None,
         only_turn_id: Optional[str] = None,
+        transaction: Optional[Any] = None,
     ) -> List[SessionInteraction]:
         """Cancel still-pending interactions for a session. With `except_turn_id`, spare the
         current turn's own gates (used at turn start to cancel prior turns' unanswered gates;
         without it, cancel all of them, e.g. on kill). `except_tokens` spares prior-turn gates
         the current turn answers in-band, so the resume can resolve them instead. With
         `only_turn_id`, touch nothing but that one turn's gates. Returns the rows cancelled."""
-        async with self.engine.session() as session:
+
+        async def execute(session: Any) -> List[SessionInteraction]:
             stmt = (
                 sa_update(SessionInteractionDBE)
                 .where(
@@ -169,9 +171,14 @@ class SessionInteractionsDAO(SessionInteractionsDAOInterface):
             if except_tokens:
                 stmt = stmt.where(SessionInteractionDBE.token.notin_(except_tokens))
             result = await session.execute(stmt)
-            cancelled = [
+            return [
                 map_interaction_dbe_to_dto(dbe) for dbe in result.scalars().all()
             ]
+
+        if transaction is not None:
+            return await execute(transaction)
+        async with self.engine.session() as session:
+            cancelled = await execute(session)
             await session.commit()
             return cancelled
 

--- a/api/oss/src/dbs/postgres/sessions/records/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dao.py
@@ -1,7 +1,7 @@
-from typing import Dict, List, Optional
+from typing import Dict, List, Optional, Sequence, Set, Tuple
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, tuple_
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -18,6 +18,11 @@ from oss.src.dbs.postgres.sessions.records.mappings import (
     map_record_dbe_to_dto,
 )
 from oss.src.dbs.postgres.shared.engine import AnalyticsEngine, get_analytics_engine
+
+# The runner's terminal per-turn record type. Mirrored in
+# oss/src/tasks/asyncio/sessions/records_worker.py, which reads the same marker off the
+# ingest stream; both come from services/runner/src/protocol.ts (`{ type: "done" }`).
+TERMINAL_RECORD_TYPE = "done"
 
 
 class RecordsDAO(RecordsDAOInterface):
@@ -224,6 +229,38 @@ class RecordsDAO(RecordsDAOInterface):
                 timestamp=row.timestamp or row.created_at,
             )
         return previews
+
+    async def settled_turns(
+        self,
+        *,
+        project_id: UUID,
+        keys: Sequence[Tuple[str, str]],
+    ) -> Set[Tuple[str, str]]:
+        """Which of these `(session_id, turn_id)` pairs already carry a terminal record.
+
+        The watchdog asks this before it writes one of its own, so a turn whose runner DID
+        report an outcome is never given a second, contradictory ending. One query for the
+        whole batch, served by `ix_records_project_id_session_id_turn_id`.
+        """
+        if not keys:
+            return set()
+
+        async with self.engine.session() as session:
+            stmt = (
+                select(RecordDBE.session_id, RecordDBE.turn_id)
+                .where(
+                    RecordDBE.project_id == project_id,
+                    RecordDBE.record_type == TERMINAL_RECORD_TYPE,
+                    RecordDBE.deleted_at.is_(None),
+                    tuple_(RecordDBE.session_id, RecordDBE.turn_id).in_(
+                        [(session_id, turn_id) for session_id, turn_id in keys]
+                    ),
+                )
+                .distinct()
+            )
+            rows = (await session.execute(stmt)).all()
+
+        return {(row.session_id, row.turn_id) for row in rows}
 
     async def get_event(
         self,

--- a/api/oss/src/dbs/postgres/sessions/records/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dao.py
@@ -6,7 +6,9 @@ from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
 from oss.src.core.sessions.records.dtos import (
+    RECORD_SETTLED_BY_ATTRIBUTE,
     SESSION_MESSAGE_PREVIEW_TEXT_LIMIT,
+    TERMINAL_RECORD_TYPE,
     SessionMessagePreview,
     SessionRecord,
     SessionRecordEvent,
@@ -18,11 +20,6 @@ from oss.src.dbs.postgres.sessions.records.mappings import (
     map_record_dbe_to_dto,
 )
 from oss.src.dbs.postgres.shared.engine import AnalyticsEngine, get_analytics_engine
-
-# The runner's terminal per-turn record type. Mirrored in
-# oss/src/tasks/asyncio/sessions/records_worker.py, which reads the same marker off the
-# ingest stream; both come from services/runner/src/protocol.ts (`{ type: "done" }`).
-TERMINAL_RECORD_TYPE = "done"
 
 
 class RecordsDAO(RecordsDAOInterface):
@@ -99,6 +96,7 @@ class RecordsDAO(RecordsDAOInterface):
         "attributes",
         "turn_id",
         "span_id",
+        "quarantined_at",
     )
 
     @staticmethod
@@ -137,6 +135,14 @@ class RecordsDAO(RecordsDAOInterface):
                 "attributes": stmt.excluded.attributes,
                 "turn_id": stmt.excluded.turn_id,
                 "span_id": stmt.excluded.span_id,
+                # coalesce, not a plain overwrite: quarantine is one-way. A redelivery of a
+                # late record keeps the instant it was FIRST quarantined, so the column is
+                # stable however many times the stream replays the message, and a delivery
+                # that somehow arrives unmarked can never resurrect the row into the
+                # transcript.
+                "quarantined_at": func.coalesce(
+                    RecordDBE.quarantined_at, stmt.excluded.quarantined_at
+                ),
             },
         ).returning(RecordDBE)
 
@@ -152,6 +158,11 @@ class RecordsDAO(RecordsDAOInterface):
                 .where(
                     RecordDBE.project_id == project_id,
                     RecordDBE.session_id == session_id,
+                    # A quarantined record is history the platform refused: it reached ingest
+                    # for a turn the watchdog had already ended. Excluding it HERE is what
+                    # makes one execution render one ending, because this is the read every
+                    # transcript reconstruction goes through.
+                    RecordDBE.quarantined_at.is_(None),
                 )
                 # Producer event time first: it is the only key that is monotonic across
                 # turns. `record_index` restarts at 0 every turn, and the worker can batch
@@ -205,6 +216,7 @@ class RecordsDAO(RecordsDAOInterface):
                     RecordDBE.session_id.in_(session_ids),
                     RecordDBE.record_type == "message",
                     RecordDBE.deleted_at.is_(None),
+                    RecordDBE.quarantined_at.is_(None),
                 )
                 .distinct(RecordDBE.session_id)
                 .order_by(
@@ -235,27 +247,48 @@ class RecordsDAO(RecordsDAOInterface):
         *,
         project_id: UUID,
         keys: Sequence[Tuple[str, str]],
+        settled_by: Optional[str] = None,
     ) -> Set[Tuple[str, str]]:
         """Which of these `(session_id, turn_id)` pairs already carry a terminal record.
 
-        The watchdog asks this before it writes one of its own, so a turn whose runner DID
-        report an outcome is never given a second, contradictory ending. One query for the
-        whole batch, served by `ix_records_project_id_session_id_turn_id`.
+        Two callers ask nearly the same question and mean different things by it, which is
+        why `settled_by` exists rather than a second query.
+
+        * The watchdog asks with no writer, before it writes an ending of its own: ANY
+          terminal record means this turn already ended and must not be given a second,
+          contradictory one.
+        * The ingest guard asks with `settled_by="watchdog"`, and only the watchdog's own
+          ending counts. A runner that wrote its honest ending has not lost the turn to the
+          platform, so nothing arriving afterwards is late in the sense that matters.
+
+        A QUARANTINED terminal record never answers yes to either. It is precisely the
+        second, refused ending both callers exist to keep out of the transcript, so counting
+        it would let one late `done` suppress the real one.
+
+        One query for the whole batch, served by
+        `ix_records_project_id_session_id_turn_id`.
         """
         if not keys:
             return set()
 
+        conditions = [
+            RecordDBE.project_id == project_id,
+            RecordDBE.record_type == TERMINAL_RECORD_TYPE,
+            RecordDBE.deleted_at.is_(None),
+            RecordDBE.quarantined_at.is_(None),
+            tuple_(RecordDBE.session_id, RecordDBE.turn_id).in_(
+                [(session_id, turn_id) for session_id, turn_id in keys]
+            ),
+        ]
+        if settled_by is not None:
+            conditions.append(
+                RecordDBE.attributes[RECORD_SETTLED_BY_ATTRIBUTE].astext == settled_by
+            )
+
         async with self.engine.session() as session:
             stmt = (
                 select(RecordDBE.session_id, RecordDBE.turn_id)
-                .where(
-                    RecordDBE.project_id == project_id,
-                    RecordDBE.record_type == TERMINAL_RECORD_TYPE,
-                    RecordDBE.deleted_at.is_(None),
-                    tuple_(RecordDBE.session_id, RecordDBE.turn_id).in_(
-                        [(session_id, turn_id) for session_id, turn_id in keys]
-                    ),
-                )
+                .where(*conditions)
                 .distinct()
             )
             rows = (await session.execute(stmt)).all()

--- a/api/oss/src/dbs/postgres/sessions/records/dbas.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dbas.py
@@ -65,3 +65,13 @@ class RecordDBA:
         JSONB(none_as_null=True),
         nullable=True,
     )
+
+    # Non-null when this record reached ingest for a turn the watchdog had ALREADY ended.
+    # The row is kept — the agent really did that work, and the token accounting on a late
+    # `usage` is real money — but every read that rebuilds a transcript excludes it, so one
+    # execution still shows exactly one ending. Written only by the ingest guard in
+    # `RecordsService.append_many`; forward-fill only, like every other column here.
+    quarantined_at = Column(
+        TIMESTAMP(timezone=True),
+        nullable=True,
+    )

--- a/api/oss/src/dbs/postgres/sessions/records/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/records/mappings.py
@@ -25,6 +25,7 @@ def map_record_event_to_dbe(
         attributes=event.attributes,
         turn_id=event.turn_id,
         span_id=event.span_id,
+        quarantined_at=event.quarantined_at,
     )
 
 
@@ -40,5 +41,6 @@ def map_record_dbe_to_dto(*, dbe: RecordDBE) -> SessionRecord:
         attributes=dbe.attributes,
         turn_id=dbe.turn_id,
         span_id=dbe.span_id,
+        quarantined_at=dbe.quarantined_at,
         created_at=dbe.created_at,
     )

--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -48,6 +48,7 @@ from oss.src.dbs.postgres.sessions.references import (
     references_containment_json,
     references_to_json,
 )
+from oss.src.dbs.postgres.sessions.executions.dbes import SessionExecutionDBE
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.dbs.postgres.sessions.streams.mappings import (
     SESSION_ORIGIN_TAG_KEY,
@@ -530,6 +531,45 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
         session_id: str,
         stream: SessionStreamEdit,
     ) -> Optional[SessionStream]:
+        if stream.expected_turn_id is not None:
+            terminal_execution_exists = (
+                select(SessionExecutionDBE.execution_id)
+                .where(
+                    SessionExecutionDBE.project_id == project_id,
+                    SessionExecutionDBE.session_id == session_id,
+                    SessionExecutionDBE.execution_id == stream.expected_turn_id,
+                )
+                .exists()
+            )
+            values = {
+                "updated_by_id": user_id,
+                "updated_at": datetime.now(timezone.utc),
+            }
+            if stream.flags is not None:
+                values["flags"] = stream.flags.model_dump(mode="json")
+            if stream.turn_id is not None:
+                values["turn_id"] = stream.turn_id
+
+            async with self.engine.session() as session:
+                result = await session.execute(
+                    sa_update(SessionStreamDBE)
+                    .where(
+                        SessionStreamDBE.project_id == project_id,
+                        SessionStreamDBE.session_id == session_id,
+                        SessionStreamDBE.deleted_at.is_(None),
+                        SessionStreamDBE.turn_id == stream.expected_turn_id,
+                        ~terminal_execution_exists,
+                    )
+                    .values(**values)
+                    .returning(SessionStreamDBE)
+                    .execution_options(synchronize_session=False)
+                )
+                dbe = result.scalar_one_or_none()
+                await session.commit()
+            if dbe is None:
+                return None
+            return map_stream_dbe_to_dto(stream_dbe=dbe)
+
         async with self.engine.session() as session:
             stmt = select(SessionStreamDBE).where(
                 SessionStreamDBE.project_id == project_id,

--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -1,5 +1,5 @@
 from datetime import datetime, timezone
-from typing import List, Optional
+from typing import Any, List, Optional
 from uuid import UUID
 
 import uuid_utils.compat as uuid
@@ -94,6 +94,42 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
         if engine is None:
             engine = get_transactions_engine()
         self.engine = engine
+
+    async def settle_command(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        turn_id: Optional[str],
+        mirror_stopped: bool,
+        transaction: Optional[Any] = None,
+    ) -> None:
+        now = datetime.now(timezone.utc)
+        values = {"stopping_turn_id": None, "updated_at": now}
+        if mirror_stopped:
+            values["flags"] = func.coalesce(SessionStreamDBE.flags, cast({}, JSONB)).op(
+                "||"
+            )(cast({"is_running": False}, JSONB))
+        stmt = sa_update(SessionStreamDBE).where(
+            SessionStreamDBE.project_id == project_id,
+            SessionStreamDBE.session_id == session_id,
+        )
+        if turn_id is not None:
+            stmt = stmt.where(
+                or_(
+                    SessionStreamDBE.stopping_turn_id == turn_id,
+                    SessionStreamDBE.stopping_turn_id.is_(None),
+                )
+            )
+
+        async def execute(session: Any) -> None:
+            await session.execute(stmt.values(**values))
+
+        if transaction is not None:
+            await execute(transaction)
+            return
+        async with self.engine.session() as session:
+            await execute(session)
 
     async def create(
         self,

--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -558,6 +558,9 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
                         SessionStreamDBE.session_id == session_id,
                         SessionStreamDBE.deleted_at.is_(None),
                         SessionStreamDBE.turn_id == stream.expected_turn_id,
+                        SessionStreamDBE.flags.contains(
+                            {"is_alive": True, "is_running": True}
+                        ),
                         ~terminal_execution_exists,
                     )
                     .values(**values)

--- a/api/oss/src/dbs/redis/sessions/contract.py
+++ b/api/oss/src/dbs/redis/sessions/contract.py
@@ -159,6 +159,42 @@ else
 end
 """.strip()
 
+# Atomically release only the generation the watchdog swept. A new Send or Steer may install
+# another turn after the database commit, so every destructive Redis action must compare the
+# value captured before the guarded stream update. The swept turn is tombstoned regardless of
+# whether its old lock keys still exist.
+WATCHDOG_RELEASE_TURN_LUA = """
+-- AGENTA_WATCHDOG_RELEASE_TURN
+local expected_turn = ARGV[1]
+local expected_owner = ARGV[2]
+local superseded_ttl = tonumber(ARGV[3])
+local alive = redis.call('GET', KEYS[1]) or ''
+local running = redis.call('GET', KEYS[2]) or ''
+local owner = redis.call('GET', KEYS[3]) or ''
+local released_alive = 0
+local released_running = 0
+local released_owner = 0
+
+if expected_turn ~= '' and alive == expected_turn then
+    released_alive = redis.call('DEL', KEYS[1])
+end
+if expected_turn ~= '' and running == expected_turn then
+    released_running = redis.call('DEL', KEYS[2])
+end
+
+local foreign_turn = (alive ~= '' and alive ~= expected_turn)
+    or (running ~= '' and running ~= expected_turn)
+if expected_owner ~= '' and owner == expected_owner and not foreign_turn then
+    released_owner = redis.call('DEL', KEYS[3])
+end
+
+if expected_turn ~= '' then
+    redis.call('SET', KEYS[4], '1', 'EX', superseded_ttl)
+end
+
+return {released_alive, released_running, released_owner}
+""".strip()
+
 # Atomic claim-or-read: take ownership iff the key is absent or already ours (refreshing the
 # TTL), never steal it from another replica. Returns the actual owner after the operation, so
 # the caller learns who won without a second racy read.

--- a/api/oss/src/dbs/redis/sessions/contract.py
+++ b/api/oss/src/dbs/redis/sessions/contract.py
@@ -8,7 +8,7 @@ Key namespace — every key is project-scoped:
   alive:<project_id>:session:<session_id>      — session claimed; runner owns it
   running:<project_id>:session:<session_id>    — a turn is actively executing right now
   attached:<project_id>:session:<session_id>   — attach lock (client watching live view)
-  owner:<project_id>:session:<session_id>      — which replica currently owns this session
+  owner:<project_id>:session:<session_id>      — replica + turn generation owning this session
   displaced:<project_id>:session:<session_id>  — pub/sub for attach-steal notifications
   watch:<project_id>:session:<session_id>      — pub/sub for the live relay (SSE watch)
   superseded:<project_id>:session:<session_id>:turn:<turn_id>
@@ -44,6 +44,20 @@ HEARTBEAT_WRITE_THRESHOLD_SECONDS: int = env.sessions.heartbeat_write_threshold_
 # API-side only — the runner never reads the tombstone key, so this constant is
 # deliberately absent from the shared golden fixture (like `watch_heartbeat_seconds`).
 SUPERSEDED_TTL_SECONDS: int = env.sessions.superseded_ttl_seconds
+
+# API-side owner payload. The runner reaches affinity through the heartbeat response and never
+# reads this Redis value directly. Unit Separator cannot occur in either UUID-like component and
+# keeps legacy bare-replica values unambiguous.
+OWNER_VALUE_SEPARATOR = "\x1f"
+
+
+def make_owner_value(*, replica_id: str, turn_id: str | None) -> str:
+    return f"{replica_id}{OWNER_VALUE_SEPARATOR}{turn_id or ''}"
+
+
+def owner_replica_id(owner_value: str) -> str:
+    return owner_value.split(OWNER_VALUE_SEPARATOR, 1)[0]
+
 
 # ---------------------------------------------------------------------------
 # Key builders
@@ -195,12 +209,20 @@ end
 return {released_alive, released_running, released_owner}
 """.strip()
 
-# Atomic claim-or-read: take ownership iff the key is absent or already ours (refreshing the
-# TTL), never steal it from another replica. Returns the actual owner after the operation, so
-# the caller learns who won without a second racy read.
+# Atomic claim-or-read: take ownership iff the key is absent or already belongs to this replica,
+# refreshing both its TTL and turn generation. Returns the full actual value without a second
+# racy read. Bare legacy values compare as their own replica id and are upgraded on refresh.
 CLAIM_OWNER_LUA = """
 local current = redis.call('GET', KEYS[1])
-if current == false or current == ARGV[1] then
+local separator = string.char(31)
+local function replica(value)
+    local boundary = string.find(value, separator, 1, true)
+    if boundary then
+        return string.sub(value, 1, boundary - 1)
+    end
+    return value
+end
+if current == false or replica(current) == replica(ARGV[1]) then
     redis.call('SET', KEYS[1], ARGV[1], 'EX', ARGV[2])
     return ARGV[1]
 end

--- a/api/oss/src/dbs/redis/sessions/locks.py
+++ b/api/oss/src/dbs/redis/sessions/locks.py
@@ -6,7 +6,7 @@ every key name, TTL, and wire shape.
 """
 
 import json
-from typing import Optional
+from typing import Optional, Tuple
 
 from oss.src.dbs.redis.shared.engine import LockEngine
 from oss.src.dbs.redis.sessions.contract import (
@@ -17,6 +17,7 @@ from oss.src.dbs.redis.sessions.contract import (
     RELEASE_IF_OWNER_LUA,
     RUNNING_TTL_SECONDS,
     SUPERSEDED_TTL_SECONDS,
+    WATCHDOG_RELEASE_TURN_LUA,
     alive_key,
     attached_key,
     displaced_channel,
@@ -152,6 +153,29 @@ async def is_turn_superseded(
         return False
     await engine.expire(key, SUPERSEDED_TTL_SECONDS)
     return True
+
+
+async def release_watchdog_turn(
+    engine: LockEngine,
+    *,
+    project_id: str,
+    session_id: str,
+    turn_id: Optional[str],
+    replica_id: Optional[str],
+) -> Tuple[bool, bool, bool]:
+    """Atomically release only the swept turn and its observed replica owner."""
+    result = await engine.eval(
+        WATCHDOG_RELEASE_TURN_LUA,
+        4,
+        alive_key(project_id, session_id).encode(),
+        running_key(project_id, session_id).encode(),
+        owner_key(project_id, session_id).encode(),
+        superseded_key(project_id, session_id, turn_id or "").encode(),
+        (turn_id or "").encode(),
+        (replica_id or "").encode(),
+        SUPERSEDED_TTL_SECONDS,
+    )
+    return bool(int(result[0])), bool(int(result[1])), bool(int(result[2]))
 
 
 # ---------------------------------------------------------------------------

--- a/api/oss/src/dbs/redis/sessions/locks.py
+++ b/api/oss/src/dbs/redis/sessions/locks.py
@@ -365,7 +365,7 @@ async def get_owner_value(
     return current.decode() if current else None
 
 
-async def claim_owner(
+async def claim_owner_value(
     engine: LockEngine,
     *,
     project_id: str,
@@ -373,10 +373,10 @@ async def claim_owner(
     replica_id: str,
     turn_id: Optional[str] = None,
 ) -> str:
-    """Atomically claim ownership iff unowned or already ours, and return the actual owner.
+    """Atomically claim ownership and return the full observed owner generation.
 
     Never steals from a live different owner: if another replica holds it, its id is
-    returned so the caller can refuse to serve a local session on the wrong host.
+    returned with its turn generation so a later compare-and-delete cannot clear a refresh.
     """
     key = owner_key(project_id, session_id)
     owner_value = make_owner_value(replica_id=replica_id, turn_id=turn_id)
@@ -388,7 +388,44 @@ async def claim_owner(
         str(OWNER_TTL_SECONDS).encode(),
     )
     actual = result.decode() if isinstance(result, (bytes, bytearray)) else str(result)
+    return actual
+
+
+async def claim_owner(
+    engine: LockEngine,
+    *,
+    project_id: str,
+    session_id: str,
+    replica_id: str,
+    turn_id: Optional[str] = None,
+) -> str:
+    """Claim ownership and return the actual owner's replica id."""
+    actual = await claim_owner_value(
+        engine,
+        project_id=project_id,
+        session_id=session_id,
+        replica_id=replica_id,
+        turn_id=turn_id,
+    )
     return owner_replica_id(actual)
+
+
+async def release_owner_value(
+    engine: LockEngine,
+    *,
+    project_id: str,
+    session_id: str,
+    owner_value: str,
+) -> bool:
+    """Remove the owner key only if its full replica + turn generation still matches."""
+    key = owner_key(project_id, session_id)
+    result = await engine.eval(
+        RELEASE_IF_OWNER_LUA,
+        1,
+        key.encode(),
+        owner_value.encode(),
+    )
+    return result == 1
 
 
 async def clear_owner(
@@ -404,14 +441,12 @@ async def clear_owner(
     )
     if owner_value is None or owner_replica_id(owner_value) != replica_id:
         return False
-    key = owner_key(project_id, session_id)
-    result = await engine.eval(
-        RELEASE_IF_OWNER_LUA,
-        1,
-        key.encode(),
-        owner_value.encode(),
+    return await release_owner_value(
+        engine,
+        project_id=project_id,
+        session_id=session_id,
+        owner_value=owner_value,
     )
-    return result == 1
 
 
 async def force_clear_owner(

--- a/api/oss/src/dbs/redis/sessions/locks.py
+++ b/api/oss/src/dbs/redis/sessions/locks.py
@@ -22,6 +22,8 @@ from oss.src.dbs.redis.sessions.contract import (
     attached_key,
     displaced_channel,
     make_displacement_payload,
+    make_owner_value,
+    owner_replica_id,
     owner_key,
     running_key,
     superseded_key,
@@ -161,7 +163,7 @@ async def release_watchdog_turn(
     project_id: str,
     session_id: str,
     turn_id: Optional[str],
-    replica_id: Optional[str],
+    owner_value: Optional[str],
 ) -> Tuple[bool, bool, bool]:
     """Atomically release only the swept turn and its observed replica owner."""
     result = await engine.eval(
@@ -172,7 +174,7 @@ async def release_watchdog_turn(
         owner_key(project_id, session_id).encode(),
         superseded_key(project_id, session_id, turn_id or "").encode(),
         (turn_id or "").encode(),
-        (replica_id or "").encode(),
+        (owner_value or "").encode(),
         SUPERSEDED_TTL_SECONDS,
     )
     return bool(int(result[0])), bool(int(result[1])), bool(int(result[2]))
@@ -345,6 +347,19 @@ async def get_owner(
     session_id: str,
 ) -> Optional[str]:
     """Return the replica id currently owning this session, or None."""
+    current = await get_owner_value(
+        engine, project_id=project_id, session_id=session_id
+    )
+    return owner_replica_id(current) if current else None
+
+
+async def get_owner_value(
+    engine: LockEngine,
+    *,
+    project_id: str,
+    session_id: str,
+) -> Optional[str]:
+    """Return the full replica + turn-generation owner value, or None."""
     key = owner_key(project_id, session_id)
     current = await engine.get(key)
     return current.decode() if current else None
@@ -356,6 +371,7 @@ async def claim_owner(
     project_id: str,
     session_id: str,
     replica_id: str,
+    turn_id: Optional[str] = None,
 ) -> str:
     """Atomically claim ownership iff unowned or already ours, and return the actual owner.
 
@@ -363,14 +379,16 @@ async def claim_owner(
     returned so the caller can refuse to serve a local session on the wrong host.
     """
     key = owner_key(project_id, session_id)
+    owner_value = make_owner_value(replica_id=replica_id, turn_id=turn_id)
     result = await engine.eval(
         CLAIM_OWNER_LUA,
         1,
         key.encode(),
-        replica_id.encode(),
+        owner_value.encode(),
         str(OWNER_TTL_SECONDS).encode(),
     )
-    return result.decode() if isinstance(result, (bytes, bytearray)) else str(result)
+    actual = result.decode() if isinstance(result, (bytes, bytearray)) else str(result)
+    return owner_replica_id(actual)
 
 
 async def clear_owner(
@@ -381,12 +399,17 @@ async def clear_owner(
     replica_id: str,
 ) -> bool:
     """Remove the owner key if replica_id is still the owner."""
+    owner_value = await get_owner_value(
+        engine, project_id=project_id, session_id=session_id
+    )
+    if owner_value is None or owner_replica_id(owner_value) != replica_id:
+        return False
     key = owner_key(project_id, session_id)
     result = await engine.eval(
         RELEASE_IF_OWNER_LUA,
         1,
         key.encode(),
-        replica_id.encode(),
+        owner_value.encode(),
     )
     return result == 1
 
@@ -406,7 +429,7 @@ async def force_clear_owner(
     key = owner_key(project_id, session_id)
     current = await engine.get(key)
     await engine.delete(key)
-    return current.decode() if current else None
+    return owner_replica_id(current.decode()) if current else None
 
 
 # ---------------------------------------------------------------------------

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -9,14 +9,14 @@ session refuses a new message until a threshold far away expires.
 This pass closes that hole. It scans `session_streams` for rows whose mirror still says
 `is_alive` but whose heartbeat (`updated_at`) is stale, and for each one it:
 
-1. writes the terminal records the dead runner owed, preserving stopped vs lost;
-2. collapses the row's flags so the session reads as ended;
+1. compare-and-sets the stale stream generation so a renewed turn cannot be settled;
+2. settles the execution and writes the terminal records the dead runner owed;
 3. clears the Redis nest and tombstones the turn, so a late beat cannot re-nest it;
 4. publishes the watch notification, so an open browser refreshes without a reload.
 
-Step 1 is what makes the outcome durable, and it is deliberately first: a crash between the
-steps leaves the row a candidate for the next pass, which is recoverable, whereas collapsing
-the flags first would hide the row forever with no ending ever written.
+Steps 1 and 2 share one Postgres transaction. Terminal records publish before its commit with
+stable ids, so a crash rolls the stream and execution changes back and the next pass safely
+re-publishes the same records.
 
 Two thresholds, not one. A RUNNING row beats every 30 seconds, so a short silence means the
 runner died. An ALIVE-but-idle row is a different animal: between turns, and while a turn is
@@ -60,12 +60,8 @@ from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterfa
 from oss.src.dbs.redis.sessions.contract import WATCH_LIFECYCLE_ENDED
 from oss.src.dbs.redis.shared.engine import LockEngine
 from oss.src.dbs.redis.sessions.locks import (
-    force_cancel_alive,
-    clear_running,
-    force_clear_owner,
-    mark_turn_superseded,
-    release_alive,
-    release_running,
+    get_owner,
+    release_watchdog_turn,
 )
 
 from sqlalchemy import and_, func, not_, or_, select, tuple_, update as sa_update
@@ -479,13 +475,97 @@ async def run_orphan_sweep(
                 await _repair_terminal_redis(commands_service)
             return
 
-        # Durable ending FIRST. A crash after this point leaves the row a candidate for the
-        # next pass, which re-reads the record it just wrote and does not write a second.
         now = datetime.now(timezone.utc)
+
+        # Capture the affinity generation before the guarded database update. Redis cleanup
+        # compares this replica and the swept turn atomically after commit, so a new Send or
+        # Steer generation cannot be deleted.
+        observed_owners: Dict[Tuple[UUID, str, str], Optional[str]] = {}
+        owner_keys = {
+            (project_id, session_id, turn_id)
+            for project_id, session_id, turn_id in unsettled
+        }
+        owner_keys.update(
+            (project_id, session_id, turn_id)
+            for _row_id, project_id, session_id, turn_id, _updated_at in orphan_rows
+            if turn_id is not None
+        )
+        for project_id, session_id, turn_id in sorted(
+            owner_keys, key=lambda key: key[1]
+        ):
+            observed_owners[(project_id, session_id, turn_id)] = await get_owner(
+                lock_engine,
+                project_id=str(project_id),
+                session_id=session_id,
+            )
+
+        # Win the stale stream generation before settling its execution or publishing records.
+        # The update and execution settlement share this transaction; an exception rolls both
+        # back, while record ids make a publish-before-commit retry idempotent.
+        collapsed_flags = SessionStreamFlags(
+            is_alive=False, is_running=False, is_attached=False
+        ).model_dump(mode="json")
+        collapsed_rows: List[
+            Tuple[UUID, UUID, str, Optional[str], Optional[datetime]]
+        ] = []
+        skipped_orphan_turns: Set[Tuple[UUID, str, str]] = set()
+        for (
+            row_id,
+            project_uuid,
+            session_id,
+            turn_id,
+            observed_updated_at,
+        ) in orphan_rows:
+            conditions = [
+                SessionStreamDBE.id == row_id,
+                SessionStreamDBE.project_id == project_uuid,
+                SessionStreamDBE.session_id == session_id,
+                SessionStreamDBE.deleted_at.is_(None),
+                (
+                    SessionStreamDBE.turn_id == turn_id
+                    if turn_id is not None
+                    else SessionStreamDBE.turn_id.is_(None)
+                ),
+                (
+                    SessionStreamDBE.updated_at == observed_updated_at
+                    if observed_updated_at is not None
+                    else SessionStreamDBE.updated_at.is_(None)
+                ),
+            ]
+            result = await session.execute(
+                sa_update(SessionStreamDBE)
+                .where(*conditions)
+                .values(flags=collapsed_flags, updated_at=now)
+                .execution_options(synchronize_session=False)
+            )
+            if result.rowcount != 1:
+                if turn_id is not None:
+                    skipped_orphan_turns.add((project_uuid, session_id, turn_id))
+                log.info(
+                    "watchdog: orphan stream advanced during sweep; leaving it untouched",
+                    session_id=session_id,
+                    turn_id=turn_id,
+                )
+                continue
+            collapsed_rows.append(
+                (row_id, project_uuid, session_id, turn_id, observed_updated_at)
+            )
+            log.warning(
+                "watchdog: settled a session_stream whose runner went silent",
+                extra={
+                    "session_id": session_id,
+                    "stream_id": str(row_id),
+                    "turn_id": turn_id,
+                    "lost": (project_uuid, session_id, turn_id) in unsettled,
+                },
+            )
+
         terminal_winners: Set[Tuple[UUID, str, str]] = set()
         endings_written: Set[Tuple[UUID, str, str]] = set()
         for project_id, session_id, turn_id in sorted(unsettled, key=lambda t: t[1]):
             key = (project_id, session_id, turn_id)
+            if key in skipped_orphan_turns:
+                continue
             if (
                 key not in terminal_turns
                 and env.agenta.sessions.durable_stop
@@ -495,6 +575,7 @@ async def run_orphan_sweep(
                     session_id=session_id,
                     execution_id=turn_id,
                     settled_at=now,
+                    transaction=session,
                 )
             ):
                 continue
@@ -543,11 +624,11 @@ async def run_orphan_sweep(
         # brought to rest here, in this same pass, or the SEND gate refuses the next message
         # until the runner returns -- which, for a lost turn, may be never. The RFC's rule is
         # that the settlement writes the ending, clears `is_running`, releases `alive`, and
-        # updates the mirror together. The collapse below owns the rows the orphan query
+        # updates the mirror together. The collapse above owns the rows the orphan query
         # matched; this owns every other lost turn (a row the query did not return, or an
         # older execution whose row has since advanced). Everything here is guarded on
         # `turn_id`, so a row that now names a NEWER running turn is never disturbed.
-        collapsing = {(p, s, t) for (_id, p, s, t, _u) in orphan_rows}
+        collapsing = {(p, s, t) for (_id, p, s, t, _u) in collapsed_rows}
         newly_lost = sorted(unsettled - collapsing, key=lambda t: t[1])
 
         # Clear `is_running` on the DB row that STILL names a lost turn, keeping `is_alive` so
@@ -594,11 +675,8 @@ async def run_orphan_sweep(
                     )
                 )
 
-        # Both writes to `session_streams` happen HERE, from the values captured above, and both
-        # go through a Core UPDATE. No ORM attribute write on this table survives anywhere in
-        # this pass, on purpose: the rows were loaded before nested `engine.session()` calls that
-        # detach them, and a detached row's mutation is dropped at commit with no error.
-        # Every lost turn's row first, keeping `is_alive` so the session stays resumable.
+        # Every write to `session_streams` uses a Core UPDATE. No ORM attribute write on this
+        # table survives anywhere in this pass: nested scoped sessions can detach loaded rows.
         running_rows_cleared: List[
             Tuple[UUID, UUID, str, str, Optional[datetime], Dict[str, Any]]
         ] = []
@@ -648,105 +726,34 @@ async def run_orphan_sweep(
                 )
             )
 
-        # Then the orphan rows, through guarded Core UPDATEs (finding 7).
-        # `synchronize_session=False` because nothing after this reads these rows back through
-        # the ORM identity map.
-        collapsed_flags = SessionStreamFlags(
-            is_alive=False, is_running=False, is_attached=False
-        ).model_dump(mode="json")
-        collapsed_rows: List[
-            Tuple[UUID, UUID, str, Optional[str], Optional[datetime]]
-        ] = []
-        for (
-            row_id,
-            project_uuid,
-            session_id,
-            turn_id,
-            observed_updated_at,
-        ) in orphan_rows:
-            conditions = [
-                SessionStreamDBE.id == row_id,
-                SessionStreamDBE.project_id == project_uuid,
-                SessionStreamDBE.session_id == session_id,
-                SessionStreamDBE.deleted_at.is_(None),
-                (
-                    SessionStreamDBE.turn_id == turn_id
-                    if turn_id is not None
-                    else SessionStreamDBE.turn_id.is_(None)
-                ),
-                (
-                    SessionStreamDBE.updated_at == observed_updated_at
-                    if observed_updated_at is not None
-                    else SessionStreamDBE.updated_at.is_(None)
-                ),
-            ]
-            result = await session.execute(
-                sa_update(SessionStreamDBE)
-                .where(*conditions)
-                .values(flags=collapsed_flags, updated_at=now)
-                .execution_options(synchronize_session=False)
-            )
-            if result.rowcount != 1:
-                log.info(
-                    "watchdog: orphan stream advanced during sweep; leaving it untouched",
-                    session_id=session_id,
-                    turn_id=turn_id,
-                )
-                continue
-            collapsed_rows.append(
-                (row_id, project_uuid, session_id, turn_id, observed_updated_at)
-            )
-            log.warning(
-                "watchdog: settled a session_stream whose runner went silent",
-                extra={
-                    "session_id": session_id,
-                    "stream_id": str(row_id),
-                    "turn_id": turn_id,
-                    "lost": (project_uuid, session_id, turn_id) in unsettled,
-                },
-            )
-
         await session.commit()
 
-        # The old turn remains the Redis owner until its guarded row update commits. A failed
-        # compare-and-set means a newer heartbeat or turn won, so none of its Redis state is ours.
+        # Redis cleanup is one compare-and-delete operation per session. A new Send or Steer may
+        # install another generation after this commit; the script leaves its keys and affinity
+        # untouched and tombstones only the swept turn.
         for project_uuid, session_id, turn_id in newly_lost:
             if (project_uuid, session_id, turn_id) in failed_running_clears:
                 continue
-            released = await release_alive(
+            (
+                released_alive,
+                _released_running,
+                _released_owner,
+            ) = await release_watchdog_turn(
                 lock_engine,
                 project_id=str(project_uuid),
                 session_id=session_id,
                 turn_id=turn_id,
-            )
-            if released:
-                await force_clear_owner(
-                    lock_engine,
-                    project_id=str(project_uuid),
-                    session_id=session_id,
-                )
-            await release_running(
-                lock_engine,
-                project_id=str(project_uuid),
-                session_id=session_id,
-                turn_id=turn_id,
-            )
-            await mark_turn_superseded(
-                lock_engine,
-                project_id=str(project_uuid),
-                session_id=session_id,
-                turn_id=turn_id,
+                replica_id=observed_owners.get((project_uuid, session_id, turn_id)),
             )
             log.warning(
                 "watchdog: wrote the ending a stopped turn's runner never reported",
                 extra={
                     "session_id": session_id,
                     "turn_id": turn_id,
-                    "released_alive": released,
+                    "released_alive": released_alive,
                 },
             )
 
-        # Bring the Redis locks the SEND gate reads in sync with the rows just written.
         for (
             _row_id,
             project_uuid,
@@ -754,33 +761,16 @@ async def run_orphan_sweep(
             row_turn_id,
             _observed_updated_at,
         ) in collapsed_rows:
-            project_id = str(project_uuid)
-            displaced_alive = await force_cancel_alive(
-                lock_engine, project_id=project_id, session_id=session_id
-            )
-            displaced_running = await clear_running(
-                lock_engine, project_id=project_id, session_id=session_id
-            )
-            # A swept turn is declared dead; tombstone it so a late beat from it cannot
-            # re-nest the session it was just evicted from. Tombstone the row's OWN turn too,
-            # not only whoever still held the Redis keys: a turn whose alive/running keys a
-            # prior Stop settlement already cleared holds nothing here, yet its runner can
-            # still return and beat that turn_id. The heartbeat path refuses a superseded
-            # turn, so without this tombstone a returning runner re-set is_running on the row
-            # after the sweep had just cleared it (observed live: run 1e, turn e49c060b).
-            doomed_turns = {t for t in (displaced_alive, displaced_running) if t}
-            if row_turn_id:
-                doomed_turns.add(row_turn_id)
-            for turn_id in doomed_turns:
-                await mark_turn_superseded(
-                    lock_engine,
-                    project_id=project_id,
-                    session_id=session_id,
-                    turn_id=turn_id,
-                )
-            # A swept session is dead; free its affinity like kill does.
-            await force_clear_owner(
-                lock_engine, project_id=project_id, session_id=session_id
+            await release_watchdog_turn(
+                lock_engine,
+                project_id=str(project_uuid),
+                session_id=session_id,
+                turn_id=row_turn_id,
+                replica_id=(
+                    observed_owners.get((project_uuid, session_id, row_turn_id))
+                    if row_turn_id is not None
+                    else None
+                ),
             )
 
         # Tell every open reader the session ended. Without this a browser sitting on the

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -437,6 +437,14 @@ async def run_orphan_sweep(
                 session_id=session_id,
                 turn_id=turn_id,
             )
+            # Clearing affinity is safe only when this turn still owned `alive`; otherwise a
+            # newer turn may already have claimed the session and its owner lease must survive.
+            if released:
+                await force_clear_owner(
+                    lock_engine,
+                    project_id=str(project_id),
+                    session_id=session_id,
+                )
             await mark_turn_superseded(
                 lock_engine,
                 project_id=str(project_id),

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -60,7 +60,11 @@ from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterfa
 from oss.src.dbs.redis.sessions.contract import WATCH_LIFECYCLE_ENDED
 from oss.src.dbs.redis.shared.engine import LockEngine
 from oss.src.dbs.redis.sessions.locks import (
+    clear_running,
+    force_cancel_alive,
+    force_clear_owner,
     get_owner_value,
+    mark_turn_superseded,
     release_watchdog_turn,
 )
 
@@ -761,15 +765,36 @@ async def run_orphan_sweep(
             row_turn_id,
             _observed_updated_at,
         ) in collapsed_rows:
+            if row_turn_id is None:
+                project_id = str(project_uuid)
+                displaced_alive = await force_cancel_alive(
+                    lock_engine, project_id=project_id, session_id=session_id
+                )
+                displaced_running = await clear_running(
+                    lock_engine, project_id=project_id, session_id=session_id
+                )
+                for displaced_turn_id in {
+                    turn_id
+                    for turn_id in (displaced_alive, displaced_running)
+                    if turn_id
+                }:
+                    await mark_turn_superseded(
+                        lock_engine,
+                        project_id=project_id,
+                        session_id=session_id,
+                        turn_id=displaced_turn_id,
+                    )
+                await force_clear_owner(
+                    lock_engine, project_id=project_id, session_id=session_id
+                )
+                continue
             await release_watchdog_turn(
                 lock_engine,
                 project_id=str(project_uuid),
                 session_id=session_id,
                 turn_id=row_turn_id,
-                owner_value=(
-                    observed_owners.get((project_uuid, session_id, row_turn_id))
-                    if row_turn_id is not None
-                    else None
+                owner_value=observed_owners.get(
+                    (project_uuid, session_id, row_turn_id)
                 ),
             )
 

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -62,6 +62,7 @@ from oss.src.dbs.redis.sessions.locks import (
     clear_running,
     force_clear_owner,
     mark_turn_superseded,
+    release_alive,
 )
 
 from sqlalchemy import and_, func, not_, or_, select
@@ -245,15 +246,41 @@ async def _unsettled_turns(
     return unsettled
 
 
+async def _settle_abandoned_commands(
+    commands_service: Optional[Any],
+    now: datetime,
+) -> int:
+    """Settle every Stop command whose runner accepted it and never reported.
+
+    Delegates the decision to the commands plane, which owns the command state machine, so
+    this sweep and a runner report can never write two different terminal outcomes for the
+    same command. Never raises: an abandoned command must not stop the pass that settles
+    executions.
+    """
+    if commands_service is None:
+        return 0
+    try:
+        return await commands_service.settle_abandoned_commands(now=now)
+    except Exception:
+        log.warning("watchdog: failed to settle abandoned commands", exc_info=True)
+        return 0
+
+
 async def run_orphan_sweep(
     engine: TransactionsEngine,
     lock_engine: LockEngine,
     *,
     records_service: Optional[RecordsService] = None,
     watch_publisher: Optional[SessionsWatchPublisherInterface] = None,
+    commands_service: Optional[Any] = None,
     publish: Any = publish_record,
 ) -> None:
-    """Single watchdog pass: settle every stale is_alive row."""
+    """Single watchdog pass: settle every stale is_alive row, then every abandoned command.
+
+    `commands_service` is a `SessionCommandsService`. It is optional and typed loosely so this
+    module keeps no import edge on the commands plane, which would be a cycle. When it is
+    given, this pass is also the one writer that settles a Stop the runner never reported.
+    """
     now_utc = datetime.now(timezone.utc)
     threshold = now_utc - timedelta(seconds=ORPHAN_THRESHOLD_SECONDS)
     idle_threshold = now_utc - timedelta(seconds=IDLE_THRESHOLD_SECONDS)
@@ -350,6 +377,38 @@ async def run_orphan_sweep(
                         exc_info=True,
                     )
 
+        # A stopped row whose turn was just given its ending is NOT collapsed, but the dead
+        # turn may still hold the session's `alive` lock: settlement leaves `alive` to its
+        # TTL on purpose, and that TTL is an hour. The SEND gate reads that lock, so a new
+        # message would be refused with "another turn owns this session" until it expired.
+        # Release it only if it still names the dead turn, and tombstone the turn so a late
+        # beat cannot re-nest the session. Observed live on the integration stack: the
+        # ending landed at 96.7 s and the next message was still refused.
+        collapsing = {(r.project_id, r.session_id, str(r.turn_id)) for r in orphans}
+        for project_id, session_id, turn_id in sorted(
+            unsettled - collapsing, key=lambda t: t[1]
+        ):
+            released = await release_alive(
+                lock_engine,
+                project_id=str(project_id),
+                session_id=session_id,
+                turn_id=turn_id,
+            )
+            await mark_turn_superseded(
+                lock_engine,
+                project_id=str(project_id),
+                session_id=session_id,
+                turn_id=turn_id,
+            )
+            log.warning(
+                "watchdog: wrote the ending a stopped turn's runner never reported",
+                extra={
+                    "session_id": session_id,
+                    "turn_id": turn_id,
+                    "released_alive": released,
+                },
+            )
+
         for row in orphans:
             row.flags = SessionStreamFlags(
                 is_alive=False, is_running=False, is_attached=False
@@ -417,10 +476,18 @@ async def run_orphan_sweep(
                         exc_info=True,
                     )
 
+        # AFTER the rows above are collapsed, on purpose. A command is only abandoned when its
+        # session has stopped beating, and the collapse just made that true for every row in
+        # this batch. Running it first would leave the runner-gone case waiting a second pass.
+        commands_settled = await _settle_abandoned_commands(
+            commands_service, datetime.now(timezone.utc)
+        )
+
         log.info(
-            "watchdog: settled %d sessions (%d turns marked lost)",
+            "watchdog: settled %d sessions (%d turns marked lost, %d commands lost)",
             len(orphans),
             len(unsettled),
+            commands_settled,
         )
 
 
@@ -430,19 +497,38 @@ async def orphan_sweep_loop(
     *,
     records_service: Optional[RecordsService] = None,
     watch_publisher: Optional[SessionsWatchPublisherInterface] = None,
+    commands_service: Optional[Any] = None,
 ) -> None:
     """Infinite loop; runs as a background asyncio task during app lifespan."""
+    # A pass that never returns would end the watchdog for the life of the process with
+    # nothing in the log; observed on the integration stack on 2026-09-03, when the sweep
+    # went silent after one pass and never ran again. Bound every pass, log the timeout,
+    # and go round again.
+    pass_timeout = float(max(SWEEP_INTERVAL_SECONDS * 2, 120))
     while True:
+        started = datetime.now(timezone.utc)
         try:
-            await run_orphan_sweep(
-                engine,
-                lock_engine,
-                records_service=records_service,
-                watch_publisher=watch_publisher,
+            await asyncio.wait_for(
+                run_orphan_sweep(
+                    engine,
+                    lock_engine,
+                    records_service=records_service,
+                    watch_publisher=watch_publisher,
+                    commands_service=commands_service,
+                ),
+                timeout=pass_timeout,
             )
         except asyncio.CancelledError:
             raise
+        except asyncio.TimeoutError:
+            log.error(
+                "watchdog: sweep pass timed out after %.0fs; skipping to the next pass",
+                pass_timeout,
+            )
         except Exception:
             log.exception("watchdog: error during sweep pass")
+        elapsed = (datetime.now(timezone.utc) - started).total_seconds()
+        if elapsed > SWEEP_INTERVAL_SECONDS:
+            log.warning("watchdog: sweep pass took %.1fs", elapsed)
         # Floored: a zero or negative interval would turn the loop into a hot spin.
         await asyncio.sleep(max(SWEEP_INTERVAL_SECONDS, 1))

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -266,6 +266,16 @@ async def _settle_abandoned_commands(
         return 0
 
 
+async def _repair_terminal_redis(commands_service: Optional[Any]) -> int:
+    if commands_service is None:
+        return 0
+    try:
+        return await commands_service.repair_terminal_redis()
+    except Exception:
+        log.warning("watchdog: failed to repair terminal Redis state", exc_info=True)
+        return 0
+
+
 async def run_orphan_sweep(
     engine: TransactionsEngine,
     lock_engine: LockEngine,
@@ -282,6 +292,7 @@ async def run_orphan_sweep(
     given, this pass is also the one writer that settles a Stop the runner never reported.
     """
     now_utc = datetime.now(timezone.utc)
+    await _repair_terminal_redis(commands_service)
     threshold = now_utc - timedelta(seconds=ORPHAN_THRESHOLD_SECONDS)
     idle_threshold = now_utc - timedelta(seconds=IDLE_THRESHOLD_SECONDS)
     # coalesce, not a bare `updated_at`: a row never updated since creation has updated_at

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -292,7 +292,6 @@ async def run_orphan_sweep(
     given, this pass is also the one writer that settles a Stop the runner never reported.
     """
     now_utc = datetime.now(timezone.utc)
-    await _repair_terminal_redis(commands_service)
     threshold = now_utc - timedelta(seconds=ORPHAN_THRESHOLD_SECONDS)
     idle_threshold = now_utc - timedelta(seconds=IDLE_THRESHOLD_SECONDS)
     # coalesce, not a bare `updated_at`: a row never updated since creation has updated_at
@@ -365,6 +364,7 @@ async def run_orphan_sweep(
             # No stale row and nothing owed an ending, but a command can still be abandoned:
             # its execution may have ended normally between the claim and the report.
             await _settle_abandoned_commands(commands_service, now_utc)
+            await _repair_terminal_redis(commands_service)
             return
 
         # Durable ending FIRST. A crash after this point leaves the row a candidate for the
@@ -508,6 +508,7 @@ async def run_orphan_sweep(
         commands_settled = await _settle_abandoned_commands(
             commands_service, datetime.now(timezone.utc)
         )
+        await _repair_terminal_redis(commands_service)
 
         log.info(
             "watchdog: settled %d sessions (%d turns marked lost, %d commands lost)",

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -42,6 +42,7 @@ from uuid import UUID, uuid5, NAMESPACE_URL
 
 from oss.src.utils.env import env
 from oss.src.utils.logging import get_module_logger
+from oss.src.dbs.postgres.sessions.executions.dbes import SessionExecutionDBE
 from oss.src.dbs.postgres.shared.engine import TransactionsEngine
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.core.sessions.records.dtos import (
@@ -316,21 +317,8 @@ async def run_orphan_sweep(
         result = await session.execute(stmt)
         orphans = result.scalars().all()
 
-        # A SECOND selection, for the ending only. The rule above reads "not running, so its
-        # last turn already ended", and a durable Stop broke that premise: settlement clears
-        # `is_running` on the row the moment it releases the Redis key, so the tab that pressed
-        # Stop is not left spinning. The runner then owes its own terminal record — and if it
-        # dies in that window, the row is already not-running, the rule above skips it, and the
-        # 30-minute idle branch collapses the row without ever writing an ending. Observed live
-        # on the integration stack: a Stop settled `stopped` at 13:09:19, the runner was killed
-        # a moment later, and turn 295351c3 still carried nothing but the user's own message
-        # five minutes on. So the premise is now CHECKED rather than assumed: any stale row
-        # that names a turn is a candidate, and `_unsettled_turns` writes an ending only for a
-        # turn that carries none. A row between turns, or parked on an approval, has its own
-        # terminal record and is filtered out there, at the cost of one lookup per project.
-        #
-        # These rows are NOT collapsed. Collapsing keeps its own, much longer idle grace: a
-        # parked approval lives for thirty minutes and must not be reclaimed at ninety seconds.
+        # Current stopped turns get their missing ending on the short clock without collapsing
+        # a parked session, whose reclamation stays on the longer idle grace.
         ending_stmt = (
             select(SessionStreamDBE)
             .where(
@@ -344,6 +332,21 @@ async def run_orphan_sweep(
         )
         ending_only = (await session.execute(ending_stmt)).scalars().all()
 
+        # A stream row names only its current turn. Older terminal executions must remain
+        # visible after that row advances, or their missing transcript ending is permanent.
+        terminal_executions = []
+        if records_service is not None:
+            terminal_stmt = (
+                select(SessionExecutionDBE)
+                .where(
+                    SessionExecutionDBE.terminal_outcome.in_(("stopped", "lost")),
+                    SessionExecutionDBE.settled_at < threshold,
+                )
+                .order_by(SessionExecutionDBE.settled_at)
+                .limit(SWEEP_BATCH_SIZE)
+            )
+            terminal_executions = (await session.execute(terminal_stmt)).scalars().all()
+
         # A row that claimed a RUNNING turn owes that turn an ending. So does a stopped row
         # whose runner never wrote one; see the note above.
         seen: Set[Tuple[UUID, str, str]] = set()
@@ -352,6 +355,19 @@ async def run_orphan_sweep(
             if not row.turn_id:
                 continue
             key = (row.project_id, row.session_id, str(row.turn_id))
+            if key in seen:
+                continue
+            seen.add(key)
+            claimed.append(key)
+        current_turns = set(claimed)
+        terminal_turns: Set[Tuple[UUID, str, str]] = set()
+        for execution in terminal_executions:
+            key = (
+                execution.project_id,
+                execution.session_id,
+                execution.execution_id,
+            )
+            terminal_turns.add(key)
             if key in seen:
                 continue
             seen.add(key)
@@ -373,7 +389,8 @@ async def run_orphan_sweep(
         terminal_winners: Set[Tuple[UUID, str, str]] = set()
         for project_id, session_id, turn_id in sorted(unsettled, key=lambda t: t[1]):
             if (
-                env.agenta.sessions.durable_stop
+                (project_id, session_id, turn_id) not in terminal_turns
+                and env.agenta.sessions.durable_stop
                 and commands_service is not None
                 and not await commands_service.settle_execution_lost(
                     project_id=project_id,
@@ -412,7 +429,7 @@ async def run_orphan_sweep(
         # ending landed at 96.7 s and the next message was still refused.
         collapsing = {(r.project_id, r.session_id, str(r.turn_id)) for r in orphans}
         for project_id, session_id, turn_id in sorted(
-            unsettled - collapsing, key=lambda t: t[1]
+            (unsettled - collapsing) & current_turns, key=lambda t: t[1]
         ):
             released = await release_alive(
                 lock_engine,

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -359,7 +359,20 @@ async def run_orphan_sweep(
         # Durable ending FIRST. A crash after this point leaves the row a candidate for the
         # next pass, which re-reads the record it just wrote and does not write a second.
         now = datetime.now(timezone.utc)
+        terminal_winners: Set[Tuple[UUID, str, str]] = set()
         for project_id, session_id, turn_id in sorted(unsettled, key=lambda t: t[1]):
+            if (
+                env.agenta.sessions.durable_stop
+                and commands_service is not None
+                and not await commands_service.settle_execution_lost(
+                    project_id=project_id,
+                    session_id=session_id,
+                    execution_id=turn_id,
+                    settled_at=now,
+                )
+            ):
+                continue
+            terminal_winners.add((project_id, session_id, turn_id))
             for record_event in _lost_turn_records(
                 project_id=project_id,
                 session_id=session_id,
@@ -376,6 +389,8 @@ async def run_orphan_sweep(
                         turn_id=turn_id,
                         exc_info=True,
                     )
+
+        unsettled = terminal_winners
 
         # A stopped row whose turn was just given its ending is NOT collapsed, but the dead
         # turn may still hold the session's `alive` lock: settlement leaves `alive` to its

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -20,9 +20,17 @@ the flags first would hide the row forever with no ending ever written.
 
 Two thresholds, not one. A RUNNING row beats every 30 seconds, so a short silence means the
 runner died. An ALIVE-but-idle row is a different animal: between turns, and while a turn is
-parked awaiting a human, the runner stops beating entirely but keeps the sandbox warm for the
-approval TTL. Settling those on the short threshold would end a session the user was about to
-resume. Both thresholds are settings; see `SessionWatchdogConfig` in `oss/src/utils/env.py`.
+parked awaiting a human, the runner sends a final beat with `is_running: false` and then stops
+beating on purpose. That state is resumable, so it is never given a terminal record here.
+Both thresholds are settings; see `SessionWatchdogConfig` in `oss/src/utils/env.py`.
+
+WHAT THIS PASS CANNOT SEE, and why the runner needs its own detector. This scan keys off
+heartbeat age, and a turn whose SANDBOX died keeps beating perfectly well: the runner is
+healthy, only the machine under it is gone. Such a row never becomes stale and is invisible
+here for ever. That case is issue #6418 and it is closed on the runner side, by the sandbox
+liveness probe in `services/runner/src/engines/sandbox_agent/sandbox-liveness.ts`. This pass
+covers the complementary case, where the RUNNER is what disappeared and nothing on that side
+can write anything at all.
 
 Called from the FastAPI lifespan; runs as a background asyncio task.
 """
@@ -56,18 +64,23 @@ from sqlalchemy import and_, func, not_, or_, select
 
 log = get_module_logger(__name__)
 
-# A RUNNING stream whose heartbeat (updated_at) is older than this is lost: a live turn beats
-# every `heartbeat_interval_seconds`, so one interval plus the configured grace of silence
-# means the owning runner is gone. 30 + 90 = 120 seconds by default, which is three missed
-# beats. Raise AGENTA_SESSIONS_WATCHDOG_GRACE_SECONDS if healthy turns are being settled.
-ORPHAN_THRESHOLD_SECONDS: int = (
-    env.sessions.heartbeat_interval_seconds
-    + env.agenta.sessions.watchdog.running_grace_seconds
-)
+# A RUNNING stream whose heartbeat is older than this is lost.
+#
+# The rule is HEARTBEAT AGE, deliberately, and not the Redis lease. The `alive` and `running`
+# keys carry a one-hour TTL (`env.sessions.alive_ttl_seconds`), so waiting for a lease to
+# expire would mean waiting an hour. The runner beats every 30 seconds and the beat is
+# mirrored onto `session_streams.updated_at`, so the age of that column is what actually says
+# whether anyone is still running the turn. 90 seconds is three missed beats.
+#
+# Raise AGENTA_SESSIONS_WATCHDOG_STALE_HEARTBEAT_SECONDS if healthy turns are being settled.
+ORPHAN_THRESHOLD_SECONDS: int = env.agenta.sessions.watchdog.stale_heartbeat_seconds
 
-# Alive-but-idle rows (between turns, or parked awaiting approval) get a longer grace: the
-# runner stops beating while a turn is parked, and it keeps that sandbox warm for the
-# approval TTL (30 min). Sweeping those at two minutes would declare a resumable session dead.
+# Alive-but-NOT-running rows are a different thing and owe no ending. Between turns, and while
+# a turn is parked awaiting a human, the runner sends one final beat with `is_running: false`
+# and then stops beating on purpose; that state is resumable and its last turn already reached
+# its own terminal record. Such a row is still reclaimed after a much longer silence — the
+# pre-existing orphan-sweep behaviour, keyed to the 30-minute approval TTL — but the watchdog
+# never writes a terminal record for it. See `_lost_turn_records` callers below.
 IDLE_THRESHOLD_SECONDS: int = env.agenta.sessions.watchdog.idle_grace_seconds
 
 # How often the watchdog runs.

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -60,7 +60,7 @@ from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterfa
 from oss.src.dbs.redis.sessions.contract import WATCH_LIFECYCLE_ENDED
 from oss.src.dbs.redis.shared.engine import LockEngine
 from oss.src.dbs.redis.sessions.locks import (
-    get_owner,
+    get_owner_value,
     release_watchdog_turn,
 )
 
@@ -493,7 +493,7 @@ async def run_orphan_sweep(
         for project_id, session_id, turn_id in sorted(
             owner_keys, key=lambda key: key[1]
         ):
-            observed_owners[(project_id, session_id, turn_id)] = await get_owner(
+            observed_owners[(project_id, session_id, turn_id)] = await get_owner_value(
                 lock_engine,
                 project_id=str(project_id),
                 session_id=session_id,
@@ -743,7 +743,7 @@ async def run_orphan_sweep(
                 project_id=str(project_uuid),
                 session_id=session_id,
                 turn_id=turn_id,
-                replica_id=observed_owners.get((project_uuid, session_id, turn_id)),
+                owner_value=observed_owners.get((project_uuid, session_id, turn_id)),
             )
             log.warning(
                 "watchdog: wrote the ending a stopped turn's runner never reported",
@@ -766,7 +766,7 @@ async def run_orphan_sweep(
                 project_id=str(project_uuid),
                 session_id=session_id,
                 turn_id=row_turn_id,
-                replica_id=(
+                owner_value=(
                     observed_owners.get((project_uuid, session_id, row_turn_id))
                     if row_turn_id is not None
                     else None

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -382,12 +382,13 @@ async def run_orphan_sweep(
         # settle's `stopping_turn_id`) still lands. That is the finding-7 bug: the row kept
         # `is_running: true` after the sweep. The collapse below writes through a Core UPDATE
         # keyed by these ids, and the Redis/watch steps read these tuples, never the rows.
-        orphan_rows: List[Tuple[UUID, UUID, str, Optional[str]]] = [
+        orphan_rows: List[Tuple[UUID, UUID, str, Optional[str], Optional[datetime]]] = [
             (
                 row.id,
                 row.project_id,
                 row.session_id,
                 str(row.turn_id) if row.turn_id else None,
+                row.updated_at,
             )
             for row in orphans
         ]
@@ -533,7 +534,7 @@ async def run_orphan_sweep(
         # matched; this owns every other lost turn (a row the query did not return, or an
         # older execution whose row has since advanced). Everything here is guarded on
         # `turn_id`, so a row that now names a NEWER running turn is never disturbed.
-        collapsing = {(p, s, t) for (_id, p, s, t) in orphan_rows}
+        collapsing = {(p, s, t) for (_id, p, s, t, _u) in orphan_rows}
         newly_lost = sorted(unsettled - collapsing, key=lambda t: t[1])
 
         # Clear `is_running` on the DB row that STILL names a lost turn, keeping `is_alive` so
@@ -545,7 +546,9 @@ async def run_orphan_sweep(
         # edit puts between the load and the write, can open a nested `engine.session()`, whose
         # `finally` closes the shared task-scoped session and detaches these rows. A mutation on
         # a detached row is tracked by no session and is dropped at commit with no error.
-        running_rows_cleared: List[Tuple[UUID, UUID, str, Dict[str, Any]]] = []
+        running_rows_to_clear: List[
+            Tuple[UUID, UUID, str, str, Optional[datetime], Dict[str, Any]]
+        ] = []
         if newly_lost:
             rows_to_clear = (
                 (
@@ -567,37 +570,157 @@ async def run_orphan_sweep(
             for row in rows_to_clear:
                 flags = dict(row.flags or {})
                 flags["is_running"] = False
-                running_rows_cleared.append(
-                    (row.id, row.project_id, row.session_id, flags)
+                running_rows_to_clear.append(
+                    (
+                        row.id,
+                        row.project_id,
+                        row.session_id,
+                        str(row.turn_id),
+                        row.updated_at,
+                        flags,
+                    )
                 )
 
-        for project_id, session_id, turn_id in newly_lost:
+        # Both writes to `session_streams` happen HERE, from the values captured above, and both
+        # go through a Core UPDATE. No ORM attribute write on this table survives anywhere in
+        # this pass, on purpose: the rows were loaded before nested `engine.session()` calls that
+        # detach them, and a detached row's mutation is dropped at commit with no error.
+        # Every lost turn's row first, keeping `is_alive` so the session stays resumable.
+        running_rows_cleared: List[
+            Tuple[UUID, UUID, str, str, Optional[datetime], Dict[str, Any]]
+        ] = []
+        failed_running_clears: Set[Tuple[UUID, str, str]] = set()
+        for (
+            row_id,
+            project_uuid,
+            session_id,
+            turn_id,
+            observed_updated_at,
+            cleared_flags,
+        ) in running_rows_to_clear:
+            conditions = [
+                SessionStreamDBE.id == row_id,
+                SessionStreamDBE.project_id == project_uuid,
+                SessionStreamDBE.session_id == session_id,
+                SessionStreamDBE.turn_id == turn_id,
+                SessionStreamDBE.deleted_at.is_(None),
+                (
+                    SessionStreamDBE.updated_at == observed_updated_at
+                    if observed_updated_at is not None
+                    else SessionStreamDBE.updated_at.is_(None)
+                ),
+            ]
+            result = await session.execute(
+                sa_update(SessionStreamDBE)
+                .where(*conditions)
+                .values(flags=cleared_flags, updated_at=now)
+                .execution_options(synchronize_session=False)
+            )
+            if result.rowcount != 1:
+                failed_running_clears.add((project_uuid, session_id, turn_id))
+                log.info(
+                    "watchdog: lost-turn stream advanced during sweep; leaving it untouched",
+                    session_id=session_id,
+                    turn_id=turn_id,
+                )
+                continue
+            running_rows_cleared.append(
+                (
+                    row_id,
+                    project_uuid,
+                    session_id,
+                    turn_id,
+                    observed_updated_at,
+                    cleared_flags,
+                )
+            )
+
+        # Then the orphan rows, through guarded Core UPDATEs (finding 7).
+        # `synchronize_session=False` because nothing after this reads these rows back through
+        # the ORM identity map.
+        collapsed_flags = SessionStreamFlags(
+            is_alive=False, is_running=False, is_attached=False
+        ).model_dump(mode="json")
+        collapsed_rows: List[
+            Tuple[UUID, UUID, str, Optional[str], Optional[datetime]]
+        ] = []
+        for (
+            row_id,
+            project_uuid,
+            session_id,
+            turn_id,
+            observed_updated_at,
+        ) in orphan_rows:
+            conditions = [
+                SessionStreamDBE.id == row_id,
+                SessionStreamDBE.project_id == project_uuid,
+                SessionStreamDBE.session_id == session_id,
+                SessionStreamDBE.deleted_at.is_(None),
+                (
+                    SessionStreamDBE.turn_id == turn_id
+                    if turn_id is not None
+                    else SessionStreamDBE.turn_id.is_(None)
+                ),
+                (
+                    SessionStreamDBE.updated_at == observed_updated_at
+                    if observed_updated_at is not None
+                    else SessionStreamDBE.updated_at.is_(None)
+                ),
+            ]
+            result = await session.execute(
+                sa_update(SessionStreamDBE)
+                .where(*conditions)
+                .values(flags=collapsed_flags, updated_at=now)
+                .execution_options(synchronize_session=False)
+            )
+            if result.rowcount != 1:
+                log.info(
+                    "watchdog: orphan stream advanced during sweep; leaving it untouched",
+                    session_id=session_id,
+                    turn_id=turn_id,
+                )
+                continue
+            collapsed_rows.append(
+                (row_id, project_uuid, session_id, turn_id, observed_updated_at)
+            )
+            log.warning(
+                "watchdog: settled a session_stream whose runner went silent",
+                extra={
+                    "session_id": session_id,
+                    "stream_id": str(row_id),
+                    "turn_id": turn_id,
+                    "lost": (project_uuid, session_id, turn_id) in unsettled,
+                },
+            )
+
+        await session.commit()
+
+        # The old turn remains the Redis owner until its guarded row update commits. A failed
+        # compare-and-set means a newer heartbeat or turn won, so none of its Redis state is ours.
+        for project_uuid, session_id, turn_id in newly_lost:
+            if (project_uuid, session_id, turn_id) in failed_running_clears:
+                continue
             released = await release_alive(
                 lock_engine,
-                project_id=str(project_id),
+                project_id=str(project_uuid),
                 session_id=session_id,
                 turn_id=turn_id,
             )
-            # Clearing affinity is safe only when this turn still owned `alive`; otherwise a
-            # newer turn may already have claimed the session and its owner lease must survive.
             if released:
                 await force_clear_owner(
                     lock_engine,
-                    project_id=str(project_id),
+                    project_id=str(project_uuid),
                     session_id=session_id,
                 )
-            # Clear the running lock too, guarded so a newer turn's lock survives. Without this
-            # the SEND gate's running check keeps refusing even after `is_running` is cleared
-            # on the row.
             await release_running(
                 lock_engine,
-                project_id=str(project_id),
+                project_id=str(project_uuid),
                 session_id=session_id,
                 turn_id=turn_id,
             )
             await mark_turn_superseded(
                 lock_engine,
-                project_id=str(project_id),
+                project_id=str(project_uuid),
                 session_id=session_id,
                 turn_id=turn_id,
             )
@@ -610,48 +733,14 @@ async def run_orphan_sweep(
                 },
             )
 
-        # Both writes to `session_streams` happen HERE, from the values captured above, and both
-        # go through a Core UPDATE. No ORM attribute write on this table survives anywhere in
-        # this pass, on purpose: the rows were loaded before nested `engine.session()` calls that
-        # detach them, and a detached row's mutation is dropped at commit with no error.
-        # Every lost turn's row first, keeping `is_alive` so the session stays resumable.
-        for row_id, _p, _s, cleared_flags in running_rows_cleared:
-            await session.execute(
-                sa_update(SessionStreamDBE)
-                .where(SessionStreamDBE.id == row_id)
-                .values(flags=cleared_flags, updated_at=now)
-                .execution_options(synchronize_session=False)
-            )
-
-        # Then the orphan rows, through ONE Core UPDATE keyed by their ids (finding 7).
-        # `synchronize_session=False` because nothing after this reads these rows back through
-        # the ORM identity map.
-        collapsed_flags = SessionStreamFlags(
-            is_alive=False, is_running=False, is_attached=False
-        ).model_dump(mode="json")
-        orphan_ids = [oid for (oid, _p, _s, _t) in orphan_rows]
-        if orphan_ids:
-            await session.execute(
-                sa_update(SessionStreamDBE)
-                .where(SessionStreamDBE.id.in_(orphan_ids))
-                .values(flags=collapsed_flags, updated_at=now)
-                .execution_options(synchronize_session=False)
-            )
-        for _oid, project_uuid, session_id, turn_id in orphan_rows:
-            log.warning(
-                "watchdog: settled a session_stream whose runner went silent",
-                extra={
-                    "session_id": session_id,
-                    "stream_id": str(_oid),
-                    "turn_id": turn_id,
-                    "lost": (project_uuid, session_id, turn_id) in unsettled,
-                },
-            )
-
-        await session.commit()
-
         # Bring the Redis locks the SEND gate reads in sync with the rows just written.
-        for _oid, project_uuid, session_id, row_turn_id in orphan_rows:
+        for (
+            _row_id,
+            project_uuid,
+            session_id,
+            row_turn_id,
+            _observed_updated_at,
+        ) in collapsed_rows:
             project_id = str(project_uuid)
             displaced_alive = await force_cancel_alive(
                 lock_engine, project_id=project_id, session_id=session_id
@@ -685,7 +774,13 @@ async def run_orphan_sweep(
         # settled turn keeps showing it as running until the user reloads. Best effort: the
         # publisher never raises and never re-drives the settle above.
         if watch_publisher is not None:
-            for _oid, project_uuid, session_id, _turn_id in orphan_rows:
+            for (
+                _row_id,
+                project_uuid,
+                session_id,
+                _turn_id,
+                _observed_updated_at,
+            ) in collapsed_rows:
                 try:
                     await watch_publisher.lifecycle(
                         project_id=str(project_uuid),
@@ -709,7 +804,14 @@ async def run_orphan_sweep(
 
             # A row whose `is_running` was cleared (but not collapsed) also needs the mirror
             # update, or a browser sitting on it keeps the turn drawn as running until a reload.
-            for _row_id, project_uuid, session_id, _flags in running_rows_cleared:
+            for (
+                _row_id,
+                project_uuid,
+                session_id,
+                _turn_id,
+                _observed_updated_at,
+                _flags,
+            ) in running_rows_cleared:
                 try:
                     await watch_publisher.changed(
                         project_id=str(project_uuid),
@@ -733,7 +835,7 @@ async def run_orphan_sweep(
 
         log.info(
             "watchdog: settled %d sessions (%d turns marked lost, %d commands lost)",
-            len(orphans),
+            len(collapsed_rows),
             len(unsettled),
             commands_settled,
         )

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -44,7 +44,11 @@ from oss.src.utils.env import env
 from oss.src.utils.logging import get_module_logger
 from oss.src.dbs.postgres.shared.engine import TransactionsEngine
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
-from oss.src.core.sessions.records.dtos import SessionRecordEvent
+from oss.src.core.sessions.records.dtos import (
+    RECORD_SETTLED_BY_ATTRIBUTE,
+    SETTLED_BY_WATCHDOG,
+    SessionRecordEvent,
+)
 from oss.src.core.sessions.records.service import RecordsService
 from oss.src.core.sessions.records.streaming import publish_record
 from oss.src.core.sessions.streams.dtos import (
@@ -102,6 +106,13 @@ LOST_ERROR_MESSAGE = "The agent stopped responding and the run was closed. Send 
 
 # Records are attributed to the agent, matching every record the runner writes for a turn.
 RECORD_SOURCE_AGENT = "agent"
+
+# Both records carry this marker, and it is the ONLY thing that distinguishes the watchdog's
+# ending from a runner's. That matters twice at ingest: a record arriving for a turn this
+# marker has already closed is quarantined rather than appended, and the watchdog's own two
+# records are exempt from that rule so a redelivery cannot quarantine the ending itself. See
+# `RecordsService.append_many`.
+SETTLED_BY = {RECORD_SETTLED_BY_ATTRIBUTE: SETTLED_BY_WATCHDOG}
 
 
 def _watchdog_record_id(
@@ -161,6 +172,7 @@ def _lost_turn_records(
                 "type": "error",
                 "message": LOST_ERROR_MESSAGE,
                 "code": LOST_ERROR_CODE,
+                **SETTLED_BY,
             },
             turn_id=turn_id,
         ),
@@ -177,7 +189,7 @@ def _lost_turn_records(
             record_index=1,
             record_type="done",
             record_source=RECORD_SOURCE_AGENT,
-            attributes={"type": "done"},
+            attributes={"type": "done", **SETTLED_BY},
             turn_id=turn_id,
         ),
     ]

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -9,7 +9,7 @@ session refuses a new message until a threshold far away expires.
 This pass closes that hole. It scans `session_streams` for rows whose mirror still says
 `is_alive` but whose heartbeat (`updated_at`) is stale, and for each one it:
 
-1. writes the terminal records the dead runner owed, marked `execution_lost`;
+1. writes the terminal records the dead runner owed, preserving stopped vs lost;
 2. collapses the row's flags so the session reads as ended;
 3. clears the Redis nest and tombstones the turn, so a late beat cannot re-nest it;
 4. publishes the watch notification, so an open browser refreshes without a reload.
@@ -48,6 +48,7 @@ from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
 from oss.src.core.sessions.records.dtos import (
     RECORD_SETTLED_BY_ATTRIBUTE,
     SETTLED_BY_WATCHDOG,
+    TERMINAL_RECORD_TYPE,
     SessionRecordEvent,
 )
 from oss.src.core.sessions.records.service import RecordsService
@@ -66,7 +67,7 @@ from oss.src.dbs.redis.sessions.locks import (
     release_alive,
 )
 
-from sqlalchemy import and_, func, not_, or_, select
+from sqlalchemy import and_, func, not_, or_, select, tuple_, update as sa_update
 
 log = get_module_logger(__name__)
 
@@ -201,12 +202,39 @@ def _lost_turn_records(
     ]
 
 
+def _stopped_turn_records(
+    *,
+    project_id: UUID,
+    session_id: str,
+    turn_id: str,
+    now: datetime,
+) -> List[SessionRecordEvent]:
+    return [
+        SessionRecordEvent(
+            project_id=project_id,
+            session_id=session_id,
+            record_id=_watchdog_record_id(
+                project_id=str(project_id),
+                session_id=session_id,
+                turn_id=turn_id,
+                suffix="done",
+            ),
+            timestamp=now,
+            record_index=0,
+            record_type=TERMINAL_RECORD_TYPE,
+            record_source=RECORD_SOURCE_AGENT,
+            attributes={"type": "done", "stopReason": "cancelled", **SETTLED_BY},
+            turn_id=turn_id,
+        )
+    ]
+
+
 async def _unsettled_turns(
     *,
     records_service: Optional[RecordsService],
     candidates: Sequence[Tuple[UUID, str, str]],
-) -> Set[Tuple[UUID, str, str]]:
-    """Of these `(project_id, session_id, turn_id)` triples, the ones with no terminal record.
+) -> Tuple[Set[Tuple[UUID, str, str]], Set[Tuple[UUID, str, str]]]:
+    """Partition candidates into turns without and with a terminal record.
 
     A runner can die AFTER writing its outcome but BEFORE its final `is_running=false`
     heartbeat lands — the last beat is best-effort and untimed. Such a turn is already
@@ -214,17 +242,18 @@ async def _unsettled_turns(
     would corrupt the transcript. One query per project, never one per candidate.
     """
     if not candidates:
-        return set()
+        return set(), set()
 
     if records_service is None:
         # No records plane wired (minimal test compositions): settle the row, write nothing.
-        return set()
+        return set(), set()
 
     by_project: Dict[UUID, List[Tuple[str, str]]] = {}
     for project_id, session_id, turn_id in candidates:
         by_project.setdefault(project_id, []).append((session_id, turn_id))
 
     unsettled: Set[Tuple[UUID, str, str]] = set()
+    ended: Set[Tuple[UUID, str, str]] = set()
     for project_id, keys in by_project.items():
         try:
             settled = await records_service.settled_turns(
@@ -241,10 +270,35 @@ async def _unsettled_turns(
             continue
 
         for session_id, turn_id in keys:
-            if (session_id, turn_id) not in settled:
-                unsettled.add((project_id, session_id, turn_id))
+            key = (project_id, session_id, turn_id)
+            if (session_id, turn_id) in settled:
+                ended.add(key)
+            else:
+                unsettled.add(key)
 
-    return unsettled
+    return unsettled, ended
+
+
+async def _mark_endings_written(
+    *,
+    session: Any,
+    keys: Set[Tuple[UUID, str, str]],
+    written_at: datetime,
+) -> None:
+    if not keys:
+        return
+    await session.execute(
+        sa_update(SessionExecutionDBE)
+        .where(
+            tuple_(
+                SessionExecutionDBE.project_id,
+                SessionExecutionDBE.session_id,
+                SessionExecutionDBE.execution_id,
+            ).in_(keys),
+            SessionExecutionDBE.ending_written_at.is_(None),
+        )
+        .values(ending_written_at=written_at)
+    )
 
 
 async def _settle_abandoned_commands(
@@ -340,9 +394,10 @@ async def run_orphan_sweep(
                 select(SessionExecutionDBE)
                 .where(
                     SessionExecutionDBE.terminal_outcome.in_(("stopped", "lost")),
+                    SessionExecutionDBE.ending_written_at.is_(None),
                     SessionExecutionDBE.settled_at < threshold,
                 )
-                .order_by(SessionExecutionDBE.settled_at)
+                .order_by(SessionExecutionDBE.settled_at.desc())
                 .limit(SWEEP_BATCH_SIZE)
             )
             terminal_executions = (await session.execute(terminal_stmt)).scalars().all()
@@ -361,6 +416,7 @@ async def run_orphan_sweep(
             claimed.append(key)
         current_turns = set(claimed)
         terminal_turns: Set[Tuple[UUID, str, str]] = set()
+        terminal_outcomes: Dict[Tuple[UUID, str, str], str] = {}
         for execution in terminal_executions:
             key = (
                 execution.project_id,
@@ -368,12 +424,18 @@ async def run_orphan_sweep(
                 execution.execution_id,
             )
             terminal_turns.add(key)
+            terminal_outcomes[key] = execution.terminal_outcome
             if key in seen:
                 continue
             seen.add(key)
             claimed.append(key)
-        unsettled = await _unsettled_turns(
+        unsettled, ended = await _unsettled_turns(
             records_service=records_service, candidates=claimed
+        )
+        await _mark_endings_written(
+            session=session,
+            keys=ended & terminal_turns,
+            written_at=now_utc,
         )
 
         if not orphans and not unsettled:
@@ -387,9 +449,11 @@ async def run_orphan_sweep(
         # next pass, which re-reads the record it just wrote and does not write a second.
         now = datetime.now(timezone.utc)
         terminal_winners: Set[Tuple[UUID, str, str]] = set()
+        endings_written: Set[Tuple[UUID, str, str]] = set()
         for project_id, session_id, turn_id in sorted(unsettled, key=lambda t: t[1]):
+            key = (project_id, session_id, turn_id)
             if (
-                (project_id, session_id, turn_id) not in terminal_turns
+                key not in terminal_turns
                 and env.agenta.sessions.durable_stop
                 and commands_service is not None
                 and not await commands_service.settle_execution_lost(
@@ -400,15 +464,28 @@ async def run_orphan_sweep(
                 )
             ):
                 continue
-            terminal_winners.add((project_id, session_id, turn_id))
-            for record_event in _lost_turn_records(
-                project_id=project_id,
-                session_id=session_id,
-                turn_id=turn_id,
-                now=now,
-            ):
+            terminal_winners.add(key)
+            record_events = (
+                _stopped_turn_records(
+                    project_id=project_id,
+                    session_id=session_id,
+                    turn_id=turn_id,
+                    now=now,
+                )
+                if terminal_outcomes.get(key) == "stopped"
+                else _lost_turn_records(
+                    project_id=project_id,
+                    session_id=session_id,
+                    turn_id=turn_id,
+                    now=now,
+                )
+            )
+            for record_event in record_events:
+                published = False
                 try:
-                    await publish(project_id=project_id, record_event=record_event)
+                    published = await publish(
+                        project_id=project_id, record_event=record_event
+                    )
                 except Exception:
                     log.warning(
                         "watchdog: failed to publish a terminal record",
@@ -417,6 +494,14 @@ async def run_orphan_sweep(
                         turn_id=turn_id,
                         exc_info=True,
                     )
+                if published and record_event.record_type == TERMINAL_RECORD_TYPE:
+                    endings_written.add(key)
+
+        await _mark_endings_written(
+            session=session,
+            keys=endings_written,
+            written_at=now,
+        )
 
         unsettled = terminal_winners
 

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -1,22 +1,49 @@
-"""Orphan sweep — SCA-6.
+"""Execution watchdog (formerly the orphan sweep) — SCA-6.
 
-Periodically scans session_streams for rows whose mirror says is_alive but whose
-heartbeat (updated_at) is stale — the owning runner died mid-turn and its Redis
-alive lock has expired. Marks each orphan ended + collapses its flags so the
-sandbox can be reaped.
+Every accepted execution must reach exactly one durable terminal outcome. The runner writes
+that outcome on every path it controls, but it cannot write one when it is gone: its container
+restarts, its process dies, or its `run()` never returns. The session then keeps the Redis
+`alive`/`running` nest of a turn nobody is running, the transcript stops mid-turn, and the
+session refuses a new message until a threshold far away expires.
+
+This pass closes that hole. It scans `session_streams` for rows whose mirror still says
+`is_alive` but whose heartbeat (`updated_at`) is stale, and for each one it:
+
+1. writes the terminal records the dead runner owed, marked `execution_lost`;
+2. collapses the row's flags so the session reads as ended;
+3. clears the Redis nest and tombstones the turn, so a late beat cannot re-nest it;
+4. publishes the watch notification, so an open browser refreshes without a reload.
+
+Step 1 is what makes the outcome durable, and it is deliberately first: a crash between the
+steps leaves the row a candidate for the next pass, which is recoverable, whereas collapsing
+the flags first would hide the row forever with no ending ever written.
+
+Two thresholds, not one. A RUNNING row beats every 30 seconds, so a short silence means the
+runner died. An ALIVE-but-idle row is a different animal: between turns, and while a turn is
+parked awaiting a human, the runner stops beating entirely but keeps the sandbox warm for the
+approval TTL. Settling those on the short threshold would end a session the user was about to
+resume. Both thresholds are settings; see `SessionWatchdogConfig` in `oss/src/utils/env.py`.
 
 Called from the FastAPI lifespan; runs as a background asyncio task.
 """
 
 import asyncio
 from datetime import datetime, timezone, timedelta
+from typing import Any, Dict, List, Optional, Sequence, Set, Tuple
+from uuid import UUID, uuid5, NAMESPACE_URL
 
+from oss.src.utils.env import env
 from oss.src.utils.logging import get_module_logger
 from oss.src.dbs.postgres.shared.engine import TransactionsEngine
 from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE
+from oss.src.core.sessions.records.dtos import SessionRecordEvent
+from oss.src.core.sessions.records.service import RecordsService
+from oss.src.core.sessions.records.streaming import publish_record
 from oss.src.core.sessions.streams.dtos import (
     SessionStreamFlags,
 )
+from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterface
+from oss.src.dbs.redis.sessions.contract import WATCH_LIFECYCLE_ENDED
 from oss.src.dbs.redis.shared.engine import LockEngine
 from oss.src.dbs.redis.sessions.locks import (
     force_cancel_alive,
@@ -29,24 +56,175 @@ from sqlalchemy import and_, func, not_, or_, select
 
 log = get_module_logger(__name__)
 
-# A RUNNING stream whose heartbeat (updated_at) is older than this is orphaned: a live turn
-# beats every 30s, so this much silence means the owning runner died.
-ORPHAN_THRESHOLD_SECONDS: int = 300  # 5 minutes
+# A RUNNING stream whose heartbeat (updated_at) is older than this is lost: a live turn beats
+# every `heartbeat_interval_seconds`, so one interval plus the configured grace of silence
+# means the owning runner is gone. 30 + 90 = 120 seconds by default, which is three missed
+# beats. Raise AGENTA_SESSIONS_WATCHDOG_GRACE_SECONDS if healthy turns are being settled.
+ORPHAN_THRESHOLD_SECONDS: int = (
+    env.sessions.heartbeat_interval_seconds
+    + env.agenta.sessions.watchdog.running_grace_seconds
+)
 
 # Alive-but-idle rows (between turns, or parked awaiting approval) get a longer grace: the
 # runner stops beating while a turn is parked, and it keeps that sandbox warm for the
-# approval TTL (30 min). Sweeping those at 5 min would declare a resumable session dead.
-IDLE_THRESHOLD_SECONDS: int = 1800  # 30 minutes
+# approval TTL (30 min). Sweeping those at two minutes would declare a resumable session dead.
+IDLE_THRESHOLD_SECONDS: int = env.agenta.sessions.watchdog.idle_grace_seconds
 
-# How often the sweep runs.
-SWEEP_INTERVAL_SECONDS: int = 60
+# How often the watchdog runs.
+SWEEP_INTERVAL_SECONDS: int = env.agenta.sessions.watchdog.interval_seconds
 
 # Rows swept per pass. A backlog drains over successive passes instead of one huge commit.
-SWEEP_BATCH_SIZE: int = 500
+SWEEP_BATCH_SIZE: int = env.agenta.sessions.watchdog.batch_size
+
+# The error class the watchdog stamps on the turn it settles. One of the `RunErrorCode`
+# values in services/runner/src/engines/sandbox_agent/errors.ts; the client reads it to offer
+# a retry rather than parsing the message.
+LOST_ERROR_CODE = "execution_lost"
+
+# The line the user reads in place of the answer the dead runner never gave. Identical to
+# `EXECUTION_LOST_MESSAGE` in services/runner/src/engines/sandbox_agent/errors.ts, which the
+# runner writes for the same class when a turn will not unwind: one outcome must not reach
+# the user in two different wordings depending on which side noticed it.
+LOST_ERROR_MESSAGE = "The agent stopped responding and the run was closed. Send the message again to retry."
+
+# Records are attributed to the agent, matching every record the runner writes for a turn.
+RECORD_SOURCE_AGENT = "agent"
 
 
-async def run_orphan_sweep(engine: TransactionsEngine, lock_engine: LockEngine) -> None:
-    """Single sweep pass: mark stale is_alive rows as ended."""
+def _watchdog_record_id(
+    *,
+    project_id: str,
+    session_id: str,
+    turn_id: str,
+    suffix: str,
+) -> UUID:
+    """A stable id per (turn, record), so re-running the watchdog upserts instead of appending.
+
+    The ingest path is `INSERT ... ON CONFLICT (project_id, record_id) DO UPDATE`, so two
+    passes — or two API replicas sweeping at once — write the same two rows, never four.
+    """
+    return uuid5(
+        NAMESPACE_URL,
+        f"agenta:sessions:watchdog:{project_id}:{session_id}:{turn_id}:{suffix}",
+    )
+
+
+def _lost_turn_records(
+    *,
+    project_id: UUID,
+    session_id: str,
+    turn_id: str,
+    now: datetime,
+) -> List[SessionRecordEvent]:
+    """The two records a runner writes when a turn ends badly, written on its behalf.
+
+    Shape and order mirror `run-turn.ts`'s error path exactly: an `error` event carrying the
+    class a client can act on, then the terminal `done`. A lone `done` would render as a
+    clean finish, which is the opposite of what happened.
+
+    The two are ordered explicitly. The transcript sorts on (`timestamp`, `created_at`,
+    `record_index`), and one write batch shares a single `created_at`, so two records stamped
+    at the same instant with no index would come back in whatever order Postgres chose. A
+    `done` read before its `error` closes the turn early, and the failure then renders as a
+    stray bubble beside a turn that claims it got no response.
+    """
+    project = str(project_id)
+
+    return [
+        SessionRecordEvent(
+            project_id=project_id,
+            session_id=session_id,
+            record_id=_watchdog_record_id(
+                project_id=project,
+                session_id=session_id,
+                turn_id=turn_id,
+                suffix="error",
+            ),
+            timestamp=now,
+            record_index=0,
+            record_type="error",
+            record_source=RECORD_SOURCE_AGENT,
+            attributes={
+                "type": "error",
+                "message": LOST_ERROR_MESSAGE,
+                "code": LOST_ERROR_CODE,
+            },
+            turn_id=turn_id,
+        ),
+        SessionRecordEvent(
+            project_id=project_id,
+            session_id=session_id,
+            record_id=_watchdog_record_id(
+                project_id=project,
+                session_id=session_id,
+                turn_id=turn_id,
+                suffix="done",
+            ),
+            timestamp=now + timedelta(milliseconds=1),
+            record_index=1,
+            record_type="done",
+            record_source=RECORD_SOURCE_AGENT,
+            attributes={"type": "done"},
+            turn_id=turn_id,
+        ),
+    ]
+
+
+async def _unsettled_turns(
+    *,
+    records_service: Optional[RecordsService],
+    candidates: Sequence[Tuple[UUID, str, str]],
+) -> Set[Tuple[UUID, str, str]]:
+    """Of these `(project_id, session_id, turn_id)` triples, the ones with no terminal record.
+
+    A runner can die AFTER writing its outcome but BEFORE its final `is_running=false`
+    heartbeat lands — the last beat is best-effort and untimed. Such a turn is already
+    settled; the row still needs collapsing, but writing a second, contradictory ending
+    would corrupt the transcript. One query per project, never one per candidate.
+    """
+    if not candidates:
+        return set()
+
+    if records_service is None:
+        # No records plane wired (minimal test compositions): settle the row, write nothing.
+        return set()
+
+    by_project: Dict[UUID, List[Tuple[str, str]]] = {}
+    for project_id, session_id, turn_id in candidates:
+        by_project.setdefault(project_id, []).append((session_id, turn_id))
+
+    unsettled: Set[Tuple[UUID, str, str]] = set()
+    for project_id, keys in by_project.items():
+        try:
+            settled = await records_service.settled_turns(
+                project_id=project_id, keys=keys
+            )
+        except Exception:
+            # A failed lookup must not produce a duplicate ending. Skip the write; the row
+            # is still collapsed below, and the next pass will not see it again.
+            log.warning(
+                "watchdog: terminal-record lookup failed; skipping record write",
+                project_id=str(project_id),
+                exc_info=True,
+            )
+            continue
+
+        for session_id, turn_id in keys:
+            if (session_id, turn_id) not in settled:
+                unsettled.add((project_id, session_id, turn_id))
+
+    return unsettled
+
+
+async def run_orphan_sweep(
+    engine: TransactionsEngine,
+    lock_engine: LockEngine,
+    *,
+    records_service: Optional[RecordsService] = None,
+    watch_publisher: Optional[SessionsWatchPublisherInterface] = None,
+    publish: Any = publish_record,
+) -> None:
+    """Single watchdog pass: settle every stale is_alive row."""
     now_utc = datetime.now(timezone.utc)
     threshold = now_utc - timedelta(seconds=ORPHAN_THRESHOLD_SECONDS)
     idle_threshold = now_utc - timedelta(seconds=IDLE_THRESHOLD_SECONDS)
@@ -75,15 +253,52 @@ async def run_orphan_sweep(engine: TransactionsEngine, lock_engine: LockEngine) 
         if not orphans:
             return
 
+        # A row that claimed a RUNNING turn owes that turn an ending. A row that was merely
+        # alive between turns owes nothing: its last turn already ended normally.
+        claimed: List[Tuple[UUID, str, str]] = [
+            (row.project_id, row.session_id, str(row.turn_id))
+            for row in orphans
+            if row.turn_id and (row.flags or {}).get("is_running") is True
+        ]
+        unsettled = await _unsettled_turns(
+            records_service=records_service, candidates=claimed
+        )
+
+        # Durable ending FIRST. A crash after this point leaves the row a candidate for the
+        # next pass, which re-reads the record it just wrote and does not write a second.
         now = datetime.now(timezone.utc)
+        for project_id, session_id, turn_id in sorted(unsettled, key=lambda t: t[1]):
+            for record_event in _lost_turn_records(
+                project_id=project_id,
+                session_id=session_id,
+                turn_id=turn_id,
+                now=now,
+            ):
+                try:
+                    await publish(project_id=project_id, record_event=record_event)
+                except Exception:
+                    log.warning(
+                        "watchdog: failed to publish a terminal record",
+                        project_id=str(project_id),
+                        session_id=session_id,
+                        turn_id=turn_id,
+                        exc_info=True,
+                    )
+
         for row in orphans:
             row.flags = SessionStreamFlags(
                 is_alive=False, is_running=False, is_attached=False
             ).model_dump(mode="json")
             row.updated_at = now
             log.warning(
-                "orphan_sweep: marking session_stream ended",
-                extra={"session_id": row.session_id, "stream_id": str(row.id)},
+                "watchdog: settled a session_stream whose runner went silent",
+                extra={
+                    "session_id": row.session_id,
+                    "stream_id": str(row.id),
+                    "turn_id": str(row.turn_id) if row.turn_id else None,
+                    "lost": (row.project_id, row.session_id, str(row.turn_id))
+                    in unsettled,
+                },
             )
 
         await session.commit()
@@ -111,16 +326,58 @@ async def run_orphan_sweep(engine: TransactionsEngine, lock_engine: LockEngine) 
                 lock_engine, project_id=project_id, session_id=row.session_id
             )
 
-        log.info("orphan_sweep: marked %d orphans ended", len(orphans))
+        # Tell every open reader the session ended. Without this a browser sitting on the
+        # settled turn keeps showing it as running until the user reloads. Best effort: the
+        # publisher never raises and never re-drives the settle above.
+        if watch_publisher is not None:
+            for row in orphans:
+                try:
+                    await watch_publisher.lifecycle(
+                        project_id=str(row.project_id),
+                        session_id=row.session_id,
+                        state=WATCH_LIFECYCLE_ENDED,
+                    )
+                    # The session channel reaches a tab that has this session open. A list
+                    # row lives on the project channel, so publish there too, or every other
+                    # tab keeps the session marked running until its own poll comes round.
+                    await watch_publisher.changed(
+                        project_id=str(row.project_id),
+                        entity="session",
+                        id=row.session_id,
+                    )
+                except Exception:
+                    log.warning(
+                        "watchdog: watch publish failed",
+                        session_id=row.session_id,
+                        exc_info=True,
+                    )
+
+        log.info(
+            "watchdog: settled %d sessions (%d turns marked lost)",
+            len(orphans),
+            len(unsettled),
+        )
 
 
 async def orphan_sweep_loop(
-    engine: TransactionsEngine, lock_engine: LockEngine
+    engine: TransactionsEngine,
+    lock_engine: LockEngine,
+    *,
+    records_service: Optional[RecordsService] = None,
+    watch_publisher: Optional[SessionsWatchPublisherInterface] = None,
 ) -> None:
     """Infinite loop; runs as a background asyncio task during app lifespan."""
     while True:
         try:
-            await run_orphan_sweep(engine, lock_engine)
+            await run_orphan_sweep(
+                engine,
+                lock_engine,
+                records_service=records_service,
+                watch_publisher=watch_publisher,
+            )
+        except asyncio.CancelledError:
+            raise
         except Exception:
-            log.exception("orphan_sweep: error during sweep pass")
-        await asyncio.sleep(SWEEP_INTERVAL_SECONDS)
+            log.exception("watchdog: error during sweep pass")
+        # Floored: a zero or negative interval would turn the loop into a hot spin.
+        await asyncio.sleep(max(SWEEP_INTERVAL_SECONDS, 1))

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -79,12 +79,16 @@ log = get_module_logger(__name__)
 # Raise AGENTA_SESSIONS_WATCHDOG_STALE_HEARTBEAT_SECONDS if healthy turns are being settled.
 ORPHAN_THRESHOLD_SECONDS: int = env.agenta.sessions.watchdog.stale_heartbeat_seconds
 
-# Alive-but-NOT-running rows are a different thing and owe no ending. Between turns, and while
-# a turn is parked awaiting a human, the runner sends one final beat with `is_running: false`
-# and then stops beating on purpose; that state is resumable and its last turn already reached
-# its own terminal record. Such a row is still reclaimed after a much longer silence — the
-# pre-existing orphan-sweep behaviour, keyed to the 30-minute approval TTL — but the watchdog
-# never writes a terminal record for it. See `_lost_turn_records` callers below.
+# Alive-but-NOT-running rows are RECLAIMED on a different, much longer clock. Between turns, and
+# while a turn is parked awaiting a human, the runner sends one final beat with `is_running:
+# false` and then stops beating on purpose; that state is resumable, so collapsing it is keyed
+# to the 30-minute approval TTL rather than to three missed beats.
+#
+# It does NOT decide whether such a row owes its turn an ending. It used to, on the premise that
+# a not-running row's last turn had already reached a terminal record — a premise a durable Stop
+# broke, because settlement clears `is_running` before the runner has written that record. The
+# ending is now decided by asking the records plane, on the ninety-second clock. See the second
+# selection in `run_orphan_sweep`.
 IDLE_THRESHOLD_SECONDS: int = env.agenta.sessions.watchdog.idle_grace_seconds
 
 # How often the watchdog runs.
@@ -275,19 +279,55 @@ async def run_orphan_sweep(
         result = await session.execute(stmt)
         orphans = result.scalars().all()
 
-        if not orphans:
-            return
+        # A SECOND selection, for the ending only. The rule above reads "not running, so its
+        # last turn already ended", and a durable Stop broke that premise: settlement clears
+        # `is_running` on the row the moment it releases the Redis key, so the tab that pressed
+        # Stop is not left spinning. The runner then owes its own terminal record — and if it
+        # dies in that window, the row is already not-running, the rule above skips it, and the
+        # 30-minute idle branch collapses the row without ever writing an ending. Observed live
+        # on the integration stack: a Stop settled `stopped` at 13:09:19, the runner was killed
+        # a moment later, and turn 295351c3 still carried nothing but the user's own message
+        # five minutes on. So the premise is now CHECKED rather than assumed: any stale row
+        # that names a turn is a candidate, and `_unsettled_turns` writes an ending only for a
+        # turn that carries none. A row between turns, or parked on an approval, has its own
+        # terminal record and is filtered out there, at the cost of one lookup per project.
+        #
+        # These rows are NOT collapsed. Collapsing keeps its own, much longer idle grace: a
+        # parked approval lives for thirty minutes and must not be reclaimed at ninety seconds.
+        ending_stmt = (
+            select(SessionStreamDBE)
+            .where(
+                SessionStreamDBE.deleted_at.is_(None),
+                SessionStreamDBE.flags.contains({"is_alive": True}),
+                not_(is_running),
+                SessionStreamDBE.turn_id.is_not(None),
+                last_beat < threshold,
+            )
+            .limit(SWEEP_BATCH_SIZE)
+        )
+        ending_only = (await session.execute(ending_stmt)).scalars().all()
 
-        # A row that claimed a RUNNING turn owes that turn an ending. A row that was merely
-        # alive between turns owes nothing: its last turn already ended normally.
-        claimed: List[Tuple[UUID, str, str]] = [
-            (row.project_id, row.session_id, str(row.turn_id))
-            for row in orphans
-            if row.turn_id and (row.flags or {}).get("is_running") is True
-        ]
+        # A row that claimed a RUNNING turn owes that turn an ending. So does a stopped row
+        # whose runner never wrote one; see the note above.
+        seen: Set[Tuple[UUID, str, str]] = set()
+        claimed: List[Tuple[UUID, str, str]] = []
+        for row in [*orphans, *ending_only]:
+            if not row.turn_id:
+                continue
+            key = (row.project_id, row.session_id, str(row.turn_id))
+            if key in seen:
+                continue
+            seen.add(key)
+            claimed.append(key)
         unsettled = await _unsettled_turns(
             records_service=records_service, candidates=claimed
         )
+
+        if not orphans and not unsettled:
+            # No stale row and nothing owed an ending, but a command can still be abandoned:
+            # its execution may have ended normally between the claim and the report.
+            await _settle_abandoned_commands(commands_service, now_utc)
+            return
 
         # Durable ending FIRST. A crash after this point leaves the row a candidate for the
         # next pass, which re-reads the record it just wrote and does not write a second.

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -613,8 +613,16 @@ async def run_orphan_sweep(
                 lock_engine, project_id=project_id, session_id=row.session_id
             )
             # A swept turn is declared dead; tombstone it so a late beat from it cannot
-            # re-nest the session it was just evicted from.
-            for turn_id in {t for t in (displaced_alive, displaced_running) if t}:
+            # re-nest the session it was just evicted from. Tombstone the row's OWN turn too,
+            # not only whoever still held the Redis keys: a turn whose alive/running keys a
+            # prior Stop settlement already cleared holds nothing here, yet its runner can
+            # still return and beat that turn_id. The heartbeat path refuses a superseded
+            # turn, so without this tombstone a returning runner re-set is_running on the row
+            # after the sweep had just cleared it (observed live: run 1e, turn e49c060b).
+            doomed_turns = {t for t in (displaced_alive, displaced_running) if t}
+            if row.turn_id:
+                doomed_turns.add(str(row.turn_id))
+            for turn_id in doomed_turns:
                 await mark_turn_superseded(
                     lock_engine,
                     project_id=project_id,

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -372,6 +372,26 @@ async def run_orphan_sweep(
         result = await session.execute(stmt)
         orphans = result.scalars().all()
 
+        # Capture what the collapse and its Redis/watch follow-up need as plain values NOW,
+        # before any nested `engine.session()` in this pass runs. The records lookup and the
+        # command settlement below each open `engine.session()`, which returns the SAME
+        # current-task-scoped session and, in its `finally`, calls `session.close()` (see
+        # `TransactionsEngine.session`). That close detaches every ORM row loaded here, so a
+        # later `row.flags = ...` mutation is tracked by no session and is silently dropped at
+        # commit -- the flags UPDATE is never emitted, while a Core UPDATE (the command
+        # settle's `stopping_turn_id`) still lands. That is the finding-7 bug: the row kept
+        # `is_running: true` after the sweep. The collapse below writes through a Core UPDATE
+        # keyed by these ids, and the Redis/watch steps read these tuples, never the rows.
+        orphan_rows: List[Tuple[UUID, UUID, str, Optional[str]]] = [
+            (
+                row.id,
+                row.project_id,
+                row.session_id,
+                str(row.turn_id) if row.turn_id else None,
+            )
+            for row in orphans
+        ]
+
         # Current stopped turns get their missing ending on the short clock without collapsing
         # a parked session, whose reclamation stays on the longer idle grace.
         ending_stmt = (
@@ -513,7 +533,7 @@ async def run_orphan_sweep(
         # matched; this owns every other lost turn (a row the query did not return, or an
         # older execution whose row has since advanced). Everything here is guarded on
         # `turn_id`, so a row that now names a NEWER running turn is never disturbed.
-        collapsing = {(r.project_id, r.session_id, str(r.turn_id)) for r in orphans}
+        collapsing = {(p, s, t) for (_id, p, s, t) in orphan_rows}
         newly_lost = sorted(unsettled - collapsing, key=lambda t: t[1])
 
         # Clear `is_running` on the DB row that STILL names a lost turn, keeping `is_alive` so
@@ -585,32 +605,43 @@ async def run_orphan_sweep(
                 },
             )
 
-        for row in orphans:
-            row.flags = SessionStreamFlags(
-                is_alive=False, is_running=False, is_attached=False
-            ).model_dump(mode="json")
-            row.updated_at = now
+        # Collapse the orphan rows through ONE Core UPDATE keyed by their ids, NOT by mutating
+        # the ORM objects: those objects were detached by the nested `engine.session()` calls
+        # above, so a `row.flags = ...` write would never be flushed (finding 7). A Core UPDATE
+        # is not tied to ORM instance state and always lands. `synchronize_session=False`
+        # because nothing after this reads these rows back through the ORM identity map.
+        collapsed_flags = SessionStreamFlags(
+            is_alive=False, is_running=False, is_attached=False
+        ).model_dump(mode="json")
+        orphan_ids = [oid for (oid, _p, _s, _t) in orphan_rows]
+        if orphan_ids:
+            await session.execute(
+                sa_update(SessionStreamDBE)
+                .where(SessionStreamDBE.id.in_(orphan_ids))
+                .values(flags=collapsed_flags, updated_at=now)
+                .execution_options(synchronize_session=False)
+            )
+        for _oid, project_uuid, session_id, turn_id in orphan_rows:
             log.warning(
                 "watchdog: settled a session_stream whose runner went silent",
                 extra={
-                    "session_id": row.session_id,
-                    "stream_id": str(row.id),
-                    "turn_id": str(row.turn_id) if row.turn_id else None,
-                    "lost": (row.project_id, row.session_id, str(row.turn_id))
-                    in unsettled,
+                    "session_id": session_id,
+                    "stream_id": str(_oid),
+                    "turn_id": turn_id,
+                    "lost": (project_uuid, session_id, turn_id) in unsettled,
                 },
             )
 
         await session.commit()
 
         # Bring the Redis locks the SEND gate reads in sync with the rows just written.
-        for row in orphans:
-            project_id = str(row.project_id)
+        for _oid, project_uuid, session_id, row_turn_id in orphan_rows:
+            project_id = str(project_uuid)
             displaced_alive = await force_cancel_alive(
-                lock_engine, project_id=project_id, session_id=row.session_id
+                lock_engine, project_id=project_id, session_id=session_id
             )
             displaced_running = await clear_running(
-                lock_engine, project_id=project_id, session_id=row.session_id
+                lock_engine, project_id=project_id, session_id=session_id
             )
             # A swept turn is declared dead; tombstone it so a late beat from it cannot
             # re-nest the session it was just evicted from. Tombstone the row's OWN turn too,
@@ -620,43 +651,43 @@ async def run_orphan_sweep(
             # turn, so without this tombstone a returning runner re-set is_running on the row
             # after the sweep had just cleared it (observed live: run 1e, turn e49c060b).
             doomed_turns = {t for t in (displaced_alive, displaced_running) if t}
-            if row.turn_id:
-                doomed_turns.add(str(row.turn_id))
+            if row_turn_id:
+                doomed_turns.add(row_turn_id)
             for turn_id in doomed_turns:
                 await mark_turn_superseded(
                     lock_engine,
                     project_id=project_id,
-                    session_id=row.session_id,
+                    session_id=session_id,
                     turn_id=turn_id,
                 )
             # A swept session is dead; free its affinity like kill does.
             await force_clear_owner(
-                lock_engine, project_id=project_id, session_id=row.session_id
+                lock_engine, project_id=project_id, session_id=session_id
             )
 
         # Tell every open reader the session ended. Without this a browser sitting on the
         # settled turn keeps showing it as running until the user reloads. Best effort: the
         # publisher never raises and never re-drives the settle above.
         if watch_publisher is not None:
-            for row in orphans:
+            for _oid, project_uuid, session_id, _turn_id in orphan_rows:
                 try:
                     await watch_publisher.lifecycle(
-                        project_id=str(row.project_id),
-                        session_id=row.session_id,
+                        project_id=str(project_uuid),
+                        session_id=session_id,
                         state=WATCH_LIFECYCLE_ENDED,
                     )
                     # The session channel reaches a tab that has this session open. A list
                     # row lives on the project channel, so publish there too, or every other
                     # tab keeps the session marked running until its own poll comes round.
                     await watch_publisher.changed(
-                        project_id=str(row.project_id),
+                        project_id=str(project_uuid),
                         entity="session",
-                        id=row.session_id,
+                        id=session_id,
                     )
                 except Exception:
                     log.warning(
                         "watchdog: watch publish failed",
-                        session_id=row.session_id,
+                        session_id=session_id,
                         exc_info=True,
                     )
 

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -65,6 +65,7 @@ from oss.src.dbs.redis.sessions.locks import (
     force_clear_owner,
     mark_turn_superseded,
     release_alive,
+    release_running,
 )
 
 from sqlalchemy import and_, func, not_, or_, select, tuple_, update as sa_update
@@ -414,7 +415,6 @@ async def run_orphan_sweep(
                 continue
             seen.add(key)
             claimed.append(key)
-        current_turns = set(claimed)
         terminal_turns: Set[Tuple[UUID, str, str]] = set()
         terminal_outcomes: Dict[Tuple[UUID, str, str], str] = {}
         for execution in terminal_executions:
@@ -505,17 +505,48 @@ async def run_orphan_sweep(
 
         unsettled = terminal_winners
 
-        # A stopped row whose turn was just given its ending is NOT collapsed, but the dead
-        # turn may still hold the session's `alive` lock: settlement leaves `alive` to its
-        # TTL on purpose, and that TTL is an hour. The SEND gate reads that lock, so a new
-        # message would be refused with "another turn owns this session" until it expired.
-        # Release it only if it still names the dead turn, and tombstone the turn so a late
-        # beat cannot re-nest the session. Observed live on the integration stack: the
-        # ending landed at 96.7 s and the next message was still refused.
+        # A lost turn whose stream row the went-silent collapse did NOT touch must still be
+        # brought to rest here, in this same pass, or the SEND gate refuses the next message
+        # until the runner returns -- which, for a lost turn, may be never. The RFC's rule is
+        # that the settlement writes the ending, clears `is_running`, releases `alive`, and
+        # updates the mirror together. The collapse below owns the rows the orphan query
+        # matched; this owns every other lost turn (a row the query did not return, or an
+        # older execution whose row has since advanced). Everything here is guarded on
+        # `turn_id`, so a row that now names a NEWER running turn is never disturbed.
         collapsing = {(r.project_id, r.session_id, str(r.turn_id)) for r in orphans}
-        for project_id, session_id, turn_id in sorted(
-            (unsettled - collapsing) & current_turns, key=lambda t: t[1]
-        ):
+        newly_lost = sorted(unsettled - collapsing, key=lambda t: t[1])
+
+        # Clear `is_running` on the DB row that STILL names a lost turn, keeping `is_alive` so
+        # the session stays resumable. Guarded on turn_id: a row that advanced to a newer turn
+        # is left alone. Observed live on the integration stack: the execution was settled lost
+        # but the stream row kept `is_running: true`, and the next Send was refused.
+        running_rows_cleared: List[SessionStreamDBE] = []
+        if newly_lost:
+            rows_to_clear = (
+                (
+                    await session.execute(
+                        select(SessionStreamDBE).where(
+                            SessionStreamDBE.deleted_at.is_(None),
+                            SessionStreamDBE.flags.contains({"is_running": True}),
+                            tuple_(
+                                SessionStreamDBE.project_id,
+                                SessionStreamDBE.session_id,
+                                SessionStreamDBE.turn_id,
+                            ).in_(list(newly_lost)),
+                        )
+                    )
+                )
+                .scalars()
+                .all()
+            )
+            for row in rows_to_clear:
+                flags = dict(row.flags or {})
+                flags["is_running"] = False
+                row.flags = flags
+                row.updated_at = now
+                running_rows_cleared.append(row)
+
+        for project_id, session_id, turn_id in newly_lost:
             released = await release_alive(
                 lock_engine,
                 project_id=str(project_id),
@@ -530,6 +561,15 @@ async def run_orphan_sweep(
                     project_id=str(project_id),
                     session_id=session_id,
                 )
+            # Clear the running lock too, guarded so a newer turn's lock survives. Without this
+            # the SEND gate's running check keeps refusing even after `is_running` is cleared
+            # on the row.
+            await release_running(
+                lock_engine,
+                project_id=str(project_id),
+                session_id=session_id,
+                turn_id=turn_id,
+            )
             await mark_turn_superseded(
                 lock_engine,
                 project_id=str(project_id),
@@ -600,6 +640,22 @@ async def run_orphan_sweep(
                     # The session channel reaches a tab that has this session open. A list
                     # row lives on the project channel, so publish there too, or every other
                     # tab keeps the session marked running until its own poll comes round.
+                    await watch_publisher.changed(
+                        project_id=str(row.project_id),
+                        entity="session",
+                        id=row.session_id,
+                    )
+                except Exception:
+                    log.warning(
+                        "watchdog: watch publish failed",
+                        session_id=row.session_id,
+                        exc_info=True,
+                    )
+
+            # A row whose `is_running` was cleared (but not collapsed) also needs the mirror
+            # update, or a browser sitting on it keeps the turn drawn as running until a reload.
+            for row in running_rows_cleared:
+                try:
                     await watch_publisher.changed(
                         project_id=str(row.project_id),
                         entity="session",

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -540,7 +540,12 @@ async def run_orphan_sweep(
         # the session stays resumable. Guarded on turn_id: a row that advanced to a newer turn
         # is left alone. Observed live on the integration stack: the execution was settled lost
         # but the stream row kept `is_running: true`, and the next Send was refused.
-        running_rows_cleared: List[SessionStreamDBE] = []
+        # Captured as plain values, and written by a Core UPDATE further down, for the same
+        # reason the collapse is: the Redis calls that follow this block, and anything a future
+        # edit puts between the load and the write, can open a nested `engine.session()`, whose
+        # `finally` closes the shared task-scoped session and detaches these rows. A mutation on
+        # a detached row is tracked by no session and is dropped at commit with no error.
+        running_rows_cleared: List[Tuple[UUID, UUID, str, Dict[str, Any]]] = []
         if newly_lost:
             rows_to_clear = (
                 (
@@ -562,9 +567,9 @@ async def run_orphan_sweep(
             for row in rows_to_clear:
                 flags = dict(row.flags or {})
                 flags["is_running"] = False
-                row.flags = flags
-                row.updated_at = now
-                running_rows_cleared.append(row)
+                running_rows_cleared.append(
+                    (row.id, row.project_id, row.session_id, flags)
+                )
 
         for project_id, session_id, turn_id in newly_lost:
             released = await release_alive(
@@ -605,11 +610,22 @@ async def run_orphan_sweep(
                 },
             )
 
-        # Collapse the orphan rows through ONE Core UPDATE keyed by their ids, NOT by mutating
-        # the ORM objects: those objects were detached by the nested `engine.session()` calls
-        # above, so a `row.flags = ...` write would never be flushed (finding 7). A Core UPDATE
-        # is not tied to ORM instance state and always lands. `synchronize_session=False`
-        # because nothing after this reads these rows back through the ORM identity map.
+        # Both writes to `session_streams` happen HERE, from the values captured above, and both
+        # go through a Core UPDATE. No ORM attribute write on this table survives anywhere in
+        # this pass, on purpose: the rows were loaded before nested `engine.session()` calls that
+        # detach them, and a detached row's mutation is dropped at commit with no error.
+        # Every lost turn's row first, keeping `is_alive` so the session stays resumable.
+        for row_id, _p, _s, cleared_flags in running_rows_cleared:
+            await session.execute(
+                sa_update(SessionStreamDBE)
+                .where(SessionStreamDBE.id == row_id)
+                .values(flags=cleared_flags, updated_at=now)
+                .execution_options(synchronize_session=False)
+            )
+
+        # Then the orphan rows, through ONE Core UPDATE keyed by their ids (finding 7).
+        # `synchronize_session=False` because nothing after this reads these rows back through
+        # the ORM identity map.
         collapsed_flags = SessionStreamFlags(
             is_alive=False, is_running=False, is_attached=False
         ).model_dump(mode="json")
@@ -693,17 +709,17 @@ async def run_orphan_sweep(
 
             # A row whose `is_running` was cleared (but not collapsed) also needs the mirror
             # update, or a browser sitting on it keeps the turn drawn as running until a reload.
-            for row in running_rows_cleared:
+            for _row_id, project_uuid, session_id, _flags in running_rows_cleared:
                 try:
                     await watch_publisher.changed(
-                        project_id=str(row.project_id),
+                        project_id=str(project_uuid),
                         entity="session",
-                        id=row.session_id,
+                        id=session_id,
                     )
                 except Exception:
                     log.warning(
                         "watchdog: watch publish failed",
-                        session_id=row.session_id,
+                        session_id=session_id,
                         exc_info=True,
                     )
 

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -663,7 +663,11 @@ async def orphan_sweep_loop(
                 pass_timeout,
             )
         except Exception:
-            log.exception("watchdog: error during sweep pass")
+            # `log` is a MultiLogger, which has no `exception` method; calling one would
+            # raise AttributeError from inside this handler and kill the loop for the life
+            # of the process. Use `error(..., exc_info=True)`, the same shape the helpers
+            # above use, so the first sweep error is logged and the loop goes round again.
+            log.error("watchdog: error during sweep pass", exc_info=True)
         elapsed = (datetime.now(timezone.utc) - started).total_seconds()
         if elapsed > SWEEP_INTERVAL_SECONDS:
             log.warning("watchdog: sweep pass took %.1fs", elapsed)

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -234,7 +234,11 @@ async def _unsettled_turns(
     *,
     records_service: Optional[RecordsService],
     candidates: Sequence[Tuple[UUID, str, str]],
-) -> Tuple[Set[Tuple[UUID, str, str]], Set[Tuple[UUID, str, str]]]:
+) -> Tuple[
+    Set[Tuple[UUID, str, str]],
+    Set[Tuple[UUID, str, str]],
+    Set[Tuple[UUID, str, str]],
+]:
     """Partition candidates into turns without and with a terminal record.
 
     A runner can die AFTER writing its outcome but BEFORE its final `is_running=false`
@@ -243,11 +247,11 @@ async def _unsettled_turns(
     would corrupt the transcript. One query per project, never one per candidate.
     """
     if not candidates:
-        return set(), set()
+        return set(), set(), set()
 
     if records_service is None:
         # No records plane wired (minimal test compositions): settle the row, write nothing.
-        return set(), set()
+        return set(), set(), set()
 
     by_project: Dict[UUID, List[Tuple[str, str]]] = {}
     for project_id, session_id, turn_id in candidates:
@@ -255,18 +259,20 @@ async def _unsettled_turns(
 
     unsettled: Set[Tuple[UUID, str, str]] = set()
     ended: Set[Tuple[UUID, str, str]] = set()
+    deferred: Set[Tuple[UUID, str, str]] = set()
     for project_id, keys in by_project.items():
         try:
             settled = await records_service.settled_turns(
                 project_id=project_id, keys=keys
             )
         except Exception:
-            # A failed lookup must not produce a duplicate ending. Skip the write; the row
-            # is still collapsed below, and the next pass will not see it again.
             log.warning(
-                "watchdog: terminal-record lookup failed; skipping record write",
+                "watchdog: terminal-record lookup failed; deferring project candidates",
                 project_id=str(project_id),
                 exc_info=True,
+            )
+            deferred.update(
+                (project_id, session_id, turn_id) for session_id, turn_id in keys
             )
             continue
 
@@ -277,7 +283,7 @@ async def _unsettled_turns(
             else:
                 unsettled.add(key)
 
-    return unsettled, ended
+    return unsettled, ended, deferred
 
 
 async def _mark_endings_written(
@@ -450,20 +456,27 @@ async def run_orphan_sweep(
                 continue
             seen.add(key)
             claimed.append(key)
-        unsettled, ended = await _unsettled_turns(
+        unsettled, ended, deferred = await _unsettled_turns(
             records_service=records_service, candidates=claimed
         )
+        if deferred:
+            orphan_rows = [
+                row
+                for row in orphan_rows
+                if row[3] is None or (row[1], row[2], row[3]) not in deferred
+            ]
         await _mark_endings_written(
             session=session,
             keys=ended & terminal_turns,
             written_at=now_utc,
         )
 
-        if not orphans and not unsettled:
+        if not orphan_rows and not unsettled:
             # No stale row and nothing owed an ending, but a command can still be abandoned:
             # its execution may have ended normally between the claim and the report.
-            await _settle_abandoned_commands(commands_service, now_utc)
-            await _repair_terminal_redis(commands_service)
+            if not deferred:
+                await _settle_abandoned_commands(commands_service, now_utc)
+                await _repair_terminal_redis(commands_service)
             return
 
         # Durable ending FIRST. A crash after this point leaves the row a candidate for the
@@ -828,10 +841,12 @@ async def run_orphan_sweep(
         # AFTER the rows above are collapsed, on purpose. A command is only abandoned when its
         # session has stopped beating, and the collapse just made that true for every row in
         # this batch. Running it first would leave the runner-gone case waiting a second pass.
-        commands_settled = await _settle_abandoned_commands(
-            commands_service, datetime.now(timezone.utc)
-        )
-        await _repair_terminal_redis(commands_service)
+        commands_settled = 0
+        if not deferred:
+            commands_settled = await _settle_abandoned_commands(
+                commands_service, datetime.now(timezone.utc)
+            )
+            await _repair_terminal_redis(commands_service)
 
         log.info(
             "watchdog: settled %d sessions (%d turns marked lost, %d commands lost)",

--- a/api/oss/src/tasks/asyncio/sessions/records_worker.py
+++ b/api/oss/src/tasks/asyncio/sessions/records_worker.py
@@ -4,6 +4,7 @@ from uuid import UUID
 from redis.asyncio import Redis
 
 from oss.src.core.sessions.interactions.service import SessionInteractionsService
+from oss.src.core.sessions.records.dtos import TERMINAL_RECORD_TYPE
 from oss.src.core.sessions.records.service import RecordsService
 from oss.src.core.sessions.records.streaming import deserialize_record
 from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterface
@@ -18,10 +19,9 @@ if is_ee():
     from ee.src.core.access.entitlements.types import Counter
 
 
-# The runner's terminal per-turn record, and the marker it stamps on that record when the turn
-# stopped to wait for a human instead of finishing (services/runner/src/tracing/otel.ts: the
-# field is written ONLY for a pause and omitted on every other stop reason).
-TERMINAL_RECORD_TYPE = "done"
+# The marker the runner stamps on its terminal record when the turn stopped to wait for a
+# human instead of finishing (services/runner/src/tracing/otel.ts: the field is written ONLY
+# for a pause and omitted on every other stop reason).
 PAUSED_STOP_REASON = "paused"
 
 
@@ -178,6 +178,17 @@ class RecordsWorker(StreamConsumer):
             results = await self.service.append_many(
                 events=[msg.record_event for _, msg in entries],
             )
+            quarantined = [row for row in results if row.quarantined_at is not None]
+            if quarantined:
+                log.warning(
+                    "[RECORDS] Quarantined late records for settled turns",
+                    project_id=str(project_id),
+                    quarantined=len(quarantined),
+                    appended=len(results),
+                    turns=sorted(
+                        {f"{row.session_id}:{row.turn_id}" for row in quarantined}
+                    ),
+                )
             self.mark_committed()
             return len(results), True
         except Exception:

--- a/api/oss/src/tasks/asyncio/sessions/records_worker.py
+++ b/api/oss/src/tasks/asyncio/sessions/records_worker.py
@@ -178,7 +178,11 @@ class RecordsWorker(StreamConsumer):
             results = await self.service.append_many(
                 events=[msg.record_event for _, msg in entries],
             )
-            quarantined = [row for row in results if row.quarantined_at is not None]
+            quarantined = [
+                row
+                for row in results
+                if getattr(row, "quarantined_at", None) is not None
+            ]
             if quarantined:
                 log.warning(
                     "[RECORDS] Quarantined late records for settled turns",

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -613,6 +613,45 @@ class SessionsCommandsConfig(BaseModel):
     delivery_timeout_seconds: float = float(
         os.getenv("AGENTA_SESSIONS_COMMAND_DELIVERY_TIMEOUT_SECONDS") or 5.0
     )
+
+
+class SessionWatchdogConfig(BaseModel):
+    """The execution watchdog: how long a running turn may go silent before it is settled.
+
+    A turn is declared lost when its stream row still claims `is_running` and its heartbeat
+    (`session_streams.updated_at`) is older than
+    `heartbeat_interval_seconds + running_grace_seconds`. The runner beats every 30 seconds,
+    so the default of 90 seconds of grace means three missed beats, and a turn is settled
+    about two minutes after its runner stops.
+
+    Raise `running_grace_seconds` if a healthy deployment settles live turns. Lower it to
+    settle a dead turn sooner. It is a plain restart-time setting; nothing else changes.
+    """
+
+    # Extra silence, on top of one heartbeat interval, before a RUNNING turn is declared lost.
+    running_grace_seconds: int = (
+        _parse_optional_positive_int_env("AGENTA_SESSIONS_WATCHDOG_GRACE_SECONDS") or 90
+    )
+
+    # An ALIVE-but-not-running row (between turns, or parked awaiting a human) gets a much
+    # longer grace: the runner stops beating while a turn is parked and keeps that sandbox
+    # warm for the approval TTL. Settling those at two minutes would end a resumable session.
+    idle_grace_seconds: int = (
+        _parse_optional_positive_int_env("AGENTA_SESSIONS_WATCHDOG_IDLE_GRACE_SECONDS")
+        or 1_800
+    )
+
+    # How often the watchdog runs.
+    interval_seconds: int = (
+        _parse_optional_positive_int_env("AGENTA_SESSIONS_WATCHDOG_INTERVAL_SECONDS")
+        or 60
+    )
+
+    # Rows settled per pass. A backlog drains over successive passes, not one huge commit.
+    batch_size: int = (
+        _parse_optional_positive_int_env("AGENTA_SESSIONS_WATCHDOG_BATCH_SIZE") or 500
+    )
+
     model_config = ConfigDict(extra="ignore")
 
 
@@ -625,6 +664,7 @@ class SessionsConfig(BaseModel):
     attachments: SessionAttachmentsConfig = SessionAttachmentsConfig()
     commands: SessionsCommandsConfig = SessionsCommandsConfig()
     records: SessionsRecordsConfig = SessionsRecordsConfig()
+    watchdog: SessionWatchdogConfig = SessionWatchdogConfig()
 
     model_config = ConfigDict(extra="ignore")
 

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -569,52 +569,6 @@ class SessionAttachmentsConfig(BaseModel):
     model_config = ConfigDict(extra="ignore")
 
 
-class SessionsCommandsConfig(BaseModel):
-    """Durable session commands: how a Stop reaches the runner, and how long it may wait.
-
-    `adapter` picks the control-delivery transport behind `ControlDeliveryPort`:
-
-      * `direct` — the API posts the command to the runner's own `/cancel`, over the
-        authenticated hop that already carries hard kill. One runner process, no held
-        connection, no poll loop. This is the default.
-      * `long_poll` — the runner holds a claim request open and the API answers it. Correct for
-        two or more runner replicas and for a runner the API cannot reach inbound. Not built in
-        this slice; naming it here fails loudly rather than silently falling back.
-
-    `direct` calls one service address, so with two runner replicas behind a load balancer the
-    call lands on the right process only by luck. Nothing here guards that, on purpose: the
-    detector is exact and lives in the service, where a `not_held` for a session that is alive
-    and beating is the wrong-replica failure and nothing else produces it.
-    """
-
-    adapter: str = os.getenv("AGENTA_SESSIONS_CONTROL_ADAPTER") or "direct"
-
-    # How long a claimed command may go unreported before the settlement sweep acts. Three
-    # heartbeat intervals.
-    lease_seconds: int = (
-        _parse_optional_positive_int_env("AGENTA_SESSIONS_COMMAND_LEASE_SECONDS") or 90
-    )
-    # Bounds a delivery loop where a runner accepts a command and never reports.
-    max_deliveries: int = (
-        _parse_optional_positive_int_env("AGENTA_SESSIONS_COMMAND_MAX_DELIVERIES") or 3
-    )
-    sweep_seconds: int = (
-        _parse_optional_positive_int_env("AGENTA_SESSIONS_COMMAND_SWEEP_SECONDS") or 10
-    )
-    # A command nobody ever claimed is a runner that is not there.
-    admission_timeout_seconds: int = (
-        _parse_optional_positive_int_env(
-            "AGENTA_SESSIONS_COMMAND_ADMISSION_TIMEOUT_SECONDS"
-        )
-        or 90
-    )
-    # How long the direct call waits for the runner to acknowledge. The runner answers before
-    # it cancels anything, so this covers a network hop, not a harness cancel.
-    delivery_timeout_seconds: float = float(
-        os.getenv("AGENTA_SESSIONS_COMMAND_DELIVERY_TIMEOUT_SECONDS") or 5.0
-    )
-
-
 class SessionWatchdogConfig(BaseModel):
     """The execution watchdog: how long a running turn may go silent before it is settled.
 
@@ -665,6 +619,53 @@ class SessionWatchdogConfig(BaseModel):
         _parse_optional_positive_int_env("AGENTA_SESSIONS_WATCHDOG_BATCH_SIZE") or 500
     )
 
+    model_config = ConfigDict(extra="ignore")
+
+
+class SessionsCommandsConfig(BaseModel):
+    """Durable session commands: how a Stop reaches the runner, and how long it may wait.
+
+    `adapter` picks the control-delivery transport behind `ControlDeliveryPort`:
+
+      * `direct` — the API posts the command to the runner's own `/cancel`, over the
+        authenticated hop that already carries hard kill. One runner process, no held
+        connection, no poll loop. This is the default.
+      * `long_poll` — the runner holds a claim request open and the API answers it. Correct for
+        two or more runner replicas and for a runner the API cannot reach inbound. Not built in
+        this slice; naming it here fails loudly rather than silently falling back.
+
+    `direct` calls one service address, so with two runner replicas behind a load balancer the
+    call lands on the right process only by luck. Nothing here guards that, on purpose: the
+    detector is exact and lives in the service, where a `not_held` for a session that is alive
+    and beating is the wrong-replica failure and nothing else produces it.
+    """
+
+    adapter: str = os.getenv("AGENTA_SESSIONS_CONTROL_ADAPTER") or "direct"
+
+    # How long a claimed command may go unreported before the settlement sweep acts. Three
+    # heartbeat intervals.
+    lease_seconds: int = (
+        _parse_optional_positive_int_env("AGENTA_SESSIONS_COMMAND_LEASE_SECONDS") or 90
+    )
+    # Bounds a delivery loop where a runner accepts a command and never reports.
+    max_deliveries: int = (
+        _parse_optional_positive_int_env("AGENTA_SESSIONS_COMMAND_MAX_DELIVERIES") or 3
+    )
+    sweep_seconds: int = (
+        _parse_optional_positive_int_env("AGENTA_SESSIONS_COMMAND_SWEEP_SECONDS") or 10
+    )
+    # A command nobody ever claimed is a runner that is not there.
+    admission_timeout_seconds: int = (
+        _parse_optional_positive_int_env(
+            "AGENTA_SESSIONS_COMMAND_ADMISSION_TIMEOUT_SECONDS"
+        )
+        or 90
+    )
+    # How long the direct call waits for the runner to acknowledge. The runner answers before
+    # it cancels anything, so this covers a network hop, not a harness cancel.
+    delivery_timeout_seconds: float = float(
+        os.getenv("AGENTA_SESSIONS_COMMAND_DELIVERY_TIMEOUT_SECONDS") or 5.0
+    )
     model_config = ConfigDict(extra="ignore")
 
 

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -512,6 +512,18 @@ class RedactionConfig(BaseModel):
 # ---------------------------------------------------------------------------
 
 
+def _parse_sessions_late_output() -> Literal["quarantine", "reject"]:
+    value = (os.getenv("AGENTA_SESSIONS_LATE_OUTPUT") or "quarantine").strip().lower()
+    if value in ("quarantine", "reject"):
+        return value
+    warnings.warn(
+        f"AGENTA_SESSIONS_LATE_OUTPUT={value!r} is not recognized; "
+        "behaving as 'quarantine'.",
+        stacklevel=2,
+    )
+    return "quarantine"
+
+
 class SessionsRecordsConfig(BaseModel):
     """Durable session-record ingest tuning (server-side history reconstruction)."""
 
@@ -675,9 +687,7 @@ class SessionsConfig(BaseModel):
     durable_stop: bool = (
         os.getenv("AGENTA_SESSIONS_DURABLE_STOP") or "false"
     ).lower() in _TRUTHY
-    late_output: Literal["quarantine", "reject"] = (
-        (os.getenv("AGENTA_SESSIONS_LATE_OUTPUT") or "quarantine").strip().lower()
-    )
+    late_output: Literal["quarantine", "reject"] = _parse_sessions_late_output()
     attachments: SessionAttachmentsConfig = SessionAttachmentsConfig()
     commands: SessionsCommandsConfig = SessionsCommandsConfig()
     records: SessionsRecordsConfig = SessionsRecordsConfig()

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -618,24 +618,36 @@ class SessionsCommandsConfig(BaseModel):
 class SessionWatchdogConfig(BaseModel):
     """The execution watchdog: how long a running turn may go silent before it is settled.
 
-    A turn is declared lost when its stream row still claims `is_running` and its heartbeat
-    (`session_streams.updated_at`) is older than
-    `heartbeat_interval_seconds + running_grace_seconds`. The runner beats every 30 seconds,
-    so the default of 90 seconds of grace means three missed beats, and a turn is settled
-    about two minutes after its runner stops.
+    The rule is HEARTBEAT AGE, not lease expiry. The Redis `alive` and `running` keys carry a
+    one-hour TTL, so "shortly after the lease expires" would mean an hour after the runner
+    died. The runner beats every `heartbeat_interval_seconds` (30) and the beat is mirrored
+    onto `session_streams.updated_at`, so the age of that column is the real liveness signal.
 
-    Raise `running_grace_seconds` if a healthy deployment settles live turns. Lower it to
+    A turn is declared lost when its stream row still claims `is_running` and its last
+    heartbeat is older than `stale_heartbeat_seconds`. The default of 90 seconds is three
+    missed beats.
+
+    Only a turn that still claims `is_running` is eligible. A turn parked for a human sends a
+    final beat with `is_running: false` and then stops beating on purpose; that state is
+    resumable, not lost, and the watchdog must never end it.
+
+    Raise `stale_heartbeat_seconds` if a healthy deployment settles live turns. Lower it to
     settle a dead turn sooner. It is a plain restart-time setting; nothing else changes.
     """
 
-    # Extra silence, on top of one heartbeat interval, before a RUNNING turn is declared lost.
-    running_grace_seconds: int = (
-        _parse_optional_positive_int_env("AGENTA_SESSIONS_WATCHDOG_GRACE_SECONDS") or 90
+    # Maximum age of the last heartbeat before a RUNNING turn is declared lost.
+    stale_heartbeat_seconds: int = (
+        _parse_optional_positive_int_env(
+            "AGENTA_SESSIONS_WATCHDOG_STALE_HEARTBEAT_SECONDS"
+        )
+        or 90
     )
 
-    # An ALIVE-but-not-running row (between turns, or parked awaiting a human) gets a much
-    # longer grace: the runner stops beating while a turn is parked and keeps that sandbox
-    # warm for the approval TTL. Settling those at two minutes would end a resumable session.
+    # An ALIVE-but-not-running row (between turns, or parked awaiting a human) is not the
+    # watchdog's business: it owes no ending, because its last turn already reached one. It is
+    # still reclaimed here after a much longer silence, which is the pre-existing orphan-sweep
+    # behaviour and is keyed to the 30-minute approval TTL. No terminal record is ever written
+    # for these rows.
     idle_grace_seconds: int = (
         _parse_optional_positive_int_env("AGENTA_SESSIONS_WATCHDOG_IDLE_GRACE_SECONDS")
         or 1_800

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -1,7 +1,7 @@
 import os
 import hashlib
 import warnings
-from typing import List, Optional
+from typing import List, Literal, Optional
 from uuid import getnode
 from json import loads
 from urllib.parse import urlparse, quote_plus
@@ -675,6 +675,9 @@ class SessionsConfig(BaseModel):
     durable_stop: bool = (
         os.getenv("AGENTA_SESSIONS_DURABLE_STOP") or "false"
     ).lower() in _TRUTHY
+    late_output: Literal["quarantine", "reject"] = (
+        (os.getenv("AGENTA_SESSIONS_LATE_OUTPUT") or "quarantine").strip().lower()
+    )
     attachments: SessionAttachmentsConfig = SessionAttachmentsConfig()
     commands: SessionsCommandsConfig = SessionsCommandsConfig()
     records: SessionsRecordsConfig = SessionsRecordsConfig()

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -643,11 +643,12 @@ class SessionWatchdogConfig(BaseModel):
         or 90
     )
 
-    # An ALIVE-but-not-running row (between turns, or parked awaiting a human) is not the
-    # watchdog's business: it owes no ending, because its last turn already reached one. It is
-    # still reclaimed here after a much longer silence, which is the pre-existing orphan-sweep
-    # behaviour and is keyed to the 30-minute approval TTL. No terminal record is ever written
-    # for these rows.
+    # How long an ALIVE-but-not-running row (between turns, or parked awaiting a human) is left
+    # alone before it is RECLAIMED. That state is resumable, so it is keyed to the 30-minute
+    # approval TTL rather than to three missed beats. It does not govern whether such a row owes
+    # its turn a terminal record: that question is asked of the records plane on the
+    # `stale_heartbeat_seconds` clock, because a durable Stop clears `is_running` before the
+    # runner has written its own ending.
     idle_grace_seconds: int = (
         _parse_optional_positive_int_env("AGENTA_SESSIONS_WATCHDOG_IDLE_GRACE_SECONDS")
         or 1_800

--- a/api/oss/src/utils/logging.py
+++ b/api/oss/src/utils/logging.py
@@ -208,6 +208,14 @@ class MultiLogger:
     def error(self, *a, **k):
         self._log("error", *a, **k)
 
+    def exception(self, *a, **k):
+        # Mirror stdlib `Logger.exception`: log at error level with the active
+        # traceback. Without this method a caller reaching for `log.exception(...)`
+        # -- the natural thing to write inside an `except` block -- would raise
+        # AttributeError from inside the handler and take the caller down with it.
+        k.setdefault("exc_info", True)
+        self._log("error", *a, **k)
+
     def critical(self, *a, **k):
         self._log("critical", *a, **k)
 

--- a/api/oss/tests/pytest/unit/sessions/test_command_claim_unknown_kind.py
+++ b/api/oss/tests/pytest/unit/sessions/test_command_claim_unknown_kind.py
@@ -1,0 +1,89 @@
+"""A runner's claim must take the commands it understands past a row it cannot map.
+
+`claim_commands` returned `[map_command_dbe_to_dto(dbe) for dbe in claimed]`, the same batch
+map that poisoned the abandoned-command sweep: a newer API replica can write a command `kind`
+this older replica's enum does not know, and `map_command_dbe_to_dto` raises `ValueError` on
+that row. One such row in a claimed batch would have thrown away the whole claim, including a
+Stop the runner could act on. The claim path now maps through
+`_map_commands_skipping_unmappable`, which skips the rows this API cannot map, warns once per
+batch, and returns the rest.
+"""
+
+from datetime import datetime, timezone
+from uuid import uuid4
+
+from types import SimpleNamespace
+
+from oss.src.core.sessions.commands.dtos import (
+    SessionCommandKind,
+    SessionCommandState,
+)
+from oss.src.dbs.postgres.sessions.commands import dao as commands_dao
+
+
+def _row(kind: str):
+    """A claimed command row as the DAO reads it, with a given `kind` string."""
+    return SimpleNamespace(
+        id=uuid4(),
+        created_at=datetime.now(timezone.utc),
+        updated_at=None,
+        deleted_at=None,
+        created_by_id=None,
+        updated_by_id=None,
+        deleted_by_id=None,
+        project_id=uuid4(),
+        session_id="sess-" + kind,
+        kind=kind,
+        target_turn_id="turn-1",
+        expected_turn_id=None,
+        data=None,
+        state=SessionCommandState.claimed.value,
+        claimed_by="runner-1",
+        claim_expires_at=datetime.now(timezone.utc),
+        claim_count=1,
+        outcome=None,
+        idempotency_key=None,
+        settled_at=None,
+        tags=None,
+        meta=None,
+    )
+
+
+class _RecordingLog:
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, *args, **kwargs):
+        self.warnings.append((args, kwargs))
+
+
+def test_a_claimable_stop_survives_an_unknown_kind_in_the_batch(monkeypatch):
+    recorder = _RecordingLog()
+    monkeypatch.setattr(commands_dao, "log", recorder)
+
+    stop = _row(SessionCommandKind.cancel.value)
+    unknown = _row("continue_interaction")
+
+    mapped = commands_dao._map_commands_skipping_unmappable(
+        [stop, unknown], context="claimed"
+    )
+
+    # The Stop is handed to the runner; the unknown row is left for a replica that knows it.
+    assert [c.id for c in mapped] == [stop.id]
+    assert unknown.id not in {c.id for c in mapped}
+
+
+def test_the_claim_warning_names_the_claimed_context_and_the_kind(monkeypatch):
+    recorder = _RecordingLog()
+    monkeypatch.setattr(commands_dao, "log", recorder)
+
+    commands_dao._map_commands_skipping_unmappable(
+        [_row(SessionCommandKind.cancel.value), _row("continue_interaction")],
+        context="claimed",
+    )
+
+    assert len(recorder.warnings) == 1
+    args = recorder.warnings[0][0]
+    assert args[1] == 1  # one unmappable row
+    assert args[2] == "claimed"  # the batch context
+    assert "continue_interaction=1" in args[3]

--- a/api/oss/tests/pytest/unit/sessions/test_command_matrix_inputs_data.py
+++ b/api/oss/tests/pytest/unit/sessions/test_command_matrix_inputs_data.py
@@ -23,6 +23,7 @@ import pytest_asyncio
 
 from agenta.sdk.models.workflows import WorkflowServiceRequestData
 
+from oss.src.apis.fastapi.sessions.models import SessionCancelRequest
 from oss.src.core.sessions.streams.dtos import (
     CommandMode,
     SessionStream,
@@ -298,7 +299,7 @@ async def test_cancel_with_a_stale_execution_guard_touches_no_holder(lock_engine
 
 
 def test_expected_execution_id_schema_documents_cancel_only_guard():
-    description = SessionStreamCommandRequest.model_json_schema()["properties"][
+    description = SessionCancelRequest.model_json_schema()["properties"][
         "expected_execution_id"
     ]["description"]
 

--- a/api/oss/tests/pytest/unit/sessions/test_command_matrix_inputs_data.py
+++ b/api/oss/tests/pytest/unit/sessions/test_command_matrix_inputs_data.py
@@ -297,6 +297,15 @@ async def test_cancel_with_a_stale_execution_guard_touches_no_holder(lock_engine
     )
 
 
+def test_expected_execution_id_schema_documents_cancel_only_guard():
+    description = SessionStreamCommandRequest.model_json_schema()["properties"][
+        "expected_execution_id"
+    ]["description"]
+
+    assert "only in cancel mode" in description
+    assert "ignored for send, steer, and attach" in description
+
+
 @pytest.mark.asyncio
 async def test_no_inputs_and_force_is_attach(lock_engine):
     svc = _service(lock_engine)

--- a/api/oss/tests/pytest/unit/sessions/test_command_settle_unknown_kind.py
+++ b/api/oss/tests/pytest/unit/sessions/test_command_settle_unknown_kind.py
@@ -8,7 +8,7 @@ raised `ValueError: 'continue_interaction' is not a valid SessionCommandKind` on
 The ValueError escaped the batch, so NO command was settled and the Stop stayed pending pass
 after pass.
 
-`_map_settle_candidates` now skips the rows this API cannot map, warns once with the kinds and
+`_map_commands_skipping_unmappable` now skips the rows this API cannot map, warns once with the kinds and
 count, and returns the rest. These tests hold that contract: the known Stop survives as a
 settle candidate, the unknown row is dropped and left for a replica that knows its kind, and
 the skip is logged exactly once.
@@ -68,7 +68,9 @@ def test_a_known_stop_survives_and_an_unknown_kind_is_left_alone(monkeypatch):
     stop = _row(SessionCommandKind.cancel.value)
     unknown = _row("continue_interaction")
 
-    mapped = commands_dao._map_settle_candidates([stop, unknown])
+    mapped = commands_dao._map_commands_skipping_unmappable(
+        [stop, unknown], context="abandoned"
+    )
 
     # The Stop is returned, so the sweep will settle it.
     assert [c.id for c in mapped] == [stop.id]
@@ -87,21 +89,23 @@ def test_the_unknown_kind_is_warned_once_with_its_kind_and_count(monkeypatch):
         _row("continue_interaction"),
     ]
 
-    commands_dao._map_settle_candidates(rows)
+    commands_dao._map_commands_skipping_unmappable(rows, context="abandoned")
 
     assert len(recorder.warnings) == 1, "exactly one warning per pass"
     args = recorder.warnings[0][0]
-    # The message and its args name the count and the offending kind.
+    # The message and its args name the count, the batch context, and the offending kind.
     assert args[1] == 2  # two unmappable rows
-    assert "continue_interaction=2" in args[2]
+    assert args[2] == "abandoned"  # the batch context
+    assert "continue_interaction=2" in args[3]
 
 
 def test_an_all_mappable_batch_logs_nothing(monkeypatch):
     recorder = _RecordingLog()
     monkeypatch.setattr(commands_dao, "log", recorder)
 
-    mapped = commands_dao._map_settle_candidates(
-        [_row(SessionCommandKind.cancel.value), _row(SessionCommandKind.cancel.value)]
+    mapped = commands_dao._map_commands_skipping_unmappable(
+        [_row(SessionCommandKind.cancel.value), _row(SessionCommandKind.cancel.value)],
+        context="abandoned",
     )
 
     assert len(mapped) == 2

--- a/api/oss/tests/pytest/unit/sessions/test_command_settle_unknown_kind.py
+++ b/api/oss/tests/pytest/unit/sessions/test_command_settle_unknown_kind.py
@@ -1,0 +1,108 @@
+"""The watchdog must settle the commands it understands past a row it cannot map.
+
+A newer API replica can write a command `kind` (or state, or outcome) an older replica's
+enums do not know. On the integration stack a `continue_interaction` row (increment 6, not on
+this head) sat in the claimed table next to an abandoned Stop. The abandoned-command sweep
+mapped the whole batch to DTOs before it settled any of it, and `map_command_dbe_to_dto`
+raised `ValueError: 'continue_interaction' is not a valid SessionCommandKind` on that one row.
+The ValueError escaped the batch, so NO command was settled and the Stop stayed pending pass
+after pass.
+
+`_map_settle_candidates` now skips the rows this API cannot map, warns once with the kinds and
+count, and returns the rest. These tests hold that contract: the known Stop survives as a
+settle candidate, the unknown row is dropped and left for a replica that knows its kind, and
+the skip is logged exactly once.
+"""
+
+from datetime import datetime, timezone
+from types import SimpleNamespace
+from uuid import uuid4
+
+from oss.src.core.sessions.commands.dtos import (
+    SessionCommandKind,
+    SessionCommandState,
+)
+from oss.src.dbs.postgres.sessions.commands import dao as commands_dao
+
+
+def _row(kind: str):
+    """A claimed, abandoned command row as the DAO reads it, with a given `kind` string."""
+    return SimpleNamespace(
+        id=uuid4(),
+        created_at=datetime.now(timezone.utc),
+        updated_at=None,
+        deleted_at=None,
+        created_by_id=None,
+        updated_by_id=None,
+        deleted_by_id=None,
+        project_id=uuid4(),
+        session_id="sess-" + kind,
+        kind=kind,
+        target_turn_id="turn-1",
+        expected_turn_id=None,
+        data=None,
+        state=SessionCommandState.claimed.value,
+        claimed_by="runner-1",
+        claim_expires_at=datetime.now(timezone.utc),
+        claim_count=1,
+        outcome=None,
+        idempotency_key=None,
+        settled_at=None,
+        tags=None,
+        meta=None,
+    )
+
+
+class _RecordingLog:
+    def __init__(self):
+        self.warnings = []
+
+    def warning(self, *args, **kwargs):
+        self.warnings.append((args, kwargs))
+
+
+def test_a_known_stop_survives_and_an_unknown_kind_is_left_alone(monkeypatch):
+    recorder = _RecordingLog()
+    monkeypatch.setattr(commands_dao, "log", recorder)
+
+    stop = _row(SessionCommandKind.cancel.value)
+    unknown = _row("continue_interaction")
+
+    mapped = commands_dao._map_settle_candidates([stop, unknown])
+
+    # The Stop is returned, so the sweep will settle it.
+    assert [c.id for c in mapped] == [stop.id]
+    assert mapped[0].kind is SessionCommandKind.cancel
+    # The unknown-kind row is dropped, not settled -- left for a replica that knows its kind.
+    assert unknown.id not in {c.id for c in mapped}
+
+
+def test_the_unknown_kind_is_warned_once_with_its_kind_and_count(monkeypatch):
+    recorder = _RecordingLog()
+    monkeypatch.setattr(commands_dao, "log", recorder)
+
+    rows = [
+        _row(SessionCommandKind.cancel.value),
+        _row("continue_interaction"),
+        _row("continue_interaction"),
+    ]
+
+    commands_dao._map_settle_candidates(rows)
+
+    assert len(recorder.warnings) == 1, "exactly one warning per pass"
+    args = recorder.warnings[0][0]
+    # The message and its args name the count and the offending kind.
+    assert args[1] == 2  # two unmappable rows
+    assert "continue_interaction=2" in args[2]
+
+
+def test_an_all_mappable_batch_logs_nothing(monkeypatch):
+    recorder = _RecordingLog()
+    monkeypatch.setattr(commands_dao, "log", recorder)
+
+    mapped = commands_dao._map_settle_candidates(
+        [_row(SessionCommandKind.cancel.value), _row(SessionCommandKind.cancel.value)]
+    )
+
+    assert len(mapped) == 2
+    assert recorder.warnings == []

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -144,6 +144,28 @@ class _FakePgSession:
                 )[:SWEEP_BATCH_SIZE]
             )
 
+        # The lost-turn is_running clear: a session_streams SELECT keyed by a list of
+        # (project_id, session_id, turn_id) tuples. Return the rows those keys name that still
+        # read is_running true, so the sweep can clear the flag on them.
+        params = stmt.compile().params
+        key_lists = [
+            value
+            for value in params.values()
+            if isinstance(value, (list, set, tuple))
+            and value
+            and all(isinstance(key, tuple) and len(key) == 3 for key in value)
+        ]
+        if key_lists:
+            keys = set(key_lists[0])
+            return _FakeResult(
+                [
+                    r
+                    for r in self._rows
+                    if r.flags.get("is_running") is True
+                    and (r.project_id, r.session_id, str(r.turn_id)) in keys
+                ]
+            )
+
         def age(row):
             return (now - (row.updated_at or row.created_at)).total_seconds()
 
@@ -241,9 +263,13 @@ class _FakeRecordsService:
 class _FakeWatchPublisher:
     def __init__(self):
         self.lifecycles: List[Tuple[str, str, str]] = []
+        self.changes: List[Tuple[str, str, str]] = []
 
     async def lifecycle(self, *, project_id, session_id, state):
         self.lifecycles.append((project_id, session_id, state))
+
+    async def changed(self, *, project_id, entity, id):
+        self.changes.append((project_id, entity, id))
 
 
 class _Publisher:
@@ -770,3 +796,85 @@ async def test_records_plane_ending_marks_candidate_and_skips_publish(anyio_back
 
     assert publisher.published == []
     assert execution.ending_written_at is not None
+
+
+@pytest.mark.anyio
+async def test_a_lost_execution_clears_is_running_on_a_row_that_still_names_it(
+    anyio_backend,
+):
+    # The execution is settled lost, but the session's stream row still names that turn and
+    # still reads is_running true, so the SEND gate would refuse the next message. The pass
+    # that writes the lost ending must clear is_running (keeping is_alive so the session stays
+    # resumable), clear the running lock, and update the mirror -- in the same pass. The row is
+    # fresh here so the went-silent collapse never touches it; the fix must.
+    stream = _FakeRow(
+        session_id="sess-stuck-running",
+        turn_id="turn-lost",
+        is_running=True,
+        age_seconds=0,
+    )
+    execution = _FakeExecutionRow(
+        session_id=stream.session_id,
+        execution_id="turn-lost",
+        terminal_outcome="lost",
+    )
+    redis = _FakeRedis()
+    alive_key = f"alive:{stream.project_id}:session:{stream.session_id}"
+    running_key = f"running:{stream.project_id}:session:{stream.session_id}"
+    redis._store[running_key] = b"turn-lost"
+    redis._store[alive_key] = b"turn-lost"
+    publisher = _Publisher()
+    watch = _FakeWatchPublisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([stream], [execution]),
+        redis,
+        records_service=_FakeRecordsService(),
+        watch_publisher=watch,
+        publish=publisher,
+    )
+
+    # is_running is cleared on the row, is_alive is kept, and the row is NOT collapsed.
+    assert stream.flags == {
+        "is_alive": True,
+        "is_running": False,
+        "is_attached": False,
+    }
+    # The running lock the SEND gate reads is cleared too, guarded on the dead turn.
+    assert running_key not in redis._store
+    # The mirror update reaches open readers.
+    assert (str(stream.project_id), "session", stream.session_id) in watch.changes
+
+
+@pytest.mark.anyio
+async def test_a_lost_execution_leaves_a_newer_running_turn_running(anyio_backend):
+    # The row has advanced to a NEWER turn that is genuinely running. Settling the OLD turn
+    # lost must not clear is_running on that row, nor its running lock.
+    stream = _FakeRow(
+        session_id="sess-advanced-newer",
+        turn_id="turn-new",
+        is_running=True,
+        age_seconds=0,
+    )
+    execution = _FakeExecutionRow(
+        session_id=stream.session_id,
+        execution_id="turn-old",
+        terminal_outcome="lost",
+    )
+    redis = _FakeRedis()
+    running_key = f"running:{stream.project_id}:session:{stream.session_id}"
+    redis._store[running_key] = b"turn-new"
+    publisher = _Publisher()
+    watch = _FakeWatchPublisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([stream], [execution]),
+        redis,
+        records_service=_FakeRecordsService(),
+        watch_publisher=watch,
+        publish=publisher,
+    )
+
+    # The newer running turn is untouched: its flag stands and its lock survives.
+    assert stream.flags["is_running"] is True
+    assert redis._store[running_key] == b"turn-new"

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -19,7 +19,11 @@ from uuid import UUID
 
 import pytest
 
-from oss.src.core.sessions.records.dtos import SessionRecordEvent
+from oss.src.core.sessions.records.dtos import (
+    RECORD_SETTLED_BY_ATTRIBUTE,
+    SETTLED_BY_WATCHDOG,
+    SessionRecordEvent,
+)
 from oss.src.tasks.asyncio.sessions.orphan_sweep import (
     LOST_ERROR_CODE,
     LOST_ERROR_MESSAGE,
@@ -185,12 +189,20 @@ async def test_a_lost_turn_gets_an_error_then_a_done(anyio_backend):
     assert [event.record_type for event in publisher.published] == ["error", "done"]
 
     error_event, done_event = publisher.published
+    # Both carry the writer marker. It is the ONLY thing separating this ending from a
+    # runner's — the wording and the `done` shape are copied deliberately — and the ingest
+    # guard reads it to tell a thawed runner's tail apart from ordinary history. See
+    # `RecordsService.append_many`.
     assert error_event.attributes == {
         "type": "error",
         "message": LOST_ERROR_MESSAGE,
         "code": LOST_ERROR_CODE,
+        RECORD_SETTLED_BY_ATTRIBUTE: SETTLED_BY_WATCHDOG,
     }
-    assert done_event.attributes == {"type": "done"}
+    assert done_event.attributes == {
+        "type": "done",
+        RECORD_SETTLED_BY_ATTRIBUTE: SETTLED_BY_WATCHDOG,
+    }
     assert error_event.turn_id == "turn-1"
     assert done_event.turn_id == "turn-1"
     assert error_event.session_id == "sess-lost"

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -24,7 +24,7 @@ from oss.src.core.sessions.records.dtos import (
     SETTLED_BY_WATCHDOG,
     SessionRecordEvent,
 )
-from oss.src.dbs.redis.sessions.locks import claim_owner
+from oss.src.dbs.redis.sessions.locks import claim_owner, is_turn_superseded
 from oss.src.tasks.asyncio.sessions.orphan_sweep import (
     LOST_ERROR_CODE,
     LOST_ERROR_MESSAGE,
@@ -878,3 +878,31 @@ async def test_a_lost_execution_leaves_a_newer_running_turn_running(anyio_backen
     # The newer running turn is untouched: its flag stands and its lock survives.
     assert stream.flags["is_running"] is True
     assert redis._store[running_key] == b"turn-new"
+
+
+@pytest.mark.anyio
+async def test_a_swept_turn_is_tombstoned_even_when_it_holds_no_redis_keys(
+    anyio_backend,
+):
+    # A prior Stop settlement can clear the alive/running keys before the sweep runs, so the
+    # collapse finds nothing to displace. The turn is still dead: tombstone it anyway, or a
+    # returning runner's beat for that turn is admitted and re-sets is_running on the row the
+    # sweep just collapsed (observed live: run 1e, a beat 3.5 s after the settle).
+    stream = _stale_running_row(session_id="sess-returning-runner", turn_id="turn-gone")
+    redis = _FakeRedis()  # deliberately empty: no alive/running keys to displace
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([stream], []),
+        redis,
+        records_service=_FakeRecordsService(),
+        publish=publisher,
+    )
+
+    assert _collapsed(stream)
+    assert await is_turn_superseded(
+        redis,
+        project_id=str(stream.project_id),
+        session_id=stream.session_id,
+        turn_id="turn-gone",
+    )

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -63,6 +63,23 @@ class _FakeRow:
         self.updated_at = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
 
 
+class _FakeExecutionRow:
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        execution_id: str,
+        terminal_outcome: str = "stopped",
+        age_seconds: int = ORPHAN_THRESHOLD_SECONDS + 30,
+    ):
+        self.project_id = _PROJECT_ID
+        self.session_id = session_id
+        self.execution_id = execution_id
+        self.terminal_outcome = terminal_outcome
+        self.settled_by = "runner"
+        self.settled_at = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+
+
 class _FakeResult:
     def __init__(self, rows):
         self._rows = rows
@@ -75,8 +92,9 @@ class _FakeResult:
 
 
 class _FakePgSession:
-    def __init__(self, rows):
+    def __init__(self, rows, executions):
         self._rows = rows
+        self._executions = executions
         self.commits = 0
 
     async def execute(self, stmt):
@@ -86,6 +104,16 @@ class _FakePgSession:
         # the running and idle branches.
         text = str(stmt)
         now = datetime.now(timezone.utc)
+
+        if "session_executions" in text:
+            rows = [
+                execution
+                for execution in self._executions
+                if execution.terminal_outcome in {"stopped", "lost"}
+                and (now - execution.settled_at).total_seconds()
+                > ORPHAN_THRESHOLD_SECONDS
+            ]
+            return _FakeResult(sorted(rows, key=lambda row: row.settled_at))
 
         def age(row):
             return (now - (row.updated_at or row.created_at)).total_seconds()
@@ -122,12 +150,13 @@ class _FakePgSession:
 
 
 class _FakeTransactionsEngine:
-    def __init__(self, rows):
+    def __init__(self, rows, executions=None):
         self._rows = rows
+        self._executions = executions or []
 
     @asynccontextmanager
     async def session(self):
-        yield _FakePgSession(self._rows)
+        yield _FakePgSession(self._rows, self._executions)
 
 
 class _FakeRedis:
@@ -541,3 +570,71 @@ async def test_a_stopped_turn_owned_by_a_newer_turn_keeps_that_lock(anyio_backen
     )
 
     assert redis._store.get(alive_key) == b"turn-newer"
+
+
+@pytest.mark.anyio
+async def test_a_stopped_execution_gets_an_ending_after_stream_advances(
+    anyio_backend,
+):
+    stream = _FakeRow(
+        session_id="sess-advanced",
+        turn_id="turn-later",
+        is_running=False,
+        age_seconds=0,
+    )
+    execution = _FakeExecutionRow(
+        session_id=stream.session_id,
+        execution_id="turn-stopped",
+    )
+    redis = _FakeRedis()
+    alive_key = f"alive:{stream.project_id}:session:{stream.session_id}"
+    running_key = f"running:{stream.project_id}:session:{stream.session_id}"
+    redis._store[alive_key] = b"turn-later"
+    redis._store[running_key] = b"turn-later"
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([stream], [execution]),
+        redis,
+        records_service=_FakeRecordsService({("sess-advanced", "turn-later")}),
+        publish=publisher,
+    )
+
+    assert [event.record_type for event in publisher.published] == ["error", "done"]
+    assert all(event.turn_id == "turn-stopped" for event in publisher.published)
+    assert redis._store[alive_key] == b"turn-later"
+    assert redis._store[running_key] == b"turn-later"
+
+
+@pytest.mark.anyio
+async def test_a_stopped_execution_does_not_touch_a_newer_running_turn(
+    anyio_backend,
+):
+    stream = _FakeRow(
+        session_id="sess-advanced-running",
+        turn_id="turn-running",
+        is_running=True,
+        age_seconds=0,
+    )
+    execution = _FakeExecutionRow(
+        session_id=stream.session_id,
+        execution_id="turn-stopped",
+    )
+    redis = _FakeRedis()
+    alive_key = f"alive:{stream.project_id}:session:{stream.session_id}"
+    running_key = f"running:{stream.project_id}:session:{stream.session_id}"
+    redis._store[alive_key] = b"turn-running"
+    redis._store[running_key] = b"turn-running"
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([stream], [execution]),
+        redis,
+        records_service=_FakeRecordsService(),
+        publish=publisher,
+    )
+
+    assert [event.record_type for event in publisher.published] == ["error", "done"]
+    assert all(event.turn_id == "turn-stopped" for event in publisher.published)
+    assert redis._store[alive_key] == b"turn-running"
+    assert redis._store[running_key] == b"turn-running"

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -337,12 +337,13 @@ async def test_terminal_record_checks_are_batched_once_per_project(anyio_backend
     ]
     second_project = [(other_project, "session-other", "turn-other")]
 
-    unsettled, ended = await _unsettled_turns(
+    unsettled, ended, deferred = await _unsettled_turns(
         records_service=records,
         candidates=[*first_project, *second_project],
     )
 
     assert ended == set()
+    assert deferred == set()
     assert unsettled == set(first_project + second_project)
     assert [(project_id, len(keys)) for project_id, keys in records.queries] == [
         (_PROJECT_ID, 100),
@@ -632,24 +633,52 @@ async def test_the_redis_nest_follows_the_settled_row(anyio_backend):
 @pytest.mark.anyio
 async def test_a_failed_lookup_never_invents_an_ending(anyio_backend):
     """If we cannot tell whether the turn already ended, say nothing rather than risk a
-    second, contradictory ending. The row is still settled."""
+    second, contradictory ending. Preserve the row and Redis ownership so the next pass retries."""
 
-    class _BrokenRecords(_FakeRecordsService):
+    class _FlakyRecords(_FakeRecordsService):
+        def __init__(self):
+            super().__init__()
+            self.calls = 0
+
         async def settled_turns(self, *, project_id, keys):
-            raise RuntimeError("tracing db unreachable")
+            self.calls += 1
+            if self.calls == 1:
+                raise RuntimeError("tracing db unreachable")
+            return set()
 
     row = _stale_running_row()
     publisher = _Publisher()
+    records = _FlakyRecords()
+    redis = _FakeRedis()
+    project = str(row.project_id)
+    alive_key = f"alive:{project}:session:{row.session_id}"
+    running_key = f"running:{project}:session:{row.session_id}"
+    redis._store[alive_key] = b"turn-1"
+    redis._store[running_key] = b"turn-1"
 
     await run_orphan_sweep(
         _FakeTransactionsEngine([row]),
-        _FakeRedis(),
-        records_service=_BrokenRecords(),
+        redis,
+        records_service=records,
         publish=publisher,
     )
 
     assert publisher.published == []
+    assert not _collapsed(row)
+    assert redis._store[alive_key] == b"turn-1"
+    assert redis._store[running_key] == b"turn-1"
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row]),
+        redis,
+        records_service=records,
+        publish=publisher,
+    )
+
     assert _collapsed(row)
+    assert alive_key not in redis._store
+    assert running_key not in redis._store
+    assert [event.record_type for event in publisher.published] == ["error", "done"]
 
 
 @pytest.mark.anyio

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -8,8 +8,8 @@ an ending IS written for a turn that has none, and a SECOND ending is never writ
 that already has one.
 
 The threshold predicate itself is covered by `test_orphan_sweep_thresholds.py`; the fake
-session here returns whatever rows the test hands it, so these tests are about what the
-watchdog DOES with a candidate, not which rows it picks.
+session here models the execution filter, order, and batch limit so the durable candidate
+window is also covered.
 """
 
 from contextlib import asynccontextmanager
@@ -30,6 +30,7 @@ from oss.src.tasks.asyncio.sessions.orphan_sweep import (
     LOST_ERROR_MESSAGE,
     ORPHAN_THRESHOLD_SECONDS,
     IDLE_THRESHOLD_SECONDS,
+    SWEEP_BATCH_SIZE,
     run_orphan_sweep,
 )
 
@@ -72,6 +73,7 @@ class _FakeExecutionRow:
         execution_id: str,
         terminal_outcome: str = "stopped",
         age_seconds: int = ORPHAN_THRESHOLD_SECONDS + 30,
+        ending_written_at: Optional[datetime] = None,
     ):
         self.project_id = _PROJECT_ID
         self.session_id = session_id
@@ -79,6 +81,7 @@ class _FakeExecutionRow:
         self.terminal_outcome = terminal_outcome
         self.settled_by = "runner"
         self.settled_at = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+        self.ending_written_at = ending_written_at
 
 
 class _FakeResult:
@@ -107,6 +110,23 @@ class _FakePgSession:
         now = datetime.now(timezone.utc)
 
         if "session_executions" in text:
+            if text.startswith("UPDATE"):
+                params = stmt.compile().params
+                keys = next(
+                    value
+                    for value in params.values()
+                    if isinstance(value, (list, set, tuple))
+                    and all(isinstance(key, tuple) and len(key) == 3 for key in value)
+                )
+                for execution in self._executions:
+                    key = (
+                        execution.project_id,
+                        execution.session_id,
+                        execution.execution_id,
+                    )
+                    if key in keys and execution.ending_written_at is None:
+                        execution.ending_written_at = now
+                return _FakeResult([])
             rows = [
                 execution
                 for execution in self._executions
@@ -114,7 +134,15 @@ class _FakePgSession:
                 and (now - execution.settled_at).total_seconds()
                 > ORPHAN_THRESHOLD_SECONDS
             ]
-            return _FakeResult(sorted(rows, key=lambda row: row.settled_at))
+            if "ending_written_at IS NULL" in text:
+                rows = [row for row in rows if row.ending_written_at is None]
+            return _FakeResult(
+                sorted(
+                    rows,
+                    key=lambda row: row.settled_at,
+                    reverse="DESC" in text,
+                )[:SWEEP_BATCH_SIZE]
+            )
 
         def age(row):
             return (now - (row.updated_at or row.created_at)).total_seconds()
@@ -532,6 +560,10 @@ async def test_a_stopped_turn_whose_runner_died_still_gets_an_ending(anyio_backe
         age_seconds=ORPHAN_THRESHOLD_SECONDS + 30,
     )
     publisher = _Publisher()
+    execution = _FakeExecutionRow(
+        session_id=row.session_id,
+        execution_id="turn-stopped",
+    )
     redis = _FakeRedis()
     # Settlement leaves `alive` to its TTL, so the dead turn still holds the session's
     # alive lock when the sweep runs; the SEND gate reads that lock.
@@ -548,16 +580,22 @@ async def test_a_stopped_turn_whose_runner_died_still_gets_an_ending(anyio_backe
     )
 
     await run_orphan_sweep(
-        _FakeTransactionsEngine([row]),
+        _FakeTransactionsEngine([row], [execution]),
         redis,
         records_service=_FakeRecordsService(),
         publish=publisher,
     )
 
-    assert [event.record_type for event in publisher.published] == ["error", "done"], (
+    assert [event.record_type for event in publisher.published] == ["done"], (
         "a stopped turn whose runner never wrote an ending must be given one"
     )
+    assert publisher.published[0].attributes == {
+        "type": "done",
+        "stopReason": "cancelled",
+        RECORD_SETTLED_BY_ATTRIBUTE: SETTLED_BY_WATCHDOG,
+    }
     assert all(event.turn_id == "turn-stopped" for event in publisher.published)
+    assert execution.ending_written_at is not None
     assert alive_key not in redis._store, (
         "the dead turn's alive lock must be released, or the next Send is refused for an hour"
     )
@@ -638,7 +676,8 @@ async def test_a_stopped_execution_gets_an_ending_after_stream_advances(
         publish=publisher,
     )
 
-    assert [event.record_type for event in publisher.published] == ["error", "done"]
+    assert [event.record_type for event in publisher.published] == ["done"]
+    assert publisher.published[0].attributes["stopReason"] == "cancelled"
     assert all(event.turn_id == "turn-stopped" for event in publisher.published)
     assert redis._store[alive_key] == b"turn-later"
     assert redis._store[running_key] == b"turn-later"
@@ -672,7 +711,62 @@ async def test_a_stopped_execution_does_not_touch_a_newer_running_turn(
         publish=publisher,
     )
 
-    assert [event.record_type for event in publisher.published] == ["error", "done"]
+    assert [event.record_type for event in publisher.published] == ["done"]
+    assert publisher.published[0].attributes["stopReason"] == "cancelled"
     assert all(event.turn_id == "turn-stopped" for event in publisher.published)
     assert redis._store[alive_key] == b"turn-running"
     assert redis._store[running_key] == b"turn-running"
+
+
+@pytest.mark.anyio
+async def test_ended_execution_backlog_cannot_hide_a_recent_orphan(anyio_backend):
+    ended_at = datetime.now(timezone.utc)
+    ended = [
+        _FakeExecutionRow(
+            session_id=f"sess-ended-{index}",
+            execution_id=f"turn-ended-{index}",
+            age_seconds=ORPHAN_THRESHOLD_SECONDS + 1_000 + index,
+            ending_written_at=ended_at,
+        )
+        for index in range(SWEEP_BATCH_SIZE + 1)
+    ]
+    orphan = _FakeExecutionRow(
+        session_id="sess-recent-orphan",
+        execution_id="turn-recent-orphan",
+    )
+    records = _FakeRecordsService()
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([], [*ended, orphan]),
+        _FakeRedis(),
+        records_service=records,
+        publish=publisher,
+    )
+
+    assert records.queries == [[("sess-recent-orphan", "turn-recent-orphan")]]
+    assert [event.record_type for event in publisher.published] == ["done"]
+    assert publisher.published[0].turn_id == "turn-recent-orphan"
+    assert orphan.ending_written_at is not None
+
+
+@pytest.mark.anyio
+async def test_records_plane_ending_marks_candidate_and_skips_publish(anyio_backend):
+    execution = _FakeExecutionRow(
+        session_id="sess-already-ended",
+        execution_id="turn-already-ended",
+        terminal_outcome="lost",
+    )
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([], [execution]),
+        _FakeRedis(),
+        records_service=_FakeRecordsService(
+            {("sess-already-ended", "turn-already-ended")}
+        ),
+        publish=publisher,
+    )
+
+    assert publisher.published == []
+    assert execution.ending_written_at is not None

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -286,6 +286,37 @@ async def test_an_idle_row_owes_no_ending(anyio_backend):
 
 
 @pytest.mark.anyio
+async def test_a_parked_approval_is_never_settled(anyio_backend):
+    """The hazard the heartbeat-age rule creates, pinned.
+
+    A turn that parks for a human sends one final beat with `is_running: false` and then stops
+    beating on purpose. Its heartbeat therefore goes stale immediately, and it is exactly the
+    state we most need to keep: the sandbox is warm, the user is about to answer, and the turn
+    is resumable. Only a row that still CLAIMS running is eligible, so this one is not a
+    candidate however long it sits.
+    """
+    row = _FakeRow(
+        session_id="sess-parked",
+        turn_id="turn-parked",
+        is_running=False,
+        age_seconds=ORPHAN_THRESHOLD_SECONDS * 5,
+    )
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row]),
+        _FakeRedis(),
+        records_service=_FakeRecordsService(),
+        publish=publisher,
+    )
+
+    assert publisher.published == [], (
+        "a parked approval must never be given a terminal record: the user is still going to "
+        "answer it"
+    )
+
+
+@pytest.mark.anyio
 async def test_a_running_row_without_a_turn_id_is_settled_silently(anyio_backend):
     """Nothing to attribute an ending to, so the row is collapsed and no record is written."""
     row = _FakeRow(

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -34,6 +34,7 @@ from oss.src.tasks.asyncio.sessions.orphan_sweep import (
     _unsettled_turns,
     run_orphan_sweep,
 )
+from oss.src.utils.env import env
 
 _PROJECT_ID = UUID("00000000-0000-4000-8000-000000000001")
 
@@ -238,14 +239,23 @@ class _FakePgSession:
 
 
 class _FakeTransactionsEngine:
-    def __init__(self, rows, executions=None, before_stream_update=None):
+    def __init__(
+        self,
+        rows,
+        executions=None,
+        before_stream_update=None,
+        after_commit=None,
+    ):
         self._rows = rows
         self._executions = executions or []
         self._before_stream_update = before_stream_update
+        self._after_commit = after_commit
         self.committed = False
 
     def _mark_committed(self):
         self.committed = True
+        if self._after_commit is not None:
+            self._after_commit()
 
     @asynccontextmanager
     async def session(self):
@@ -277,13 +287,48 @@ class _FakeRedis:
     async def expire(self, key, ttl):
         return True
 
-    async def eval(self, script, numkeys, key, value, *args):
-        k = key.decode() if isinstance(key, bytes) else key
-        v = value.decode() if isinstance(value, bytes) else value
+    async def eval(self, script, numkeys, *keys_and_args):
+        def decode(value):
+            return value.decode() if isinstance(value, bytes) else str(value)
+
+        keys = [decode(value) for value in keys_and_args[:numkeys]]
+        argv = [decode(value) for value in keys_and_args[numkeys:]]
+        if "AGENTA_WATCHDOG_RELEASE_TURN" in script:
+            alive, running, owner, superseded = keys
+            expected_turn, expected_owner, _ttl = argv
+            alive_value = decode(self._store[alive]) if alive in self._store else ""
+            running_value = (
+                decode(self._store[running]) if running in self._store else ""
+            )
+            owner_value = decode(self._store[owner]) if owner in self._store else ""
+            released_alive = int(bool(expected_turn) and alive_value == expected_turn)
+            released_running = int(
+                bool(expected_turn) and running_value == expected_turn
+            )
+            if released_alive:
+                self._store.pop(alive, None)
+            if released_running:
+                self._store.pop(running, None)
+            foreign_turn = (alive_value and alive_value != expected_turn) or (
+                running_value and running_value != expected_turn
+            )
+            released_owner = int(
+                bool(expected_owner)
+                and owner_value == expected_owner
+                and not foreign_turn
+            )
+            if released_owner:
+                self._store.pop(owner, None)
+            if expected_turn:
+                self._store[superseded] = b"1"
+            return [released_alive, released_running, released_owner]
+
+        k = keys[0]
+        v = argv[0]
         current = self._store.get(k)
         if isinstance(current, bytes):
             current = current.decode()
-        if args:
+        if len(argv) > 1:
             if current is None or current == v:
                 self._store[k] = v.encode()
                 return v.encode()
@@ -372,6 +417,22 @@ class _Publisher:
     async def __call__(self, *, project_id, record_event):
         self.published.append(record_event)
         return True
+
+
+class _CommandsService:
+    def __init__(self):
+        self.execution_lost_calls = []
+
+    async def settle_execution_lost(self, **kwargs):
+        assert kwargs["transaction"] is not None
+        self.execution_lost_calls.append(kwargs)
+        return True
+
+    async def settle_abandoned_commands(self, *, now):
+        return 0
+
+    async def repair_terminal_redis(self):
+        return 0
 
 
 def _stale_running_row(session_id="sess-lost", turn_id="turn-1") -> _FakeRow:
@@ -628,6 +689,43 @@ async def test_the_redis_nest_follows_the_settled_row(anyio_backend):
         await redis.get(f"superseded:{project}:session:sess-lost:turn:turn-1")
         is not None
     ), "a late beat from the lost turn must not re-nest the session"
+
+
+@pytest.mark.anyio
+async def test_post_commit_cleanup_preserves_a_new_turn_generation(anyio_backend):
+    stream = _stale_running_row(session_id="sess-cleanup-race", turn_id="turn-a")
+    redis = _FakeRedis()
+    project = str(stream.project_id)
+    alive_key = f"alive:{project}:session:{stream.session_id}"
+    running_key = f"running:{project}:session:{stream.session_id}"
+    owner_key = f"owner:{project}:session:{stream.session_id}"
+    redis._store[alive_key] = b"turn-a"
+    redis._store[running_key] = b"turn-a"
+    redis._store[owner_key] = b"replica-a"
+
+    def install_turn_b():
+        redis._store[alive_key] = b"turn-b"
+        redis._store[running_key] = b"turn-b"
+        redis._store[owner_key] = b"replica-b"
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([stream], after_commit=install_turn_b),
+        redis,
+        records_service=_FakeRecordsService(),
+        publish=_Publisher(),
+    )
+
+    assert redis._store[alive_key] == b"turn-b"
+    assert redis._store[running_key] == b"turn-b"
+    assert redis._store[owner_key] == b"replica-b"
+    assert (
+        redis._store[f"superseded:{project}:session:{stream.session_id}:turn:turn-a"]
+        == b"1"
+    )
+    assert (
+        f"superseded:{project}:session:{stream.session_id}:turn:turn-b"
+        not in redis._store
+    )
 
 
 @pytest.mark.anyio
@@ -1034,6 +1132,35 @@ async def test_lost_turn_clear_loses_to_a_concurrent_turn_advance(anyio_backend)
     assert redis._store[alive_key] == b"turn-new"
     assert redis._store[running_key] == b"turn-new"
     assert redis._store[owner_key] == b"runner-new"
+
+
+@pytest.mark.anyio
+async def test_heartbeat_before_orphan_cas_prevents_settlement_and_records(
+    anyio_backend,
+    monkeypatch,
+):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    stream = _stale_running_row(
+        session_id="sess-heartbeat-before-cas", turn_id="turn-current"
+    )
+    publisher = _Publisher()
+    commands = _CommandsService()
+
+    def heartbeat():
+        stream.updated_at = datetime.now(timezone.utc)
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([stream], before_stream_update=heartbeat),
+        _FakeRedis(),
+        records_service=_FakeRecordsService(),
+        commands_service=commands,
+        publish=publisher,
+    )
+
+    assert commands.execution_lost_calls == []
+    assert publisher.published == []
+    assert stream.flags["is_alive"] is True
+    assert stream.flags["is_running"] is True
 
 
 @pytest.mark.anyio

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -86,8 +86,9 @@ class _FakeExecutionRow:
 
 
 class _FakeResult:
-    def __init__(self, rows):
+    def __init__(self, rows, *, rowcount=0):
         self._rows = rows
+        self.rowcount = rowcount
 
     def scalars(self):
         return self
@@ -97,9 +98,11 @@ class _FakeResult:
 
 
 class _FakePgSession:
-    def __init__(self, rows, executions):
+    def __init__(self, rows, executions, before_stream_update=None, on_commit=None):
         self._rows = rows
         self._executions = executions
+        self._before_stream_update = before_stream_update
+        self._on_commit = on_commit
         self.commits = 0
 
     async def execute(self, stmt):
@@ -151,6 +154,10 @@ class _FakePgSession:
         # clear binds `id = ...`, a scalar. Row ids are strings here and are the only string
         # bind in either statement.
         if text.startswith("UPDATE") and "session_streams" in text:
+            if self._before_stream_update is not None:
+                self._before_stream_update()
+                self._before_stream_update = None
+                return _FakeResult([], rowcount=0)
             params = stmt.compile().params
             flags_val = next(
                 (v for v in params.values() if isinstance(v, dict) and "is_alive" in v),
@@ -163,10 +170,13 @@ class _FakePgSession:
                 elif isinstance(value, (str, UUID)):
                     ids.add(value)
             if flags_val is not None:
+                matched = 0
                 for r in self._rows:
                     if r.id in ids:
                         r.flags = dict(flags_val)
                         r.updated_at = now
+                        matched += 1
+                return _FakeResult([], rowcount=matched)
             return _FakeResult([])
 
         # The lost-turn is_running clear: a session_streams SELECT keyed by a list of
@@ -223,16 +233,28 @@ class _FakePgSession:
 
     async def commit(self):
         self.commits += 1
+        if self._on_commit is not None:
+            self._on_commit()
 
 
 class _FakeTransactionsEngine:
-    def __init__(self, rows, executions=None):
+    def __init__(self, rows, executions=None, before_stream_update=None):
         self._rows = rows
         self._executions = executions or []
+        self._before_stream_update = before_stream_update
+        self.committed = False
+
+    def _mark_committed(self):
+        self.committed = True
 
     @asynccontextmanager
     async def session(self):
-        yield _FakePgSession(self._rows, self._executions)
+        yield _FakePgSession(
+            self._rows,
+            self._executions,
+            self._before_stream_update,
+            self._mark_committed,
+        )
 
 
 class _FakeRedis:
@@ -271,6 +293,18 @@ class _FakeRedis:
             self._store.pop(k, None)
             return 1
         return 0
+
+
+class _CommitObservingRedis(_FakeRedis):
+    def __init__(self, engine: _FakeTransactionsEngine):
+        super().__init__()
+        self._engine = engine
+
+    async def eval(self, *args, **kwargs):
+        assert self._engine.committed, (
+            "Redis ownership was released before the DB commit"
+        )
+        return await super().eval(*args, **kwargs)
 
 
 class _FakeRecordsService:
@@ -900,6 +934,77 @@ async def test_a_lost_execution_clears_is_running_on_a_row_that_still_names_it(
     assert running_key not in redis._store
     # The mirror update reaches open readers.
     assert (str(stream.project_id), "session", stream.session_id) in watch.changes
+
+
+@pytest.mark.anyio
+async def test_lost_turn_redis_release_follows_the_stream_commit(anyio_backend):
+    stream = _FakeRow(
+        session_id="sess-commit-before-release",
+        turn_id="turn-lost",
+        is_running=True,
+        age_seconds=0,
+    )
+    execution = _FakeExecutionRow(
+        session_id=stream.session_id,
+        execution_id="turn-lost",
+        terminal_outcome="lost",
+    )
+    engine = _FakeTransactionsEngine([stream], [execution])
+    redis = _CommitObservingRedis(engine)
+    for prefix in ("alive", "running"):
+        redis._store[f"{prefix}:{stream.project_id}:session:{stream.session_id}"] = (
+            b"turn-lost"
+        )
+
+    await run_orphan_sweep(
+        engine,
+        redis,
+        records_service=_FakeRecordsService(),
+        publish=_Publisher(),
+    )
+
+    assert engine.committed is True
+
+
+@pytest.mark.anyio
+async def test_lost_turn_clear_loses_to_a_concurrent_turn_advance(anyio_backend):
+    stream = _FakeRow(
+        session_id="sess-advance-during-lost-clear",
+        turn_id="turn-old",
+        is_running=True,
+        age_seconds=0,
+    )
+    execution = _FakeExecutionRow(
+        session_id=stream.session_id,
+        execution_id="turn-old",
+        terminal_outcome="lost",
+    )
+    redis = _FakeRedis()
+    alive_key = f"alive:{stream.project_id}:session:{stream.session_id}"
+    running_key = f"running:{stream.project_id}:session:{stream.session_id}"
+    owner_key = f"owner:{stream.project_id}:session:{stream.session_id}"
+    redis._store[alive_key] = b"turn-new"
+    redis._store[running_key] = b"turn-new"
+    redis._store[owner_key] = b"runner-new"
+
+    def advance_stream():
+        stream.turn_id = "turn-new"
+        stream.updated_at = datetime.now(timezone.utc)
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine(
+            [stream], [execution], before_stream_update=advance_stream
+        ),
+        redis,
+        records_service=_FakeRecordsService(),
+        publish=_Publisher(),
+    )
+
+    assert stream.turn_id == "turn-new"
+    assert stream.flags["is_running"] is True
+    assert redis._store[alive_key] == b"turn-new"
+    assert redis._store[running_key] == b"turn-new"
+    assert redis._store[owner_key] == b"runner-new"
 
 
 @pytest.mark.anyio

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -24,6 +24,7 @@ from oss.src.core.sessions.records.dtos import (
     SETTLED_BY_WATCHDOG,
     SessionRecordEvent,
 )
+from oss.src.dbs.redis.sessions.locks import claim_owner
 from oss.src.tasks.asyncio.sessions.orphan_sweep import (
     LOST_ERROR_CODE,
     LOST_ERROR_MESSAGE,
@@ -179,14 +180,18 @@ class _FakeRedis:
     async def expire(self, key, ttl):
         return True
 
-    async def eval(self, script, numkeys, key, value):
-        # The one script the sweep runs is release-if-owner: delete the key when its value
-        # is the caller's turn id, answer 1, else 0. Keys arrive as bytes.
+    async def eval(self, script, numkeys, key, value, *args):
         k = key.decode() if isinstance(key, bytes) else key
         v = value.decode() if isinstance(value, bytes) else value
         current = self._store.get(k)
         if isinstance(current, bytes):
             current = current.decode()
+        if args:
+            if current is None or current == v:
+                self._store[k] = v.encode()
+                return v.encode()
+            return current.encode()
+        # The sweep's script is release-if-owner: delete only when the value matches.
         if current == v:
             self._store.pop(k, None)
             return 1
@@ -532,6 +537,15 @@ async def test_a_stopped_turn_whose_runner_died_still_gets_an_ending(anyio_backe
     # alive lock when the sweep runs; the SEND gate reads that lock.
     alive_key = f"alive:{row.project_id}:session:{row.session_id}"
     redis._store[alive_key] = b"turn-stopped"
+    assert (
+        await claim_owner(
+            redis,
+            project_id=str(row.project_id),
+            session_id=row.session_id,
+            replica_id="replica-dead",
+        )
+        == "replica-dead"
+    )
 
     await run_orphan_sweep(
         _FakeTransactionsEngine([row]),
@@ -547,6 +561,15 @@ async def test_a_stopped_turn_whose_runner_died_still_gets_an_ending(anyio_backe
     assert alive_key not in redis._store, (
         "the dead turn's alive lock must be released, or the next Send is refused for an hour"
     )
+    assert (
+        await claim_owner(
+            redis,
+            project_id=str(row.project_id),
+            session_id=row.session_id,
+            replica_id="replica-new",
+        )
+        == "replica-new"
+    ), "the next runner must claim affinity without waiting for the dead owner's TTL"
     assert row.flags["is_alive"] is True, "the stopped row itself is not collapsed"
 
 
@@ -561,6 +584,12 @@ async def test_a_stopped_turn_owned_by_a_newer_turn_keeps_that_lock(anyio_backen
     redis = _FakeRedis()
     alive_key = f"alive:{row.project_id}:session:{row.session_id}"
     redis._store[alive_key] = b"turn-newer"
+    await claim_owner(
+        redis,
+        project_id=str(row.project_id),
+        session_id=row.session_id,
+        replica_id="replica-newer",
+    )
 
     await run_orphan_sweep(
         _FakeTransactionsEngine([row]),
@@ -570,6 +599,15 @@ async def test_a_stopped_turn_owned_by_a_newer_turn_keeps_that_lock(anyio_backen
     )
 
     assert redis._store.get(alive_key) == b"turn-newer"
+    assert (
+        await claim_owner(
+            redis,
+            project_id=str(row.project_id),
+            session_id=row.session_id,
+            replica_id="replica-other",
+        )
+        == "replica-newer"
+    ), "settling an older turn must not clear a newer turn's affinity"
 
 
 @pytest.mark.anyio

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -144,6 +144,32 @@ class _FakePgSession:
                 )[:SWEEP_BATCH_SIZE]
             )
 
+        # The collapse: a Core UPDATE of session_streams flags/updated_at keyed by row id.
+        # Apply it to the in-memory rows so a test can see the collapse the way Postgres would,
+        # since the sweep no longer mutates the ORM row objects (finding 7).
+        if text.startswith("UPDATE") and "session_streams" in text:
+            params = stmt.compile().params
+            flags_val = next(
+                (v for v in params.values() if isinstance(v, dict) and "is_alive" in v),
+                None,
+            )
+            id_list = next(
+                (
+                    list(v)
+                    for v in params.values()
+                    if isinstance(v, (list, set, tuple))
+                    and v
+                    and all(not isinstance(x, tuple) for x in v)
+                ),
+                None,
+            )
+            if flags_val is not None and id_list is not None:
+                for r in self._rows:
+                    if r.id in id_list:
+                        r.flags = dict(flags_val)
+                        r.updated_at = now
+            return _FakeResult([])
+
         # The lost-turn is_running clear: a session_streams SELECT keyed by a list of
         # (project_id, session_id, turn_id) tuples. Return the rows those keys name that still
         # read is_running true, so the sweep can clear the flag on them.

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -24,6 +24,7 @@ from oss.src.core.sessions.records.dtos import (
     SETTLED_BY_WATCHDOG,
     SessionRecordEvent,
 )
+from oss.src.dbs.redis.sessions.contract import make_owner_value, owner_replica_id
 from oss.src.dbs.redis.sessions.locks import claim_owner, is_turn_superseded
 from oss.src.tasks.asyncio.sessions.orphan_sweep import (
     LOST_ERROR_CODE,
@@ -329,7 +330,7 @@ class _FakeRedis:
         if isinstance(current, bytes):
             current = current.decode()
         if len(argv) > 1:
-            if current is None or current == v:
+            if current is None or owner_replica_id(current) == owner_replica_id(v):
                 self._store[k] = v.encode()
                 return v.encode()
             return current.encode()
@@ -692,7 +693,9 @@ async def test_the_redis_nest_follows_the_settled_row(anyio_backend):
 
 
 @pytest.mark.anyio
-async def test_post_commit_cleanup_preserves_a_new_turn_generation(anyio_backend):
+async def test_cleanup_preserves_same_replica_owner_refresh_before_new_turn_locks(
+    anyio_backend,
+):
     stream = _stale_running_row(session_id="sess-cleanup-race", turn_id="turn-a")
     redis = _FakeRedis()
     project = str(stream.project_id)
@@ -701,23 +704,30 @@ async def test_post_commit_cleanup_preserves_a_new_turn_generation(anyio_backend
     owner_key = f"owner:{project}:session:{stream.session_id}"
     redis._store[alive_key] = b"turn-a"
     redis._store[running_key] = b"turn-a"
-    redis._store[owner_key] = b"replica-a"
+    redis._store[owner_key] = make_owner_value(
+        replica_id="replica-a", turn_id="turn-a"
+    ).encode()
 
-    def install_turn_b():
-        redis._store[alive_key] = b"turn-b"
-        redis._store[running_key] = b"turn-b"
-        redis._store[owner_key] = b"replica-b"
+    def refresh_turn_b_owner():
+        # Exact ABA gap: the same replica refreshed affinity for B, but has not installed B's
+        # alive/running keys yet. Cleanup must compare the owner generation, not the replica.
+        redis._store[owner_key] = make_owner_value(
+            replica_id="replica-a", turn_id="turn-b"
+        ).encode()
 
     await run_orphan_sweep(
-        _FakeTransactionsEngine([stream], after_commit=install_turn_b),
+        _FakeTransactionsEngine([stream], after_commit=refresh_turn_b_owner),
         redis,
         records_service=_FakeRecordsService(),
         publish=_Publisher(),
     )
 
-    assert redis._store[alive_key] == b"turn-b"
-    assert redis._store[running_key] == b"turn-b"
-    assert redis._store[owner_key] == b"replica-b"
+    assert alive_key not in redis._store
+    assert running_key not in redis._store
+    assert (
+        redis._store[owner_key]
+        == make_owner_value(replica_id="replica-a", turn_id="turn-b").encode()
+    )
     assert (
         redis._store[f"superseded:{project}:session:{stream.session_id}:turn:turn-a"]
         == b"1"

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -277,6 +277,10 @@ async def test_an_idle_row_owes_no_ending(anyio_backend):
 
     Its last turn already reached its own terminal record. Writing an error here would
     invent a failure that never happened.
+
+    The records fake says so, because that record is now what decides. The `is_running` flag
+    used to decide instead, and a durable Stop broke it: settlement clears the flag before the
+    runner has written its ending.
     """
     row = _FakeRow(
         session_id="sess-idle",
@@ -289,7 +293,7 @@ async def test_an_idle_row_owes_no_ending(anyio_backend):
     await run_orphan_sweep(
         _FakeTransactionsEngine([row]),
         _FakeRedis(),
-        records_service=_FakeRecordsService(),
+        records_service=_FakeRecordsService({("sess-idle", "turn-old")}),
         publish=publisher,
     )
 
@@ -304,8 +308,13 @@ async def test_a_parked_approval_is_never_settled(anyio_backend):
     A turn that parks for a human sends one final beat with `is_running: false` and then stops
     beating on purpose. Its heartbeat therefore goes stale immediately, and it is exactly the
     state we most need to keep: the sandbox is warm, the user is about to answer, and the turn
-    is resumable. Only a row that still CLAIMS running is eligible, so this one is not a
-    candidate however long it sits.
+    is resumable.
+
+    What protects it is its own terminal record: a turn that parks writes `done` with
+    `stopReason: paused` at the moment it parks, and any terminal record makes `settled_turns`
+    answer yes. Verified on the integration stack, session f0018938: `done`/`paused` landed in
+    the same second as the `interaction_request`. The `is_running` flag protected it before,
+    and stopped being able to when a durable Stop began clearing that flag early.
     """
     row = _FakeRow(
         session_id="sess-parked",
@@ -318,7 +327,7 @@ async def test_a_parked_approval_is_never_settled(anyio_backend):
     await run_orphan_sweep(
         _FakeTransactionsEngine([row]),
         _FakeRedis(),
-        records_service=_FakeRecordsService(),
+        records_service=_FakeRecordsService({("sess-parked", "turn-parked")}),
         publish=publisher,
     )
 
@@ -414,3 +423,41 @@ async def test_a_failed_lookup_never_invents_an_ending(anyio_backend):
 
     assert publisher.published == []
     assert _collapsed(row)
+
+
+@pytest.mark.anyio
+async def test_a_stopped_turn_whose_runner_died_still_gets_an_ending(anyio_backend):
+    """The seam between the durable Stop and the watchdog, found by running the cells.
+
+    Settlement writes `is_running: false` onto the row the moment it releases the Redis key,
+    so the tab that pressed Stop is not left spinning. The runner still owes its own terminal
+    record. If it dies in that window the row is already not-running, and the old rule — only
+    a row that CLAIMS running owes an ending — skipped it for ever: the 30-minute idle branch
+    collapses such a row and writes nothing.
+
+    Observed live on the integration stack. Command 01a06763-5807 settled `applied`/`stopped`
+    at 13:09:19, the runner was killed a moment later, and turn 295351c3 still carried nothing
+    but the user's own `message` five minutes and five sweep passes later.
+
+    This row is deliberately NOT collapsed here: it is younger than the idle grace, and a
+    parked approval of the same age must survive. Only the ending is owed.
+    """
+    row = _FakeRow(
+        session_id="sess-stopped",
+        turn_id="turn-stopped",
+        is_running=False,
+        age_seconds=ORPHAN_THRESHOLD_SECONDS + 30,
+    )
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row]),
+        _FakeRedis(),
+        records_service=_FakeRecordsService(),
+        publish=publisher,
+    )
+
+    assert [event.record_type for event in publisher.published] == ["error", "done"], (
+        "a stopped turn whose runner never wrote an ending must be given one"
+    )
+    assert all(event.turn_id == "turn-stopped" for event in publisher.published)

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -31,6 +31,7 @@ from oss.src.tasks.asyncio.sessions.orphan_sweep import (
     ORPHAN_THRESHOLD_SECONDS,
     IDLE_THRESHOLD_SECONDS,
     SWEEP_BATCH_SIZE,
+    _unsettled_turns,
     run_orphan_sweep,
 )
 
@@ -282,6 +283,37 @@ class _FakeRecordsService:
     async def settled_turns(self, *, project_id, keys):
         self.queries.append(list(keys))
         return {key for key in keys if key in self.settled}
+
+
+@pytest.mark.anyio
+async def test_terminal_record_checks_are_batched_once_per_project(anyio_backend):
+    other_project = UUID("00000000-0000-4000-8000-000000000002")
+
+    class _RecordingRecords:
+        def __init__(self):
+            self.queries = []
+
+        async def settled_turns(self, *, project_id, keys):
+            self.queries.append((project_id, list(keys)))
+            return set()
+
+    records = _RecordingRecords()
+    first_project = [
+        (_PROJECT_ID, f"session-{index}", f"turn-{index}") for index in range(100)
+    ]
+    second_project = [(other_project, "session-other", "turn-other")]
+
+    unsettled, ended = await _unsettled_turns(
+        records_service=records,
+        candidates=[*first_project, *second_project],
+    )
+
+    assert ended == set()
+    assert unsettled == set(first_project + second_project)
+    assert [(project_id, len(keys)) for project_id, keys in records.queries] == [
+        (_PROJECT_ID, 100),
+        (other_project, 1),
+    ]
 
 
 class _FakeWatchPublisher:

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -1,0 +1,373 @@
+"""The execution watchdog must give a lost turn a real ending, exactly once.
+
+Before this, the sweep collapsed a dead session's flags and cleared its Redis nest, but wrote
+nothing to the transcript: the turn simply stopped mid-sentence and the browser kept showing
+it as running until the user reloaded. The invariant these tests hold is the RFC's — every
+accepted execution reaches exactly ONE durable terminal outcome — so they check both halves:
+an ending IS written for a turn that has none, and a SECOND ending is never written for a turn
+that already has one.
+
+The threshold predicate itself is covered by `test_orphan_sweep_thresholds.py`; the fake
+session here returns whatever rows the test hands it, so these tests are about what the
+watchdog DOES with a candidate, not which rows it picks.
+"""
+
+from contextlib import asynccontextmanager
+from datetime import datetime, timezone, timedelta
+from typing import List, Optional, Sequence, Set, Tuple
+from uuid import UUID
+
+import pytest
+
+from oss.src.core.sessions.records.dtos import SessionRecordEvent
+from oss.src.tasks.asyncio.sessions.orphan_sweep import (
+    LOST_ERROR_CODE,
+    LOST_ERROR_MESSAGE,
+    ORPHAN_THRESHOLD_SECONDS,
+    run_orphan_sweep,
+)
+
+_PROJECT_ID = UUID("00000000-0000-4000-8000-000000000001")
+
+
+# --------------------------------------------------------------------------- #
+# Fakes
+# --------------------------------------------------------------------------- #
+
+
+class _FakeRow:
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        turn_id: Optional[str],
+        is_running: bool,
+        age_seconds: int,
+    ):
+        self.session_id = session_id
+        self.project_id = _PROJECT_ID
+        self.id = f"stream-{session_id}"
+        self.turn_id = turn_id
+        self.deleted_at = None
+        self.flags = {
+            "is_alive": True,
+            "is_running": is_running,
+            "is_attached": False,
+        }
+        self.created_at = datetime.now(timezone.utc) - timedelta(days=1)
+        self.updated_at = datetime.now(timezone.utc) - timedelta(seconds=age_seconds)
+
+
+class _FakeResult:
+    def __init__(self, rows):
+        self._rows = rows
+
+    def scalars(self):
+        return self
+
+    def all(self):
+        return self._rows
+
+
+class _FakePgSession:
+    def __init__(self, rows):
+        self._rows = rows
+        self.commits = 0
+
+    async def execute(self, stmt):
+        return _FakeResult(self._rows)
+
+    async def commit(self):
+        self.commits += 1
+
+
+class _FakeTransactionsEngine:
+    def __init__(self, rows):
+        self._rows = rows
+
+    @asynccontextmanager
+    async def session(self):
+        yield _FakePgSession(self._rows)
+
+
+class _FakeRedis:
+    def __init__(self):
+        self._store: dict = {}
+
+    async def get(self, key):
+        return self._store.get(key)
+
+    async def set(self, key, value, nx=False, ex=None):
+        if nx and key in self._store:
+            return None
+        self._store[key] = value
+        return True
+
+    async def delete(self, key):
+        self._store.pop(key, None)
+        return 1
+
+    async def expire(self, key, ttl):
+        return True
+
+
+class _FakeRecordsService:
+    """Stands in for the records plane. `settled` is what the tracing DB already holds."""
+
+    def __init__(self, settled: Optional[Set[Tuple[str, str]]] = None):
+        self.settled = settled or set()
+        self.queries: List[Sequence[Tuple[str, str]]] = []
+
+    async def settled_turns(self, *, project_id, keys):
+        self.queries.append(list(keys))
+        return {key for key in keys if key in self.settled}
+
+
+class _FakeWatchPublisher:
+    def __init__(self):
+        self.lifecycles: List[Tuple[str, str, str]] = []
+
+    async def lifecycle(self, *, project_id, session_id, state):
+        self.lifecycles.append((project_id, session_id, state))
+
+
+class _Publisher:
+    """Captures what the watchdog would put on the record ingest stream."""
+
+    def __init__(self):
+        self.published: List[SessionRecordEvent] = []
+
+    async def __call__(self, *, project_id, record_event):
+        self.published.append(record_event)
+        return True
+
+
+def _stale_running_row(session_id="sess-lost", turn_id="turn-1") -> _FakeRow:
+    return _FakeRow(
+        session_id=session_id,
+        turn_id=turn_id,
+        is_running=True,
+        age_seconds=ORPHAN_THRESHOLD_SECONDS + 60,
+    )
+
+
+def _collapsed(row: _FakeRow) -> bool:
+    return row.flags == {"is_alive": False, "is_running": False, "is_attached": False}
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+# --------------------------------------------------------------------------- #
+# Tests
+# --------------------------------------------------------------------------- #
+
+
+@pytest.mark.anyio
+async def test_a_lost_turn_gets_an_error_then_a_done(anyio_backend):
+    """The shape a runner writes when a turn ends badly, written on its behalf.
+
+    A lone `done` would render as a clean finish, which is the opposite of what happened, so
+    the error must come first and must carry the class a client can act on.
+    """
+    row = _stale_running_row()
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row]),
+        _FakeRedis(),
+        records_service=_FakeRecordsService(),
+        publish=publisher,
+    )
+
+    assert [event.record_type for event in publisher.published] == ["error", "done"]
+
+    error_event, done_event = publisher.published
+    assert error_event.attributes == {
+        "type": "error",
+        "message": LOST_ERROR_MESSAGE,
+        "code": LOST_ERROR_CODE,
+    }
+    assert done_event.attributes == {"type": "done"}
+    assert error_event.turn_id == "turn-1"
+    assert done_event.turn_id == "turn-1"
+    assert error_event.session_id == "sess-lost"
+    assert _collapsed(row), "the row must still be marked ended"
+
+
+@pytest.mark.anyio
+async def test_a_second_pass_writes_no_second_ending(anyio_backend):
+    """Idempotency, the guarantee the RFC asks for: exactly one terminal outcome.
+
+    Two passes can see the same turn — a crash between the record write and the flag
+    collapse, or two API replicas sweeping at once. The second pass reads the record the
+    first one wrote and must stay silent.
+    """
+    records = _FakeRecordsService()
+    first_publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([_stale_running_row()]),
+        _FakeRedis(),
+        records_service=records,
+        publish=first_publisher,
+    )
+    assert len(first_publisher.published) == 2
+
+    # The records worker has now landed those rows in the tracing DB.
+    records.settled.add(("sess-lost", "turn-1"))
+
+    second_publisher = _Publisher()
+    row = _stale_running_row()
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row]),
+        _FakeRedis(),
+        records_service=records,
+        publish=second_publisher,
+    )
+
+    assert second_publisher.published == [], (
+        "a turn that already carries a terminal record must never be given a second one"
+    )
+    assert _collapsed(row), "the row is still settled even when no record is owed"
+
+
+@pytest.mark.anyio
+async def test_record_ids_are_stable_across_passes(anyio_backend):
+    """The second guard, for the window before the worker has landed the first write.
+
+    Ingest upserts on (project_id, record_id), so two publishes of the same id write the
+    same row rather than appending a duplicate.
+    """
+    first, second = _Publisher(), _Publisher()
+
+    for publisher in (first, second):
+        await run_orphan_sweep(
+            _FakeTransactionsEngine([_stale_running_row()]),
+            _FakeRedis(),
+            records_service=_FakeRecordsService(),
+            publish=publisher,
+        )
+
+    assert [event.record_id for event in first.published] == [
+        event.record_id for event in second.published
+    ]
+    assert len({event.record_id for event in first.published}) == 2, (
+        "the error and the done must not collide on one id"
+    )
+
+
+@pytest.mark.anyio
+async def test_an_idle_row_owes_no_ending(anyio_backend):
+    """A row that was alive between turns has no running turn to end.
+
+    Its last turn already reached its own terminal record. Writing an error here would
+    invent a failure that never happened.
+    """
+    row = _FakeRow(
+        session_id="sess-idle",
+        turn_id="turn-old",
+        is_running=False,
+        age_seconds=99_999,
+    )
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row]),
+        _FakeRedis(),
+        records_service=_FakeRecordsService(),
+        publish=publisher,
+    )
+
+    assert publisher.published == []
+    assert _collapsed(row)
+
+
+@pytest.mark.anyio
+async def test_a_running_row_without_a_turn_id_is_settled_silently(anyio_backend):
+    """Nothing to attribute an ending to, so the row is collapsed and no record is written."""
+    row = _FakeRow(
+        session_id="sess-no-turn",
+        turn_id=None,
+        is_running=True,
+        age_seconds=ORPHAN_THRESHOLD_SECONDS + 60,
+    )
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row]),
+        _FakeRedis(),
+        records_service=_FakeRecordsService(),
+        publish=publisher,
+    )
+
+    assert publisher.published == []
+    assert _collapsed(row)
+
+
+@pytest.mark.anyio
+async def test_open_readers_are_told_the_session_ended(anyio_backend):
+    """Without this a browser keeps rendering the dead turn as running until a reload."""
+    row = _stale_running_row(session_id="sess-watch")
+    watch = _FakeWatchPublisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row]),
+        _FakeRedis(),
+        records_service=_FakeRecordsService(),
+        watch_publisher=watch,
+        publish=_Publisher(),
+    )
+
+    assert watch.lifecycles == [(str(_PROJECT_ID), "sess-watch", "ended")]
+
+
+@pytest.mark.anyio
+async def test_the_redis_nest_follows_the_settled_row(anyio_backend):
+    """The SEND gate reads Redis, not the row: a session left nested keeps refusing a
+    new message long after the watchdog declared its turn lost."""
+    redis = _FakeRedis()
+    project = str(_PROJECT_ID)
+    await redis.set(f"alive:{project}:session:sess-lost", b"turn-1", ex=3600)
+    await redis.set(f"running:{project}:session:sess-lost", b"turn-1", ex=3600)
+    await redis.set(f"owner:{project}:session:sess-lost", b"replica-1", ex=3600)
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([_stale_running_row()]),
+        redis,
+        records_service=_FakeRecordsService(),
+        publish=_Publisher(),
+    )
+
+    assert await redis.get(f"alive:{project}:session:sess-lost") is None
+    assert await redis.get(f"running:{project}:session:sess-lost") is None
+    assert await redis.get(f"owner:{project}:session:sess-lost") is None
+    assert (
+        await redis.get(f"superseded:{project}:session:sess-lost:turn:turn-1")
+        is not None
+    ), "a late beat from the lost turn must not re-nest the session"
+
+
+@pytest.mark.anyio
+async def test_a_failed_lookup_never_invents_an_ending(anyio_backend):
+    """If we cannot tell whether the turn already ended, say nothing rather than risk a
+    second, contradictory ending. The row is still settled."""
+
+    class _BrokenRecords(_FakeRecordsService):
+        async def settled_turns(self, *, project_id, keys):
+            raise RuntimeError("tracing db unreachable")
+
+    row = _stale_running_row()
+    publisher = _Publisher()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row]),
+        _FakeRedis(),
+        records_service=_BrokenRecords(),
+        publish=publisher,
+    )
+
+    assert publisher.published == []
+    assert _collapsed(row)

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -144,28 +144,26 @@ class _FakePgSession:
                 )[:SWEEP_BATCH_SIZE]
             )
 
-        # The collapse: a Core UPDATE of session_streams flags/updated_at keyed by row id.
-        # Apply it to the in-memory rows so a test can see the collapse the way Postgres would,
-        # since the sweep no longer mutates the ORM row objects (finding 7).
+        # Both session_streams writes are Core UPDATEs of flags/updated_at keyed by row id, and
+        # never ORM attribute writes (finding 7). Apply them to the in-memory rows so a test
+        # sees what Postgres would. The collapse binds `id IN (...)`, a list. The lost-turn
+        # clear binds `id = ...`, a scalar. Row ids are strings here and are the only string
+        # bind in either statement.
         if text.startswith("UPDATE") and "session_streams" in text:
             params = stmt.compile().params
             flags_val = next(
                 (v for v in params.values() if isinstance(v, dict) and "is_alive" in v),
                 None,
             )
-            id_list = next(
-                (
-                    list(v)
-                    for v in params.values()
-                    if isinstance(v, (list, set, tuple))
-                    and v
-                    and all(not isinstance(x, tuple) for x in v)
-                ),
-                None,
-            )
-            if flags_val is not None and id_list is not None:
+            ids = set()
+            for value in params.values():
+                if isinstance(value, (list, set, tuple)):
+                    ids.update(x for x in value if isinstance(x, (str, UUID)))
+                elif isinstance(value, (str, UUID)):
+                    ids.add(value)
+            if flags_val is not None:
                 for r in self._rows:
-                    if r.id in id_list:
+                    if r.id in ids:
                         r.flags = dict(flags_val)
                         r.updated_at = now
             return _FakeResult([])

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -28,6 +28,7 @@ from oss.src.tasks.asyncio.sessions.orphan_sweep import (
     LOST_ERROR_CODE,
     LOST_ERROR_MESSAGE,
     ORPHAN_THRESHOLD_SECONDS,
+    IDLE_THRESHOLD_SECONDS,
     run_orphan_sweep,
 )
 
@@ -79,7 +80,42 @@ class _FakePgSession:
         self.commits = 0
 
     async def execute(self, stmt):
-        return _FakeResult(self._rows)
+        # Evaluate the sweep's two selections the way Postgres would, so a test can tell a
+        # collapsed row from one that only owed an ending. The ending-only statement is the
+        # one that filters on `turn_id IS NOT NULL`; the first statement carries the OR of
+        # the running and idle branches.
+        text = str(stmt)
+        now = datetime.now(timezone.utc)
+
+        def age(row):
+            return (now - (row.updated_at or row.created_at)).total_seconds()
+
+        if "IS NOT NULL" in text:
+            rows = [
+                r
+                for r in self._rows
+                if r.flags.get("is_alive") is True
+                and r.flags.get("is_running") is not True
+                and r.turn_id is not None
+                and age(r) > ORPHAN_THRESHOLD_SECONDS
+            ]
+        else:
+            rows = [
+                r
+                for r in self._rows
+                if r.flags.get("is_alive") is True
+                and (
+                    (
+                        r.flags.get("is_running") is True
+                        and age(r) > ORPHAN_THRESHOLD_SECONDS
+                    )
+                    or (
+                        r.flags.get("is_running") is not True
+                        and age(r) > IDLE_THRESHOLD_SECONDS
+                    )
+                )
+            ]
+        return _FakeResult(rows)
 
     async def commit(self):
         self.commits += 1
@@ -113,6 +149,19 @@ class _FakeRedis:
 
     async def expire(self, key, ttl):
         return True
+
+    async def eval(self, script, numkeys, key, value):
+        # The one script the sweep runs is release-if-owner: delete the key when its value
+        # is the caller's turn id, answer 1, else 0. Keys arrive as bytes.
+        k = key.decode() if isinstance(key, bytes) else key
+        v = value.decode() if isinstance(value, bytes) else value
+        current = self._store.get(k)
+        if isinstance(current, bytes):
+            current = current.decode()
+        if current == v:
+            self._store.pop(k, None)
+            return 1
+        return 0
 
 
 class _FakeRecordsService:
@@ -449,10 +498,15 @@ async def test_a_stopped_turn_whose_runner_died_still_gets_an_ending(anyio_backe
         age_seconds=ORPHAN_THRESHOLD_SECONDS + 30,
     )
     publisher = _Publisher()
+    redis = _FakeRedis()
+    # Settlement leaves `alive` to its TTL, so the dead turn still holds the session's
+    # alive lock when the sweep runs; the SEND gate reads that lock.
+    alive_key = f"alive:{row.project_id}:session:{row.session_id}"
+    redis._store[alive_key] = b"turn-stopped"
 
     await run_orphan_sweep(
         _FakeTransactionsEngine([row]),
-        _FakeRedis(),
+        redis,
         records_service=_FakeRecordsService(),
         publish=publisher,
     )
@@ -461,3 +515,29 @@ async def test_a_stopped_turn_whose_runner_died_still_gets_an_ending(anyio_backe
         "a stopped turn whose runner never wrote an ending must be given one"
     )
     assert all(event.turn_id == "turn-stopped" for event in publisher.published)
+    assert alive_key not in redis._store, (
+        "the dead turn's alive lock must be released, or the next Send is refused for an hour"
+    )
+    assert row.flags["is_alive"] is True, "the stopped row itself is not collapsed"
+
+
+async def test_a_stopped_turn_owned_by_a_newer_turn_keeps_that_lock(anyio_backend):
+    """Release is owner-checked: if a newer turn already holds `alive`, leave it alone."""
+    row = _FakeRow(
+        session_id="sess-stopped",
+        turn_id="turn-stopped",
+        is_running=False,
+        age_seconds=ORPHAN_THRESHOLD_SECONDS + 30,
+    )
+    redis = _FakeRedis()
+    alive_key = f"alive:{row.project_id}:session:{row.session_id}"
+    redis._store[alive_key] = b"turn-newer"
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row]),
+        redis,
+        records_service=_FakeRecordsService(),
+        publish=_Publisher(),
+    )
+
+    assert redis._store.get(alive_key) == b"turn-newer"

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog_loop.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog_loop.py
@@ -1,0 +1,146 @@
+"""The watchdog loop must survive a failing pass and go round again.
+
+Root cause of the integration-stack silence on 2026-09-04: `orphan_sweep_loop`'s generic
+error handler called `log.exception(...)`, but `log` is a `MultiLogger`, which defines no
+`exception` method and no `__getattr__`. The first sweep error -- a `session_executions`
+column that did not exist yet during a migration window -- turned that handler into an
+`AttributeError` that escaped the `while` loop and killed the watchdog task for the life of
+the process. There was no timeout log, no error log, and no further pass, so stale rows were
+never settled. The `asyncio.wait_for` guard could not help, because the defect was in the
+handler, not in a pass that ran long.
+
+These tests drive the loop, not a single pass, so the error handler is exercised: a pass
+that raises must be logged and the loop must run a second pass; the same must hold for a pass
+the timeout cuts. The single-pass behavior lives in `test_execution_watchdog.py`.
+"""
+
+import asyncio
+
+import pytest
+
+from oss.src.tasks.asyncio.sessions import orphan_sweep
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+async def _noop_sleep(*_args, **_kwargs):
+    return None
+
+
+class _RecordingLog:
+    """A stand-in for the module `MultiLogger`.
+
+    It exposes only the methods `MultiLogger` really has, so a call the real logger cannot
+    serve (for example `exception`) raises `AttributeError` here too, exactly as it did live.
+    """
+
+    def __init__(self):
+        self.calls = []
+
+    def error(self, *args, **kwargs):
+        self.calls.append(("error", args, kwargs))
+
+    def info(self, *args, **kwargs):
+        self.calls.append(("info", args, kwargs))
+
+    def warning(self, *args, **kwargs):
+        self.calls.append(("warning", args, kwargs))
+
+
+def _logged_errors(recorder):
+    return [c for c in recorder.calls if c[0] == "error"]
+
+
+async def _run_loop_over(monkeypatch, first_pass_raises):
+    """Drive the loop over two passes: the first raises `first_pass_raises`, the second stops
+    the loop with `CancelledError`. Returns the pass count and the recording logger."""
+    passes = 0
+
+    async def fake_sweep(*_args, **_kwargs):
+        nonlocal passes
+        passes += 1
+        if passes == 1:
+            raise first_pass_raises
+        raise asyncio.CancelledError()
+
+    recorder = _RecordingLog()
+    monkeypatch.setattr(orphan_sweep, "run_orphan_sweep", fake_sweep)
+    monkeypatch.setattr(orphan_sweep, "log", recorder)
+    monkeypatch.setattr(orphan_sweep, "SWEEP_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(orphan_sweep.asyncio, "sleep", _noop_sleep)
+
+    with pytest.raises(asyncio.CancelledError):
+        await orphan_sweep.orphan_sweep_loop(engine=None, lock_engine=None)
+
+    return passes, recorder
+
+
+@pytest.mark.anyio
+async def test_a_failing_pass_is_logged_and_the_loop_continues(
+    anyio_backend, monkeypatch
+):
+    # A real error from inside a pass -- the shape of the live UndefinedColumnError.
+    passes, recorder = await _run_loop_over(
+        monkeypatch,
+        RuntimeError("column session_executions.ending_written_at does not exist"),
+    )
+
+    # The loop survived the first error and ran a second pass. Before the fix, the handler
+    # itself raised AttributeError on the first pass and the loop never reached pass two.
+    assert passes == 2
+
+    errors = _logged_errors(recorder)
+    assert errors, "the failing pass must be logged"
+    assert errors[0][2].get("exc_info"), "the error must carry the traceback"
+
+
+@pytest.mark.anyio
+async def test_a_timed_out_pass_is_logged_and_the_loop_continues(
+    anyio_backend, monkeypatch
+):
+    # `asyncio.wait_for` raises TimeoutError when it cuts a pass that runs too long. The loop
+    # must log it and go round again, never die.
+    passes, recorder = await _run_loop_over(monkeypatch, asyncio.TimeoutError())
+
+    assert passes == 2
+    assert _logged_errors(recorder), "the timed-out pass must be logged"
+
+
+@pytest.mark.anyio
+async def test_a_hanging_pass_is_cut_by_the_timeout(anyio_backend, monkeypatch):
+    """A pass that blocks forever must be cut by `asyncio.wait_for`, not hang the loop.
+
+    The production floor on `pass_timeout` is 120 s, so the loop's own timeout is patched to a
+    short value here to keep the test fast while still exercising the real `asyncio.wait_for`.
+    """
+    passes = 0
+
+    async def fake_sweep(*_args, **_kwargs):
+        nonlocal passes
+        passes += 1
+        if passes == 1:
+            await asyncio.Event().wait()  # blocks forever
+        raise asyncio.CancelledError()
+
+    recorder = _RecordingLog()
+    monkeypatch.setattr(orphan_sweep, "run_orphan_sweep", fake_sweep)
+    monkeypatch.setattr(orphan_sweep, "log", recorder)
+    monkeypatch.setattr(orphan_sweep, "SWEEP_INTERVAL_SECONDS", 0)
+    monkeypatch.setattr(orphan_sweep.asyncio, "sleep", _noop_sleep)
+
+    real_wait_for = asyncio.wait_for
+
+    async def short_wait_for(awaitable, timeout):  # noqa: ARG001
+        return await real_wait_for(awaitable, timeout=0.05)
+
+    monkeypatch.setattr(orphan_sweep.asyncio, "wait_for", short_wait_for)
+
+    with pytest.raises(asyncio.CancelledError):
+        await orphan_sweep.orphan_sweep_loop(engine=None, lock_engine=None)
+
+    # The first pass hung; the timeout cut it and the loop ran a second pass.
+    assert passes == 2
+    assert _logged_errors(recorder), "the cut pass must be logged"

--- a/api/oss/tests/pytest/unit/sessions/test_heartbeat_departed_replica_affinity.py
+++ b/api/oss/tests/pytest/unit/sessions/test_heartbeat_departed_replica_affinity.py
@@ -32,10 +32,13 @@ from oss.src.core.sessions.streams.dtos import (
 )
 from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.dbs.redis.sessions.locks import (
+    claim_owner,
     get_alive_owner,
     get_owner,
+    get_owner_value,
     get_running_owner,
 )
+from oss.src.dbs.redis.sessions.contract import make_owner_value
 
 from unit.sessions.test_project_scoped_locks import _FakeRedis
 
@@ -214,6 +217,41 @@ async def test_a_turn_that_already_holds_running_may_reclaim(lock_engine):
 
     assert result.is_current_turn is True
     assert await get_owner(lock_engine, project_id=pid, session_id=_SESSION) == _FRESH
+
+
+@pytest.mark.asyncio
+async def test_reclaim_does_not_clear_a_refreshed_owner_generation(lock_engine):
+    """A same-replica new turn may refresh affinity after the failed claim is observed."""
+    svc = _service(lock_engine)
+    pid = str(_PROJECT)
+    await _replay_the_killed_runner(svc)
+
+    async def refresh_owner_generation(engine, *, project_id, session_id):
+        await claim_owner(
+            engine,
+            project_id=project_id,
+            session_id=session_id,
+            replica_id=_DEAD,
+            turn_id="turn-new-on-incumbent",
+        )
+        return None
+
+    with patch(
+        "oss.src.core.sessions.streams.service.get_running_owner",
+        side_effect=refresh_owner_generation,
+    ):
+        result = await svc.heartbeat(
+            project_id=_PROJECT, request=_beat(_FRESH, "turn-challenger")
+        )
+
+    assert result.is_current_turn is False
+    assert result.replica_id == _DEAD
+    assert await get_owner_value(
+        lock_engine, project_id=pid, session_id=_SESSION
+    ) == make_owner_value(
+        replica_id=_DEAD,
+        turn_id="turn-new-on-incumbent",
+    )
 
 
 @pytest.mark.asyncio

--- a/api/oss/tests/pytest/unit/sessions/test_heartbeat_departed_replica_affinity.py
+++ b/api/oss/tests/pytest/unit/sessions/test_heartbeat_departed_replica_affinity.py
@@ -1,0 +1,246 @@
+"""A runner that dies ungracefully must not lock its sessions out for the owner lease.
+
+Live failure this pins (matrix run 3, cell `runner-gone-late`, harness codex, session
+2fdf43f0-c728-42e5-987e-2371501fe748): a Stop settled, the runner reported the outcome, and
+the runner was then killed with no grace period. Nothing released `owner:session:<id>`, so it
+stayed pointing at the dead replica for the rest of OWNER_TTL_SECONDS. The replacement replica
+picked up the user's next message 6 s later, its first heartbeat lost the non-stealing
+`claim_owner`, the API answered `is_current_turn: false`, and the runner turned that into
+"This session is already running a turn" although no turn was running anywhere.
+
+`running` is what tells a serving replica from a departed one, so these tests drive both
+sides of it:
+
+  - no running turn -> the new replica takes affinity and its first beat is current;
+  - a different turn holding `running` -> the claim is honoured and the newcomer is refused;
+  - the caller's OWN turn holding `running` (the `_start_turn` path) -> reclaim allowed;
+  - a turn-end beat never reclaims;
+  - the reclaim survives the alive lock the dead turn left behind (the whole point: the next
+    message has to actually run).
+"""
+
+from typing import Optional
+from unittest.mock import patch
+from uuid import UUID, uuid4
+
+import pytest
+import pytest_asyncio
+
+from oss.src.core.sessions.streams.dtos import (
+    SessionHeartbeatRequest,
+    SessionStream,
+)
+from oss.src.core.sessions.streams.service import SessionStreamsService
+from oss.src.dbs.redis.sessions.locks import (
+    get_alive_owner,
+    get_owner,
+    get_running_owner,
+)
+
+from unit.sessions.test_project_scoped_locks import _FakeRedis
+
+
+_PROJECT = uuid4()
+_SESSION = "session_departed_replica"
+
+_DEAD = "replica-that-was-killed"
+_FRESH = "replica-that-replaced-it"
+
+
+class _FakeDAO:
+    def __init__(self, existing: Optional[SessionStream] = None):
+        self.row = existing
+
+    async def get_by_session_id(self, *, project_id: UUID, session_id: str):
+        return self.row
+
+    async def create(self, *, project_id, user_id, stream):
+        self.row = SessionStream(
+            id=uuid4(),
+            project_id=project_id,
+            session_id=stream.session_id,
+            flags=stream.flags,
+            turn_id=stream.turn_id,
+        )
+        return self.row
+
+    async def update(self, *, project_id, user_id, session_id, stream):
+        prior = self.row
+        self.row = SessionStream(
+            id=prior.id if prior else uuid4(),
+            project_id=project_id,
+            session_id=session_id,
+            flags=stream.flags
+            if stream.flags is not None
+            else (prior.flags if prior else None),
+            turn_id=stream.turn_id
+            if stream.turn_id is not None
+            else (prior.turn_id if prior else None),
+        )
+        return self.row
+
+    async def delete_by_session_id(self, *, project_id, session_id):
+        return True
+
+
+@pytest_asyncio.fixture
+async def lock_engine():
+    from oss.src.dbs.redis.shared.engine import LockEngine
+
+    eng = LockEngine()
+    with patch.object(eng, "_client", return_value=_FakeRedis()):
+        yield eng
+
+
+def _service(lock_engine, dao=None):
+    return SessionStreamsService(streams_dao=dao or _FakeDAO(), lock_engine=lock_engine)
+
+
+def _beat(replica: str, turn: Optional[str], running: bool = True):
+    return SessionHeartbeatRequest(
+        session_id=_SESSION, replica_id=replica, turn_id=turn, is_running=running
+    )
+
+
+async def _replay_the_killed_runner(svc):
+    """The exact state the live failure left: a turn that ran, was stopped, reported
+    `is_running: false`, and whose replica then died without releasing affinity."""
+    await svc.heartbeat(project_id=_PROJECT, request=_beat(_DEAD, "turn-stopped"))
+    await svc.heartbeat(
+        project_id=_PROJECT, request=_beat(_DEAD, "turn-stopped", running=False)
+    )
+
+
+@pytest.mark.asyncio
+async def test_next_turn_is_admitted_after_the_owning_runner_is_killed(lock_engine):
+    svc = _service(lock_engine)
+    pid = str(_PROJECT)
+    await _replay_the_killed_runner(svc)
+
+    # Preconditions: affinity still names the dead replica, nothing is running, and the dead
+    # turn's `alive` lock outlives it by design.
+    assert await get_owner(lock_engine, project_id=pid, session_id=_SESSION) == _DEAD
+    assert (
+        await get_running_owner(lock_engine, project_id=pid, session_id=_SESSION)
+    ) is None
+    assert await get_alive_owner(lock_engine, project_id=pid, session_id=_SESSION) == (
+        "turn-stopped"
+    )
+
+    recovery = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat(_FRESH, "turn-recovery")
+    )
+
+    assert recovery.is_current_turn is True, (
+        "the replacement replica was refused, so the user's next message is rejected as "
+        "'this session is already running a turn' for the rest of the owner lease"
+    )
+    assert recovery.replica_id == _FRESH
+    assert await get_owner(lock_engine, project_id=pid, session_id=_SESSION) == _FRESH
+
+
+@pytest.mark.asyncio
+async def test_recovery_turn_takes_the_nest_the_dead_turn_left(lock_engine):
+    """Admission is not enough: the recovery turn must end up owning alive and running, or
+    the next beat sees a foreign nest and aborts the turn it just started."""
+    svc = _service(lock_engine)
+    pid = str(_PROJECT)
+    await _replay_the_killed_runner(svc)
+
+    await svc.heartbeat(project_id=_PROJECT, request=_beat(_FRESH, "turn-recovery"))
+
+    assert await get_alive_owner(lock_engine, project_id=pid, session_id=_SESSION) == (
+        "turn-recovery"
+    )
+    assert await get_running_owner(
+        lock_engine, project_id=pid, session_id=_SESSION
+    ) == ("turn-recovery")
+
+    second = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat(_FRESH, "turn-recovery")
+    )
+    assert second.is_current_turn is True
+
+
+@pytest.mark.asyncio
+async def test_a_live_turn_on_another_replica_still_refuses_the_newcomer(lock_engine):
+    """The guard this reclaim relaxes must still hold where it matters: a replica running a
+    turn keeps its session, and a second replica's turn is refused rather than admitted
+    alongside it."""
+    svc = _service(lock_engine)
+    pid = str(_PROJECT)
+
+    await svc.heartbeat(project_id=_PROJECT, request=_beat(_DEAD, "turn-live"))
+
+    intruder = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat(_FRESH, "turn-intruder")
+    )
+
+    assert intruder.is_current_turn is False
+    assert intruder.replica_id == _DEAD
+    assert await get_owner(lock_engine, project_id=pid, session_id=_SESSION) == _DEAD
+    assert await get_alive_owner(lock_engine, project_id=pid, session_id=_SESSION) == (
+        "turn-live"
+    )
+    assert await get_running_owner(
+        lock_engine, project_id=pid, session_id=_SESSION
+    ) == ("turn-live")
+
+
+@pytest.mark.asyncio
+async def test_a_turn_that_already_holds_running_may_reclaim(lock_engine):
+    """`_start_turn` arms alive and running before the runner beats at all, so an API-minted
+    turn reaches the heartbeat with its own `running` lock already held. That must not read as
+    'another turn is live here'."""
+    from oss.src.dbs.redis.sessions.locks import acquire_alive, acquire_running
+
+    svc = _service(lock_engine)
+    pid = str(_PROJECT)
+    await _replay_the_killed_runner(svc)
+    # The API starts the recovery turn itself, then the replacement replica beats for it.
+    from oss.src.dbs.redis.sessions.locks import force_cancel_alive
+
+    await force_cancel_alive(lock_engine, project_id=pid, session_id=_SESSION)
+    await acquire_alive(
+        lock_engine, project_id=pid, session_id=_SESSION, turn_id="turn-api-minted"
+    )
+    await acquire_running(
+        lock_engine, project_id=pid, session_id=_SESSION, turn_id="turn-api-minted"
+    )
+
+    result = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat(_FRESH, "turn-api-minted")
+    )
+
+    assert result.is_current_turn is True
+    assert await get_owner(lock_engine, project_id=pid, session_id=_SESSION) == _FRESH
+
+
+@pytest.mark.asyncio
+async def test_a_turn_end_beat_never_reclaims_affinity(lock_engine):
+    """A beat that reports a turn ENDING asserts nothing about who should serve the session
+    next, so it must leave affinity alone."""
+    svc = _service(lock_engine)
+    pid = str(_PROJECT)
+    await _replay_the_killed_runner(svc)
+
+    result = await svc.heartbeat(
+        project_id=_PROJECT, request=_beat(_FRESH, "turn-recovery", running=False)
+    )
+
+    assert result.is_current_turn is False
+    assert result.replica_id == _DEAD
+    assert await get_owner(lock_engine, project_id=pid, session_id=_SESSION) == _DEAD
+
+
+@pytest.mark.asyncio
+async def test_a_beat_with_no_turn_never_reclaims_affinity(lock_engine):
+    """The ownership-probe beat carries no turn id. It reads affinity; it may not move it."""
+    svc = _service(lock_engine)
+    pid = str(_PROJECT)
+    await _replay_the_killed_runner(svc)
+
+    result = await svc.heartbeat(project_id=_PROJECT, request=_beat(_FRESH, None))
+
+    assert result.replica_id == _DEAD
+    assert await get_owner(lock_engine, project_id=pid, session_id=_SESSION) == _DEAD

--- a/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
+++ b/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
@@ -1,0 +1,330 @@
+"""The ingest guard that keeps one execution to one ending.
+
+RFC "Required behavior / Execution" item 3: after an execution reaches its terminal outcome,
+later non-terminal output for it is rejected or quarantined. `RecordsService.append_many` is
+where that is enforced, because ingest is the only place the watchdog and the runner meet.
+
+The case these tests pin was caught live. A runner wedges past the watchdog's stale-heartbeat
+threshold, the watchdog writes the turn's `error` and `done` on its behalf, and the runner
+then thaws and submits everything it had buffered: a tool call, its result, a `usage`, and a
+second `done`. The reader was left with a failure notice followed by the work the agent went
+on to do, and with two endings for one turn.
+
+Every test here drives the service against a stub DAO, so they run with no Postgres. The
+DAO-level half — that a quarantined row is invisible to `get_records` and does not answer
+`settled_turns` — lives in `test_late_record_quarantine_dao.py` against a real database.
+"""
+
+from typing import Dict, List, Optional, Sequence, Set, Tuple
+from uuid import UUID, uuid4
+
+from oss.src.core.sessions.records.dtos import (
+    RECORD_SETTLED_BY_ATTRIBUTE,
+    SETTLED_BY_WATCHDOG,
+    SessionRecord,
+    SessionRecordEvent,
+)
+from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
+from oss.src.core.sessions.records.service import RecordsService
+
+
+_PROJECT = UUID("00000000-0000-0000-0000-0000000000aa")
+_SESSION = "sess-late-tail"
+_TURN = "turn-abc"
+
+
+class _StubDAO(RecordsDAOInterface):
+    """Answers `settled_turns` from a fixed set and remembers what `append_many` was given.
+
+    The settled sets belong to `project`, and the real DAO scopes its query the same way, so a
+    key from another project is never a hit however it is spelled.
+    """
+
+    def __init__(
+        self,
+        *,
+        watchdog_settled: Optional[Set[Tuple[str, str]]] = None,
+        any_settled: Optional[Set[Tuple[str, str]]] = None,
+        project: UUID = _PROJECT,
+        raises: bool = False,
+    ):
+        self.watchdog_settled = watchdog_settled or set()
+        self.any_settled = any_settled or set()
+        self.project = project
+        self.raises = raises
+        self.appended: List[SessionRecordEvent] = []
+        self.lookups: List[Dict] = []
+
+    async def settled_turns(
+        self,
+        *,
+        project_id: UUID,
+        keys: Sequence[Tuple[str, str]],
+        settled_by: Optional[str] = None,
+    ) -> Set[Tuple[str, str]]:
+        self.lookups.append({"project_id": project_id, "settled_by": settled_by})
+        if self.raises:
+            raise RuntimeError("tracing database is unreachable")
+        if project_id != self.project:
+            return set()
+        source = (
+            self.watchdog_settled
+            if settled_by == SETTLED_BY_WATCHDOG
+            else self.any_settled
+        )
+        return {key for key in keys if key in source}
+
+    async def append_many(
+        self, *, events: List[SessionRecordEvent]
+    ) -> List[SessionRecord]:
+        self.appended.extend(events)
+        return [
+            SessionRecord(
+                record_id=event.record_id or uuid4(),
+                session_id=event.session_id,
+                project_id=event.project_id,
+                record_index=event.record_index,
+                record_type=event.record_type,
+                record_source=event.record_source,
+                attributes=event.attributes,
+                turn_id=event.turn_id,
+                quarantined_at=event.quarantined_at,
+            )
+            for event in events
+        ]
+
+
+def _event(record_type: str, **over) -> SessionRecordEvent:
+    base = {
+        "project_id": _PROJECT,
+        "session_id": _SESSION,
+        "record_id": uuid4(),
+        "record_type": record_type,
+        "record_source": "agent",
+        "attributes": {"type": record_type},
+        "turn_id": _TURN,
+    }
+    base.update(over)
+    return SessionRecordEvent(**base)
+
+
+def _watchdog_event(record_type: str, **over) -> SessionRecordEvent:
+    """What `orphan_sweep._lost_turn_records` puts on the stream."""
+    event = _event(record_type, **over)
+    event.attributes = {
+        **(event.attributes or {}),
+        RECORD_SETTLED_BY_ATTRIBUTE: SETTLED_BY_WATCHDOG,
+    }
+    return event
+
+
+def _quarantined(dao: _StubDAO) -> List[SessionRecordEvent]:
+    return [event for event in dao.appended if event.quarantined_at is not None]
+
+
+# --------------------------------------------------------------------------- #
+# The tail: output produced before termination, delivered after it
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_thawed_runners_tail_is_quarantined_not_appended_as_history():
+    """The live defect, in one test: four records land after the watchdog's ending."""
+    dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    tail = [
+        _event("tool_call"),
+        _event("tool_result"),
+        _event("usage"),
+        _event("done", attributes={"type": "done", "stopReason": "cancelled"}),
+    ]
+    results = await service.append_many(events=tail)
+
+    # Every record is still written — quarantine keeps the evidence — and every one of them
+    # is marked, so no read that rebuilds the transcript will show it.
+    assert len(results) == 4
+    assert len(_quarantined(dao)) == 4
+    assert all(row.quarantined_at is not None for row in results)
+
+
+async def test_the_guard_asks_only_about_watchdog_endings():
+    dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    await service.append_many(events=[_event("usage")])
+
+    assert [lookup["settled_by"] for lookup in dao.lookups] == [SETTLED_BY_WATCHDOG]
+
+
+async def test_a_late_terminal_record_is_quarantined_like_the_rest_of_the_tail():
+    """One effective ending. The runner's contradicting `done` is kept, but not as history.
+
+    Folding it into the watchdog's ending would rewrite the record the user has already
+    read, and would hide that two writers disagreed about how the turn finished.
+    """
+    dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    await service.append_many(
+        events=[_event("done", attributes={"type": "done", "stopReason": "cancelled"})]
+    )
+
+    assert len(_quarantined(dao)) == 1
+    assert _quarantined(dao)[0].record_type == "done"
+
+
+# --------------------------------------------------------------------------- #
+# What the guard must never touch
+# --------------------------------------------------------------------------- #
+
+
+async def test_an_ordinary_stop_the_watchdog_never_saw_is_untouched():
+    """The runner's own honest single ending still lands, unmarked."""
+    dao = _StubDAO(watchdog_settled=set())
+    service = RecordsService(records_dao=dao)
+
+    ending = [
+        _event("usage"),
+        _event("done", attributes={"type": "done", "stopReason": "cancelled"}),
+    ]
+    results = await service.append_many(events=ending)
+
+    assert _quarantined(dao) == []
+    assert all(row.quarantined_at is None for row in results)
+
+
+async def test_a_turn_the_runner_settled_itself_does_not_trigger_the_guard():
+    """A terminal record is not enough; it has to be the WATCHDOG's.
+
+    A `usage` that trails its own `done` through the stream is ordinary history, and a turn
+    that reached its own ending never lost the argument with the platform.
+    """
+    dao = _StubDAO(watchdog_settled=set(), any_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    await service.append_many(events=[_event("usage")])
+
+    assert _quarantined(dao) == []
+
+
+async def test_the_watchdogs_own_records_are_never_quarantined():
+    """Its `error` is not terminal, so without the exemption a redelivery would mark it."""
+    dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    await service.append_many(
+        events=[
+            _watchdog_event(
+                "error", attributes={"type": "error", "code": "execution_lost"}
+            ),
+            _watchdog_event("done"),
+        ]
+    )
+
+    assert _quarantined(dao) == []
+    # And they are not even looked up: a watchdog record can never be late for its own turn.
+    assert dao.lookups == []
+
+
+async def test_a_record_with_no_turn_id_is_never_quarantined():
+    """Nothing to attribute it to. Old records carry no turn key at all."""
+    dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    await service.append_many(events=[_event("message", turn_id=None)])
+
+    assert _quarantined(dao) == []
+
+
+async def test_another_turn_in_the_same_session_is_untouched():
+    """The user sent a new message after the failure; that turn is nobody's tail."""
+    dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    await service.append_many(
+        events=[_event("message", turn_id="turn-next"), _event("usage")]
+    )
+
+    assert [event.record_type for event in _quarantined(dao)] == ["usage"]
+
+
+# --------------------------------------------------------------------------- #
+# Batching, redelivery, and failure
+# --------------------------------------------------------------------------- #
+
+
+async def test_a_watchdog_ending_settles_its_turn_for_the_rest_of_its_own_batch():
+    """Ingest batches up to fifty messages; the tail can share one with the ending.
+
+    Without this the DB lookup would find nothing — the ending is not committed yet — and the
+    tail would be appended as ordinary history.
+    """
+    dao = _StubDAO(watchdog_settled=set())
+    service = RecordsService(records_dao=dao)
+
+    await service.append_many(
+        events=[
+            _watchdog_event(
+                "error", attributes={"type": "error", "code": "execution_lost"}
+            ),
+            _watchdog_event("done"),
+            _event("tool_result"),
+            _event("done", attributes={"type": "done", "stopReason": "cancelled"}),
+        ]
+    )
+
+    assert [event.record_type for event in _quarantined(dao)] == ["tool_result", "done"]
+
+
+async def test_redelivery_quarantines_the_same_records_again():
+    """The stream replays on a consumer-group failure; the outcome must not drift.
+
+    The upsert coalesces `quarantined_at`, so the row keeps the instant it was FIRST marked;
+    what this pins is that the guard's own verdict is the same on every delivery.
+    """
+    dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    tail = [_event("tool_call"), _event("usage")]
+    first = await service.append_many(events=tail)
+    second = await service.append_many(events=tail)
+
+    assert [row.record_id for row in first] == [row.record_id for row in second]
+    assert all(row.quarantined_at is not None for row in first + second)
+
+
+async def test_a_failed_lookup_appends_the_batch_rather_than_losing_it():
+    """Losing a record is worse than showing one that should have been hidden."""
+    dao = _StubDAO(raises=True)
+    service = RecordsService(records_dao=dao)
+
+    results = await service.append_many(events=[_event("tool_call"), _event("done")])
+
+    assert len(results) == 2
+    assert _quarantined(dao) == []
+
+
+async def test_an_empty_batch_asks_the_database_nothing():
+    dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    assert await service.append_many(events=[]) == []
+    assert dao.lookups == []
+    assert dao.appended == []
+
+
+async def test_each_project_in_a_batch_gets_its_own_lookup():
+    """`settled_turns` is project-scoped; a mixed batch must not ask across the boundary."""
+    other_project = UUID("00000000-0000-0000-0000-0000000000bb")
+    dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    await service.append_many(
+        events=[_event("usage"), _event("usage", project_id=other_project)]
+    )
+
+    assert sorted(str(lookup["project_id"]) for lookup in dao.lookups) == sorted(
+        [str(_PROJECT), str(other_project)]
+    )
+    # Only the project whose turn the watchdog settled is affected.
+    assert [event.project_id for event in _quarantined(dao)] == [_PROJECT]

--- a/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
+++ b/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
@@ -182,10 +182,16 @@ def _quarantined(dao: _StubDAO) -> List[SessionRecordEvent]:
 # --------------------------------------------------------------------------- #
 
 
-async def test_a_thawed_runners_tail_is_quarantined_not_appended_as_history():
+async def test_a_thawed_runners_tail_is_quarantined_with_durable_stop_off(
+    monkeypatch,
+):
     """The live defect, in one test: four records land after the watchdog's ending."""
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", False)
     dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
-    service = RecordsService(records_dao=dao)
+    service = RecordsService(
+        records_dao=dao,
+        executions_dao=_ExecutionSettlements(),
+    )
 
     tail = [
         _event("tool_call"),

--- a/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
+++ b/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
@@ -26,6 +26,7 @@ from oss.src.core.sessions.records.dtos import (
 )
 from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
 from oss.src.core.sessions.records.service import RecordsService
+from oss.src.utils.env import env
 
 
 _PROJECT = UUID("00000000-0000-0000-0000-0000000000aa")
@@ -145,6 +146,17 @@ async def test_a_thawed_runners_tail_is_quarantined_not_appended_as_history():
     assert len(results) == 4
     assert len(_quarantined(dao)) == 4
     assert all(row.quarantined_at is not None for row in results)
+
+
+async def test_reject_policy_drops_a_late_tail(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "late_output", "reject")
+    dao = _StubDAO(watchdog_settled={(_SESSION, _TURN)})
+    service = RecordsService(records_dao=dao)
+
+    results = await service.append_many(events=[_event("tool_result"), _event("usage")])
+
+    assert results == []
+    assert dao.appended == []
 
 
 async def test_the_guard_asks_only_about_watchdog_endings():

--- a/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
+++ b/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
@@ -136,14 +136,6 @@ class _ExecutionSettlements:
             raise RuntimeError("core database is unreachable")
         return {key: self.rows[key] for key in keys if key in self.rows}
 
-    async def close_records(self, *, project_id, keys, settled_by):
-        for key in keys:
-            row = self.rows.get(key)
-            if row is not None and row.settled_by == settled_by:
-                self.rows[key] = row.model_copy(
-                    update={"records_closed_at": datetime.now(timezone.utc)}
-                )
-
 
 def _event(record_type: str, **over) -> SessionRecordEvent:
     base = {

--- a/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
+++ b/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
@@ -101,9 +101,10 @@ class _StubDAO(RecordsDAOInterface):
 
 
 class _ExecutionSettlements:
-    def __init__(self, *, raises: bool = False):
+    def __init__(self, *, raises: bool = False, mark_raises: bool = False):
         self.rows: Dict[Tuple[str, str], SessionExecutionSettlement] = {}
         self.raises = raises
+        self.mark_raises = mark_raises
 
     async def settle(
         self,
@@ -135,6 +136,17 @@ class _ExecutionSettlements:
         if self.raises:
             raise RuntimeError("core database is unreachable")
         return {key: self.rows[key] for key in keys if key in self.rows}
+
+    async def mark_endings_written(self, *, project_id, keys, written_at=None):
+        if self.raises or self.mark_raises:
+            raise RuntimeError("core database is unreachable")
+        for key in keys:
+            if key in self.rows and self.rows[key].ending_written_at is None:
+                self.rows[key] = self.rows[key].model_copy(
+                    update={
+                        "ending_written_at": written_at or datetime.now(timezone.utc)
+                    }
+                )
 
 
 def _event(record_type: str, **over) -> SessionRecordEvent:
@@ -324,6 +336,45 @@ async def test_ingest_does_not_write_a_terminal_execution(monkeypatch):
     )
 
     assert executions.rows == {}
+
+
+async def test_ingest_marks_the_runners_terminal_record_written(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    executions = _ExecutionSettlements()
+    await executions.settle(
+        project_id=_PROJECT,
+        session_id=_SESSION,
+        execution_id=_TURN,
+        terminal_outcome="stopped",
+        settled_by="runner",
+    )
+    service = RecordsService(records_dao=_StubDAO(), executions_dao=executions)
+
+    await service.append_many(
+        events=[_event("done", attributes={"type": "done", "stopReason": "cancelled"})]
+    )
+
+    assert executions.rows[(_SESSION, _TURN)].ending_written_at is not None
+
+
+async def test_ending_marker_failure_does_not_fail_record_ingest(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    executions = _ExecutionSettlements(mark_raises=True)
+    await executions.settle(
+        project_id=_PROJECT,
+        session_id=_SESSION,
+        execution_id=_TURN,
+        terminal_outcome="stopped",
+        settled_by="runner",
+    )
+    dao = _StubDAO()
+    service = RecordsService(records_dao=dao, executions_dao=executions)
+
+    results = await service.append_many(events=[_event("done")])
+
+    assert len(results) == 1
+    assert [event.record_type for event in dao.appended] == ["done"]
+    assert executions.rows[(_SESSION, _TURN)].ending_written_at is None
 
 
 async def test_the_guard_asks_only_about_watchdog_endings():

--- a/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
+++ b/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
@@ -101,8 +101,9 @@ class _StubDAO(RecordsDAOInterface):
 
 
 class _ExecutionSettlements:
-    def __init__(self):
+    def __init__(self, *, raises: bool = False):
         self.rows: Dict[Tuple[str, str], SessionExecutionSettlement] = {}
+        self.raises = raises
 
     async def settle(
         self,
@@ -131,6 +132,8 @@ class _ExecutionSettlements:
         return SessionExecutionSettlementResult(settlement=row, won=True)
 
     async def query_settled(self, *, project_id, keys):
+        if self.raises:
+            raise RuntimeError("core database is unreachable")
         return {key: self.rows[key] for key in keys if key in self.rows}
 
     async def close_records(self, *, project_id, keys, settled_by):
@@ -271,7 +274,7 @@ async def test_runner_winner_quarantines_the_watchdogs_records(monkeypatch):
     assert [event.record_type for event in _quarantined(dao)] == ["error", "done"]
 
 
-async def test_output_after_the_runners_terminal_batch_is_quarantined(monkeypatch):
+async def test_output_after_the_runners_own_stop_is_ordinary_history(monkeypatch):
     monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
     executions = _ExecutionSettlements()
     dao = _StubDAO()
@@ -280,7 +283,55 @@ async def test_output_after_the_runners_terminal_batch_is_quarantined(monkeypatc
     await service.append_many(events=[_event("usage"), _event("done")])
     await service.append_many(events=[_event("tool_result")])
 
-    assert [event.record_type for event in _quarantined(dao)] == ["tool_result"]
+    assert _quarantined(dao) == []
+
+
+async def test_an_ordinary_completion_row_does_not_make_trailing_usage_late(
+    monkeypatch,
+):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    executions = _ExecutionSettlements()
+    await executions.settle(
+        project_id=_PROJECT,
+        session_id=_SESSION,
+        execution_id=_TURN,
+        terminal_outcome="completed",
+        settled_by="runner",
+    )
+    dao = _StubDAO()
+    service = RecordsService(records_dao=dao, executions_dao=executions)
+
+    await service.append_many(events=[_event("usage")])
+
+    assert _quarantined(dao) == []
+
+
+async def test_execution_lookup_failure_appends_the_batch_unguarded(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    dao = _StubDAO()
+    service = RecordsService(
+        records_dao=dao,
+        executions_dao=_ExecutionSettlements(raises=True),
+    )
+    events = [_event("usage"), _event("done")]
+
+    results = await service.append_many(events=events)
+
+    assert len(results) == 2
+    assert dao.appended == events
+    assert _quarantined(dao) == []
+
+
+async def test_ingest_does_not_write_a_terminal_execution(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    executions = _ExecutionSettlements()
+    service = RecordsService(records_dao=_StubDAO(), executions_dao=executions)
+
+    await service.append_many(
+        events=[_event("done", attributes={"type": "done", "stopReason": "cancelled"})]
+    )
+
+    assert executions.rows == {}
 
 
 async def test_the_guard_asks_only_about_watchdog_endings():

--- a/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
+++ b/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
@@ -15,6 +15,7 @@ DAO-level half — that a quarantined row is invisible to `get_records` and does
 `settled_turns` — lives in `test_late_record_quarantine_dao.py` against a real database.
 """
 
+from datetime import datetime, timezone
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 from uuid import UUID, uuid4
 
@@ -26,6 +27,10 @@ from oss.src.core.sessions.records.dtos import (
 )
 from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
 from oss.src.core.sessions.records.service import RecordsService
+from oss.src.core.sessions.executions.dtos import (
+    SessionExecutionSettlement,
+    SessionExecutionSettlementResult,
+)
 from oss.src.utils.env import env
 
 
@@ -95,6 +100,48 @@ class _StubDAO(RecordsDAOInterface):
         ]
 
 
+class _ExecutionSettlements:
+    def __init__(self):
+        self.rows: Dict[Tuple[str, str], SessionExecutionSettlement] = {}
+
+    async def settle(
+        self,
+        *,
+        project_id,
+        session_id,
+        execution_id,
+        terminal_outcome,
+        settled_by,
+        settled_at=None,
+    ):
+        key = (session_id, execution_id)
+        if key in self.rows:
+            return SessionExecutionSettlementResult(
+                settlement=self.rows[key], won=False
+            )
+        row = SessionExecutionSettlement(
+            project_id=project_id,
+            session_id=session_id,
+            execution_id=execution_id,
+            terminal_outcome=terminal_outcome,
+            settled_by=settled_by,
+            settled_at=settled_at or datetime.now(timezone.utc),
+        )
+        self.rows[key] = row
+        return SessionExecutionSettlementResult(settlement=row, won=True)
+
+    async def query_settled(self, *, project_id, keys):
+        return {key: self.rows[key] for key in keys if key in self.rows}
+
+    async def close_records(self, *, project_id, keys, settled_by):
+        for key in keys:
+            row = self.rows.get(key)
+            if row is not None and row.settled_by == settled_by:
+                self.rows[key] = row.model_copy(
+                    update={"records_closed_at": datetime.now(timezone.utc)}
+                )
+
+
 def _event(record_type: str, **over) -> SessionRecordEvent:
     base = {
         "project_id": _PROJECT,
@@ -157,6 +204,83 @@ async def test_reject_policy_drops_a_late_tail(monkeypatch):
 
     assert results == []
     assert dao.appended == []
+
+
+async def test_watchdog_winner_quarantines_the_runners_records(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    executions = _ExecutionSettlements()
+    winner = await executions.settle(
+        project_id=_PROJECT,
+        session_id=_SESSION,
+        execution_id=_TURN,
+        terminal_outcome="lost",
+        settled_by="watchdog",
+    )
+    assert winner.won is True
+    dao = _StubDAO()
+    service = RecordsService(records_dao=dao, executions_dao=executions)
+
+    await service.append_many(
+        events=[
+            _event("usage"),
+            _event("done", attributes={"type": "done", "stopReason": "cancelled"}),
+        ]
+    )
+
+    assert [event.record_type for event in _quarantined(dao)] == ["usage", "done"]
+
+
+async def test_watchdog_winner_rejects_the_runners_records_when_configured(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    monkeypatch.setattr(env.agenta.sessions, "late_output", "reject")
+    executions = _ExecutionSettlements()
+    await executions.settle(
+        project_id=_PROJECT,
+        session_id=_SESSION,
+        execution_id=_TURN,
+        terminal_outcome="lost",
+        settled_by="watchdog",
+    )
+    dao = _StubDAO()
+    service = RecordsService(records_dao=dao, executions_dao=executions)
+
+    results = await service.append_many(events=[_event("usage"), _event("done")])
+
+    assert results == []
+    assert dao.appended == []
+
+
+async def test_runner_winner_quarantines_the_watchdogs_records(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    executions = _ExecutionSettlements()
+    winner = await executions.settle(
+        project_id=_PROJECT,
+        session_id=_SESSION,
+        execution_id=_TURN,
+        terminal_outcome="stopped",
+        settled_by="runner",
+    )
+    assert winner.won is True
+    dao = _StubDAO()
+    service = RecordsService(records_dao=dao, executions_dao=executions)
+
+    await service.append_many(
+        events=[_watchdog_event("error"), _watchdog_event("done")]
+    )
+
+    assert [event.record_type for event in _quarantined(dao)] == ["error", "done"]
+
+
+async def test_output_after_the_runners_terminal_batch_is_quarantined(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    executions = _ExecutionSettlements()
+    dao = _StubDAO()
+    service = RecordsService(records_dao=dao, executions_dao=executions)
+
+    await service.append_many(events=[_event("usage"), _event("done")])
+    await service.append_many(events=[_event("tool_result")])
+
+    assert [event.record_type for event in _quarantined(dao)] == ["tool_result"]
 
 
 async def test_the_guard_asks_only_about_watchdog_endings():

--- a/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine_dao.py
@@ -1,0 +1,245 @@
+"""The database half of the late-record guard, against a real Postgres.
+
+The service decides WHICH records are late (`test_late_record_quarantine.py`, no database
+needed). These tests pin what the mark then does, and none of it is visible from a stub:
+
+  - a quarantined row is invisible to `get_records`, which is the read every transcript
+    reconstruction goes through, so one execution renders one ending;
+  - a quarantined row does not answer `settled_turns`, so a late `done` can never stand in
+    for the real ending and suppress the watchdog's next pass;
+  - `settled_by` narrows `settled_turns` to one writer;
+  - the upsert coalesces `quarantined_at`, so a redelivery keeps the first mark and can never
+    resurrect a row into the transcript.
+
+Requires the tracing_oss chain through oss000000005_add_records_quarantined_at, with
+POSTGRES_URI_TRACING pointed at that database.
+"""
+
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from oss.src.core.sessions.records.dtos import (
+    RECORD_SETTLED_BY_ATTRIBUTE,
+    SETTLED_BY_WATCHDOG,
+    SessionRecordEvent,
+)
+from oss.src.dbs.postgres.sessions.records.dao import RecordsDAO
+import oss.src.dbs.postgres.shared.engine as engine_module
+from oss.src.dbs.postgres.shared.engine import get_analytics_engine
+
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(autouse=True)
+async def _fresh_engine_per_test():
+    """Each pytest-asyncio test gets its own event loop; the module-level engine singleton
+    binds its asyncpg pool to the first loop that touches it."""
+    engine_module._analytics_engine = None
+    yield
+    if engine_module._analytics_engine is not None:
+        await engine_module._analytics_engine.close()
+        engine_module._analytics_engine = None
+
+
+def _ids():
+    return uuid.uuid4(), f"late-record-test-{uuid.uuid4().hex[:8]}"
+
+
+def _event(project_id, session_id, turn_id, record_type, **over):
+    base = dict(
+        project_id=project_id,
+        session_id=session_id,
+        record_id=uuid.uuid4(),
+        record_index=0,
+        record_type=record_type,
+        record_source="agent",
+        attributes={"type": record_type},
+        turn_id=turn_id,
+    )
+    base.update(over)
+    return SessionRecordEvent(**base)
+
+
+def _watchdog_done(project_id, session_id, turn_id):
+    return _event(
+        project_id,
+        session_id,
+        turn_id,
+        "done",
+        record_index=1,
+        attributes={"type": "done", RECORD_SETTLED_BY_ATTRIBUTE: SETTLED_BY_WATCHDOG},
+    )
+
+
+async def test_a_quarantined_record_is_absent_from_the_transcript():
+    project_id, session_id = _ids()
+    turn_id = f"turn-{uuid.uuid4().hex[:8]}"
+    dao = RecordsDAO(engine=get_analytics_engine())
+
+    await dao.append_many(
+        events=[
+            _event(project_id, session_id, turn_id, "message", record_index=0),
+            _watchdog_done(project_id, session_id, turn_id),
+            _event(
+                project_id,
+                session_id,
+                turn_id,
+                "tool_call",
+                record_index=2,
+                quarantined_at=datetime.now(timezone.utc),
+            ),
+            _event(
+                project_id,
+                session_id,
+                turn_id,
+                "done",
+                record_index=3,
+                quarantined_at=datetime.now(timezone.utc),
+            ),
+        ]
+    )
+
+    rows = await dao.get_records(project_id=project_id, session_id=session_id)
+
+    assert [row.record_type for row in rows] == ["message", "done"]
+    # Exactly one ending, and it is the watchdog's.
+    endings = [row for row in rows if row.record_type == "done"]
+    assert len(endings) == 1
+    assert endings[0].attributes[RECORD_SETTLED_BY_ATTRIBUTE] == SETTLED_BY_WATCHDOG
+
+
+async def test_a_quarantined_terminal_record_does_not_settle_its_turn():
+    project_id, session_id = _ids()
+    turn_id = f"turn-{uuid.uuid4().hex[:8]}"
+    dao = RecordsDAO(engine=get_analytics_engine())
+
+    await dao.append_many(
+        events=[
+            _event(
+                project_id,
+                session_id,
+                turn_id,
+                "done",
+                quarantined_at=datetime.now(timezone.utc),
+            )
+        ]
+    )
+
+    settled = await dao.settled_turns(
+        project_id=project_id, keys=[(session_id, turn_id)]
+    )
+
+    assert settled == set()
+
+
+async def test_settled_by_narrows_the_answer_to_one_writer():
+    project_id, session_id = _ids()
+    runner_turn = f"turn-{uuid.uuid4().hex[:8]}"
+    watchdog_turn = f"turn-{uuid.uuid4().hex[:8]}"
+    dao = RecordsDAO(engine=get_analytics_engine())
+
+    await dao.append_many(
+        events=[
+            _event(project_id, session_id, runner_turn, "done"),
+            _watchdog_done(project_id, session_id, watchdog_turn),
+        ]
+    )
+
+    keys = [(session_id, runner_turn), (session_id, watchdog_turn)]
+
+    # The watchdog's own idempotency question: has this turn ANY ending?
+    assert await dao.settled_turns(project_id=project_id, keys=keys) == set(keys)
+    # The ingest guard's question: did the PLATFORM end this turn?
+    assert await dao.settled_turns(
+        project_id=project_id, keys=keys, settled_by=SETTLED_BY_WATCHDOG
+    ) == {(session_id, watchdog_turn)}
+
+
+async def test_a_redelivery_keeps_the_first_quarantine_instant():
+    project_id, session_id = _ids()
+    turn_id = f"turn-{uuid.uuid4().hex[:8]}"
+    dao = RecordsDAO(engine=get_analytics_engine())
+
+    first_mark = datetime(2026, 9, 3, 12, 0, 0, tzinfo=timezone.utc)
+    event = _event(project_id, session_id, turn_id, "usage", quarantined_at=first_mark)
+
+    await dao.append_many(events=[event])
+    later = event.model_copy(
+        update={"quarantined_at": datetime(2026, 9, 3, 13, 0, 0, tzinfo=timezone.utc)}
+    )
+    rows = await dao.append_many(events=[later])
+
+    assert rows[0].quarantined_at == first_mark
+
+
+async def test_an_unmarked_redelivery_cannot_resurrect_a_quarantined_record():
+    """Quarantine is one-way. A delivery that somehow arrives unguarded must not undo it."""
+    project_id, session_id = _ids()
+    turn_id = f"turn-{uuid.uuid4().hex[:8]}"
+    dao = RecordsDAO(engine=get_analytics_engine())
+
+    mark = datetime.now(timezone.utc)
+    event = _event(project_id, session_id, turn_id, "tool_call", quarantined_at=mark)
+    await dao.append_many(events=[event])
+
+    await dao.append_many(events=[event.model_copy(update={"quarantined_at": None})])
+
+    rows = await dao.get_records(project_id=project_id, session_id=session_id)
+    assert rows == []
+
+
+async def test_an_ordinary_record_is_still_written_and_read_unmarked():
+    project_id, session_id = _ids()
+    turn_id = f"turn-{uuid.uuid4().hex[:8]}"
+    dao = RecordsDAO(engine=get_analytics_engine())
+
+    await dao.append_many(
+        events=[
+            _event(project_id, session_id, turn_id, "message", record_index=0),
+            _event(project_id, session_id, turn_id, "done", record_index=1),
+        ]
+    )
+
+    rows = await dao.get_records(project_id=project_id, session_id=session_id)
+
+    assert [row.record_type for row in rows] == ["message", "done"]
+    assert all(row.quarantined_at is None for row in rows)
+
+
+async def test_a_quarantined_message_never_becomes_the_session_preview():
+    project_id, session_id = _ids()
+    turn_id = f"turn-{uuid.uuid4().hex[:8]}"
+    dao = RecordsDAO(engine=get_analytics_engine())
+
+    now = datetime.now(timezone.utc)
+    await dao.append_many(
+        events=[
+            _event(
+                project_id,
+                session_id,
+                turn_id,
+                "message",
+                attributes={"type": "message", "text": "the real last message"},
+                timestamp=now,
+            ),
+            _event(
+                project_id,
+                session_id,
+                turn_id,
+                "message",
+                attributes={"type": "message", "text": "written after the ending"},
+                # Newer than the real one: without the filter this would win the preview.
+                timestamp=now + timedelta(seconds=10),
+                quarantined_at=now,
+            ),
+        ]
+    )
+
+    previews = await dao.latest_message_per_session(
+        project_id=project_id, session_ids=[session_id]
+    )
+
+    assert previews[session_id].text == "the real last message"

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
@@ -9,6 +9,8 @@ fake-engine pattern in test_streams_dao_conflict.py.
 """
 
 from contextlib import asynccontextmanager
+from typing import Optional
+
 from datetime import datetime, timezone, timedelta
 
 import pytest
@@ -22,10 +24,17 @@ _PROJECT_ID = "proj-orphan-1"
 
 
 class _FakeRow:
-    def __init__(self, *, session_id: str, updated_at: datetime):
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        updated_at: datetime,
+        turn_id: Optional[str] = None,
+    ):
         self.session_id = session_id
         self.project_id = _PROJECT_ID
         self.id = "stream-1"
+        self.turn_id = turn_id
         self.deleted_at = None
         self.flags = {"is_alive": True, "is_running": True, "is_attached": False}
         self.updated_at = updated_at

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
@@ -178,11 +178,14 @@ async def test_orphan_sweep_clears_alive_lock_and_unblocks_send(anyio_backend):
     await lock_engine.set(
         f"running:{_PROJECT_ID}:session:{_SESSION_ID}", b"turn-1", ex=3600
     )
+    await lock_engine.set(
+        f"owner:{_PROJECT_ID}:session:{_SESSION_ID}", b"replica-legacy", ex=120
+    )
 
     stale_row = _FakeRow(
         session_id=_SESSION_ID,
         updated_at=datetime.now(timezone.utc) - timedelta(seconds=600),
-        turn_id="turn-1",
+        turn_id=None,
     )
     pg_engine = _FakeTransactionsEngine([stale_row])
 
@@ -206,6 +209,7 @@ async def test_orphan_sweep_clears_alive_lock_and_unblocks_send(anyio_backend):
         lock_engine, project_id=_PROJECT_ID, session_id=_SESSION_ID
     )
     assert liveness_after == {"alive": False, "running": False, "attached": False}
+    assert await lock_engine.get(f"owner:{_PROJECT_ID}:session:{_SESSION_ID}") is None
 
     # SEND gate logic (service.py:99-101): would raise if alive were still true.
     def _send_gate(liveness):
@@ -233,7 +237,7 @@ async def test_orphan_sweep_tombstones_the_turn_it_swept(anyio_backend):
     stale_row = _FakeRow(
         session_id=_SESSION_ID,
         updated_at=datetime.now(timezone.utc) - timedelta(seconds=600),
-        turn_id="turn-1",
+        turn_id=None,
     )
 
     await run_orphan_sweep(_FakeTransactionsEngine([stale_row]), lock_engine)

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
@@ -128,6 +128,36 @@ class _FakeRedis:
     async def expire(self, key, ttl):
         return True
 
+    async def eval(self, script, numkeys, *keys_and_args):
+        def decode(value):
+            return value.decode() if isinstance(value, bytes) else str(value)
+
+        keys = [decode(value) for value in keys_and_args[:numkeys]]
+        argv = [decode(value) for value in keys_and_args[numkeys:]]
+        assert "AGENTA_WATCHDOG_RELEASE_TURN" in script
+        alive, running, owner, superseded = keys
+        expected_turn, expected_owner, _ttl = argv
+        alive_value = decode(self._store[alive]) if alive in self._store else ""
+        running_value = decode(self._store[running]) if running in self._store else ""
+        owner_value = decode(self._store[owner]) if owner in self._store else ""
+        released_alive = int(bool(expected_turn) and alive_value == expected_turn)
+        released_running = int(bool(expected_turn) and running_value == expected_turn)
+        if released_alive:
+            self._store.pop(alive, None)
+        if released_running:
+            self._store.pop(running, None)
+        foreign_turn = (alive_value and alive_value != expected_turn) or (
+            running_value and running_value != expected_turn
+        )
+        released_owner = int(
+            bool(expected_owner) and owner_value == expected_owner and not foreign_turn
+        )
+        if released_owner:
+            self._store.pop(owner, None)
+        if expected_turn:
+            self._store[superseded] = b"1"
+        return [released_alive, released_running, released_owner]
+
 
 @pytest.fixture
 def anyio_backend():
@@ -152,6 +182,7 @@ async def test_orphan_sweep_clears_alive_lock_and_unblocks_send(anyio_backend):
     stale_row = _FakeRow(
         session_id=_SESSION_ID,
         updated_at=datetime.now(timezone.utc) - timedelta(seconds=600),
+        turn_id="turn-1",
     )
     pg_engine = _FakeTransactionsEngine([stale_row])
 
@@ -202,6 +233,7 @@ async def test_orphan_sweep_tombstones_the_turn_it_swept(anyio_backend):
     stale_row = _FakeRow(
         session_id=_SESSION_ID,
         updated_at=datetime.now(timezone.utc) - timedelta(seconds=600),
+        turn_id="turn-1",
     )
 
     await run_orphan_sweep(_FakeTransactionsEngine([stale_row]), lock_engine)

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
@@ -49,8 +49,9 @@ class _FakeScalars:
 
 
 class _FakeResult:
-    def __init__(self, rows):
+    def __init__(self, rows, *, rowcount=0):
         self._rows = rows
+        self.rowcount = rowcount
 
     def scalars(self):
         return _FakeScalars(self._rows)
@@ -80,9 +81,12 @@ class _FakePgSession:
                 elif isinstance(value, str):
                     ids.add(value)
             if flags_val is not None:
+                matched = 0
                 for row in self._rows:
                     if row.id in ids:
                         row.flags = dict(flags_val)
+                        matched += 1
+                return _FakeResult([], rowcount=matched)
             return _FakeResult([])
         return _FakeResult(self._rows)
 

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
@@ -65,25 +65,23 @@ class _FakePgSession:
         self._seen.append(stmt)
         text = str(stmt)
         if text.startswith("UPDATE") and "session_streams" in text:
-            # The collapse is a Core UPDATE keyed by row id; apply it to the in-memory rows.
+            # Both session_streams writes are Core UPDATEs keyed by row id, never ORM
+            # attribute writes (finding 7). The collapse binds `id IN (...)`, a list; the
+            # lost-turn clear binds `id = ...`, a scalar. Apply either to the in-memory rows.
             params = stmt.compile().params
             flags_val = next(
                 (v for v in params.values() if isinstance(v, dict) and "is_alive" in v),
                 None,
             )
-            id_list = next(
-                (
-                    list(v)
-                    for v in params.values()
-                    if isinstance(v, (list, set, tuple))
-                    and v
-                    and all(not isinstance(x, tuple) for x in v)
-                ),
-                None,
-            )
-            if flags_val is not None and id_list is not None:
+            ids = set()
+            for value in params.values():
+                if isinstance(value, (list, set, tuple)):
+                    ids.update(x for x in value if isinstance(x, str))
+                elif isinstance(value, str):
+                    ids.add(value)
+            if flags_val is not None:
                 for row in self._rows:
-                    if row.id in id_list:
+                    if row.id in ids:
                         row.flags = dict(flags_val)
             return _FakeResult([])
         return _FakeResult(self._rows)

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_clears_redis.py
@@ -63,6 +63,29 @@ class _FakePgSession:
 
     async def execute(self, stmt):
         self._seen.append(stmt)
+        text = str(stmt)
+        if text.startswith("UPDATE") and "session_streams" in text:
+            # The collapse is a Core UPDATE keyed by row id; apply it to the in-memory rows.
+            params = stmt.compile().params
+            flags_val = next(
+                (v for v in params.values() if isinstance(v, dict) and "is_alive" in v),
+                None,
+            )
+            id_list = next(
+                (
+                    list(v)
+                    for v in params.values()
+                    if isinstance(v, (list, set, tuple))
+                    and v
+                    and all(not isinstance(x, tuple) for x in v)
+                ),
+                None,
+            )
+            if flags_val is not None and id_list is not None:
+                for row in self._rows:
+                    if row.id in id_list:
+                        row.flags = dict(flags_val)
+            return _FakeResult([])
         return _FakeResult(self._rows)
 
     async def commit(self):

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -80,6 +80,10 @@ def _evaluate(node, row) -> Optional[bool]:
         left, right = _value(node.left, row), _value(node.right, row)
         if node.operator is operators.is_:
             return left is right
+        if node.operator is operators.is_not:
+            # `turn_id IS NOT NULL`, from the ending-only selection. Postgres `IS NOT` is a
+            # total predicate: it never returns NULL, so neither does this.
+            return left is not right
         if node.operator is operators.lt:
             return None if left is None or right is None else left < right
         if getattr(node.operator, "opstring", None) == "@>":

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -156,6 +156,29 @@ class _FakePgSession:
         self._rows = rows
 
     async def execute(self, stmt):
+        text = str(stmt)
+        if text.startswith("UPDATE") and "session_streams" in text:
+            # The collapse is a Core UPDATE keyed by row id; apply it to the in-memory rows.
+            params = stmt.compile().params
+            flags_val = next(
+                (v for v in params.values() if isinstance(v, dict) and "is_alive" in v),
+                None,
+            )
+            id_list = next(
+                (
+                    list(v)
+                    for v in params.values()
+                    if isinstance(v, (list, set, tuple))
+                    and v
+                    and all(not isinstance(x, tuple) for x in v)
+                ),
+                None,
+            )
+            if flags_val is not None and id_list is not None:
+                for row in self._rows:
+                    if row.id in id_list:
+                        row.flags = dict(flags_val)
+            return _FakeResult([])
         matched = [
             row for row in self._rows if _evaluate(stmt.whereclause, row) is True
         ]

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -204,6 +204,32 @@ def anyio_backend():
     return "asyncio"
 
 
+class _OrderedCommandsService:
+    def __init__(self) -> None:
+        self.calls = []
+
+    async def settle_abandoned_commands(self, *, now):
+        self.calls.append("settle")
+        return 0
+
+    async def repair_terminal_redis(self):
+        self.calls.append("repair")
+        return 0
+
+
+@pytest.mark.anyio
+async def test_redis_repair_runs_after_the_sweeps_main_work(anyio_backend):
+    commands = _OrderedCommandsService()
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([]),
+        _FakeRedis(),
+        commands_service=commands,
+    )
+
+    assert commands.calls == ["settle", "repair"]
+
+
 @pytest.mark.anyio
 async def test_running_row_is_swept_at_the_short_threshold(anyio_backend):
     row = _FakeRow(

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -158,25 +158,23 @@ class _FakePgSession:
     async def execute(self, stmt):
         text = str(stmt)
         if text.startswith("UPDATE") and "session_streams" in text:
-            # The collapse is a Core UPDATE keyed by row id; apply it to the in-memory rows.
+            # Both session_streams writes are Core UPDATEs keyed by row id, never ORM
+            # attribute writes (finding 7). The collapse binds `id IN (...)`, a list; the
+            # lost-turn clear binds `id = ...`, a scalar. Apply either to the in-memory rows.
             params = stmt.compile().params
             flags_val = next(
                 (v for v in params.values() if isinstance(v, dict) and "is_alive" in v),
                 None,
             )
-            id_list = next(
-                (
-                    list(v)
-                    for v in params.values()
-                    if isinstance(v, (list, set, tuple))
-                    and v
-                    and all(not isinstance(x, tuple) for x in v)
-                ),
-                None,
-            )
-            if flags_val is not None and id_list is not None:
+            ids = set()
+            for value in params.values():
+                if isinstance(value, (list, set, tuple)):
+                    ids.update(x for x in value if isinstance(x, str))
+                elif isinstance(value, str):
+                    ids.add(value)
+            if flags_val is not None:
                 for row in self._rows:
-                    if row.id in id_list:
+                    if row.id in ids:
                         row.flags = dict(flags_val)
             return _FakeResult([])
         matched = [

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -214,6 +214,36 @@ class _FakeRedis:
     async def expire(self, key, ttl):
         return True
 
+    async def eval(self, script, numkeys, *keys_and_args):
+        def decode(value):
+            return value.decode() if isinstance(value, bytes) else str(value)
+
+        keys = [decode(value) for value in keys_and_args[:numkeys]]
+        argv = [decode(value) for value in keys_and_args[numkeys:]]
+        assert "AGENTA_WATCHDOG_RELEASE_TURN" in script
+        alive, running, owner, superseded = keys
+        expected_turn, expected_owner, _ttl = argv
+        alive_value = decode(self._store[alive]) if alive in self._store else ""
+        running_value = decode(self._store[running]) if running in self._store else ""
+        owner_value = decode(self._store[owner]) if owner in self._store else ""
+        released_alive = int(bool(expected_turn) and alive_value == expected_turn)
+        released_running = int(bool(expected_turn) and running_value == expected_turn)
+        if released_alive:
+            self._store.pop(alive, None)
+        if released_running:
+            self._store.pop(running, None)
+        foreign_turn = (alive_value and alive_value != expected_turn) or (
+            running_value and running_value != expected_turn
+        )
+        released_owner = int(
+            bool(expected_owner) and owner_value == expected_owner and not foreign_turn
+        )
+        if released_owner:
+            self._store.pop(owner, None)
+        if expected_turn:
+            self._store[superseded] = b"1"
+        return [released_alive, released_running, released_owner]
+
 
 def _swept(row: _FakeRow) -> bool:
     return row.flags == {"is_alive": False, "is_running": False, "is_attached": False}
@@ -361,6 +391,7 @@ async def test_sweep_clears_redis_for_the_long_threshold_branch(anyio_backend):
         session_id=session_id,
         flags={"is_alive": True, "is_running": False, "is_attached": False},
         age_seconds=IDLE_THRESHOLD_SECONDS + 60,
+        turn_id="turn-1",
     )
 
     await run_orphan_sweep(_FakeTransactionsEngine([row]), redis)

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -30,6 +30,7 @@ from sqlalchemy.sql.elements import (
     UnaryExpression,
 )
 from sqlalchemy.sql.functions import Function
+from sqlalchemy.sql.dml import Update
 
 from oss.src.tasks.asyncio.sessions.orphan_sweep import (
     IDLE_THRESHOLD_SECONDS,
@@ -86,6 +87,10 @@ def _evaluate(node, row) -> Optional[bool]:
             return left is not right
         if node.operator is operators.lt:
             return None if left is None or right is None else left < right
+        if node.operator is operators.eq:
+            return None if left is None or right is None else left == right
+        if node.operator is operators.in_op:
+            return None if left is None else left in right
         if getattr(node.operator, "opstring", None) == "@>":
             return _contains(left, right)
     raise AssertionError(
@@ -144,39 +149,32 @@ class _FakeScalars:
 
 
 class _FakeResult:
-    def __init__(self, rows):
+    def __init__(self, rows, *, rowcount=0):
         self._rows = rows
+        self.rowcount = rowcount
 
     def scalars(self):
         return _FakeScalars(self._rows)
 
 
 class _FakePgSession:
-    def __init__(self, rows):
+    def __init__(self, rows, before_update=None):
         self._rows = rows
+        self._before_update = before_update
 
     async def execute(self, stmt):
-        text = str(stmt)
-        if text.startswith("UPDATE") and "session_streams" in text:
-            # Both session_streams writes are Core UPDATEs keyed by row id, never ORM
-            # attribute writes (finding 7). The collapse binds `id IN (...)`, a list; the
-            # lost-turn clear binds `id = ...`, a scalar. Apply either to the in-memory rows.
-            params = stmt.compile().params
-            flags_val = next(
-                (v for v in params.values() if isinstance(v, dict) and "is_alive" in v),
-                None,
-            )
-            ids = set()
-            for value in params.values():
-                if isinstance(value, (list, set, tuple)):
-                    ids.update(x for x in value if isinstance(x, str))
-                elif isinstance(value, str):
-                    ids.add(value)
-            if flags_val is not None:
-                for row in self._rows:
-                    if row.id in ids:
-                        row.flags = dict(flags_val)
-            return _FakeResult([])
+        if isinstance(stmt, Update):
+            if self._before_update is not None:
+                self._before_update()
+                self._before_update = None
+            matched = [
+                row for row in self._rows if _evaluate(stmt.whereclause, row) is True
+            ]
+            for row in matched:
+                for column, value in stmt._values.items():
+                    key = column if isinstance(column, str) else column.key
+                    setattr(row, key, _value(value, row))
+            return _FakeResult([], rowcount=len(matched))
         matched = [
             row for row in self._rows if _evaluate(stmt.whereclause, row) is True
         ]
@@ -187,12 +185,13 @@ class _FakePgSession:
 
 
 class _FakeTransactionsEngine:
-    def __init__(self, rows):
+    def __init__(self, rows, before_update=None):
         self._rows = rows
+        self._before_update = before_update
 
     @asynccontextmanager
     async def session(self):
-        yield _FakePgSession(self._rows)
+        yield _FakePgSession(self._rows, self._before_update)
 
 
 class _FakeRedis:
@@ -368,3 +367,54 @@ async def test_sweep_clears_redis_for_the_long_threshold_branch(anyio_backend):
 
     assert await redis.get(f"alive:{_PROJECT_ID}:session:{session_id}") is None
     assert await redis.get(f"owner:{_PROJECT_ID}:session:{session_id}") is None
+
+
+@pytest.mark.anyio
+async def test_turn_advance_during_sweep_prevents_collapse_and_redis_cleanup(
+    anyio_backend,
+):
+    session_id = "sess-advanced-during-sweep"
+    row = _FakeRow(
+        session_id=session_id,
+        flags={"is_alive": True, "is_running": True, "is_attached": False},
+        age_seconds=360,
+        turn_id="turn-old",
+    )
+    redis = _FakeRedis()
+    await redis.set(f"alive:{_PROJECT_ID}:session:{session_id}", b"turn-new")
+    await redis.set(f"running:{_PROJECT_ID}:session:{session_id}", b"turn-new")
+    await redis.set(f"owner:{_PROJECT_ID}:session:{session_id}", b"runner-new")
+
+    def advance_row():
+        row.turn_id = "turn-new"
+        row.updated_at = datetime.now(timezone.utc)
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row], before_update=advance_row), redis
+    )
+
+    assert row.flags["is_alive"] is True
+    assert row.flags["is_running"] is True
+    assert await redis.get(f"alive:{_PROJECT_ID}:session:{session_id}") == b"turn-new"
+    assert await redis.get(f"running:{_PROJECT_ID}:session:{session_id}") == b"turn-new"
+    assert await redis.get(f"owner:{_PROJECT_ID}:session:{session_id}") == b"runner-new"
+
+
+@pytest.mark.anyio
+async def test_heartbeat_during_sweep_prevents_collapse(anyio_backend):
+    row = _FakeRow(
+        session_id="sess-heartbeat-during-sweep",
+        flags={"is_alive": True, "is_running": True, "is_attached": False},
+        age_seconds=360,
+        turn_id="turn-current",
+    )
+
+    def heartbeat():
+        row.updated_at = datetime.now(timezone.utc)
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([row], before_update=heartbeat), _FakeRedis()
+    )
+
+    assert row.flags["is_alive"] is True
+    assert row.flags["is_running"] is True

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -249,12 +249,16 @@ async def test_idle_row_is_swept_at_the_long_threshold(anyio_backend):
 
 
 @pytest.mark.anyio
-async def test_thresholds_are_two_and_thirty_minutes(anyio_backend):
-    """The running threshold moved from 5 minutes to 2 when the watchdog started writing a
-    terminal record. Five minutes was safe for a sweep that only collapsed flags; a user
-    watching a dead turn should not wait that long for an ending. 120s is one 30s heartbeat
-    interval plus the 90s default grace, which is three missed beats."""
-    assert (ORPHAN_THRESHOLD_SECONDS, IDLE_THRESHOLD_SECONDS) == (120, 1800)
+async def test_the_running_threshold_is_three_missed_heartbeats(anyio_backend):
+    """90 seconds of heartbeat age, not lease expiry.
+
+    The Redis alive/running keys carry a ONE HOUR TTL, so a rule phrased as "shortly after the
+    lease expires" would leave a dead turn running for an hour. The runner beats every 30
+    seconds and mirrors the beat onto `updated_at`, so three missed beats is the signal. The
+    old value was 300s, which was defensible while the sweep only collapsed flags and nobody
+    ever saw the result; it is too long now that the sweep writes a real ending.
+    """
+    assert (ORPHAN_THRESHOLD_SECONDS, IDLE_THRESHOLD_SECONDS) == (90, 1800)
 
 
 @pytest.mark.anyio

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -113,10 +113,18 @@ def _value(node, row):
 
 
 class _FakeRow:
-    def __init__(self, *, session_id: str, flags: Optional[dict], age_seconds: int):
+    def __init__(
+        self,
+        *,
+        session_id: str,
+        flags: Optional[dict],
+        age_seconds: int,
+        turn_id: Optional[str] = None,
+    ):
         self.session_id = session_id
         self.project_id = _PROJECT_ID
         self.id = session_id
+        self.turn_id = turn_id
         self.deleted_at = None
         self.flags = flags
         self.created_at = datetime.now(timezone.utc) - timedelta(days=1)
@@ -241,8 +249,12 @@ async def test_idle_row_is_swept_at_the_long_threshold(anyio_backend):
 
 
 @pytest.mark.anyio
-async def test_thresholds_are_five_and_thirty_minutes(anyio_backend):
-    assert (ORPHAN_THRESHOLD_SECONDS, IDLE_THRESHOLD_SECONDS) == (300, 1800)
+async def test_thresholds_are_two_and_thirty_minutes(anyio_backend):
+    """The running threshold moved from 5 minutes to 2 when the watchdog started writing a
+    terminal record. Five minutes was safe for a sweep that only collapsed flags; a user
+    watching a dead turn should not wait that long for an ending. 120s is one 30s heartbeat
+    interval plus the 90s default grace, which is three missed beats."""
+    assert (ORPHAN_THRESHOLD_SECONDS, IDLE_THRESHOLD_SECONDS) == (120, 1800)
 
 
 @pytest.mark.anyio

--- a/api/oss/tests/pytest/unit/sessions/test_owner_claim.py
+++ b/api/oss/tests/pytest/unit/sessions/test_owner_claim.py
@@ -78,12 +78,16 @@ class _FakeEvalRedis:
         )
 
         if script == CLAIM_OWNER_LUA:
-            replica_id, ex = argv
+            owner_value, ex = argv
             current = self._values.get(key)
-            replica_id_bytes = self._val(replica_id)
-            if current is None or current == replica_id_bytes:
-                await self.set(key, replica_id_bytes, ex=int(ex))
-                return replica_id_bytes
+            owner_value_bytes = self._val(owner_value)
+            from oss.src.dbs.redis.sessions.contract import owner_replica_id
+
+            if current is None or owner_replica_id(
+                current.decode()
+            ) == owner_replica_id(owner_value_bytes.decode()):
+                await self.set(key, owner_value_bytes, ex=int(ex))
+                return owner_value_bytes
             return current
         if script == RELEASE_IF_OWNER_LUA:
             (owner,) = argv
@@ -163,6 +167,37 @@ async def test_claim_owner_same_replica_refreshes_without_stealing(fake_redis):
         "refresh must reset the TTL back to OWNER_TTL_SECONDS, not leave it decayed"
     )
     assert ttl <= OWNER_TTL_SECONDS
+
+
+@pytest.mark.asyncio
+async def test_claim_owner_same_replica_refreshes_to_the_new_turn_generation(
+    fake_redis,
+):
+    from oss.src.dbs.redis.sessions.contract import make_owner_value, owner_key
+    from oss.src.dbs.redis.sessions.locks import claim_owner
+
+    engine, client = fake_redis
+    session_id = _session_id()
+
+    await claim_owner(
+        engine,
+        project_id=_PROJECT_ID,
+        session_id=session_id,
+        replica_id="replica-a",
+        turn_id="turn-a",
+    )
+    await claim_owner(
+        engine,
+        project_id=_PROJECT_ID,
+        session_id=session_id,
+        replica_id="replica-a",
+        turn_id="turn-b",
+    )
+
+    assert (
+        await client.get(owner_key(_PROJECT_ID, session_id))
+        == make_owner_value(replica_id="replica-a", turn_id="turn-b").encode()
+    )
 
 
 @pytest.mark.asyncio

--- a/api/oss/tests/pytest/unit/sessions/test_project_scoped_locks.py
+++ b/api/oss/tests/pytest/unit/sessions/test_project_scoped_locks.py
@@ -96,7 +96,11 @@ class _FakeRedis:
                 return 1
             return 0
         # CLAIM_OWNER_LUA
-        if current_s is None or current_s == argv[0]:
+        from oss.src.dbs.redis.sessions.contract import owner_replica_id
+
+        if current_s is None or owner_replica_id(current_s) == owner_replica_id(
+            argv[0]
+        ):
             self._values[key] = argv[0].encode()
             self._ttl[key] = int(argv[1])
             return argv[0]

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
@@ -12,6 +12,7 @@ run they meant, and it can kill a run they never meant. These pin the rules that
   * Redis is not written at admission, so the stopping execution keeps its locks while it stops.
 """
 
+from contextlib import asynccontextmanager
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
 from unittest.mock import AsyncMock, patch
@@ -76,6 +77,10 @@ class _FakeCommandsDAO:
         self.stopping_turn_ids: List[Optional[str]] = []
         self.claims: List[Dict] = []
         self.abandoned: List[SessionCommand] = []
+
+    @asynccontextmanager
+    async def transaction(self):
+        yield object()
 
     async def create_command(
         self, *, user_id, command: SessionCommandCreate, stopping_turn_id=None
@@ -191,7 +196,7 @@ class _FakeCommandsDAO:
     async def claim_commands(self, **_):
         return []
 
-    async def settle_command(self, *, settle):
+    async def settle_command(self, *, settle, transaction=None):
         for index, row in enumerate(self.rows):
             if row.id == settle.command_id and row.state in settle.expected_states:
                 # Mirrors the real guard: a `pending` row holds no claim, so a null
@@ -273,6 +278,22 @@ class _FakeStreamsService:
             }
         )
 
+    async def settle_command(
+        self,
+        *,
+        project_id,
+        session_id,
+        turn_id,
+        mirror_stopped,
+        transaction=None,
+    ):
+        if mirror_stopped and self.stream is not None:
+            self.stream = self.stream.model_copy(
+                update={
+                    "flags": self.stream.flags.model_copy(update={"is_running": False})
+                }
+            )
+
 
 class _FakeInteractionsService:
     def __init__(self) -> None:
@@ -321,6 +342,7 @@ class _FakeExecutionsDAO:
         terminal_outcome,
         settled_by,
         settled_at=None,
+        transaction=None,
     ):
         key = (session_id, execution_id)
         if key in self.rows:
@@ -337,47 +359,6 @@ class _FakeExecutionsDAO:
         )
         self.rows[key] = row
         return SessionExecutionSettlementResult(settlement=row, won=True)
-
-    async def settle_command_execution(
-        self,
-        *,
-        settle,
-        session_id,
-        execution_id,
-        terminal_outcome,
-        settled_by,
-        mirror_stopped,
-        cancel_interactions,
-    ):
-        if execution_id and terminal_outcome and settled_by:
-            result = await self.settle(
-                project_id=settle.project_id,
-                session_id=session_id,
-                execution_id=execution_id,
-                terminal_outcome=terminal_outcome,
-                settled_by=settled_by,
-            )
-            winner = result.settlement
-            if not result.won and (
-                winner.terminal_outcome != terminal_outcome
-                or winner.settled_by != settled_by
-            ):
-                return None
-        command = await self.commands.settle_command(settle=settle)
-        if command is None:
-            return None
-        await self.commands.clear_stopping_turn(
-            project_id=settle.project_id,
-            session_id=session_id,
-            turn_id=execution_id,
-        )
-        if cancel_interactions and execution_id:
-            await self.interactions.cancel_session_pending(
-                project_id=settle.project_id,
-                session_id=session_id,
-                only_turn_id=execution_id,
-            )
-        return command
 
     async def list_redis_unreconciled(self, *, limit):
         return [

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
@@ -1318,6 +1318,35 @@ async def test_next_sweep_repairs_a_post_commit_redis_failure(lock_engine, monke
     assert executions.rows[(_SESSION, "turn-A")].redis_reconciled_at is not None
 
 
+@pytest.mark.asyncio
+async def test_successful_redis_projection_is_not_offered_for_repair(lock_engine):
+    await _run_turn(lock_engine, "turn-A")
+    executions = _FakeExecutionsDAO()
+    svc = _service(
+        lock_engine,
+        streams=_FakeStreamsService(
+            _stream("turn-A", datetime.now(timezone.utc) - timedelta(seconds=30))
+        ),
+        executions=executions,
+    )
+    admission = await svc.request_cancel(
+        project_id=_PROJECT,
+        user_id=_USER,
+        session_id=_SESSION,
+    )
+
+    await svc.report_outcome(
+        command_id=admission.command.id,
+        replica_id="runner-1",
+        result="applied",
+        execution_id="turn-A",
+        execution_state="stopped",
+    )
+
+    assert executions.rows[(_SESSION, "turn-A")].redis_reconciled_at is not None
+    assert await svc.repair_terminal_redis() == 0
+
+
 def _abandoned_command(*, claim_count: int = 1) -> SessionCommand:
     return SessionCommand(
         id=uuid.uuid7(),

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
@@ -36,6 +36,10 @@ from oss.src.core.sessions.commands.types import (
     ExecutionExpectationFailed,
     SessionCommandIdempotencyConflict,
 )
+from oss.src.core.sessions.executions.dtos import (
+    SessionExecutionSettlement,
+    SessionExecutionSettlementResult,
+)
 from oss.src.core.sessions.streams.dtos import (
     CommandMode,
     SessionStream,
@@ -300,6 +304,37 @@ class _RecordingDelivery:
         return None
 
 
+class _FakeExecutionsDAO:
+    def __init__(self) -> None:
+        self.rows: Dict[tuple[str, str], SessionExecutionSettlement] = {}
+
+    async def settle(
+        self,
+        *,
+        project_id,
+        session_id,
+        execution_id,
+        terminal_outcome,
+        settled_by,
+        settled_at=None,
+    ):
+        key = (session_id, execution_id)
+        if key in self.rows:
+            return SessionExecutionSettlementResult(
+                settlement=self.rows[key], won=False
+            )
+        row = SessionExecutionSettlement(
+            project_id=project_id,
+            session_id=session_id,
+            execution_id=execution_id,
+            terminal_outcome=terminal_outcome,
+            settled_by=settled_by,
+            settled_at=settled_at or datetime.now(timezone.utc),
+        )
+        self.rows[key] = row
+        return SessionExecutionSettlementResult(settlement=row, won=True)
+
+
 def _stream(
     turn_id: Optional[str], turn_started_at: Optional[datetime]
 ) -> SessionStream:
@@ -323,7 +358,15 @@ async def lock_engine():
         yield eng
 
 
-def _service(lock_engine, *, dao=None, streams=None, interactions=None, delivery=None):
+def _service(
+    lock_engine,
+    *,
+    dao=None,
+    streams=None,
+    interactions=None,
+    delivery=None,
+    executions=None,
+):
     streams = streams or _FakeStreamsService()
     # The fake mirrors from Redis, so it reads the same engine the service writes through.
     if streams.lock_engine is None:
@@ -334,6 +377,7 @@ def _service(lock_engine, *, dao=None, streams=None, interactions=None, delivery
         interactions_service=interactions or _FakeInteractionsService(),
         lock_engine=lock_engine,
         delivery=delivery or _RecordingDelivery(),
+        executions_dao=executions,
     )
 
 
@@ -1136,6 +1180,58 @@ async def test_a_second_outcome_report_changes_nothing(lock_engine):
         )
 
     assert interactions.cancelled == ["turn-A"], "the side effects run exactly once"
+
+
+@pytest.mark.asyncio
+async def test_runner_outcome_settles_the_execution_authority(lock_engine):
+    await _run_turn(lock_engine, "turn-A")
+    executions = _FakeExecutionsDAO()
+    svc = _service(
+        lock_engine,
+        streams=_FakeStreamsService(
+            _stream("turn-A", datetime.now(timezone.utc) - timedelta(seconds=30))
+        ),
+        executions=executions,
+    )
+
+    admission = await svc.request_cancel(
+        project_id=_PROJECT, user_id=_USER, session_id=_SESSION
+    )
+    await svc.report_outcome(
+        command_id=admission.command.id,
+        replica_id="runner-1",
+        result="applied",
+        execution_id="turn-A",
+        execution_state="stopped",
+    )
+
+    winner = executions.rows[(_SESSION, "turn-A")]
+    assert winner.terminal_outcome == "stopped"
+    assert winner.settled_by == "runner"
+
+
+@pytest.mark.asyncio
+async def test_watchdog_cannot_replace_the_runners_terminal_outcome(lock_engine):
+    executions = _FakeExecutionsDAO()
+    svc = _service(lock_engine, executions=executions)
+    first = await executions.settle(
+        project_id=_PROJECT,
+        session_id=_SESSION,
+        execution_id="turn-A",
+        terminal_outcome="stopped",
+        settled_by="runner",
+    )
+    assert first.won is True
+
+    won = await svc.settle_execution_lost(
+        project_id=_PROJECT,
+        session_id=_SESSION,
+        execution_id="turn-A",
+        settled_at=datetime.now(timezone.utc),
+    )
+
+    assert won is False
+    assert executions.rows[(_SESSION, "turn-A")].terminal_outcome == "stopped"
 
 
 def _abandoned_command(*, claim_count: int = 1) -> SessionCommand:

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
@@ -52,6 +52,7 @@ from oss.src.dbs.redis.sessions.locks import (
     is_turn_superseded,
     release_running,
 )
+from oss.src.utils.env import env
 
 from unit.sessions.test_project_scoped_locks import _FakeRedis
 
@@ -68,6 +69,7 @@ class _FakeCommandsDAO:
         self.rows: List[SessionCommand] = []
         self.stopping_turn_ids: List[Optional[str]] = []
         self.claims: List[Dict] = []
+        self.abandoned: List[SessionCommand] = []
 
     async def create_command(
         self, *, user_id, command: SessionCommandCreate, stopping_turn_id=None
@@ -157,6 +159,29 @@ class _FakeCommandsDAO:
                 return claimed
         return None
 
+    async def record_delivery_attempt(
+        self, *, project_id, command_id, now, max_deliveries
+    ):
+        for index, row in enumerate(self.rows):
+            if (
+                row.id == command_id
+                and row.state
+                in (SessionCommandState.pending, SessionCommandState.claimed)
+                and row.claim_count < max_deliveries
+            ):
+                attempted = row.model_copy(
+                    update={
+                        "state": SessionCommandState.pending,
+                        "claimed_by": None,
+                        "claim_expires_at": None,
+                        "claim_count": row.claim_count + 1,
+                        "updated_at": now,
+                    }
+                )
+                self.rows[index] = attempted
+                return attempted
+        return None
+
     async def claim_commands(self, **_):
         return []
 
@@ -185,8 +210,8 @@ class _FakeCommandsDAO:
     async def clear_stopping_turn(self, *, project_id, session_id, turn_id=None):
         self.stopping_turn_ids.append(None)
 
-    async def expire_claims(self, *, now, max_deliveries):
-        return []
+    async def expire_claims(self, *, now, max_deliveries, pending_before=None):
+        return self.abandoned
 
 
 class _FakeStreamsService:
@@ -1111,6 +1136,92 @@ async def test_a_second_outcome_report_changes_nothing(lock_engine):
         )
 
     assert interactions.cancelled == ["turn-A"], "the side effects run exactly once"
+
+
+def _abandoned_command(*, claim_count: int = 1) -> SessionCommand:
+    return SessionCommand(
+        id=uuid.uuid7(),
+        project_id=_PROJECT,
+        session_id=_SESSION,
+        kind="cancel",
+        target_turn_id="turn-A",
+        state=SessionCommandState.pending,
+        claim_count=claim_count,
+        created_at=datetime.now(timezone.utc) - timedelta(minutes=5),
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_pending_command_is_redelivered_while_the_session_beats(lock_engine):
+    command = _abandoned_command()
+    dao = _FakeCommandsDAO()
+    dao.rows = [command]
+    dao.abandoned = [command]
+    delivery = _RecordingDelivery()
+    svc = _service(
+        lock_engine,
+        dao=dao,
+        streams=_FakeStreamsService(_stream("turn-A", datetime.now(timezone.utc))),
+        delivery=delivery,
+    )
+
+    settled = await svc.settle_abandoned_commands(now=datetime.now(timezone.utc))
+
+    assert settled == 0
+    assert [row.id for row in delivery.delivered] == [command.id]
+    assert dao.rows[0].claim_count == command.claim_count + 1
+
+
+@pytest.mark.asyncio
+async def test_a_pending_command_is_settled_lost_when_the_runner_is_gone(lock_engine):
+    command = _abandoned_command()
+    dao = _FakeCommandsDAO()
+    dao.rows = [command]
+    dao.abandoned = [command]
+    delivery = _RecordingDelivery()
+    svc = _service(
+        lock_engine,
+        dao=dao,
+        streams=_FakeStreamsService(
+            _stream(
+                "turn-A",
+                datetime.now(timezone.utc) - timedelta(minutes=5),
+            ).model_copy(
+                update={"updated_at": datetime.now(timezone.utc) - timedelta(minutes=5)}
+            )
+        ),
+        delivery=delivery,
+    )
+
+    settled = await svc.settle_abandoned_commands(now=datetime.now(timezone.utc))
+
+    assert settled == 1
+    assert delivery.delivered == []
+    assert dao.rows[0].state == SessionCommandState.obsolete
+    assert dao.rows[0].outcome == SessionCommandOutcome.lost
+
+
+@pytest.mark.asyncio
+async def test_redelivery_stops_at_the_configured_maximum(lock_engine, monkeypatch):
+    maximum = 2
+    monkeypatch.setattr(env.agenta.sessions.commands, "max_deliveries", maximum)
+    command = _abandoned_command(claim_count=maximum)
+    dao = _FakeCommandsDAO()
+    dao.rows = [command]
+    dao.abandoned = [command]
+    delivery = _RecordingDelivery()
+    svc = _service(
+        lock_engine,
+        dao=dao,
+        streams=_FakeStreamsService(_stream("turn-A", datetime.now(timezone.utc))),
+        delivery=delivery,
+    )
+
+    settled = await svc.settle_abandoned_commands(now=datetime.now(timezone.utc))
+
+    assert settled == 1
+    assert delivery.delivered == []
+    assert dao.rows[0].outcome == SessionCommandOutcome.lost
 
 
 @pytest.mark.asyncio

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
@@ -14,7 +14,7 @@ run they meant, and it can kill a run they never meant. These pin the rules that
 
 from datetime import datetime, timedelta, timezone
 from typing import Dict, List, Optional
-from unittest.mock import patch
+from unittest.mock import AsyncMock, patch
 from uuid import UUID, uuid4
 
 import pytest
@@ -31,6 +31,7 @@ from oss.src.core.sessions.commands.interfaces import (
     CommandCreateResult,
     DeliveryReceipt,
 )
+from oss.src.core.sessions.commands import service as commands_service_module
 from oss.src.core.sessions.commands.service import SessionCommandsService
 from oss.src.core.sessions.commands.types import (
     ExecutionExpectationFailed,
@@ -57,6 +58,7 @@ from oss.src.dbs.redis.sessions.locks import (
     release_running,
 )
 from oss.src.utils.env import env
+from oss.src.tasks.asyncio.sessions.orphan_sweep import _repair_terminal_redis
 
 from unit.sessions.test_project_scoped_locks import _FakeRedis
 
@@ -307,6 +309,8 @@ class _RecordingDelivery:
 class _FakeExecutionsDAO:
     def __init__(self) -> None:
         self.rows: Dict[tuple[str, str], SessionExecutionSettlement] = {}
+        self.commands = None
+        self.interactions = None
 
     async def settle(
         self,
@@ -333,6 +337,62 @@ class _FakeExecutionsDAO:
         )
         self.rows[key] = row
         return SessionExecutionSettlementResult(settlement=row, won=True)
+
+    async def settle_command_execution(
+        self,
+        *,
+        settle,
+        session_id,
+        execution_id,
+        terminal_outcome,
+        settled_by,
+        mirror_stopped,
+        cancel_interactions,
+    ):
+        if execution_id and terminal_outcome and settled_by:
+            result = await self.settle(
+                project_id=settle.project_id,
+                session_id=session_id,
+                execution_id=execution_id,
+                terminal_outcome=terminal_outcome,
+                settled_by=settled_by,
+            )
+            winner = result.settlement
+            if not result.won and (
+                winner.terminal_outcome != terminal_outcome
+                or winner.settled_by != settled_by
+            ):
+                return None
+        command = await self.commands.settle_command(settle=settle)
+        if command is None:
+            return None
+        await self.commands.clear_stopping_turn(
+            project_id=settle.project_id,
+            session_id=session_id,
+            turn_id=execution_id,
+        )
+        if cancel_interactions and execution_id:
+            await self.interactions.cancel_session_pending(
+                project_id=settle.project_id,
+                session_id=session_id,
+                only_turn_id=execution_id,
+            )
+        return command
+
+    async def list_redis_unreconciled(self, *, limit):
+        return [
+            row
+            for row in self.rows.values()
+            if row.settled_by == "runner"
+            and row.terminal_outcome == "stopped"
+            and row.redis_reconciled_at is None
+        ][:limit]
+
+    async def mark_redis_reconciled(self, *, project_id, session_id, execution_id):
+        key = (session_id, execution_id)
+        self.rows[key] = self.rows[key].model_copy(
+            update={"redis_reconciled_at": datetime.now(timezone.utc)}
+        )
 
 
 def _stream(
@@ -371,10 +431,15 @@ def _service(
     # The fake mirrors from Redis, so it reads the same engine the service writes through.
     if streams.lock_engine is None:
         streams.lock_engine = lock_engine
+    commands = dao or _FakeCommandsDAO()
+    interactions = interactions or _FakeInteractionsService()
+    if executions is not None:
+        executions.commands = commands
+        executions.interactions = interactions
     return SessionCommandsService(
-        commands_dao=dao or _FakeCommandsDAO(),
+        commands_dao=commands,
         streams_service=streams,
-        interactions_service=interactions or _FakeInteractionsService(),
+        interactions_service=interactions,
         lock_engine=lock_engine,
         delivery=delivery or _RecordingDelivery(),
         executions_dao=executions,
@@ -1232,6 +1297,44 @@ async def test_watchdog_cannot_replace_the_runners_terminal_outcome(lock_engine)
 
     assert won is False
     assert executions.rows[(_SESSION, "turn-A")].terminal_outcome == "stopped"
+
+
+@pytest.mark.asyncio
+async def test_next_sweep_repairs_a_post_commit_redis_failure(lock_engine, monkeypatch):
+    await _run_turn(lock_engine, "turn-A")
+    dao = _FakeCommandsDAO()
+    executions = _FakeExecutionsDAO()
+    svc = _service(
+        lock_engine,
+        dao=dao,
+        streams=_FakeStreamsService(
+            _stream("turn-A", datetime.now(timezone.utc) - timedelta(seconds=30))
+        ),
+        executions=executions,
+    )
+    admission = await svc.request_cancel(
+        project_id=_PROJECT, user_id=_USER, session_id=_SESSION
+    )
+    supersede = AsyncMock(side_effect=RuntimeError("injected after commit"))
+    monkeypatch.setattr(commands_service_module, "mark_turn_superseded", supersede)
+
+    with pytest.raises(RuntimeError, match="injected after commit"):
+        await svc.report_outcome(
+            command_id=admission.command.id,
+            replica_id="runner-1",
+            result="applied",
+            execution_id="turn-A",
+            execution_state="stopped",
+        )
+
+    assert dao.rows[0].state == SessionCommandState.applied
+    assert executions.rows[(_SESSION, "turn-A")].redis_reconciled_at is None
+
+    supersede.side_effect = None
+    repaired = await _repair_terminal_redis(svc)
+
+    assert repaired == 1
+    assert executions.rows[(_SESSION, "turn-A")].redis_reconciled_at is not None
 
 
 def _abandoned_command(*, claim_count: int = 1) -> SessionCommand:

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
@@ -37,6 +37,7 @@ from oss.src.core.sessions.commands.service import SessionCommandsService
 from oss.src.core.sessions.commands.types import (
     ExecutionExpectationFailed,
     SessionCommandIdempotencyConflict,
+    SessionCommandNotClaimable,
 )
 from oss.src.core.sessions.executions.dtos import (
     SessionExecutionSettlement,
@@ -1428,6 +1429,7 @@ async def test_a_pending_command_is_settled_lost_when_the_runner_is_gone(lock_en
     dao.rows = [command]
     dao.abandoned = [command]
     delivery = _RecordingDelivery()
+    executions = _FakeExecutionsDAO()
     svc = _service(
         lock_engine,
         dao=dao,
@@ -1440,6 +1442,7 @@ async def test_a_pending_command_is_settled_lost_when_the_runner_is_gone(lock_en
             )
         ),
         delivery=delivery,
+        executions=executions,
     )
 
     settled = await svc.settle_abandoned_commands(now=datetime.now(timezone.utc))
@@ -1448,6 +1451,22 @@ async def test_a_pending_command_is_settled_lost_when_the_runner_is_gone(lock_en
     assert delivery.delivered == []
     assert dao.rows[0].state == SessionCommandState.obsolete
     assert dao.rows[0].outcome == SessionCommandOutcome.lost
+    winner = executions.rows[(_SESSION, "turn-A")]
+    assert winner.terminal_outcome == "lost"
+    assert winner.settled_by == "watchdog"
+
+    with pytest.raises(SessionCommandNotClaimable):
+        await svc.report_outcome(
+            command_id=command.id,
+            replica_id="runner-1",
+            result="applied",
+            execution_id="turn-A",
+            execution_state="stopped",
+        )
+
+    assert dao.rows[0].state == SessionCommandState.obsolete
+    assert dao.rows[0].outcome == SessionCommandOutcome.lost
+    assert executions.rows[(_SESSION, "turn-A")] == winner
 
 
 @pytest.mark.asyncio

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
@@ -296,9 +296,11 @@ class _FakeStreamsService:
 
 
 class _FakeInteractionsService:
-    def __init__(self) -> None:
+    def __init__(self, *, cancelled_count: int = 1) -> None:
         self.cancelled: List[Optional[str]] = []
         self.command_ids: List[Optional[UUID]] = []
+        self.published_cancelled: List[str] = []
+        self.cancelled_count = cancelled_count
 
     async def cancel_session_pending(
         self,
@@ -311,7 +313,12 @@ class _FakeInteractionsService:
     ):
         self.cancelled.append(only_turn_id)
         self.command_ids.append(command_id)
-        return 1
+        return self.cancelled_count
+
+    async def publish_session_pending_cancelled(
+        self, *, project_id, session_id
+    ) -> None:
+        self.published_cancelled.append(session_id)
 
 
 class _RecordingDelivery:
@@ -1232,11 +1239,13 @@ async def test_a_second_outcome_report_changes_nothing(lock_engine):
 async def test_runner_outcome_settles_the_execution_authority(lock_engine):
     await _run_turn(lock_engine, "turn-A")
     executions = _FakeExecutionsDAO()
+    interactions = _FakeInteractionsService()
     svc = _service(
         lock_engine,
         streams=_FakeStreamsService(
             _stream("turn-A", datetime.now(timezone.utc) - timedelta(seconds=30))
         ),
+        interactions=interactions,
         executions=executions,
     )
 
@@ -1254,6 +1263,37 @@ async def test_runner_outcome_settles_the_execution_authority(lock_engine):
     winner = executions.rows[(_SESSION, "turn-A")]
     assert winner.terminal_outcome == "stopped"
     assert winner.settled_by == "runner"
+    assert interactions.published_cancelled == [_SESSION]
+
+
+@pytest.mark.asyncio
+async def test_atomic_settlement_does_not_publish_when_no_gate_was_cancelled(
+    lock_engine,
+):
+    await _run_turn(lock_engine, "turn-A")
+    interactions = _FakeInteractionsService(cancelled_count=0)
+    svc = _service(
+        lock_engine,
+        streams=_FakeStreamsService(
+            _stream("turn-A", datetime.now(timezone.utc) - timedelta(seconds=30))
+        ),
+        interactions=interactions,
+        executions=_FakeExecutionsDAO(),
+    )
+
+    admission = await svc.request_cancel(
+        project_id=_PROJECT, user_id=_USER, session_id=_SESSION
+    )
+    await svc.report_outcome(
+        command_id=admission.command.id,
+        replica_id="runner-1",
+        result="applied",
+        execution_id="turn-A",
+        execution_state="stopped",
+    )
+
+    assert interactions.cancelled == ["turn-A"]
+    assert interactions.published_cancelled == []
 
 
 @pytest.mark.asyncio

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_feature_flag.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_feature_flag.py
@@ -12,10 +12,20 @@ from oss.src.apis.fastapi.sessions.router import SessionControlRouter
 from oss.src.core.sessions.commands.dtos import SessionCommandState
 from oss.src.core.sessions.streams.dtos import CommandMode, SessionStreamCommandResponse
 from oss.src.utils.env import env
+from oss.src.utils.env import _parse_sessions_late_output
 
 
 _PROJECT = UUID("00000000-0000-0000-0000-0000000000aa")
 _USER = UUID("00000000-0000-0000-0000-0000000000bb")
+
+
+def test_unknown_late_output_policy_falls_back_to_quarantine(monkeypatch):
+    monkeypatch.setenv("AGENTA_SESSIONS_LATE_OUTPUT", "typo")
+
+    with pytest.warns(UserWarning, match="behaving as 'quarantine'"):
+        value = _parse_sessions_late_output()
+
+    assert value == "quarantine"
 
 
 def _request():

--- a/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
@@ -621,6 +621,37 @@ async def test_runner_and_watchdog_have_one_terminal_winner(command_scope):
     assert runner.settlement == watchdog.settlement
 
 
+async def test_execution_ending_marker_is_one_way(command_scope):
+    dao = SessionExecutionsDAO(engine=command_scope["engine"])
+    await dao.settle(
+        project_id=command_scope["project_id"],
+        session_id=command_scope["session_id"],
+        execution_id="turn-A",
+        terminal_outcome="stopped",
+        settled_by="runner",
+    )
+    written_at = datetime.now(timezone.utc)
+
+    await dao.mark_endings_written(
+        project_id=command_scope["project_id"],
+        keys=[(command_scope["session_id"], "turn-A")],
+        written_at=written_at,
+    )
+    await dao.mark_endings_written(
+        project_id=command_scope["project_id"],
+        keys=[(command_scope["session_id"], "turn-A")],
+        written_at=written_at + timedelta(seconds=1),
+    )
+
+    stored = await dao.query_settled(
+        project_id=command_scope["project_id"],
+        keys=[(command_scope["session_id"], "turn-A")],
+    )
+    assert (
+        stored[(command_scope["session_id"], "turn-A")].ending_written_at == written_at
+    )
+
+
 async def test_terminal_core_facts_commit_in_one_transaction(command_scope):
     commands = SessionCommandsDAO(engine=command_scope["engine"])
     executions = SessionExecutionsDAO(engine=command_scope["engine"])

--- a/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
@@ -24,6 +24,7 @@ from oss.src.core.sessions.commands.dtos import (
 )
 from oss.src.core.sessions.commands.interfaces import SessionScope
 from oss.src.dbs.postgres.sessions.commands.dao import SessionCommandsDAO
+from oss.src.dbs.postgres.sessions.executions.dao import SessionExecutionsDAO
 import oss.src.dbs.postgres.shared.engine as engine_module
 from oss.src.dbs.postgres.shared.engine import get_transactions_engine
 import oss.src.models.db_models  # noqa: F401
@@ -592,3 +593,27 @@ async def test_delivery_attempts_are_bounded_in_the_database(command_scope):
     assert first is not None
     assert first.claim_count == 1
     assert second is None
+
+
+async def test_runner_and_watchdog_have_one_terminal_winner(command_scope):
+    dao = SessionExecutionsDAO(engine=command_scope["engine"])
+
+    runner, watchdog = await asyncio.gather(
+        dao.settle(
+            project_id=command_scope["project_id"],
+            session_id=command_scope["session_id"],
+            execution_id="turn-A",
+            terminal_outcome="stopped",
+            settled_by="runner",
+        ),
+        dao.settle(
+            project_id=command_scope["project_id"],
+            session_id=command_scope["session_id"],
+            execution_id="turn-A",
+            terminal_outcome="lost",
+            settled_by="watchdog",
+        ),
+    )
+
+    assert sum(result.won for result in (runner, watchdog)) == 1
+    assert runner.settlement == watchdog.settlement

--- a/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
@@ -721,7 +721,7 @@ async def test_terminal_core_facts_commit_in_one_transaction(command_scope):
                 "INSERT INTO session_interactions "
                 "(project_id, id, session_id, turn_id, token, kind, status) "
                 "VALUES (:project_id, :id, :session_id, 'turn-A', "
-                "'token-A', 'approval', 'pending')"
+                "'token-A', 'user_approval', 'pending')"
             ),
             {
                 "project_id": command_scope["project_id"],

--- a/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
@@ -25,6 +25,8 @@ from oss.src.core.sessions.commands.dtos import (
 from oss.src.core.sessions.commands.interfaces import SessionScope
 from oss.src.dbs.postgres.sessions.commands.dao import SessionCommandsDAO
 from oss.src.dbs.postgres.sessions.executions.dao import SessionExecutionsDAO
+from oss.src.dbs.postgres.sessions.interactions.dao import SessionInteractionsDAO
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
 import oss.src.dbs.postgres.shared.engine as engine_module
 from oss.src.dbs.postgres.shared.engine import get_transactions_engine
 import oss.src.models.db_models  # noqa: F401
@@ -622,6 +624,8 @@ async def test_runner_and_watchdog_have_one_terminal_winner(command_scope):
 async def test_terminal_core_facts_commit_in_one_transaction(command_scope):
     commands = SessionCommandsDAO(engine=command_scope["engine"])
     executions = SessionExecutionsDAO(engine=command_scope["engine"])
+    streams = SessionStreamsDAO(engine=command_scope["engine"])
+    interactions = SessionInteractionsDAO(engine=command_scope["engine"])
     command = await commands.create_command(
         user_id=command_scope["user_id"],
         command=_create(command_scope),
@@ -667,24 +671,43 @@ async def test_terminal_core_facts_commit_in_one_transaction(command_scope):
             },
         )
 
-    settled = await executions.settle_command_execution(
-        settle=SessionCommandSettle(
-            project_id=command_scope["project_id"],
-            command_id=command.id,
-            state=SessionCommandState.applied,
-            outcome=SessionCommandOutcome.stopped,
-            expected_states=[SessionCommandState.claimed],
-            replica_id="runner-1",
-        ),
-        session_id=command_scope["session_id"],
-        execution_id="turn-A",
-        terminal_outcome="stopped",
-        settled_by="runner",
-        mirror_stopped=True,
-        cancel_interactions=True,
+    transition = SessionCommandSettle(
+        project_id=command_scope["project_id"],
+        command_id=command.id,
+        state=SessionCommandState.applied,
+        outcome=SessionCommandOutcome.stopped,
+        expected_states=[SessionCommandState.claimed],
+        replica_id="runner-1",
     )
+    async with commands.transaction() as transaction:
+        settled = await commands.settle_command(
+            settle=transition,
+            transaction=transaction,
+        )
+        execution = await executions.settle(
+            project_id=command_scope["project_id"],
+            session_id=command_scope["session_id"],
+            execution_id="turn-A",
+            terminal_outcome="stopped",
+            settled_by="runner",
+            transaction=transaction,
+        )
+        await streams.settle_command(
+            project_id=command_scope["project_id"],
+            session_id=command_scope["session_id"],
+            turn_id="turn-A",
+            mirror_stopped=True,
+            transaction=transaction,
+        )
+        await interactions.cancel_session_pending(
+            project_id=command_scope["project_id"],
+            session_id=command_scope["session_id"],
+            only_turn_id="turn-A",
+            transaction=transaction,
+        )
 
     assert settled is not None
+    assert execution.won is True
     async with command_scope["engine"].session() as session:
         row = (
             await session.execute(
@@ -713,7 +736,7 @@ async def test_terminal_core_facts_commit_in_one_transaction(command_scope):
         "stopped",
         None,
         "false",
-        "false",
+        "true",
         "cancelled",
         "stopped",
     )

--- a/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
@@ -617,3 +617,103 @@ async def test_runner_and_watchdog_have_one_terminal_winner(command_scope):
 
     assert sum(result.won for result in (runner, watchdog)) == 1
     assert runner.settlement == watchdog.settlement
+
+
+async def test_terminal_core_facts_commit_in_one_transaction(command_scope):
+    commands = SessionCommandsDAO(engine=command_scope["engine"])
+    executions = SessionExecutionsDAO(engine=command_scope["engine"])
+    command = await commands.create_command(
+        user_id=command_scope["user_id"],
+        command=_create(command_scope),
+        stopping_turn_id="turn-A",
+    )
+    await commands.record_delivery_attempt(
+        project_id=command_scope["project_id"],
+        command_id=command.id,
+        now=datetime.now(timezone.utc),
+        max_deliveries=3,
+    )
+    await commands.claim_for_delivery(
+        project_id=command_scope["project_id"],
+        command_id=command.id,
+        replica_id="runner-1",
+        lease_seconds=90,
+    )
+    interaction_id = uuid.uuid4()
+    async with command_scope["engine"].session() as session:
+        await session.execute(
+            text(
+                "UPDATE session_streams SET flags = "
+                '\'{"is_alive": true, "is_running": true, '
+                '"is_attached": true}\'::jsonb '
+                "WHERE project_id = :project_id AND session_id = :session_id"
+            ),
+            {
+                "project_id": command_scope["project_id"],
+                "session_id": command_scope["session_id"],
+            },
+        )
+        await session.execute(
+            text(
+                "INSERT INTO session_interactions "
+                "(project_id, id, session_id, turn_id, token, kind, status) "
+                "VALUES (:project_id, :id, :session_id, 'turn-A', "
+                "'token-A', 'approval', 'pending')"
+            ),
+            {
+                "project_id": command_scope["project_id"],
+                "id": interaction_id,
+                "session_id": command_scope["session_id"],
+            },
+        )
+
+    settled = await executions.settle_command_execution(
+        settle=SessionCommandSettle(
+            project_id=command_scope["project_id"],
+            command_id=command.id,
+            state=SessionCommandState.applied,
+            outcome=SessionCommandOutcome.stopped,
+            expected_states=[SessionCommandState.claimed],
+            replica_id="runner-1",
+        ),
+        session_id=command_scope["session_id"],
+        execution_id="turn-A",
+        terminal_outcome="stopped",
+        settled_by="runner",
+        mirror_stopped=True,
+        cancel_interactions=True,
+    )
+
+    assert settled is not None
+    async with command_scope["engine"].session() as session:
+        row = (
+            await session.execute(
+                text(
+                    "SELECT c.state, c.outcome, s.stopping_turn_id, "
+                    "s.flags->>'is_running', s.flags->>'is_attached', i.status, "
+                    "e.terminal_outcome "
+                    "FROM session_commands c "
+                    "JOIN session_streams s ON s.project_id = c.project_id "
+                    "AND s.session_id = c.session_id "
+                    "JOIN session_interactions i ON i.project_id = c.project_id "
+                    "AND i.session_id = c.session_id "
+                    "JOIN session_executions e ON e.project_id = c.project_id "
+                    "AND e.session_id = c.session_id "
+                    "AND e.execution_id = c.target_turn_id "
+                    "WHERE c.project_id = :project_id AND c.id = :command_id"
+                ),
+                {
+                    "project_id": command_scope["project_id"],
+                    "command_id": command.id,
+                },
+            )
+        ).one()
+    assert tuple(row) == (
+        "applied",
+        "stopped",
+        None,
+        "false",
+        "false",
+        "cancelled",
+        "stopped",
+    )

--- a/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
@@ -23,6 +23,9 @@ from oss.src.core.sessions.commands.dtos import (
     SessionCommandState,
 )
 from oss.src.core.sessions.commands.interfaces import SessionScope
+from oss.src.core.sessions.commands.service import SessionCommandsService
+from oss.src.core.sessions.interactions.service import SessionInteractionsService
+from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.dbs.postgres.sessions.commands.dao import SessionCommandsDAO
 from oss.src.dbs.postgres.sessions.executions.dao import SessionExecutionsDAO
 from oss.src.dbs.postgres.sessions.interactions.dao import SessionInteractionsDAO
@@ -621,6 +624,31 @@ async def test_runner_and_watchdog_have_one_terminal_winner(command_scope):
     assert runner.settlement == watchdog.settlement
 
 
+async def test_repeating_the_same_execution_settlement_reports_only_the_insert_as_winner(
+    command_scope,
+):
+    dao = SessionExecutionsDAO(engine=command_scope["engine"])
+
+    first = await dao.settle(
+        project_id=command_scope["project_id"],
+        session_id=command_scope["session_id"],
+        execution_id="turn-A",
+        terminal_outcome="lost",
+        settled_by="watchdog",
+    )
+    repeated = await dao.settle(
+        project_id=command_scope["project_id"],
+        session_id=command_scope["session_id"],
+        execution_id="turn-A",
+        terminal_outcome="lost",
+        settled_by="watchdog",
+    )
+
+    assert first.won is True
+    assert repeated.won is False
+    assert repeated.settlement == first.settlement
+
+
 async def test_execution_ending_marker_is_one_way(command_scope):
     dao = SessionExecutionsDAO(engine=command_scope["engine"])
     await dao.settle(
@@ -771,3 +799,63 @@ async def test_terminal_core_facts_commit_in_one_transaction(command_scope):
         "cancelled",
         "stopped",
     )
+
+
+async def test_execution_conflict_rolls_back_the_command_transition(command_scope):
+    commands = SessionCommandsDAO(engine=command_scope["engine"])
+    executions = SessionExecutionsDAO(engine=command_scope["engine"])
+    streams = SessionStreamsDAO(engine=command_scope["engine"])
+    interactions = SessionInteractionsDAO(engine=command_scope["engine"])
+    command = await commands.create_command(
+        user_id=command_scope["user_id"],
+        command=_create(command_scope),
+        stopping_turn_id="turn-A",
+    )
+    await commands.record_delivery_attempt(
+        project_id=command_scope["project_id"],
+        command_id=command.id,
+        now=datetime.now(timezone.utc),
+        max_deliveries=3,
+    )
+    await commands.claim_for_delivery(
+        project_id=command_scope["project_id"],
+        command_id=command.id,
+        replica_id="runner-1",
+        lease_seconds=90,
+    )
+    await executions.settle(
+        project_id=command_scope["project_id"],
+        session_id=command_scope["session_id"],
+        execution_id="turn-A",
+        terminal_outcome="lost",
+        settled_by="watchdog",
+    )
+
+    service = SessionCommandsService(
+        commands_dao=commands,
+        streams_service=SessionStreamsService(
+            streams_dao=streams,
+            lock_engine=None,
+        ),
+        interactions_service=SessionInteractionsService(
+            interactions_dao=interactions,
+        ),
+        lock_engine=None,
+        delivery=None,
+        executions_dao=executions,
+    )
+    settled = await service.settle(
+        command_id=command.id,
+        project_id=command_scope["project_id"],
+        replica_id="runner-1",
+        expected_states=[SessionCommandState.claimed],
+        state=SessionCommandState.applied,
+        outcome=SessionCommandOutcome.stopped,
+        execution_id="turn-A",
+    )
+
+    assert settled is None
+    stored = await commands.fetch_command(command_id=command.id)
+    assert stored is not None
+    assert stored.state == SessionCommandState.claimed
+    assert stored.outcome is None

--- a/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
@@ -360,6 +360,13 @@ async def test_the_claim_records_the_lease_and_counts_the_delivery(command_scope
     command = await dao.create_command(
         user_id=command_scope["user_id"], command=_create(command_scope)
     )
+    attempted = await dao.record_delivery_attempt(
+        project_id=command_scope["project_id"],
+        command_id=command.id,
+        now=datetime.now(timezone.utc),
+        max_deliveries=3,
+    )
+    assert attempted is not None
 
     claimed = await dao.claim_for_delivery(
         project_id=command_scope["project_id"],
@@ -543,3 +550,45 @@ async def test_expire_claims_returns_only_leases_that_have_passed(command_scope)
     # An hour later the same lease has passed, and the settlement sweep sees it.
     later = await dao.expire_claims(now=now + timedelta(hours=1), max_deliveries=3)
     assert fresh.id in {row.id for row in later}
+
+
+async def test_old_pending_commands_are_returned_for_redelivery(command_scope):
+    dao = SessionCommandsDAO(engine=command_scope["engine"])
+    now = datetime.now(timezone.utc)
+    command = await dao.create_command(
+        user_id=command_scope["user_id"],
+        command=_create(command_scope, created_at=now - timedelta(minutes=5)),
+    )
+
+    rows = await dao.expire_claims(
+        now=now,
+        max_deliveries=3,
+        pending_before=now - timedelta(seconds=90),
+    )
+
+    assert command.id in {row.id for row in rows}
+
+
+async def test_delivery_attempts_are_bounded_in_the_database(command_scope):
+    dao = SessionCommandsDAO(engine=command_scope["engine"])
+    command = await dao.create_command(
+        user_id=command_scope["user_id"], command=_create(command_scope)
+    )
+    now = datetime.now(timezone.utc)
+
+    first = await dao.record_delivery_attempt(
+        project_id=command_scope["project_id"],
+        command_id=command.id,
+        now=now,
+        max_deliveries=1,
+    )
+    second = await dao.record_delivery_attempt(
+        project_id=command_scope["project_id"],
+        command_id=command.id,
+        now=now + timedelta(seconds=1),
+        max_deliveries=1,
+    )
+
+    assert first is not None
+    assert first.claim_count == 1
+    assert second is None

--- a/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
@@ -420,16 +420,20 @@ async def test_b_lost_turn_clear_persists_after_a_nested_session_close(
         wd_engine, session_id=session_id, turn_id=turn_id
     )
 
-    real_get_owner = orphan_sweep.get_owner
+    real_get_owner_value = orphan_sweep.get_owner_value
     nested_sessions = []
 
-    async def _get_owner_through_a_nested_session(*args, **kwargs):
+    async def _get_owner_value_through_a_nested_session(*args, **kwargs):
         # Open and close the shared task-scoped session, exactly as a DAO call would.
         async with wd_engine.session():
             nested_sessions.append(1)
-        return await real_get_owner(*args, **kwargs)
+        return await real_get_owner_value(*args, **kwargs)
 
-    monkeypatch.setattr(orphan_sweep, "get_owner", _get_owner_through_a_nested_session)
+    monkeypatch.setattr(
+        orphan_sweep,
+        "get_owner_value",
+        _get_owner_value_through_a_nested_session,
+    )
 
     lock, records_service, commands_service = _build_services(wd_engine)
     await orphan_sweep.run_orphan_sweep(

--- a/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
@@ -24,6 +24,7 @@ the fixture creates its own and drops it. Point it at any reachable core Postgre
         uv run --no-sync pytest oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py -q
 """
 
+import asyncio
 import uuid
 from datetime import datetime, timezone, timedelta
 from urllib.parse import urlparse, urlunparse
@@ -45,6 +46,7 @@ from oss.src.dbs.postgres.sessions.interactions.dbes import (  # noqa: F401
 )
 from oss.src.dbs.postgres.shared.base import Base
 
+from oss.src.core.sessions.streams.dtos import SessionHeartbeatRequest
 from oss.src.utils.env import env
 from oss.src.dbs.postgres.shared.engine import TransactionsEngine
 from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
@@ -451,3 +453,79 @@ async def test_b_lost_turn_clear_persists_after_a_nested_session_close(
     # is_running cleared and PERSISTED; is_alive kept, so the session stays resumable.
     assert flags["is_running"] is False
     assert flags["is_alive"] is True
+
+
+@pytest.mark.anyio
+async def test_c_heartbeat_finishing_after_sweep_commit_cannot_revive_row(
+    anyio_backend, wd_engine, monkeypatch
+):
+    """Redis refresh wins first; the sweep commits; only then may the heartbeat write."""
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+
+    session_id = "wd-" + uuid.uuid4().hex[:12]
+    turn_id = str(uuid.uuid4())
+    project_id = await _seed_scenario(wd_engine, session_id=session_id, turn_id=turn_id)
+
+    heartbeat_waiting = asyncio.Event()
+    allow_heartbeat_write = asyncio.Event()
+
+    class _DelayedHeartbeatDAO(SessionStreamsDAO):
+        async def update(self, *, project_id, user_id, session_id, stream):
+            if stream.expected_turn_id is not None:
+                heartbeat_waiting.set()
+                await allow_heartbeat_write.wait()
+            return await super().update(
+                project_id=project_id,
+                user_id=user_id,
+                session_id=session_id,
+                stream=stream,
+            )
+
+    lock, records_service, commands_service = _build_services(wd_engine)
+    heartbeat_service = SessionStreamsService(
+        streams_dao=_DelayedHeartbeatDAO(wd_engine), lock_engine=lock
+    )
+    heartbeat = asyncio.create_task(
+        heartbeat_service.heartbeat(
+            project_id=project_id,
+            request=SessionHeartbeatRequest(
+                session_id=session_id,
+                replica_id="replica-a",
+                turn_id=turn_id,
+                is_running=True,
+            ),
+        )
+    )
+    await heartbeat_waiting.wait()
+
+    await orphan_sweep.run_orphan_sweep(
+        wd_engine,
+        lock,
+        records_service=records_service,
+        watch_publisher=None,
+        commands_service=commands_service,
+        publish=_noop_publish,
+    )
+    allow_heartbeat_write.set()
+    heartbeat_result = await heartbeat
+
+    async with wd_engine.session() as s:
+        flags, outcome = (
+            await s.execute(
+                text(
+                    "SELECT ss.flags, se.terminal_outcome "
+                    "FROM session_streams ss JOIN session_executions se "
+                    "ON se.project_id=ss.project_id AND se.session_id=ss.session_id "
+                    "AND se.execution_id=ss.turn_id WHERE ss.session_id=:s"
+                ),
+                {"s": session_id},
+            )
+        ).one()
+
+    assert heartbeat_result.is_current_turn is False
+    assert outcome == "lost"
+    assert flags == {
+        "is_alive": False,
+        "is_running": False,
+        "is_attached": False,
+    }

--- a/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
@@ -173,32 +173,36 @@ async def wd_engine(monkeypatch):
         await admin.close()
 
 
-async def _seed_scenario(engine, *, session_id, turn_id):
+async def _seed_tenant(s):
+    """One user, organization, workspace and project. Returns the project id."""
     project_id = uuid.uuid4()
+    uid, org, ws = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+    await s.execute(
+        text("INSERT INTO users (id, uid, username, email) VALUES (:i,:u,:n,:e)"),
+        {"i": uid, "u": str(uid), "n": "wd", "e": f"wd-{uid.hex[:8]}@e.com"},
+    )
+    await s.execute(
+        text("INSERT INTO organizations (id, name, owner_id) VALUES (:i,:n,:o)"),
+        {"i": org, "n": "wd", "o": uid},
+    )
+    await s.execute(
+        text("INSERT INTO workspaces (id, name, organization_id) VALUES (:i,:n,:o)"),
+        {"i": ws, "n": "wd", "o": org},
+    )
+    await s.execute(
+        text(
+            "INSERT INTO projects (id, project_name, organization_id, workspace_id) "
+            "VALUES (:i,:n,:o,:w)"
+        ),
+        {"i": project_id, "n": "wd", "o": org, "w": ws},
+    )
+    return project_id
+
+
+async def _seed_scenario(engine, *, session_id, turn_id):
     stale = datetime.now(timezone.utc) - timedelta(hours=1)
     async with engine.session() as s:
-        uid, org, ws = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
-        await s.execute(
-            text("INSERT INTO users (id, uid, username, email) VALUES (:i,:u,:n,:e)"),
-            {"i": uid, "u": str(uid), "n": "wd", "e": f"wd-{uid.hex[:8]}@e.com"},
-        )
-        await s.execute(
-            text("INSERT INTO organizations (id, name, owner_id) VALUES (:i,:n,:o)"),
-            {"i": org, "n": "wd", "o": uid},
-        )
-        await s.execute(
-            text(
-                "INSERT INTO workspaces (id, name, organization_id) VALUES (:i,:n,:o)"
-            ),
-            {"i": ws, "n": "wd", "o": org},
-        )
-        await s.execute(
-            text(
-                "INSERT INTO projects (id, project_name, organization_id, workspace_id) "
-                "VALUES (:i,:n,:o,:w)"
-            ),
-            {"i": project_id, "n": "wd", "o": org, "w": ws},
-        )
+        project_id = await _seed_tenant(s)
         await s.execute(
             text(
                 "INSERT INTO session_streams "
@@ -229,6 +233,45 @@ async def _seed_scenario(engine, *, session_id, turn_id):
                 "t": turn_id,
                 "c": stale,
             },
+        )
+        await s.commit()
+    return project_id
+
+
+async def _seed_lost_execution_scenario(engine, *, session_id, turn_id):
+    """A row the ORPHAN query never returns, whose turn is owed an ending.
+
+    The stream row beats normally (a fresh `updated_at`), so it is not stale and is not
+    collapsed. Its turn is already settled `lost` with no ending written, which is what puts it
+    in `newly_lost`: the branch that clears `is_running` and keeps `is_alive`.
+    """
+    fresh = datetime.now(timezone.utc)
+    stale = fresh - timedelta(hours=1)
+    async with engine.session() as s:
+        project_id = await _seed_tenant(s)
+        await s.execute(
+            text(
+                "INSERT INTO session_streams "
+                "(id, project_id, session_id, turn_id, flags, created_at, updated_at) "
+                "VALUES (:i,:p,:s,:t, CAST(:f AS JSONB), :c, :u)"
+            ),
+            {
+                "i": uuid.uuid4(),
+                "p": project_id,
+                "s": session_id,
+                "t": turn_id,
+                "f": '{"is_alive": true, "is_running": true, "is_attached": true}',
+                "c": fresh,
+                "u": fresh,
+            },
+        )
+        await s.execute(
+            text(
+                "INSERT INTO session_executions "
+                "(project_id, session_id, execution_id, terminal_outcome, settled_by, settled_at) "
+                "VALUES (:p,:s,:t,'lost','watchdog',:a)"
+            ),
+            {"p": project_id, "s": session_id, "t": turn_id, "a": stale},
         )
         await s.commit()
     return project_id
@@ -316,3 +359,67 @@ async def test_a_lost_pass_persists_the_collapse_against_real_postgres(
     # The Stop command was settled, not left pending.
     assert cmd[0] == "obsolete"
     assert cmd[1] == "lost"
+
+
+@pytest.mark.anyio
+async def test_b_lost_turn_clear_persists_across_a_nested_session(
+    anyio_backend, wd_engine, monkeypatch
+):
+    """The `newly_lost` is_running clear survives a nested session between load and write.
+
+    Same failure mode as finding 7, one branch up. The sweep loads the row that still names the
+    lost turn, runs its Redis releases, then writes. If any step between the load and the write
+    opens an `engine.session()`, its `finally` closes the shared task-scoped session and
+    detaches the loaded row, and an ORM attribute write on that row is then dropped at commit
+    with no error. `release_alive` is patched here to open exactly such a nested session, which
+    is what a future edit could easily introduce for real.
+
+    This never failed in production: before the fix the write sat immediately after the load,
+    with nothing nested in between. The test pins the property rather than a past bug. Make the
+    write an ORM attribute assignment again and it fails on `is_running` still true.
+    """
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+
+    session_id = "wd-" + uuid.uuid4().hex[:12]
+    turn_id = str(uuid.uuid4())
+    await _seed_lost_execution_scenario(
+        wd_engine, session_id=session_id, turn_id=turn_id
+    )
+
+    real_release_alive = orphan_sweep.release_alive
+    nested_sessions = []
+
+    async def _release_alive_through_a_nested_session(*args, **kwargs):
+        # Open and close the shared task-scoped session, exactly as a DAO call would.
+        async with wd_engine.session():
+            nested_sessions.append(1)
+        return await real_release_alive(*args, **kwargs)
+
+    monkeypatch.setattr(
+        orphan_sweep, "release_alive", _release_alive_through_a_nested_session
+    )
+
+    lock, records_service, commands_service = _build_services(wd_engine)
+    await orphan_sweep.run_orphan_sweep(
+        wd_engine,
+        lock,
+        records_service=records_service,
+        watch_publisher=None,
+        commands_service=commands_service,
+        publish=_noop_publish,
+    )
+
+    # The pass must actually have reached the branch under test.
+    assert nested_sessions, "the lost-turn branch never ran, so nothing was proven"
+
+    async with wd_engine.session() as s:
+        flags = (
+            await s.execute(
+                text("SELECT flags FROM session_streams WHERE session_id=:s"),
+                {"s": session_id},
+            )
+        ).scalar_one()
+
+    # is_running cleared and PERSISTED; is_alive kept, so the session stays resumable.
+    assert flags["is_running"] is False
+    assert flags["is_alive"] is True

--- a/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
@@ -131,7 +131,9 @@ class _FakeLock:
         if isinstance(cur, bytes):
             cur = cur.decode()
         if len(argv) > 1:
-            if cur is None or cur == v:
+            from oss.src.dbs.redis.sessions.contract import owner_replica_id
+
+            if cur is None or owner_replica_id(cur) == owner_replica_id(v):
                 self._s[k] = v.encode()
                 return v.encode()
             return cur.encode() if cur else None

--- a/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
@@ -31,7 +31,7 @@ from urllib.parse import urlparse, urlunparse
 
 import asyncpg
 import pytest
-from sqlalchemy import text
+from sqlalchemy import event, text
 from sqlalchemy.ext.asyncio import create_async_engine
 
 import oss.src.models.db_models  # noqa: F401  (register auth/org tables on Base)
@@ -46,7 +46,10 @@ from oss.src.dbs.postgres.sessions.interactions.dbes import (  # noqa: F401
 )
 from oss.src.dbs.postgres.shared.base import Base
 
-from oss.src.core.sessions.streams.dtos import SessionHeartbeatRequest
+from oss.src.core.sessions.streams.dtos import (
+    SessionStreamEdit,
+    SessionStreamFlags,
+)
 from oss.src.utils.env import env
 from oss.src.dbs.postgres.shared.engine import TransactionsEngine
 from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
@@ -462,58 +465,104 @@ async def test_b_lost_turn_clear_persists_after_a_nested_session_close(
 
 
 @pytest.mark.anyio
-async def test_c_heartbeat_finishing_after_sweep_commit_cannot_revive_row(
-    anyio_backend, wd_engine, monkeypatch
+async def test_c_heartbeat_blocked_on_sweep_cannot_revive_collapsed_row(
+    anyio_backend, wd_engine
 ):
-    """Redis refresh wins first; the sweep commits; only then may the heartbeat write."""
-    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
-
+    """A heartbeat whose UPDATE snapshot predates the sweep commit must lose its CAS."""
     session_id = "wd-" + uuid.uuid4().hex[:12]
     turn_id = str(uuid.uuid4())
     project_id = await _seed_scenario(wd_engine, session_id=session_id, turn_id=turn_id)
 
-    heartbeat_waiting = asyncio.Event()
-    allow_heartbeat_write = asyncio.Event()
+    parsed = urlparse(env.postgres.uri_core)
+    dsn = urlunparse(("postgresql", parsed.netloc, parsed.path, "", "", ""))
+    sweep = await asyncpg.connect(dsn=dsn)
+    observer = await asyncpg.connect(dsn=dsn)
+    sweep_transaction = sweep.transaction()
+    heartbeat = None
+    committed = False
+    heartbeat_rowcounts = []
 
-    class _DelayedHeartbeatDAO(SessionStreamsDAO):
-        async def update(self, *, project_id, user_id, session_id, stream):
-            if stream.expected_turn_id is not None:
-                heartbeat_waiting.set()
-                await allow_heartbeat_write.wait()
-            return await super().update(
-                project_id=project_id,
-                user_id=user_id,
-                session_id=session_id,
-                stream=stream,
-            )
+    def capture_heartbeat_rowcount(
+        _connection,
+        clauseelement,
+        _multiparams,
+        _params,
+        _execution_options,
+        result,
+    ):
+        if getattr(clauseelement, "is_update", False):
+            table = getattr(clauseelement, "table", None)
+            if table is not None and table.name == "session_streams":
+                heartbeat_rowcounts.append(result.rowcount)
 
-    lock, records_service, commands_service = _build_services(wd_engine)
-    heartbeat_service = SessionStreamsService(
-        streams_dao=_DelayedHeartbeatDAO(wd_engine), lock_engine=lock
+    event.listen(
+        wd_engine._engine.sync_engine, "after_execute", capture_heartbeat_rowcount
     )
-    heartbeat = asyncio.create_task(
-        heartbeat_service.heartbeat(
-            project_id=project_id,
-            request=SessionHeartbeatRequest(
-                session_id=session_id,
-                replica_id="replica-a",
-                turn_id=turn_id,
-                is_running=True,
-            ),
+    try:
+        await sweep_transaction.start()
+        await sweep.execute(
+            "UPDATE session_streams "
+            "SET flags=$1::jsonb, updated_at=NOW() "
+            "WHERE project_id=$2 AND session_id=$3",
+            '{"is_alive": false, "is_running": false, "is_attached": false}',
+            project_id,
+            session_id,
         )
-    )
-    await heartbeat_waiting.wait()
+        await sweep.execute(
+            "INSERT INTO session_executions "
+            "(project_id, session_id, execution_id, terminal_outcome, settled_by, settled_at) "
+            "VALUES ($1,$2,$3,'lost','watchdog',NOW())",
+            project_id,
+            session_id,
+            turn_id,
+        )
 
-    await orphan_sweep.run_orphan_sweep(
-        wd_engine,
-        lock,
-        records_service=records_service,
-        watch_publisher=None,
-        commands_service=commands_service,
-        publish=_noop_publish,
-    )
-    allow_heartbeat_write.set()
-    heartbeat_result = await heartbeat
+        heartbeat = asyncio.create_task(
+            SessionStreamsDAO(wd_engine).update(
+                project_id=project_id,
+                user_id=None,
+                session_id=session_id,
+                stream=SessionStreamEdit(
+                    flags=SessionStreamFlags(
+                        is_alive=True, is_running=True, is_attached=False
+                    ),
+                    turn_id=turn_id,
+                    expected_turn_id=turn_id,
+                ),
+            )
+        )
+
+        async def heartbeat_is_blocked_on_the_sweep():
+            while True:
+                blocked = await observer.fetchval(
+                    "SELECT EXISTS ("
+                    "SELECT 1 FROM pg_stat_activity "
+                    "WHERE datname=current_database() "
+                    "AND wait_event_type='Lock' "
+                    "AND query LIKE 'UPDATE session_streams%')"
+                )
+                if blocked:
+                    return
+                await asyncio.sleep(0.01)
+
+        await asyncio.wait_for(heartbeat_is_blocked_on_the_sweep(), timeout=5)
+        await sweep_transaction.commit()
+        committed = True
+        heartbeat_result = await asyncio.wait_for(heartbeat, timeout=5)
+    finally:
+        event.remove(
+            wd_engine._engine.sync_engine, "after_execute", capture_heartbeat_rowcount
+        )
+        if heartbeat is not None and not heartbeat.done():
+            heartbeat.cancel()
+            await asyncio.gather(heartbeat, return_exceptions=True)
+        if not committed:
+            await sweep_transaction.rollback()
+        await observer.close()
+        await sweep.close()
+
+    assert heartbeat_result is None
+    assert heartbeat_rowcounts == [0]
 
     async with wd_engine.session() as s:
         flags, outcome = (
@@ -528,7 +577,6 @@ async def test_c_heartbeat_finishing_after_sweep_commit_cannot_revive_row(
             )
         ).one()
 
-    assert heartbeat_result.is_current_turn is False
     assert outcome == "lost"
     assert flags == {
         "is_alive": False,

--- a/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
@@ -89,13 +89,46 @@ class _FakeLock:
     async def expire(self, k, ttl):
         return True
 
-    async def eval(self, script, numkeys, key, value, *args):
-        k = key.decode() if isinstance(key, bytes) else key
-        v = value.decode() if isinstance(value, bytes) else value
+    async def eval(self, script, numkeys, *keys_and_args):
+        def decode(value):
+            return value.decode() if isinstance(value, bytes) else str(value)
+
+        keys = [decode(value) for value in keys_and_args[:numkeys]]
+        argv = [decode(value) for value in keys_and_args[numkeys:]]
+        if "AGENTA_WATCHDOG_RELEASE_TURN" in script:
+            alive, running, owner, superseded = keys
+            expected_turn, expected_owner, _ttl = argv
+            alive_value = decode(self._s[alive]) if alive in self._s else ""
+            running_value = decode(self._s[running]) if running in self._s else ""
+            owner_value = decode(self._s[owner]) if owner in self._s else ""
+            released_alive = int(bool(expected_turn) and alive_value == expected_turn)
+            released_running = int(
+                bool(expected_turn) and running_value == expected_turn
+            )
+            if released_alive:
+                self._s.pop(alive, None)
+            if released_running:
+                self._s.pop(running, None)
+            foreign_turn = (alive_value and alive_value != expected_turn) or (
+                running_value and running_value != expected_turn
+            )
+            released_owner = int(
+                bool(expected_owner)
+                and owner_value == expected_owner
+                and not foreign_turn
+            )
+            if released_owner:
+                self._s.pop(owner, None)
+            if expected_turn:
+                self._s[superseded] = b"1"
+            return [released_alive, released_running, released_owner]
+
+        k = keys[0]
+        v = argv[0]
         cur = self._s.get(k)
         if isinstance(cur, bytes):
             cur = cur.decode()
-        if args:
+        if len(argv) > 1:
             if cur is None or cur == v:
                 self._s[k] = v.encode()
                 return v.encode()
@@ -362,17 +395,14 @@ async def test_a_lost_pass_persists_the_collapse_against_real_postgres(
 
 
 @pytest.mark.anyio
-async def test_b_lost_turn_clear_persists_across_a_nested_session(
+async def test_b_lost_turn_clear_persists_after_a_nested_session_close(
     anyio_backend, wd_engine, monkeypatch
 ):
     """The `newly_lost` is_running clear survives a nested session between load and write.
 
-    Same failure mode as finding 7, one branch up. The sweep loads the row that still names the
-    lost turn, runs its Redis releases, then writes. If any step between the load and the write
-    opens an `engine.session()`, its `finally` closes the shared task-scoped session and
-    detaches the loaded row, and an ORM attribute write on that row is then dropped at commit
-    with no error. `release_alive` is patched here to open exactly such a nested session, which
-    is what a future edit could easily introduce for real.
+    Same failure mode as finding 7, one branch up. The owner lookup is patched to open an
+    `engine.session()`, whose `finally` closes the shared task-scoped session before settlement
+    and the lost-turn update. Core writes must still reopen that session and persist.
 
     This never failed in production: before the fix the write sat immediately after the load,
     with nothing nested in between. The test pins the property rather than a past bug. Make the
@@ -386,18 +416,16 @@ async def test_b_lost_turn_clear_persists_across_a_nested_session(
         wd_engine, session_id=session_id, turn_id=turn_id
     )
 
-    real_release_alive = orphan_sweep.release_alive
+    real_get_owner = orphan_sweep.get_owner
     nested_sessions = []
 
-    async def _release_alive_through_a_nested_session(*args, **kwargs):
+    async def _get_owner_through_a_nested_session(*args, **kwargs):
         # Open and close the shared task-scoped session, exactly as a DAO call would.
         async with wd_engine.session():
             nested_sessions.append(1)
-        return await real_release_alive(*args, **kwargs)
+        return await real_get_owner(*args, **kwargs)
 
-    monkeypatch.setattr(
-        orphan_sweep, "release_alive", _release_alive_through_a_nested_session
-    )
+    monkeypatch.setattr(orphan_sweep, "get_owner", _get_owner_through_a_nested_session)
 
     lock, records_service, commands_service = _build_services(wd_engine)
     await orphan_sweep.run_orphan_sweep(

--- a/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
@@ -1,0 +1,318 @@
+"""The watchdog's collapse must PERSIST against a real Postgres, in the same pass that
+settles the command.
+
+Finding 7 (run 2d, session 6721d762): the sweep logged the collapse, but the row still read
+is_running true afterwards with no other writer. Cause: the collapse mutated ORM row objects
+(`row.flags = ...`), but those objects had been detached from the task-scoped session by the
+nested `engine.session()` calls the pass makes (the records lookup, the command settlement) --
+each opens the SAME current-task-scoped session and closes it in its `finally`. A detached
+object's mutation is tracked by no session, so `session.commit()` never emits the flags
+UPDATE, while the command settle's Core UPDATE (stopping_turn_id) still lands. A unit test
+with fakes cannot catch this: it needs the real async_scoped_session + close semantics, so
+this test drives a real Postgres.
+
+It replays the real pass end to end with the real DAOs on a FRESH, isolated database (created
+per test on the same server, dropped after), so the global sweep sees only the seeded row and
+nothing is polluted. It seeds one alive+running stream naming a turn, one pending Stop for it,
+and a stale heartbeat; runs one real sweep pass; then reads the row back through a fresh
+session and asserts the collapse persisted, the execution was settled lost, and the command
+went obsolete/lost.
+
+Only the SERVER in POSTGRES_URI_CORE is used. The database named in that URI is never written:
+the fixture creates its own and drops it. Point it at any reachable core Postgres, for example
+    cd api && POSTGRES_URI_CORE=postgresql+asyncpg://username:password@localhost:5432/agenta_oss_core \
+        uv run --no-sync pytest oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py -q
+"""
+
+import uuid
+from datetime import datetime, timezone, timedelta
+from urllib.parse import urlparse, urlunparse
+
+import asyncpg
+import pytest
+from sqlalchemy import text
+from sqlalchemy.ext.asyncio import create_async_engine
+
+import oss.src.models.db_models  # noqa: F401  (register auth/org tables on Base)
+
+# Register the session tables on the shared Base so create_all builds them.
+from oss.src.dbs.postgres.sessions.streams.dbes import SessionStreamDBE  # noqa: F401
+from oss.src.dbs.postgres.sessions.executions.dbes import SessionExecutionDBE  # noqa: F401
+from oss.src.dbs.postgres.sessions.commands.dbes import SessionCommandDBE  # noqa: F401
+from oss.src.dbs.postgres.sessions.records.dbes import RecordDBE  # noqa: F401
+from oss.src.dbs.postgres.sessions.interactions.dbes import (  # noqa: F401
+    SessionInteractionDBE,
+)
+from oss.src.dbs.postgres.shared.base import Base
+
+from oss.src.utils.env import env
+from oss.src.dbs.postgres.shared.engine import TransactionsEngine
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
+from oss.src.dbs.postgres.sessions.commands.dao import SessionCommandsDAO
+from oss.src.dbs.postgres.sessions.executions.dao import SessionExecutionsDAO
+from oss.src.dbs.postgres.sessions.interactions.dao import SessionInteractionsDAO
+from oss.src.dbs.postgres.sessions.records.dao import RecordsDAO
+from oss.src.core.sessions.streams.service import SessionStreamsService
+from oss.src.core.sessions.interactions.service import SessionInteractionsService
+from oss.src.core.sessions.commands.service import SessionCommandsService
+from oss.src.core.sessions.records.service import RecordsService
+from oss.src.dbs.http.sessions.control_delivery_direct import DirectControlDelivery
+from oss.src.tasks.asyncio.sessions import orphan_sweep
+
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"
+
+
+class _FakeLock:
+    """In-memory Redis stand-in — the DB persistence is what this test is about."""
+
+    def __init__(self):
+        self._s = {}
+
+    async def get(self, k):
+        return self._s.get(k)
+
+    async def set(self, k, v, nx=False, ex=None):
+        if nx and k in self._s:
+            return None
+        self._s[k] = v
+        return True
+
+    async def delete(self, k):
+        self._s.pop(k, None)
+        return 1
+
+    async def expire(self, k, ttl):
+        return True
+
+    async def eval(self, script, numkeys, key, value, *args):
+        k = key.decode() if isinstance(key, bytes) else key
+        v = value.decode() if isinstance(value, bytes) else value
+        cur = self._s.get(k)
+        if isinstance(cur, bytes):
+            cur = cur.decode()
+        if args:
+            if cur is None or cur == v:
+                self._s[k] = v.encode()
+                return v.encode()
+            return cur.encode() if cur else None
+        if cur == v:
+            self._s.pop(k, None)
+            return 1
+        return 0
+
+
+async def _noop_publish(*, project_id, record_event):
+    return False
+
+
+def _admin_dsn() -> str:
+    parsed = urlparse(env.postgres.uri_core)
+    # asyncpg DSN (no +asyncpg driver tag), connect to the maintenance db.
+    return urlunparse(("postgresql", parsed.netloc, "/postgres", "", "", ""))
+
+
+def _sqlalchemy_url_for(db_name: str) -> str:
+    parsed = urlparse(env.postgres.uri_core)
+    return urlunparse(("postgresql+asyncpg", parsed.netloc, f"/{db_name}", "", "", ""))
+
+
+@pytest.fixture
+async def wd_engine(monkeypatch):
+    """A TransactionsEngine bound to a fresh, isolated database with the full schema."""
+    db_name = f"agenta_wd_rca_{uuid.uuid4().hex[:12]}"
+    admin = await asyncpg.connect(dsn=_admin_dsn())
+    await admin.execute(f'CREATE DATABASE "{db_name}"')
+    await admin.close()
+
+    seed = await asyncpg.connect(dsn=_admin_dsn().replace("/postgres", f"/{db_name}"))
+    for ext in ("pgcrypto", "ltree"):
+        await seed.execute(f'CREATE EXTENSION IF NOT EXISTS "{ext}"')
+    await seed.close()
+
+    # Only the tables this pass touches; the full metadata carries unrelated tables with
+    # foreign keys to modules we do not import here.
+    needed = [
+        Base.metadata.tables[name]
+        for name in (
+            "users",
+            "organizations",
+            "workspaces",
+            "projects",
+            "session_streams",
+            "session_executions",
+            "session_commands",
+            "records",
+            "session_interactions",
+        )
+    ]
+    schema_engine = create_async_engine(_sqlalchemy_url_for(db_name))
+    async with schema_engine.begin() as conn:
+        await conn.run_sync(Base.metadata.create_all, tables=needed)
+    await schema_engine.dispose()
+
+    # Point the real TransactionsEngine at the fresh DB so its exact async_scoped_session +
+    # close semantics (the trigger for the detach bug) are what runs.
+    monkeypatch.setattr(env.postgres, "uri_core", _sqlalchemy_url_for(db_name))
+    engine = TransactionsEngine()
+    try:
+        yield engine
+    finally:
+        await engine.close()
+        admin = await asyncpg.connect(dsn=_admin_dsn())
+        await admin.execute(
+            "SELECT pg_terminate_backend(pid) FROM pg_stat_activity "
+            "WHERE datname=$1 AND pid<>pg_backend_pid()",
+            db_name,
+        )
+        await admin.execute(f'DROP DATABASE IF EXISTS "{db_name}"')
+        await admin.close()
+
+
+async def _seed_scenario(engine, *, session_id, turn_id):
+    project_id = uuid.uuid4()
+    stale = datetime.now(timezone.utc) - timedelta(hours=1)
+    async with engine.session() as s:
+        uid, org, ws = uuid.uuid4(), uuid.uuid4(), uuid.uuid4()
+        await s.execute(
+            text("INSERT INTO users (id, uid, username, email) VALUES (:i,:u,:n,:e)"),
+            {"i": uid, "u": str(uid), "n": "wd", "e": f"wd-{uid.hex[:8]}@e.com"},
+        )
+        await s.execute(
+            text("INSERT INTO organizations (id, name, owner_id) VALUES (:i,:n,:o)"),
+            {"i": org, "n": "wd", "o": uid},
+        )
+        await s.execute(
+            text(
+                "INSERT INTO workspaces (id, name, organization_id) VALUES (:i,:n,:o)"
+            ),
+            {"i": ws, "n": "wd", "o": org},
+        )
+        await s.execute(
+            text(
+                "INSERT INTO projects (id, project_name, organization_id, workspace_id) "
+                "VALUES (:i,:n,:o,:w)"
+            ),
+            {"i": project_id, "n": "wd", "o": org, "w": ws},
+        )
+        await s.execute(
+            text(
+                "INSERT INTO session_streams "
+                "(id, project_id, session_id, turn_id, flags, stopping_turn_id, created_at, updated_at) "
+                "VALUES (:i,:p,:s,:t, CAST(:f AS JSONB), :st, :c, :u)"
+            ),
+            {
+                "i": uuid.uuid4(),
+                "p": project_id,
+                "s": session_id,
+                "t": turn_id,
+                "f": '{"is_alive": true, "is_running": true, "is_attached": false}',
+                "st": turn_id,
+                "c": stale,
+                "u": stale,
+            },
+        )
+        await s.execute(
+            text(
+                "INSERT INTO session_commands "
+                "(id, project_id, session_id, kind, target_turn_id, state, claim_count, created_at) "
+                "VALUES (:i,:p,:s,'cancel',:t,'pending',0,:c)"
+            ),
+            {
+                "i": uuid.uuid4(),
+                "p": project_id,
+                "s": session_id,
+                "t": turn_id,
+                "c": stale,
+            },
+        )
+        await s.commit()
+    return project_id
+
+
+def _build_services(engine):
+    lock = _FakeLock()
+    streams_service = SessionStreamsService(
+        streams_dao=SessionStreamsDAO(engine), lock_engine=lock
+    )
+    interactions_service = SessionInteractionsService(
+        interactions_dao=SessionInteractionsDAO(engine)
+    )
+    executions_dao = SessionExecutionsDAO(engine)
+    commands_service = SessionCommandsService(
+        commands_dao=SessionCommandsDAO(engine),
+        streams_service=streams_service,
+        interactions_service=interactions_service,
+        lock_engine=lock,
+        delivery=DirectControlDelivery(),
+        executions_dao=executions_dao,
+    )
+    records_service = RecordsService(RecordsDAO(engine), executions_dao)
+    return lock, records_service, commands_service
+
+
+@pytest.mark.anyio
+async def test_a_lost_pass_persists_the_collapse_against_real_postgres(
+    anyio_backend, wd_engine, monkeypatch
+):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+
+    session_id = "wd-" + uuid.uuid4().hex[:12]
+    turn_id = str(uuid.uuid4())
+    await _seed_scenario(wd_engine, session_id=session_id, turn_id=turn_id)
+
+    lock, records_service, commands_service = _build_services(wd_engine)
+    await orphan_sweep.run_orphan_sweep(
+        wd_engine,
+        lock,
+        records_service=records_service,
+        watch_publisher=None,
+        commands_service=commands_service,
+        publish=_noop_publish,
+    )
+
+    # Read back through a FRESH session so the assertions see committed DB state, not any
+    # in-memory ORM object the pass held.
+    async with wd_engine.session() as s:
+        flags, stopping = (
+            await s.execute(
+                text(
+                    "SELECT flags, stopping_turn_id FROM session_streams WHERE session_id=:s"
+                ),
+                {"s": session_id},
+            )
+        ).one()
+        ex = (
+            await s.execute(
+                text(
+                    "SELECT terminal_outcome, settled_by FROM session_executions "
+                    "WHERE session_id=:s AND execution_id=:t"
+                ),
+                {"s": session_id, "t": turn_id},
+            )
+        ).one_or_none()
+        cmd = (
+            await s.execute(
+                text(
+                    "SELECT state, outcome FROM session_commands "
+                    "WHERE session_id=:s AND target_turn_id=:t"
+                ),
+                {"s": session_id, "t": turn_id},
+            )
+        ).one()
+
+    # The collapse persisted: this is the finding-7 assertion.
+    assert flags["is_alive"] is False
+    assert flags["is_running"] is False
+    assert stopping is None
+    # The execution reached its durable terminal outcome, settled by the watchdog.
+    assert ex is not None
+    assert ex[0] == "lost"
+    assert ex[1] == "watchdog"
+    # The Stop command was settled, not left pending.
+    assert cmd[0] == "obsolete"
+    assert cmd[1] == "lost"

--- a/api/oss/tests/pytest/unit/sessions/test_watchdog_lifespan_wiring.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watchdog_lifespan_wiring.py
@@ -1,0 +1,50 @@
+import asyncio
+import importlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_lifespan_wires_the_commands_service_into_the_watchdog(monkeypatch):
+    with patch("alembic.script.ScriptDirectory.from_config", return_value=object()):
+        routers = importlib.import_module("entrypoints.routers")
+
+    transactions_engine = SimpleNamespace(close=AsyncMock())
+    monkeypatch.setattr(routers, "_transactions_engine", transactions_engine)
+    monkeypatch.setattr(
+        routers, "_analytics_engine", SimpleNamespace(close=AsyncMock())
+    )
+    monkeypatch.setattr(routers, "_streams_engine", SimpleNamespace(close=AsyncMock()))
+    monkeypatch.setattr(routers, "_lock_engine", object())
+    monkeypatch.setattr(
+        routers,
+        "_triggers_broker",
+        SimpleNamespace(startup=AsyncMock(), shutdown=AsyncMock()),
+    )
+    monkeypatch.setattr(routers, "_composio_adapters", {})
+    monkeypatch.setattr(routers, "_composio_connections_adapters", {})
+    monkeypatch.setattr(routers, "_composio_triggers_adapters", {})
+    monkeypatch.setattr(routers.env.store, "bucket", None)
+    monkeypatch.setattr(routers.env, "composio", SimpleNamespace(enabled=False))
+    monkeypatch.setattr(routers, "check_for_new_core_migrations", AsyncMock())
+    monkeypatch.setattr(routers, "check_for_new_tracing_migrations", AsyncMock())
+    monkeypatch.setattr(routers, "warn_deprecated_env_vars", lambda: None)
+    monkeypatch.setattr(routers, "validate_required_env_vars", lambda: None)
+    monkeypatch.setattr(routers, "validate_platform_runtime_key", lambda: None)
+
+    watchdog = AsyncMock()
+    monkeypatch.setattr(routers, "orphan_sweep_loop", watchdog)
+    monkeypatch.setattr(routers, "attachment_sweep_loop", AsyncMock())
+
+    async with routers.lifespan():
+        await asyncio.sleep(0)
+        watchdog.assert_awaited_once_with(
+            transactions_engine,
+            routers._lock_engine,
+            records_service=routers.records_service,
+            watch_publisher=routers._sessions_watch_publisher,
+            commands_service=routers.session_commands_service,
+        )
+        assert routers.session_commands_service is not None

--- a/api/oss/tests/pytest/unit/test_multilogger.py
+++ b/api/oss/tests/pytest/unit/test_multilogger.py
@@ -1,0 +1,46 @@
+"""MultiLogger must expose `exception`, like the stdlib logger.
+
+The application logger returned by `get_module_logger` is a `MultiLogger`. It used to define
+every level method except `exception`, so `log.exception(...)` -- the natural call inside an
+`except` block -- raised AttributeError from inside the handler and took the caller down. The
+execution watchdog died exactly this way. These tests hold the contract that closed that gap:
+the method exists, it does not raise when called from an `except` block, and it forwards to
+the wrapped logger's `error` with the active traceback.
+"""
+
+from oss.src.utils.logging import MultiLogger, get_module_logger
+
+
+class _Spy:
+    """A stand-in wrapped logger that records the `error` calls MultiLogger forwards to it."""
+
+    def __init__(self):
+        self.calls = []
+
+    def error(self, *args, **kwargs):
+        self.calls.append((args, kwargs))
+
+
+def test_multilogger_has_an_exception_method():
+    assert hasattr(MultiLogger(), "exception")
+
+
+def test_real_module_logger_exposes_exception():
+    log = get_module_logger(__name__)
+    assert hasattr(log, "exception")
+
+
+def test_exception_from_an_except_block_does_not_raise_and_logs_with_traceback():
+    spy = _Spy()
+    log = MultiLogger(spy)
+
+    try:
+        raise RuntimeError("boom")
+    except RuntimeError:
+        # Before the fix this raised AttributeError instead of logging.
+        log.exception("something failed")
+
+    assert spy.calls, "exception() must forward to the wrapped logger's error()"
+    args, kwargs = spy.calls[0]
+    assert args[0] == "something failed"
+    assert kwargs.get("exc_info") is True

--- a/docs/design/session-control-and-live-events/slice-watchdog.md
+++ b/docs/design/session-control-and-live-events/slice-watchdog.md
@@ -1,0 +1,384 @@
+# Slice: the execution watchdog
+
+Branch `feat/session-execution-watchdog`. Commits `59fb1a7864` and `5bbd5a36df`.
+
+This slice makes one RFC requirement true: **every accepted execution reaches exactly one
+durable terminal outcome within a bounded time** (`requirements.md:36`, D-016 at
+`decisions.md:129-139`). It adds no table, no transport, and no new subsystem.
+
+## What happens today
+
+A turn can run out of ways to end.
+
+The runner writes its terminal record downstream of `await run(...)`
+(`services/runner/src/server.ts:622`), and releases its alive watchdog in the `finally` around
+that same await (`services/runner/src/server.ts:618`). Both are correct on every path where
+`run()` returns. Neither happens when it does not. An await inside the run that never settles
+leaves the heartbeat announcing `running=true` every thirty seconds for good, and each beat
+re-arms a Redis lease whose TTL is an hour.
+
+The user sees a session that is running, refuses a new message, and never finishes. The only
+exits were the thirty-minute idle threshold and pressing Stop.
+
+Three ways in, all reported:
+
+- The sandbox dies under the turn ([#6418](https://github.com/Agenta-AI/agenta/issues/6418)).
+  Verified: the agent-to-client half of the ACP channel is a long-lived SSE `GET`; when the peer
+  dies the transport's read loop swallows the severed stream and never fails the readable
+  (`services/runner/node_modules/acp-http-client/dist/index.js:335-339`), so the pending
+  `session/prompt` request is structurally incapable of settling.
+- The runner itself is gone: a container restart, a crash, an OOM kill. Nothing on the runner
+  can write an outcome, because there is no runner.
+- A write failure is swallowed and the turn beats on
+  ([#6100](https://github.com/Agenta-AI/agenta/issues/6100),
+  [#5327](https://github.com/Agenta-AI/agenta/issues/5327),
+  [#6099](https://github.com/Agenta-AI/agenta/issues/6099)).
+
+The existing run limits do not cover these. Time-to-first-byte (2 min) catches a sandbox that
+dies before the first token and idle (30 min) catches one that dies mid-stream, but
+`notePaused()` retires every timer permanently the moment a turn parks for a human
+(`services/runner/src/engines/sandbox_agent/run-limits.ts:207-210`) — which is exactly when a
+long turn is most likely to outlive its sandbox. Verified.
+
+An embryonic watchdog already existed. `orphan_sweep.py` found stale rows and cleared their
+Redis nest, but it wrote nothing to the transcript and told no open browser, so a swept
+session's conversation simply stopped mid-turn. Verified before this change.
+
+## What this slice changes
+
+Two halves. Either one alone leaves a hole, because the runner cannot report an outcome when it
+is gone, and the platform cannot see a dead sandbox under a runner that is still beating.
+
+### API: settle an execution whose runner cannot report one
+
+`api/oss/src/tasks/asyncio/sessions/orphan_sweep.py`, extended rather than duplicated. A second
+job scanning the same rows would race this one: whichever collapsed the flags first would hide
+the row from the other, and the terminal record would sometimes never be written.
+
+For each stale row that claims a running turn, in this order:
+
+1. Write the two records the dead runner owed, `_lost_turn_records` at `orphan_sweep.py:112`.
+2. Collapse the row's flags so the session reads as ended.
+3. Clear the Redis nest and tombstone the turn, so a late beat cannot re-nest it.
+4. Publish the watch notification on the session channel and the project channel.
+
+Step 1 is deliberately first. A crash between the steps leaves the row a candidate for the next
+pass, which is recoverable; collapsing the flags first would hide the row forever with no
+ending ever written.
+
+**The records mirror the runner's own error path exactly**: an `error` event carrying the class
+a client can act on, then the terminal `done`. A lone `done` would render as a clean finish,
+which is the opposite of what happened. The message is character-for-character the runner's
+`EXECUTION_LOST_MESSAGE`, so one outcome never reaches the user in two wordings.
+
+**Idempotent twice over.** A stable `uuid5` per (turn, record) (`orphan_sweep.py:94`) means the
+ingest upsert writes the same two rows however many passes or replicas see the turn. And
+`RecordsDAO.settled_turns` (`api/oss/src/dbs/postgres/sessions/records/dao.py:233`) asks, in one
+query per project, which turns already carry a terminal record — because a runner can die
+*after* writing its outcome but *before* its final `is_running=false` beat lands. That turn is
+already settled; its row still needs collapsing, but a second, contradictory ending would
+corrupt the transcript. The records table lives in the tracing database and the stream rows in
+the core database, so this is a two-phase read, never a join.
+
+If that lookup fails, the pass writes nothing and still collapses the row. Saying nothing is
+better than inventing a second ending.
+
+### Runner: never wait on a run forever
+
+`services/runner/src/sessions/turn-settle.ts` (new). `awaitTurnOrAbandon` wraps the run in
+`server.ts`. It waits normally, and gives up when the platform says the turn is no longer
+current, or when the hard deadline elapses. Giving up is two steps: `abort()` first, because
+most hangs do unwind from an abort, and only if the run is still pending after the grace window
+does the request write the outcome itself and stop waiting.
+
+This closes the loop with the API half. When the watchdog settles a turn it tombstones it, so
+the wedged runner's next heartbeat answers `is_current_turn: false`, which already aborts the
+run (`services/runner/src/sessions/alive.ts:207`). Where that abort lands somewhere the signal
+is observed, the turn ends cleanly. Where it does not, the grace window ends the request anyway.
+
+`services/runner/src/engines/sandbox_agent/sandbox-liveness.ts` (new) covers the case the API
+cannot see: a dead sandbox under a runner that is still beating happily. It probes the daemon's
+own health route, a different socket from the wedged ACP channel, and trips the existing
+run-limit path after three consecutive failures. Any HTTP status counts as alive, 401 and 404
+included: the question is whether something is listening, and only a transport failure answers
+it.
+
+The turn is closed to further events once the request has written its outcome
+(`services/runner/src/server.ts`, the `gatedEmit` wrapper). An abandoned run that unwinds
+minutes later must not append a second ending.
+
+The heartbeat itself gained a request timeout and an in-flight guard
+(`services/runner/src/sessions/alive.ts`). Both beats used a bare `fetch` with no signal, so a
+stalled socket never settled: beats piled up behind it, and the final beat in `release()` could
+hold the whole request open after the turn had ended.
+
+### Web
+
+Two small changes, both found by tracing what a browser does when the records land.
+
+- `execution_lost` joins `RETRYABLE_CODES`
+  (`web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx:154`). The retry wiring
+  already existed; the code was simply in no branch, so the failed turn offered no action.
+- The desktop watch now listens for `lifecycle`
+  (`web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts`). It previously
+  registered only `ready`, `records-changed` and `interaction`, so the watchdog's `ended` event
+  was received by the EventSource and discarded, and the session kept *looking* alive until the
+  next fifteen-second liveness poll. Mobile already did this.
+
+The error itself needed no frontend change: the replay adapter already folds
+`{type: "error", message, code}` onto the interrupted turn and `done` already closes it.
+
+## The timeouts, and how to change them
+
+Every value is a setting. Nothing here needs a redesign to tune.
+
+| Setting | Default | Environment variable |
+|---|---|---|
+| Grace past one heartbeat before a running turn is lost | 90 s | `AGENTA_SESSIONS_WATCHDOG_GRACE_SECONDS` |
+| Grace before an alive-but-idle row is settled | 1800 s | `AGENTA_SESSIONS_WATCHDOG_IDLE_GRACE_SECONDS` |
+| How often the watchdog runs | 60 s | `AGENTA_SESSIONS_WATCHDOG_INTERVAL_SECONDS` |
+| Rows settled per pass | 500 | `AGENTA_SESSIONS_WATCHDOG_BATCH_SIZE` |
+| Sandbox probe interval | 30 s | `AGENTA_RUNNER_SANDBOX_PROBE_INTERVAL_MS` |
+| Sandbox probe timeout | 10 s | `AGENTA_RUNNER_SANDBOX_PROBE_TIMEOUT_MS` |
+| Consecutive probe failures before the sandbox is declared gone | 3 | `AGENTA_RUNNER_SANDBOX_PROBE_FAILURES` |
+| Hard per-turn deadline | 11.5 h | `AGENTA_RUNNER_TURN_HARD_DEADLINE_MS` |
+| Grace after an abort before the request stops waiting | 60 s | `AGENTA_RUNNER_TURN_ABANDON_GRACE_MS` |
+| Heartbeat request timeout | 15 s | `AGENTA_RUNNER_HEARTBEAT_TIMEOUT_MS` |
+
+Definitions live in `api/oss/src/utils/env.py:564` (`SessionWatchdogConfig`),
+`services/runner/src/engines/sandbox_agent/sandbox-liveness.ts` and
+`services/runner/src/sessions/turn-settle.ts`.
+
+Two of these deserve their reasoning stated.
+
+**The running threshold is one heartbeat interval plus the grace, so 120 seconds by default.**
+It was a flat 300 seconds. Five minutes was defensible for a sweep that only collapsed flags;
+it is too long to make a user watch a dead turn now that the sweep writes a real ending. 120
+seconds is three missed beats. Raise the grace if a healthy deployment ever settles a live turn.
+
+**The hard per-turn deadline sits ABOVE the longest legitimate run, not below it.** The run
+limits already own when a real turn should stop, and users have asked for longer runs, not
+shorter ones ([#6084](https://github.com/Agenta-AI/agenta/issues/6084),
+[#5356](https://github.com/Agenta-AI/agenta/issues/5356)). A turn that reaches this deadline is
+one whose own limits already tripped and failed to end it. `AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS`
+is unchanged.
+
+## Tests
+
+**API**, `api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py`, 8 tests, all passing.
+A lost turn gets an `error` then a `done`; a second pass writes no second ending; record ids are
+stable across passes; an idle row owes no ending; a running row with no turn id is settled
+silently; open readers are told the session ended; the Redis nest follows the settled row; a
+failed lookup never invents an ending.
+
+The existing `test_orphan_sweep_thresholds.py` and `test_orphan_sweep_clears_redis.py` still
+pass. Their fixtures gained the `turn_id` column, and the threshold assertion now names 120
+seconds with the reason written down.
+
+**Runner**, vitest, 14 tests, all passing.
+`services/runner/tests/unit/sandbox-liveness.test.ts` (6): the threshold of consecutive
+failures, tolerance of a single blip, a probe that *hangs* counted as a failure, and firing at
+most once and never after dispose. `services/runner/tests/unit/turn-settle.test.ts` (8): the
+happy path leaves no timer armed, a rejecting run still reaches the caller's own catch, an
+interruption aborts first, a run that will not unwind hands back a reason, the hard deadline
+works with no interruption signal at all, and an abort that throws does not break the settle.
+
+Full suites: `services/runner` 2642 unit tests pass. `api/oss/tests/pytest/unit/sessions` 333
+pass. 11 modules in that directory error on import with
+`cannot import name 'InvalidHarnessKindError' from 'agenta.sdk.agents'`; that is pre-existing,
+confirmed by running the same command on the unmodified tree, and comes from borrowing the main
+checkout's virtual environment, whose SDK is installed from a different tree.
+
+Commands:
+
+```
+cd services/runner && pnpm exec vitest run --project unit
+cd api && PYTHONPATH=$PWD python -m pytest oss/tests/pytest/unit/sessions/ -q
+```
+
+## Live verification
+
+Stack: `agenta-ee-dev-session-watchdog` at **http://144.76.237.122:8880**, EE, dev images,
+local sandbox provider, its own Postgres on 5442. Deployed from this worktree at commit
+`59fb1a7864`; the runner picked up `5bbd5a36df` by hot reload. Images were 40 minutes old at
+deploy time, so `--build` was skipped as the brief allows.
+
+### Scenario A: the runner is gone
+
+A turn was opened by beating `POST /sessions/streams/heartbeat` once with
+`is_running: true` — the runner's only liveness contribution — and then going silent, which is
+byte-for-byte what a runner that died produces.
+
+Before: the Redis lease had 3586 seconds left, a second turn asking for the session got
+`is_current_turn = False`, and the session had zero records.
+
+```
+2026-09-02T21:26:29.624Z [WARN.] watchdog: settled a session_stream whose runner went silent
+  extra={'session_id': 'wd-scenario-a-161c2d24',
+         'stream_id': '01a06402-25b6-7072-97ea-9164efb69baf',
+         'turn_id': 'e79207c5-813c-4913-98b8-a12d244afefb', 'lost': True}
+2026-09-02T21:26:29.643Z [INFO.] watchdog: settled 1 sessions (1 turns marked lost)
+```
+
+The row was created at 21:24:17 and settled at 21:26:29, so 132 seconds: the 120-second
+threshold plus part of one sweep interval.
+
+After, all four verified by reading the stores:
+
+| Check | Result |
+|---|---|
+| Records for the turn | `error` (`code: execution_lost`) at `21:26:29.623`, then `done` at `21:26:29.624` |
+| Stream row flags | `is_alive: false, is_running: false, is_attached: false` |
+| Redis `alive` / `running` / `owner` | all empty |
+| Redis `superseded:...:turn:<lost turn>` | `1` |
+| A new turn on the same session | `is_current_turn = True` |
+
+### Scenario A2: the runner wrote its outcome but lost its final beat
+
+The idempotency guard, on a real deployment. A turn was opened, the runner's own `done` record
+was ingested, and the beating stopped.
+
+```
+2026-09-02T21:29:29.654Z [WARN.] watchdog: settled a session_stream whose runner went silent
+  extra={'session_id': 'wd-already-settled-4863aef0', ..., 'lost': False}
+2026-09-02T21:29:29.663Z [INFO.] watchdog: settled 2 sessions (1 turns marked lost)
+```
+
+`lost: False`, and the session still holds exactly one record: the runner's own `done`. The row
+was collapsed and the Redis nest cleared, with no second ending invented. The other session
+settled in the same pass was a genuinely different lost turn, and it got its own single
+`error` + `done` pair.
+
+### Scenario B: the sandbox dies under the turn
+
+A real agent turn on the local sandbox provider (codex harness, OpenAI through the vault), asked
+to run `sleep 240`. Once the tool call was in flight, the sandbox's process group was killed
+from outside the runner.
+
+The kill produced exactly the reported failure shape, and this is what made the first attempt
+worth having:
+
+```
+Error: connect ECONNREFUSED 127.0.0.1:35171
+  at async StreamableHttpAcpTransport.postMessage (acp-http-client/src/index.ts:406:21)
+[sandbox-agent] unhandledRejection: TypeError: fetch failed
+[sessions/alive] heartbeat OK session=wd-sandbox-gone-3eb8bb02 turn=0bc24bf1... running=true
+```
+
+The ACP socket was refusing every write while the heartbeat kept reporting the turn as running,
+and the turn never ended. **The first version of the probe did not catch it**, because it called
+`SandboxAgent.getSession()`, which reads a local persist driver and never touches the daemon —
+so it answered happily while the sandbox was dead. That is fixed in `5bbd5a36df` and written
+into the module docstring so nobody reaches for it again.
+
+Re-run with the corrected probe. The sandbox was killed at 21:32:08, mid tool call:
+
+```
+[sandbox-agent] [sandbox-liveness] probe failed (1/3): fetch failed
+[sessions/alive] heartbeat OK session=wd-sandbox-gone-75399fc3 turn=c682ebb5... running=true
+[sandbox-agent] [sandbox-liveness] probe failed (2/3): fetch failed
+[sessions/alive] heartbeat OK session=wd-sandbox-gone-75399fc3 turn=c682ebb5... running=true
+[sandbox-agent] [sandbox-liveness] probe failed (3/3): fetch failed
+[sandbox-agent] [sandbox-liveness] sandbox is gone: 3 consecutive liveness probes failed (last: fetch failed)
+[sessions/alive] heartbeat OK session=wd-sandbox-gone-75399fc3 turn=c682ebb5... running=false
+```
+
+The turn ended at 21:33:30, 82 seconds after the kill, and the last line is the point of the
+whole exercise: the beat that used to say `running=true` for ever now says `running=false` once
+and stops.
+
+The client's stream carried a real ending rather than closing on a broken pipe:
+
+```
+error:  {"type": "error", "errorText": "The sandbox running this session stopped responding,
+         so the run was ended. Send the message again to start a fresh sandbox."}
+finish: {"type": "finish", "messageMetadata": {...}}
+```
+
+And the durable transcript for that turn, read back from the records endpoint:
+
+| Record | Content |
+|---|---|
+| `message` | the user's prompt |
+| `message` | "I'm running the command and will report its output when it completes." |
+| `tool_call` | `sleep 240 && echo finished` |
+| `usage` | the turn's token accounting |
+| `error` | `code: sandbox_gone`, with the line above |
+| `done` | terminal |
+
+The stream row ended as `is_alive: true, is_running: false`. That is the intended result and not
+an oversight: the turn is over, and the session stays alive and reattachable. Only the runner
+being gone entirely makes a session not alive.
+
+Without this change the same kill produced, and stopped at, this — captured on the first attempt:
+
+```
+Error: connect ECONNREFUSED 127.0.0.1:35171
+[sandbox-agent] unhandledRejection: TypeError: fetch failed
+[sessions/alive] heartbeat OK session=... running=true      <- for ever
+```
+
+### Reproducing it
+
+```bash
+docker exec agenta-ee-dev-session-watchdog-runner-1 sh -c 'ps -eo pid,args | grep "[s]andbox-agent server"'
+docker exec agenta-ee-dev-session-watchdog-runner-1 sh -c 'kill -9 -<pid>'
+docker logs -f agenta-ee-dev-session-watchdog-runner-1 2>&1 | grep -E "sandbox-liveness|turn-settle"
+docker logs -f agenta-ee-dev-session-watchdog-api-1 2>&1 | grep -i watchdog
+```
+
+The stack is left running. To tear it down:
+
+```bash
+cd /home/mahmoud/code/agenta-2-worktrees/slice-watchdog
+set -a && . hosting/docker-compose/ee/.env.ee.dev.watchdog && set +a
+bash ./hosting/docker-compose/run.sh --license ee --dev --env-file .env.ee.dev.watchdog --no-tunnel --down
+```
+
+The env file `hosting/docker-compose/ee/.env.ee.dev.watchdog` is gitignored and holds a
+stack-local `AGENTA_SERVICES_INTERNAL_KEY` and the QA OpenAI key is in the stack's vault, not in
+the repository.
+
+## What this slice does not do
+
+- It does not change `shouldPark` or any teardown rule. An abandoned run keeps its environment
+  and still runs its own teardown if it ever unwinds. Reclaiming machines stays with the
+  keep-alive pool.
+- It does not close the turns ledger. `session_turns.end_time` still stays NULL on a lost turn.
+  `SessionTurnsDAO.complete` is idempotent and safe to call, but it needs the turn index, which
+  is an extra read per row, and nothing in the transcript depends on it.
+- It does not hold a distributed lock across API replicas, because deterministic record ids make
+  a concurrent pass harmless rather than merely unlikely. Two replicas would each do the work;
+  neither would write a duplicate.
+- It does not fix the originating tab. `refreshFromRecords` deliberately early-returns while the
+  tab is busy, so a tab holding an open-but-dead HTTP stream ignores the watchdog's records until
+  its own stream errors. Other tabs and a reload see the settled turn immediately.
+
+## Open questions for Mahmoud
+
+1. **Is 120 seconds the right time to declare a turn lost?** *Recommendation: ship it and watch.*
+   It is three missed heartbeats, and it is now a setting rather than a constant, so a wrong
+   answer costs a restart. The old 300 was chosen when the sweep only collapsed flags and nobody
+   saw the result.
+
+2. **Should the watchdog also close the turns ledger?** *Recommendation: not in this slice.*
+   `session_turns.end_time` stays NULL on a lost turn, which is a real inconsistency, but nothing
+   reads it for the transcript and closing it costs a query per row. Worth doing when something
+   actually reports on turn durations.
+
+3. **Should the sandbox probe run on Daytona too, given it cannot tell a deleted sandbox from a
+   proxy error?** *Recommendation: yes, leave it on.* It is a strict improvement where the proxy
+   does refuse, it costs one request per turn per thirty seconds, and the API watchdog is the
+   backstop where the proxy answers for a sandbox that is gone.
+
+4. **Does a lost turn deserve a distinct look in the transcript, rather than the same red
+   callout as a model failure?** *Recommendation: leave it as it is for now.* The copy and the
+   Try again button say the useful part, and a new visual state is worth designing only once we
+   know how often users see this.
+
+5. **The runner's SSE read loop swallows a severed stream instead of failing the pending
+   request** (`acp-http-client/dist/index.js:335-339`). That is the true root cause of
+   [#6418](https://github.com/Agenta-AI/agenta/issues/6418), and this slice bounds it rather than
+   fixing it. *Recommendation: raise it upstream rather than growing the local patch.* The patch
+   file already carries four changes, and a fifth in the read path is the kind that breaks
+   quietly on the next version bump.

--- a/docs/design/session-control-and-live-events/slice-watchdog.md
+++ b/docs/design/session-control-and-live-events/slice-watchdog.md
@@ -397,10 +397,12 @@ command in the same loop that settles its execution.
 
 ## Open questions for Mahmoud
 
-1. **Is 120 seconds the right time to declare a turn lost?** *Recommendation: ship it and watch.*
-   It is three missed heartbeats, and it is now a setting rather than a constant, so a wrong
-   answer costs a restart. The old 300 was chosen when the sweep only collapsed flags and nobody
-   saw the result.
+1. **Is 90 seconds of heartbeat silence the right time to declare a turn lost?**
+   *Recommendation: ship it and watch.* It is three missed beats at the runner's 30-second
+   cadence, and it is a setting rather than a constant, so a wrong answer costs a restart rather
+   than a redesign. The old 300 was chosen when the sweep only collapsed flags and nobody saw the
+   result. The risk to watch for is the opposite of the obvious one: not settling a turn too
+   late, but settling a live turn whose runner was merely slow to beat.
 
 2. **Should the watchdog also close the turns ledger?** *Recommendation: not in this slice.*
    `session_turns.end_time` stays NULL on a lost turn, which is a real inconsistency, but nothing

--- a/docs/design/session-control-and-live-events/slice-watchdog.md
+++ b/docs/design/session-control-and-live-events/slice-watchdog.md
@@ -261,6 +261,41 @@ After, all four verified by reading the stores:
 | Redis `superseded:...:turn:<lost turn>` | `1` |
 | A new turn on the same session | `is_current_turn = True` |
 
+### Scenario A1: re-run at the 90-second threshold, beside a parked approval
+
+Run again after the threshold changed from 120 seconds to 90, on a redeployed stack, with two
+sessions opened in the same second so the two rules are tested against each other:
+
+- one turn beating `is_running: true` and then going silent, which is a runner that died;
+- one turn sending a final beat with `is_running: false` and then going silent on purpose,
+  which is a turn parked for a human.
+
+Both were opened at 21:56:24. The constants in the running container, read from the live process:
+
+```
+running threshold (heartbeat age): 90 seconds
+idle threshold: 1800 seconds
+sweep interval: 60 seconds
+```
+
+```
+2026-09-02T21:58:02.911Z [WARN.] watchdog: settled a session_stream whose runner went silent
+  extra={'session_id': 'wd-90s-cdb259fb', ..., 'lost': True}
+2026-09-02T21:58:02.926Z [INFO.] watchdog: settled 1 sessions (1 turns marked lost)
+```
+
+One session, not two. 98 seconds from the last beat, which is the 90-second threshold plus the
+part of a sweep interval that had still to run.
+
+| Session | Records written | Row after |
+|---|---|---|
+| Runner died | `error` (`code: execution_lost`), then `done` | `is_alive: false, is_running: false` |
+| Parked for a human | none | `is_alive: true, is_running: false` |
+
+The parked session kept its warm, resumable state and was given no ending, while sitting on a
+heartbeat that had been stale for the same 98 seconds. That is the whole point of eligibility
+resting on `is_running` rather than on silence alone.
+
 ### Scenario A2: the runner wrote its outcome but lost its final beat
 
 The idempotency guard, on a real deployment. A turn was opened, the runner's own `done` record

--- a/docs/design/session-control-and-live-events/slice-watchdog.md
+++ b/docs/design/session-control-and-live-events/slice-watchdog.md
@@ -46,8 +46,20 @@ session's conversation simply stopped mid-turn. Verified before this change.
 
 ## What this slice changes
 
-Two halves. Either one alone leaves a hole, because the runner cannot report an outcome when it
-is gone, and the platform cannot see a dead sandbox under a runner that is still beating.
+Two halves, and **they close different bugs**. Neither one alone is enough, and it is worth
+being precise about which does what, because the obvious reading is wrong.
+
+| Failure | Detected by | Why the other half cannot |
+|---|---|---|
+| The sandbox dies under the turn ([#6418](https://github.com/Agenta-AI/agenta/issues/6418)) | The runner's sandbox liveness probe | The runner is healthy and keeps beating, so its heartbeat never goes stale and the API scan never sees the row |
+| The runner is gone: restart, crash, OOM | The API watchdog | There is no runner left to detect anything |
+
+**The API watchdog does not close [#6418](https://github.com/Agenta-AI/agenta/issues/6418), and
+cannot.** It keys off heartbeat age, and a wedged turn's own heartbeat stays perfectly fresh —
+only the machine underneath is gone. The runner-side probe is what closes that one, and it is
+proved live in Scenario B below. This was flagged from the Stop map before the work started and
+it held up in the live test: at the moment of the kill the runner logged `ECONNREFUSED` on the
+ACP socket and `heartbeat OK ... running=true` in the same second.
 
 ### API: settle an execution whose runner cannot report one
 
@@ -82,6 +94,15 @@ the core database, so this is a two-phase read, never a join.
 
 If that lookup fails, the pass writes nothing and still collapses the row. Saying nothing is
 better than inventing a second ending.
+
+**Only a turn that still claims `is_running` is eligible**, and that is what protects a parked
+approval. A turn that parks for a human sends one final beat with `is_running: false`
+(`services/runner/src/sessions/alive.ts:241-252`) and then stops beating on purpose, so its
+heartbeat goes stale within seconds. It is also the state we most need to keep: the sandbox is
+warm and the user is about to answer. Such a row never becomes a candidate for a terminal
+record however long it sits. It is still reclaimed after thirty minutes, which is the
+pre-existing sweep behaviour keyed to the approval TTL, but no ending is written for it.
+Pinned by `test_a_parked_approval_is_never_settled`.
 
 ### Runner: never wait on a run forever
 
@@ -134,7 +155,7 @@ Every value is a setting. Nothing here needs a redesign to tune.
 
 | Setting | Default | Environment variable |
 |---|---|---|
-| Grace past one heartbeat before a running turn is lost | 90 s | `AGENTA_SESSIONS_WATCHDOG_GRACE_SECONDS` |
+| Heartbeat age before a running turn is lost | 90 s | `AGENTA_SESSIONS_WATCHDOG_STALE_HEARTBEAT_SECONDS` |
 | Grace before an alive-but-idle row is settled | 1800 s | `AGENTA_SESSIONS_WATCHDOG_IDLE_GRACE_SECONDS` |
 | How often the watchdog runs | 60 s | `AGENTA_SESSIONS_WATCHDOG_INTERVAL_SECONDS` |
 | Rows settled per pass | 500 | `AGENTA_SESSIONS_WATCHDOG_BATCH_SIZE` |
@@ -151,10 +172,15 @@ Definitions live in `api/oss/src/utils/env.py:564` (`SessionWatchdogConfig`),
 
 Two of these deserve their reasoning stated.
 
-**The running threshold is one heartbeat interval plus the grace, so 120 seconds by default.**
-It was a flat 300 seconds. Five minutes was defensible for a sweep that only collapsed flags;
-it is too long to make a user watch a dead turn now that the sweep writes a real ending. 120
-seconds is three missed beats. Raise the grace if a healthy deployment ever settles a live turn.
+**The rule is heartbeat age, not lease expiry, and the difference is an hour.** The Redis
+`alive` and `running` keys carry a 3600-second TTL (`api/oss/src/utils/env.py:1416-1422`), so a
+watchdog phrased as "settle shortly after the lease expires" would leave a dead turn running for
+an hour. The runner beats every 30 seconds
+(`services/runner/src/sessions/contract.ts:18`) and the beat is mirrored onto
+`session_streams.updated_at`, so the age of that column is the real signal. The threshold is 90
+seconds of it: three missed beats. It was a flat 300 seconds, which was defensible while the
+sweep only collapsed flags and nobody saw the result, and is too long now that it writes an
+ending a user reads.
 
 **The hard per-turn deadline sits ABOVE the longest legitimate run, not below it.** The run
 limits already own when a real turn should stop, and users have asked for longer runs, not
@@ -220,8 +246,10 @@ Before: the Redis lease had 3586 seconds left, a second turn asking for the sess
 2026-09-02T21:26:29.643Z [INFO.] watchdog: settled 1 sessions (1 turns marked lost)
 ```
 
-The row was created at 21:24:17 and settled at 21:26:29, so 132 seconds: the 120-second
-threshold plus part of one sweep interval.
+The row was created at 21:24:17 and settled at 21:26:29, so 132 seconds. That run used the
+earlier 120-second threshold; at the 90-second threshold this slice now ships, the same case
+settles between 90 and 150 seconds depending on where the sweep tick falls. The behaviour under
+test is unchanged — only the constant moved.
 
 After, all four verified by reading the stores:
 
@@ -353,6 +381,19 @@ the repository.
 - It does not fix the originating tab. `refreshFromRecords` deliberately early-returns while the
   tab is busy, so a tab holding an open-but-dead HTTP stream ignores the watchdog's records until
   its own stream errors. Other tabs and a reload see the settled turn immediately.
+
+## Handover: command settlement
+
+The durable-cancel slice writes a command's terminal outcome and deliberately does not sweep
+expired claims. Its DAO exposes `expire_claims(now, max_deliveries)` and `settle_command` for
+this watchdog to call, on the principle that one execution reaches one terminal outcome from
+one writer, and that the watchdog is that writer.
+
+**Agreed, and not built here.** Those functions do not exist on this branch, so code written
+against them could be neither compiled nor tested, and a second sweep beside this one is exactly
+the race this slice avoided. The work is small and belongs in the pass that already exists: once
+the commands slice lands, extend `run_orphan_sweep` to expire claims and settle each expired
+command in the same loop that settles its execution.
 
 ## Open questions for Mahmoud
 

--- a/docs/design/session-control-and-live-events/slice-watchdog.md
+++ b/docs/design/session-control-and-live-events/slice-watchdog.md
@@ -390,17 +390,20 @@ docker logs -f agenta-ee-dev-session-watchdog-runner-1 2>&1 | grep -E "sandbox-l
 docker logs -f agenta-ee-dev-session-watchdog-api-1 2>&1 | grep -i watchdog
 ```
 
-The stack is left running. To tear it down:
+**The stack has been torn down.** It ran on port 8880 as `agenta-ee-dev-session-watchdog` while
+the scenarios above were recorded, and was stopped with `--down` once they were, to give the box
+back its memory. Volumes were kept, so a rebuild is a redeploy rather than a fresh database.
+
+To bring it back, from this worktree:
 
 ```bash
-cd /home/mahmoud/code/agenta-2-worktrees/slice-watchdog
 set -a && . hosting/docker-compose/ee/.env.ee.dev.watchdog && set +a
-bash ./hosting/docker-compose/run.sh --license ee --dev --env-file .env.ee.dev.watchdog --no-tunnel --down
+bash ./hosting/docker-compose/run.sh --license ee --dev --env-file .env.ee.dev.watchdog --no-tunnel
 ```
 
-The env file `hosting/docker-compose/ee/.env.ee.dev.watchdog` is gitignored and holds a
-stack-local `AGENTA_SERVICES_INTERNAL_KEY` and the QA OpenAI key is in the stack's vault, not in
-the repository.
+Two notes for whoever does. The env file is gitignored and carries a stack-local
+`AGENTA_SERVICES_INTERNAL_KEY`, which is not in the template and which the deploy refuses to
+start without. And the QA OpenAI key lives in that stack's vault, never in this repository.
 
 ## What this slice does not do
 

--- a/hosting/docker-compose/ee/docker-compose.dev.yml
+++ b/hosting/docker-compose/ee/docker-compose.dev.yml
@@ -498,6 +498,9 @@ services:
             # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
             # plus 60s of skew, or every dispatch rebuilds the environment cold.
             AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
+            # Defaults: 30 min without progress; 30 min for one tool call.
+            AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS:-}
+            AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS: ${AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS:-}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}
             AGENTA_RUNNER_DAYTONA_TARGET: ${AGENTA_RUNNER_DAYTONA_TARGET:-}

--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -332,6 +332,9 @@ services:
             # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
             # plus 60s of skew, or every dispatch rebuilds the environment cold.
             AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
+            # Defaults: 30 min without progress; 30 min for one tool call.
+            AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS:-}
+            AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS: ${AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS:-}
             PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}

--- a/hosting/docker-compose/ee/docker-compose.gh.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.yml
@@ -334,6 +334,9 @@ services:
             # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
             # plus 60s of skew, or every dispatch rebuilds the environment cold.
             AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
+            # Defaults: 30 min without progress; 30 min for one tool call.
+            AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS:-}
+            AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS: ${AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS:-}
             PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -138,6 +138,7 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # AGENTA_RECORDS_SMART_TRUNCATION=true
 # Durable Stop is exercised in development; production keeps the API default off.
 AGENTA_SESSIONS_DURABLE_STOP=true
+# AGENTA_SESSIONS_LATE_OUTPUT=quarantine
 
 # --- Attachment limits (files attached to an agent chat turn) ---
 # Per-file caps in bytes, by kind: 10 MB, except audio at 15 MB. Read by the api.

--- a/hosting/docker-compose/oss/docker-compose.dev.yml
+++ b/hosting/docker-compose/oss/docker-compose.dev.yml
@@ -463,6 +463,9 @@ services:
             # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
             # plus 60s of skew, or every dispatch rebuilds the environment cold.
             AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
+            # Defaults: 30 min without progress; 30 min for one tool call.
+            AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS:-}
+            AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS: ${AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS:-}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}
             AGENTA_RUNNER_DAYTONA_TARGET: ${AGENTA_RUNNER_DAYTONA_TARGET:-}

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -328,6 +328,9 @@ services:
             # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
             # plus 60s of skew, or every dispatch rebuilds the environment cold.
             AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
+            # Defaults: 30 min without progress; 30 min for one tool call.
+            AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS:-}
+            AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS: ${AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS:-}
             PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -355,6 +355,9 @@ services:
             # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
             # plus 60s of skew, or every dispatch rebuilds the environment cold.
             AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
+            # Defaults: 30 min without progress; 30 min for one tool call.
+            AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS:-}
+            AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS: ${AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS:-}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}
             AGENTA_RUNNER_DAYTONA_TARGET: ${AGENTA_RUNNER_DAYTONA_TARGET:-}

--- a/hosting/docker-compose/oss/docker-compose.gh.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.yml
@@ -352,6 +352,9 @@ services:
             # Worst-case turn duration. Keep AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS (API) above it
             # plus 60s of skew, or every dispatch rebuilds the environment cold.
             AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_TOTAL_TIMEOUT_MS:-}
+            # Defaults: 30 min without progress; 30 min for one tool call.
+            AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS: ${AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS:-}
+            AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS: ${AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS:-}
             PI_CODING_AGENT_DIR: ${PI_CODING_AGENT_DIR:-/pi-agent}
             AGENTA_RUNNER_DAYTONA_API_KEY: ${AGENTA_RUNNER_DAYTONA_API_KEY:-}
             AGENTA_RUNNER_DAYTONA_API_URL: ${AGENTA_RUNNER_DAYTONA_API_URL:-}

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -144,6 +144,7 @@ NEXT_PUBLIC_AGENT_FILE_UPLOADS=true
 # AGENTA_RECORDS_SMART_TRUNCATION=true
 # Durable Stop is exercised in development; production keeps the API default off.
 AGENTA_SESSIONS_DURABLE_STOP=true
+# AGENTA_SESSIONS_LATE_OUTPUT=quarantine
 
 # --- Attachment limits (files attached to an agent chat turn) ---
 # Per-file caps in bytes, by kind: 10 MB, except audio at 15 MB. Read by the api.

--- a/services/runner/src/engines/sandbox_agent/acp-fetch.ts
+++ b/services/runner/src/engines/sandbox_agent/acp-fetch.ts
@@ -1,5 +1,7 @@
 import { Agent, fetch as undiciFetch } from "undici";
 
+import { sandboxGoneReason } from "./sandbox-gone.ts";
+
 /**
  * HITL pauses keep the ACP HTTP connection open for human-timescale delays: when a tool call needs
  * approval, the runner holds the in-flight `prompt` request while it waits for the human to
@@ -52,12 +54,50 @@ export function createAcpDispatcher(): Agent {
   });
 }
 
+export interface AcpFetchOptions {
+  /**
+   * Called when a response proves the sandbox is gone (see `sandbox-gone.ts`).
+   *
+   * This fetch is the socket the turn runs on, so it sees a deleted remote sandbox seconds before
+   * any poll can. It cannot end the turn itself: the ACP transport swallows the failure (it errors
+   * its readable, and the protocol SDK's read loop never rejects the pending `session/prompt`), so
+   * the promise the turn awaits stays pending forever. Reporting it here is what lets the liveness
+   * probe end the turn at once instead of one probe interval later, or never.
+   */
+  onSandboxGone?: (reason: string) => void;
+}
+
+/**
+ * Wrap a `fetch` so a response that names the sandbox as gone is reported once.
+ *
+ * The response is passed through untouched, body included: this wrapper reads only the status and
+ * the headers, because draining the body here would break every caller. With no
+ * `onSandboxGone` it is the identity, so nothing is inspected on a path that cannot act on it.
+ */
+export function withSandboxGoneReport(
+  inner: typeof fetch,
+  options: AcpFetchOptions = {},
+): typeof fetch {
+  const report = options.onSandboxGone;
+  if (!report) return inner;
+  return (async (input: any, init?: any) => {
+    const response = await inner(input, init);
+    const reason = sandboxGoneReason(response);
+    if (reason) report(reason);
+    return response;
+  }) as unknown as typeof fetch;
+}
+
 /**
  * A `fetch` for the ACP HTTP client backed by {@link createAcpDispatcher}. We use undici's own
  * `fetch` so the `dispatcher` option is honored regardless of how the global dispatcher is set.
  * The `sandbox-agent` SDK accepts a custom `fetch`; we hand it this one on every path.
  */
-export function createAcpFetch(dispatcher: Agent = createAcpDispatcher()): typeof fetch {
-  return ((input: any, init?: any) =>
+export function createAcpFetch(
+  dispatcher: Agent = createAcpDispatcher(),
+  options: AcpFetchOptions = {},
+): typeof fetch {
+  const bound = ((input: any, init?: any) =>
     undiciFetch(input, { ...init, dispatcher })) as unknown as typeof fetch;
+  return withSandboxGoneReport(bound, options);
 }

--- a/services/runner/src/engines/sandbox_agent/daytona.ts
+++ b/services/runner/src/engines/sandbox_agent/daytona.ts
@@ -1,6 +1,10 @@
 import { join } from "node:path";
 
-import { createAcpFetch } from "./acp-fetch.ts";
+import {
+  createAcpFetch,
+  withSandboxGoneReport,
+  type AcpFetchOptions,
+} from "./acp-fetch.ts";
 import {
   resolvePiToolSpecsDelivery,
   uploadPiExtensionToSandbox,
@@ -293,11 +297,17 @@ export async function prepareDaytonaPiAssets({
  * required" / 502. The sandbox-agent SDK accepts a custom fetch, so we hand it this one.
  *
  * It layers on {@link createAcpFetch} (the long-timeout ACP dispatcher) so a paused HITL turn
- * over Daytona is not reaped by undici's default `headersTimeout` either.
+ * over Daytona is not reaped by undici's default `headersTimeout` either, and so `options` (the
+ * sandbox-gone report) reaches the one place that inspects every ACP response. Daytona is the
+ * provider whose proxy answers for a deleted sandbox, so this is the path that needs it most.
  */
 export function createCookieFetch(
-  inner: typeof fetch = createAcpFetch(),
+  inner?: typeof fetch,
+  options: AcpFetchOptions = {},
 ): typeof fetch {
+  const base = inner
+    ? withSandboxGoneReport(inner, options)
+    : createAcpFetch(undefined, options);
   const jar = new Map<string, Map<string, string>>(); // host -> (name -> "name=value")
   return async (input: any, init?: any) => {
     const url = new URL(typeof input === "string" ? input : input.url);
@@ -312,7 +322,7 @@ export function createCookieFetch(
       if (existing) merged.unshift(existing);
       headers.set("cookie", merged.join("; "));
     }
-    const response = await inner(input, { ...init, headers });
+    const response = await base(input, { ...init, headers });
     const setCookies =
       typeof (response.headers as any).getSetCookie === "function"
         ? (response.headers as any).getSetCookie()

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -51,6 +51,7 @@ import {
 } from "../../protocol.ts";
 import { advertisedToolSpecs } from "../../tools/public-spec.ts";
 import { createAcpFetch } from "./acp-fetch.ts";
+import { createSandboxGoneLatch } from "./sandbox-gone.ts";
 import {
   assert,
   assertRequiredCapabilities,
@@ -686,6 +687,23 @@ async function acquireEnvironmentOnce(
       signal,
       logger,
     );
+    // The turn's own socket is the first thing to learn that a remote sandbox was deleted, and it
+    // cannot end a turn by itself (the ACP transport swallows the failure and the pending prompt
+    // never settles). It notes the death here; `run-turn.ts` hands this latch to the liveness
+    // probe, which ends the turn. See `sandbox-gone.ts`.
+    //
+    // ARMED ONLY AFTER ACQUIRE. The same fetch also carries the SDK's health wait, which polls a
+    // sandbox that is still coming up and tolerates a provider error by design. On a warm resume
+    // the provider's proxy can lag its own control plane and answer for a sandbox it has not
+    // finished re-exposing. A report during acquire would latch a HEALTHY sandbox as dead and kill
+    // its first turn, and the latch is one-way, so the window has to be closed before it rather
+    // than reasoned about after. Acquire already has its own failure path for a sandbox that
+    // genuinely never comes up.
+    const sandboxGone = createSandboxGoneLatch();
+    environment.sandboxGone = sandboxGone;
+    const acpFetchOptions = {
+      onSandboxGone: (reason: string) => sandboxGone.note(reason),
+    };
     const startOptions = {
       sandbox: sandboxProvider,
       persist,
@@ -695,8 +713,11 @@ async function acquireEnvironmentOnce(
       // Long-timeout undici dispatcher so a paused HITL turn is not reaped by undici's default
       // headersTimeout; Daytona additionally carries the per-sandbox auth cookie.
       fetch: plan.isDaytona
-        ? (deps.createCookieFetch ?? createCookieFetch)()
-        : (deps.createAcpFetch ?? createAcpFetch)(),
+        ? (deps.createCookieFetch ?? createCookieFetch)(
+            undefined,
+            acpFetchOptions,
+          )
+        : (deps.createAcpFetch ?? createAcpFetch)(undefined, acpFetchOptions),
     };
     // SandboxLifecycle owns the reconnect ladder, the fresh-create fallback, and both
     // `sandbox_start` timing marks. See `environment/sandbox-lifecycle.ts`.
@@ -722,6 +743,9 @@ async function acquireEnvironmentOnce(
     environment.sandbox = acquiredSandbox.sandbox;
     throwIfAcquireAborted(signal);
     environment.resumable = acquiredSandbox.resumable;
+    // The sandbox is up and the reconnect ladder is done, so a "sandbox not found" from here on is
+    // a real death rather than a proxy that has not caught up. See the latch above.
+    sandboxGone.arm();
     // Read AFTER the sandbox is acquired, because the port is bound to a sandbox: the provider has
     // no allocation to deliver against until create (or reconnect) has settled. Undefined for
     // every provider that cannot deliver a credential to a live sandbox, which is what routes a

--- a/services/runner/src/engines/sandbox_agent/errors.ts
+++ b/services/runner/src/engines/sandbox_agent/errors.ts
@@ -57,6 +57,24 @@ function keyHintFor(
  * `runner_error` is the catch-all every unclassified failure keeps, matching what the SDK stamped
  * on runner-reported errors before the runner had a say.
  */
+/**
+ * Markers the runner puts in an error message so `classifyRunError` can set the class.
+ *
+ * Both are strings only this runner produces, so a match needs no corroboration. They live
+ * here, next to the codes they map to, and are imported by the modules that raise them.
+ */
+export const SANDBOX_GONE_MARKER = "sandbox is gone";
+export const ABANDONED_TURN_MARKER = "execution abandoned";
+
+/** The line the user reads when the machine running their turn disappeared. */
+export const SANDBOX_GONE_MESSAGE =
+  "The sandbox running this session stopped responding, so the run was ended. " +
+  "Send the message again to start a fresh sandbox.";
+
+/** The line the user reads when the run never produced an outcome of its own. */
+export const EXECUTION_LOST_MESSAGE =
+  "The agent stopped responding and the run was closed. Send the message again to retry.";
+
 export type RunErrorCode =
   | "runner_error"
   | "starter_credits_exhausted"
@@ -68,7 +86,16 @@ export type RunErrorCode =
   // this session. Nothing ran, nothing was destroyed, and the user's message was never sent.
   // Clients render it as a "not sent, try again" state and keep the text, never as a run error.
   // Produced by `sessions/admission.ts`, not by this module's classifier.
-  | "session_turn_in_use";
+  | "session_turn_in_use"
+  // The sandbox died under a running turn: its liveness probe stopped answering, so the turn
+  // was ended rather than left holding a machine that no longer exists. See
+  // `sandbox-liveness.ts`.
+  | "sandbox_gone"
+  // The execution never produced an outcome of its own, so one was written for it. Two
+  // producers: this runner, when a turn will not unwind after its abort (`sessions/
+  // turn-settle.ts`), and the platform's execution watchdog, when the runner itself is gone
+  // (`api/oss/src/tasks/asyncio/sessions/orphan_sweep.py`).
+  | "execution_lost";
 
 /** One failed run, condensed: the line the user reads plus the class a client can act on. */
 export interface ClassifiedRunError {
@@ -340,6 +367,14 @@ export function classifyRunError(
       message: CREDENTIAL_DELIVERY_FAILED_MESSAGE,
       code: "credential_delivery_failed",
     };
+  }
+  // First, and self-evidencing: this marker is produced by our own liveness probe and by
+  // nothing else, so it needs no corroboration and must not be re-read as a provider fault.
+  if (raw.includes(SANDBOX_GONE_MARKER)) {
+    return { message: SANDBOX_GONE_MESSAGE, code: "sandbox_gone" };
+  }
+  if (raw.includes(ABANDONED_TURN_MARKER)) {
+    return { message: EXECUTION_LOST_MESSAGE, code: "execution_lost" };
   }
   // A budget refusal is checked first: it is the most specific reading of a 429, and its body also
   // trips the rate-limit and quota matchers below.

--- a/services/runner/src/engines/sandbox_agent/run-limits.ts
+++ b/services/runner/src/engines/sandbox_agent/run-limits.ts
@@ -37,9 +37,11 @@ export const TOOL_CALL_TIMEOUT_ENV = "AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS";
 // every mount-backed warm session rebuild cold. The ~1h gap under the 12h lease is
 // the warm parking window.
 export const DEFAULT_TOTAL_DEADLINE_MS = 11 * 60 * 60_000; // 11 hours
-export const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60_000; // 30 min
+// 30 minutes; override with AGENTA_RUNNER_RUN_IDLE_TIMEOUT_MS.
+export const DEFAULT_IDLE_TIMEOUT_MS = 30 * 60_000;
 export const DEFAULT_TTFB_TIMEOUT_MS = 2 * 60_000; // 2 min
-export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 30 * 60_000; // 30 min
+// 30 minutes; override with AGENTA_RUNNER_TOOL_CALL_TIMEOUT_MS.
+export const DEFAULT_TOOL_CALL_TIMEOUT_MS = 30 * 60_000;
 
 /** Every field is a usable timer delay (integer ms, at least 1, within Node's timer range) —
  *  `resolveRunLimits` guarantees it, so callers can arm any of them without re-checking. */

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -1203,16 +1203,6 @@ export async function runTurn(
         }
         pause.pause();
       }
-      if (opts.settleApprovalsThenPrompt) {
-        // The request ends in a NEW user turn. Finish applying the interaction decision to the
-        // old prompt first, then make the request's actual work a regular prompt. Without this
-        // second prompt the runner silently answers the old denied tool call and drops the new
-        // text. `continuation` makes promptBlocks contain only that fresh tail.
-        await promptPromise;
-        promptStartedAtMs = Date.now();
-        promptPromise = Promise.resolve(env.session.prompt(promptBlocks));
-        promptPromise.catch(() => {});
-      }
     } else {
       promptStartedAtMs = Date.now();
       promptPromise = Promise.resolve(env.session.prompt(promptBlocks));
@@ -1235,15 +1225,34 @@ export async function runTurn(
           once: true,
         });
     });
-    const raced = await Promise.race([
-      promptPromise.then(
-        (value) => value,
-        (err) => (signal?.aborted ? CANCELLED : Promise.reject(err)),
-      ),
-      pause.signal.then(() => PAUSED),
-      runLimitTripped.then(() => RUN_LIMIT_TRIPPED),
-      cancelled,
-    ]);
+    const racePrompt = (pending: Promise<unknown>) =>
+      Promise.race([
+        pending.then(
+          (value) => value,
+          (err) => (signal?.aborted ? CANCELLED : Promise.reject(err)),
+        ),
+        pause.signal.then(() => PAUSED),
+        runLimitTripped.then(() => RUN_LIMIT_TRIPPED),
+        cancelled,
+      ]);
+    let raced = await racePrompt(promptPromise);
+    if (
+      opts.settleApprovalsThenPrompt &&
+      raced !== PAUSED &&
+      raced !== RUN_LIMIT_TRIPPED &&
+      raced !== CANCELLED &&
+      !pause.active
+    ) {
+      // The request ends in a NEW user turn. Finish applying the interaction decision to the old
+      // prompt first, then make the request's actual work a regular prompt. Without this second
+      // prompt the runner silently answers the old denied tool call and drops the new text. The
+      // old prompt was raced above, so a harness that opened another gate after the denial pauses
+      // this turn instead of hanging unwatched. `continuation` makes promptBlocks the fresh tail.
+      promptStartedAtMs = Date.now();
+      promptPromise = Promise.resolve(env.session.prompt(promptBlocks));
+      promptPromise.catch(() => {});
+      raced = await racePrompt(promptPromise);
+    }
     // A tripped run-limit ends the turn as an error: throw into the shared catch below so the
     // trace is flushed and the caller's teardown reclaims the (wedged) sandbox.
     if (raced === RUN_LIMIT_TRIPPED) {

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -86,6 +86,10 @@ import {
 } from "./approved-content.ts";
 import { createRunLimits, resolveRunLimits } from "./run-limits.ts";
 import {
+  resolveSandboxLivenessLimits,
+  startSandboxLivenessProbe,
+} from "./sandbox-liveness.ts";
+import {
   RUN_LIMIT_TRIPPED,
   sendLastMessageOnly,
   type CurrentTurn,
@@ -261,6 +265,24 @@ export async function runTurn(
     runLimitReason = reason;
     runLimitTrip?.();
   });
+
+  // The run limits above cannot see a sandbox that DIED under the turn: the ACP prompt they
+  // race against never settles once the peer is gone, and `notePaused()` retires them entirely
+  // while a turn waits for a human. So probe the sandbox's own HTTP surface, independently of
+  // the wedged ACP channel, and end the turn through the same trip path any other limit uses.
+  // See `sandbox-liveness.ts` and issue #6418.
+  const sandboxLiveness =
+    typeof env.sandbox?.getSession === "function"
+      ? startSandboxLivenessProbe({
+          probe: () => env.sandbox.getSession(env.sessionId),
+          limits: resolveSandboxLivenessLimits(logger),
+          onGone: (reason: string) => {
+            runLimitReason = reason;
+            runLimitTrip?.();
+          },
+          log: logger,
+        })
+      : undefined;
 
   try {
     // AGENTA_SESSIONS_RECONSTRUCT defaults on so minimal-history clients keep their conversation;
@@ -1560,6 +1582,8 @@ export async function runTurn(
     void settleInBandInteractions?.();
     // Release every run-limits timer (idempotent, never re-arms on a late event) on EVERY path.
     runLimits.dispose();
+    // Same contract for the sandbox liveness probe: one timer, released on EVERY path.
+    sandboxLiveness?.dispose();
     // This turn owns its relay: stop it on EVERY exit path (the happy path already stopped it
     // after the prompt; stop is safe to repeat, matching the old finally). Null it afterwards so
     // a later `destroy()` — possibly after the dispatch cleared the sink — cannot double-stop or

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -229,7 +229,8 @@ export async function runTurn(
   // A fresh turn never inherits an approval. Only a resume may consume records minted before
   // the park; anything else starts empty, so no call can execute on the strength of an approval
   // raised for an earlier turn.
-  if (!opts.resume) env.commitAuthorization = undefined;
+  if (!opts.resume && !opts.settleApprovalsThenPrompt)
+    env.commitAuthorization = undefined;
   env.nonParkablePauseCount = 0;
   // Hoisted so the catch can flush a partial trace (mirroring the pre-split `otel?` handling —
   // a createOtel throw must still return `{ ok: false }`, not propagate raw) and the finally can
@@ -1118,10 +1119,12 @@ export async function runTurn(
     // from one the SESSION started earlier (an stdio MCP server). A resumed turn keeps the
     // resume's own start, which only ever makes the reap more conservative. See `reap-exec.ts`.
     let promptStartedAtMs = Date.now();
-    if (opts.resume) {
+    const approvalTransition =
+      opts.resume ?? opts.settleApprovalsThenPrompt;
+    if (approvalTransition) {
       // The resume turn owns continued events; each decision answers one parked gate by id.
       // Carried gates keep the shared original prompt pending until a later answer.
-      const decisions = opts.resume.decisions;
+      const decisions = approvalTransition.decisions;
       promptPromise = Promise.resolve(decisions[0]?.promptPromise);
       promptPromise.catch(() => {});
       for (const seed of carriedApprovedExecutions) {
@@ -1187,7 +1190,7 @@ export async function runTurn(
       // refresh the carried gates' approval TTL. Pi is exempt on purpose: it prepares the whole
       // batch before executing any call, so while a carried sibling gate is pending closure is
       // impossible and the paused-settle's park-and-carry branch owns those spans.
-      if (opts.resume.carriedForward.length > 0) {
+      if (opts.resume && opts.resume.carriedForward.length > 0) {
         if (!plan.isPi) {
           const answeredAllowedIds = decisions
             .filter((decision) => decision.reply === "once")
@@ -1199,6 +1202,16 @@ export async function runTurn(
           );
         }
         pause.pause();
+      }
+      if (opts.settleApprovalsThenPrompt) {
+        // The request ends in a NEW user turn. Finish applying the interaction decision to the
+        // old prompt first, then make the request's actual work a regular prompt. Without this
+        // second prompt the runner silently answers the old denied tool call and drops the new
+        // text. `continuation` makes promptBlocks contain only that fresh tail.
+        await promptPromise;
+        promptStartedAtMs = Date.now();
+        promptPromise = Promise.resolve(env.session.prompt(promptBlocks));
+        promptPromise.catch(() => {});
       }
     } else {
       promptStartedAtMs = Date.now();

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -274,20 +274,26 @@ export async function runTurn(
   // while a turn waits for a human. So probe the sandbox's own HTTP surface, independently of
   // the wedged ACP channel, and end the turn through the same trip path any other limit uses.
   // See `sandbox-liveness.ts` and issue #6418.
+  // A remote sandbox does not refuse the socket when it dies: its provider's proxy answers for it
+  // with "sandbox <id> not found" indefinitely, which the poll reads as alive. So the turn's own
+  // ACP transport reports that answer on `env.sandboxGone`, and the probe ends the turn on it at
+  // once. That path needs no health URL, so it is wired even when the poll is disabled.
   const sandboxHealth = sandboxHealthUrl(env.sandbox);
-  const sandboxLiveness = sandboxHealth
-    ? startSandboxLivenessProbe({
-        probe: httpLivenessProbe(sandboxHealth),
-        limits: resolveSandboxLivenessLimits(logger),
-        onGone: (reason: string) => {
-          runLimitReason = reason;
-          runLimitTrip?.();
-        },
-        log: logger,
-      })
-    : undefined;
+  const sandboxLiveness = startSandboxLivenessProbe({
+    ...(sandboxHealth ? { probe: httpLivenessProbe(sandboxHealth) } : {}),
+    goneSignal: env.sandboxGone,
+    limits: resolveSandboxLivenessLimits(logger),
+    onGone: (reason: string) => {
+      runLimitReason = reason;
+      runLimitTrip?.();
+    },
+    log: logger,
+  });
   if (!sandboxHealth) {
-    logger("[sandbox-liveness] no health URL on this sandbox; probe disabled");
+    logger(
+      "[sandbox-liveness] no health URL on this sandbox; polling disabled " +
+        "(the transport's own sandbox-gone report still ends the turn)",
+    );
   }
 
   try {

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -86,7 +86,9 @@ import {
 } from "./approved-content.ts";
 import { createRunLimits, resolveRunLimits } from "./run-limits.ts";
 import {
+  httpLivenessProbe,
   resolveSandboxLivenessLimits,
+  sandboxHealthUrl,
   startSandboxLivenessProbe,
 } from "./sandbox-liveness.ts";
 import {
@@ -271,18 +273,21 @@ export async function runTurn(
   // while a turn waits for a human. So probe the sandbox's own HTTP surface, independently of
   // the wedged ACP channel, and end the turn through the same trip path any other limit uses.
   // See `sandbox-liveness.ts` and issue #6418.
-  const sandboxLiveness =
-    typeof env.sandbox?.getSession === "function"
-      ? startSandboxLivenessProbe({
-          probe: () => env.sandbox.getSession(env.sessionId),
-          limits: resolveSandboxLivenessLimits(logger),
-          onGone: (reason: string) => {
-            runLimitReason = reason;
-            runLimitTrip?.();
-          },
-          log: logger,
-        })
-      : undefined;
+  const sandboxHealth = sandboxHealthUrl(env.sandbox);
+  const sandboxLiveness = sandboxHealth
+    ? startSandboxLivenessProbe({
+        probe: httpLivenessProbe(sandboxHealth),
+        limits: resolveSandboxLivenessLimits(logger),
+        onGone: (reason: string) => {
+          runLimitReason = reason;
+          runLimitTrip?.();
+        },
+        log: logger,
+      })
+    : undefined;
+  if (!sandboxHealth) {
+    logger("[sandbox-liveness] no health URL on this sandbox; probe disabled");
+  }
 
   try {
     // AGENTA_SESSIONS_RECONSTRUCT defaults on so minimal-history clients keep their conversation;

--- a/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
@@ -217,6 +217,14 @@ export interface RunTurnOptions {
     decisions: ResumeApprovalInput[];
     carriedForward: ParkedApproval[];
   };
+  /**
+   * Settle the parked gate first, then send this request's fresh user tail as a normal prompt on
+   * the same warm session. Unlike `resume`, this does not make the old prompt the request's turn:
+   * its decision is context for the new prompt rather than the turn's terminal interaction.
+   */
+  settleApprovalsThenPrompt?: {
+    decisions: ResumeApprovalInput[];
+  };
 }
 
 /**

--- a/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
+++ b/services/runner/src/engines/sandbox_agent/runtime-contracts.ts
@@ -296,6 +296,13 @@ export interface SessionEnvironment {
   plan: RunPlan;
   logger: Log;
   deps: SandboxAgentDeps;
+  /**
+   * Set once this environment's sandbox is known to be gone, by the ACP transport that talks to
+   * it. A remote provider answers for a deleted sandbox instead of refusing the socket, so this
+   * report is often the only evidence of the death that arrives at all. `run-turn.ts` hands the
+   * latch to the liveness probe, which is what ends the turn. See `sandbox-gone.ts`.
+   */
+  sandboxGone?: import("./sandbox-gone.ts").SandboxGoneLatch;
   sandbox: any;
   session: any;
   sessionId: string;

--- a/services/runner/src/engines/sandbox_agent/sandbox-gone.ts
+++ b/services/runner/src/engines/sandbox_agent/sandbox-gone.ts
@@ -1,0 +1,148 @@
+/**
+ * Recognise a provider answer that says THIS SANDBOX no longer exists.
+ *
+ * A local sandbox announces its death by refusing the socket: the probe's `fetch` rejects and the
+ * liveness counter climbs. A REMOTE sandbox never does that. Daytona keeps its proxy host alive
+ * after the sandbox is deleted and answers every request for it with a normal HTTP error that
+ * names the sandbox:
+ *
+ *   404, `x-daytona-error-code: SANDBOX_NOT_FOUND`,
+ *   "not found: sandbox <id> not found, it may have been deleted or stopped"
+ *
+ * The liveness probe reads any HTTP status as alive on purpose (see `sandbox-liveness.ts`), so
+ * that answer used to mean "still there" and the turn hung until the runner process died. That is
+ * the blind spot this module closes. The answer is authoritative in a way a status alone is not:
+ * the provider's own control plane is telling us the machine is gone, so it counts as death on
+ * the FIRST sighting rather than after the usual three failures.
+ *
+ * Recognition is deliberately narrow, because a false positive ends a healthy turn:
+ *  - The answer must be an HTTP ERROR (>= 400). A 200 body that merely quotes this prose, such as
+ *    an agent describing its own earlier failure, is not evidence of anything.
+ *  - Either the provider's own error-code header names the sandbox, or the error body does. A
+ *    bare 404 stays "alive": the daemon's health route may simply not exist on an older image,
+ *    and reading that as death would end healthy turns.
+ */
+
+/** The shape both the probe's `fetch` and the ACP transport's response satisfy. */
+export interface SandboxAnswer {
+  status: number;
+  headers: { get(name: string): string | null };
+}
+
+/** Provider headers that carry a machine-readable error code for the sandbox itself. */
+const GONE_CODE_HEADERS = ["x-daytona-error-code"] as const;
+
+/**
+ * Error codes that mean the sandbox is GONE, not that the request was bad and not that the sandbox
+ * is merely between states.
+ *
+ * `SANDBOX_STOPPED` and `SANDBOX_ARCHIVED` are deliberately absent. Both are RESUMABLE states the
+ * provider itself handles, and the reconnect ladder can legitimately meet either one while it
+ * brings a parked sandbox back. Reading them as death would end a turn on a sandbox that is about
+ * to answer.
+ */
+const GONE_CODE = /^SANDBOX_(NOT_FOUND|DELETED|DESTROYED)$/i;
+
+/**
+ * The same verdict in prose, for a proxy that sends no code header. "may have been deleted or
+ * stopped" is Daytona's own wording for a sandbox it cannot find, so it stays even though a
+ * `SANDBOX_STOPPED` code does not count.
+ */
+const GONE_BODY =
+  /sandbox\s+\S+\s+not found|may have been deleted or stopped|sandbox\s+\S+\s+(?:has been |was )?(?:deleted|destroyed)/i;
+
+/**
+ * The reason this answer proves the sandbox is gone, or undefined when it proves nothing.
+ *
+ * `bodyText` is optional: the ACP transport must not drain the response body it is about to hand
+ * to its caller, so it passes headers only. The liveness probe owns its response and passes the
+ * body too.
+ */
+export function sandboxGoneReason(
+  response: SandboxAnswer,
+  bodyText?: string,
+): string | undefined {
+  if (response.status < 400) return undefined;
+  for (const header of GONE_CODE_HEADERS) {
+    const code = response.headers.get(header)?.trim();
+    if (code && GONE_CODE.test(code)) {
+      return `provider reports the sandbox is gone (HTTP ${response.status}, ${header}: ${code})`;
+    }
+  }
+  if (bodyText && GONE_BODY.test(bodyText)) {
+    return `provider reports the sandbox is gone (HTTP ${response.status}: ${bodyText.slice(0, 200)})`;
+  }
+  return undefined;
+}
+
+/**
+ * A one-way latch shared by everything that talks to one sandbox.
+ *
+ * The ACP transport sees the death first — it is the socket carrying the turn — but it has no way
+ * to end a turn. The liveness probe can end a turn but only wakes every 30 seconds. The latch is
+ * the seam between them: the transport notes the reason, the probe fires on it at once. First
+ * reason wins; later notes are ignored, so one death yields one outcome.
+ */
+export interface SandboxGoneLatch {
+  /**
+   * Open the latch. Every `note` before this is DISCARDED.
+   *
+   * The latch starts closed because the same fetch that carries a turn also carries the SDK's
+   * health wait during acquire, and that wait polls a sandbox which is still coming up. A
+   * provider proxy that lags its own control plane can answer "not found" for a sandbox it has
+   * not finished re-exposing, which is a normal step of a warm resume rather than a death. The
+   * latch is one-way, so a report from that window has to be discarded rather than reasoned about
+   * later. The owner of the environment arms it once the sandbox is acquired.
+   */
+  arm(): void;
+  /**
+   * Record that the sandbox is gone. Idempotent; only the first reason after `arm()` is kept, and
+   * a note before `arm()` is ignored.
+   */
+  note(reason: string): void;
+  /** The recorded reason, or undefined while the sandbox still answers. */
+  reason(): string | undefined;
+  /**
+   * Call `listener` when the sandbox is declared gone, or immediately when it already was. At
+   * most one call per listener.
+   *
+   * Returns an unsubscribe function the caller MUST call when its turn ends. A warm environment
+   * outlives every turn that runs on it, so a turn that leaves its listener behind leaks one dead
+   * closure per turn and would end up calling a finished turn's `onGone`.
+   */
+  subscribe(listener: (reason: string) => void): () => void;
+}
+
+export function createSandboxGoneLatch(): SandboxGoneLatch {
+  let armed = false;
+  let reason: string | undefined;
+  const listeners = new Set<(reason: string) => void>();
+  return {
+    arm(): void {
+      armed = true;
+    },
+    note(next: string): void {
+      if (!armed || reason) return;
+      reason = next;
+      for (const listener of listeners) {
+        try {
+          listener(next);
+        } catch {
+          // A listener fault must not stop the others, nor the request that noticed the death.
+        }
+      }
+      listeners.clear();
+    },
+    reason: () => reason,
+    subscribe(listener: (next: string) => void): () => void {
+      if (reason) {
+        listener(reason);
+        return () => {};
+      }
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+  };
+}

--- a/services/runner/src/engines/sandbox_agent/sandbox-liveness.ts
+++ b/services/runner/src/engines/sandbox_agent/sandbox-liveness.ts
@@ -1,0 +1,172 @@
+/**
+ * Detect that the sandbox died UNDER a running turn, so the turn ends instead of hanging.
+ *
+ * The runner talks to the sandbox agent over ACP, a JSON-RPC channel whose agent-to-client half
+ * is a long-lived SSE `GET`. When the sandbox process disappears that stream is severed, but the
+ * transport's read loop swallows the error and never fails the readable, so the pending
+ * `session/prompt` request is structurally incapable of settling. The turn then holds its
+ * sandbox, its mount and its slot forever, while the alive watchdog keeps telling the platform
+ * `running=true` every 30 seconds. That is issue #6418.
+ *
+ * The existing run limits do not cover it. Time-to-first-byte (2 min) catches a sandbox that
+ * dies before the first token, and idle (30 min) catches one that dies mid-stream — but
+ * `notePaused()` retires every one of them for good the moment the turn parks for a human, and a
+ * sandbox that dies during a pause therefore has no deadline at all.
+ *
+ * So probe the sandbox directly. A cheap REST call on the daemon's own HTTP surface is
+ * independent of the wedged ACP channel: it answers while the sandbox lives and fails once it is
+ * gone. `failureThreshold` consecutive failures — not one — is what separates a dead sandbox from
+ * a slow network, and each probe carries its own timeout because a vanished host can hang a
+ * request rather than refuse it.
+ *
+ * The probe deliberately keeps running while the turn is paused. A pause is a legitimate wait for
+ * a human; it is not a reason to stop noticing that the machine underneath is gone.
+ */
+
+import { envInt, envTimerMs } from "../../env.ts";
+import { SANDBOX_GONE_MARKER } from "./errors.ts";
+
+export const PROBE_INTERVAL_ENV = "AGENTA_RUNNER_SANDBOX_PROBE_INTERVAL_MS";
+export const PROBE_TIMEOUT_ENV = "AGENTA_RUNNER_SANDBOX_PROBE_TIMEOUT_MS";
+export const PROBE_FAILURES_ENV = "AGENTA_RUNNER_SANDBOX_PROBE_FAILURES";
+export const PROBE_DISABLED_ENV = "AGENTA_RUNNER_SANDBOX_PROBE_DISABLED";
+
+// One probe per heartbeat interval. Anything faster buys latency the user cannot perceive and
+// costs a request per sandbox per tick.
+export const DEFAULT_PROBE_INTERVAL_MS = 30_000;
+// A live daemon answers a session read in milliseconds; ten seconds is a generous ceiling that
+// still bounds a hung request well inside one interval.
+export const DEFAULT_PROBE_TIMEOUT_MS = 10_000;
+// Three consecutive failures, so a single dropped request or a brief network stall is not a
+// death sentence. At the defaults that is about 90 seconds before a turn is ended.
+export const DEFAULT_PROBE_FAILURES = 3;
+
+export interface SandboxLivenessLimits {
+  intervalMs: number;
+  timeoutMs: number;
+  failureThreshold: number;
+}
+
+export interface Clock {
+  setTimeout(fn: () => void, ms: number): NodeJS.Timeout;
+  clearTimeout(handle: NodeJS.Timeout): void;
+}
+
+const realClock: Clock = {
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (handle) => clearTimeout(handle),
+};
+
+/** Read the probe's limits from env, with wide defaults. */
+export function resolveSandboxLivenessLimits(
+  log: (message: string) => void = () => {},
+): SandboxLivenessLimits {
+  return {
+    intervalMs: envTimerMs(PROBE_INTERVAL_ENV, DEFAULT_PROBE_INTERVAL_MS, { log }),
+    timeoutMs: envTimerMs(PROBE_TIMEOUT_ENV, DEFAULT_PROBE_TIMEOUT_MS, { log }),
+    failureThreshold: envInt(PROBE_FAILURES_ENV, DEFAULT_PROBE_FAILURES, {
+      min: 1,
+      log,
+    }),
+  };
+}
+
+export interface SandboxLivenessHandle {
+  /** Release the probe's timer. Always call this once the turn ends, on every path. */
+  dispose(): void;
+  /** Consecutive failures observed so far; for tests and diagnostics. */
+  failures(): number;
+}
+
+export interface SandboxLivenessOptions {
+  /** One liveness check. Resolves when the sandbox answered, rejects or hangs when it did not. */
+  probe: () => Promise<unknown>;
+  limits: SandboxLivenessLimits;
+  /** Called at most once, with a human-readable reason, when the sandbox is declared gone. */
+  onGone: (reason: string) => void;
+  clock?: Clock;
+  log?: (message: string) => void;
+}
+
+/**
+ * Start probing. Returns immediately; the first probe runs one interval later, because a turn
+ * that just acquired its environment has already proved the sandbox was up.
+ */
+export function startSandboxLivenessProbe({
+  probe,
+  limits,
+  onGone,
+  clock = realClock,
+  log = () => {},
+}: SandboxLivenessOptions): SandboxLivenessHandle {
+  let disposed = false;
+  let fired = false;
+  let inFlight = false;
+  let failures = 0;
+  let timer: NodeJS.Timeout | undefined;
+
+  const schedule = (): void => {
+    if (disposed || fired) return;
+    timer = clock.setTimeout(() => void tick(), limits.intervalMs);
+  };
+
+  const withTimeout = async (): Promise<void> => {
+    let timeoutHandle: NodeJS.Timeout | undefined;
+    try {
+      await Promise.race([
+        probe(),
+        new Promise<never>((_resolve, reject) => {
+          timeoutHandle = clock.setTimeout(
+            () => reject(new Error(`probe timed out after ${limits.timeoutMs}ms`)),
+            limits.timeoutMs,
+          );
+        }),
+      ]);
+    } finally {
+      if (timeoutHandle) clock.clearTimeout(timeoutHandle);
+    }
+  };
+
+  const tick = async (): Promise<void> => {
+    // A probe still running when the next tick lands means the sandbox is not answering; let
+    // the in-flight one reach its own timeout rather than stacking requests on a dead host.
+    if (disposed || fired || inFlight) {
+      schedule();
+      return;
+    }
+    inFlight = true;
+    try {
+      await withTimeout();
+      failures = 0;
+    } catch (err) {
+      failures += 1;
+      const detail = err instanceof Error ? err.message : String(err);
+      log(
+        `[sandbox-liveness] probe failed (${failures}/${limits.failureThreshold}): ${detail}`,
+      );
+      if (failures >= limits.failureThreshold && !fired && !disposed) {
+        fired = true;
+        const reason =
+          `${SANDBOX_GONE_MARKER}: ${failures} consecutive liveness probes failed ` +
+          `(last: ${detail})`;
+        log(`[sandbox-liveness] ${reason}`);
+        onGone(reason);
+        return;
+      }
+    } finally {
+      inFlight = false;
+    }
+    schedule();
+  };
+
+  if (!process.env[PROBE_DISABLED_ENV]) schedule();
+
+  return {
+    dispose() {
+      disposed = true;
+      if (timer) clock.clearTimeout(timer);
+      timer = undefined;
+    },
+    failures: () => failures,
+  };
+}

--- a/services/runner/src/engines/sandbox_agent/sandbox-liveness.ts
+++ b/services/runner/src/engines/sandbox_agent/sandbox-liveness.ts
@@ -13,11 +13,23 @@
  * `notePaused()` retires every one of them for good the moment the turn parks for a human, and a
  * sandbox that dies during a pause therefore has no deadline at all.
  *
- * So probe the sandbox directly. A cheap REST call on the daemon's own HTTP surface is
- * independent of the wedged ACP channel: it answers while the sandbox lives and fails once it is
- * gone. `failureThreshold` consecutive failures — not one — is what separates a dead sandbox from
- * a slow network, and each probe carries its own timeout because a vanished host can hang a
+ * So probe the sandbox directly, over its own HTTP surface, which is a different socket from the
+ * wedged ACP channel: it answers while the sandbox lives and refuses once it is gone.
+ * `failureThreshold` consecutive failures — not one — is what separates a dead sandbox from a
+ * slow network, and each probe carries its own timeout because a vanished host can hang a
  * request rather than refuse it.
+ *
+ * What counts as alive is deliberately weak: ANY HTTP response, including 401 or 404. The
+ * question is whether something is listening, not whether we are authorised or whether the
+ * route exists, and only a transport failure answers that with certainty. That also keeps the
+ * probe honest about its one blind spot: behind a remote provider's proxy, a deleted sandbox can
+ * still draw an HTTP error from the proxy itself, and this probe will read that as alive. The
+ * platform's execution watchdog is what covers that case.
+ *
+ * NOTE on what NOT to probe: `SandboxAgent.getSession()` looks like a liveness check and is not
+ * one. It reads the local persist driver and never touches the daemon, so it answers happily
+ * while the sandbox is dead — verified live on 2026-09-02, where a killed daemon logged
+ * `ECONNREFUSED` on the ACP socket while every `getSession` succeeded.
  *
  * The probe deliberately keeps running while the turn is paused. A pause is a legitimate wait for
  * a human; it is not a reason to stop noticing that the machine underneath is gone.
@@ -68,6 +80,34 @@ export function resolveSandboxLivenessLimits(
       min: 1,
       log,
     }),
+  };
+}
+
+/**
+ * The daemon's health URL, derived from the only public handle on the agent that carries its
+ * base address. `inspectorUrl` is `<base>/ui/`; the health route is `<base>/v1/health`.
+ *
+ * Returns undefined when the agent exposes no usable URL, which disables the probe rather than
+ * guessing — a probe pointed at the wrong host would end healthy turns.
+ */
+export function sandboxHealthUrl(sandbox: unknown): string | undefined {
+  const inspector = (sandbox as { inspectorUrl?: unknown } | undefined)?.inspectorUrl;
+  if (typeof inspector !== "string" || !inspector) return undefined;
+  const base = inspector.replace(/\/ui\/?$/, "").replace(/\/+$/, "");
+  if (!/^https?:\/\//.test(base)) return undefined;
+  return `${base}/v1/health`;
+}
+
+/**
+ * The default probe: one unauthenticated GET at the daemon's health route.
+ *
+ * Resolves on any HTTP status. Rejects only when the request never became a response, which is
+ * what "nothing is listening any more" looks like from here.
+ */
+export function httpLivenessProbe(url: string): () => Promise<unknown> {
+  return async () => {
+    const response = await fetch(url, { method: "GET" });
+    return response.status;
   };
 }
 

--- a/services/runner/src/engines/sandbox_agent/sandbox-liveness.ts
+++ b/services/runner/src/engines/sandbox_agent/sandbox-liveness.ts
@@ -21,10 +21,18 @@
  *
  * What counts as alive is deliberately weak: ANY HTTP response, including 401 or 404. The
  * question is whether something is listening, not whether we are authorised or whether the
- * route exists, and only a transport failure answers that with certainty. That also keeps the
- * probe honest about its one blind spot: behind a remote provider's proxy, a deleted sandbox can
- * still draw an HTTP error from the proxy itself, and this probe will read that as alive. The
- * platform's execution watchdog is what covers that case.
+ * route exists, and only a transport failure answers that with certainty.
+ *
+ * The ONE exception is an answer that names the SANDBOX as gone, which `sandbox-gone.ts`
+ * recognises. Behind a remote provider's proxy the transport failure never arrives: Daytona keeps
+ * the proxy host up after the sandbox is deleted and answers "sandbox <id> not found" for it
+ * indefinitely, so the weak rule alone read a dead sandbox as alive and the turn hung until the
+ * runner process died. That answer is the provider's own verdict rather than a network symptom,
+ * so it ends the turn on the FIRST sighting instead of after three failures.
+ *
+ * `goneSignal` is the other half of the same fix. The ACP transport carrying the turn sees that
+ * answer seconds before any poll can, and it cannot end a turn on its own, so it notes the death
+ * on a shared latch and this probe fires on the latch at once.
  *
  * NOTE on what NOT to probe: `SandboxAgent.getSession()` looks like a liveness check and is not
  * one. It reads the local persist driver and never touches the daemon, so it answers happily
@@ -37,6 +45,7 @@
 
 import { envInt, envTimerMs } from "../../env.ts";
 import { SANDBOX_GONE_MARKER } from "./errors.ts";
+import { sandboxGoneReason, type SandboxGoneLatch } from "./sandbox-gone.ts";
 
 export const PROBE_INTERVAL_ENV = "AGENTA_RUNNER_SANDBOX_PROBE_INTERVAL_MS";
 export const PROBE_TIMEOUT_ENV = "AGENTA_RUNNER_SANDBOX_PROBE_TIMEOUT_MS";
@@ -74,7 +83,9 @@ export function resolveSandboxLivenessLimits(
   log: (message: string) => void = () => {},
 ): SandboxLivenessLimits {
   return {
-    intervalMs: envTimerMs(PROBE_INTERVAL_ENV, DEFAULT_PROBE_INTERVAL_MS, { log }),
+    intervalMs: envTimerMs(PROBE_INTERVAL_ENV, DEFAULT_PROBE_INTERVAL_MS, {
+      log,
+    }),
     timeoutMs: envTimerMs(PROBE_TIMEOUT_ENV, DEFAULT_PROBE_TIMEOUT_MS, { log }),
     failureThreshold: envInt(PROBE_FAILURES_ENV, DEFAULT_PROBE_FAILURES, {
       min: 1,
@@ -91,7 +102,8 @@ export function resolveSandboxLivenessLimits(
  * guessing — a probe pointed at the wrong host would end healthy turns.
  */
 export function sandboxHealthUrl(sandbox: unknown): string | undefined {
-  const inspector = (sandbox as { inspectorUrl?: unknown } | undefined)?.inspectorUrl;
+  const inspector = (sandbox as { inspectorUrl?: unknown } | undefined)
+    ?.inspectorUrl;
   if (typeof inspector !== "string" || !inspector) return undefined;
   const base = inspector.replace(/\/ui\/?$/, "").replace(/\/+$/, "");
   if (!/^https?:\/\//.test(base)) return undefined;
@@ -99,14 +111,35 @@ export function sandboxHealthUrl(sandbox: unknown): string | undefined {
 }
 
 /**
+ * A failure the provider itself confirmed: the sandbox is gone, so waiting for two more probes
+ * would only delay an outcome that is already certain.
+ */
+export class SandboxGoneError extends Error {
+  constructor(reason: string) {
+    super(reason);
+    this.name = "SandboxGoneError";
+  }
+}
+
+/**
  * The default probe: one unauthenticated GET at the daemon's health route.
  *
- * Resolves on any HTTP status. Rejects only when the request never became a response, which is
- * what "nothing is listening any more" looks like from here.
+ * Resolves on any HTTP status, except one whose headers or body name the sandbox as gone — that
+ * rejects with {@link SandboxGoneError}. Otherwise it rejects only when the request never became a
+ * response, which is what "nothing is listening any more" looks like from here.
+ *
+ * The body is read only for an HTTP error, so a healthy answer costs nothing extra and a 200 that
+ * happens to quote the provider's prose can never be misread as death.
  */
 export function httpLivenessProbe(url: string): () => Promise<unknown> {
   return async () => {
     const response = await fetch(url, { method: "GET" });
+    const bodyText =
+      response.status >= 400
+        ? await response.text().catch(() => "")
+        : undefined;
+    const reason = sandboxGoneReason(response, bodyText);
+    if (reason) throw new SandboxGoneError(reason);
     return response.status;
   };
 }
@@ -119,11 +152,21 @@ export interface SandboxLivenessHandle {
 }
 
 export interface SandboxLivenessOptions {
-  /** One liveness check. Resolves when the sandbox answered, rejects or hangs when it did not. */
-  probe: () => Promise<unknown>;
+  /**
+   * One liveness check. Resolves when the sandbox answered, rejects or hangs when it did not.
+   *
+   * Optional: a sandbox that exposes no health URL still gets the `goneSignal` route, which needs
+   * no polling at all.
+   */
+  probe?: () => Promise<unknown>;
   limits: SandboxLivenessLimits;
   /** Called at most once, with a human-readable reason, when the sandbox is declared gone. */
   onGone: (reason: string) => void;
+  /**
+   * The latch the turn's ACP transport writes to when a response names the sandbox as gone. It
+   * ends the turn on the spot, without waiting for the next probe interval.
+   */
+  goneSignal?: SandboxGoneLatch;
   clock?: Clock;
   log?: (message: string) => void;
 }
@@ -136,6 +179,7 @@ export function startSandboxLivenessProbe({
   probe,
   limits,
   onGone,
+  goneSignal,
   clock = realClock,
   log = () => {},
 }: SandboxLivenessOptions): SandboxLivenessHandle {
@@ -144,6 +188,16 @@ export function startSandboxLivenessProbe({
   let inFlight = false;
   let failures = 0;
   let timer: NodeJS.Timeout | undefined;
+
+  /** Declare the sandbox gone, at most once for the life of this handle. */
+  const fire = (reason: string): void => {
+    if (fired || disposed) return;
+    fired = true;
+    if (timer) clock.clearTimeout(timer);
+    timer = undefined;
+    log(`[sandbox-liveness] ${reason}`);
+    onGone(reason);
+  };
 
   const schedule = (): void => {
     if (disposed || fired) return;
@@ -154,10 +208,11 @@ export function startSandboxLivenessProbe({
     let timeoutHandle: NodeJS.Timeout | undefined;
     try {
       await Promise.race([
-        probe(),
+        probe!(),
         new Promise<never>((_resolve, reject) => {
           timeoutHandle = clock.setTimeout(
-            () => reject(new Error(`probe timed out after ${limits.timeoutMs}ms`)),
+            () =>
+              reject(new Error(`probe timed out after ${limits.timeoutMs}ms`)),
             limits.timeoutMs,
           );
         }),
@@ -181,16 +236,21 @@ export function startSandboxLivenessProbe({
     } catch (err) {
       failures += 1;
       const detail = err instanceof Error ? err.message : String(err);
+      // The provider answering "that sandbox does not exist" is a verdict, not a symptom, so it
+      // needs no corroboration from two more probes.
+      if (err instanceof SandboxGoneError) {
+        log(`[sandbox-liveness] probe failed (definitive): ${detail}`);
+        fire(`${SANDBOX_GONE_MARKER}: ${detail}`);
+        return;
+      }
       log(
         `[sandbox-liveness] probe failed (${failures}/${limits.failureThreshold}): ${detail}`,
       );
-      if (failures >= limits.failureThreshold && !fired && !disposed) {
-        fired = true;
-        const reason =
+      if (failures >= limits.failureThreshold) {
+        fire(
           `${SANDBOX_GONE_MARKER}: ${failures} consecutive liveness probes failed ` +
-          `(last: ${detail})`;
-        log(`[sandbox-liveness] ${reason}`);
-        onGone(reason);
+            `(last: ${detail})`,
+        );
         return;
       }
     } finally {
@@ -199,13 +259,22 @@ export function startSandboxLivenessProbe({
     schedule();
   };
 
-  if (!process.env[PROBE_DISABLED_ENV]) schedule();
+  // The transport's report is not a poll, so `PROBE_DISABLED_ENV` does not silence it: that switch
+  // exists to stop the runner making a request per sandbox per tick, not to make the runner ignore
+  // a death it was told about. The latch belongs to the ENVIRONMENT, which outlives this turn on a
+  // warm sandbox, so `dispose` must hand the listener back or every turn leaves one behind.
+  const unsubscribeGone = goneSignal?.subscribe((reason) => {
+    fire(`${SANDBOX_GONE_MARKER}: ${reason}`);
+  });
+
+  if (probe && !process.env[PROBE_DISABLED_ENV]) schedule();
 
   return {
     dispose() {
       disposed = true;
       if (timer) clock.clearTimeout(timer);
       timer = undefined;
+      unsubscribeGone?.();
     },
     failures: () => failures,
   };

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -537,15 +537,34 @@ export function approvalDecisionForToolCall(
   toolCallId: string,
 ): "allow" | "deny" | undefined {
   if (!toolCallId) return undefined;
-  for (const message of request.messages ?? []) {
-    const content = message?.content;
-    if (!Array.isArray(content)) continue;
-    for (const block of content) {
-      if (block?.type !== "tool_result" || block.toolCallId !== toolCallId) {
-        continue;
+  const messages = request.messages ?? [];
+  if (messages.length === 0) return undefined;
+
+  // A pure interaction reply carries its decision at the request tail. A fresh user turn can
+  // carry a rewritten `output-denied` tool part in its history; only the LAST assistant message
+  // is relevant there. Scanning the whole transcript lets an older denial bind to a newer gate
+  // that reused the id and incorrectly diverts the new user text into approval-resume.
+  let message: ChatMessage | undefined;
+  if (!tailIsFreshUserMessage(request)) {
+    message = messages[messages.length - 1];
+  } else {
+    for (let i = messages.length - 2; i >= 0; i--) {
+      if (messages[i]?.role === "assistant") {
+        message = messages[i];
+        break;
       }
-      const decision = approvalDecisionOf(block);
-      if (decision !== undefined) return decision;
+    }
+  }
+  if (message) {
+    const content = message?.content;
+    if (Array.isArray(content)) {
+      for (const block of content) {
+        if (block?.type !== "tool_result" || block.toolCallId !== toolCallId) {
+          continue;
+        }
+        const decision = approvalDecisionOf(block);
+        if (decision !== undefined) return decision;
+      }
     }
   }
   return undefined;

--- a/services/runner/src/lifecycle/session-coordinator.ts
+++ b/services/runner/src/lifecycle/session-coordinator.ts
@@ -1185,6 +1185,7 @@ export async function runWithKeepalive(
     const parkedList = [...existing.environment.parkedApprovals.values()];
     const resumeDecisions: ResumeApprovalInput[] = [];
     const carriedForward: ParkedApproval[] = [];
+    const freshUserTail = tailIsFreshUserMessage(request);
     let mismatch: string | undefined;
     if (parkedList.length === 0) {
       mismatch = "no-parked-gate";
@@ -1234,7 +1235,14 @@ export async function runWithKeepalive(
     // session; the history check only guards a client that DID assert a transcript.
     const clientAssertsHistory = !carriesApprovalReplyOnly(request);
     if (!mismatch) {
-      if (clientAssertsHistory && priorFp !== existing.historyFingerprint) {
+      if (freshUserTail && carriedForward.length > 0) {
+        // A new prompt cannot start while any old gate still holds the harness's original prompt.
+        // Only a complete decision set can settle that prompt and keep this environment warm.
+        mismatch = "fresh-prompt-unanswered-gate";
+      } else if (
+        clientAssertsHistory &&
+        priorFp !== existing.historyFingerprint
+      ) {
         mismatch = "history";
       } else if (mountCredentialsExpired(existing.credentialEpoch)) {
         mismatch = "credentials-expired";
@@ -1290,21 +1298,25 @@ export async function runWithKeepalive(
 
     const live = pool.checkoutApproval(key);
     if (live) {
-      shadowRoute(existing, "reuse", "approval-resume");
+      const decisionRoute = freshUserTail
+        ? "approval-decision-then-prompt"
+        : "approval-resume";
+      shadowRoute(existing, "reuse", decisionRoute);
       const approveCount = resumeDecisions.filter(
         (d) => d.reply === "once",
       ).length;
       const rejectCount = resumeDecisions.length - approveCount;
       klog(
-        `resume key=${key} gates=${parkedList.length} answered=${resumeDecisions.length} ` +
+        `${freshUserTail ? "decision-then-prompt" : "resume"} key=${key} ` +
+          `gates=${parkedList.length} answered=${resumeDecisions.length} ` +
           `carried=${carriedForward.length} ` +
           `approve=${approveCount} reject=${rejectCount} tool=${parked?.toolName ?? "?"}`,
       );
       let result: AgentRunResult;
       try {
-        // Answer the parked gate on the SAME live session; the original prompt continues and this
-        // (new) turn owns streaming + tracing. The gated tool runs with its original byte-exact
-        // args — no model re-issues anything, so argument drift/task restart cannot happen.
+        // A pure decision resumes the original prompt. A decision followed by fresh user text
+        // settles that gate first and then sends the text as a normal continuation prompt on the
+        // same warm session; the decision becomes context instead of swallowing the new turn.
         result = await engine.runTurn(
           live.environment,
           request,
@@ -1312,7 +1324,14 @@ export async function runWithKeepalive(
           signal,
           {
             approvalParkMode: true,
-            resume: { decisions: resumeDecisions, carriedForward },
+            ...(freshUserTail
+              ? {
+                  continuation: true,
+                  settleApprovalsThenPrompt: { decisions: resumeDecisions },
+                }
+              : {
+                  resume: { decisions: resumeDecisions, carriedForward },
+                }),
             ...turnCredential,
           },
         );

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -979,8 +979,20 @@ export async function stopParkedApprovalSession(
       wait: input.wait,
     });
     if (cancel.requested) env.sessionDestroyRequested = true;
-    if (!cancel.settled) {
+    if (!cancel.settled && cancel.requested) {
+      // The ACP cancel WAS sent but the harness did not confirm it inside the budget. The prompt
+      // may still be open, so fail closed rather than present a possibly-running turn as idle.
       throw new Error("parked approval harness cancel did not settle");
+    }
+    if (!cancel.settled) {
+      // No ACP cancel could be SENT: a local runtime whose sandbox client has no `cancelSession`
+      // (`stage=harness_cancel sent=false reason=client-has-no-cancelSession`). The reject above
+      // is still the stop signal for a parked approval, which runs no turn, and a Stop must NEVER
+      // evict the warm sandbox. So repark it warm, exactly as the reject-then-repark path did
+      // before the ACP cancel was added, instead of tearing it down and reporting a failed Stop.
+      env.logger(
+        "stage=parked_stop reject-only (client has no cancelSession); reparking warm",
+      );
     }
 
     env.parkedApprovals.clear();

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -52,6 +52,10 @@ import {
   type SessionEnvironment,
 } from "./engines/sandbox_agent.ts";
 import {
+  cancelHarnessTurn,
+  resolveCancelSettleMs,
+} from "./engines/sandbox_agent/cancel-turn.ts";
+import {
   isMounted,
   type MountCredentials,
 } from "./engines/sandbox_agent/mount.ts";
@@ -919,45 +923,82 @@ function parkedSessionControl(
         // permission gate while Stop is releasing it.
         const live = pool.checkoutApproval(key);
         if (!live) throw new Error("parked approval was already checked out");
-        const env = live.environment;
-        const gates = [...env.parkedApprovals.values()];
-        try {
-          await Promise.all(
-            gates.map((gate) =>
-              env.session.respondPermission(gate.permissionId, "reject"),
+        await stopParkedApprovalSession({
+          environment: live.environment,
+          repark: () =>
+            pool.repark(
+              live,
+              {
+                historyFingerprint: live.historyFingerprint,
+                historyAsserted: live.historyAsserted,
+                credentialEpoch: live.credentialEpoch,
+              },
+              keepaliveConfigs[provider].stoppedTtlMs ??
+                keepaliveConfigs[provider].ttlMs,
             ),
-          );
-          env.parkedApprovals.clear();
-          env.parkedApproval = undefined;
-          env.parkedApprovedExecutions?.clear();
-          env.approvalGateCount = 0;
-          env.nonParkablePauseCount = 0;
-          env.commitAuthorization = undefined;
-          env.clearTurn();
-          const reparked = await pool.repark(
-            live,
-            {
-              historyFingerprint: live.historyFingerprint,
-              historyAsserted: live.historyAsserted,
-              credentialEpoch: live.credentialEpoch,
-            },
-            keepaliveConfigs[provider].stoppedTtlMs ??
-              keepaliveConfigs[provider].ttlMs,
-          );
-          if (!reparked) {
-            await live.teardown("failed-turn");
-            throw new Error("released approval could not return to the pool");
-          }
-        } catch (error) {
-          // A partly released gate set is not safe to present as awaiting approval again. Fail
-          // closed through the normal teardown path; applyCommand reports the failed outcome.
-          await pool.evictIfCurrent(live, "stop-approval-failed", "failed-turn");
-          throw error;
-        }
+          teardown: () =>
+            pool.evictIfCurrent(
+              live,
+              "stop-approval-failed",
+              "failed-turn",
+            ),
+        });
       },
     };
   }
   return undefined;
+}
+
+interface StopParkedApprovalSessionInput {
+  environment: SessionEnvironment;
+  repark: () => Promise<boolean>;
+  teardown: () => Promise<void>;
+  /** Test seams; production uses the operator-configured bound and a real timer. */
+  cancelSettleMs?: number;
+  wait?: (ms: number) => Promise<void>;
+}
+
+/** Reject and cancel a parked prompt before exposing its environment as idle again. */
+export async function stopParkedApprovalSession(
+  input: StopParkedApprovalSessionInput,
+): Promise<void> {
+  const env = input.environment;
+  const gates = [...env.parkedApprovals.values()];
+  try {
+    await Promise.all(
+      gates.map((gate) =>
+        env.session.respondPermission(gate.permissionId, "reject"),
+      ),
+    );
+    const cancel = await cancelHarnessTurn({
+      sandbox: env.sandbox,
+      sessionId: env.session?.id,
+      promptPromise: gates[0]?.promptPromise,
+      timeoutMs: input.cancelSettleMs ?? resolveCancelSettleMs(),
+      log: env.logger,
+      wait: input.wait,
+    });
+    if (cancel.requested) env.sessionDestroyRequested = true;
+    if (!cancel.settled) {
+      throw new Error("parked approval harness cancel did not settle");
+    }
+
+    env.parkedApprovals.clear();
+    env.parkedApproval = undefined;
+    env.parkedApprovedExecutions?.clear();
+    env.approvalGateCount = 0;
+    env.nonParkablePauseCount = 0;
+    env.commitAuthorization = undefined;
+    env.clearTurn();
+    if (!(await input.repark())) {
+      throw new Error("released approval could not return to the pool");
+    }
+  } catch (error) {
+    // A partly released or unsettled prompt is not safe to present as idle. Fail closed through
+    // the normal teardown path; applyCommand reports the failed outcome.
+    await input.teardown();
+    throw error;
+  }
 }
 
 /** Build the HTTP request listener around a given engine runner (the testable seam). */

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -102,6 +102,14 @@ import {
   unregisterExecution,
 } from "./sessions/execution-registry.ts";
 import {
+  awaitTurnOrAbandon,
+  resolveTurnSettleLimits,
+} from "./sessions/turn-settle.ts";
+import {
+  ABANDONED_TURN_MARKER,
+  type RunErrorCode,
+} from "./engines/sandbox_agent/errors.ts";
+import {
   buildWorkflowReferenceList,
   cancelStaleInteractions,
 } from "./sessions/interactions.ts";
@@ -483,6 +491,13 @@ async function runAndStreamWithApiBaseResolved(
   // runs abort on disconnect (original behavior: caller drives, disconnect = cancel).
   const controller = new AbortController();
   let clientDisconnected = false;
+  // Resolves when the platform tells us this turn is no longer current — a Stop, a takeover,
+  // or the API's own execution watchdog having declared the turn lost. `awaitTurnOrAbandon`
+  // uses it to stop waiting on a run that may never return. See `sessions/turn-settle.ts`.
+  let markInterrupted: ((reason: string) => void) | undefined;
+  const interrupted = new Promise<string>((resolve) => {
+    markInterrupted = resolve;
+  });
   if (!sessionOwned) {
     // Listen on the response, not the request: the request body is already fully read, so
     // its `close` can fire early on a keep-alive connection. `res` `close` fires when the
@@ -519,8 +534,18 @@ async function runAndStreamWithApiBaseResolved(
   // For session-owned runs: wrap the live emitter so every event is also persisted
   // producer-side, independent of whether the client is still connected.
   let emitFn: EmitEvent = liveEmit;
+  // Closed once this request has written the turn's terminal outcome. An abandoned run may
+  // still unwind minutes later and emit its own `error`/`done` through the same emitter; the
+  // turn already has an ending, and a second one would put two endings in one transcript.
+  let turnClosed = false;
+  const gatedEmit: EmitEvent = (event) => {
+    if (turnClosed) return;
+    emitFn(event);
+  };
   let flushPersist: (() => Promise<void>) | undefined;
-  let persistError: ((message: string) => void) | undefined;
+  let persistError:
+    | ((message: string, code?: RunErrorCode) => void)
+    | undefined;
   let persistTerminal: ((stopReason?: string) => void) | undefined;
   let terminalRecordEmitted = false;
   let aliveWatchdog:
@@ -553,9 +578,15 @@ async function runAndStreamWithApiBaseResolved(
         sessionId,
         turnId,
         platformCredentialForRequest(request),
-        // LABELLED, not a bare abort: `shouldPark` parks only an abort it can prove was a
-        // cooperative Stop. See `sessions/stop-signal.ts`.
-        () => controller.abort(USER_STOP_ABORT_REASON),
+        () => {
+          markInterrupted?.(
+            "the platform reported this turn is no longer current (stopped, taken over, or " +
+              "declared lost)",
+          );
+          // LABELLED, not a bare abort: `shouldPark` parks only an abort it can prove was a
+          // cooperative Stop. See `sessions/stop-signal.ts`.
+          controller.abort(USER_STOP_ABORT_REASON);
+        },
         {
           name: proposeSessionName(request),
           references: buildWorkflowReferenceList(request.runContext?.workflow),
@@ -673,7 +704,8 @@ async function runAndStreamWithApiBaseResolved(
         persistingEmit(event);
       };
       flushPersist = flush;
-      persistError = (message) => persist({ type: "error", message }, "agent");
+      persistError = (message, code) =>
+        persist({ type: "error", message, ...(code ? { code } : {}) }, "agent");
       persistTerminal = (stopReason) => {
         terminalRecordEmitted = true;
         persist(
@@ -693,29 +725,56 @@ async function runAndStreamWithApiBaseResolved(
 
   let result: AgentRunResult;
   try {
-    result = await run(request, emitFn, controller.signal, {
-      clientGone: () => clientDisconnected,
-      credential: aliveWatchdog?.credential,
+    // Not a bare `await run(...)`: an await inside the run that never settles would keep this
+    // function parked forever, and with it the terminal record below AND the alive watchdog's
+    // release in the `finally` — the turn would announce `running=true` every 30s for good.
+    // `awaitTurnOrAbandon` returns either the run's own result or a reason to write one
+    // without it, so this request always produces exactly one terminal outcome.
+    const outcome = await awaitTurnOrAbandon({
+      run: run(request, gatedEmit, controller.signal, {
+        clientGone: () => clientDisconnected,
+        credential: aliveWatchdog?.credential,
+      }),
+      abort: () => controller.abort(),
+      interrupted: sessionOwned ? interrupted : undefined,
+      limits: resolveTurnSettleLimits((message) =>
+        process.stderr.write(`${message}\n`),
+      ),
+      log: (message) => process.stderr.write(`${message}\n`),
     });
-    // `runTurn` normally emits `done` itself. Acquisition can fail before `runTurn` starts,
-    // though, and a cooperative Stop during a cold sandbox create reaches exactly that path.
-    // Close any failed run that emitted no terminal record; preserve the Stop marker when the
-    // labelled control-plane abort caused it. A genuine acquire failure never reached runTurn's
-    // error emitter, so preserve its error before the done backstop instead of making the empty
-    // turn look successful. Both records use the same ordered persistence chain as runTurn's
-    // emitter but stay off the live stream, whose result envelope is unchanged.
-    if (
-      !terminalRecordEmitted &&
-      persistTerminal &&
-      (!result.ok || isUserStopAbort(controller.signal))
-    ) {
-      const userStopped = isUserStopAbort(controller.signal);
-      if (!userStopped && !result.ok && persistError) {
-        persistError(result.error ?? "Agent run failed.");
+    if (outcome.settled) {
+      result = outcome.value;
+      // `runTurn` normally emits `done` itself. Acquisition can fail before `runTurn` starts,
+      // though, and a cooperative Stop during a cold sandbox create reaches exactly that path.
+      // Close any failed run that emitted no terminal record; preserve the Stop marker when the
+      // labelled control-plane abort caused it. A genuine acquire failure never reached runTurn's
+      // error emitter, so preserve its error before the done backstop instead of making the empty
+      // turn look successful. Both records use the same ordered persistence chain as runTurn's
+      // emitter but stay off the live stream, whose result envelope is unchanged.
+      if (
+        !terminalRecordEmitted &&
+        persistTerminal &&
+        (!result.ok || isUserStopAbort(controller.signal))
+      ) {
+        const userStopped = isUserStopAbort(controller.signal);
+        if (!userStopped && !result.ok && persistError) {
+          persistError(result.error ?? "Agent run failed.");
+        }
+        persistTerminal(userStopped ? "cancelled" : undefined);
       }
-      persistTerminal(userStopped ? "cancelled" : undefined);
+    } else {
+      // The run is still pending and may never settle. Give the turn the ending the runner
+      // owes it, and let the abandoned run keep its own teardown if it ever unwinds.
+      turnClosed = true;
+      const message = `${ABANDONED_TURN_MARKER}: ${outcome.reason}`;
+      process.stderr.write(
+        `[sessions] ABANDONED session=${sessionId ?? "-"} turn=${turnId ?? "-"}: ${outcome.reason}\n`,
+      );
+      if (persistError) persistError(message, "execution_lost");
+      result = { ok: false, error: message };
     }
-    // Drain the terminal backstop and all prior persists before the sandbox tears down.
+    // Drain the terminal backstop or abandonment marker and all prior persists before the
+    // sandbox tears down.
     if (flushPersist) await flushPersist();
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -95,6 +95,7 @@ import {
   applyCommand,
   holdsSession,
   type ControlCommand,
+  type ParkedSessionControl,
 } from "./sessions/control-channel.ts";
 import {
   noteExecutionProject,
@@ -901,11 +902,62 @@ function readRequiredId(value: unknown): string | null {
  * control channel at all today: a parked session stops heartbeating, so the only existing Stop
  * signal never reaches it.
  */
-function isSessionParked(projectId: string, sessionId: string): boolean {
+function parkedSessionControl(
+  projectId: string,
+  sessionId: string,
+): ParkedSessionControl | undefined {
   const key = `${projectId}:${sessionId}`;
-  return Object.values(keepalivePools).some(
-    (pool) => pool.get(key)?.state === "awaiting_approval",
-  );
+  for (const provider of Object.keys(
+    keepalivePools,
+  ) as KeepaliveProviderName[]) {
+    const pool = keepalivePools[provider];
+    const parked = pool.get(key);
+    if (!parked || parked.state !== "awaiting_approval") continue;
+    return {
+      stop: async () => {
+        // Checkout makes the transition exclusive: a racing request cannot consume the same
+        // permission gate while Stop is releasing it.
+        const live = pool.checkoutApproval(key);
+        if (!live) throw new Error("parked approval was already checked out");
+        const env = live.environment;
+        const gates = [...env.parkedApprovals.values()];
+        try {
+          await Promise.all(
+            gates.map((gate) =>
+              env.session.respondPermission(gate.permissionId, "reject"),
+            ),
+          );
+          env.parkedApprovals.clear();
+          env.parkedApproval = undefined;
+          env.parkedApprovedExecutions?.clear();
+          env.approvalGateCount = 0;
+          env.nonParkablePauseCount = 0;
+          env.commitAuthorization = undefined;
+          env.clearTurn();
+          const reparked = await pool.repark(
+            live,
+            {
+              historyFingerprint: live.historyFingerprint,
+              historyAsserted: live.historyAsserted,
+              credentialEpoch: live.credentialEpoch,
+            },
+            keepaliveConfigs[provider].stoppedTtlMs ??
+              keepaliveConfigs[provider].ttlMs,
+          );
+          if (!reparked) {
+            await live.teardown("failed-turn");
+            throw new Error("released approval could not return to the pool");
+          }
+        } catch (error) {
+          // A partly released gate set is not safe to present as awaiting approval again. Fail
+          // closed through the normal teardown path; applyCommand reports the failed outcome.
+          await pool.evictIfCurrent(live, "stop-approval-failed", "failed-turn");
+          throw error;
+        }
+      },
+    };
+  }
+  return undefined;
 }
 
 /** Build the HTTP request listener around a given engine runner (the testable seam). */
@@ -1030,16 +1082,22 @@ export function createRequestListener(
               ? cancelBody.createdAt
               : "",
         };
-        if (!holdsSession(cancelProjectId, cancelSessionId, isSessionParked)) {
+        if (
+          !holdsSession(
+            cancelProjectId,
+            cancelSessionId,
+            parkedSessionControl,
+          )
+        ) {
           // 404 is ambiguous on purpose and the API disambiguates it: a `not_held` for a
           // session whose row is alive and beating means the call reached the wrong replica.
           return send(res, 404, { ok: false, error: "session not held here" });
         }
         // Answer before the outcome. The applier reports it separately, and a Stop that takes
         // seconds to settle must not hold this request open.
-        void applyCommand(command, { isParked: isSessionParked }).catch(
-          () => {},
-        );
+        void applyCommand(command, {
+          isParked: parkedSessionControl,
+        }).catch(() => {});
         return send(res, 202, { ok: true, replicaId: REPLICA_ID });
       }
 

--- a/services/runner/src/sessions/alive.ts
+++ b/services/runner/src/sessions/alive.ts
@@ -15,12 +15,27 @@
  * Key contract constants mirror `sessions/contract.ts`; do not duplicate them.
  */
 
+import { envTimerMs } from "../env.ts";
 import { apiBase } from "../apiBase.ts";
 import { randomUUID } from "node:crypto";
 
 import { HEARTBEAT_INTERVAL_SECONDS, OWNER_TTL_SECONDS } from "./contract.ts";
 
 const REFRESH_INTERVAL_MS = HEARTBEAT_INTERVAL_SECONDS * 1000;
+
+export const HEARTBEAT_TIMEOUT_ENV = "AGENTA_RUNNER_HEARTBEAT_TIMEOUT_MS";
+/**
+ * A beat that never answers must not outlive its interval.
+ *
+ * The beat used a bare `fetch` with no signal, so a stalled socket never settled: beats piled
+ * up behind it, and the final `is_running: false` beat in `release()` could hold the request
+ * open after the turn had already ended. Half an interval keeps at most one beat in flight.
+ */
+export const DEFAULT_HEARTBEAT_TIMEOUT_MS = Math.floor(REFRESH_INTERVAL_MS / 2);
+
+function heartbeatTimeoutMs(): number {
+  return envTimerMs(HEARTBEAT_TIMEOUT_ENV, DEFAULT_HEARTBEAT_TIMEOUT_MS);
+}
 
 /**
  * This runner container's stable id, minted once per process. An orchestrator can inject a
@@ -135,6 +150,7 @@ async function sendHeartbeat(
     const url = `${apiBase()}/sessions/streams/heartbeat`;
     const res = await fetch(url, {
       method: "POST",
+      signal: AbortSignal.timeout(heartbeatTimeoutMs()),
       headers: {
         "content-type": "application/json",
         authorization,
@@ -300,17 +316,29 @@ export async function startAliveWatchdog(
   );
   handleBeat(first);
 
+  // One beat in flight at a time. `setInterval` fires unconditionally, so without this a
+  // slow API stacks a new request every 30s on top of every request already waiting.
+  let beatInFlight = false;
   const interval = setInterval(() => {
+    if (beatInFlight) {
+      log(`heartbeat skipped (previous still in flight) session=${sessionId}`);
+      return;
+    }
+    beatInFlight = true;
     void (async () => {
-      handleBeat(
-        await sendHeartbeat(
-          sessionId,
-          turnId,
-          credentialLease.credential(),
-          true,
-          proposal,
-        ),
-      );
+      try {
+        handleBeat(
+          await sendHeartbeat(
+            sessionId,
+            turnId,
+            credentialLease.credential(),
+            true,
+            proposal,
+          ),
+        );
+      } finally {
+        beatInFlight = false;
+      }
     })();
   }, REFRESH_INTERVAL_MS);
 

--- a/services/runner/src/sessions/control-channel.ts
+++ b/services/runner/src/sessions/control-channel.ts
@@ -13,11 +13,10 @@
  * THE THREE ANSWERS.
  *
  *   stopped                  — this process held the target execution and aborted it.
- *   not_running              — it holds no execution that can still be stopped. A session
- *                              parked awaiting an approval answers this, and so does a turn
- *                              whose prompt has already settled and is only tearing down. In
- *                              both cases there is nothing to abort, the parked environment
- *                              stays in the pool, and the session stays warm.
+ *   not_running              — it holds no execution that can still be stopped. A turn whose
+ *                              prompt has already settled and is only tearing down answers this.
+ *                              An approval-parked turn is still stoppable: its pending gate is
+ *                              released and it answers `stopped` like a live execution.
  *   superseded_by_newer_turn — it holds an execution that STARTED AFTER the command was
  *                              created, so the command was meant for a turn that has since
  *                              ended. Nothing is aborted. This check is exact, because it
@@ -65,9 +64,15 @@ export interface ControlOutcome {
   };
 }
 
+/** The control operation exposed by one approval-parked session. */
+export interface ParkedSessionControl {
+  /** Release every gate and return the same environment to the pool as idle. */
+  stop(): Promise<void> | void;
+}
+
 /** How the runner reaches a parked session. Injected so tests need no pool. */
 export interface ParkedLookup {
-  (projectId: string, sessionId: string): boolean;
+  (projectId: string, sessionId: string): ParkedSessionControl | undefined;
 }
 
 export interface ApplyCommandDeps {
@@ -87,7 +92,7 @@ export function holdsSession(
   isParked?: ParkedLookup,
 ): boolean {
   if (findExecution(projectId, sessionId)) return true;
-  return isParked ? isParked(projectId, sessionId) : false;
+  return isParked ? isParked(projectId, sessionId) !== undefined : false;
 }
 
 /**
@@ -123,7 +128,10 @@ export async function applyCommand(
 
   const createdAtMs = Date.parse(command.createdAt);
   const live = findLive(command.projectId, command.sessionId);
-  const outcome = decideOutcome(command, live, createdAtMs);
+  const parked = live
+    ? undefined
+    : deps.isParked?.(command.projectId, command.sessionId);
+  const outcome = decideOutcome(command, live, parked, createdAtMs);
 
   // Remember BEFORE aborting. A duplicate that arrives while the first abort is still settling
   // must find the command already taken, not start a second one.
@@ -137,15 +145,26 @@ export async function applyCommand(
     now(),
   );
 
-  if (outcome.execution.state === "stopped" && live) {
+  if (outcome.execution.state === "stopped") {
     try {
-      // The abort is the cancel. It makes the turn end `cancelled`, which is what sends the
-      // ACP `session/cancel` to the harness and lets the environment be PARKED rather than
-      // deleted (see `cancel-turn.ts` and `shouldPark`). Stop keeps the session warm.
-      live.abort();
-      log(
-        `aborted command=${command.id} session=${command.sessionId} turn=${live.turnId}`,
-      );
+      if (live) {
+        // The abort is the cancel. It makes the turn end `cancelled`, which is what sends the
+        // ACP `session/cancel` to the harness and lets the environment be PARKED rather than
+        // deleted (see `cancel-turn.ts` and `shouldPark`). Stop keeps the session warm.
+        live.abort();
+        log(
+          `aborted command=${command.id} session=${command.sessionId} turn=${live.turnId}`,
+        );
+      } else if (parked) {
+        // An approval park has no live execution to abort, but its harness still holds the
+        // original prompt on one or more permission gates. Releasing those gates ends the work
+        // and returns the SAME environment to the idle pool, so the next user message is a
+        // normal warm prompt rather than an approval resume.
+        await parked.stop();
+        log(
+          `released parked approval command=${command.id} session=${command.sessionId}`,
+        );
+      }
     } catch (error) {
       const message =
         error instanceof Error ? error.message : String(error ?? "abort failed");
@@ -174,12 +193,17 @@ export async function applyCommand(
 function decideOutcome(
   command: ControlCommand,
   live: LiveExecution | undefined,
+  parked: ParkedSessionControl | undefined,
   createdAtMs: number,
 ): ControlOutcome {
   if (!live) {
-    // No turn is running here. A parked approval lands here too, and that is the right answer:
-    // there is nothing to abort, and the parked environment must stay in the pool so the next
-    // message is warm. Stop ends the work, not the session.
+    if (parked) {
+      return {
+        result: "applied",
+        execution: { id: command.target.turnId, state: "stopped" },
+      };
+    }
+    // No live or approval-parked turn is held here. There is nothing to stop.
     return {
       result: "applied",
       execution: { id: command.target.turnId, state: "not_running" },

--- a/services/runner/src/sessions/turn-settle.ts
+++ b/services/runner/src/sessions/turn-settle.ts
@@ -1,0 +1,177 @@
+/**
+ * Guarantee that a turn ends, even when `run()` does not.
+ *
+ * The runner's terminal record, and the release of its alive watchdog, both sit downstream of
+ * `await run(...)`. That is correct for every path where `run()` returns, and it is the whole
+ * bug where it does not: an await inside the run that never settles leaves the heartbeat
+ * announcing `running=true` every thirty seconds forever, so the platform holds the session
+ * open under a turn nobody is running and no terminal record is ever written. See issues #6418,
+ * #6100 and #5327.
+ *
+ * This module bounds that. It waits for `run()` normally, and gives up on it when either:
+ *
+ * * the platform says this turn is no longer current (a Stop, a takeover, or the API's own
+ *   execution watchdog declaring the turn lost), or
+ * * the hard deadline elapses.
+ *
+ * Giving up is two steps, never one. First `abort()`, because most hangs DO unwind from an
+ * abort — the prompt race inside the turn resolves on the signal — and an unwound turn tears
+ * its sandbox down properly. Only if the run is still pending after `abandonGraceMs` does the
+ * caller stop waiting and write the outcome itself.
+ *
+ * What this deliberately does NOT do: kill the sandbox, or change any teardown rule. The
+ * abandoned `run()` still owns its environment and still runs its own `finally` if it ever
+ * settles. This is about the platform always learning the outcome, not about reclaiming
+ * machines — the keep-alive pool and the API watchdog already own that.
+ */
+
+import { envTimerMs } from "../env.ts";
+import { DEFAULT_TOTAL_DEADLINE_MS } from "../engines/sandbox_agent/run-limits.ts";
+
+export const HARD_DEADLINE_ENV = "AGENTA_RUNNER_TURN_HARD_DEADLINE_MS";
+export const ABANDON_GRACE_ENV = "AGENTA_RUNNER_TURN_ABANDON_GRACE_MS";
+
+/**
+ * Half an hour past the longest legitimate run.
+ *
+ * This is a backstop, not a policy: it must never be the limit that ends a real turn, because
+ * the run limits already own that decision and users have asked for LONGER runs, not shorter
+ * ones (issues #6084, #5356). Keeping it above `DEFAULT_TOTAL_DEADLINE_MS` means a turn that
+ * reaches it is one whose own deadline already tripped and failed to end it.
+ */
+export const DEFAULT_HARD_DEADLINE_MS = DEFAULT_TOTAL_DEADLINE_MS + 30 * 60_000;
+
+/**
+ * How long a turn may take to unwind after its abort before the caller stops waiting.
+ *
+ * Long enough for a normal teardown (flush the trace, settle the interaction rows, destroy or
+ * park the sandbox), short enough that a user who pressed Stop is not left watching a spinner.
+ */
+export const DEFAULT_ABANDON_GRACE_MS = 60_000;
+
+export interface TurnSettleLimits {
+  hardDeadlineMs: number;
+  abandonGraceMs: number;
+}
+
+export interface Clock {
+  setTimeout(fn: () => void, ms: number): NodeJS.Timeout;
+  clearTimeout(handle: NodeJS.Timeout): void;
+}
+
+const realClock: Clock = {
+  setTimeout: (fn, ms) => setTimeout(fn, ms),
+  clearTimeout: (handle) => clearTimeout(handle),
+};
+
+export function resolveTurnSettleLimits(
+  log: (message: string) => void = () => {},
+): TurnSettleLimits {
+  return {
+    hardDeadlineMs: envTimerMs(HARD_DEADLINE_ENV, DEFAULT_HARD_DEADLINE_MS, {
+      log,
+    }),
+    abandonGraceMs: envTimerMs(ABANDON_GRACE_ENV, DEFAULT_ABANDON_GRACE_MS, {
+      log,
+    }),
+  };
+}
+
+export type TurnSettleOutcome<T> =
+  /** `run()` returned. The normal path, and the only one that carries the run's own result. */
+  | { settled: true; value: T }
+  /** `run()` never returned. The caller must write the terminal outcome itself. */
+  | { settled: false; reason: string };
+
+export interface AwaitTurnOptions<T> {
+  /** The in-flight run. Never rejected by this function; the caller keeps its own catch. */
+  run: Promise<T>;
+  /** Ask the run to stop. Called once, before the grace window opens. */
+  abort: () => void;
+  /**
+   * Resolves when the platform says this turn is no longer current — the heartbeat answered
+   * `is_current_turn: false`. Optional: a non-session run has no such signal.
+   */
+  interrupted?: Promise<string>;
+  limits: TurnSettleLimits;
+  clock?: Clock;
+  log?: (message: string) => void;
+}
+
+/**
+ * Await `run`, or give up on it and say why.
+ *
+ * Resolves as soon as `run` settles on the happy path, with no timer left armed.
+ */
+export async function awaitTurnOrAbandon<T>({
+  run,
+  abort,
+  interrupted,
+  limits,
+  clock = realClock,
+  log = () => {},
+}: AwaitTurnOptions<T>): Promise<TurnSettleOutcome<T>> {
+  const timers: NodeJS.Timeout[] = [];
+  const clearTimers = (): void => {
+    for (const timer of timers) clock.clearTimeout(timer);
+    timers.length = 0;
+  };
+
+  // A tagged sentinel, not a symbol on the value channel: `run` may resolve to anything,
+  // including a symbol, and the race must be able to tell the two apart with certainty.
+  type Raced =
+    | { kind: "resolved"; value: T }
+    | { kind: "rejected"; error: unknown }
+    | { kind: "abandon" };
+  const trigger: Raced = { kind: "abandon" };
+  let triggerReason: string | undefined;
+  const settled: Promise<Raced> = run.then(
+    (value) => ({ kind: "resolved" as const, value }),
+    (error) => ({ kind: "rejected" as const, error }),
+  );
+
+  try {
+    const deadline = new Promise<Raced>((resolve) => {
+      timers.push(
+        clock.setTimeout(() => {
+          triggerReason = `hard turn deadline of ${limits.hardDeadlineMs}ms exceeded`;
+          resolve(trigger);
+        }, limits.hardDeadlineMs),
+      );
+    });
+    const displaced: Promise<Raced> | undefined = interrupted?.then((reason) => {
+      triggerReason = reason;
+      return trigger;
+    });
+
+    const first = await Promise.race(
+      displaced ? [settled, deadline, displaced] : [settled, deadline],
+    );
+    if (first.kind === "resolved") return { settled: true, value: first.value };
+    if (first.kind === "rejected") throw first.error;
+
+    // The run must stop. Most hangs unwind from here, so ask before giving up.
+    const reason = triggerReason ?? "turn abandoned";
+    log(`[turn-settle] ${reason}; aborting and waiting ${limits.abandonGraceMs}ms`);
+    try {
+      abort();
+    } catch (err) {
+      log(`[turn-settle] abort threw: ${err instanceof Error ? err.message : err}`);
+    }
+
+    const grace = new Promise<Raced>((resolve) => {
+      timers.push(clock.setTimeout(() => resolve(trigger), limits.abandonGraceMs));
+    });
+    const second = await Promise.race([settled, grace]);
+    if (second.kind === "resolved") return { settled: true, value: second.value };
+    if (second.kind === "rejected") throw second.error;
+
+    log(
+      `[turn-settle] run did not unwind within ${limits.abandonGraceMs}ms of the abort; ` +
+        `writing the terminal outcome without it`,
+    );
+    return { settled: false, reason };
+  } finally {
+    clearTimers();
+  }
+}

--- a/services/runner/tests/unit/control-command-apply.test.ts
+++ b/services/runner/tests/unit/control-command-apply.test.ts
@@ -8,8 +8,8 @@
  *     (the abort ends the turn `cancelled`, and only a cancelled turn takes the park path).
  *  2. It aborts NOTHING when it holds an execution that started after the command was created.
  *     That is the late-Stop guard, and it is exact because it reads this process's own memory.
- *  3. A session it holds parked awaiting an approval answers `not_running` and stays parked.
- *     Stop ends the work, not the session.
+ *  3. A session it holds parked awaiting an approval releases every gate, answers `stopped`,
+ *     and stays warm as an idle session for the next normal prompt.
  *  4. The same command delivered twice aborts once and acknowledges twice.
  *  5. It aborts NOTHING when the named execution's prompt has already settled and only its
  *     teardown is still running. That Stop lost the race by a moment, and aborting a finished
@@ -110,9 +110,7 @@ describe("applyCommand", () => {
     assert.deepEqual(reported, [outcome]);
   });
 
-  it("aborts nothing when this process holds no execution for the session", async () => {
-    // The parked-approval case. There is no turn to abort, and the parked environment must
-    // stay in the pool so the next message is warm.
+  it("reports not_running when this process holds no execution or parked approval", async () => {
     const { reported, report } = collector();
 
     const outcome = await applyCommand(command(), {
@@ -123,6 +121,65 @@ describe("applyCommand", () => {
     assert.equal(outcome.result, "applied");
     assert.equal(outcome.execution.state, "not_running");
     assert.equal(reported.length, 1);
+  });
+
+  it("stops a parked approval, clears its gates, and leaves the next prompt warm", async () => {
+    const { reported, report } = collector();
+    const permissionReplies: Array<{ id: string; reply: string }> = [];
+    const prompts: string[] = [];
+    const parked = {
+      state: "awaiting_approval" as "awaiting_approval" | "idle",
+      gates: new Map([
+        ["tool-a", { permissionId: "perm-a" }],
+        ["tool-b", { permissionId: "perm-b" }],
+      ]),
+      session: {
+        respondPermission: async (id: string, reply: string) => {
+          permissionReplies.push({ id, reply });
+        },
+        prompt: async (text: string) => {
+          prompts.push(text);
+        },
+      },
+    };
+
+    const outcome = await applyCommand(command(), {
+      findLive: () => undefined,
+      isParked: (projectId, sessionId) =>
+        projectId === PROJECT &&
+        sessionId === SESSION &&
+        parked.state === "awaiting_approval"
+          ? {
+              stop: async () => {
+                for (const gate of parked.gates.values()) {
+                  await parked.session.respondPermission(
+                    gate.permissionId,
+                    "reject",
+                  );
+                }
+                parked.gates.clear();
+                parked.state = "idle";
+              },
+            }
+          : undefined,
+      report,
+    });
+
+    assert.equal(outcome.result, "applied");
+    assert.equal(outcome.execution.state, "stopped");
+    assert.equal(outcome.execution.id, TURN);
+    assert.deepEqual(permissionReplies, [
+      { id: "perm-a", reply: "reject" },
+      { id: "perm-b", reply: "reject" },
+    ]);
+    assert.equal(parked.gates.size, 0);
+    assert.equal(parked.state, "idle");
+
+    if (parked.state === "idle") {
+      await parked.session.prompt("what next?");
+    }
+    assert.deepEqual(prompts, ["what next?"]);
+    assert.deepEqual(reported, [outcome]);
   });
 
   it("refuses to abort an execution that started AFTER the command was created", async () => {
@@ -408,11 +465,10 @@ describe("holdsSession", () => {
     // heartbeating, so the existing Stop signal never reaches it.
     assert.equal(holdsSession(PROJECT, SESSION), false);
     assert.equal(
-      holdsSession(
-        PROJECT,
-        SESSION,
-        (projectId, sessionId) =>
-          projectId === PROJECT && sessionId === SESSION,
+      holdsSession(PROJECT, SESSION, (projectId, sessionId) =>
+        projectId === PROJECT && sessionId === SESSION
+          ? { stop: () => {} }
+          : undefined,
       ),
       true,
     );
@@ -425,14 +481,19 @@ describe("holdsSession", () => {
         SESSION,
         (projectId, sessionId) =>
           projectId === "22222222-2222-4222-8222-222222222222" &&
-          sessionId === SESSION,
+          sessionId === SESSION
+            ? { stop: () => {} }
+            : undefined,
       ),
       false,
     );
   });
 
   it("is false for a session this process does not hold, which is what answers 404", () => {
-    assert.equal(holdsSession(PROJECT, "other-session", () => false), false);
+    assert.equal(
+      holdsSession(PROJECT, "other-session", () => undefined),
+      false,
+    );
   });
 });
 

--- a/services/runner/tests/unit/control-command-apply.test.ts
+++ b/services/runner/tests/unit/control-command-apply.test.ts
@@ -25,8 +25,13 @@ import {
   type ControlCommand,
   type ControlOutcome,
 } from "../../src/sessions/control-channel.ts";
+import { stopParkedApprovalSession } from "../../src/server.ts";
 import { resetAppliedCommandsForTest } from "../../src/sessions/applied-commands.ts";
 import { shouldPark } from "../../src/engines/sandbox_agent/engine.ts";
+import type {
+  ParkedApproval,
+  SessionEnvironment,
+} from "../../src/engines/sandbox_agent.ts";
 import {
   isUserStopAbort,
   USER_STOP_ABORT_REASON,
@@ -180,6 +185,116 @@ describe("applyCommand", () => {
     }
     assert.deepEqual(prompts, ["what next?"]);
     assert.deepEqual(reported, [outcome]);
+  });
+
+  it("reparks a stopped approval only after the harness cancel settles", async () => {
+    const journal: string[] = [];
+    let settlePrompt!: (value: unknown) => void;
+    const promptPromise = new Promise<unknown>((resolve) => {
+      settlePrompt = resolve;
+    });
+    const gate: ParkedApproval = {
+      gateType: "claude-acp-permission",
+      permissionId: "perm-a",
+      toolCallId: "tool-a",
+      toolName: "commit",
+      args: {},
+      interactionToken: "interaction-a",
+      promptPromise,
+    };
+    const env = {
+      sandbox: {
+        cancelSession: async () => {
+          journal.push("cancel");
+          settlePrompt({ stopReason: "cancelled" });
+        },
+      },
+      session: {
+        id: "harness-session",
+        respondPermission: async () => journal.push("reject"),
+      },
+      logger: () => {},
+      parkedApprovals: new Map([[gate.toolCallId, gate]]),
+      parkedApproval: gate,
+      parkedApprovedExecutions: new Map([["approved", {}]]),
+      approvalGateCount: 1,
+      nonParkablePauseCount: 1,
+      commitAuthorization: {},
+      sessionDestroyRequested: false,
+      clearTurn: () => journal.push("clear"),
+    } as unknown as SessionEnvironment;
+    let tornDown = 0;
+
+    await stopParkedApprovalSession({
+      environment: env,
+      repark: async () => {
+        journal.push("repark");
+        return true;
+      },
+      teardown: async () => {
+        tornDown += 1;
+      },
+      cancelSettleMs: 1,
+      wait: async () => {},
+    });
+
+    assert.deepEqual(journal, ["reject", "cancel", "clear", "repark"]);
+    assert.equal(env.parkedApprovals.size, 0);
+    assert.equal(env.parkedApproval, undefined);
+    assert.equal(env.sessionDestroyRequested, true);
+    assert.equal(tornDown, 0);
+  });
+
+  it("tears down a stopped approval when the harness cancel does not settle", async () => {
+    const journal: string[] = [];
+    const gate: ParkedApproval = {
+      gateType: "claude-acp-permission",
+      permissionId: "perm-a",
+      toolCallId: "tool-a",
+      toolName: "commit",
+      args: {},
+      interactionToken: "interaction-a",
+      promptPromise: new Promise(() => {}),
+    };
+    const env = {
+      sandbox: {
+        cancelSession: async () => journal.push("cancel"),
+      },
+      session: {
+        id: "harness-session",
+        respondPermission: async () => journal.push("reject"),
+      },
+      logger: () => {},
+      parkedApprovals: new Map([[gate.toolCallId, gate]]),
+      parkedApproval: gate,
+      parkedApprovedExecutions: new Map(),
+      approvalGateCount: 1,
+      nonParkablePauseCount: 0,
+      sessionDestroyRequested: false,
+      clearTurn: () => journal.push("clear"),
+    } as unknown as SessionEnvironment;
+
+    await assert.rejects(
+      stopParkedApprovalSession({
+        environment: env,
+        repark: async () => {
+          journal.push("repark");
+          return true;
+        },
+        teardown: async () => {
+          journal.push("teardown");
+        },
+        cancelSettleMs: 1,
+        wait: async () => {
+          journal.push("timeout");
+        },
+      }),
+      /parked approval harness cancel did not settle/,
+    );
+
+    assert.deepEqual(journal, ["reject", "cancel", "timeout", "teardown"]);
+    assert.equal(env.parkedApprovals.size, 1);
+    assert.equal(env.sessionDestroyRequested, true);
   });
 
   it("refuses to abort an execution that started AFTER the command was created", async () => {

--- a/services/runner/tests/unit/control-command-apply.test.ts
+++ b/services/runner/tests/unit/control-command-apply.test.ts
@@ -297,6 +297,141 @@ describe("applyCommand", () => {
     assert.equal(env.sessionDestroyRequested, true);
   });
 
+  it("reparks a parked approval warm when the sandbox client has no cancelSession", async () => {
+    // The local provider's sandbox client can lack `cancelSession` (an older runtime), so the
+    // runner cannot send the ACP session/cancel and `cancelHarnessTurn` answers
+    // `sent=false reason=client-has-no-cancelSession`. A parked approval runs no turn, and the
+    // reject below is still the stop signal, so the environment must repark WARM and the Stop must
+    // report `stopped` — never tear the sandbox down and report a failed cancel.
+    const journal: string[] = [];
+    const gate: ParkedApproval = {
+      gateType: "claude-acp-permission",
+      permissionId: "perm-a",
+      toolCallId: "tool-a",
+      toolName: "commit",
+      args: {},
+      interactionToken: "interaction-a",
+      // A prompt that never settles: without a cancelSession the runner never waits on it, so a
+      // pending prompt must not block or fail the repark.
+      promptPromise: new Promise(() => {}),
+    };
+    const env = {
+      // No `cancelSession` on the sandbox client. This is the local-runtime case.
+      sandbox: {},
+      session: {
+        id: "harness-session",
+        respondPermission: async () => journal.push("reject"),
+      },
+      logger: () => {},
+      parkedApprovals: new Map([[gate.toolCallId, gate]]),
+      parkedApproval: gate,
+      parkedApprovedExecutions: new Map([["approved", {}]]),
+      approvalGateCount: 1,
+      nonParkablePauseCount: 0,
+      commitAuthorization: {},
+      sessionDestroyRequested: false,
+      clearTurn: () => journal.push("clear"),
+    } as unknown as SessionEnvironment;
+    let tornDown = 0;
+
+    await stopParkedApprovalSession({
+      environment: env,
+      repark: async () => {
+        journal.push("repark");
+        return true;
+      },
+      teardown: async () => {
+        tornDown += 1;
+      },
+      cancelSettleMs: 1,
+      wait: async () => {},
+    });
+
+    // No cancel was sent, so the environment is reparked straight from the reject and never
+    // tears down.
+    assert.deepEqual(journal, ["reject", "clear", "repark"]);
+    assert.equal(tornDown, 0, "a Stop must never evict the warm sandbox");
+    assert.equal(env.parkedApprovals.size, 0);
+    assert.equal(env.parkedApproval, undefined);
+    // No cancel notification left the runner, so no destroy was ever requested for the session.
+    assert.equal(env.sessionDestroyRequested, false);
+  });
+
+  it("stops a local parked approval, staying warm, and reports it stopped end to end", async () => {
+    // The same case as above, but through `applyCommand`, which is what the /cancel route calls.
+    // It proves the OUTCOME the API settles on: `applied` / `stopped`, which is what writes the
+    // one terminal `session_executions` row. Before the fix this answered `applied` / `failed`,
+    // which the API never records as a terminal execution.
+    const { reported, report } = collector();
+    const parked = { state: "awaiting_approval" as "awaiting_approval" | "idle" };
+    let reparked = false;
+    let tornDown = false;
+
+    const env = {
+      sandbox: {}, // no cancelSession
+      session: {
+        id: "harness-session",
+        respondPermission: async () => {},
+      },
+      logger: () => {},
+      parkedApprovals: new Map([
+        [
+          "tool-a",
+          {
+            gateType: "claude-acp-permission",
+            permissionId: "perm-a",
+            toolCallId: "tool-a",
+            toolName: "commit",
+            args: {},
+            interactionToken: "interaction-a",
+            promptPromise: new Promise(() => {}),
+          } as ParkedApproval,
+        ],
+      ]),
+      parkedApproval: undefined,
+      parkedApprovedExecutions: new Map(),
+      approvalGateCount: 1,
+      nonParkablePauseCount: 0,
+      commitAuthorization: {},
+      sessionDestroyRequested: false,
+      clearTurn: () => {},
+    } as unknown as SessionEnvironment;
+
+    const outcome = await applyCommand(command(), {
+      findLive: () => undefined,
+      isParked: (projectId, sessionId) =>
+        projectId === PROJECT &&
+        sessionId === SESSION &&
+        parked.state === "awaiting_approval"
+          ? {
+              stop: () =>
+                stopParkedApprovalSession({
+                  environment: env,
+                  repark: async () => {
+                    reparked = true;
+                    parked.state = "idle";
+                    return true;
+                  },
+                  teardown: async () => {
+                    tornDown = true;
+                  },
+                  cancelSettleMs: 1,
+                  wait: async () => {},
+                }),
+            }
+          : undefined,
+      report,
+    });
+
+    assert.equal(outcome.result, "applied");
+    assert.equal(outcome.execution.state, "stopped");
+    assert.equal(outcome.execution.id, TURN);
+    assert.equal(reparked, true, "the warm sandbox returns to the pool");
+    assert.equal(tornDown, false, "and is never evicted");
+    assert.equal(parked.state, "idle");
+    assert.deepEqual(reported, [outcome]);
+  });
+
   it("refuses to abort an execution that started AFTER the command was created", async () => {
     const { execution, aborts } = liveRun({
       turnId: "turn-B",

--- a/services/runner/tests/unit/sandbox-agent-acp-fetch.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-acp-fetch.test.ts
@@ -15,6 +15,7 @@ import assert from "node:assert/strict";
 import {
   createAcpDispatcher,
   createAcpFetch,
+  withSandboxGoneReport,
 } from "../../src/engines/sandbox_agent/acp-fetch.ts";
 
 const envKeys = [
@@ -77,5 +78,51 @@ describe("createAcpFetch", () => {
   it("returns a fetch bound to the long-timeout ACP dispatcher", () => {
     const acpFetch = createAcpFetch();
     assert.equal(typeof acpFetch, "function");
+  });
+});
+
+/**
+ * The turn's own socket is the first thing to learn that a remote sandbox was deleted: Daytona
+ * answers `404 SANDBOX_NOT_FOUND` from its proxy while the ACP transport swallows the failure and
+ * the pending prompt never settles. This wrapper is how that death reaches the liveness probe.
+ */
+describe("withSandboxGoneReport", () => {
+  const goneResponse = () =>
+    new Response("not found: sandbox a476c238 not found", {
+      status: 404,
+      headers: { "x-daytona-error-code": "SANDBOX_NOT_FOUND" },
+    });
+
+  it("reports a provider answer that names the sandbox as gone", async () => {
+    const reasons: string[] = [];
+    const wrapped = withSandboxGoneReport(
+      (async () => goneResponse()) as unknown as typeof fetch,
+      { onSandboxGone: (reason) => reasons.push(reason) },
+    );
+
+    const response = await wrapped("http://sandbox/v1/acp/session");
+
+    assert.equal(reasons.length, 1);
+    assert.ok(reasons[0].includes("SANDBOX_NOT_FOUND"));
+    // The body must still be readable by the ACP client that asked for it.
+    assert.ok((await response.text()).includes("a476c238"));
+  });
+
+  it("reports nothing for an ordinary answer", async () => {
+    const reasons: string[] = [];
+    const wrapped = withSandboxGoneReport(
+      (async () =>
+        new Response("{}", { status: 200 })) as unknown as typeof fetch,
+      { onSandboxGone: (reason) => reasons.push(reason) },
+    );
+
+    await wrapped("http://sandbox/v1/acp/session");
+
+    assert.equal(reasons.length, 0);
+  });
+
+  it("is the identity when no reporter is wired", () => {
+    const inner = (async () => new Response("{}")) as unknown as typeof fetch;
+    assert.equal(withSandboxGoneReport(inner), inner);
   });
 });

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -36,6 +36,8 @@ import {
   shouldSuppressPausedToolCallUpdate,
 } from "../../src/engines/sandbox_agent/runtime-policy.ts";
 import { mountStorage } from "../../src/engines/sandbox_agent/mount.ts";
+import { withSandboxGoneReport } from "../../src/engines/sandbox_agent/acp-fetch.ts";
+import { SANDBOX_GONE_MESSAGE } from "../../src/engines/sandbox_agent/errors.ts";
 import { buildPiGateEnvelope } from "../../src/engines/sandbox_agent/pi-gate-envelope.ts";
 import { appendPlatformGuidance } from "../../src/engines/sandbox_agent/system-prompt-appendix.ts";
 import { platformGuidanceAppendix } from "../../src/engines/sandbox_agent/platform-guidance.ts";
@@ -3513,5 +3515,120 @@ describe("runTurn run-limits deadline (split path)", () => {
     // Paused, not a deadline error: the pause path — not a tripped limit — ended the turn.
     assert.equal(result.stopReason, "paused");
     assert.equal(calls.sandboxDestroyed, 1);
+  });
+});
+
+/**
+ * The Daytona sandbox-gone path, end to end through the real environment wiring.
+ *
+ * On 2026-09-04 an isolated re-run showed the full cost of the gap this closes: the sandbox was
+ * deleted at 16:26:31, the runner's own socket was told `SANDBOX_NOT_FOUND` at 16:26:37, and the
+ * turn still beat `running=true` for THIRTY minutes. Nothing detected the death. What finally
+ * ended the turn was the 30 minute per-tool-call deadline
+ * (`[run-limits] tool call ... exceeded 1800000ms`), and only then did the turn's error and done
+ * records persist, 27 minutes after the client had already given up.
+ *
+ * Everything downstream of the turn ending is already correct: the error terminal, the records,
+ * the `running=false` beat that clears the row, the teardown. The only defect was WHEN the turn
+ * ended. So these tests pin the trigger and the terminal it produces, which is what puts all of
+ * that 27 minutes earlier.
+ */
+describe("a sandbox the provider deletes under a running turn", () => {
+  /** Daytona's real answer for a deleted sandbox, from the runner log of that re-run. */
+  const goneAnswer = () =>
+    new Response(
+      "not found: sandbox 39f3aa96-ddc7-4417-b8ab-71804894edf6 not found, " +
+        "it may have been deleted or stopped - inspect audit logs for more info",
+      { status: 404, headers: { "x-daytona-error-code": "SANDBOX_NOT_FOUND" } },
+    );
+
+  /**
+   * Production's reporter over a fake socket. The double stands in for the network only: the
+   * wrapper, the latch and the arming are the real ones, so this exercises the wiring rather
+   * than a copy of it.
+   */
+  function harnessWithGoneSocket(answer: () => Response) {
+    const fake = fakeHarness({ hangPrompt: true });
+    fake.deps.createAcpFetch = ((_dispatcher: unknown, options: any) =>
+      withSandboxGoneReport(
+        (async () => answer()) as unknown as typeof fetch,
+        options,
+      )) as any;
+    return fake;
+  }
+
+  /** Let the run reach its prompt, which is where the real turn sits when its sandbox dies. */
+  async function waitForStartedTurn(calls: { startOptions: any }) {
+    for (let i = 0; i < 50 && !calls.startOptions; i += 1)
+      await flushPromises();
+    assert.ok(calls.startOptions, "the run should have started its sandbox");
+    await flushPromises();
+  }
+
+  it("ends the turn with a sandbox_gone error terminal, from the turn's own socket", async () => {
+    const { calls, deps, events } = harnessWithGoneSocket(goneAnswer);
+
+    const run = runSandboxAgent(
+      {
+        harness: "claude",
+        sessionId: "conv-sandbox-deleted",
+        messages: [{ role: "user", content: "run one shell command" }],
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+    await waitForStartedTurn(calls);
+
+    // The turn is parked on a prompt that can never settle, exactly as on 2026-09-04. Its own
+    // socket is the next thing to speak, and what it says is that the sandbox is gone.
+    await (calls.startOptions.fetch as typeof fetch)(
+      "http://sandbox/v1/acp/session",
+    );
+    const result = await run;
+
+    // The turn RETURNED rather than hanging for thirty minutes, and it returned as this error.
+    assert.equal(result.ok, false);
+    if (result.ok) return;
+    assert.equal(result.error, SANDBOX_GONE_MESSAGE);
+    // The terminal the client reads, and the record that persists at this moment.
+    const errorEvent = events.find((event) => event.type === "error") as any;
+    assert.ok(errorEvent, "the run should emit an error terminal");
+    assert.equal(errorEvent.code, "sandbox_gone");
+    // The teardown ran, so the sandbox and its slot are reclaimed here rather than at eviction.
+    assert.equal(calls.sandboxDestroyed, 1);
+  });
+
+  it("keeps running when the same socket merely returns an ordinary error", async () => {
+    // A 502 from the proxy is a blip, not a death. Nothing must end the turn on it, or a
+    // transient network fault would kill healthy runs.
+    const { calls, deps } = harnessWithGoneSocket(
+      () => new Response("", { status: 502 }),
+    );
+
+    const run = runSandboxAgent(
+      {
+        harness: "claude",
+        sessionId: "conv-proxy-blip",
+        messages: [{ role: "user", content: "run one shell command" }],
+      } as AgentRunRequest,
+      undefined,
+      undefined,
+      deps,
+    );
+    await waitForStartedTurn(calls);
+
+    await (calls.startOptions.fetch as typeof fetch)(
+      "http://sandbox/v1/acp/session",
+    );
+    for (let i = 0; i < 20; i += 1) await flushPromises();
+
+    // Still parked on its prompt: no terminal, no teardown.
+    assert.equal(calls.sandboxDestroyed, 0);
+    const settled = await Promise.race([
+      run.then(() => "settled" as const),
+      Promise.resolve("pending" as const),
+    ]);
+    assert.equal(settled, "pending");
   });
 });

--- a/services/runner/tests/unit/sandbox-gone.test.ts
+++ b/services/runner/tests/unit/sandbox-gone.test.ts
@@ -1,0 +1,214 @@
+/**
+ * A REMOTE sandbox does not refuse the socket when it dies.
+ *
+ * Daytona keeps the proxy host up after the sandbox is deleted and answers every request for it
+ * with `404` + `x-daytona-error-code: SANDBOX_NOT_FOUND`. The liveness probe reads any HTTP answer
+ * as alive on purpose, so that answer used to mean "still there": on 2026-09-04 a turn whose
+ * sandbox was deleted under it kept heartbeating `running=true` for five minutes and only stopped
+ * because the runner process was terminated.
+ *
+ * These tests hold the recognition rule. It has to be narrow in both directions: it must catch the
+ * provider's verdict, and it must not read a healthy answer, an unrelated error, or a 200 body that
+ * merely quotes the prose as a death.
+ */
+
+import { describe, it, expect, vi } from "vitest";
+
+import {
+  createSandboxGoneLatch,
+  sandboxGoneReason,
+} from "../../src/engines/sandbox_agent/sandbox-gone.ts";
+
+/** The shape the probe and the ACP transport both hand to the predicate. */
+function answer(status: number, headers: Record<string, string> = {}) {
+  const lower = new Map(
+    Object.entries(headers).map(([k, v]) => [k.toLowerCase(), v]),
+  );
+  return {
+    status,
+    headers: { get: (name: string) => lower.get(name.toLowerCase()) ?? null },
+  };
+}
+
+/** The exact answer Daytona gave for the deleted sandbox on 2026-09-04. */
+const DAYTONA_BODY =
+  "not found: sandbox a476c238-dfdb-492c-bb4a-0ca15f42fddf not found, " +
+  "it may have been deleted or stopped - inspect audit logs for more info";
+
+describe("sandboxGoneReason", () => {
+  it("reads the provider's own error code as a death", () => {
+    const reason = sandboxGoneReason(
+      answer(404, { "x-daytona-error-code": "SANDBOX_NOT_FOUND" }),
+    );
+
+    expect(reason).toBeTruthy();
+    expect(reason).toContain("SANDBOX_NOT_FOUND");
+  });
+
+  it("reads the provider's prose as a death when no code header rides along", () => {
+    expect(sandboxGoneReason(answer(404), DAYTONA_BODY)).toBeTruthy();
+  });
+
+  it("keeps a bare 404 alive: the health route may simply not exist", () => {
+    expect(sandboxGoneReason(answer(404), "Not Found")).toBeUndefined();
+  });
+
+  it("keeps 401 alive: unauthorised proves something is listening", () => {
+    expect(sandboxGoneReason(answer(401))).toBeUndefined();
+  });
+
+  it("keeps a 502 alive: a proxy blip is not a deleted sandbox", () => {
+    expect(sandboxGoneReason(answer(502), "")).toBeUndefined();
+  });
+
+  it("ignores the prose in a SUCCESSFUL answer, which proves the sandbox answered", () => {
+    expect(sandboxGoneReason(answer(200), DAYTONA_BODY)).toBeUndefined();
+  });
+
+  it("ignores an unrelated provider error code", () => {
+    expect(
+      sandboxGoneReason(answer(400, { "x-daytona-error-code": "BAD_REQUEST" })),
+    ).toBeUndefined();
+  });
+
+  /*
+   * A stopped or archived sandbox is a RESUMABLE state the provider itself handles, and the
+   * reconnect ladder can legitimately meet either one while it brings a parked sandbox back.
+   * Reading them as death would end a turn on a sandbox that is about to answer.
+   */
+  it("keeps a stopped sandbox alive: the provider can resume it", () => {
+    expect(
+      sandboxGoneReason(
+        answer(404, { "x-daytona-error-code": "SANDBOX_STOPPED" }),
+      ),
+    ).toBeUndefined();
+  });
+
+  it("keeps an archived sandbox alive, for the same reason", () => {
+    expect(
+      sandboxGoneReason(
+        answer(404, { "x-daytona-error-code": "SANDBOX_ARCHIVED" }),
+      ),
+    ).toBeUndefined();
+  });
+});
+
+/** An armed latch, which is what every caller past acquire holds. */
+function armedLatch() {
+  const latch = createSandboxGoneLatch();
+  latch.arm();
+  return latch;
+}
+
+describe("sandbox gone latch", () => {
+  it("delivers the first reason to a listener that subscribed earlier", () => {
+    const latch = armedLatch();
+    const listener = vi.fn();
+
+    latch.subscribe(listener);
+    latch.note("deleted");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(listener).toHaveBeenCalledWith("deleted");
+    expect(latch.reason()).toBe("deleted");
+  });
+
+  it("delivers to a listener that subscribed after the death", () => {
+    const latch = armedLatch();
+    const listener = vi.fn();
+
+    latch.note("deleted");
+    latch.subscribe(listener);
+
+    expect(listener).toHaveBeenCalledWith("deleted");
+  });
+
+  it("keeps one death for one sandbox, however many requests observe it", () => {
+    const latch = armedLatch();
+    const listener = vi.fn();
+    latch.subscribe(listener);
+
+    latch.note("first");
+    latch.note("second");
+    latch.note("third");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(latch.reason()).toBe("first");
+  });
+
+  it("reports nothing while the sandbox still answers", () => {
+    expect(armedLatch().reason()).toBeUndefined();
+  });
+
+  it("drops a listener that unsubscribed, so a warm sandbox keeps no dead turns", () => {
+    const latch = armedLatch();
+    const finishedTurn = vi.fn();
+    const currentTurn = vi.fn();
+
+    const unsubscribe = latch.subscribe(finishedTurn);
+    unsubscribe();
+    latch.subscribe(currentTurn);
+    latch.note("deleted");
+
+    expect(finishedTurn).not.toHaveBeenCalled();
+    expect(currentTurn).toHaveBeenCalledTimes(1);
+  });
+
+  it("survives a listener that throws, and still tells the others", () => {
+    const latch = armedLatch();
+    const other = vi.fn();
+    latch.subscribe(() => {
+      throw new Error("listener fault");
+    });
+    latch.subscribe(other);
+
+    latch.note("deleted");
+
+    expect(other).toHaveBeenCalledTimes(1);
+    expect(latch.reason()).toBe("deleted");
+  });
+});
+
+/*
+ * The startup window. The same fetch carries the SDK's health wait during acquire, which polls a
+ * sandbox that is still coming up and tolerates a provider error by design. On a warm resume the
+ * proxy can lag its own control plane and answer "not found" for a sandbox it has not finished
+ * re-exposing. The latch is one-way, so a report from that window must be discarded, or the first
+ * turn on a healthy sandbox is killed.
+ */
+describe("sandbox gone latch before it is armed", () => {
+  it("discards a gone report seen before acquire resolves", () => {
+    const latch = createSandboxGoneLatch();
+    const listener = vi.fn();
+    latch.subscribe(listener);
+
+    latch.note("provider reports the sandbox is gone (HTTP 404)");
+
+    expect(listener).not.toHaveBeenCalled();
+    expect(latch.reason()).toBeUndefined();
+  });
+
+  it("latches the SAME report once acquire has resolved", () => {
+    const latch = createSandboxGoneLatch();
+    const listener = vi.fn();
+    latch.subscribe(listener);
+
+    latch.note("provider reports the sandbox is gone (HTTP 404)");
+    latch.arm();
+    latch.note("provider reports the sandbox is gone (HTTP 404)");
+
+    expect(listener).toHaveBeenCalledTimes(1);
+    expect(latch.reason()).toBe(
+      "provider reports the sandbox is gone (HTTP 404)",
+    );
+  });
+
+  it("does not remember a discarded report: arming alone declares nothing", () => {
+    const latch = createSandboxGoneLatch();
+
+    latch.note("seen during acquire");
+    latch.arm();
+
+    expect(latch.reason()).toBeUndefined();
+  });
+});

--- a/services/runner/tests/unit/sandbox-liveness.test.ts
+++ b/services/runner/tests/unit/sandbox-liveness.test.ts
@@ -18,13 +18,16 @@ import {
   DEFAULT_PROBE_TIMEOUT_MS,
   PROBE_FAILURES_ENV,
   PROBE_INTERVAL_ENV,
+  httpLivenessProbe,
   resolveSandboxLivenessLimits,
+  SandboxGoneError,
   sandboxHealthUrl,
   startSandboxLivenessProbe,
   type Clock,
   type SandboxLivenessLimits,
 } from "../../src/engines/sandbox_agent/sandbox-liveness.ts";
 import { SANDBOX_GONE_MARKER } from "../../src/engines/sandbox_agent/errors.ts";
+import { createSandboxGoneLatch } from "../../src/engines/sandbox_agent/sandbox-gone.ts";
 
 /** A clock whose timers only run when the test says so, in scheduled order. */
 function fakeClock(): Clock & { tick(): Promise<void>; pending(): number } {
@@ -146,6 +149,158 @@ describe("sandbox liveness probe", () => {
     expect(probe).not.toHaveBeenCalled();
     expect(onGone).not.toHaveBeenCalled();
     expect(clock.pending()).toBe(0);
+  });
+});
+
+/** A latch the environment already armed, which is what every turn past acquire holds. */
+function armedLatch() {
+  const latch = createSandboxGoneLatch();
+  latch.arm();
+  return latch;
+}
+
+/**
+ * The Daytona case. The proxy answers for a deleted sandbox, so no probe ever fails the weak way
+ * and the three-strike counter never moves. Both routes below end the turn instead.
+ */
+describe("a sandbox the provider says is gone", () => {
+  it("ends the turn on the FIRST such answer, without waiting for the threshold", async () => {
+    const onGone = vi.fn();
+    const probe = vi
+      .fn()
+      .mockRejectedValue(new SandboxGoneError("sandbox a476c238 not found"));
+    const clock = fakeClock();
+
+    const handle = startSandboxLivenessProbe({ probe, limits, onGone, clock });
+
+    await clock.tick(); // one interval, one probe
+    await clock.tick();
+
+    expect(probe).toHaveBeenCalledTimes(1);
+    expect(onGone).toHaveBeenCalledTimes(1);
+    expect(onGone.mock.calls[0][0]).toContain(SANDBOX_GONE_MARKER);
+    expect(onGone.mock.calls[0][0]).toContain("a476c238");
+    handle.dispose();
+  });
+
+  it("ends the turn the moment the ACP transport reports it, with no probe at all", async () => {
+    const onGone = vi.fn();
+    const goneSignal = armedLatch();
+    const clock = fakeClock();
+
+    const handle = startSandboxLivenessProbe({
+      probe: vi.fn().mockResolvedValue(200),
+      goneSignal,
+      limits,
+      onGone,
+      clock,
+    });
+    goneSignal.note("provider reports the sandbox is gone (HTTP 404)");
+
+    expect(onGone).toHaveBeenCalledTimes(1);
+    expect(onGone.mock.calls[0][0]).toContain(SANDBOX_GONE_MARKER);
+    handle.dispose();
+  });
+
+  it("honours the transport's report on a sandbox with no health URL to poll", () => {
+    const onGone = vi.fn();
+    const goneSignal = armedLatch();
+    const clock = fakeClock();
+
+    const handle = startSandboxLivenessProbe({
+      goneSignal,
+      limits,
+      onGone,
+      clock,
+    });
+
+    expect(clock.pending()).toBe(0); // nothing to poll, so nothing is scheduled
+    goneSignal.note("deleted");
+
+    expect(onGone).toHaveBeenCalledTimes(1);
+    handle.dispose();
+  });
+
+  it("still reports one death when the probe and the transport both see it", async () => {
+    const onGone = vi.fn();
+    const goneSignal = armedLatch();
+    const probe = vi
+      .fn()
+      .mockRejectedValue(new SandboxGoneError("sandbox gone per probe"));
+    const clock = fakeClock();
+
+    const handle = startSandboxLivenessProbe({
+      probe,
+      goneSignal,
+      limits,
+      onGone,
+      clock,
+    });
+    goneSignal.note("sandbox gone per transport");
+    await clock.tick();
+    await clock.tick();
+
+    expect(onGone).toHaveBeenCalledTimes(1);
+    handle.dispose();
+  });
+
+  it("hands the listener back on dispose, so a warm sandbox keeps no finished turns", () => {
+    const goneSignal = armedLatch();
+    const finishedTurn = vi.fn();
+    const currentTurn = vi.fn();
+    const clock = fakeClock();
+
+    // Turn 1 runs and ends. Turn 2 starts on the SAME warm environment, so the same latch.
+    startSandboxLivenessProbe({
+      goneSignal,
+      limits,
+      onGone: finishedTurn,
+      clock,
+    }).dispose();
+    const handle = startSandboxLivenessProbe({
+      goneSignal,
+      limits,
+      onGone: currentTurn,
+      clock,
+    });
+
+    goneSignal.note("deleted");
+
+    expect(finishedTurn).not.toHaveBeenCalled();
+    expect(currentTurn).toHaveBeenCalledTimes(1);
+    handle.dispose();
+  });
+});
+
+describe("httpLivenessProbe", () => {
+  const originalFetch = globalThis.fetch;
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("rejects with a definitive error when the provider names the sandbox as gone", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue(
+      new Response("not found: sandbox a476c238 not found", {
+        status: 404,
+        headers: { "x-daytona-error-code": "SANDBOX_NOT_FOUND" },
+      }),
+    ) as unknown as typeof fetch;
+
+    await expect(
+      httpLivenessProbe("http://sandbox/v1/health")(),
+    ).rejects.toBeInstanceOf(SandboxGoneError);
+  });
+
+  it("keeps reading an ordinary 404 as alive", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValue(
+        new Response("Not Found", { status: 404 }),
+      ) as unknown as typeof fetch;
+
+    await expect(httpLivenessProbe("http://sandbox/v1/health")()).resolves.toBe(
+      404,
+    );
   });
 });
 

--- a/services/runner/tests/unit/sandbox-liveness.test.ts
+++ b/services/runner/tests/unit/sandbox-liveness.test.ts
@@ -19,6 +19,7 @@ import {
   PROBE_FAILURES_ENV,
   PROBE_INTERVAL_ENV,
   resolveSandboxLivenessLimits,
+  sandboxHealthUrl,
   startSandboxLivenessProbe,
   type Clock,
   type SandboxLivenessLimits,
@@ -66,6 +67,20 @@ afterEach(() => {
 });
 
 describe("sandbox liveness probe", () => {
+  it.each([
+    ["local", "http://127.0.0.1:43123/ui/", "http://127.0.0.1:43123/v1/health"],
+    [
+      "Daytona",
+      "https://3000-sandbox-id.proxy.daytona.works/ui/",
+      "https://3000-sandbox-id.proxy.daytona.works/v1/health",
+    ],
+  ])(
+    "derives the daemon health route from a %s inspector URL",
+    (_provider, inspectorUrl, expected) => {
+      expect(sandboxHealthUrl({ inspectorUrl })).toBe(expected);
+    },
+  );
+
   it("declares the sandbox gone after the threshold of consecutive failures", async () => {
     const onGone = vi.fn();
     const probe = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));

--- a/services/runner/tests/unit/sandbox-liveness.test.ts
+++ b/services/runner/tests/unit/sandbox-liveness.test.ts
@@ -1,0 +1,155 @@
+/**
+ * A sandbox that dies under a running turn must end the turn, not hang it.
+ *
+ * The ACP prompt the turn is parked on can never settle once the sandbox process is gone: the
+ * transport's read loop swallows the severed stream and never rejects the pending request. The
+ * existing run limits do not save it either — `notePaused()` retires all of them the moment the
+ * turn parks for a human, which is exactly when a long turn is most likely to outlive its
+ * sandbox. So the runner probes the sandbox's own HTTP surface, independently of the wedged ACP
+ * channel. These tests hold the probe's contract: it tolerates a blip, it declares death once,
+ * and it never fires after the turn released it. Issue #6418.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import {
+  DEFAULT_PROBE_FAILURES,
+  DEFAULT_PROBE_INTERVAL_MS,
+  DEFAULT_PROBE_TIMEOUT_MS,
+  PROBE_FAILURES_ENV,
+  PROBE_INTERVAL_ENV,
+  resolveSandboxLivenessLimits,
+  startSandboxLivenessProbe,
+  type Clock,
+  type SandboxLivenessLimits,
+} from "../../src/engines/sandbox_agent/sandbox-liveness.ts";
+import { SANDBOX_GONE_MARKER } from "../../src/engines/sandbox_agent/errors.ts";
+
+/** A clock whose timers only run when the test says so, in scheduled order. */
+function fakeClock(): Clock & { tick(): Promise<void>; pending(): number } {
+  let nextId = 1;
+  const timers = new Map<number, { fn: () => void; at: number }>();
+  let now = 0;
+
+  const clock = {
+    setTimeout(fn: () => void, ms: number) {
+      const id = nextId++;
+      timers.set(id, { fn, at: now + ms });
+      return id as unknown as NodeJS.Timeout;
+    },
+    clearTimeout(handle: NodeJS.Timeout) {
+      timers.delete(handle as unknown as number);
+    },
+    pending: () => timers.size,
+    /** Run the earliest pending timer, then drain the microtask queue. */
+    async tick() {
+      const entries = [...timers.entries()].sort((a, b) => a[1].at - b[1].at);
+      const next = entries[0];
+      if (!next) return;
+      timers.delete(next[0]);
+      now = next[1].at;
+      next[1].fn();
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    },
+  };
+  return clock;
+}
+
+const limits: SandboxLivenessLimits = {
+  intervalMs: 1_000,
+  timeoutMs: 500,
+  failureThreshold: 3,
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("sandbox liveness probe", () => {
+  it("declares the sandbox gone after the threshold of consecutive failures", async () => {
+    const onGone = vi.fn();
+    const probe = vi.fn().mockRejectedValue(new Error("ECONNREFUSED"));
+    const clock = fakeClock();
+
+    const handle = startSandboxLivenessProbe({ probe, limits, onGone, clock });
+
+    // Each pass is one interval timer, then the probe's own timeout timer.
+    for (let i = 0; i < 3; i++) {
+      await clock.tick(); // interval fires, probe rejects
+      await clock.tick(); // the (already settled) probe timeout is cleared/drained
+    }
+
+    expect(probe).toHaveBeenCalledTimes(3);
+    expect(onGone).toHaveBeenCalledTimes(1);
+    expect(onGone.mock.calls[0][0]).toContain(SANDBOX_GONE_MARKER);
+    handle.dispose();
+  });
+
+  it("tolerates a blip: one failure between successes is not a death", async () => {
+    const onGone = vi.fn();
+    const probe = vi
+      .fn()
+      .mockRejectedValueOnce(new Error("transient"))
+      .mockResolvedValue({ id: "session-1" });
+    const clock = fakeClock();
+
+    const handle = startSandboxLivenessProbe({ probe, limits, onGone, clock });
+
+    for (let i = 0; i < 8; i++) await clock.tick();
+
+    expect(onGone).not.toHaveBeenCalled();
+    expect(handle.failures()).toBe(0);
+    handle.dispose();
+  });
+
+  it("counts a probe that hangs as a failure, so a vanished host is not waited on forever", async () => {
+    const onGone = vi.fn();
+    // The exact #6418 shape: the request neither answers nor refuses.
+    const probe = vi.fn().mockImplementation(() => new Promise(() => {}));
+    const clock = fakeClock();
+
+    const handle = startSandboxLivenessProbe({ probe, limits, onGone, clock });
+
+    // interval -> probe hangs -> its timeout fires, three times over.
+    for (let i = 0; i < 6; i++) await clock.tick();
+
+    expect(onGone).toHaveBeenCalledTimes(1);
+    expect(onGone.mock.calls[0][0]).toContain("probe timed out");
+    handle.dispose();
+  });
+
+  it("fires at most once, and never after dispose", async () => {
+    const onGone = vi.fn();
+    const probe = vi.fn().mockRejectedValue(new Error("gone"));
+    const clock = fakeClock();
+
+    const handle = startSandboxLivenessProbe({ probe, limits, onGone, clock });
+    handle.dispose();
+
+    for (let i = 0; i < 10; i++) await clock.tick();
+
+    expect(probe).not.toHaveBeenCalled();
+    expect(onGone).not.toHaveBeenCalled();
+    expect(clock.pending()).toBe(0);
+  });
+});
+
+describe("sandbox liveness limits", () => {
+  it("defaults to one probe per heartbeat interval and three strikes", () => {
+    expect(resolveSandboxLivenessLimits()).toEqual({
+      intervalMs: DEFAULT_PROBE_INTERVAL_MS,
+      timeoutMs: DEFAULT_PROBE_TIMEOUT_MS,
+      failureThreshold: DEFAULT_PROBE_FAILURES,
+    });
+  });
+
+  it("takes an operator override", () => {
+    vi.stubEnv(PROBE_INTERVAL_ENV, "5000");
+    vi.stubEnv(PROBE_FAILURES_ENV, "2");
+
+    const resolved = resolveSandboxLivenessLimits();
+
+    expect(resolved.intervalMs).toBe(5_000);
+    expect(resolved.failureThreshold).toBe(2);
+  });
+});

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -30,6 +30,7 @@ import {
 } from "../../src/server.ts";
 import { SessionPool } from "../../src/engines/sandbox_agent/session-pool.ts";
 import {
+  approvalDecisionForToolCall,
   computeCredentialEpoch,
   configFingerprint,
   mountExpiryMs,
@@ -139,6 +140,12 @@ function makeApprovalEngine(
       reply: string;
       toolCallId: string;
     }>,
+    settledBeforePrompts: [] as Array<{
+      permissionId: string;
+      reply: string;
+      toolCallId: string;
+    }>,
+    prompts: [] as string[],
     acquiredEnvs: [] as DispatchFakeEnv[],
     /** One control per approvalPause turn: settle the parked prompt promise from the test. */
     promptControls: [] as Array<{
@@ -190,6 +197,7 @@ function makeApprovalEngine(
 
   const applyScript = async (
     env: DispatchFakeEnv,
+    request: AgentRunRequest,
     opts: any,
   ): Promise<AgentRunResult> => {
     const idx = calls.turns.length;
@@ -214,6 +222,19 @@ function makeApprovalEngine(
           reply: decision.reply,
           toolCallId: decision.toolCallId,
         });
+      }
+    }
+    if (opts?.settleApprovalsThenPrompt) {
+      for (const decision of opts.settleApprovalsThenPrompt.decisions) {
+        calls.settledBeforePrompts.push({
+          permissionId: decision.permissionId,
+          reply: decision.reply,
+          toolCallId: decision.toolCallId,
+        });
+      }
+      const tail = request.messages?.[request.messages.length - 1];
+      if (tail?.role === "user" && typeof tail.content === "string") {
+        calls.prompts.push(tail.content);
       }
     }
     if (script.hold) {
@@ -277,8 +298,8 @@ function makeApprovalEngine(
       calls.acquiredEnvs.push(env);
       return { ok: true, env: env as unknown as SessionEnvironment };
     },
-    async runTurn(env, _request, _emit, _signal, opts) {
-      return applyScript(env as unknown as DispatchFakeEnv, opts);
+    async runTurn(env, request, _emit, _signal, opts) {
+      return applyScript(env as unknown as DispatchFakeEnv, request, opts);
     },
     async runCold(_request, _emit, _signal, _presigned) {
       calls.cold += 1;
@@ -544,6 +565,83 @@ describe("runWithKeepalive: approval park + resume", () => {
       calls.resumes[0].reply,
       "reject",
       "deny -> respondPermission reject",
+    );
+  });
+
+  it("settles a rewritten denial then prompts a trailing fresh user turn on the warm session", async () => {
+    const { engine, calls } = makeApprovalEngine([
+      {
+        approvalPause: {
+          permissionId: "perm-1",
+          toolCallId: "tc-gate",
+          toolName: "commit",
+        },
+        toolCallIds: ["tc-gate"],
+      },
+    ]);
+    const ctx = makeCtx(engine);
+    await runWithKeepalive(pauseTurn(), undefined, undefined, ctx);
+
+    const request: AgentRunRequest = {
+      ...pauseTurn(),
+      messages: [
+        { role: "user", content: "do X" },
+        {
+          role: "assistant",
+          content: [
+            { type: "tool_call", toolCallId: "tc-gate", toolName: "commit" },
+            {
+              type: "tool_result",
+              toolCallId: "tc-gate",
+              output: { approved: false },
+            },
+          ],
+        },
+        { role: "user", content: "What was the codeword I gave you?" },
+      ],
+    };
+
+    const result = await runWithKeepalive(
+      request,
+      undefined,
+      undefined,
+      ctx,
+    );
+
+    assert.equal(result.ok, true);
+    assert.equal(calls.acquire, 1, "the fresh turn kept the warm environment");
+    assert.equal(calls.resumes.length, 0, "it did not take approval-resume");
+    assert.deepEqual(calls.settledBeforePrompts, [
+      { permissionId: "perm-1", reply: "reject", toolCallId: "tc-gate" },
+    ]);
+    assert.deepEqual(calls.prompts, ["What was the codeword I gave you?"]);
+    assert.equal(calls.turns[1].opts.continuation, true);
+    assert.equal(calls.turns[1].env, calls.turns[0].env);
+  });
+
+  it("ignores a denied tool result older than the last assistant message", () => {
+    const request: AgentRunRequest = {
+      messages: [
+        { role: "user", content: "first" },
+        {
+          role: "assistant",
+          content: [
+            {
+              type: "tool_result",
+              toolCallId: "tc-gate",
+              output: { approved: false },
+            },
+          ],
+        },
+        { role: "user", content: "second" },
+        { role: "assistant", content: "finished a later turn" },
+        { role: "user", content: "fresh question" },
+      ],
+    };
+
+    assert.equal(
+      approvalDecisionForToolCall(request, "tc-gate"),
+      undefined,
     );
   });
 
@@ -1572,6 +1670,7 @@ function pausableHarness(
     logs: [] as string[],
     resolvePrompt: undefined as ((value: unknown) => void) | undefined,
     promptCount: 0,
+    prompts: [] as any[],
     /** Ordered marks for the settle-before-terminal-record invariant (see the test at the end). */
     journal: [] as string[],
   };
@@ -1645,8 +1744,9 @@ function pausableHarness(
         queueMicrotask(emitPiBatchResults);
       }
     },
-    prompt(_blocks: any) {
+    prompt(blocks: any) {
       calls.promptCount += 1;
+      calls.prompts.push(blocks);
       // Stays pending (Claude never resolves prompt on an unanswered gate) until the test resolves
       // it — modelling the ORIGINAL prompt continuing after the parked gate is answered.
       return new Promise((resolve) => {
@@ -2038,6 +2138,88 @@ describe("runTurn: real approval park + respondPermission resume", () => {
       ],
     );
 
+    await env.destroy();
+  });
+
+  it("settles a parked denial before sending a fresh prompt to session.prompt", async () => {
+    const { calls, deps, captured } = pausableHarness();
+    const acquired = await acquireEnvironment(engineReq, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+    const env = acquired.env;
+
+    const firstTurn = runTurn(env, engineReq, undefined, undefined, {
+      approvalParkMode: true,
+    });
+    await flush();
+    captured.onEvent!(
+      updateEvent({
+        sessionUpdate: "tool_call",
+        toolCallId: "tc-gate",
+        title: "commit",
+      }),
+    );
+    captured.onPermissionRequest!({
+      id: "perm-1",
+      availableReplies: ["once", "reject"],
+      toolCall: { toolCallId: "tc-gate", name: "commit", rawInput: {} },
+    });
+    await flush();
+    await firstTurn;
+
+    const parked = env.parkedApproval!;
+    const resolveOriginalPrompt = calls.resolvePrompt!;
+    env.clearTurn();
+    const freshText = "What was the codeword I gave you?";
+    const freshRequest: AgentRunRequest = {
+      ...engineReq,
+      messages: [{ role: "user", content: freshText }],
+    };
+    const secondTurn = runTurn(
+      env,
+      freshRequest,
+      undefined,
+      undefined,
+      {
+        approvalParkMode: true,
+        continuation: true,
+        settleApprovalsThenPrompt: {
+          decisions: [
+            {
+              permissionId: parked.permissionId,
+              reply: "reject",
+              toolCallId: parked.toolCallId,
+              toolName: parked.toolName,
+              args: parked.args,
+              interactionToken: parked.interactionToken,
+              promptPromise: parked.promptPromise,
+            },
+          ],
+        },
+      },
+    );
+    for (let i = 0; i < 20 && calls.permissionReplies.length === 0; i += 1) {
+      await flush();
+    }
+    assert.deepEqual(calls.permissionReplies, [
+      { id: "perm-1", reply: "reject" },
+    ]);
+
+    resolveOriginalPrompt({
+      stopReason: "complete",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+    for (let i = 0; i < 20 && calls.promptCount < 2; i += 1) await flush();
+    assert.equal(calls.promptCount, 2, "the fresh text became a new prompt");
+    assert.deepEqual(calls.prompts[1], [{ type: "text", text: freshText }]);
+    calls.resolvePrompt!({
+      stopReason: "complete",
+      usage: { inputTokens: 1, outputTokens: 1 },
+    });
+
+    const result = await secondTurn;
+    assert.equal(result.ok, true);
+    assert.equal(result.stopReason, "complete");
     await env.destroy();
   });
 

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -2223,6 +2223,71 @@ describe("runTurn: real approval park + respondPermission resume", () => {
     await env.destroy();
   });
 
+  it("pauses when the harness re-gates after a denial instead of hanging on the old prompt", async () => {
+    const { calls, deps, captured } = pausableHarness();
+    const acquired = await acquireEnvironment(engineReq, deps);
+    assert.equal(acquired.ok, true);
+    if (!acquired.ok) return;
+    const env = acquired.env;
+
+    const firstTurn = runTurn(env, engineReq, undefined, undefined, {
+      approvalParkMode: true,
+    });
+    await flush();
+    captured.onPermissionRequest!({
+      id: "perm-1",
+      availableReplies: ["once", "reject"],
+      toolCall: { toolCallId: "tc-gate", name: "commit", rawInput: {} },
+    });
+    await flush();
+    await firstTurn;
+
+    const parked = env.parkedApproval!;
+    env.clearTurn();
+    const secondTurn = runTurn(
+      env,
+      { ...engineReq, messages: [{ role: "user", content: "try another way" }] },
+      undefined,
+      undefined,
+      {
+        approvalParkMode: true,
+        continuation: true,
+        settleApprovalsThenPrompt: {
+          decisions: [
+            {
+              permissionId: parked.permissionId,
+              reply: "reject",
+              toolCallId: parked.toolCallId,
+              toolName: parked.toolName,
+              args: parked.args,
+              interactionToken: parked.interactionToken,
+              promptPromise: parked.promptPromise,
+            },
+          ],
+        },
+      },
+    );
+    for (let i = 0; i < 20 && calls.permissionReplies.length === 0; i += 1) {
+      await flush();
+    }
+    captured.onPermissionRequest!({
+      id: "perm-2",
+      availableReplies: ["once", "reject"],
+      toolCall: { toolCallId: "tc-regated", name: "deploy", rawInput: {} },
+    });
+
+    const result = await secondTurn;
+    assert.equal(result.ok, true);
+    assert.equal(result.stopReason, "paused");
+    assert.equal(
+      calls.promptCount,
+      1,
+      "the fresh prompt was not sent behind a new gate",
+    );
+    assert.equal(env.parkedApproval?.toolCallId, "tc-regated");
+    await env.destroy();
+  }, 1_000);
+
   it("creates and resolves a durable gate row without workflow context", async () => {
     const posted: Array<{ url: string; body: Record<string, unknown> }> = [];
     const fetchSpy = vi

--- a/services/runner/tests/unit/turn-settle.test.ts
+++ b/services/runner/tests/unit/turn-settle.test.ts
@@ -1,0 +1,198 @@
+/**
+ * A turn must reach exactly one terminal outcome, even when `run()` never returns.
+ *
+ * The runner writes its terminal record, and releases the alive watchdog, downstream of
+ * `await run(...)`. A run that never settles therefore leaves the session announcing
+ * `running=true` every thirty seconds with no ending ever written — issue #6418, and the shape
+ * behind #6100 and #5327 too. `awaitTurnOrAbandon` bounds that wait.
+ *
+ * The contract these tests hold: the happy path is untouched and leaves no timer armed; giving
+ * up always tries an abort FIRST, because most hangs unwind from one; and the caller is only
+ * told to write its own ending when the run is genuinely still pending afterwards.
+ */
+
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import {
+  ABANDON_GRACE_ENV,
+  DEFAULT_ABANDON_GRACE_MS,
+  DEFAULT_HARD_DEADLINE_MS,
+  HARD_DEADLINE_ENV,
+  awaitTurnOrAbandon,
+  resolveTurnSettleLimits,
+  type Clock,
+  type TurnSettleLimits,
+} from "../../src/sessions/turn-settle.ts";
+import { DEFAULT_TOTAL_DEADLINE_MS } from "../../src/engines/sandbox_agent/run-limits.ts";
+
+function fakeClock(): Clock & { fireAll(): Promise<void>; pending(): number } {
+  let nextId = 1;
+  const timers = new Map<number, () => void>();
+  return {
+    setTimeout(fn: () => void) {
+      const id = nextId++;
+      timers.set(id, fn);
+      return id as unknown as NodeJS.Timeout;
+    },
+    clearTimeout(handle: NodeJS.Timeout) {
+      timers.delete(handle as unknown as number);
+    },
+    pending: () => timers.size,
+    async fireAll() {
+      for (const [id, fn] of [...timers.entries()]) {
+        timers.delete(id);
+        fn();
+      }
+      await new Promise((resolve) => setTimeout(resolve, 0));
+    },
+  };
+}
+
+const limits: TurnSettleLimits = {
+  hardDeadlineMs: 10_000,
+  abandonGraceMs: 1_000,
+};
+
+afterEach(() => {
+  vi.unstubAllEnvs();
+});
+
+describe("awaitTurnOrAbandon", () => {
+  it("returns the run's own result and leaves no timer armed", async () => {
+    const clock = fakeClock();
+    const abort = vi.fn();
+
+    const outcome = await awaitTurnOrAbandon({
+      run: Promise.resolve({ ok: true }),
+      abort,
+      limits,
+      clock,
+    });
+
+    expect(outcome).toEqual({ settled: true, value: { ok: true } });
+    expect(abort).not.toHaveBeenCalled();
+    expect(clock.pending()).toBe(0);
+  });
+
+  it("rethrows a run that rejects, so the caller's own catch still owns the error", async () => {
+    const clock = fakeClock();
+
+    await expect(
+      awaitTurnOrAbandon({
+        run: Promise.reject(new Error("harness blew up")),
+        abort: vi.fn(),
+        limits,
+        clock,
+      }),
+    ).rejects.toThrow("harness blew up");
+    expect(clock.pending()).toBe(0);
+  });
+
+  it("aborts first when the platform says the turn is no longer current", async () => {
+    const clock = fakeClock();
+    let finishRun: ((value: unknown) => void) | undefined;
+    const run = new Promise((resolve) => {
+      finishRun = resolve;
+    });
+    // The real run unwinds from its abort; model that.
+    const abort = vi.fn(() => finishRun?.({ ok: false, error: "cancelled" }));
+
+    const settling = awaitTurnOrAbandon({
+      run,
+      abort,
+      interrupted: Promise.resolve("stopped by the user"),
+      limits,
+      clock,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(abort).toHaveBeenCalledTimes(1);
+    await expect(settling).resolves.toEqual({
+      settled: true,
+      value: { ok: false, error: "cancelled" },
+    });
+    expect(clock.pending()).toBe(0);
+  });
+
+  it("gives up and hands the caller a reason when the run will not unwind", async () => {
+    const clock = fakeClock();
+    // The wedged case: aborting changes nothing, because the pending ACP request cannot settle.
+    const run = new Promise(() => {});
+    const abort = vi.fn();
+
+    const settling = awaitTurnOrAbandon({
+      run,
+      abort,
+      interrupted: Promise.resolve("declared lost by the platform"),
+      limits,
+      clock,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(abort).toHaveBeenCalledTimes(1);
+    await clock.fireAll(); // the grace window closes
+
+    await expect(settling).resolves.toEqual({
+      settled: false,
+      reason: "declared lost by the platform",
+    });
+    expect(clock.pending()).toBe(0);
+  });
+
+  it("gives up on the hard deadline even with no interruption signal at all", async () => {
+    const clock = fakeClock();
+    const settling = awaitTurnOrAbandon({
+      run: new Promise(() => {}),
+      abort: vi.fn(),
+      limits,
+      clock,
+    });
+
+    await clock.fireAll(); // the hard deadline
+    await clock.fireAll(); // the grace window
+
+    const outcome = await settling;
+    expect(outcome.settled).toBe(false);
+    if (outcome.settled) return;
+    expect(outcome.reason).toContain("hard turn deadline");
+  });
+
+  it("survives an abort that throws", async () => {
+    const clock = fakeClock();
+    const settling = awaitTurnOrAbandon({
+      run: new Promise(() => {}),
+      abort: () => {
+        throw new Error("controller already closed");
+      },
+      interrupted: Promise.resolve("lost"),
+      limits,
+      clock,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await clock.fireAll();
+
+    await expect(settling).resolves.toEqual({ settled: false, reason: "lost" });
+  });
+});
+
+describe("turn settle limits", () => {
+  it("keeps the hard deadline above the longest legitimate run", () => {
+    // A backstop that fired before the run limits would shorten real runs, which is the
+    // opposite of what users have asked for (issues #6084, #5356).
+    expect(DEFAULT_HARD_DEADLINE_MS).toBeGreaterThan(DEFAULT_TOTAL_DEADLINE_MS);
+    expect(resolveTurnSettleLimits()).toEqual({
+      hardDeadlineMs: DEFAULT_HARD_DEADLINE_MS,
+      abandonGraceMs: DEFAULT_ABANDON_GRACE_MS,
+    });
+  });
+
+  it("takes an operator override", () => {
+    vi.stubEnv(HARD_DEADLINE_ENV, "120000");
+    vi.stubEnv(ABANDON_GRACE_ENV, "5000");
+
+    expect(resolveTurnSettleLimits()).toEqual({
+      hardDeadlineMs: 120_000,
+      abandonGraceMs: 5_000,
+    });
+  });
+});

--- a/services/runner/tests/unit/turn-settle.test.ts
+++ b/services/runner/tests/unit/turn-settle.test.ts
@@ -139,6 +139,35 @@ describe("awaitTurnOrAbandon", () => {
     expect(clock.pending()).toBe(0);
   });
 
+  it("leaves an abandoned run alive to execute its own teardown when it later settles", async () => {
+    const clock = fakeClock();
+    const teardown = vi.fn();
+    let finishRun: ((value: { ok: boolean }) => void) | undefined;
+    const run = new Promise<{ ok: boolean }>((resolve) => {
+      finishRun = resolve;
+    }).finally(teardown);
+
+    const settling = awaitTurnOrAbandon({
+      run,
+      abort: vi.fn(),
+      interrupted: Promise.resolve("declared lost by the platform"),
+      limits,
+      clock,
+    });
+    await new Promise((resolve) => setTimeout(resolve, 0));
+    await clock.fireAll();
+
+    await expect(settling).resolves.toEqual({
+      settled: false,
+      reason: "declared lost by the platform",
+    });
+    expect(teardown).not.toHaveBeenCalled();
+
+    finishRun?.({ ok: false });
+    await run;
+    expect(teardown).toHaveBeenCalledTimes(1);
+  });
+
   it("gives up on the hard deadline even with no interruption signal at all", async () => {
     const clock = fakeClock();
     const settling = awaitTurnOrAbandon({

--- a/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentMessage.tsx
@@ -157,6 +157,10 @@ const RETRYABLE_CODES = new Set([
     "credential_delivery_failed",
     "starter_credits_unavailable",
     "rate_limited",
+    // The run never produced an outcome of its own and was closed for it — by the runner when
+    // a turn would not unwind, or by the platform's execution watchdog when the runner itself
+    // was gone. Nothing is wrong with the request, so sending it again is the whole fix.
+    "execution_lost",
 ])
 
 /**

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionRecordsWatch.ts
@@ -1,4 +1,5 @@
 import {useWatchEventSource} from "@agenta/sessions/watch"
+import {useQueryClient} from "@tanstack/react-query"
 
 import {getAgentaApiUrl} from "@/oss/lib/helpers/api"
 import {refreshSession} from "@/oss/lib/helpers/auth/refreshSession"
@@ -32,6 +33,7 @@ export const useSessionRecordsWatch = ({
     onRecordsChanged: () => void
     onInteractionChanged: () => void
 }): void => {
+    const queryClient = useQueryClient()
     const url = sessionId && projectId ? sessionWatchUrl(sessionId, projectId) : null
     useWatchEventSource({
         url,
@@ -41,6 +43,14 @@ export const useSessionRecordsWatch = ({
             ready: onReady,
             "records-changed": onRecordsChanged,
             interaction: onInteractionChanged,
+            // A session that ends without this tab running it — a Stop from elsewhere, or the
+            // execution watchdog settling a turn whose runner went silent. The records arrive
+            // on their own event; this is the half that stops the session still LOOKING alive,
+            // which otherwise waits out the 15s liveness poll. Mobile already does this
+            // (web/mobile/src/features/chat/useSessionWatch.ts).
+            lifecycle: () => {
+                void queryClient.invalidateQueries({queryKey: ["session-liveness"]})
+            },
         },
     })
 }

--- a/web/packages/agenta-chat/src/components/RunningElsewhereStrip.tsx
+++ b/web/packages/agenta-chat/src/components/RunningElsewhereStrip.tsx
@@ -17,10 +17,10 @@ import {cn} from "@agenta/ui/ui"
  *
  * The copy stops short of promising the transcript WILL move. `is_running` says a turn took the
  * lock, not that anything is still serving it: a runner that dies mid-turn leaves the flag set
- * until its shutdown drain completes, or failing that until the orphan sweep clears it
- * (`ORPHAN_THRESHOLD_SECONDS`, 300s). Measured on a dev stack, that window runs from ~20s to a few
- * minutes. Asserting progress through it told people to keep waiting on a run that was over, so
- * the second sentence names that possibility instead. It is deliberately not a call to action:
+ * until its shutdown drain completes, or failing that until the execution watchdog settles it
+ * (`ORPHAN_THRESHOLD_SECONDS`, 120s by default). Measured on a dev stack, that window runs from
+ * ~20s to a couple of minutes. Asserting progress through it told people to keep waiting on a run
+ * that was over, so the second sentence names that possibility instead. It is deliberately not a call to action:
  * only /m passes a Stop here, and the desktop has no control to point at.
  *
  * Matches the `running` dot in the session bar (`bg-colorInfo`, pulsing) so the two read as one


### PR DESCRIPTION
## Context
When a runner died mid-turn, the session stayed "running" forever. When the runner came back after the watchdog had already ended the turn, its late output landed in the transcript beside the ending, so one turn showed two endings. This PR is the watchdog half of the Stop package in the session-control design (PR #6495), stacked on the durable Stop command in PR #6503.

## Changes
The branch carries three groups of commits. Read them in order.

**Watchdog and quarantine (the original slice).** A sweep every 60 s ends any turn whose runner heartbeat is older than 90 s with one `execution_lost` error and one `done`, keyed on heartbeat age rather than on the owner lease. Records that arrive after that ending are kept but marked `quarantined_at` and hidden from every transcript read, so one ending stays effective. `reject` is one setting away.

**Two sweep fixes found on the integrated stack.** A stopped row whose runner died before its terminal record got no ending; now the sweep writes it and releases the dead turn's `alive` lock. Each sweep pass is bounded, and a pass that times out is logged.

**Review fixes from 3 September.** These came from the staff review of the design and touch the command path as well, so they sit here rather than on #6503:

- The rollback switch `AGENTA_SESSIONS_DURABLE_STOP` and the legacy cancel response moved down into PR #6503 on 2026-09-04, so #6503 is safe alone. This PR keeps `AGENTA_SESSIONS_LATE_OUTPUT` (`quarantine` default or `reject`) and everything below. Rebased on the new #6503 head; 26 commits; head `43d77f1989`.
- A pending Stop whose runner is still alive is redelivered with the same command id, bounded by `max_deliveries`; a Stop whose runner is gone settles `lost`. Before this, the sweep skipped that case and the session read "stopping" forever.
- One terminal outcome per execution is enforced by the database: a new core table `session_executions` takes a compare-and-set from the runner outcome route and from the watchdog; the loser gets a clear "lost the race" result. Records ingest only reads that state, fails open when core Postgres is down, and quarantines only output written after an involuntary ending (`lost`, or `stopped` by the other writer). A `usage` that trails its own `done` is ordinary history.
- Command settle, execution terminal claim, stopping-marker clear, liveness mirror, and interaction cancel commit in one core transaction; the Redis write happens after commit and the sweep repairs a missed one. The cancel notice is published after commit.
- Runner: a Stop on a session parked on an approval now rejects and clears the gates, waits for the prompt to settle inside the cancel window, and parks warm. A fresh user message after a denied tool part goes to `session.prompt` with the new text instead of resuming the old prompt. Before this, the next message after an approval Stop answered the tool denial and never saw the new question, on both providers.

Before: `POST /sessions/{id}/cancel` during an approval → 202, gate cancelled, next message → "The command was refused. How would you like to proceed?"
After: the same Stop → 202, gate cleared and parked warm, next message → the answer to the new question in the same sandbox.

## Tests
- `pytest oss/tests/pytest/unit/sessions -q` against Postgres: 622 passed on this branch, 671 on the integrated branch.
- `pnpm test` in `services/runner`: 2,692 passed on this branch, 2,743 integrated.
- Reviewed by an Opus agent in two rounds (the terminal compare-and-set commit was "do not ship" in round one and "ship" after the step 3 fixes; the runner approval fix was reviewed by the agent that found the defect). Review files: the `reviews/` folder on PR #6495 and the night status on PR #6505.
- Migrations `oss000000023_add_session_executions` and `oss000000024_add_execution_redis_reconciliation` are additive with downgrades. Note: PR #6517's migration was renumbered to 25 so the ids no longer collide; whichever PR lands second re-points its `down_revision` to the new head.

## What to QA
Live cells run on the integrated stack with the release-gate driver from PR #6518 (`session_control.py`). The morning report on PR #6505 lists the results per harness and provider. Watch for: stop-approval on Pi local and Daytona (the fix above), post-stop-row (`is_running` false within seconds of the Stop), stale-tail (late `done` quarantined), restart-after-stop (native session survives).


## Fixes of 2026-09-04 (found by the new failure cells)
- Runner-gone: the watchdog was started without the commands service, so an abandoned Stop was never settled lost and a resurrected runner's late report won the compare-and-set. The service is wired at startup with a lifespan test (`6d3add4b58`).
- Runner restart: the ending-only sweep branch never cleared the dead runner's owner lease, so the next Send was refused "already running a turn" for up to 120 s. The branch now clears the lease, only for the dead turn's own owner (`8b809fafef`).
- Concurrent Stops: the sweep only saw the session's current turn, so a stopped turn of a session that moved on never got its ending. The ending selection is now execution-centric over `session_executions` (`bd5b330b89`), with a nullable `ending_written_at` mark set by the watchdog and by records ingest, a partial index, descending order, and a stopped-shaped ending for a user Stop (migration `oss000000026`, `eee7fd7d33`).
All three were reviewed by the agents that found them. Live re-runs on the merged head follow.

## Fixes of 2026-09-04, afternoon (found by the full matrix on the merged head)
- Stop during a parked approval: the Stop required a settled harness cancel; on a client without `cancelSession` it threw, tore down the warm sandbox, and wrote no execution row. When no cancel can be sent, the Stop now reparks the sandbox warm and settles as stopped (`3e9d5c1651`).
- Watchdog loop dead on the first error: the loop's except branch called `log.exception` on `MultiLogger`, which had no such method, so the first failed pass killed the loop for the life of the process with zero log lines. The loop logs with `exc_info` and `MultiLogger` gained `exception` (`6e0962cd14`, `d9df2f2cd4`).
- Sweep poisoned by one unknown command row: a row with a kind this build cannot map raised inside the batch and left every abandoned Stop pending. Both the claim and the abandoned paths now skip unmappable rows through one shared mapper and warn once per batch (`757900145c`, `c663b43b50`).
- Lost settlement left the row running: the watchdog settled the execution lost but `session_streams.is_running` stayed true until the runner's own beat. The same pass now clears the flag, the running lock, and the mirror on the row that still names the dead turn (`d40dd7c9d0`).
- Returning runner re-beat a dead turn: after the sweep cleared the row, an unpaused runner's late heartbeat set it running again. The sweep tombstones every swept turn, and the heartbeat path refuses a tombstoned turn (`a8e7920e0f`).
- Hard kill keeps the session affinity: a runner killed with no grace never released `owner:session:<id>`, so the restarted runner's first heartbeat for the next turn lost the non-stealing owner claim and refused the message with "already running a turn" for up to 120 s; the earlier fix only covered a turn the sweep declared lost. The heartbeat now reclaims affinity from a departed replica when the running lock is free or its own; the alive lock stays the single arbiter. Not behind the flag, because the key and the lock primitives are shared with the legacy path (`15d58add1c`).

- The lost settlement did not clear the running flag (finding 7): the watchdog pass wrote the session row's flags through the ORM after nested sessions had detached the row, so the write never reached the database while a plain UPDATE in the same pass did. Both session_streams writes in the sweep are now plain UPDATEs from captured ids; a Postgres test replays the real pass (`2cbd1d3cdd`, `2613968468`).
- A deleted Daytona sandbox left a dead turn beating for 30 minutes: the provider's proxy keeps answering "not found" for a deleted sandbox, which the liveness probe counted as alive, and the transport's error died unhandled inside the protocol library. A "not found" answer now ends the turn with one error record within seconds; the detector arms only after the sandbox is acquired so a start-up race cannot trip it (`1ddea5e81e`). Follow-ups: the two-minute first-byte timer never fires; the Python SDK adapter's idle timeout (180 s) is shorter than the runner's own (360 s).

Live on the integration stack after these fixes (Pi local and Codex local, last-message shape): stop-approval, runner-gone-late, stale-tail, sandbox-gone, concurrent-stops, repeat-stop, stop-during-completion, and records-outage pass. The Codex runner-gone-late re-run on `15d58add1c` and the runner-gone read-while-paused cell are still open.


Agent-generated, low weight. Not merged.

https://claude.ai/code/session_01GAqSs7fw6QRi2n1ZJ2tmAV