### PR TITLE
fix(api): acknowledge session records after Postgres commits

### DIFF
--- a/api/ee/src/dbs/postgres/sessions/records/dao.py
+++ b/api/ee/src/dbs/postgres/sessions/records/dao.py
@@ -99,10 +99,12 @@ class RecordsRetentionDAO:
                 type_=ARRAY(PG_UUID(as_uuid=True)),
             )
 
+            # The key is (project_id, record_id). `RecordDBE.id` does not exist, so the
+            # earlier version of this statement raised before it deleted anything.
             expired = (
                 select(
                     RecordDBE.project_id.label("project_id"),
-                    RecordDBE.id.label("id"),
+                    RecordDBE.record_id.label("record_id"),
                 )
                 .where(
                     RecordDBE.project_id == any_(project_ids_param),
@@ -116,8 +118,8 @@ class RecordsRetentionDAO:
             deleted = (
                 delete(RecordDBE)
                 .where(
-                    tuple_(RecordDBE.project_id, RecordDBE.id).in_(
-                        select(expired.c.project_id, expired.c.id)
+                    tuple_(RecordDBE.project_id, RecordDBE.record_id).in_(
+                        select(expired.c.project_id, expired.c.record_id)
                     )
                 )
                 .returning(literal(1).label("deleted"))

--- a/api/entrypoints/worker_streams.py
+++ b/api/entrypoints/worker_streams.py
@@ -97,6 +97,9 @@ async def _build_records_worker(redis_client: Redis) -> StreamConsumer:
             interactions_dao=SessionInteractionsDAO(),
             watch_publisher=watch_publisher,
         ),
+        # Redelivery bound for records the Postgres write rejected.
+        reclaim_min_idle_ms=env.agenta.sessions.records.reclaim_idle_ms,
+        max_deliveries=env.agenta.sessions.records.max_deliveries,
     )
 
 

--- a/api/oss/src/tasks/asyncio/sessions/records_worker.py
+++ b/api/oss/src/tasks/asyncio/sessions/records_worker.py
@@ -52,13 +52,18 @@ class RecordsWorker(StreamConsumer):
     Consumer group: worker-records
 
     Flow:
-    1. Read batch from stream (XREADGROUP) — StreamConsumer
+    1. Read batch from stream (XREADGROUP), or reclaim unacknowledged entries — StreamConsumer
     2. Deserialize messages
     3. Group by project_id
     4. EE: L2 quota check per org (Counter.RECORDS_INGESTED)
     5. Append record events to DB
     6. Reconcile HITL gates orphaned by a finished turn
-    7. ACK + DEL messages — StreamConsumer
+    7. ACK + DEL only the messages whose Postgres write committed — StreamConsumer
+
+    A message id leaves this worker in the acknowledged list for exactly three reasons: its
+    write committed, it could not be decoded, or its org is over quota. Everything else stays
+    pending so the reclaim pass writes it later. Acknowledging before the write, which is what
+    this worker used to do, turned every Postgres failure into permanent silent record loss.
     """
 
     log_prefix = "[RECORDS]"
@@ -76,6 +81,8 @@ class RecordsWorker(StreamConsumer):
         max_batch_mb: int = 50,
         watch_publisher: Optional[SessionsWatchPublisherInterface] = None,
         interactions_service: Optional[SessionInteractionsService] = None,
+        reclaim_min_idle_ms: int = 30_000,
+        max_deliveries: int = 5,
     ):
         super().__init__(
             redis_client=redis_client,
@@ -86,6 +93,11 @@ class RecordsWorker(StreamConsumer):
             max_block_ms=max_block_ms,
             max_delay_ms=max_delay_ms,
             max_batch_mb=max_batch_mb,
+            # Records are the durable transcript. A pending entry that is never redelivered is
+            # a lost turn, so this worker always runs the reclaim pass.
+            reclaim_pending=True,
+            reclaim_min_idle_ms=reclaim_min_idle_ms,
+            max_deliveries=max_deliveries,
         )
         self.service = service
         self.watch_publisher = watch_publisher
@@ -147,13 +159,90 @@ class RecordsWorker(StreamConsumer):
                     exc_info=True,
                 )
 
+    def describe_message(self, data: Dict[bytes, bytes]) -> Optional[str]:
+        """`session:record:type` for the dropped-message log, so a loss is traceable."""
+        try:
+            record = deserialize_record(payload=data[b"data"]).record_event
+            return f"{record.session_id}:{record.record_id}:{record.record_type}"
+        except Exception:
+            return None
+
+    async def _append(
+        self,
+        *,
+        project_id: UUID,
+        entries: List[Tuple[bytes, Any]],
+    ) -> Tuple[int, bool]:
+        """One `append_many` call. Returns the rows written and whether it committed."""
+        try:
+            results = await self.service.append_many(
+                events=[msg.record_event for _, msg in entries],
+            )
+            self.mark_committed()
+            return len(results), True
+        except Exception:
+            log.error(
+                "[RECORDS] Failed to append event batch",
+                project_id=str(project_id),
+                size=len(entries),
+                exc_info=True,
+            )
+            return 0, False
+
+    async def _append_committed(
+        self,
+        *,
+        project_id: UUID,
+        entries: List[Tuple[bytes, Any]],
+    ) -> Tuple[int, List[bytes]]:
+        """Write a project group and report the message ids that are durable.
+
+        `append_many` is one statement in one transaction, so a single record Postgres rejects
+        takes the whole group down with it. The retry writes the group one record at a time so
+        the unrelated records still land. One record at a time rather than a binary split: the
+        split is cheaper only when the failure is a lone poison record, and it is more expensive
+        when Postgres itself is down, which is the common case.
+        """
+        appended, committed = await self._append(project_id=project_id, entries=entries)
+        if committed:
+            return appended, [msg_id for msg_id, _ in entries]
+
+        if len(entries) == 1:
+            return 0, []
+
+        log.warning(
+            "[RECORDS] Batch append failed, retrying one record at a time",
+            project_id=str(project_id),
+            size=len(entries),
+        )
+
+        total_appended = 0
+        committed_ids: List[bytes] = []
+        for entry in entries:
+            appended, ok = await self._append(project_id=project_id, entries=[entry])
+            if ok:
+                total_appended += appended
+                committed_ids.append(entry[0])
+
+        log.warning(
+            "[RECORDS] Retry finished",
+            project_id=str(project_id),
+            committed=len(committed_ids),
+            pending=len(entries) - len(committed_ids),
+        )
+        return total_appended, committed_ids
+
     async def process_batch(
         self,
         batch: List[Tuple[bytes, Dict[bytes, bytes]]],
     ) -> Tuple[int, List[bytes]]:
-        """Process batch — deserialize, group by org for EE quota, append to DB."""
+        """Process batch — deserialize, group by org for EE quota, append to DB.
+
+        The returned ids are acknowledged and deleted by the consumer loop, so an id only goes
+        in once its rows are committed, or once this worker has decided to drop it on purpose.
+        """
         groups: Dict[UUID, Dict[str, Any]] = {}
-        processed_ids: List[bytes] = []
+        acked_ids: List[bytes] = []
         batch_bytes = 0
 
         for msg_id, data in batch:
@@ -162,6 +251,8 @@ class RecordsWorker(StreamConsumer):
 
                 batch_bytes += len(payload)
                 if batch_bytes > self.max_batch_mb * 1024 * 1024:
+                    # The rest of the batch stays unacknowledged and comes back through the
+                    # reclaim pass, rather than being silently skipped.
                     break
 
                 msg = deserialize_record(payload=payload)
@@ -170,23 +261,28 @@ class RecordsWorker(StreamConsumer):
                     group = {
                         "organization_id": msg.organization_id,
                         "project_id": msg.project_id,
-                        "events": [],
+                        "entries": [],
                     }
                     groups[msg.project_id] = group
-                group["events"].append(msg)
-                processed_ids.append(msg_id)
+                group["entries"].append((msg_id, msg))
             except Exception:
                 log.error(
                     "[RECORDS] Failed to deserialize message",
                     msg_id=repr(msg_id),
                     exc_info=True,
                 )
-                processed_ids.append(msg_id)
+                # A message that does not decode will not decode on redelivery either, so
+                # acknowledge it instead of letting it hold the pending list. Counted as a loss.
+                self.dropped_messages += 1
+                acked_ids.append(msg_id)
 
         batches = list(groups.values())
         total_appended = 0
 
         org_allowed: Dict[UUID, bool] = {}
+        # Orgs whose quota question could not be answered. Their records are not over quota,
+        # they are unmetered, so they wait for the next delivery instead of being dropped.
+        org_deferred: set = set()
         events_per_org: Dict[UUID, int] = {}
 
         if is_ee():
@@ -195,7 +291,7 @@ class RecordsWorker(StreamConsumer):
                 if org_id is None:
                     continue
                 events_per_org[org_id] = events_per_org.get(org_id, 0) + len(
-                    project_batch["events"]
+                    project_batch["entries"]
                 )
 
             for org_id, delta in events_per_org.items():
@@ -216,6 +312,7 @@ class RecordsWorker(StreamConsumer):
                         exc_info=True,
                     )
                     org_allowed[org_id] = False
+                    org_deferred.add(org_id)
                     continue
 
                 if not quota_allowed:
@@ -231,27 +328,37 @@ class RecordsWorker(StreamConsumer):
 
         for project_batch in batches:
             org_id = project_batch["organization_id"]
+            entries: List[Tuple[bytes, Any]] = project_batch["entries"]
+
             if is_ee() and org_id and not org_allowed.get(org_id, True):
+                if org_id in org_deferred:
+                    # The meter was unreachable, not exceeded. Leave the entries pending so a
+                    # transient entitlements outage does not delete a conversation.
+                    continue
+                # An over-quota org is a deliberate product drop, so acknowledging is correct.
+                # Count it, because it is still a record the transcript will never have.
+                self.dropped_messages += len(entries)
+                acked_ids.extend(msg_id for msg_id, _ in entries)
                 continue
 
-            try:
-                results = await self.service.append_many(
-                    events=[msg.record_event for msg in project_batch["events"]],
-                )
-                total_appended += len(results)
-            except Exception:
-                log.error(
-                    "[RECORDS] Failed to append event batch",
-                    project_id=str(project_batch["project_id"]),
-                    exc_info=True,
-                )
+            appended, committed_ids = await self._append_committed(
+                project_id=project_batch["project_id"],
+                entries=entries,
+            )
+            total_appended += appended
+            acked_ids.extend(committed_ids)
+
+            if not committed_ids:
                 continue
+
+            committed = set(committed_ids)
+            committed_events = [msg for msg_id, msg in entries if msg_id in committed]
 
             # Strictly post-append, and BEFORE the relay tee: a client woken by the records
             # notification below must already see the cancelled gate, not re-render it.
             await self.reconcile_orphaned_gates(
                 project_id=project_batch["project_id"],
-                events=project_batch["events"],
+                events=committed_events,
             )
 
             # Relay tee (M3): strictly post-append so a notified client that
@@ -259,9 +366,7 @@ class RecordsWorker(StreamConsumer):
             # session in the project batch; failures never re-drive the append.
             if self.watch_publisher is not None:
                 project_id = str(project_batch["project_id"])
-                session_ids = {
-                    msg.record_event.session_id for msg in project_batch["events"]
-                }
+                session_ids = {msg.record_event.session_id for msg in committed_events}
                 for session_id in sorted(session_ids):
                     try:
                         await self.watch_publisher.records_changed(
@@ -275,4 +380,4 @@ class RecordsWorker(StreamConsumer):
                             session_id=session_id,
                         )
 
-        return total_appended, processed_ids
+        return total_appended, acked_ids

--- a/api/oss/src/tasks/asyncio/shared/consumer.py
+++ b/api/oss/src/tasks/asyncio/shared/consumer.py
@@ -12,6 +12,10 @@ Batch Configuration:
 - max_block_ms: 5000ms (XREADGROUP BLOCK) - max wait time when queue is empty
 - max_batch_mb: 50 - max batch size in megabytes
 - max_delay_ms: 250ms - max wait time for batch accumulation when small batches arrive
+
+Redelivery (opt-in, `reclaim_pending`):
+- reclaim_min_idle_ms: 30000 - how long an unacknowledged entry sits before it is retried
+- max_deliveries: 5 - deliveries after which an entry is dropped loudly instead of retried
 """
 
 import time
@@ -31,9 +35,10 @@ class StreamConsumer:
     Base class for a Redis Streams consumer-group loop.
 
     Flow:
-    1. Read batch from Redis Streams (XREADGROUP)
+    1. Read batch from Redis Streams (XREADGROUP), or reclaim entries an earlier
+       pass left unacknowledged (opt-in, see `reclaim_batch`)
     2. `process_batch` (subclass): deserialize, group, meter, write
-    3. ACK + DEL processed messages
+    3. ACK + DEL the message ids `process_batch` reports as durable
     """
 
     #: Short tag prepended to log messages by subclasses (e.g. "[INGEST]").
@@ -49,6 +54,9 @@ class StreamConsumer:
         max_block_ms: int = 5000,  # 5 seconds
         max_delay_ms: int = 250,  # 250 milliseconds
         max_batch_mb: int = 50,  # 50 MB
+        reclaim_pending: bool = False,
+        reclaim_min_idle_ms: int = 30_000,  # 30 seconds
+        max_deliveries: int = 5,
     ):
         self.redis = redis_client
         self.stream_name = stream_name
@@ -62,6 +70,13 @@ class StreamConsumer:
         self.max_block_ms = max_block_ms
         self.max_batch_mb = max_batch_mb
         self.max_delay_ms = max_delay_ms
+        self.reclaim_pending = reclaim_pending
+        self.reclaim_min_idle_ms = reclaim_min_idle_ms
+        self.max_deliveries = max_deliveries
+        #: Messages this process gave up on. Only ever grows; read by tests and logs.
+        self.dropped_messages = 0
+        self._last_reclaim_at = 0.0
+        self._last_commit_at = 0.0
 
     async def create_consumer_group(self):
         """Create consumer group if it doesn't exist. Safe to call multiple times (idempotent)."""
@@ -141,6 +156,138 @@ class StreamConsumer:
             log.error(f"{self.log_prefix} Failed to read batch: {e}")
             return []
 
+    def describe_message(self, data: Dict[bytes, bytes]) -> Optional[str]:
+        """Subclass hook: a short identity for a dropped message, for the loss log."""
+        return None
+
+    def mark_committed(self) -> None:
+        """Subclasses call this after a durable write. See `write_path_is_healthy`."""
+        self._last_commit_at = time.monotonic()
+
+    def write_path_is_healthy(self) -> bool:
+        """Has anything at all been written recently?
+
+        The delivery counter alone cannot tell a message the write path will never accept apart
+        from a write path that is simply down: both fail every delivery. Dropping on the count
+        alone therefore deletes every message in flight whenever an outage lasts longer than
+        `max_deliveries` windows, which is the loss this worker exists to prevent. So the drop
+        only applies while other messages are committing.
+        """
+        if self._last_commit_at == 0.0:
+            return False
+        window_ms = max(self.reclaim_min_idle_ms, 1_000) * 2
+        return (time.monotonic() - self._last_commit_at) * 1000 <= window_ms
+
+    async def reclaim_batch(self) -> List[Tuple[bytes, Dict[bytes, bytes]]]:
+        """Re-deliver entries an earlier pass left unacknowledged, and drop the ones that never
+        write.
+
+        `read_batch` only ever asks Redis for `>`, so an entry that is never acknowledged is
+        invisible to every later read of this group. Without this pass, "skip the ACK so Redis
+        retries it" means "lose it quietly with a growing pending list". Redis' own per-entry
+        delivery counter bounds the retry, so one poison entry cannot hold the group forever.
+        """
+        if not self.reclaim_pending:
+            return []
+
+        # One XPENDING per idle window, not one per loop turn: a busy stream spins this loop
+        # as fast as Postgres answers, and the pending list cannot change faster than the
+        # window anyway.
+        now = time.monotonic()
+        if (now - self._last_reclaim_at) * 1000 < self.reclaim_min_idle_ms:
+            return []
+        self._last_reclaim_at = now
+
+        try:
+            pending = await self.redis.xpending_range(
+                name=self.stream_name,
+                groupname=self.consumer_group,
+                min="-",
+                max="+",
+                count=self.max_batch_size,
+                # A zero window means "no idle filter", not "idle exactly zero".
+                idle=self.reclaim_min_idle_ms or None,
+            )
+        except Exception as e:
+            log.error(f"{self.log_prefix} Failed to read pending entries: {e}")
+            return []
+
+        if not pending:
+            return []
+
+        deliveries = {
+            entry["message_id"]: int(entry["times_delivered"]) for entry in pending
+        }
+
+        try:
+            claimed = await self.redis.xclaim(
+                name=self.stream_name,
+                groupname=self.consumer_group,
+                consumername=self.consumer_name,
+                min_idle_time=self.reclaim_min_idle_ms,
+                message_ids=list(deliveries.keys()),
+            )
+        except Exception as e:
+            log.error(f"{self.log_prefix} Failed to claim pending entries: {e}")
+            return []
+
+        # XCLAIM returns nothing for an entry whose stream payload is already gone (MAXLEN
+        # trim), and removes it from the pending list itself.
+        healthy = self.write_path_is_healthy()
+        retry: List[Tuple[bytes, Dict[bytes, bytes]]] = []
+        expired: List[Tuple[bytes, Dict[bytes, bytes]]] = []
+        over_budget = 0
+        for msg_id, data in claimed:
+            if not data:
+                continue
+            if deliveries.get(msg_id, 1) >= self.max_deliveries:
+                over_budget += 1
+                if healthy:
+                    expired.append((msg_id, data))
+                    continue
+            retry.append((msg_id, data))
+
+        if expired:
+            await self.drop_expired(expired)
+        elif over_budget:
+            log.warning(
+                f"{self.log_prefix} Keeping over-budget messages: nothing is writing",
+                stream=self.stream_name,
+                group=self.consumer_group,
+                count=over_budget,
+            )
+
+        if retry:
+            log.warning(
+                f"{self.log_prefix} Redelivering unacknowledged messages",
+                stream=self.stream_name,
+                group=self.consumer_group,
+                count=len(retry),
+            )
+
+        return retry
+
+    async def drop_expired(self, entries: List[Tuple[bytes, Dict[bytes, bytes]]]):
+        """Give up on entries that failed `max_deliveries` times, loudly.
+
+        This is data loss. It is preferred over an unbounded retry because a single entry the
+        write path can never accept would otherwise stall every later entry in the group. The
+        log line names each lost message so the loss is countable after the fact.
+        """
+        self.dropped_messages += len(entries)
+        log.error(
+            f"{self.log_prefix} Dropping messages after repeated delivery failures",
+            stream=self.stream_name,
+            group=self.consumer_group,
+            max_deliveries=self.max_deliveries,
+            count=len(entries),
+            messages=[
+                self.describe_message(data) or repr(msg_id) for msg_id, data in entries
+            ],
+            dropped_total=self.dropped_messages,
+        )
+        await self.ack_and_delete([msg_id for msg_id, _ in entries])
+
     async def ack_and_delete(self, message_ids: List[bytes]):
         """ACK and DELETE messages after successful processing."""
         if not message_ids:
@@ -168,10 +315,10 @@ class StreamConsumer:
         Main worker loop.
 
         Flow:
-        1. Read batch via XREADGROUP
+        1. Reclaim entries an earlier pass left unacknowledged, else read via XREADGROUP
         2. Process batch
-        3. ACK + DEL on success
-        4. On error, messages remain pending for retry
+        3. ACK + DEL only the message ids `process_batch` reports as durable
+        4. Everything else stays pending and comes back through step 1
         """
         log.info(
             f"{self.log_prefix} Starting worker",
@@ -183,7 +330,9 @@ class StreamConsumer:
 
         while True:
             try:
-                batch = await self.read_batch()
+                batch = await self.reclaim_batch()
+                if not batch:
+                    batch = await self.read_batch()
                 if not batch:
                     continue
 

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -523,6 +523,14 @@ class SessionsRecordsConfig(BaseModel):
         os.getenv("AGENTA_RECORDS_SMART_TRUNCATION") or "true"
     ).lower() in _TRUTHY
 
+    # How long a record message the worker failed to write sits unacknowledged before the
+    # worker claims it back and tries again.
+    reclaim_idle_ms: int = int(os.getenv("AGENTA_RECORDS_RECLAIM_IDLE_MS") or 30_000)
+
+    # Deliveries after which a record message is dropped instead of retried forever. A message
+    # Postgres never accepts would otherwise hold every later message in the group.
+    max_deliveries: int = int(os.getenv("AGENTA_RECORDS_MAX_DELIVERIES") or 5)
+
     model_config = ConfigDict(extra="ignore")
 
 

--- a/api/oss/tests/pytest/unit/sessions/test_records_worker_durability.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_worker_durability.py
@@ -1,0 +1,451 @@
+"""Records must not be acknowledged before Postgres has them (#5496, #5594).
+
+`RecordsWorker.process_batch` used to add every decoded Redis message id to its
+acknowledged list DURING deserialization, before `append_many` ran. A failed write logged
+and continued, and the shared consumer loop then acknowledged and deleted those messages
+from the stream. Every Postgres hiccup was therefore permanent, silent record loss, and one
+record Postgres rejected took its whole batch with it.
+
+These tests pin three properties:
+
+* a message id is acknowledged only after its rows commit, and the redelivered batch is
+  written exactly once;
+* one bad record does not discard the rest of its batch;
+* a message that never writes is dropped loudly and counted, instead of holding the
+  pending list forever.
+
+The redelivery tests run against fakeredis so the pending-list bookkeeping is real Redis
+consumer-group behaviour, not a mock of it.
+"""
+
+import asyncio
+import zlib
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+from uuid import uuid4
+
+import fakeredis.aioredis as fakeredis
+import pytest
+from orjson import dumps
+
+from oss.src.core.sessions.records.dtos import SessionRecord
+from oss.src.core.sessions.records.service import RecordsService
+from oss.src.tasks.asyncio.sessions import records_worker
+from oss.src.tasks.asyncio.sessions.records_worker import RecordsWorker
+
+STREAM = "streams:records"
+GROUP = "worker-records"
+
+
+def _payload(*, project_id, session_id, record_id, record_type="message", turn_id=None):
+    message = {
+        "organization_id": None,
+        "project_id": str(project_id),
+        "record_event": {
+            "project_id": str(project_id),
+            "session_id": session_id,
+            "record_id": str(record_id),
+            "record_type": record_type,
+            "turn_id": turn_id,
+        },
+    }
+    return zlib.compress(dumps(message))
+
+
+class FakeRecordsDAO:
+    """Records what committed, and fails the events the caller names."""
+
+    def __init__(self, *, poison_ids=(), fail_calls=0):
+        self.poison_ids = {str(record_id) for record_id in poison_ids}
+        self.fail_calls = fail_calls
+        self.calls = 0
+        self.committed: list[str] = []
+
+    async def append_many(self, *, events):
+        self.calls += 1
+        if self.calls <= self.fail_calls:
+            raise RuntimeError("postgres is down")
+        if any(str(event.record_id) in self.poison_ids for event in events):
+            # `append_many` is one statement in one transaction: a rejected row takes the
+            # whole call with it, and nothing in the call commits.
+            raise RuntimeError("record rejected")
+        for event in events:
+            self.committed.append(str(event.record_id))
+        return [
+            SessionRecord(
+                record_id=event.record_id,
+                session_id=event.session_id,
+                project_id=event.project_id,
+            )
+            for event in events
+        ]
+
+
+def _worker(dao, *, redis_client=None, max_deliveries=5):
+    return RecordsWorker(
+        service=RecordsService(records_dao=dao),
+        redis_client=redis_client,
+        stream_name=STREAM,
+        consumer_group=GROUP,
+        consumer_name="test-consumer",
+        reclaim_min_idle_ms=0,
+        max_deliveries=max_deliveries,
+    )
+
+
+def _batch(*, project_id, record_ids):
+    return [
+        (
+            f"{index}-0".encode(),
+            {
+                b"data": _payload(
+                    project_id=project_id, session_id="sess-1", record_id=record_id
+                )
+            },
+        )
+        for index, record_id in enumerate(record_ids)
+    ]
+
+
+@pytest.mark.asyncio
+async def test_failed_batch_acknowledges_nothing():
+    project_id = uuid4()
+    record_ids = [uuid4(), uuid4()]
+    dao = FakeRecordsDAO(fail_calls=99)
+
+    appended, acked_ids = await _worker(dao).process_batch(
+        _batch(project_id=project_id, record_ids=record_ids)
+    )
+
+    assert appended == 0
+    # Nothing committed, so nothing may be acknowledged: the shared consumer loop deletes
+    # every id this list carries.
+    assert acked_ids == []
+    assert dao.committed == []
+
+
+@pytest.mark.asyncio
+async def test_redelivered_batch_is_acknowledged_once_and_written_once():
+    project_id = uuid4()
+    record_ids = [uuid4(), uuid4()]
+    batch = _batch(project_id=project_id, record_ids=record_ids)
+    # The whole-batch call fails, then the per-record retry fails twice, then Postgres is back.
+    dao = FakeRecordsDAO(fail_calls=3)
+    worker = _worker(dao)
+
+    _, first_acked = await worker.process_batch(batch)
+    assert first_acked == []
+
+    appended, second_acked = await worker.process_batch(batch)
+
+    assert appended == 2
+    assert second_acked == [msg_id for msg_id, _ in batch]
+    assert dao.committed == [str(record_id) for record_id in record_ids]
+    assert worker.dropped_messages == 0
+
+
+@pytest.mark.asyncio
+async def test_one_bad_record_does_not_discard_its_batch():
+    project_id = uuid4()
+    good_a, poison, good_b = uuid4(), uuid4(), uuid4()
+    batch = _batch(project_id=project_id, record_ids=[good_a, poison, good_b])
+    dao = FakeRecordsDAO(poison_ids=[poison])
+
+    appended, acked_ids = await _worker(dao).process_batch(batch)
+
+    assert appended == 2
+    assert dao.committed == [str(good_a), str(good_b)]
+    # Only the two good ids are acknowledged. The rejected record stays pending.
+    assert acked_ids == [batch[0][0], batch[2][0]]
+
+
+@pytest.mark.asyncio
+async def test_undecodable_message_is_acknowledged_and_counted():
+    dao = FakeRecordsDAO()
+    worker = _worker(dao)
+
+    appended, acked_ids = await worker.process_batch([(b"1-0", {b"data": b"not-zlib"})])
+
+    assert appended == 0
+    # A message that does not decode will not decode on redelivery, so it is dropped on
+    # purpose rather than left to hold the pending list.
+    assert acked_ids == [b"1-0"]
+    assert worker.dropped_messages == 1
+
+
+@pytest.mark.asyncio
+async def test_watch_and_gate_reconciliation_see_only_committed_records():
+    project_id = uuid4()
+    good, poison = uuid4(), uuid4()
+    batch = [
+        (
+            b"1-0",
+            {
+                b"data": _payload(
+                    project_id=project_id,
+                    session_id="sess-good",
+                    record_id=good,
+                    record_type="done",
+                    turn_id="turn-good",
+                )
+            },
+        ),
+        (
+            b"2-0",
+            {
+                b"data": _payload(
+                    project_id=project_id,
+                    session_id="sess-poison",
+                    record_id=poison,
+                    record_type="done",
+                    turn_id="turn-poison",
+                )
+            },
+        ),
+    ]
+
+    watch_publisher = AsyncMock()
+    interactions_service = AsyncMock()
+    interactions_service.cancel_session_pending = AsyncMock(return_value=0)
+
+    worker = RecordsWorker(
+        service=RecordsService(records_dao=FakeRecordsDAO(poison_ids=[poison])),
+        redis_client=None,
+        stream_name=STREAM,
+        consumer_group=GROUP,
+        watch_publisher=watch_publisher,
+        interactions_service=interactions_service,
+    )
+
+    await worker.process_batch(batch)
+
+    # A record that never committed must not wake a client or cancel a gate: the reader it
+    # would send to Postgres cannot see the row.
+    notified = {
+        call.kwargs["session_id"]
+        for call in watch_publisher.records_changed.await_args_list
+    }
+    assert notified == {"sess-good"}
+    reconciled = {
+        call.kwargs["session_id"]
+        for call in interactions_service.cancel_session_pending.await_args_list
+    }
+    assert reconciled == {"sess-good"}
+
+
+async def _seed(redis_client, payloads):
+    await redis_client.xgroup_create(
+        name=STREAM, groupname=GROUP, id="0", mkstream=True
+    )
+    for payload in payloads:
+        await redis_client.xadd(name=STREAM, fields={"data": payload})
+
+
+@pytest.mark.asyncio
+async def test_unacknowledged_entry_comes_back_through_the_reclaim_pass():
+    project_id = uuid4()
+    record_id = uuid4()
+    redis_client = fakeredis.FakeRedis()
+    await _seed(
+        redis_client,
+        [_payload(project_id=project_id, session_id="s", record_id=record_id)],
+    )
+
+    dao = FakeRecordsDAO(fail_calls=1)
+    worker = _worker(dao, redis_client=redis_client)
+
+    batch = await worker.read_batch()
+    assert len(batch) == 1
+    _, acked_ids = await worker.process_batch(batch)
+    assert acked_ids == []
+
+    # `read_batch` only ever asks for `>`, so without the reclaim pass this entry is invisible
+    # to every later read and the "leave it pending" fix would lose it silently.
+    assert await worker.read_batch() == []
+
+    await asyncio.sleep(0.01)
+    reclaimed = await worker.reclaim_batch()
+    assert [msg_id for msg_id, _ in reclaimed] == [msg_id for msg_id, _ in batch]
+
+    _, acked_ids = await worker.process_batch(reclaimed)
+    assert acked_ids == [batch[0][0]]
+    await worker.ack_and_delete(acked_ids)
+
+    assert dao.committed == [str(record_id)]
+    assert await redis_client.xlen(STREAM) == 0
+    pending = await redis_client.xpending_range(
+        name=STREAM, groupname=GROUP, min="-", max="+", count=10
+    )
+    assert pending == []
+
+
+@pytest.mark.asyncio
+async def test_a_record_that_never_writes_is_dropped_loudly_and_counted(caplog):
+    project_id = uuid4()
+    good, poison = uuid4(), uuid4()
+    redis_client = fakeredis.FakeRedis()
+    await _seed(
+        redis_client,
+        [
+            _payload(project_id=project_id, session_id="s", record_id=good),
+            _payload(
+                project_id=project_id,
+                session_id="doomed-session",
+                record_id=poison,
+                record_type="done",
+            ),
+        ],
+    )
+
+    dao = FakeRecordsDAO(poison_ids=[poison])
+    worker = _worker(dao, redis_client=redis_client, max_deliveries=3)
+
+    batch = await worker.read_batch()
+    _, acked_ids = await worker.process_batch(batch)
+    await worker.ack_and_delete(acked_ids)
+
+    for _ in range(6):
+        await asyncio.sleep(0.01)
+        reclaimed = await worker.reclaim_batch()
+        if not reclaimed:
+            break
+        _, acked_ids = await worker.process_batch(reclaimed)
+        await worker.ack_and_delete(acked_ids)
+
+    assert dao.committed == [str(good)]
+    assert worker.dropped_messages == 1
+    pending = await redis_client.xpending_range(
+        name=STREAM, groupname=GROUP, min="-", max="+", count=10
+    )
+    # The poison entry is gone, so it stops costing a write attempt every window.
+    assert pending == []
+
+    dropped = [
+        record
+        for record in caplog.records
+        if "Dropping messages after repeated delivery failures" in record.getMessage()
+    ]
+    assert dropped, "the loss must be logged at error level"
+    assert dropped[0].levelname == "ERROR"
+    # The log names the lost record so the loss is traceable after the fact.
+    assert worker.describe_message(batch[1][1]) == f"doomed-session:{poison}:done"
+
+
+@pytest.mark.asyncio
+async def test_nothing_is_dropped_while_the_write_path_is_down():
+    """A long outage must not consume the drop budget.
+
+    The delivery counter cannot tell a rejected record apart from an unreachable database, so
+    dropping on the count alone would delete every record in flight once an outage outlasts
+    `max_deliveries` windows. That is exactly the loss this worker exists to prevent.
+    """
+    project_id = uuid4()
+    record_ids = [uuid4(), uuid4()]
+    redis_client = fakeredis.FakeRedis()
+    await _seed(
+        redis_client,
+        [
+            _payload(project_id=project_id, session_id="s", record_id=record_id)
+            for record_id in record_ids
+        ],
+    )
+
+    dao = FakeRecordsDAO(fail_calls=99)
+    worker = _worker(dao, redis_client=redis_client, max_deliveries=2)
+
+    batch = await worker.read_batch()
+    await worker.process_batch(batch)
+
+    for _ in range(6):
+        await asyncio.sleep(0.01)
+        reclaimed = await worker.reclaim_batch()
+        assert len(reclaimed) == 2
+        await worker.process_batch(reclaimed)
+
+    assert worker.dropped_messages == 0
+    assert await redis_client.xlen(STREAM) == 2
+
+    # Postgres comes back. Both records land, and neither was deleted meanwhile.
+    dao.fail_calls = 0
+    await asyncio.sleep(0.01)
+    reclaimed = await worker.reclaim_batch()
+    _, acked_ids = await worker.process_batch(reclaimed)
+    await worker.ack_and_delete(acked_ids)
+
+    assert dao.committed == [str(record_id) for record_id in record_ids]
+    assert await redis_client.xlen(STREAM) == 0
+
+
+@pytest.mark.asyncio
+async def test_describe_message_survives_an_undecodable_payload():
+    assert _worker(FakeRecordsDAO()).describe_message({b"data": b"not-zlib"}) is None
+
+
+def _fake_ee(monkeypatch, *, allowed=True, raises=False):
+    """Run the EE quota branch of `process_batch` without an EE build."""
+
+    async def check_entitlements(**_):
+        if raises:
+            raise RuntimeError("entitlements unreachable")
+        return allowed, None, None
+
+    monkeypatch.setattr(records_worker, "is_ee", lambda: True)
+    monkeypatch.setattr(
+        records_worker, "check_entitlements", check_entitlements, raising=False
+    )
+    monkeypatch.setattr(
+        records_worker,
+        "Counter",
+        SimpleNamespace(RECORDS_INGESTED="records"),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        records_worker, "scope_from", lambda **kwargs: kwargs, raising=False
+    )
+
+
+def _org_batch(*, organization_id, project_id, record_id):
+    message = {
+        "organization_id": str(organization_id),
+        "project_id": str(project_id),
+        "record_event": {
+            "project_id": str(project_id),
+            "session_id": "sess-1",
+            "record_id": str(record_id),
+            "record_type": "message",
+        },
+    }
+    return [(b"1-0", {b"data": zlib.compress(dumps(message))})]
+
+
+@pytest.mark.asyncio
+async def test_over_quota_org_is_acknowledged_and_counted(monkeypatch):
+    _fake_ee(monkeypatch, allowed=False)
+    dao = FakeRecordsDAO()
+    worker = _worker(dao)
+
+    _, acked_ids = await worker.process_batch(
+        _org_batch(organization_id=uuid4(), project_id=uuid4(), record_id=uuid4())
+    )
+
+    # Over quota is a deliberate product drop, so redelivering it would spin forever.
+    assert acked_ids == [b"1-0"]
+    assert worker.dropped_messages == 1
+    assert dao.committed == []
+
+
+@pytest.mark.asyncio
+async def test_unreachable_quota_meter_leaves_the_record_pending(monkeypatch):
+    _fake_ee(monkeypatch, raises=True)
+    dao = FakeRecordsDAO()
+    worker = _worker(dao)
+
+    _, acked_ids = await worker.process_batch(
+        _org_batch(organization_id=uuid4(), project_id=uuid4(), record_id=uuid4())
+    )
+
+    # The meter was unreachable, not exceeded. Deleting the record would turn an
+    # entitlements outage into a deleted conversation.
+    assert acked_ids == []
+    assert worker.dropped_messages == 0
+    assert dao.committed == []

--- a/api/oss/tests/pytest/unit/sessions/test_watch_publish.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watch_publish.py
@@ -136,11 +136,11 @@ async def test_worker_skips_publish_when_append_fails():
 
     assert total_appended == 0
     assert publisher.calls == []
-    # `process_batch` acknowledges at parse time, before the append, so a failed append is still
-    # acked and dropped by the shared consumer loop. That predates this change and is shared by
-    # every worker on `BaseStreamConsumer`; the relay tee neither causes it nor repairs it. This
-    # assertion pins the tee's scope, not an endorsement of the acknowledgement rule.
-    assert len(processed_ids) == 1
+    # A failed append acknowledges nothing, so the record stays in the Redis pending list and
+    # the reclaim pass writes it later. `process_batch` used to acknowledge at parse time,
+    # before the append, which made every Postgres failure permanent record loss (#5496).
+    # `test_records_worker_durability.py` pins that rule; this line pins the tee's scope.
+    assert processed_ids == []
 
 
 @pytest.mark.asyncio

--- a/docs/design/session-control-and-live-events/README.md
+++ b/docs/design/session-control-and-live-events/README.md
@@ -1,0 +1,32 @@
+# Session control and live events
+
+> AGENT-GENERATED, low weight. Draft for discussion. Mahmoud makes final decisions.
+
+This folder holds the design work for session execution control, shared live output,
+durable event replay, and durable commands.
+
+## Reading order
+
+1. [Context](context.md) explains the user problems and the current system boundary.
+2. [Requirements](requirements.md) lists the open issues and draft system requirements.
+3. [Decisions](decisions.md) separates confirmed decisions from proposals and open questions.
+4. [Plan](plan.md) defines the design tracks and the order of discussion.
+5. [Research](research.md) records verified repository findings and external dependency checks.
+6. [RFC](rfc.md) is the living architecture proposal. It remains incomplete until each track is discussed.
+7. [Status](status.md) records current progress and the next discussion.
+
+## Terms under review
+
+- **Session:** One durable conversation and its workspace.
+- **Execution:** One runner attempt that can start, pause, complete, fail, or be cancelled.
+- **Conversation turn:** One user message and the resulting agent response. One conversation turn
+  can contain several executions when an approval pauses and resumes work.
+- **Runner:** The service that starts a sandbox and drives the coding harness.
+- **Harness:** The coding-agent program inside the sandbox, such as Pi or Claude Code.
+- **Live frame:** A temporary output update, such as a text delta or tool progress update.
+- **Durable event:** An append-only saved fact used for replay and recovery.
+- **Command:** A saved request to send, cancel, approve, queue, or steer.
+- **Lease:** Temporary proof that one runner owns a session or execution.
+
+The names are provisional. The contract discussion must settle how these terms map to the
+existing `turn_id` and `turn_index` fields.

--- a/docs/design/session-control-and-live-events/README.md
+++ b/docs/design/session-control-and-live-events/README.md
@@ -12,8 +12,10 @@ durable event replay, and durable commands.
 3. [Decisions](decisions.md) separates confirmed decisions from proposals and open questions.
 4. [Plan](plan.md) defines the design tracks and the order of discussion.
 5. [Research](research.md) records verified repository findings and external dependency checks.
-6. [RFC](rfc.md) is the living architecture proposal. It remains incomplete until each track is discussed.
-7. [Status](status.md) records current progress and the next discussion.
+6. [Record properties](records-invariants.md) evaluates the existing record model before storage
+   options are compared.
+7. [RFC](rfc.md) is the living architecture proposal. It remains incomplete until each track is discussed.
+8. [Status](status.md) records current progress and the next discussion.
 
 ## Terms under review
 

--- a/docs/design/session-control-and-live-events/README.md
+++ b/docs/design/session-control-and-live-events/README.md
@@ -16,6 +16,7 @@ durable event replay, and durable commands.
    options are compared.
 7. [RFC](rfc.md) is the living architecture proposal. It remains incomplete until each track is discussed.
 8. [Status](status.md) records current progress and the next discussion.
+9. [Tonight handoff](tonight-handoff.md) contains independent spike and implementation briefs.
 
 ## Terms under review
 

--- a/docs/design/session-control-and-live-events/context.md
+++ b/docs/design/session-control-and-live-events/context.md
@@ -1,0 +1,64 @@
+# Context
+
+> AGENT-GENERATED, low weight. Draft for discussion. Mahmoud makes final decisions.
+
+## Current user experience
+
+The browser that sends a message owns the live invoke response. Other clients receive saved
+record changes later. Stop uses the session control endpoint, but the runner learns about normal
+cancellation through its next heartbeat. Session records use upserts and do not provide a durable
+per-session replay cursor.
+
+These behaviors cause several visible problems:
+
+- Stop can update the browser while execution continues in the runner.
+- A failed or missing terminal signal can leave a session shown as running.
+- A second message can race with the active execution and break the session.
+- Another browser cannot receive the same live text stream as the sender.
+- A reconnecting browser cannot request all durable changes after a stable cursor.
+- Approval, cancellation, and resume races can leave an interaction or session unusable.
+- A re-sent record can change the apparent reading order because records are mutable upserts.
+
+## Design scope
+
+The final design must cover four independent paths:
+
+1. **Live output:** runner to API to every connected reader.
+2. **Durable facts:** append-only session history with stable ordering and replay.
+3. **Commands:** client to API to the execution owner, with durable admission where required.
+4. **Ownership:** one active execution owner, renewed through a temporary lease.
+
+The read path and control path can progress in parallel. Stop is not blocked on the live relay.
+The live relay is not blocked on the final Stop behavior.
+
+## Goals
+
+- Stop reaches active execution promptly and produces one terminal outcome.
+- Normal Stop preserves the resumable session and sandbox when the harness supports this.
+- Multiple clients receive live frames from the same execution.
+- Refreshing or closing the sender does not stop execution.
+- Clients can recover durable changes after a cursor.
+- A second message has an explicit server-side delivery policy.
+- Steer saves the new message before it interrupts current work.
+- Approval state remains correct across pause, Stop, refresh, and resume.
+- Records and events have stable ordering that retries cannot change.
+- Runner failure eventually releases ownership and leaves a terminal durable outcome.
+
+## Non-goals for the first RFC pass
+
+- Selecting a new broker before current Redis options are evaluated.
+- Storing every token permanently in Postgres.
+- Replacing every frontend session view in the first implementation.
+- Solving all harness limitations through one common behavior.
+- Treating the current issue grouping as a confirmed roadmap priority.
+
+## Design process
+
+Each track will follow the same sequence:
+
+1. Review current behavior and linked failures.
+2. Agree on the invariant and user-visible requirement.
+3. Compare the high-level options.
+4. Record the decision and rejected alternatives.
+5. Add the approved design to the living RFC.
+6. Define one live-stack test that proves the track.

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -60,6 +60,29 @@ Within five seconds of an accepted Stop request, the active execution must stop 
 requests and new tool actions. The exact deadline for terminating an already-running provider or
 tool operation remains open until harness and tool cancellation capabilities are verified.
 
+### D-008: Separate Stop from Delete
+
+**Status:** Confirmed by Mahmoud on 2026-09-02.
+
+Stop preserves the session, its history, and its resumable sandbox state. Delete permanently
+removes the session and its session-scoped resources. The public interface must not overload one
+operation to mean both.
+
+### D-009: Let first-party and external clients use the same session API
+
+**Status:** Confirmed direction from Mahmoud on 2026-09-02.
+
+Desktop, mobile, integrations, and external API consumers should use the same public session
+contract. Private API-to-runner delivery remains an implementation detail behind that contract.
+
+### D-010: Make the expected execution guard optional
+
+**Status:** Confirmed direction from Mahmoud on 2026-09-02.
+
+A Cancel request can include `expected_execution_id`. When supplied, the API cancels only that
+execution and rejects a stale request. When omitted, the API cancels the session's current active
+execution.
+
 ## Proposed design decisions
 
 ### P-001: Use one raw runner event ingress
@@ -140,10 +163,17 @@ Choose whether Cancel publicly targets:
 - A specific execution resource.
 - The current work in a session plus `expected_execution_id` as a stale-request guard.
 
-The current proposal favors the third option. The browser supplies the ID from session state. The
-person pressing Stop does not manage it.
+The selected direction combines the first and third options. Cancel targets the current work in a
+session. `expected_execution_id` is an optional stale-request guard supplied by clients that know
+the current execution.
 
 ### O-009: Busy-message policy names
 
 Choose the public names and defaults for a message submitted while work is active. The current
 working set is `reject`, `queue`, and `steer` under an `on_busy` field.
+
+### O-010: Pending input management
+
+Decide whether clients can edit, remove, and reorder messages that the server accepted with
+`on_busy: queue`. Pending messages must at least be visible in the session snapshot and event
+stream so all clients show the same queue.

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -83,6 +83,14 @@ A Cancel request can include `expected_execution_id`. When supplied, the API can
 execution and rejects a stale request. When omitted, the API cancels the session's current active
 execution.
 
+### D-011: Keep queued inputs immutable
+
+**Status:** Confirmed by Mahmoud on 2026-09-02.
+
+Clients can view and remove a pending input. They cannot edit or reorder it. To change pending
+content, a client removes the old input and submits a replacement. The API rejects removal after
+the input has been promoted into active work.
+
 ## Proposed design decisions
 
 ### P-001: Use one raw runner event ingress
@@ -172,8 +180,7 @@ the current execution.
 Choose the public names and defaults for a message submitted while work is active. The current
 working set is `reject`, `queue`, and `steer` under an `on_busy` field.
 
-### O-010: Pending input management
+### O-010: Pending input ordering
 
-Decide whether clients can edit, remove, and reorder messages that the server accepted with
-`on_busy: queue`. Pending messages must at least be visible in the session snapshot and event
-stream so all clients show the same queue.
+Pending inputs remain visible in the session snapshot and event stream. The initial contract uses
+server-assigned FIFO order. Clients cannot edit or reorder queued inputs.

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -131,3 +131,19 @@ shows a need to change that boundary.
 Decide whether public callers submit every execution action to one command collection or use
 clear resource endpoints that translate into internal commands. The current proposal favors clear
 public resources with one internal command envelope.
+
+### O-008: Public Cancel target
+
+Choose whether Cancel publicly targets:
+
+- The current work in a session, with no execution ID.
+- A specific execution resource.
+- The current work in a session plus `expected_execution_id` as a stale-request guard.
+
+The current proposal favors the third option. The browser supplies the ID from session state. The
+person pressing Stop does not manage it.
+
+### O-009: Busy-message policy names
+
+Choose the public names and defaults for a message submitted while work is active. The current
+working set is `reject`, `queue`, and `steer` under an `on_busy` field.

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -117,6 +117,14 @@ raw live output as secret to the browser that started the execution. Existing co
 redaction and authorization behavior must be understood, but sender-only visibility is not a
 target product rule.
 
+### D-015: Add the new session interface beside the current endpoints
+
+**Status:** Confirmed as a fair first draft by Mahmoud on 2026-09-02.
+
+The new snapshot and replayable event interface is introduced without changing the meaning of the
+current stream and watch endpoints. Desktop and mobile migrate before obsolete endpoints are
+deprecated. Final endpoint names remain open for a later interface review.
+
 ## Proposed design decisions
 
 ### P-001: Use one raw runner event ingress

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -175,7 +175,8 @@ Settle the meanings of `session`, `conversation turn`, and `execution`. Decide h
 ### O-002: Stop behavior inside sandbox-agent
 
 Verify whether the vendored sandbox-agent can cancel one execution while preserving its harness
-session. If it cannot, define the required patch and whether Daytona needs a rebuilt snapshot.
+session. Warm resume is the required outcome. If current behavior cannot provide it, define the
+required patch and whether Daytona needs a rebuilt snapshot.
 
 ### O-003: Durable ordering
 
@@ -200,9 +201,10 @@ and harness reconstruction.
 
 ### O-006: Immediate runner control
 
-Choose direct runner HTTP, per-runner Redis control delivery, or a persistent runner connection.
-The current API knows the logical owner `replica_id`, but its configured runner URL is not a
-replica-specific route.
+Choose runner-initiated long polling or a persistent runner connection. Future user-operated
+runners can be behind firewalls, so the design must not require inbound API access or direct Redis
+access from the runner. The current API knows the logical owner `replica_id`, but its configured
+runner URL is not a replica-specific route.
 
 ### O-007: Command boundary
 

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -202,9 +202,14 @@ and harness reconstruction.
 ### O-006: Immediate runner control
 
 Choose runner-initiated long polling or a persistent runner connection. Future user-operated
-runners can be behind firewalls, so the design must not require inbound API access or direct Redis
-access from the runner. The current API knows the logical owner `replica_id`, but its configured
-runner URL is not a replica-specific route.
+runners are possible but not confirmed. Treat their firewall and credential constraints as one
+consideration, not a binding requirement. The current API knows the logical owner `replica_id`,
+but its configured runner URL is not a replica-specific route.
+
+The current preference is durable long polling because it uses ordinary HTTP, supports prompt
+delivery, and keeps commands recoverable during disconnection. The implementation should place
+transport behind a control-delivery port so Stop and command logic do not depend on long polling,
+Redis, WebSockets, or direct runner routing.
 
 ### O-007: Command boundary
 

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -99,6 +99,15 @@ The discussion focuses on resource boundaries, execution ownership, event flow, 
 user-visible behavior. Routine endpoint naming, status codes, defaults, and validation details use
 established API conventions during RFC drafting unless they materially change those properties.
 
+### D-013: A successful submission means durable acceptance
+
+**Status:** Confirmed by Mahmoud on 2026-09-02.
+
+The API confirms a submitted input only after it has durably saved the input, its idempotency
+identity, its session, and the intent to execute it. Acceptance does not wait for a runner to claim
+the work, the harness to start, or the first output frame. If no runner is available, accepted work
+remains queued rather than disappearing.
+
 ## Proposed design decisions
 
 ### P-001: Use one raw runner event ingress

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -198,26 +198,26 @@ reuses a `record_id`. Separate exact delivery retries from progressive updates a
 re-emissions. Add regression tests for the final state of tools, interactions, terminal events,
 and harness reconstruction.
 
-### O-005: Immediate runner control
+### O-006: Immediate runner control
 
 Choose direct runner HTTP, per-runner Redis control delivery, or a persistent runner connection.
 The current API knows the logical owner `replica_id`, but its configured runner URL is not a
 replica-specific route.
 
-### O-006: Command boundary
+### O-007: Command boundary
 
 Decide which actions enter a general command inbox. The working boundary is execution-affecting
 intent: Send, Cancel, interaction response, Queue, and Steer. Attach is a read operation. Kill,
 rename, archive, and delete remain explicit resource or lifecycle operations unless discussion
 shows a need to change that boundary.
 
-### O-007: Public resource API versus internal command transport
+### O-008: Public resource API versus internal command transport
 
 Decide whether public callers submit every execution action to one command collection or use
 clear resource endpoints that translate into internal commands. The current proposal favors clear
 public resources with one internal command envelope.
 
-### O-008: Public Cancel target
+### O-009: Public Cancel target
 
 Choose whether Cancel publicly targets:
 

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -43,6 +43,15 @@ system must deliver live frames to every connected reader.
 Live text fragments can have bounded retention. Completed messages, lifecycle facts, tools, and
 interactions require durable recovery. One raw ingress can feed both consumers.
 
+### D-006: Investigate sandbox-agent cancellation before selecting Stop semantics
+
+**Status:** Confirmed process decision on 2026-09-02.
+
+The Stop track starts with a focused sandbox-agent investigation. It must determine whether one
+execution can be cancelled while the harness session and sandbox remain resumable. It must also
+identify any required vendored patch and Daytona snapshot rebuild. This investigation can proceed
+in parallel with the API control-path design.
+
 ## Proposed design decisions
 
 ### P-001: Use one raw runner event ingress
@@ -99,3 +108,12 @@ Choose the Redis Stream layout, retention limit, redaction boundary, and browser
 ### O-005: Immediate runner control
 
 Choose direct runner HTTP, per-runner Redis control delivery, or a persistent runner connection.
+The current API knows the logical owner `replica_id`, but its configured runner URL is not a
+replica-specific route.
+
+### O-006: Command boundary
+
+Decide which actions enter a general command inbox. The working boundary is execution-affecting
+intent: Send, Cancel, interaction response, Queue, and Steer. Attach is a read operation. Kill,
+rename, archive, and delete remain explicit resource or lifecycle operations unless discussion
+shows a need to change that boundary.

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -1,0 +1,101 @@
+# Decisions
+
+> AGENT-GENERATED, low weight. Draft for discussion. Mahmoud makes final decisions.
+
+## Confirmed process decisions
+
+### D-001: Start from bugs and system requirements
+
+**Status:** Confirmed by Mahmoud on 2026-09-02.
+
+The design starts with the open issue inventory and the requirements the final system must
+satisfy. Architecture options must link back to these requirements.
+
+### D-002: Discuss one track at a time
+
+**Status:** Confirmed by Mahmoud on 2026-09-02.
+
+For each track, first present the high-level design and important questions. Record the answers
+and decisions in the RFC after discussion.
+
+### D-003: Keep the read path and control path independent
+
+**Status:** Confirmed direction on 2026-09-02.
+
+Shared reading and immediate control touch different directions and can progress in parallel:
+
+- Read path: runner to API to clients.
+- Control path: client to API to runner.
+
+Stop must not wait for the live relay, replay, or sender-as-reader work to finish.
+
+### D-004: Preserve live token output in the target experience
+
+**Status:** Confirmed direction on 2026-09-02.
+
+Moving readers behind the API must not reduce the sender to paragraph-only updates. The final
+system must deliver live frames to every connected reader.
+
+### D-005: Keep temporary frames separate from permanent facts
+
+**Status:** Confirmed direction on 2026-09-02.
+
+Live text fragments can have bounded retention. Completed messages, lifecycle facts, tools, and
+interactions require durable recovery. One raw ingress can feed both consumers.
+
+## Proposed design decisions
+
+### P-001: Use one raw runner event ingress
+
+**Status:** Proposed. Not approved.
+
+The runner sends raw frames once. A shared Redis Stream can feed both the live relay and a durable
+projector. The projector combines raw frames into durable events. The live relay forwards raw or
+briefly batched frames without waiting for message completion.
+
+The current sender response and current persistence path can remain during migration.
+
+### P-002: Keep ownership heartbeats but remove normal control delivery from them
+
+**Status:** Proposed. Not approved.
+
+Heartbeats continue to renew runner ownership and detect failures. Immediate control delivery
+handles Stop and Steer. Heartbeat detection remains a fallback when direct delivery fails.
+
+### P-003: Use append-only durable events for replay
+
+**Status:** Proposed. Requires an explicit decision reversal or separation from records.
+
+The existing records specification decided to use UUIDv7 ordering and no stored per-session
+sequence. The new replay requirement may need an append-only event log with a per-session cursor.
+The design must either reopen the existing decision or introduce a separate event-log concept.
+
+## Open decision gates
+
+### O-001: Vocabulary
+
+Settle the meanings of `session`, `conversation turn`, and `execution`. Decide how existing
+`turn_id` and `turn_index` map to those terms.
+
+### O-002: Stop behavior inside sandbox-agent
+
+Verify whether the vendored sandbox-agent can cancel one execution while preserving its harness
+session. If it cannot, define the required patch and whether Daytona needs a rebuilt snapshot.
+
+### O-003: Durable ordering
+
+Choose between:
+
+- A new append-only durable event log with a per-session sequence.
+- Append-only records with a new ordering contract.
+- Separate record storage and replay-event storage.
+
+Do not add a sequence column to mutable upserts and call the result append-only.
+
+### O-004: Raw live transport
+
+Choose the Redis Stream layout, retention limit, redaction boundary, and browser fan-out model.
+
+### O-005: Immediate runner control
+
+Choose direct runner HTTP, per-runner Redis control delivery, or a persistent runner connection.

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -152,6 +152,19 @@ The existing records specification decided to use UUIDv7 ordering and no stored 
 sequence. The new replay requirement may need an append-only event log with a per-session cursor.
 The design must either reopen the existing decision or introduce a separate event-log concept.
 
+### P-004: Require one active execution and fence stale writers
+
+**Status:** Proposed. Direction confirmed, mechanism not approved.
+
+At most one execution can be active for a session. Admission must be atomic. Each accepted owner
+receives an increasing ownership generation, also called a fencing token. Every durable write and
+effect-producing command carries that generation. The API rejects a write from an older
+generation even if the old runner is still alive.
+
+Redis heartbeats remain useful for leases and crash detection. A lease alone is not the final
+correctness guarantee because it can expire during a network partition while the old runner keeps
+working.
+
 ## Open decision gates
 
 ### O-001: Vocabulary
@@ -177,6 +190,13 @@ Do not add a sequence column to mutable upserts and call the result append-only.
 ### O-004: Raw live transport
 
 Choose the Redis Stream layout, retention limit, redaction boundary, and browser fan-out model.
+
+### O-005: Stable record-ID semantics spike
+
+Before immutable event insertion is implemented, inventory every runner and backend path that
+reuses a `record_id`. Separate exact delivery retries from progressive updates and resume
+re-emissions. Add regression tests for the final state of tools, interactions, terminal events,
+and harness reconstruction.
 
 ### O-005: Immediate runner control
 

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -125,6 +125,20 @@ The new snapshot and replayable event interface is introduced without changing t
 current stream and watch endpoints. Desktop and mobile migrate before obsolete endpoints are
 deprecated. Final endpoint names remain open for a later interface review.
 
+### D-016: Separate command delivery state from execution state
+
+**Status:** Confirmed by Mahmoud on 2026-09-02.
+
+The internal command lifecycle starts with `pending`, `claimed`, `applied`, and `obsolete`.
+Claims are temporary and can expire or retry. An execution terminal outcome is durable and cannot
+change. Public clients follow execution states such as `running`, `stopping`, `stopped`, `failed`,
+and `lost`; they do not infer execution state from internal delivery acknowledgements.
+
+Accepting Stop durably saves the command and moves the matching execution from `running` to
+`stopping` in one transaction. A runner outcome settles both the execution and the command. A
+watchdog settles an execution whose runner disappears, but its timeout remains open until the
+sandbox cancellation spike.
+
 ## Proposed design decisions
 
 ### P-001: Use one raw runner event ingress

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -139,6 +139,20 @@ Accepting Stop durably saves the command and moves the matching execution from `
 watchdog settles an execution whose runner disappears, but its timeout remains open until the
 sandbox cancellation spike.
 
+### D-017: Keep current Redis execution ownership for the first version
+
+**Status:** Confirmed by Mahmoud on 2026-09-02.
+
+The first version keeps the existing Redis `alive`, `running`, `owner`, and `superseded` model.
+It does not add Postgres execution authority, ownership generations, or full stale-writer fencing.
+Those changes have low current value because Agenta operates one runner and does not plan near-term
+runner scaling.
+
+Durable commands and runner-initiated long polling remain in scope. Stop delivery no longer depends
+on deleting ownership and waiting for a heartbeat. The current execution keeps its Redis ownership
+while stopping and releases it after cancellation settles. Heartbeat command discovery remains a
+fallback if long polling is unavailable.
+
 ## Proposed design decisions
 
 ### P-001: Use one raw runner event ingress

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -108,6 +108,15 @@ identity, its session, and the intent to execute it. Acceptance does not wait fo
 the work, the harness to start, or the first output frame. If no runner is available, accepted work
 remains queued rather than disappearing.
 
+### D-014: Do not preserve sender-only live visibility as a requirement
+
+**Status:** Confirmed by Mahmoud on 2026-09-02.
+
+The shared session stream is available to authorized session viewers. The design does not treat
+raw live output as secret to the browser that started the execution. Existing configured
+redaction and authorization behavior must be understood, but sender-only visibility is not a
+target product rule.
+
 ## Proposed design decisions
 
 ### P-001: Use one raw runner event ingress

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -91,6 +91,14 @@ Clients can view and remove a pending input. They cannot edit or reorder it. To 
 content, a client removes the old input and submits a replacement. The API rejects removal after
 the input has been promoted into active work.
 
+### D-012: Keep design discussions at the architectural level
+
+**Status:** Confirmed by Mahmoud on 2026-09-02.
+
+The discussion focuses on resource boundaries, execution ownership, event flow, recovery, and
+user-visible behavior. Routine endpoint naming, status codes, defaults, and validation details use
+established API conventions during RFC drafting unless they materially change those properties.
+
 ## Proposed design decisions
 
 ### P-001: Use one raw runner event ingress

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -52,6 +52,14 @@ execution can be cancelled while the harness session and sandbox remain resumabl
 identify any required vendored patch and Daytona snapshot rebuild. This investigation can proceed
 in parallel with the API control-path design.
 
+### D-007: Use five seconds as the provisional Stop delivery target
+
+**Status:** Provisional product direction from Mahmoud on 2026-09-02.
+
+Within five seconds of an accepted Stop request, the active execution must stop starting new model
+requests and new tool actions. The exact deadline for terminating an already-running provider or
+tool operation remains open until harness and tool cancellation capabilities are verified.
+
 ## Proposed design decisions
 
 ### P-001: Use one raw runner event ingress
@@ -117,3 +125,9 @@ Decide which actions enter a general command inbox. The working boundary is exec
 intent: Send, Cancel, interaction response, Queue, and Steer. Attach is a read operation. Kill,
 rename, archive, and delete remain explicit resource or lifecycle operations unless discussion
 shows a need to change that boundary.
+
+### O-007: Public resource API versus internal command transport
+
+Decide whether public callers submit every execution action to one command collection or use
+clear resource endpoints that translate into internal commands. The current proposal favors clear
+public resources with one internal command envelope.

--- a/docs/design/session-control-and-live-events/plan.md
+++ b/docs/design/session-control-and-live-events/plan.md
@@ -9,10 +9,11 @@ that one program finish before another starts.
 
 ### Program A: Immediate control
 
-1. Ownership and execution identity.
-2. Immediate Stop delivery.
-3. Stop settlement and sandbox preservation.
-4. Approval and Stop races.
+1. Sandbox-agent cancellation capability and Daytona rebuild impact.
+2. Ownership and execution identity.
+3. Immediate Stop delivery.
+4. Stop settlement and sandbox preservation.
+5. Approval and Stop races.
 
 ### Program B: Shared reading
 
@@ -67,3 +68,15 @@ Each track must contain:
 - The main rejected alternatives.
 - One live-stack test that proves the invariant.
 - Known harness or deployment limitations.
+
+## Initial parallel investigation
+
+The sandbox-agent investigation starts before the Stop interface is fixed. It must answer:
+
+1. Which protocol request currently ends a prompt or execution?
+2. Does that request also close the harness session?
+3. Can Pi and Claude Code resume the same native session after cancellation?
+4. Does the runner destroy or park the sandbox on each cancellation path?
+5. Which source repository owns the required change?
+6. Does Daytona need a new snapshot, and how is that snapshot version deployed?
+7. What automated test proves cancel followed by warm resume?

--- a/docs/design/session-control-and-live-events/plan.md
+++ b/docs/design/session-control-and-live-events/plan.md
@@ -58,6 +58,10 @@ The first two discussions can happen in parallel.
 7. **Shared client engine:** desktop and mobile state application after the server contracts are
    stable.
 
+Before finalizing the command contract, review the proposed public interface as a whole. The
+review must distinguish user-facing resource endpoints from the private command transport used to
+reach runners.
+
 ## Definition of a completed track
 
 Each track must contain:

--- a/docs/design/session-control-and-live-events/plan.md
+++ b/docs/design/session-control-and-live-events/plan.md
@@ -1,0 +1,69 @@
+# Design plan
+
+> AGENT-GENERATED, low weight. Draft for discussion. Mahmoud makes final decisions.
+
+## Parallel programs
+
+The work has three parallel programs. The order below is a discussion order, not a requirement
+that one program finish before another starts.
+
+### Program A: Immediate control
+
+1. Ownership and execution identity.
+2. Immediate Stop delivery.
+3. Stop settlement and sandbox preservation.
+4. Approval and Stop races.
+
+### Program B: Shared reading
+
+1. Raw live-frame ingress.
+2. Multi-client live relay.
+3. Explicit execution lifecycle facts.
+4. Append-only durable ordering and replay.
+5. Sender becomes an ordinary reader.
+
+### Program C: Durable input
+
+1. Durable command admission.
+2. Second-message policies: reject, queue, and steer.
+3. Approval responses as commands.
+4. Steer settlement and promotion.
+
+## Cross-cutting foundations
+
+These topics apply to all three programs:
+
+- Vocabulary and identifier ownership.
+- Harness capability reporting.
+- Authentication and authorization.
+- Redaction and temporary-frame retention.
+- Idempotency and duplicate delivery.
+- Live-stack tests and failure injection.
+
+## Proposed discussion order
+
+The first two discussions can happen in parallel.
+
+1. **Stop and ownership:** current lease, immediate signal options, sandbox-agent dependency,
+   terminal settlement, and watchdog behavior.
+2. **Live frames:** one raw ingress, Redis Stream layout, multi-client fan-out, and temporary
+   recovery.
+3. **Durable ordering:** append-only event model, cursor allocation, snapshot boundary, and the
+   conflict with the existing UUIDv7 record-order decision.
+4. **Sender detachment:** command acceptance, execution lifetime, and making the sender a reader.
+5. **Durable commands:** command states, delivery, retries, and owner routing.
+6. **Queue and Steer:** second-message policy, promotion order, interruption boundary, and
+   interaction races.
+7. **Shared client engine:** desktop and mobile state application after the server contracts are
+   stable.
+
+## Definition of a completed track
+
+Each track must contain:
+
+- One user problem.
+- One invariant.
+- One interface or state transition contract.
+- The main rejected alternatives.
+- One live-stack test that proves the invariant.
+- Known harness or deployment limitations.

--- a/docs/design/session-control-and-live-events/records-invariants.md
+++ b/docs/design/session-control-and-live-events/records-invariants.md
@@ -156,6 +156,34 @@ The durable model can append distinct facts such as `tool.started` and `tool.com
 one final `tool_call` fact. Reusing one ID and replacing its payload is a chosen projection model,
 not a storage necessity.
 
+### The current stable-ID behavior needs a spike before immutability work
+
+The same `record_id` can currently mean two different things:
+
+1. **Delivery retry.** The producer sends the same logical fact and payload again because it did
+   not receive an acknowledgement. The second insert should be an idempotent no-op.
+2. **Progressive update.** The producer sends a later payload for the same logical object. Treating
+   this as a duplicate no-op would discard the later state and can cause a regression.
+
+Current runner tests deliberately reuse stable IDs for repeated `tool_result` and
+`interaction_response` events. Tool-call argument snapshots share an identity but are currently
+coalesced into one final persisted record. The records DAO also documents later snapshots that
+replace earlier payloads. These behaviors must be reconciled before changing upserts to immutable
+inserts.
+
+The implementation plan therefore requires a producer-semantics spike. It must inventory every
+stable-ID producer, retry path, resume path, and progressive-update path. For each case, it must
+classify the repeated write as one of:
+
+- an identical retry that becomes a no-op;
+- a temporary live update that stays outside durable history;
+- a new durable fact that receives a new event ID and refers to the same stable tool, message, or
+  interaction ID.
+
+The spike is complete when tests cover each classified case and prove that immutable insertion
+does not lose a final tool result, interaction response, terminal outcome, or reconstructed
+conversation state. Immutable storage changes must not start before this gate passes.
+
 ### A dense per-session counter is not required, but commit order is required
 
 The earlier design rejected a dense per-session sequence because concurrent writers would need a

--- a/docs/design/session-control-and-live-events/records-invariants.md
+++ b/docs/design/session-control-and-live-events/records-invariants.md
@@ -47,8 +47,11 @@ A `snapshot + events after cursor` interface adds these requirements:
    second cursor entry.
 
 The sequence does not need to be dense or start at one for each session. It only needs to be
-strictly increasing and stable. A table-global database sequence can serve session-filtered reads;
-gaps from other sessions are harmless.
+strictly increasing and stable. Gaps are harmless. A plain table-global Postgres sequence is not
+enough by itself: Postgres allocates sequence values before commit, so transaction 102 can commit
+and become visible before transaction 101. A client that advances to 102 could then miss the late
+commit of 101. The write path must preserve commit visibility order, use a committed watermark, or
+serialize sequence assignment and commit for each session.
 
 ## Current violations
 
@@ -153,11 +156,14 @@ The durable model can append distinct facts such as `tool.started` and `tool.com
 one final `tool_call` fact. Reusing one ID and replacing its payload is a chosen projection model,
 not a storage necessity.
 
-### A dense per-session counter is not required
+### A dense per-session counter is not required, but commit order is required
 
 The earlier design rejected a dense per-session sequence because concurrent writers would need a
-counter row, lock, or serializable retry. Cursor replay does not need dense per-session numbers. A
-global Postgres sequence provides strict commit order without per-session counter contention.
+counter row, lock, or serializable retry. Cursor replay does not need dense per-session numbers,
+but it must not expose a higher cursor while a lower event can still commit later. A plain global
+sequence does not provide that guarantee. Viable designs include a per-session transactional
+counter and lock, one ordered projector per partition with session affinity, or a separate
+committed watermark protocol. The final choice must match the expected write volume.
 
 ### The asynchronous Redis worker is structurally useful
 
@@ -178,8 +184,8 @@ The existing records model could become an append-only replay source if it chang
 1. Give every durable logical event a producer-generated stable `event_id` before its first send.
 2. Make durable inserts immutable. Duplicate `event_id` writes become no-ops or verified identical
    duplicates.
-3. Add a database-assigned monotonic sequence. It can be global while reads remain filtered by
-   session.
+3. Add a monotonic cursor whose visibility order matches commit order. Do not use a plain database
+   sequence without solving out-of-order commits.
 4. Keep temporary deltas and progressive snapshots outside permanent records. Append only durable
    starts, completions, interaction changes, and execution lifecycle facts.
 5. Preserve stable message, tool, interaction, and execution IDs inside event payloads.
@@ -200,5 +206,5 @@ events.
 2. Should records contain all session lifecycle facts, or only conversation facts?
 3. Is the existing records API an internal projection, a public event contract, or both?
 4. Can we migrate current upsert rows to immutable events without breaking harness reconstruction?
-5. Does one global sequence meet operational scale requirements?
+5. Which cursor assignment method preserves commit order at the expected operational scale?
 6. Which durable facts must survive a runner crash before they reach Redis?

--- a/docs/design/session-control-and-live-events/records-invariants.md
+++ b/docs/design/session-control-and-live-events/records-invariants.md
@@ -1,0 +1,204 @@
+# Record properties and current violations
+
+> AGENT-GENERATED, low weight. Draft for discussion. Mahmoud makes final decisions.
+
+This note evaluates whether the existing `records` model can become the replayable session event
+history. It does not select a storage option.
+
+## What records do today
+
+Records are a durable conversation representation. The runner sends raw `AgentEvent` values to
+the live response, but coalesces text and thought deltas before record ingest. Tool-family events
+can use deterministic IDs. The API publishes records into a dedicated Redis Stream. A worker
+writes them into the tracing Postgres database. The frontend fetches the full record collection
+and reconstructs `UIMessage[]`.
+
+Records are therefore closer to a durable transcript projection than a raw transport log.
+
+## Properties required for the current transcript
+
+The current transcript and harness reconstruction need these properties:
+
+1. **Durability.** An acknowledged durable fact survives client, API, runner, and worker restarts
+   within the configured retention period.
+2. **Complete produced order.** Reads preserve the causal order of user messages, assistant
+   messages, tools, interactions, and terminal markers.
+3. **Idempotent retry.** Retrying one logical fact does not create a duplicate or change its place
+   in history.
+4. **Stable correlation.** Messages, tools, interactions, turns, and executions keep stable IDs so
+   later facts can refer to earlier ones.
+5. **Detectable incompleteness.** If retention, truncation, quota, or delivery failure prevents
+   complete reconstruction, the system reports that condition instead of silently replaying a
+   partial conversation.
+6. **Client independence.** Persistence does not depend on a browser connection.
+
+## Additional properties required for cursor replay
+
+A `snapshot + events after cursor` interface adds these requirements:
+
+1. **Immutable history.** Once a durable event is visible at a cursor, its payload and position do
+   not change.
+2. **Monotonic commit order.** Every committed event gets an order that only moves forward. A
+   cursor can request all later events without scanning or comparing timestamps.
+3. **Atomic visibility.** An event becomes replayable only after its durable write commits.
+4. **Replay-to-live handoff.** A reader cannot miss an event between reading history and joining
+   the live tail.
+5. **Stable event identity.** A producer retry maps to the same logical event and does not create a
+   second cursor entry.
+
+The sequence does not need to be dense or start at one for each session. It only needs to be
+strictly increasing and stable. A table-global database sequence can serve session-filtered reads;
+gaps from other sessions are harmless.
+
+## Current violations
+
+### Some rows are mutable
+
+The primary key is `(project_id, record_id)`. `append` and `append_many` use
+`ON CONFLICT DO UPDATE`. A conflict overwrites:
+
+- `record_type`
+- `record_source`
+- `timestamp`
+- `attributes`
+- `turn_id`
+- `span_id`
+
+The runner supplies deterministic UUIDv5 IDs for `tool_call`, `tool_result`,
+`interaction_request`, and `interaction_response` families. The stable ID lets repeated snapshots
+or retries target one row. The DAO deliberately keeps the last payload.
+
+This supports a latest-state model. It violates immutable event history.
+
+### Record IDs do not encode order
+
+The design document proposed UUIDv7 IDs, but the implementation does not use them:
+
+- Tool-family records use deterministic UUIDv5 IDs.
+- Other records receive backend-generated UUIDv4 IDs.
+
+UUIDv4 and UUIDv5 values are not time ordered. A client cannot use `record_id` as an `after`
+cursor.
+
+### Current read order is reconstructed from three fields
+
+The DAO orders records by:
+
+1. Producer `timestamp`.
+2. Database `created_at`.
+3. Per-turn `record_index`.
+
+`record_index` restarts at zero for each execution. `created_at` can be shared by records in one
+worker batch. Producer timestamps have clock and resolution limits. The composite order is useful
+for transcript rendering, but it is not a stable cursor.
+
+An upsert also overwrites `timestamp`. A retry or later snapshot can therefore move an existing
+row to a different place in the read order.
+
+### Retry identity is inconsistent
+
+Tool-family records have deterministic IDs and upsert on retry. Most message, thought, usage,
+error, and terminal records omit `record_id`; the API mints a new UUIDv4 for every ingest.
+
+If Redis accepted the first request but the HTTP response was lost, a runner retry without a
+stable ID can create a duplicate durable row. The system therefore uses idempotent retry for some
+record types but not all record types.
+
+### Worker failures can acknowledge unwritten records
+
+The records worker adds every successfully decoded Redis message ID to `processed_ids` before it
+attempts the Postgres batch write. If `append_many` fails, the worker logs the failure and
+continues. It still returns those IDs to the shared consumer loop, which acknowledges and deletes
+them from Redis.
+
+This is not an inherent Redis Streams limitation. It is an acknowledgement bookkeeping defect.
+
+### Runner delivery is bounded and can drop
+
+The runner retries record ingest a bounded number of times. After the limit, it records an
+in-memory failure count and drops the record. The turn-end drain can mark reconstruction unsafe in
+that runner process, but the missing fact never reaches the durable history.
+
+Bounded retry prevents an unavailable API from hanging execution forever. Permanent silent loss
+is not required by that constraint. Accepted inputs and terminal outcomes need a recoverable
+delivery source outside one runner process.
+
+### Retention, quotas, and truncation intentionally limit completeness
+
+Records live in the tracing database and have their own retention policy. Attributes larger than
+64 KB are truncated before Redis ingest. Enterprise quota rejection can also skip a batch.
+
+These are real product and operational constraints. Any design that uses records for session
+reconstruction or event replay must define what happens after retention, truncation, or quota
+loss. Calling the collection complete without marking these conditions would be incorrect.
+
+## Structural reasons behind the current design
+
+### Coalescing is structurally useful
+
+Persisting every token permanently would increase write volume and storage significantly. The
+durable transcript needs completed messages, not every typing-animation fragment. Coalescing raw
+text into a completed message is compatible with an append-only durable log.
+
+### Retries and deduplication are structurally required
+
+Network and worker delivery is at least once. Stable event IDs and duplicate handling are
+required. Mutating an existing row is not required. A final immutable fact can use
+`ON CONFLICT DO NOTHING` after every durable event receives a stable producer ID.
+
+### Progressive tool snapshots do not require mutable durable history
+
+A live tool call can publish several argument snapshots. Those snapshots can remain temporary.
+The durable model can append distinct facts such as `tool.started` and `tool.completed`, or append
+one final `tool_call` fact. Reusing one ID and replacing its payload is a chosen projection model,
+not a storage necessity.
+
+### A dense per-session counter is not required
+
+The earlier design rejected a dense per-session sequence because concurrent writers would need a
+counter row, lock, or serializable retry. Cursor replay does not need dense per-session numbers. A
+global Postgres sequence provides strict commit order without per-session counter contention.
+
+### The asynchronous Redis worker is structurally useful
+
+Redis decouples runner latency from Postgres latency and absorbs bursts. It does not require the
+worker to acknowledge failed database writes. Only successfully committed message IDs should be
+acknowledged.
+
+### Retention remains a real constraint
+
+If session history must outlive tracing retention, the existing records location cannot meet that
+requirement without changing retention or storage. If session history follows record retention,
+the tracing database remains viable. This is a product decision, not an ordering limitation.
+
+## Changes that could make records satisfy the properties
+
+The existing records model could become an append-only replay source if it changes as follows:
+
+1. Give every durable logical event a producer-generated stable `event_id` before its first send.
+2. Make durable inserts immutable. Duplicate `event_id` writes become no-ops or verified identical
+   duplicates.
+3. Add a database-assigned monotonic sequence. It can be global while reads remain filtered by
+   session.
+4. Keep temporary deltas and progressive snapshots outside permanent records. Append only durable
+   starts, completions, interaction changes, and execution lifecycle facts.
+5. Preserve stable message, tool, interaction, and execution IDs inside event payloads.
+6. Acknowledge Redis messages only after their Postgres transaction commits.
+7. Store or recover unacknowledged runner output across runner loss for required durable facts.
+8. Mark a session history incomplete when truncation, quota, retention, or unrecoverable delivery
+   loss creates a gap.
+9. Register the live wake-up before reading history so replay-to-live handoff cannot miss a commit.
+
+These changes are substantial, but there is no proven ordering or retry constraint that forces a
+separate event table. The separate-table option must instead justify itself through schema scope,
+retention, migration risk, or the desire to keep transcript projections distinct from lifecycle
+events.
+
+## Questions to answer before comparing storage options
+
+1. Must durable session history outlive tracing-record retention?
+2. Should records contain all session lifecycle facts, or only conversation facts?
+3. Is the existing records API an internal projection, a public event contract, or both?
+4. Can we migrate current upsert rows to immutable events without breaking harness reconstruction?
+5. Does one global sequence meet operational scale requirements?
+6. Which durable facts must survive a runner crash before they reach Redis?

--- a/docs/design/session-control-and-live-events/requirements.md
+++ b/docs/design/session-control-and-live-events/requirements.md
@@ -1,0 +1,178 @@
+# Bugs and system requirements
+
+> AGENT-GENERATED, low weight. Draft for discussion. Issue text is observation. Requirements are
+> proposed interpretations until Mahmoud confirms them.
+
+## Stop and hung executions
+
+Issues: [#5160](https://github.com/Agenta-AI/agenta/issues/5160),
+[#5982](https://github.com/Agenta-AI/agenta/issues/5982),
+[#6418](https://github.com/Agenta-AI/agenta/issues/6418),
+[#6100](https://github.com/Agenta-AI/agenta/issues/6100),
+[#6449](https://github.com/Agenta-AI/agenta/issues/6449),
+[#6099](https://github.com/Agenta-AI/agenta/issues/6099),
+[#6420](https://github.com/Agenta-AI/agenta/issues/6420),
+[#6327](https://github.com/Agenta-AI/agenta/issues/6327),
+[#5788](https://github.com/Agenta-AI/agenta/issues/5788),
+[#6102](https://github.com/Agenta-AI/agenta/issues/6102),
+[#6103](https://github.com/Agenta-AI/agenta/issues/6103),
+[#6084](https://github.com/Agenta-AI/agenta/issues/6084),
+[#5356](https://github.com/Agenta-AI/agenta/issues/5356),
+[#5327](https://github.com/Agenta-AI/agenta/issues/5327),
+[#6441](https://github.com/Agenta-AI/agenta/issues/6441),
+[#6313](https://github.com/Agenta-AI/agenta/issues/6313).
+
+Observed examples:
+
+> “After clicking Stop, the UI reflects the stop action immediately, but backend processing
+> continues for several minutes.” ([#5160](https://github.com/Agenta-AI/agenta/issues/5160))
+
+> “The turn hangs forever. `runTurn` never resolves, the alive watchdog keeps heartbeating
+> `running=true`.” ([#6418](https://github.com/Agenta-AI/agenta/issues/6418))
+
+Draft requirements:
+
+- Normal Stop reaches the active runner within a defined short deadline.
+- Every accepted execution reaches exactly one durable terminal outcome.
+- The sender and every other reader see the same terminal outcome.
+- Runner, sandbox, provider, tool, and adapter failures cannot leave an unbounded running state.
+- Normal Stop preserves the session workspace and resumable harness state where supported.
+- A watchdog settles work when the owning runner cannot produce the terminal outcome.
+- A slow tool fails with an explicit tool or execution result. It does not disappear silently.
+
+## Steer and concurrent sends
+
+Issues: [#6417](https://github.com/Agenta-AI/agenta/issues/6417),
+[#6020](https://github.com/Agenta-AI/agenta/issues/6020),
+[#5790](https://github.com/Agenta-AI/agenta/issues/5790),
+[#5539](https://github.com/Agenta-AI/agenta/issues/5539),
+[#5538](https://github.com/Agenta-AI/agenta/issues/5538).
+
+Observed examples:
+
+> “I expect the platform to queue the message, or to refuse it with a clear signal. Instead both
+> turns die and the session refuses every message for 30 minutes.”
+> ([#6417](https://github.com/Agenta-AI/agenta/issues/6417))
+
+> “The steering turn itself fails with an error and an empty reply, and every turn I send on that
+> session afterwards fails the same way.” ([#6020](https://github.com/Agenta-AI/agenta/issues/6020))
+
+Draft requirements:
+
+- At most one execution writes to a session at one time.
+- A second message uses an explicit `reject`, `queue`, or `steer` policy.
+- The API saves an accepted queue or steer message before interrupting current work.
+- Every control command names the execution it expects.
+- An older runner cannot reclaim ownership or write after replacement.
+- A failed steer leaves the saved message visible and recoverable.
+
+## Reattach and multiple readers
+
+Issues: [#5609](https://github.com/Agenta-AI/agenta/issues/5609),
+[#5542](https://github.com/Agenta-AI/agenta/issues/5542),
+[#6404](https://github.com/Agenta-AI/agenta/issues/6404),
+[#5611](https://github.com/Agenta-AI/agenta/issues/5611),
+[#5443](https://github.com/Agenta-AI/agenta/issues/5443),
+[#5384](https://github.com/Agenta-AI/agenta/issues/5384),
+[#6397](https://github.com/Agenta-AI/agenta/issues/6397),
+[#5990](https://github.com/Agenta-AI/agenta/issues/5990),
+[#6388](https://github.com/Agenta-AI/agenta/issues/6388),
+[#6468](https://github.com/Agenta-AI/agenta/issues/6468),
+[#5950](https://github.com/Agenta-AI/agenta/issues/5950).
+
+Observed examples:
+
+> “A tab that never regains focus misses a run started in another browser.”
+> ([#5609](https://github.com/Agenta-AI/agenta/issues/5609))
+
+> “Reload the page. After the reload: The approval card is gone entirely.”
+> ([#5542](https://github.com/Agenta-AI/agenta/issues/5542))
+
+Draft requirements:
+
+- Every authorized client can follow one execution concurrently.
+- Every connected client receives live frames, not only completed messages.
+- Refresh, navigation, and sender disconnection do not stop the execution.
+- A snapshot declares the durable event cursor it represents.
+- A reader can replay durable events after that cursor and then follow new events.
+- Missed temporary frames are repaired by the next durable checkpoint.
+- Pending interactions remain visible and actionable after reload.
+- Session identity is stable in URLs and across client caches.
+
+## Record durability and ordering
+
+Issues: [#5496](https://github.com/Agenta-AI/agenta/issues/5496),
+[#5594](https://github.com/Agenta-AI/agenta/issues/5594).
+
+Observed examples:
+
+> “The session-records pipeline loses records permanently in three separate ways, and reports
+> success while doing it.” ([#5496](https://github.com/Agenta-AI/agenta/issues/5496))
+
+> “The records worker rejects the whole batch.”
+> ([#5594](https://github.com/Agenta-AI/agenta/issues/5594))
+
+Draft requirements:
+
+- A successful ingest acknowledgment has a precise durability meaning.
+- One bad record cannot silently discard unrelated records in the same batch.
+- Retries are idempotent and cannot change established event order.
+- Durable replay uses append-only facts with a stable cursor.
+- A detected persistence gap marks the session history incomplete.
+- The runner drains required durable writes before terminal settlement.
+
+## Approvals and pauses
+
+Issues: [#6315](https://github.com/Agenta-AI/agenta/issues/6315),
+[#6316](https://github.com/Agenta-AI/agenta/issues/6316),
+[#6106](https://github.com/Agenta-AI/agenta/issues/6106),
+[#5907](https://github.com/Agenta-AI/agenta/issues/5907),
+[#5592](https://github.com/Agenta-AI/agenta/issues/5592),
+[#5638](https://github.com/Agenta-AI/agenta/issues/5638),
+[#5545](https://github.com/Agenta-AI/agenta/issues/5545),
+[#5097](https://github.com/Agenta-AI/agenta/issues/5097).
+
+Observed examples:
+
+> “The playground keeps rendering an actionable card whose buttons do nothing.”
+> ([#6315](https://github.com/Agenta-AI/agenta/issues/6315))
+
+> “When I answer a parked approval and the resumed run fails to start, the approval is gone.”
+> ([#5592](https://github.com/Agenta-AI/agenta/issues/5592))
+
+Draft requirements:
+
+- An interaction has one visible state: pending, resolved, denied, or cancelled.
+- Stop cancels pending interactions for the stopped execution.
+- A late answer cannot resume a cancelled or replaced execution.
+- An answer is not consumed until its continuation has a recoverable outcome.
+- Side-effecting tools do not run twice after pause and resume.
+- One user-visible conversation turn remains traceable across approval resumes.
+
+## Session list and identity
+
+Issues: [#6419](https://github.com/Agenta-AI/agenta/issues/6419),
+[#6463](https://github.com/Agenta-AI/agenta/issues/6463),
+[#5969](https://github.com/Agenta-AI/agenta/issues/5969),
+[#6457](https://github.com/Agenta-AI/agenta/issues/6457),
+[#6031](https://github.com/Agenta-AI/agenta/issues/6031),
+[#6214](https://github.com/Agenta-AI/agenta/issues/6214).
+
+Observed example:
+
+> “The session rail shows a session titled with my message, and the conversation is empty.”
+> ([#6419](https://github.com/Agenta-AI/agenta/issues/6419))
+
+Draft requirements:
+
+- A user message accepted by the API is never lost when execution fails to start.
+- A visible session has an explicit origin and owner type.
+- Session list updates converge without requiring a full page reload.
+- Rename and archive operations have observable success or failure.
+- Session identity does not depend on the browser that created it.
+
+## Requirement status
+
+This file does not yet state priority or implementation order. Some issues may share a cause, and
+some may fall outside the final RFC. Each design-track discussion must confirm which requirements
+it owns and which linked issues it expects to close.

--- a/docs/design/session-control-and-live-events/requirements.md
+++ b/docs/design/session-control-and-live-events/requirements.md
@@ -36,7 +36,7 @@ Draft requirements:
 - Every accepted execution reaches exactly one durable terminal outcome.
 - The sender and every other reader see the same terminal outcome.
 - Runner, sandbox, provider, tool, and adapter failures cannot leave an unbounded running state.
-- Normal Stop preserves the session workspace and resumable harness state where supported.
+- Normal Stop preserves the session workspace and leaves the harness session warm and resumable.
 - A watchdog settles work when the owning runner cannot produce the terminal outcome.
 - A slow tool fails with an explicit tool or execution result. It does not disappear silently.
 
@@ -63,7 +63,9 @@ Draft requirements:
 - Only the current execution ownership generation can append events or cause external effects.
 - A second message uses an explicit `reject`, `queue`, or `steer` policy.
 - The API saves an accepted queue or steer message before interrupting current work.
-- Every control command names the execution it expects.
+- The API resolves every execution-affecting command to one execution before delivery.
+- Public Stop can optionally name the execution the caller expects. If omitted, it targets the
+  current execution.
 - An older runner cannot reclaim ownership or write after replacement.
 - A failed steer leaves the saved message visible and recoverable.
 

--- a/docs/design/session-control-and-live-events/requirements.md
+++ b/docs/design/session-control-and-live-events/requirements.md
@@ -59,7 +59,8 @@ Observed examples:
 
 Draft requirements:
 
-- At most one execution writes to a session at one time.
+- At most one execution is active for a session at one time.
+- Only the current execution ownership generation can append events or cause external effects.
 - A second message uses an explicit `reject`, `queue`, or `steer` policy.
 - The API saves an accepted queue or steer message before interrupting current work.
 - Every control command names the execution it expects.

--- a/docs/design/session-control-and-live-events/research.md
+++ b/docs/design/session-control-and-live-events/research.md
@@ -1,0 +1,64 @@
+# Research notes
+
+> AGENT-GENERATED, low weight. Draft for discussion. Mahmoud makes final decisions.
+
+## Verified current behavior
+
+### Normal message delivery
+
+The desktop sends messages through the workflow invoke transport. The response carries the live
+event stream for that sender. The desktop Send path does not yet use the session command endpoint.
+
+### Normal Stop
+
+The desktop aborts its local response, then posts to `/sessions/streams/` with `session_id`, no
+inputs, and `force=false`. The API classifies this as Cancel. It marks the current Redis turn owner
+as superseded and clears the `alive` and `running` keys. The runner learns that it lost ownership
+when a heartbeat returns `is_current_turn=false`, then aborts locally.
+
+### Hard kill
+
+`DELETE /sessions/streams/?session_id=...` is separate from normal Cancel. It contacts the runner
+and tears down the sandbox. The session remains resumable after Cancel but not after Kill.
+
+### Heartbeat
+
+The runner posts `session_id`, `replica_id`, `turn_id`, and `is_running` to
+`/sessions/streams/heartbeat`. The heartbeat renews temporary ownership, mirrors liveness to the
+session row, and currently carries the delayed cancellation result back to the runner.
+
+### Records
+
+The runner forwards raw events to the sender and performs message and tool coalescing before
+durable ingest. Durable records travel through a Redis Stream and worker into Postgres. Record
+writes use upsert behavior.
+
+### Watch relay
+
+The current SSE watch endpoint relays change notifications through Redis Pub/Sub. A reader then
+refetches durable records. It does not relay raw tokens and cannot replay missed Pub/Sub messages.
+
+## Existing design decision that must be revisited
+
+`docs/designs/sessions/records/specs.md` states:
+
+> Ordering = uuid7 `id`, no stored `seq`.
+
+The same document describes records as append-only, but current implementation uses stable record
+IDs and upserts. A retry can therefore update an existing row. The RFC must define whether replay
+uses a new append-only event log or changes the record model.
+
+## Dependency to verify early
+
+Another design review reports that the vendored sandbox-agent cannot cancel an execution while
+preserving the harness session, and that a patch would require a Daytona snapshot rebuild. This
+has not yet been verified in this workspace. It is the first research task for the Stop track.
+
+## Existing design references
+
+- `docs/design/agent-workflows/projects/sessions-takeover/architecture.md`
+- `docs/design/agent-workflows/projects/sessions-takeover/opencode-comparison.md`
+- `docs/design/agenta-mobile/plans/2026-07-27-m3-live-relay.md`
+- `docs/design/agenta-mobile/plans/2026-07-27-mobile-approvals-steering.md`
+- `docs/designs/sessions/records/specs.md`
+- `docs/designs/sessions/interactions/specs.md`

--- a/docs/design/session-control-and-live-events/research.md
+++ b/docs/design/session-control-and-live-events/research.md
@@ -78,6 +78,21 @@ use their own endpoint and worker path. Kill uses `DELETE /sessions/streams/`.
 This means the current endpoint does not provide a durable inbox, command status, retry handling,
 or a single route for all execution-affecting actions.
 
+## Current interaction response path
+
+The frontend calls `POST /sessions/interactions/{interaction_id}/respond`. The API checks that the
+interaction is pending and atomically changes it to `responded`. The winning responder enqueues a
+TaskIQ job. The interaction dispatcher reconstructs the resume conversation from durable records
+and calls the workflow invoke service in detached mode. Approval response therefore already uses a
+resource-specific public endpoint followed by an internal invoke.
+
+## Current runner routing information
+
+Redis stores a logical `replica_id` for the runner that owns a session. The API hard-kill client
+does not resolve this identifier to an address. It calls one configured runner service URL with
+`project_id` and `session_id`. A normal load-balanced request is not sufficient when only one
+replica holds the live sandbox, unless the runner service provides its own owner routing.
+
 ## Existing design references
 
 - `docs/design/agent-workflows/projects/sessions-takeover/architecture.md`

--- a/docs/design/session-control-and-live-events/research.md
+++ b/docs/design/session-control-and-live-events/research.md
@@ -194,4 +194,4 @@ event.
 
 The proposed Agenta pending-input API therefore goes beyond these reviewed public interfaces. It
 addresses a product-specific need: Queue currently exists in browser state, and multiple clients
-need one visible and editable copy.
+need one visible shared copy. The initial design keeps queued inputs immutable.

--- a/docs/design/session-control-and-live-events/research.md
+++ b/docs/design/session-control-and-live-events/research.md
@@ -21,6 +21,11 @@ when a heartbeat returns `is_current_turn=false`, then aborts locally.
 `DELETE /sessions/streams/?session_id=...` is separate from normal Cancel. It contacts the runner
 and tears down the sandbox. The session remains resumable after Cancel but not after Kill.
 
+The direct kill client uses one configured `runner.internal_url`. Redis separately stores the
+logical owner `replica_id`. The current kill client does not resolve that identifier to a
+replica-specific address. Immediate Cancel cannot assume that logical owner identity already
+provides direct network routing.
+
 ### Heartbeat
 
 The runner posts `session_id`, `replica_id`, `turn_id`, and `is_running` to
@@ -53,6 +58,25 @@ uses a new append-only event log or changes the record model.
 Another design review reports that the vendored sandbox-agent cannot cancel an execution while
 preserving the harness session, and that a patch would require a Daytona snapshot rebuild. This
 has not yet been verified in this workspace. It is the first research task for the Stop track.
+
+## Current command endpoint is not a durable command system
+
+`POST /sessions/streams/` derives four modes from the presence of inputs and the `force` flag:
+
+| Inputs | `force` | Derived mode |
+|---|---:|---|
+| Present | `false` | Send |
+| Present | `true` | Steer |
+| Absent | `false` | Cancel |
+| Absent | `true` | Attach |
+
+The endpoint edits Redis coordination state and the session stream row. Its own DTO states that it
+runs nothing. Normal desktop Send still uses the workflow invoke path. Desktop Stop uses the Cancel
+mode. Attach acquires watcher bookkeeping but does not deliver live frames. Interaction responses
+use their own endpoint and worker path. Kill uses `DELETE /sessions/streams/`.
+
+This means the current endpoint does not provide a durable inbox, command status, retry handling,
+or a single route for all execution-affecting actions.
 
 ## Existing design references
 

--- a/docs/design/session-control-and-live-events/research.md
+++ b/docs/design/session-control-and-live-events/research.md
@@ -101,3 +101,79 @@ replica holds the live sandbox, unless the runner service provides its own owner
 - `docs/design/agenta-mobile/plans/2026-07-27-mobile-approvals-steering.md`
 - `docs/designs/sessions/records/specs.md`
 - `docs/designs/sessions/interactions/specs.md`
+
+## Public API comparison
+
+This comparison uses public vendor documentation. It describes interface shapes, not internal
+implementations.
+
+### Gumloop
+
+Gumloop models one workflow execution as a run:
+
+- `POST /api/v1/start_pipeline` starts work and returns `run_id`.
+- `GET /api/v1/get_pl_run?run_id=...` returns the run state, logs, and outputs.
+- `POST /api/v1/kill_pipeline` accepts `run_id` and stops that run.
+
+The kill operation is a POST. It does not delete the workflow definition. The caller uses the
+`run_id` returned by the start request.
+
+Sources:
+
+- https://docs.gumloop.com/api-reference/running-an-automation/start-automation
+- https://docs.gumloop.com/api-reference/running-an-automation/retrieve-run-details
+- https://docs.gumloop.com/api-reference/running-an-automation/kill-automation
+
+### OpenAI Responses background mode
+
+OpenAI models one background execution as a Response:
+
+- `POST /v1/responses` with `background: true` starts work and returns a Response with an ID.
+- `GET /v1/responses/{response_id}` retrieves its current state and result.
+- `POST /v1/responses/{response_id}/cancel` cancels it. Repeating Cancel is idempotent.
+- Creating with both `background: true` and `stream: true` provides live events. A disconnected
+  reader can reconnect with `starting_after=<sequence_number>`.
+
+This is the closest public example to the target read model. Execution continues independently
+of the first stream. The same response ID identifies retrieval, cancellation, and resumed
+streaming.
+
+Source: https://developers.openai.com/api/docs/guides/background
+
+### Claude Managed Agents
+
+Claude Managed Agents models control as events sent to a persistent session:
+
+- A `user.message` event starts or continues work.
+- A `user.interrupt` event stops current work.
+- Sending `user.interrupt` followed by `user.message` redirects the session.
+- `GET /v1/sessions/{session_id}/events/stream` provides session events. Optional delta events
+  provide live text previews. Buffered message events remain authoritative.
+- Tool confirmation is another event, `user.tool_confirmation`, tied to the pending tool event ID.
+- Deleting a session is separate. Deletion permanently removes its events and sandbox.
+
+The public interrupt targets a session. The service resolves which internal execution must stop.
+Claude also documents that model output can stop immediately while an active tool can take longer.
+
+Sources:
+
+- https://platform.claude.com/docs/en/managed-agents/events-and-streaming
+- https://platform.claude.com/docs/en/managed-agents/session-operations
+
+## Findings from the public comparison
+
+The three interfaces use different names, but they agree on four points:
+
+1. Starting work returns or uses a stable public identifier.
+2. Reading status is separate from stopping work.
+3. Stop is an action. It does not mean deleting the session or workflow.
+4. Deletion remains a separate destructive operation.
+
+They differ on the Stop target:
+
+- Gumloop and OpenAI target a specific execution ID.
+- Claude targets the session and lets the service interrupt its current work.
+
+Agenta can support both safety and convenience. The browser can send a session-scoped Cancel with
+an `expected_execution_id` prefilled from state. A human never types the execution ID. The API
+rejects the Cancel if that execution already ended and another one started.

--- a/docs/design/session-control-and-live-events/research.md
+++ b/docs/design/session-control-and-live-events/research.md
@@ -177,3 +177,21 @@ They differ on the Stop target:
 Agenta can support both safety and convenience. The browser can send a session-scoped Cancel with
 an `expected_execution_id` prefilled from state. A human never types the execution ID. The API
 rejects the Cancel if that execution already ended and another one started.
+
+## Public queue visibility
+
+The reviewed Gumloop public API exposes a run state of `QUEUED`, but its documented run API does
+not expose an editable per-session message queue. It starts runs, retrieves run state, and kills a
+run. This is a workflow-run queue rather than a conversation input queue.
+
+OpenAI background Responses expose a `queued` execution status and allow cancellation. The public
+background-mode documentation does not expose editing or reordering queued conversation inputs.
+
+Claude Managed Agents comes closer to a conversation inbox. User events are persisted in order.
+Each event has `processed_at=null` while it waits behind earlier events, and past events can be
+listed. The reviewed documentation does not describe patching or reordering an already-sent user
+event.
+
+The proposed Agenta pending-input API therefore goes beyond these reviewed public interfaces. It
+addresses a product-specific need: Queue currently exists in browser state, and multiple clients
+need one visible and editable copy.

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -286,6 +286,30 @@ inbox. It derives Send, Steer, Cancel, and Attach from inputs plus a `force` fla
 Send does not use this endpoint. A future explicit command contract must replace the ambiguous
 shape without silently changing existing invoke behavior.
 
+### Command delivery and execution settlement
+
+Command delivery and execution lifecycle are separate state machines:
+
+```text
+command:   pending -> claimed -> applied
+                              -> obsolete
+
+execution: running -> stopping -> stopped
+                              -> failed
+                              -> lost
+```
+
+The API accepts Stop by durably creating the command and moving the matching execution to
+`stopping` in one transaction. `expected_execution_id` remains optional. A command claim has a
+lease and can be delivered again after disconnection. The runner deduplicates by `command_id` and
+validates the execution ID and ownership generation before applying it.
+
+Claiming or acknowledging a command does not prove that execution stopped. Public clients follow
+execution state. The runner normally reports the terminal outcome and the API settles the command
+and execution together. If the runner disappears, a watchdog records `lost`; another runner cannot
+claim that it stopped work on the missing machine. The settlement deadline will be selected after
+the sandbox cancellation spike.
+
 ### Live frame ingress and relay
 
 The working model has one raw runner event ingress. The API acknowledges a frame only after it is

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -142,21 +142,19 @@ The event stream announces changes:
 
 ```text
 input.queued
-input.updated
 input.removed
 input.promoted
 ```
 
-The smallest useful management interface is:
+Queued inputs are immutable. The management interface only needs removal:
 
 ```http
-PATCH /sessions/{session_id}/inputs/{input_id}
 DELETE /sessions/{session_id}/inputs/{input_id}
 ```
 
-PATCH edits pending content. DELETE removes pending input. Both reject changes after the input was
-promoted into active work. Reordering is an open choice. It can use `position` in PATCH if the
-product needs it.
+To change a pending message, the client removes it and submits a replacement. DELETE rejects the
+request after the input was promoted into active work. The server processes pending inputs in FIFO
+order, which means first in, first out. The initial interface does not support reordering.
 
 This keeps clients synchronized. A message is no longer hidden inside one browser's local queue.
 

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -245,11 +245,86 @@ shape without silently changing existing invoke behavior.
 
 ### Live frame ingress and relay
 
-Pending discussion.
+The working model has one raw runner event ingress. The API acknowledges a frame only after it is
+accepted into the shared Redis Stream. Live readers consume temporary frames from that stream.
+The durable projector consumes the same source and commits permanent facts.
+
+Browser delivery never blocks the runner. A slow reader is disconnected and later recovers from
+durable state. With multiple API replicas, the runner and readers can connect to different
+replicas because Redis and Postgres hold the shared state. A runner-to-API disconnect does not
+stop execution; the runner reconnects and resends unacknowledged frames.
 
 ### Durable events and replay
 
-Pending discussion.
+The durable history requires immutable event IDs, an order whose visibility matches database
+commit order, idempotent retries, and a replay-to-live handoff that cannot miss a commit. A plain
+Postgres `BIGSERIAL` is insufficient by itself because sequence allocation can precede an
+out-of-order transaction commit.
+
+Two storage options remain under consideration.
+
+#### Option A: Repair records into the session event history
+
+Change records so every durable fact has a stable producer ID, immutable payload, and commit-safe
+session cursor. Duplicate delivery becomes a no-op. Add execution, input, and interaction
+lifecycle facts so the same append-only history can build the transcript and the session snapshot.
+
+Benefits:
+
+- One permanent history to write, retain, query, and debug.
+- Existing transcript and harness reconstruction already read records.
+- No consistency problem between two permanent logs.
+
+Costs and risks:
+
+- Changes the existing upsert contract and tool snapshot behavior.
+- Expands a conversation-oriented tracing record into the public session event contract.
+- Requires a migration story for old rows without cursors and current record retention.
+- Requires commit-safe ordering and reliable delivery changes regardless of table reuse.
+
+#### Option B: Keep records as a transcript projection and add a session event log
+
+Keep current records for conversation and harness reconstruction. Add an immutable session event
+history for input, execution, tool, interaction, and message lifecycle events. Build session
+snapshots from that history or projections updated in the same transaction.
+
+Benefits:
+
+- Leaves the current transcript and harness path largely intact during migration.
+- Gives the public event contract its own schema and retention policy.
+- Separates mutable or coalesced transcript projections from immutable lifecycle facts.
+
+Costs and risks:
+
+- Two permanent representations of some conversation facts.
+- The projector must keep records and session events consistent.
+- Debugging and recovery must define which representation is authoritative.
+- More schema, storage, migrations, and cleanup machinery.
+
+#### Redis as permanent history
+
+Redis remains the temporary ingress and delivery buffer. It is not a permanent session history in
+this draft because the Stream is bounded, entries are acknowledged and deleted, and Redis does not
+match the existing Postgres retention, query, and recovery model.
+
+#### Snapshot and stream consistency
+
+The snapshot is a durable projection through cursor N. The event endpoint replays durable events
+after N and then follows newly committed events. Snapshot data and cursor must be read from one
+consistent database view, or the projection and cursor must update in the same transaction.
+
+Temporary live frames do not advance the durable cursor. The next durable completion repairs
+missed previews. A reader subscribes to commit wake-ups before reading replay history so a commit
+cannot fall between the historical read and live tail.
+
+The delivery chain must handle these failure boundaries:
+
+1. Runner to API: retry unacknowledged frames after reconnect.
+2. API to Redis: acknowledge only after `XADD` succeeds.
+3. Redis to projector: leave failed work pending for retry.
+4. Projector to Postgres: append events and update projections in one transaction.
+5. Postgres to live wake-up: a lost wake-up is repaired by querying after the cursor.
+6. API to browser: reconnect after the last durable cursor.
 
 ### Detached sender
 

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -24,11 +24,17 @@ Pending discussion.
 
 ### Execution identity and ownership
 
-Pending discussion.
+Current Redis state identifies a logical runner replica and the current `turn_id`. The API does
+not currently map that replica identifier to a replica-specific network address. The hard-kill
+path calls one configured runner service URL. The RFC must select an immediate-control routing
+mechanism before it can define fast Cancel delivery.
 
 ### Immediate control
 
-Pending discussion.
+The existing `/sessions/streams/` endpoint is a coordination-state edit, not a durable command
+inbox. It derives Send, Steer, Cancel, and Attach from inputs plus a `force` flag. Normal desktop
+Send does not use this endpoint. A future explicit command contract must replace the ambiguous
+shape without silently changing existing invoke behavior.
 
 ### Live frame ingress and relay
 
@@ -44,7 +50,16 @@ Pending discussion.
 
 ### Durable commands
 
-Pending discussion.
+Working scope for discussion:
+
+- Send a user message.
+- Cancel an expected execution.
+- Respond to an interaction.
+- Queue a message.
+- Steer with a saved message.
+
+Attach belongs to the read path. Kill, rename, archive, and delete remain separate lifecycle or
+resource operations in the working model.
 
 ### Queue and Steer
 

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -105,7 +105,7 @@ operations. Attach is replaced by reading the snapshot and event stream.
 | Operation | Today | Proposed direction | Change |
 |---|---|---|---|
 | Send | Invoke a workflow and read its response stream | Keep this during migration. Later accept work independently and return an execution ID | Later change |
-| Stop | `POST /sessions/streams/` with no inputs and `force=false` | `POST /sessions/{id}/cancel` with an expected execution ID supplied by the client | Clearer endpoint and faster delivery |
+| Stop | `POST /sessions/streams/` with no inputs and `force=false` | `POST /sessions/{id}/cancel` with an optional expected execution ID | Clearer endpoint and faster delivery |
 | Hard kill | `DELETE /sessions/streams/?session_id=...`; destroys the sandbox | Keep as a separate destructive operation with an explicit name | Rename or reshape only |
 | Answer approval | `POST /sessions/interactions/{interaction_id}/respond` | Keep a resource-specific response endpoint. Improve acknowledgement and resume guarantees internally | Public shape mostly unchanged |
 | Queue while busy | Browser-local queue | Save the message on the server with `on_busy: queue` | Changes ownership from browser to server |
@@ -231,10 +231,19 @@ The recommended routing pattern for discussion is:
 4. The runner acknowledges and applies the command.
 5. Heartbeat or periodic recovery finds commands whose wake-up was lost.
 
-The runner can hold an authenticated outbound control stream to the API. This keeps Redis and
-Redis credentials behind the API boundary. In a multi-API deployment, Redis can route wake-ups to
-the API instance that holds the runner connection. A per-runner Redis channel is simpler but
-couples the runner directly to Redis. Direct pod addresses are the least portable option.
+The runner initiates the control connection to the API. This supports future user-operated runners
+behind firewalls and keeps Redis credentials behind the API boundary.
+
+The simplest first implementation is durable long polling. The runner makes an authenticated
+request that the API holds briefly until a command is available. The runner receives the command,
+acknowledges it, and immediately opens the next request. A disconnected runner reconnects and
+claims commands that remain durable. Redis or Postgres notifications may wake API replicas
+internally, but the runner never connects to either system.
+
+A persistent WebSocket or bidirectional stream can later reduce repeated requests and carry richer
+runner status. It is not required for the first contract. Direct API calls into runner pods and
+per-runner Redis subscriptions are poor fits for user-operated runners because they require inbound
+reachability or infrastructure credentials.
 
 The required invariant is stronger than “the second start usually gets a conflict”: at most one
 execution is active for a session, and only the current owner can write or cause external effects.

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -310,6 +310,20 @@ and execution together. If the runner disappears, a watchdog records `lost`; ano
 claim that it stopped work on the missing machine. The settlement deadline will be selected after
 the sandbox cancellation spike.
 
+### First-version ownership scope
+
+The first version retains Redis as the execution ownership authority. It does not introduce a new
+Postgres execution table, ownership generation, or general fencing migration.
+
+When Stop is accepted, the API saves the durable command but does not immediately free the current
+`alive` lock. Long polling delivers the command. The heartbeat can discover the same pending
+command as a fallback. The runner releases owner-checked `running` and `alive` keys only after
+cancellation settles, so new work cannot start during normal cancellation.
+
+This scope accepts the current network-partition limitation. Full multi-runner correctness and
+stale-writer fencing remain future work. The command and control-delivery ports must not depend on
+Redis-specific ownership details, so that later work can replace the ownership adapter.
+
 ### Live frame ingress and relay
 
 The working model has one raw runner event ingress. The API acknowledges a frame only after it is

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -231,8 +231,9 @@ The recommended routing pattern for discussion is:
 4. The runner acknowledges and applies the command.
 5. Heartbeat or periodic recovery finds commands whose wake-up was lost.
 
-The runner initiates the control connection to the API. This supports future user-operated runners
-behind firewalls and keeps Redis credentials behind the API boundary.
+The runner can initiate the control connection to the API. This would support possible future
+user-operated runners behind firewalls and keep Redis credentials behind the API boundary. That
+future deployment model is a consideration, not a confirmed requirement.
 
 The simplest first implementation is durable long polling. The runner makes an authenticated
 request that the API holds briefly until a command is available. The runner receives the command,
@@ -244,6 +245,20 @@ A persistent WebSocket or bidirectional stream can later reduce repeated request
 runner status. It is not required for the first contract. Direct API calls into runner pods and
 per-runner Redis subscriptions are poor fits for user-operated runners because they require inbound
 reachability or infrastructure credentials.
+
+Control delivery must sit behind an internal port. Session command handling depends on this port,
+not on a particular transport:
+
+```text
+deliver(owner, command)
+acknowledge(command_id, owner)
+recover(owner)
+```
+
+Initial adapter: authenticated long polling. Possible later adapters: persistent WebSocket,
+private Redis delivery, or direct managed-runner routing. Durable command state, authorization,
+idempotency, execution fencing, and terminal settlement remain outside the adapter. Replacing the
+adapter must not change the public session API or command state machine.
 
 The required invariant is stronger than “the second start usually gets a conflict”: at most one
 execution is active for a session, and only the current owner can write or cause external effects.

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -1,0 +1,72 @@
+# RFC: Session control and live events
+
+> AGENT-GENERATED, low weight. Draft for discussion. No architecture is approved yet.
+
+## Status
+
+Pre-design. The problem inventory and process decisions exist. Technical sections will be written
+after each design-track discussion.
+
+## Problem statement
+
+Agenta currently couples live output to the sending request, uses a heartbeat response as the
+normal cancellation signal, and lacks an append-only replay cursor for session changes. This makes
+multi-client reading, fast Stop, durable queueing, and reliable reconnect difficult to compose.
+
+## Required properties
+
+See [Requirements](requirements.md). The RFC will include only requirements confirmed during the
+track discussions.
+
+## Proposed architecture
+
+Pending discussion.
+
+### Execution identity and ownership
+
+Pending discussion.
+
+### Immediate control
+
+Pending discussion.
+
+### Live frame ingress and relay
+
+Pending discussion.
+
+### Durable events and replay
+
+Pending discussion.
+
+### Detached sender
+
+Pending discussion.
+
+### Durable commands
+
+Pending discussion.
+
+### Queue and Steer
+
+Pending discussion.
+
+### Approvals and pauses
+
+Pending discussion.
+
+### Client state application
+
+Pending discussion.
+
+## Migration
+
+Pending discussion. The migration must preserve the current sender stream until the shared read
+path passes its live-stack tests.
+
+## Test plan
+
+Pending discussion. Each architecture section must add one invariant and one live-stack test.
+
+## Rejected alternatives
+
+Pending discussion.

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -236,6 +236,25 @@ Redis credentials behind the API boundary. In a multi-API deployment, Redis can 
 the API instance that holds the runner connection. A per-runner Redis channel is simpler but
 couples the runner directly to Redis. Direct pod addresses are the least portable option.
 
+The required invariant is stronger than “the second start usually gets a conflict”: at most one
+execution is active for a session, and only the current owner can write or cause external effects.
+The current Redis `alive` lease, owner affinity, heartbeat refresh, and superseded markers reduce
+overlap. They do not fully enforce this invariant after lease expiry or a network partition because
+record ingest does not reject a stale ownership generation.
+
+The target design therefore separates two jobs:
+
+1. **Admission and fencing.** The API atomically accepts one execution and assigns an increasing
+   ownership generation. Every runner event carries the execution ID and generation. The API
+   rejects stale generations. Settlement releases ownership only when both values match.
+2. **Failure detection.** A heartbeat renews the active lease. If it expires, recovery can mark the
+   execution lost and assign a newer generation. The heartbeat detects failure, but it is not the
+   only protection against two writers.
+
+The RFC does not yet choose whether admission state belongs in Postgres, Redis with a durable
+command record, or a transaction across projections. The selected design must prove atomic
+concurrent admission and stale-write rejection.
+
 ### Immediate control
 
 The existing `/sessions/streams/` endpoint is a coordination-state edit, not a durable command
@@ -281,6 +300,11 @@ Costs and risks:
 - Expands a conversation-oriented tracing record into the public session event contract.
 - Requires a migration story for old rows without cursors and current record retention.
 - Requires commit-safe ordering and reliable delivery changes regardless of table reuse.
+
+This option has a mandatory discovery gate. Today a repeated stable `record_id` can be an exact
+transport retry or a later snapshot with changed payload. Only the exact retry becomes a no-op.
+The producer-semantics spike in `records-invariants.md` must classify every reuse and add regression
+tests before the upsert contract changes.
 
 #### Option B: Keep records as a transcript projection and add a session event log
 

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -22,12 +22,83 @@ track discussions.
 
 Pending discussion.
 
+### Public interface boundary
+
+The working public interface separates resources, commands, queries, and events.
+
+Create or send session work:
+
+```http
+POST /sessions/{session_id}/commands
+Idempotency-Key: <client-generated-key>
+
+{
+  "type": "send",
+  "message": "Explain this failure",
+  "delivery": "reject"
+}
+```
+
+Control an active execution:
+
+```http
+POST /sessions/{session_id}/commands
+
+{
+  "type": "cancel",
+  "expected_execution_id": "execution-12"
+}
+```
+
+Respond to an interaction through a resource-specific public endpoint:
+
+```http
+POST /sessions/{session_id}/interactions/{interaction_id}/responses
+
+{
+  "answer": {"approved": true},
+  "expected_execution_id": "execution-12"
+}
+```
+
+The API can translate the response into the same internal command envelope used by Send, Cancel,
+Queue, and Steer. The public caller does not need to understand internal runner routing.
+
+Read current state:
+
+```http
+GET /sessions/{session_id}
+```
+
+Follow durable events and live frames:
+
+```http
+GET /sessions/{session_id}/events?after=<cursor>
+Accept: text/event-stream
+```
+
+Rename, archive, delete, and hard termination remain explicit session resource or lifecycle
+operations. Attach is replaced by reading the snapshot and event stream.
+
 ### Execution identity and ownership
 
 Current Redis state identifies a logical runner replica and the current `turn_id`. The API does
 not currently map that replica identifier to a replica-specific network address. The hard-kill
 path calls one configured runner service URL. The RFC must select an immediate-control routing
 mechanism before it can define fast Cancel delivery.
+
+The recommended routing pattern for discussion is:
+
+1. The API saves or atomically records the command.
+2. The API identifies the logical owner `replica_id`.
+3. A private control channel wakes that runner immediately.
+4. The runner acknowledges and applies the command.
+5. Heartbeat or periodic recovery finds commands whose wake-up was lost.
+
+The runner can hold an authenticated outbound control stream to the API. This keeps Redis and
+Redis credentials behind the API boundary. In a multi-API deployment, Redis can route wake-ups to
+the API instance that holds the runner connection. A per-runner Redis channel is simpler but
+couples the runner directly to Redis. Direct pod addresses are the least portable option.
 
 ### Immediate control
 
@@ -60,6 +131,10 @@ Working scope for discussion:
 
 Attach belongs to the read path. Kill, rename, archive, and delete remain separate lifecycle or
 resource operations in the working model.
+
+The internal command transport does not require every public action to use one generic endpoint.
+Public resource endpoints can validate domain-specific input and then create the common internal
+command.
 
 ### Queue and Steer
 

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -59,7 +59,8 @@ POST /sessions/{session_id}/cancel
 
 The browser learns `execution-12` from the session snapshot or the `execution.started` event. The
 person pressing Stop never enters it. This field prevents a delayed Stop request from cancelling
-new work that started after the button was pressed.
+new work that started after the button was pressed. The field is optional. Without it, the API
+cancels whichever execution is active when the request is applied.
 
 Respond to an interaction through a resource-specific public endpoint:
 
@@ -117,6 +118,75 @@ execution is already running:
 
 When the session is idle, all accepted messages start normally. The contract may call this field
 `on_busy` so its purpose is clear.
+
+### Visible pending messages
+
+Once Queue moves from the browser to the server, every client must be able to see the same pending
+messages. A session snapshot can include them:
+
+```json
+{
+  "pending_inputs": [
+    {
+      "id": "input-24",
+      "type": "user_message",
+      "content": "Then check the database",
+      "position": 1,
+      "status": "pending"
+    }
+  ]
+}
+```
+
+The event stream announces changes:
+
+```text
+input.queued
+input.updated
+input.removed
+input.promoted
+```
+
+The smallest useful management interface is:
+
+```http
+PATCH /sessions/{session_id}/inputs/{input_id}
+DELETE /sessions/{session_id}/inputs/{input_id}
+```
+
+PATCH edits pending content. DELETE removes pending input. Both reject changes after the input was
+promoted into active work. Reordering is an open choice. It can use `position` in PATCH if the
+product needs it.
+
+This keeps clients synchronized. A message is no longer hidden inside one browser's local queue.
+
+### One public interface for all clients
+
+Agenta desktop, mobile, bots, and external API users should call the same public session API. A
+first-party browser must not depend on a separate privileged execution endpoint.
+
+The runner still needs a private protocol because it performs trusted internal work. That private
+protocol carries claims, heartbeats, event frames, acknowledgements, and control wake-ups. It is
+not a second product API.
+
+### Interaction responses
+
+Moving interaction response under the session URL does not itself improve correctness. It only
+makes session ownership and authorization visible in the path. The current endpoint can remain:
+
+```http
+POST /sessions/interactions/{interaction_id}/respond
+```
+
+or the clean public contract can use:
+
+```http
+POST /sessions/{session_id}/interactions/{interaction_id}/responses
+```
+
+The material change is internal. The API must durably accept the response, make one response win,
+and expose whether continuation is pending, running, or failed. URL nesting is a consistency
+choice, not the reason for changing approval handling.
 
 ### Private control path
 

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -24,7 +24,8 @@ Pending discussion.
 
 ### Public interface boundary
 
-The working public interface separates four operations. This is a proposal, not an approved API.
+The working public interface separates four operations. Every route in this section is a proposed
+new public contract, not a description of an existing endpoint and not yet an approved API.
 
 1. Send intent to a session.
 2. Read the current session snapshot.
@@ -82,12 +83,19 @@ Read current state. This is an ordinary query, not an event endpoint:
 GET /sessions/{session_id}
 ```
 
+This is not the current `GET /sessions/streams/?session_id=...`, which returns only coordination
+and liveness data.
+
 Follow durable events and live frames:
 
 ```http
 GET /sessions/{session_id}/events?after=<cursor>
 Accept: text/event-stream
 ```
+
+This is not the current `GET /sessions/streams/watch`, which sends change notifications and asks
+the client to refetch records. The proposed endpoint sends replayable session events and then live
+events.
 
 Rename, archive, delete, and hard termination remain explicit session resource or lifecycle
 operations. Attach is replaced by reading the snapshot and event stream.

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -24,7 +24,15 @@ Pending discussion.
 
 ### Public interface boundary
 
-The working public interface separates resources, commands, queries, and events.
+The working public interface separates four operations. This is a proposal, not an approved API.
+
+1. Send intent to a session.
+2. Read the current session snapshot.
+3. Follow session changes.
+4. Delete a session permanently.
+
+The proposal does not require one generic public command endpoint. Clear resource-specific
+endpoints can all feed one private command-delivery mechanism.
 
 Create or send session work:
 
@@ -39,16 +47,19 @@ Idempotency-Key: <client-generated-key>
 }
 ```
 
-Control an active execution:
+Stop the current execution, but only if it is still the execution the caller observed:
 
 ```http
-POST /sessions/{session_id}/commands
+POST /sessions/{session_id}/cancel
 
 {
-  "type": "cancel",
   "expected_execution_id": "execution-12"
 }
 ```
+
+The browser learns `execution-12` from the session snapshot or the `execution.started` event. The
+person pressing Stop never enters it. This field prevents a delayed Stop request from cancelling
+new work that started after the button was pressed.
 
 Respond to an interaction through a resource-specific public endpoint:
 
@@ -64,7 +75,7 @@ POST /sessions/{session_id}/interactions/{interaction_id}/responses
 The API can translate the response into the same internal command envelope used by Send, Cancel,
 Queue, and Steer. The public caller does not need to understand internal runner routing.
 
-Read current state:
+Read current state. This is an ordinary query, not an event endpoint:
 
 ```http
 GET /sessions/{session_id}
@@ -79,6 +90,55 @@ Accept: text/event-stream
 
 Rename, archive, delete, and hard termination remain explicit session resource or lifecycle
 operations. Attach is replaced by reading the snapshot and event stream.
+
+### Current and proposed public behavior
+
+| Operation | Today | Proposed direction | Change |
+|---|---|---|---|
+| Send | Invoke a workflow and read its response stream | Keep this during migration. Later accept work independently and return an execution ID | Later change |
+| Stop | `POST /sessions/streams/` with no inputs and `force=false` | `POST /sessions/{id}/cancel` with an expected execution ID supplied by the client | Clearer endpoint and faster delivery |
+| Hard kill | `DELETE /sessions/streams/?session_id=...`; destroys the sandbox | Keep as a separate destructive operation with an explicit name | Rename or reshape only |
+| Answer approval | `POST /sessions/interactions/{interaction_id}/respond` | Keep a resource-specific response endpoint. Improve acknowledgement and resume guarantees internally | Public shape mostly unchanged |
+| Queue while busy | Browser-local queue | Save the message on the server with `on_busy: queue` | Changes ownership from browser to server |
+| Steer while busy | Ambiguous `force=true` coordination mode; normal send still uses invoke | Save the message, request interruption, then start the saved message | Behavior becomes explicit and durable |
+| Attach | `force=true` without inputs records watcher state but does not provide live output | Remove the command. Load a snapshot, then follow events | Replaced by read operations |
+| Load current state | Several queries for records, liveness, and pending interactions | One versioned session snapshot, or a documented composition of existing queries | Open design choice |
+| Follow changes | SSE sends change notifications; the browser refetches records | Replay events after a cursor, then continue with live frames | Changes from invalidation to replay plus live tail |
+| Delete | Separate destructive behavior exists through the stream API | Explicit session deletion after work is stopped | Public naming changes |
+
+### Busy-message policies
+
+The words `reject`, `queue`, and `steer` apply only when a new user message arrives while an
+execution is already running:
+
+- `reject`: return a conflict response. Do not save or start the new message.
+- `queue`: save the new message. Start it after current work stops normally.
+- `steer`: save the new message. Interrupt current work, then start the new message.
+
+When the session is idle, all accepted messages start normally. The contract may call this field
+`on_busy` so its purpose is clear.
+
+### Private control path
+
+The public Cancel request does not need a runner address. A simple internal flow is:
+
+1. The browser sends Cancel to the API.
+2. The API records that execution 12 must stop.
+3. The API sends a private wake-up to the runner that owns execution 12.
+4. The runner stops local work and reports `execution.cancelled`.
+5. Every browser receives that event.
+
+The API already knows the logical runner owner as `replica_id`. It does not yet know a reliable
+network address for that replica. The implementation must add one of these private delivery
+mechanisms:
+
+- The runner keeps an outbound connection open to the API. The API sends control messages on it.
+- The runner subscribes to a private per-runner broker channel.
+- The runner service adds owner-aware routing behind one internal URL.
+
+This private choice does not change the public Cancel endpoint. A heartbeat remains useful for
+renewing ownership and detecting a crashed runner. It stops being the normal way to deliver
+Cancel.
 
 ### Execution identity and ownership
 

--- a/docs/design/session-control-and-live-events/rfc.md
+++ b/docs/design/session-control-and-live-events/rfc.md
@@ -245,7 +245,24 @@ Pending discussion.
 
 ### Detached sender
 
-Pending discussion.
+Starting work and watching work are separate operations. The API durably accepts an input and
+returns without waiting for a runner claim, harness start, first output frame, or reader
+connection. The execution then proceeds independently of the submitting HTTP request.
+
+The durable acceptance boundary includes:
+
+- The submitted input.
+- Its idempotency identity.
+- Its session association.
+- Its accepted execution intent.
+
+The sender then reads the same session event stream as desktop, mobile, bots, and external
+clients. Disconnecting any reader does not cancel or park the execution. A convenience request
+may submit and begin streaming in one call, but that response remains a reader of an independently
+accepted execution.
+
+During migration, the current invoke response can continue serving the sender while the shared
+read path is introduced. The final client model removes this privileged sender path.
 
 ### Durable commands
 

--- a/docs/design/session-control-and-live-events/slice-records-ack.md
+++ b/docs/design/session-control-and-live-events/slice-records-ack.md
@@ -1,0 +1,188 @@
+# Slice: the records worker acknowledges only what Postgres has
+
+> AGENT-GENERATED, low weight. Draft for discussion. Mahmoud makes final decisions.
+
+This slice closes the durability half of GitHub issue
+[#5496](https://github.com/Agenta-AI/agenta/issues/5496) and all of
+[#5594](https://github.com/Agenta-AI/agenta/issues/5594). It changes the records stream worker
+and the shared stream consumer it runs on. It does not touch the runner, the records DAO, or
+the records table.
+
+Every claim below marked **verified** was read in code at the cited `path:line`, proven by a
+test in this branch, or observed in the live run in "What I verified". Nothing here is
+reported from another document without saying so.
+
+## The answer
+
+Three defects deleted records and reported success. All three are fixed.
+
+| Defect | What happened | Where it is fixed |
+| --- | --- | --- |
+| The worker acknowledged records before the write | Every failed Postgres write deleted its records from Redis | `records_worker.py:277`, `:341`, `:349`, `:383` |
+| One rejected record discarded its whole batch | A batch of fifty lost forty-nine good records to one bad one | `records_worker.py:192-232` |
+| A record left unacknowledged was never redelivered | `read_batch` only asks for new entries, so "leave it pending" meant "lose it silently" | `consumer.py:181-268` |
+
+A fourth defect is fixed in its own commit because it is one line and unrelated to the worker.
+Enterprise record retention referenced `RecordDBE.id`, an attribute the model does not have, so
+the retention statement raised before it deleted anything. Records were never aged out. Fixed at
+`api/ee/src/dbs/postgres/sessions/records/dao.py:107` and `:121`. Verified: `hasattr(RecordDBE,
+"id")` is `False`, the key is `(project_id, record_id)`
+(`api/oss/src/dbs/postgres/sessions/records/dbes.py:18`), and the corrected statement compiles
+against the Postgres dialect.
+
+## What happened before this change
+
+The worker added every decoded Redis message id to its acknowledged list during
+deserialization, before it tried the Postgres write. A failed `append_many` logged an error and
+continued. The ids were still returned, and the shared consumer loop acknowledged and deleted
+them from the stream. Verified in the previous revision of `records_worker.py` at lines 177,
+184, 236-246 and 278, and in `shared/consumer.py:143-155`.
+
+Two consequences followed.
+
+1. Any Postgres failure deleted the records of the turn that was running. The user saw a
+   complete conversation on screen, and the durable transcript kept a hole. The runner rebuilt
+   later turns from that incomplete transcript.
+2. `append_many` writes one statement in one transaction, so one record Postgres rejected took
+   its whole batch with it. Up to fifty unrelated records were lost per rejection. This is
+   #5594.
+
+A third problem was hidden underneath. The obvious fix, "do not acknowledge a failed batch", does
+not work on its own. `read_batch` reads only `>`, which means new entries
+(`consumer.py:118`, `:143`). An entry that is never acknowledged is invisible to every later
+read of that consumer group. Without a reclaim pass, not acknowledging turns silent loss into a
+pending list that grows forever and still never writes. Verified by test:
+`test_unacknowledged_entry_comes_back_through_the_reclaim_pass` asserts that a second
+`read_batch` returns nothing.
+
+## What the worker does now
+
+An id enters the acknowledged list for exactly three reasons.
+
+1. Its rows committed.
+2. It could not be decoded, so a redelivery cannot help. Counted as a loss.
+3. Its organization is over its records quota, which is a deliberate product drop. Counted as a
+   loss.
+
+Everything else stays pending and comes back.
+
+**The write path.** `_append_committed` (`records_worker.py:192`) calls `append_many` for the
+whole project group. If that commits, every id in the group is acknowledged. If it fails and the
+group holds more than one record, the worker writes the group one record at a time and
+acknowledges only the records that committed. A rejected record stays pending on its own.
+
+**The reclaim pass.** `reclaim_batch` (`consumer.py:181`) runs at the top of the worker loop
+(`consumer.py:333`). It asks Redis for the group's pending entries with `XPENDING`, claims them
+with `XCLAIM`, and hands them back to `process_batch`. It is opt-in through `reclaim_pending`,
+which is off for the tracing and events workers and always on for records
+(`records_worker.py:98`). It runs at most once per idle window, so a busy stream does not add a
+round trip per loop turn.
+
+**The retry bound.** Redis counts deliveries per entry. After `max_deliveries` deliveries the
+worker drops the entry, logs at error with the session id, record id and record type, and
+increments `dropped_messages` (`consumer.py:270`). The drop is data loss, and the log line is
+what makes it countable.
+
+**The guard on the bound.** The delivery counter alone cannot tell a record Postgres will never
+accept apart from a Postgres that is simply down. Both fail every delivery. Dropping on the
+count alone therefore deletes every record in flight as soon as an outage outlasts
+`max_deliveries` windows, which is the loss this slice exists to prevent. So the worker drops an
+over-budget entry only while other records are committing (`consumer.py:167`,
+`records_worker.py:181`). While nothing at all is writing, over-budget entries are kept and the
+worker logs a warning instead. This is safe because a pending entry in a Redis stream does not
+block later entries: `read_batch` keeps delivering new records the whole time.
+
+I found this hole in the live run, not in review. The first live run dropped all five records of
+the second turn because the outage lasted ten reclaim windows. See "What I verified".
+
+## The retry policy, and why
+
+| Setting | Default | Environment variable | Meaning |
+| --- | --- | --- | --- |
+| `reclaim_idle_ms` | 30000 | `AGENTA_RECORDS_RECLAIM_IDLE_MS` | How long a failed record waits before the worker tries it again |
+| `max_deliveries` | 5 | `AGENTA_RECORDS_MAX_DELIVERIES` | Deliveries after which a record is dropped, but only while other records are committing |
+
+Both live in `api/oss/src/utils/env.py:528` and `:532`, and are wired in the composition root at
+`api/entrypoints/worker_streams.py:101-102`.
+
+Three choices are worth stating.
+
+**One record at a time, not a binary split.** A split costs about `2 log2(n)` calls when one
+record is bad and about `2n` calls when Postgres is down. Writing one record at a time costs `n`
+calls in both cases, and Postgres being down is the common case. The simpler rule is also the
+cheaper one where it matters.
+
+**The reclaim lives in the shared consumer, not in the records worker.** It belongs next to
+`read_batch` and `ack_and_delete`, which are the two halves it completes, and the tracing and
+events workers have the same defect waiting for them. It is off by default, so this change alters
+no other worker's behaviour.
+
+**A failed entitlements check now defers instead of dropping.** An over-quota organization is a
+deliberate drop and is still acknowledged. An entitlements service that cannot be reached is a
+transient failure, and its records now stay pending (`records_worker.py:334`). This is the same
+defect class as the main bug, so I fixed it here rather than filing it.
+
+## What I verified
+
+**Unit tests.** `api/oss/tests/pytest/unit/sessions/test_records_worker_durability.py`, 11 tests.
+The redelivery tests run against `fakeredis`, so the pending-list bookkeeping is real consumer
+group behaviour rather than a mock of it.
+
+I also updated one assertion in
+`api/oss/tests/pytest/unit/sessions/test_watch_publish.py:137-144`. That test pinned the old
+acknowledge-before-write rule, and its own comment said it was not an endorsement of it.
+
+Full API unit suite, OSS and Enterprise: 3248 passed, 74 skipped, 0 failed. The skips need a
+Postgres or an external key that this environment does not have. None of them cover the records
+worker. `ruff format` and `ruff check` are clean at version 0.15.12, which is what continuous
+integration pins.
+
+**Live run against a real Redis 8.** I did not deploy a stack. Swap on the box was fully used
+(31 GB of 31 GB) and three other agent stacks were already running, so a fourth stack would have
+put the others at risk. Instead I ran the real `RecordsWorker.run` loop against a throwaway
+`redis:8` container on port 6399, with a write path that fails on demand. The script is at
+`/tmp/claude-1000/-home-mahmoud-code-agenta-2/7c724667-82cd-41a6-ba0b-e47bc96b4f67/scratchpad/verify_records_ack.py`.
+The container is stopped and removed.
+
+| Step | Result |
+| --- | --- |
+| Turn one, three records, healthy write path | 3 committed, `XLEN` 0 |
+| Turn two, five records published while the write path is down for 20 seconds | 0 committed, `XLEN` 5, `XPENDING` 5, 0 acknowledged |
+| Write path restored | All 8 records present, 0 duplicates, `XLEN` 0, `XPENDING` 0, 0 dropped |
+| One always-rejected record among three good ones | The 3 good records committed, the rejected one stayed pending |
+| Traffic resumes | The rejected record dropped at its budget, logged at error naming `sess-2:<record id>:message`, `XLEN` 0, `XPENDING` 0 |
+
+This covers the substance of the scenario in the brief. It does not cover the real
+`RecordsDAO.append_many` against a real Postgres, or the runner and the browser. Those are not
+verified.
+
+## What I did not do
+
+- I did not deploy a docker compose stack, for the memory reason above.
+- I did not change the runner's bounded retry, the records DAO upsert rule, or the records table.
+- I did not add a metric or an alert for `dropped_messages`. It is a counter on the worker object
+  and a log line, nothing more.
+- The tracing and events workers still acknowledge before their write. The mechanism to fix them
+  now exists, and turning it on for them is one constructor argument each. I left it off.
+
+## Open questions for Mahmoud
+
+1. **Is 5 deliveries over 30 second windows the right bound?** Recommendation: keep it. With the
+   health guard, the bound only applies while other records are committing, so it now measures
+   "this record is bad" rather than "the database is slow". Both values are environment
+   variables if a deployment disagrees.
+2. **Should a dropped record raise an alert, not just a log line?** Recommendation: add one when
+   the observability plane is next touched, not now. The counter and the error log make the loss
+   countable, and Agenta runs one records worker, so the volume is small.
+3. **Should the tracing and events workers get the same treatment?** Recommendation: yes, but as
+   a separate change. They have the same acknowledge-before-write defect, and the machinery is
+   already shared and off by default. Traces and events are less costly to lose than a
+   conversation, so they do not need to ride with this one.
+4. **Enterprise record retention starts deleting records the day this ships.** It has never run
+   successfully, so old records have accumulated since the feature landed. Recommendation:
+   check the row count and the configured cutoff on the first deployment before the job runs, so
+   the first sweep is not a surprise.
+5. **The reclaim pass makes a lost record land late rather than never.** A record can now be
+   written a minute or more after its turn ended. Recommendation: accept it. The runner rebuilds
+   history at the start of the next turn, not at the end of the previous one, so a late write is
+   still in time for the reader that matters.

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -33,6 +33,8 @@
 - Corrected the cursor analysis: plain Postgres sequences do not guarantee commit visibility order.
 - Added the repaired-records and separate-event-log options with trade-offs. Redis-only permanent
   history excluded from the draft.
+- Added a mandatory stable-ID producer spike before immutable record changes.
+- Made single active execution and stale-writer fencing explicit requirements.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -17,6 +17,10 @@
 - Current interaction response path documented.
 - Public APIs from Gumloop, OpenAI background Responses, and Claude Managed Agents compared.
 - Each current operation mapped to its proposed behavior and degree of change.
+- Stop and Delete distinction confirmed.
+- Optional `expected_execution_id` guard recorded.
+- One public session API for first-party and external clients recorded.
+- Visible server-side pending inputs added to the interface discussion.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -40,6 +40,8 @@
   requirement.
 - Recorded long polling as the current control-transport preference behind a replaceable adapter.
 - Recorded warm sandbox and harness resume as the required Stop outcome.
+- Confirmed the minimal internal command lifecycle and its separation from public execution state.
+- Left the Stop settlement timeout for the sandbox cancellation spike.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -15,11 +15,13 @@
 - Five seconds recorded as the provisional Stop delivery target.
 - Public resource API separated from the proposed internal command transport.
 - Current interaction response path documented.
+- Public APIs from Gumloop, OpenAI background Responses, and Claude Managed Agents compared.
+- Each current operation mapped to its proposed behavior and degree of change.
 
-## Blockers
+## Branch
 
-- GitHub CLI is unavailable in the environment. The isolated checkout uses standard Git.
-- The branch exists only locally. It has not been committed or pushed.
+- Branch: `agent/session-execution-rfc`
+- The branch is pushed to `Agenta-AI/agenta` after each design exchange.
 
 ## Next discussion
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -10,6 +10,8 @@
 - Confirmed process decisions recorded.
 - Proposed architecture choices kept separate from confirmed decisions.
 - Living RFC created with empty sections for track-by-track discussion.
+- Current command endpoint and runner routing boundary verified.
+- Sandbox-agent cancellation investigation promoted to the first parallel task.
 
 ## Blockers
 
@@ -20,8 +22,8 @@
 
 Start with **Stop and ownership**:
 
-1. Confirm the user-visible Stop requirements and latency target.
-2. Verify the sandbox-agent cancellation limitation.
+1. Start the sandbox-agent capability investigation.
+2. Confirm the user-visible Stop requirements and latency target.
 3. Choose the immediate runner-control transport at a high level.
 4. Define terminal settlement and watchdog responsibility.
 5. Decide which current issues this track is expected to close.

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -25,6 +25,8 @@
 - Detailed API mechanics delegated to established conventions unless they affect architecture.
 - Durable acceptance defined independently from runner claim and execution start.
 - Sender-only visibility explicitly excluded from the target requirements.
+- Proposed snapshot and event routes explicitly marked as new contracts, not changed meanings of
+  current stream routes.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -22,6 +22,7 @@
 - One public session API for first-party and external clients recorded.
 - Visible server-side pending inputs added to the interface discussion.
 - Queued inputs made immutable. Clients can remove and replace them, but cannot edit or reorder.
+- Detailed API mechanics delegated to established conventions unless they affect architecture.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -35,6 +35,9 @@
   history excluded from the draft.
 - Added a mandatory stable-ID producer spike before immutable record changes.
 - Made single active execution and stale-writer fencing explicit requirements.
+- Kept the public Stop execution guard optional.
+- Added future user-operated runners as a control-transport constraint.
+- Recorded warm sandbox and harness resume as the required Stop outcome.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -24,6 +24,7 @@
 - Queued inputs made immutable. Clients can remove and replace them, but cannot edit or reorder.
 - Detailed API mechanics delegated to established conventions unless they affect architecture.
 - Durable acceptance defined independently from runner claim and execution start.
+- Sender-only visibility explicitly excluded from the target requirements.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -27,6 +27,7 @@
 - Sender-only visibility explicitly excluded from the target requirements.
 - Proposed snapshot and event routes explicitly marked as new contracts, not changed meanings of
   current stream routes.
+- Side-by-side endpoint migration accepted as the first draft. Final naming deferred.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -30,6 +30,9 @@
 - Side-by-side endpoint migration accepted as the first draft. Final naming deferred.
 - Existing record properties, violations, structural constraints, and repair options traced before
   selecting a replay storage design.
+- Corrected the cursor analysis: plain Postgres sequences do not guarantee commit visibility order.
+- Added the repaired-records and separate-event-log options with trade-offs. Redis-only permanent
+  history excluded from the draft.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -1,0 +1,29 @@
+# Status
+
+> AGENT-GENERATED, low weight. Draft for discussion. Mahmoud makes final decisions.
+
+## Current state
+
+- Isolated branch created: `agent/session-execution-rfc`.
+- Problem inventory created from 48 open GitHub issues.
+- Current Stop, heartbeat, records, and watch paths checked against the repository.
+- Confirmed process decisions recorded.
+- Proposed architecture choices kept separate from confirmed decisions.
+- Living RFC created with empty sections for track-by-track discussion.
+
+## Blockers
+
+- GitHub CLI is unavailable in the environment. The isolated checkout uses standard Git.
+- The branch exists only locally. It has not been committed or pushed.
+
+## Next discussion
+
+Start with **Stop and ownership**:
+
+1. Confirm the user-visible Stop requirements and latency target.
+2. Verify the sandbox-agent cancellation limitation.
+3. Choose the immediate runner-control transport at a high level.
+4. Define terminal settlement and watchdog responsibility.
+5. Decide which current issues this track is expected to close.
+
+The **live-frame ingress** discussion can proceed independently after that or in parallel.

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -36,7 +36,9 @@
 - Added a mandatory stable-ID producer spike before immutable record changes.
 - Made single active execution and stale-writer fencing explicit requirements.
 - Kept the public Stop execution guard optional.
-- Added future user-operated runners as a control-transport constraint.
+- Added possible future user-operated runners as a control-transport consideration, not a
+  requirement.
+- Recorded long polling as the current control-transport preference behind a replaceable adapter.
 - Recorded warm sandbox and harness resume as the required Stop outcome.
 
 ## Branch

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -28,6 +28,8 @@
 - Proposed snapshot and event routes explicitly marked as new contracts, not changed meanings of
   current stream routes.
 - Side-by-side endpoint migration accepted as the first draft. Final naming deferred.
+- Existing record properties, violations, structural constraints, and repair options traced before
+  selecting a replay storage design.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -12,6 +12,9 @@
 - Living RFC created with empty sections for track-by-track discussion.
 - Current command endpoint and runner routing boundary verified.
 - Sandbox-agent cancellation investigation promoted to the first parallel task.
+- Five seconds recorded as the provisional Stop delivery target.
+- Public resource API separated from the proposed internal command transport.
+- Current interaction response path documented.
 
 ## Blockers
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -23,6 +23,7 @@
 - Visible server-side pending inputs added to the interface discussion.
 - Queued inputs made immutable. Clients can remove and replace them, but cannot edit or reorder.
 - Detailed API mechanics delegated to established conventions unless they affect architecture.
+- Durable acceptance defined independently from runner claim and execution start.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -21,6 +21,7 @@
 - Optional `expected_execution_id` guard recorded.
 - One public session API for first-party and external clients recorded.
 - Visible server-side pending inputs added to the interface discussion.
+- Queued inputs made immutable. Clients can remove and replace them, but cannot edit or reorder.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/status.md
+++ b/docs/design/session-control-and-live-events/status.md
@@ -42,6 +42,8 @@
 - Recorded warm sandbox and harness resume as the required Stop outcome.
 - Confirmed the minimal internal command lifecycle and its separation from public execution state.
 - Left the Stop settlement timeout for the sandbox cancellation spike.
+- Confirmed that the first version keeps current Redis execution ownership.
+- Kept durable commands and long polling in scope; deferred Postgres ownership and full fencing.
 
 ## Branch
 

--- a/docs/design/session-control-and-live-events/tonight-handoff.md
+++ b/docs/design/session-control-and-live-events/tonight-handoff.md
@@ -1,0 +1,80 @@
+# Tonight handoff
+
+> AGENT-GENERATED, low weight. Draft execution handoff. Mahmoud makes final decisions.
+
+## Fixed direction
+
+- Keep current Redis execution ownership for version one.
+- Add durable commands with `pending`, `claimed`, `applied`, and `obsolete` states.
+- Use runner-initiated HTTP long polling behind a replaceable control-delivery port.
+- Keep `expected_execution_id` optional on public Stop.
+- Keep the Redis ownership lock until Stop settles.
+- Use heartbeat command discovery as delivery fallback.
+- Require Stop followed by warm resume of the same sandbox and native harness session.
+- Keep live-frame work independent from Stop work.
+- Park the repaired-records versus separate-event-table decision for review.
+
+## Work package A: sandbox cancellation spike
+
+**Goal:** Prove how to cancel current work while preserving warm resume.
+
+Answer:
+
+1. Which request cancels a prompt in each supported harness?
+2. Does it preserve the native harness session?
+3. What happens to a running tool and partial message?
+4. Does the runner park or destroy the sandbox on every cancellation path?
+5. Is a sandbox-agent patch required?
+6. Does Daytona need a rebuilt snapshot?
+
+Deliver a code-traced report, a characterization test, the smallest patch proposal, and a live test
+plan for start, Stop, and resume in the same sandbox and native session. Do not redesign ownership,
+commands, or public endpoints.
+
+## Work package B: durable command and long-poll design
+
+**Goal:** Produce an implementation-ready design for reliable API-to-runner commands.
+
+Define the command schema, claim lease, idempotency, long-poll claim and acknowledgement behavior,
+heartbeat fallback, failure recovery, adapter boundary, and how Redis ownership remains held until
+Stop settles. Deliver a short design and migration sequence. Do not implement a new execution
+ownership model.
+
+## Work package C: current Stop implementation map
+
+**Goal:** Remove uncertainty before changing Stop.
+
+Trace the browser request, API stream mutation, Redis key changes, heartbeat response, runner abort,
+sandbox cleanup, records, interactions, and frontend refresh. List every branch that means cancel,
+kill, steer, or approval interruption. Deliver a sequence diagram and file-by-file change map. Do
+not implement changes.
+
+## Work package D: stable record-ID spike
+
+**Goal:** Make the later immutable-history decision safe.
+
+Inventory every stable `record_id` producer and classify repeated IDs as exact retries,
+progressive updates, or resume re-emissions. Add or propose regression tests for final tool state,
+interaction responses, terminal events, and harness reconstruction. Do not select repaired records
+or a separate event table.
+
+## First implementation after the spikes
+
+1. Add the durable command repository and service behind interfaces.
+2. Add the runner long-poll claim loop and API adapter.
+3. Let Stop create a durable command with an optional expected-execution guard.
+4. Let the runner apply Stop through its active abort controller.
+5. Preserve Redis ownership until cancellation settles.
+6. Make heartbeat discover pending Stop as fallback.
+7. Emit the durable cancellation outcome and publish the existing watch notification.
+8. Prove Stop delivery within five seconds and warm resume on the live stack.
+
+## Deferred explicitly
+
+- Postgres execution authority.
+- Ownership generations and full fencing.
+- Multiple-runner routing guarantees.
+- User-operated runner requirements.
+- Final records versus event-table selection.
+- Final public endpoint naming.
+- WebSocket or gRPC control transport.


### PR DESCRIPTION
A Postgres outage can cause the records worker to acknowledge Redis entries before the conversation rows are durable. Those records can then disappear permanently.

The worker now acknowledges only IDs whose Postgres write committed. A failed batch is retried one record at a time. Pending-entry reclaim is opt-in, and a database outage is not treated as a poison record. The change also fixes an enterprise retention query that used a missing attribute.

## Issue coverage

Fixes the silent-loss paths described by #5496 and the bad-record batch behavior in #5594, subject to final review of each issue's acceptance conditions.

## Dependencies

Independent of Stop, warm cancellation, and the watchdog. The pull request is based on the RFC branch and will need a clean release base before merge.

## Tests

The real worker loop retained five records published during a 20-second Postgres outage and drained them after recovery.

## How to review

1. Review the transaction and acknowledgement boundary.
2. Review partial batch failure behavior.
3. Review pending-entry reclaim safeguards.
4. Review the enterprise retention correction separately.