### PR TITLE
fix(frontend): log the persist timeout event debug mode was silent about

### DIFF
--- a/web/packages/agenta-shared/src/api/persist/debug.ts
+++ b/web/packages/agenta-shared/src/api/persist/debug.ts
@@ -79,5 +79,8 @@ export const persistLog = (
         case "gc":
             console.info(`[persist] GC ${label}`)
             break
+        case "timeout":
+            console.warn(`[persist] TIMEOUT ${label} (IndexedDB blocked — served as a miss)`)
+            break
     }
 }


### PR DESCRIPTION
## What

`persistLog` had no `switch` case for the `"timeout"` event, so debug mode printed nothing for it.

## Why

#6424 added the timeout branch to the event union and emitted it from `idbStorage`, but the logger never handled it — the one failure that PR exists to diagnose (a hung IndexedDB read served as a cache miss) was the one failure you could not see with `agenta:persist:debug` on.

Caught in review on #6424; the fix missed that PR's merge, hence the follow-up.

## Change

One `case` in `persistLog`, logged at `warn` since a blocked read is degraded behaviour rather than routine bookkeeping:

```
[persist] TIMEOUT <key> (IndexedDB blocked — served as a miss)
```

## Testing

`@agenta/shared` unit tests pass. Behaviour is debug-only: no-op unless `localStorage.agenta:persist:debug === "1"`.