### PR TITLE
[6484] fix(frontend): Render pasted Markdown immediately

### DIFF
--- a/web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx
+++ b/web/packages/agenta-ui/src/Editor/plugins/markdown/markdownPlugin.tsx
@@ -38,6 +38,7 @@ import {$convertToMarkdownStringCustom, PLAYGROUND_TRANSFORMERS} from "./assets/
 import {SET_MARKDOWN_VIEW, TOGGLE_MARKDOWN_VIEW} from "./commands"
 import TableCellResizerPlugin from "./TableCellResizerPlugin"
 import {importMarkdownWithHtmlBatches} from "./utils/htmlImport"
+import {looksLikeMarkdown} from "./utils/paste"
 
 const URL_REGEX =
     /((https?:\/\/(www\.)?)|(www\.))[-a-zA-Z0-9@:%._+~#=]{1,256}\.[a-zA-Z0-9()]{1,6}\b([-a-zA-Z0-9()@:%_+.~#?&//=]*)(?<![-.+():%])/
@@ -404,6 +405,34 @@ const MarkdownPlugin = ({
                     })
 
                     return true
+                }
+
+                if (clipboardPlainText && looksLikeMarkdown(clipboardPlainText)) {
+                    let shouldRenderMarkdown = false
+                    editor.getEditorState().read(() => {
+                        const root = $getRoot()
+                        const firstChild = root.getFirstChild()
+                        const isMarkdownSource =
+                            $isCodeNode(firstChild) && firstChild.getLanguage() === "markdown"
+                        const isEmpty =
+                            root.getChildrenSize() === 0 ||
+                            (root.getChildrenSize() === 1 && firstChild?.getTextContent() === "")
+                        shouldRenderMarkdown = !isMarkdownSource && isEmpty
+                    })
+
+                    if (shouldRenderMarkdown) {
+                        event.preventDefault()
+                        event.stopPropagation()
+                        editor.update(() => {
+                            $convertFromMarkdownString(
+                                clipboardPlainText,
+                                PLAYGROUND_TRANSFORMERS,
+                                undefined,
+                                true,
+                            )
+                        })
+                        return true
+                    }
                 }
 
                 const htmlData = event.clipboardData?.getData("text/html")

--- a/web/packages/agenta-ui/src/Editor/plugins/markdown/utils/paste.ts
+++ b/web/packages/agenta-ui/src/Editor/plugins/markdown/utils/paste.ts
@@ -1,0 +1,7 @@
+const BLOCK_MARKDOWN_PATTERN = /^(?: {0,3}(?:#{1,6}\s|[-*+]\s|\d+[.)]\s|>\s|```|~~~)|\|.+\|\s*$)/m
+const INLINE_MARKDOWN_PATTERN =
+    /(?:\*\*[^*\n]+\*\*|__[^_\n]+__|~~[^~\n]+~~|`[^`\n]+`|\[[^\]\n]+\]\([^\n)]+\))/
+
+export function looksLikeMarkdown(value: string): boolean {
+    return BLOCK_MARKDOWN_PATTERN.test(value) || INLINE_MARKDOWN_PATTERN.test(value)
+}

--- a/web/packages/agenta-ui/tests/unit/markdownPaste.render.test.tsx
+++ b/web/packages/agenta-ui/tests/unit/markdownPaste.render.test.tsx
@@ -1,0 +1,45 @@
+// @vitest-environment jsdom
+import {cleanup, fireEvent, render, waitFor} from "@testing-library/react"
+import {afterEach, describe, expect, it, vi} from "vitest"
+
+import {EditorProvider} from "../../src/Editor"
+import {SharedEditor} from "../../src/SharedEditor"
+
+afterEach(cleanup)
+
+describe("Markdown editor paste", () => {
+    it("renders pasted Markdown in an empty rich-text editor", async () => {
+        const handleChange = vi.fn()
+        const {container} = render(
+            <EditorProvider id="markdown-paste" codeOnly={false} enableTokens={false}>
+                <SharedEditor
+                    id="markdown-paste"
+                    noProvider
+                    initialValue=""
+                    handleChange={handleChange}
+                    disableDebounce
+                    editorProps={{codeOnly: false, enableTokens: false, noProvider: true}}
+                />
+            </EditorProvider>,
+        )
+        const editor = await waitFor(() => {
+            const element = container.querySelector<HTMLElement>('[contenteditable="true"]')
+            expect(element).not.toBeNull()
+            return element
+        })
+        expect(editor).not.toBeNull()
+
+        fireEvent.paste(editor!, {
+            clipboardData: {
+                getData: (format: string) =>
+                    format === "text/plain" ? "# Heading\n\n**bold** text\n- list item" : "",
+            },
+        })
+
+        await waitFor(() => {
+            expect(editor!.querySelector("h1")?.textContent).toBe("Heading")
+            expect(editor!.querySelector("strong")?.textContent).toBe("bold")
+            expect(editor!.querySelector("ul li")?.textContent).toContain("list item")
+        })
+    })
+})

--- a/web/packages/agenta-ui/tests/unit/markdownPaste.test.ts
+++ b/web/packages/agenta-ui/tests/unit/markdownPaste.test.ts
@@ -1,0 +1,26 @@
+import {describe, expect, it} from "vitest"
+
+import {looksLikeMarkdown} from "../../src/Editor/plugins/markdown/utils/paste"
+
+describe("looksLikeMarkdown", () => {
+    it.each([
+        "# Heading\n\nParagraph",
+        "- first\n- second",
+        "1. first\n2. second",
+        "> quoted text",
+        "```ts\nconst value = true\n```",
+        "This is **bold** text",
+        "Read the [documentation](https://example.com)",
+    ])("recognizes Markdown syntax in pasted text", (value) => {
+        expect(looksLikeMarkdown(value)).toBe(true)
+    })
+
+    it.each([
+        "A normal sentence with punctuation.",
+        "https://example.com/path_(one)",
+        "Price is 10 * 2 dollars",
+        "Email support@example.com",
+    ])("does not treat plain text as Markdown", (value) => {
+        expect(looksLikeMarkdown(value)).toBe(false)
+    })
+})


### PR DESCRIPTION
## Summary

Pasting Markdown into an empty instruction or skills editor inserted the source characters as plain text. Users had to switch to the source tab and back before the rich-text preview rendered.

The shared Lexical paste handler only parsed large clipboard payloads or HTML copied from monospace elements. This change detects common block and inline Markdown in plain-text clipboard data and converts it immediately when the rich-text editor is empty. Ordinary prose, Markdown source mode, and paste into editors that already contain content keep their existing behavior.

Fixes #6484.

## Testing

### Verified locally

- `pnpm turbo run build --filter=@agenta/ui`
- `pnpm turbo run lint --filter=@agenta/ui`
- Focused Markdown paste tests: 12 passed
- Full `@agenta/ui` suite: 178 passed, with one unrelated existing failure in `dateRangePickerKeyboard.render.test.tsx` concerning the expected focused date

### Added or updated tests

- Added 11 unit cases covering headings, lists, quotes, fenced code, bold text, links, and plain-text negatives.
- Added a jsdom integration test that pastes a heading, bold text, and a list through the Lexical plugin and verifies the rendered HTML.

### QA follow-up

- Paste Markdown containing a heading, bold text, and a list into an empty instruction or skills editor. The formatting should render immediately.
- Confirm ordinary prose remains plain text.
- Confirm Markdown source mode and paste into an editor with existing content retain their previous behavior.

## Demo

Demo capture from the real app is in progress.

## Checklist

- [ ] Demo shows the real app running this branch (not a mock-up or recreated UI)
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [ ] I have signed the CLA, or I will sign it when the bot prompts me

## Contributor Resources

- [Contributing guide](https://agenta.ai/docs/contributing/overview)
- [Creating your first PR](https://agenta.ai/docs/contributing/first-pr)
- [Development mode](https://agenta.ai/docs/contributing/guides/development-mode)
- [Testing](https://agenta.ai/docs/contributing/guides/testing)
- [Formatting and linting](https://agenta.ai/docs/contributing/guides/formatting-and-linting)
- [Slack support](https://join.slack.com/t/agenta-hq/shared_invite/zt-37pnbp5s6-mbBrPL863d_oLB61GSNFjw)