### PR TITLE
feat(sessions): separate session history from tracing retention and gate immutable record writes

### DIFF
--- a/api/ee/src/core/sessions/records/service.py
+++ b/api/ee/src/core/sessions/records/service.py
@@ -1,17 +1,11 @@
-"""EE records service (retention).
-
-Mirrors ``ee.src.core.events.service.EventsRetentionService`` — same shape,
-different counter and DAO. The OSS counterpart
-(``oss.src.core.sessions.records.service.RecordsService``) owns append/query.
-"""
+"""EE session-record retention."""
 
 from datetime import datetime, timezone, timedelta
 
 from oss.src.utils.logging import get_module_logger
 
-from ee.src.core.access.entitlements.types import Tracker, Counter
-from ee.src.core.access.controls import get_plans
 from ee.src.dbs.postgres.sessions.records.dao import RecordsRetentionDAO
+from oss.src.utils.env import env
 
 
 log = get_module_logger(__name__)
@@ -34,64 +28,31 @@ class RecordsRetentionService:
         log.info("[flush-records] Starting records flush job")
         log.info("[flush-records] ============================================")
 
-        total_plans = 0
-        total_skipped = 0
-        total_records = 0
+        retention_days = env.sessions.history_retention_days
+        if retention_days is None:
+            log.info("[flush-records] Skipped (session history retention is unlimited)")
+            return
 
-        for plan, entitlements in get_plans().items():
-            total_plans += 1
+        cutoff = datetime.now(timezone.utc) - timedelta(days=retention_days)
+        log.info(
+            f"[flush-records] Processing with cutoff={cutoff.isoformat()} "
+            f"(retention={retention_days} days)"
+        )
 
-            if not entitlements:
-                log.info(f"[flush-records] [{plan}] Skipped (no entitlements)")
-                total_skipped += 1
-                continue
-
-            records_quota = (entitlements.get(Tracker.COUNTERS) or {}).get(
-                Counter.RECORDS_INGESTED
-            )
-
-            if not records_quota or records_quota.retention is None:
-                log.info(f"[flush-records] [{plan}] Skipped (unlimited retention)")
-                total_skipped += 1
-                continue
-
-            retention_minutes = records_quota.retention
-            cutoff = datetime.now(timezone.utc) - timedelta(minutes=retention_minutes)
-
-            log.info(
-                f"[flush-records] [{plan}] Processing with cutoff={cutoff.isoformat()} "
-                f"(retention={retention_minutes} minutes)"
-            )
-
-            try:
-                plan_records = await self._flush_records_for_plan(
-                    plan=plan,
-                    cutoff=cutoff,
-                    max_projects_per_batch=max_projects_per_batch,
-                    max_records_per_batch=max_records_per_batch,
-                )
-
-                total_records += plan_records
-
-                log.info(f"[flush-records] [{plan}] Completed: {plan_records} records")
-
-            except Exception:
-                log.error(
-                    f"[flush-records] [{plan}] Failed",
-                    exc_info=True,
-                )
+        total_records = await self._flush_records(
+            cutoff=cutoff,
+            max_projects_per_batch=max_projects_per_batch,
+            max_records_per_batch=max_records_per_batch,
+        )
 
         log.info("[flush-records] ============================================")
         log.info("[flush-records] FLUSH JOB COMPLETED")
-        log.info(f"[flush-records] Total plans  covered: {total_plans}")
-        log.info(f"[flush-records] Total plans  skipped: {total_skipped}")
         log.info(f"[flush-records] Total records deleted: {total_records}")
         log.info("[flush-records] ============================================")
 
-    async def _flush_records_for_plan(
+    async def _flush_records(
         self,
         *,
-        plan: str,
         cutoff: datetime,
         max_projects_per_batch: int,
         max_records_per_batch: int,
@@ -100,8 +61,7 @@ class RecordsRetentionService:
         total_records = 0
 
         while True:
-            project_ids = await self.records_dao.fetch_projects_with_plan(
-                plan=plan,
+            project_ids = await self.records_dao.fetch_projects(
                 project_id=last_project_id,
                 max_projects=max_projects_per_batch,
             )

--- a/api/ee/src/dbs/postgres/sessions/records/dao.py
+++ b/api/ee/src/dbs/postgres/sessions/records/dao.py
@@ -1,12 +1,4 @@
-"""EE records DAO (retention).
-
-Walks ``projects ⋈ subscriptions`` to find projects on a given plan, then
-deletes record rows older than the retention cutoff. Lives in EE because
-the project-to-plan join goes through the EE ``SubscriptionDBE`` table.
-
-The OSS counterpart (``oss.src.dbs.postgres.sessions.records.dao.RecordsDAO``)
-owns append/query and never imports EE types.
-"""
+"""EE session-record retention DAO."""
 
 from datetime import datetime
 from typing import List, Optional
@@ -28,9 +20,6 @@ from oss.src.dbs.postgres.shared.engine import (
 )
 from oss.src.dbs.postgres.sessions.records.dbes import RecordDBE
 
-from ee.src.dbs.postgres.subscriptions.dbes import SubscriptionDBE
-
-
 log = get_module_logger(__name__)
 
 
@@ -49,25 +38,15 @@ class RecordsRetentionDAO:
         self.transactions_engine = transactions_engine
         self.analytics_engine = analytics_engine
 
-    async def fetch_projects_with_plan(
+    async def fetch_projects(
         self,
         *,
-        plan: str,
         project_id: UUID | None,
         max_projects: int,
     ) -> List[UUID]:
-        """Page through projects whose org subscribes to the given plan."""
+        """Page through projects independently of tracing-plan retention."""
         async with self.transactions_engine.session() as session:
-            stmt = (
-                select(ProjectDB.id)
-                .select_from(
-                    ProjectDB.__table__.join(
-                        SubscriptionDBE.__table__,
-                        SubscriptionDBE.organization_id == ProjectDB.organization_id,
-                    )
-                )
-                .where(SubscriptionDBE.plan == plan)
-            )
+            stmt = select(ProjectDB.id)
 
             if project_id:
                 stmt = stmt.where(ProjectDB.id > project_id)
@@ -102,7 +81,7 @@ class RecordsRetentionDAO:
             expired = (
                 select(
                     RecordDBE.project_id.label("project_id"),
-                    RecordDBE.id.label("id"),
+                    RecordDBE.record_id.label("record_id"),
                 )
                 .where(
                     RecordDBE.project_id == any_(project_ids_param),
@@ -116,8 +95,8 @@ class RecordsRetentionDAO:
             deleted = (
                 delete(RecordDBE)
                 .where(
-                    tuple_(RecordDBE.project_id, RecordDBE.id).in_(
-                        select(expired.c.project_id, expired.c.id)
+                    tuple_(RecordDBE.project_id, RecordDBE.record_id).in_(
+                        select(expired.c.project_id, expired.c.record_id)
                     )
                 )
                 .returning(literal(1).label("deleted"))

--- a/api/entrypoints/worker_streams.py
+++ b/api/entrypoints/worker_streams.py
@@ -32,6 +32,7 @@ from oss.src.dbs.postgres.events.dao import EventsDAO
 from oss.src.dbs.postgres.secrets.dao import SecretsDAO
 from oss.src.dbs.postgres.sessions.interactions.dao import SessionInteractionsDAO
 from oss.src.dbs.postgres.sessions.records.dao import RecordsDAO
+from oss.src.dbs.postgres.sessions.streams.dao import SessionStreamsDAO
 from oss.src.dbs.postgres.tracing.dao import TracingDAO
 from oss.src.dbs.postgres.webhooks.dao import WebhooksDAO
 from oss.src.dbs.redis.sessions.watch import SessionsWatchPublisher
@@ -83,7 +84,10 @@ async def _build_spans_worker(redis_client: Redis) -> StreamConsumer:
 async def _build_records_worker(redis_client: Redis) -> StreamConsumer:
     watch_publisher = SessionsWatchPublisher(redis_client=redis_client)
     return RecordsWorker(
-        service=RecordsService(records_dao=RecordsDAO()),
+        service=RecordsService(
+            records_dao=RecordsDAO(),
+            streams_dao=SessionStreamsDAO(),
+        ),
         redis_client=redis_client,
         stream_name="streams:records",
         consumer_group="worker-records",

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000022_add_session_history_incomplete.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000022_add_session_history_incomplete.py
@@ -1,0 +1,28 @@
+"""add incomplete-history marker to session_streams
+
+Revision ID: oss000000022
+Revises: oss000000021
+Create Date: 2026-09-03 00:00:00.000000
+
+"""
+
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+revision: str = "oss000000022"
+down_revision: Union[str, None] = "oss000000021"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column(
+        "session_streams",
+        sa.Column("history_incomplete", sa.Boolean(), nullable=True),
+    )
+
+
+def downgrade() -> None:
+    op.drop_column("session_streams", "history_incomplete")

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000025_add_session_history_incomplete.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000025_add_session_history_incomplete.py
@@ -1,6 +1,6 @@
 """add incomplete-history marker to session_streams
 
-Revision ID: oss000000022
+Revision ID: oss000000025
 Revises: oss000000021
 Create Date: 2026-09-03 00:00:00.000000
 
@@ -11,7 +11,7 @@ from typing import Sequence, Union
 from alembic import op
 import sqlalchemy as sa
 
-revision: str = "oss000000022"
+revision: str = "oss000000025"
 down_revision: Union[str, None] = "oss000000021"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None

--- a/api/oss/databases/postgres/migrations/core_oss/versions/oss000000025_add_session_history_incomplete.py
+++ b/api/oss/databases/postgres/migrations/core_oss/versions/oss000000025_add_session_history_incomplete.py
@@ -4,6 +4,9 @@ Revision ID: oss000000025
 Revises: oss000000021
 Create Date: 2026-09-03 00:00:00.000000
 
+This branch is based on main, where ``down_revision`` is ``oss000000021``. When
+merged after the durable-cancel/watchdog stack, re-point it to ``oss000000024``.
+
 """
 
 from typing import Sequence, Union

--- a/api/oss/src/apis/fastapi/sessions/models.py
+++ b/api/oss/src/apis/fastapi/sessions/models.py
@@ -337,6 +337,8 @@ class SessionRecordIngestRequest(BaseModel):
     session_id: str
     # Optional stable id (uuid5) from the producer; absent when it has no stable key.
     record_id: Optional[UUID] = None
+    # Additive retry key. APIs predating immutable history ignore this field.
+    producer_id: Optional[UUID] = None
     record_index: Optional[int] = None
     timestamp: Optional[datetime] = None
     record_type: Optional[str] = None

--- a/api/oss/src/apis/fastapi/sessions/router.py
+++ b/api/oss/src/apis/fastapi/sessions/router.py
@@ -68,6 +68,7 @@ from oss.src.core.sessions.streams.types import (
 from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.core.sessions.records.service import RecordsService
 from oss.src.core.sessions.records.dtos import SessionRecordEvent
+from oss.src.core.sessions.records.types import RecordContentConflict
 from oss.src.core.sessions.records.streaming import publish_record
 from oss.src.core.sessions.interactions.dtos import (
     SessionInteractionCreate,
@@ -754,22 +755,29 @@ class RecordsRouter:
         ):
             raise FORBIDDEN_EXCEPTION
 
-        await publish_record(
-            organization_id=UUID(request.state.organization_id),
-            project_id=UUID(project_id),
-            record_event=SessionRecordEvent(
+        try:
+            await publish_record(
+                organization_id=UUID(request.state.organization_id),
                 project_id=UUID(project_id),
-                session_id=body.session_id,
-                record_id=body.record_id,
-                record_index=body.record_index,
-                timestamp=body.timestamp,
-                record_type=body.record_type,
-                record_source=body.record_source,
-                attributes=body.attributes,
-                turn_id=body.turn_id,
-                span_id=body.span_id,
-            ),
-        )
+                record_event=SessionRecordEvent(
+                    project_id=UUID(project_id),
+                    session_id=body.session_id,
+                    record_id=body.record_id,
+                    producer_id=body.producer_id,
+                    record_index=body.record_index,
+                    timestamp=body.timestamp,
+                    record_type=body.record_type,
+                    record_source=body.record_source,
+                    attributes=body.attributes,
+                    turn_id=body.turn_id,
+                    span_id=body.span_id,
+                ),
+            )
+        except RecordContentConflict as exc:
+            raise HTTPException(
+                status_code=status.HTTP_409_CONFLICT,
+                detail=exc.to_detail(),
+            ) from exc
         return {"ok": True}
 
 

--- a/api/oss/src/core/sessions/records/dtos.py
+++ b/api/oss/src/core/sessions/records/dtos.py
@@ -1,5 +1,5 @@
 from datetime import datetime
-from typing import Optional, Any, Dict
+from typing import Optional, Any, Dict, List
 from uuid import UUID
 
 from pydantic import BaseModel, Field
@@ -16,6 +16,9 @@ class SessionRecordEvent(BaseModel):
     session_id: str
 
     record_id: Optional[UUID] = None
+    # Retry-stable id for this emitted record. Older APIs ignore this additive field;
+    # immutable-history mode uses it when no legacy logical record_id is present.
+    producer_id: Optional[UUID] = None
     record_index: Optional[int] = None
     timestamp: Optional[datetime] = None
     record_type: Optional[str] = None
@@ -41,6 +44,11 @@ class SessionRecord(Lifecycle):
 
     turn_id: Optional[str] = None
     span_id: Optional[OTelSpanId] = None
+
+
+class SessionRecordsAppendResult(BaseModel):
+    records: List[SessionRecord] = Field(default_factory=list)
+    conflicting_record_ids: List[UUID] = Field(default_factory=list)
 
 
 class SessionMessagePreview(BaseModel):

--- a/api/oss/src/core/sessions/records/interfaces.py
+++ b/api/oss/src/core/sessions/records/interfaces.py
@@ -5,6 +5,7 @@ from oss.src.core.sessions.records.dtos import (
     SessionMessagePreview,
     SessionRecord,
     SessionRecordEvent,
+    SessionRecordsAppendResult,
 )
 
 
@@ -21,7 +22,7 @@ class RecordsDAOInterface:
         self,
         *,
         events: List[SessionRecordEvent],
-    ) -> List[SessionRecord]:
+    ) -> SessionRecordsAppendResult:
         raise NotImplementedError
 
     async def get_records(

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -5,9 +5,15 @@ from oss.src.core.sessions.records.dtos import (
     SessionMessagePreview,
     SessionRecord,
     SessionRecordEvent,
+    SessionRecordsAppendResult,
 )
 from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
+from oss.src.core.sessions.records.types import RecordContentConflict
 from oss.src.core.sessions.streams.interfaces import SessionStreamsDAOInterface
+from oss.src.utils.logging import get_module_logger
+
+
+log = get_module_logger(__name__)
 
 
 class RecordsService:
@@ -25,14 +31,61 @@ class RecordsService:
         event: SessionRecordEvent,
         session: Optional[Any] = None,
     ) -> Optional[SessionRecord]:
-        return await self.records_dao.append(event=event, session=session)
+        try:
+            return await self.records_dao.append(event=event, session=session)
+        except RecordContentConflict as exc:
+            self._log_conflicts(
+                events=[event],
+                record_ids=[detail.record_id for detail in exc.conflicts],
+                exc=exc,
+            )
+            raise
 
     async def append_many(
         self,
         *,
         events: List[SessionRecordEvent],
-    ) -> List[SessionRecord]:
-        return await self.records_dao.append_many(events=events)
+    ) -> SessionRecordsAppendResult:
+        result = await self.records_dao.append_many(events=events)
+        if result.conflicting_record_ids:
+            self._log_conflicts(
+                events=events,
+                record_ids=result.conflicting_record_ids,
+            )
+        return result
+
+    @staticmethod
+    def _log_conflicts(
+        *,
+        events: List[SessionRecordEvent],
+        record_ids: List[Optional[UUID]],
+        exc: Optional[RecordContentConflict] = None,
+    ) -> None:
+        event_by_id = {
+            event.record_id or event.producer_id: event
+            for event in events
+            if event.record_id or event.producer_id
+        }
+        details_by_id = {
+            detail.record_id: detail for detail in (exc.conflicts if exc else [])
+        }
+        for record_id in record_ids:
+            if record_id is None:
+                continue
+            event = event_by_id.get(record_id)
+            detail = details_by_id.get(record_id)
+            if event is None and detail is None:
+                continue
+            log.error(
+                "[RECORDS] Rejected stable-id retry with different content",
+                project_id=str(
+                    event.project_id if event is not None else detail.project_id
+                ),
+                session_id=(
+                    event.session_id if event is not None else detail.session_id
+                ),
+                record_id=str(record_id),
+            )
 
     async def mark_history_incomplete(
         self,

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -7,11 +7,17 @@ from oss.src.core.sessions.records.dtos import (
     SessionRecordEvent,
 )
 from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
+from oss.src.core.sessions.streams.interfaces import SessionStreamsDAOInterface
 
 
 class RecordsService:
-    def __init__(self, records_dao: RecordsDAOInterface):
+    def __init__(
+        self,
+        records_dao: RecordsDAOInterface,
+        streams_dao: Optional[SessionStreamsDAOInterface] = None,
+    ):
         self.records_dao = records_dao
+        self.streams_dao = streams_dao
 
     async def append(
         self,
@@ -27,6 +33,19 @@ class RecordsService:
         events: List[SessionRecordEvent],
     ) -> List[SessionRecord]:
         return await self.records_dao.append_many(events=events)
+
+    async def mark_history_incomplete(
+        self,
+        *,
+        project_id: UUID,
+        session_ids: List[str],
+    ) -> int:
+        if self.streams_dao is None:
+            return 0
+        return await self.streams_dao.mark_history_incomplete(
+            project_id=project_id,
+            session_ids=session_ids,
+        )
 
     async def get_records(
         self,

--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -47,6 +47,8 @@ class RecordsService:
         events: List[SessionRecordEvent],
     ) -> SessionRecordsAppendResult:
         result = await self.records_dao.append_many(events=events)
+        if isinstance(result, list):
+            result = SessionRecordsAppendResult(records=result)
         if result.conflicting_record_ids:
             self._log_conflicts(
                 events=events,

--- a/api/oss/src/core/sessions/records/types.py
+++ b/api/oss/src/core/sessions/records/types.py
@@ -1,0 +1,16 @@
+from dataclasses import dataclass
+from typing import List
+from uuid import UUID
+
+
+@dataclass(frozen=True)
+class RecordContentConflictDetails:
+    project_id: UUID
+    record_id: UUID
+    session_id: str
+
+
+class RecordContentConflict(Exception):
+    def __init__(self, conflicts: List[RecordContentConflictDetails]):
+        self.conflicts = conflicts
+        super().__init__("a stable record id was retried with different content")

--- a/api/oss/src/core/sessions/records/types.py
+++ b/api/oss/src/core/sessions/records/types.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List
+from typing import Any, Dict, List
 from uuid import UUID
 
 
@@ -10,7 +10,34 @@ class RecordContentConflictDetails:
     session_id: str
 
 
-class RecordContentConflict(Exception):
+class RecordError(Exception):
+    code: str
+    message: str
+    retryable: bool
+    next_step: str
+
+    def to_detail(self) -> Dict[str, Any]:
+        return {
+            "code": self.code,
+            "message": self.message,
+            "retryable": self.retryable,
+            "next_step": self.next_step,
+        }
+
+
+class RecordContentConflict(RecordError):
+    code = "record_conflict"
+    message = "A stable record ID already exists with different content."
+    retryable = False
+    next_step = "Use a new record ID or resend the original content unchanged."
+
     def __init__(self, conflicts: List[RecordContentConflictDetails]):
         self.conflicts = conflicts
-        super().__init__("a stable record id was retried with different content")
+        super().__init__(self.message)
+
+    def to_detail(self) -> Dict[str, Any]:
+        detail = super().to_detail()
+        detail["details"] = {
+            "record_ids": [str(conflict.record_id) for conflict in self.conflicts]
+        }
+        return detail

--- a/api/oss/src/core/sessions/streams/dtos.py
+++ b/api/oss/src/core/sessions/streams/dtos.py
@@ -47,6 +47,7 @@ class SessionStream(Identifier, Header, Lifecycle):
     references: Optional[List[SessionReference]] = None
     # Set = archived (hidden but restorable); distinct from `deleted_at` (killed, still listed).
     archived_at: Optional[datetime] = None
+    history_incomplete: Optional[bool] = None
     origin: Optional[SessionOrigin] = None
     trigger: Optional[SessionTrigger] = None
     delivery: Optional[SessionDelivery] = None

--- a/api/oss/src/core/sessions/streams/interfaces.py
+++ b/api/oss/src/core/sessions/streams/interfaces.py
@@ -116,6 +116,16 @@ class SessionStreamsDAOInterface(ABC):
         ...
 
     @abstractmethod
+    async def mark_history_incomplete(
+        self,
+        *,
+        project_id: UUID,
+        session_ids: List[str],
+    ) -> int:
+        """Permanently mark session histories that lost acknowledged records."""
+        ...
+
+    @abstractmethod
     async def delete_by_session_id(
         self,
         *,

--- a/api/oss/src/dbs/postgres/sessions/records/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dao.py
@@ -1,7 +1,7 @@
 from typing import Dict, List, Optional
 from uuid import UUID
 
-from sqlalchemy import func, select
+from sqlalchemy import and_, func, select
 from sqlalchemy.dialects.postgresql import insert
 from sqlalchemy.ext.asyncio import AsyncSession
 
@@ -12,12 +12,21 @@ from oss.src.core.sessions.records.dtos import (
     SessionRecordEvent,
 )
 from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
+from oss.src.core.sessions.records.types import (
+    RecordContentConflict,
+    RecordContentConflictDetails,
+)
 from oss.src.dbs.postgres.sessions.records.dbes import RecordDBE
 from oss.src.dbs.postgres.sessions.records.mappings import (
     map_record_event_to_dbe,
     map_record_dbe_to_dto,
 )
 from oss.src.dbs.postgres.shared.engine import AnalyticsEngine, get_analytics_engine
+from oss.src.utils.env import env
+from oss.src.utils.logging import get_module_logger
+
+
+log = get_module_logger(__name__)
 
 
 class RecordsDAO(RecordsDAOInterface):
@@ -46,11 +55,26 @@ class RecordsDAO(RecordsDAOInterface):
         event: SessionRecordEvent,
         session: AsyncSession,
     ) -> Optional[SessionRecord]:
-        stmt = RecordsDAO._upsert_stmt(values_list=[RecordsDAO._values(event=event)])
+        values = RecordsDAO._values(event=event)
+        immutable = env.sessions.history_writes
+        stmt = (
+            RecordsDAO._immutable_stmt(values_list=[values])
+            if immutable
+            else RecordsDAO._upsert_stmt(values_list=[values])
+        )
         result = await session.execute(stmt)
         await session.flush()
 
         row = result.scalars().first()
+        if row is None and immutable:
+            conflict = RecordsDAO._conflict_details(values)
+            log.error(
+                "[RECORDS] Rejected stable-id retry with different content",
+                project_id=str(conflict.project_id),
+                record_id=str(conflict.record_id),
+                session_id=conflict.session_id,
+            )
+            raise RecordContentConflict([conflict])
         if row is None:
             return None
         return map_record_dbe_to_dto(dbe=row)
@@ -65,16 +89,41 @@ class RecordsDAO(RecordsDAOInterface):
         if not events:
             return []
 
-        values_list = self._dedupe_values(
-            values_list=[self._values(event=event) for event in events]
+        immutable = env.sessions.history_writes
+        raw_values = [self._values(event=event) for event in events]
+        values_list = (
+            self._dedupe_immutable_values(values_list=raw_values)
+            if immutable
+            else self._dedupe_values(values_list=raw_values)
         )
 
         async with self.engine.session() as session:
-            stmt = self._upsert_stmt(values_list=values_list)
+            stmt = (
+                self._immutable_stmt(values_list=values_list)
+                if immutable
+                else self._upsert_stmt(values_list=values_list)
+            )
             result = await session.execute(stmt)
-            await session.commit()
+            rows = result.scalars().all()
 
-            return [map_record_dbe_to_dto(dbe=row) for row in result.scalars().all()]
+            if immutable and len(rows) != len(values_list):
+                returned_keys = {(row.project_id, row.record_id) for row in rows}
+                conflicts = [
+                    self._conflict_details(values)
+                    for values in values_list
+                    if (values["project_id"], values["record_id"]) not in returned_keys
+                ]
+                for conflict in conflicts:
+                    log.error(
+                        "[RECORDS] Rejected stable-id retry with different content",
+                        project_id=str(conflict.project_id),
+                        record_id=str(conflict.record_id),
+                        session_id=conflict.session_id,
+                    )
+                raise RecordContentConflict(conflicts)
+
+            await session.commit()
+            return [map_record_dbe_to_dto(dbe=row) for row in rows]
 
     @staticmethod
     def _values(*, event: SessionRecordEvent) -> dict:
@@ -95,6 +144,50 @@ class RecordsDAO(RecordsDAOInterface):
         "turn_id",
         "span_id",
     )
+
+    _IMMUTABLE_CONTENT_COLUMNS = (
+        "session_id",
+        "record_type",
+        "record_source",
+        "attributes",
+        "turn_id",
+        "span_id",
+    )
+
+    @staticmethod
+    def _conflict_details(values: dict) -> RecordContentConflictDetails:
+        return RecordContentConflictDetails(
+            project_id=values["project_id"],
+            record_id=values["record_id"],
+            session_id=values["session_id"],
+        )
+
+    @staticmethod
+    def _same_immutable_content(left: dict, right: dict) -> bool:
+        return all(
+            left.get(column) == right.get(column)
+            for column in RecordsDAO._IMMUTABLE_CONTENT_COLUMNS
+        )
+
+    @staticmethod
+    def _dedupe_immutable_values(*, values_list: List[dict]) -> List[dict]:
+        deduped: dict = {}
+        for values in values_list:
+            key = (values["project_id"], values["record_id"])
+            previous = deduped.get(key)
+            if previous is None:
+                deduped[key] = values
+                continue
+            if not RecordsDAO._same_immutable_content(previous, values):
+                conflict = RecordsDAO._conflict_details(values)
+                log.error(
+                    "[RECORDS] Rejected in-batch stable-id retry with different content",
+                    project_id=str(conflict.project_id),
+                    record_id=str(conflict.record_id),
+                    session_id=conflict.session_id,
+                )
+                raise RecordContentConflict([conflict])
+        return list(deduped.values())
 
     @staticmethod
     def _dedupe_values(*, values_list: List[dict]) -> List[dict]:
@@ -133,6 +226,23 @@ class RecordsDAO(RecordsDAOInterface):
                 "turn_id": stmt.excluded.turn_id,
                 "span_id": stmt.excluded.span_id,
             },
+        ).returning(RecordDBE)
+
+    @staticmethod
+    def _immutable_stmt(*, values_list: List[dict]):
+        stmt = insert(RecordDBE).values(values_list)
+        unchanged = and_(
+            *(
+                getattr(RecordDBE, column).is_not_distinct_from(
+                    getattr(stmt.excluded, column)
+                )
+                for column in RecordsDAO._IMMUTABLE_CONTENT_COLUMNS
+            )
+        )
+        return stmt.on_conflict_do_update(
+            index_elements=["project_id", "record_id"],
+            set_={"record_id": stmt.excluded.record_id},
+            where=unchanged,
         ).returning(RecordDBE)
 
     async def get_records(

--- a/api/oss/src/dbs/postgres/sessions/records/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/records/dao.py
@@ -10,6 +10,7 @@ from oss.src.core.sessions.records.dtos import (
     SessionMessagePreview,
     SessionRecord,
     SessionRecordEvent,
+    SessionRecordsAppendResult,
 )
 from oss.src.core.sessions.records.interfaces import RecordsDAOInterface
 from oss.src.core.sessions.records.types import (
@@ -23,10 +24,6 @@ from oss.src.dbs.postgres.sessions.records.mappings import (
 )
 from oss.src.dbs.postgres.shared.engine import AnalyticsEngine, get_analytics_engine
 from oss.src.utils.env import env
-from oss.src.utils.logging import get_module_logger
-
-
-log = get_module_logger(__name__)
 
 
 class RecordsDAO(RecordsDAOInterface):
@@ -55,8 +52,8 @@ class RecordsDAO(RecordsDAOInterface):
         event: SessionRecordEvent,
         session: AsyncSession,
     ) -> Optional[SessionRecord]:
-        values = RecordsDAO._values(event=event)
         immutable = env.sessions.history_writes
+        values = RecordsDAO._values(event=event, immutable=immutable)
         stmt = (
             RecordsDAO._immutable_stmt(values_list=[values])
             if immutable
@@ -68,12 +65,6 @@ class RecordsDAO(RecordsDAOInterface):
         row = result.scalars().first()
         if row is None and immutable:
             conflict = RecordsDAO._conflict_details(values)
-            log.error(
-                "[RECORDS] Rejected stable-id retry with different content",
-                project_id=str(conflict.project_id),
-                record_id=str(conflict.record_id),
-                session_id=conflict.session_id,
-            )
             raise RecordContentConflict([conflict])
         if row is None:
             return None
@@ -83,19 +74,23 @@ class RecordsDAO(RecordsDAOInterface):
         self,
         *,
         events: List[SessionRecordEvent],
-    ) -> List[SessionRecord]:
+    ) -> SessionRecordsAppendResult:
         """Upsert all events via one batched statement in one session, not one
         connection (or one round trip) per event."""
         if not events:
-            return []
+            return SessionRecordsAppendResult()
 
         immutable = env.sessions.history_writes
-        raw_values = [self._values(event=event) for event in events]
-        values_list = (
-            self._dedupe_immutable_values(values_list=raw_values)
-            if immutable
-            else self._dedupe_values(values_list=raw_values)
-        )
+        raw_values = [
+            self._values(event=event, immutable=immutable) for event in events
+        ]
+        conflicting_record_ids: List[UUID] = []
+        if immutable:
+            values_list, conflicting_record_ids = self._dedupe_immutable_values(
+                values_list=raw_values
+            )
+        else:
+            values_list = self._dedupe_values(values_list=raw_values)
 
         async with self.engine.session() as session:
             stmt = (
@@ -108,26 +103,26 @@ class RecordsDAO(RecordsDAOInterface):
 
             if immutable and len(rows) != len(values_list):
                 returned_keys = {(row.project_id, row.record_id) for row in rows}
-                conflicts = [
-                    self._conflict_details(values)
+                database_conflicts = [
+                    values["record_id"]
                     for values in values_list
                     if (values["project_id"], values["record_id"]) not in returned_keys
                 ]
-                for conflict in conflicts:
-                    log.error(
-                        "[RECORDS] Rejected stable-id retry with different content",
-                        project_id=str(conflict.project_id),
-                        record_id=str(conflict.record_id),
-                        session_id=conflict.session_id,
-                    )
-                raise RecordContentConflict(conflicts)
+                conflicting_record_ids.extend(database_conflicts)
 
             await session.commit()
-            return [map_record_dbe_to_dto(dbe=row) for row in rows]
+            return SessionRecordsAppendResult(
+                records=[map_record_dbe_to_dto(dbe=row) for row in rows],
+                conflicting_record_ids=list(dict.fromkeys(conflicting_record_ids)),
+            )
 
     @staticmethod
-    def _values(*, event: SessionRecordEvent) -> dict:
-        dbe = map_record_event_to_dbe(event=event)
+    def _values(*, event: SessionRecordEvent, immutable: Optional[bool] = None) -> dict:
+        immutable = env.sessions.history_writes if immutable is None else immutable
+        record_id = event.record_id or (event.producer_id if immutable else None)
+        dbe = map_record_event_to_dbe(
+            event=event.model_copy(update={"record_id": record_id})
+        )
         return {
             c.name: getattr(dbe, c.name)
             for c in RecordDBE.__table__.columns
@@ -170,8 +165,11 @@ class RecordsDAO(RecordsDAOInterface):
         )
 
     @staticmethod
-    def _dedupe_immutable_values(*, values_list: List[dict]) -> List[dict]:
+    def _dedupe_immutable_values(
+        *, values_list: List[dict]
+    ) -> tuple[List[dict], List[UUID]]:
         deduped: dict = {}
+        conflicting_record_ids: List[UUID] = []
         for values in values_list:
             key = (values["project_id"], values["record_id"])
             previous = deduped.get(key)
@@ -179,15 +177,8 @@ class RecordsDAO(RecordsDAOInterface):
                 deduped[key] = values
                 continue
             if not RecordsDAO._same_immutable_content(previous, values):
-                conflict = RecordsDAO._conflict_details(values)
-                log.error(
-                    "[RECORDS] Rejected in-batch stable-id retry with different content",
-                    project_id=str(conflict.project_id),
-                    record_id=str(conflict.record_id),
-                    session_id=conflict.session_id,
-                )
-                raise RecordContentConflict([conflict])
-        return list(deduped.values())
+                conflicting_record_ids.append(values["record_id"])
+        return list(deduped.values()), list(dict.fromkeys(conflicting_record_ids))
 
     @staticmethod
     def _dedupe_values(*, values_list: List[dict]) -> List[dict]:

--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -630,6 +630,29 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
             await session.refresh(dbe)
         return map_stream_dbe_to_dto(stream_dbe=dbe)
 
+    async def mark_history_incomplete(
+        self,
+        *,
+        project_id: UUID,
+        session_ids: List[str],
+    ) -> int:
+        if not session_ids:
+            return 0
+
+        async with self.engine.session() as session:
+            stmt = (
+                sa_update(SessionStreamDBE)
+                .where(
+                    SessionStreamDBE.project_id == project_id,
+                    SessionStreamDBE.session_id.in_(session_ids),
+                    SessionStreamDBE.history_incomplete.is_not(True),
+                )
+                .values(history_incomplete=True)
+            )
+            result = await session.execute(stmt)
+            await session.commit()
+        return int(result.rowcount)
+
     async def delete_by_session_id(
         self,
         *,

--- a/api/oss/src/dbs/postgres/sessions/streams/dbes.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dbes.py
@@ -1,4 +1,5 @@
 from sqlalchemy import (
+    Boolean,
     Column,
     ForeignKeyConstraint,
     Index,
@@ -62,6 +63,10 @@ class SessionStreamDBE(
     # Archive is distinct from kill: `deleted_at` (LifecycleDBA) marks a killed/ended session
     # (resumable, still listed); `archived_at` marks a deliberately-hidden one (restorable).
     archived_at = Column(TIMESTAMP(timezone=True), nullable=True)
+
+    # Null/false means no loss has been observed; true is permanent because an
+    # acknowledged record gap cannot be repaired from this table.
+    history_incomplete = Column(Boolean, nullable=True)
 
     __table_args__ = (
         ForeignKeyConstraint(

--- a/api/oss/src/dbs/postgres/sessions/streams/mappings.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/mappings.py
@@ -159,6 +159,7 @@ def map_stream_dbe_to_dto(
         turn_id=stream_dbe.turn_id,
         references=references_from_json(stream_dbe.references),
         archived_at=stream_dbe.archived_at,
+        history_incomplete=stream_dbe.history_incomplete,
         flags=SessionStreamFlags.model_validate(stream_dbe.flags)
         if stream_dbe.flags
         else SessionStreamFlags(),

--- a/api/oss/src/tasks/asyncio/sessions/records_worker.py
+++ b/api/oss/src/tasks/asyncio/sessions/records_worker.py
@@ -52,7 +52,7 @@ class RecordsWorker(StreamConsumer):
     3. Group by project_id
     4. Append record events to DB (session history is quota-exempt)
     5. Reconcile HITL gates orphaned by a finished turn
-    6. ACK + DEL messages — StreamConsumer
+    6. ACK + DEL only messages whose write committed or whose stable id was rejected
     """
 
     log_prefix = "[RECORDS]"
@@ -145,9 +145,9 @@ class RecordsWorker(StreamConsumer):
         self,
         batch: List[Tuple[bytes, Dict[bytes, bytes]]],
     ) -> Tuple[int, List[bytes]]:
-        """Process batch and append session history without tracing quota checks."""
+        """Process batch and acknowledge only durable or explicitly rejected records."""
         groups: Dict[UUID, Dict[str, Any]] = {}
-        processed_ids: List[bytes] = []
+        acknowledged_ids: List[bytes] = []
         batch_bytes = 0
 
         for msg_id, data in batch:
@@ -164,26 +164,26 @@ class RecordsWorker(StreamConsumer):
                     group = {
                         "organization_id": msg.organization_id,
                         "project_id": msg.project_id,
-                        "events": [],
+                        "entries": [],
                     }
                     groups[msg.project_id] = group
-                group["events"].append(msg)
-                processed_ids.append(msg_id)
+                group["entries"].append((msg_id, msg))
             except Exception:
                 log.error(
                     "[RECORDS] Failed to deserialize message",
                     msg_id=repr(msg_id),
                     exc_info=True,
                 )
-                processed_ids.append(msg_id)
+                acknowledged_ids.append(msg_id)
 
         batches = list(groups.values())
         total_appended = 0
 
         for project_batch in batches:
+            entries: List[Tuple[bytes, Any]] = project_batch["entries"]
             try:
                 result = await self.service.append_many(
-                    events=[msg.record_event for msg in project_batch["events"]],
+                    events=[msg.record_event for _, msg in entries],
                 )
                 total_appended += len(result.records)
             except RecordContentConflict as exc:
@@ -192,6 +192,24 @@ class RecordsWorker(StreamConsumer):
                     project_id=str(project_batch["project_id"]),
                     record_ids=[str(item.record_id) for item in exc.conflicts],
                 )
+                if len(entries) == 1:
+                    acknowledged_ids.append(entries[0][0])
+                else:
+                    for entry in entries:
+                        (
+                            appended,
+                            committed_ids,
+                            committed_events,
+                        ) = await self._append_one(
+                            project_id=project_batch["project_id"],
+                            entry=entry,
+                        )
+                        total_appended += appended
+                        acknowledged_ids.extend(committed_ids)
+                        await self._after_commit(
+                            project_id=project_batch["project_id"],
+                            events=committed_events,
+                        )
                 continue
             except Exception:
                 log.error(
@@ -199,49 +217,97 @@ class RecordsWorker(StreamConsumer):
                     project_id=str(project_batch["project_id"]),
                     exc_info=True,
                 )
-                session_ids = sorted(
-                    {msg.record_event.session_id for msg in project_batch["events"]}
-                )
-                try:
-                    await self.service.mark_history_incomplete(
-                        project_id=project_batch["project_id"],
-                        session_ids=session_ids,
-                    )
-                except Exception:
-                    log.error(
-                        "[RECORDS] Failed to mark dropped session history incomplete",
-                        project_id=str(project_batch["project_id"]),
-                        session_ids=session_ids,
-                        exc_info=True,
-                    )
+                if len(entries) > 1:
+                    for entry in entries:
+                        (
+                            appended,
+                            committed_ids,
+                            committed_events,
+                        ) = await self._append_one(
+                            project_id=project_batch["project_id"],
+                            entry=entry,
+                        )
+                        total_appended += appended
+                        acknowledged_ids.extend(committed_ids)
+                        await self._after_commit(
+                            project_id=project_batch["project_id"],
+                            events=committed_events,
+                        )
                 continue
 
-            # Strictly post-append, and BEFORE the relay tee: a client woken by the records
-            # notification below must already see the cancelled gate, not re-render it.
-            await self.reconcile_orphaned_gates(
+            acknowledged_ids.extend(msg_id for msg_id, _ in entries)
+            conflicts = set(result.conflicting_record_ids)
+            committed_events = [
+                msg
+                for _, msg in entries
+                if (msg.record_event.record_id or msg.record_event.producer_id)
+                not in conflicts
+            ]
+            await self._after_commit(
                 project_id=project_batch["project_id"],
-                events=project_batch["events"],
+                events=committed_events,
             )
 
-            # Relay tee (M3): strictly post-append so a notified client that
-            # revalidates always sees the new rows. One publish per distinct
-            # session in the project batch; failures never re-drive the append.
-            if self.watch_publisher is not None:
-                project_id = str(project_batch["project_id"])
-                session_ids = {
-                    msg.record_event.session_id for msg in project_batch["events"]
-                }
-                for session_id in sorted(session_ids):
-                    try:
-                        await self.watch_publisher.records_changed(
-                            project_id=project_id,
-                            session_id=session_id,
-                        )
-                    except Exception:
-                        log.warning(
-                            "[RECORDS] Watch publish failed",
-                            project_id=project_id,
-                            session_id=session_id,
-                        )
+        return total_appended, acknowledged_ids
 
-        return total_appended, processed_ids
+    async def _append_one(
+        self,
+        *,
+        project_id: UUID,
+        entry: Tuple[bytes, Any],
+    ) -> Tuple[int, List[bytes], List[Any]]:
+        msg_id, msg = entry
+        try:
+            result = await self.service.append_many(events=[msg.record_event])
+        except RecordContentConflict as exc:
+            log.error(
+                "[RECORDS] Rejected conflicting stable record ids",
+                project_id=str(project_id),
+                record_ids=[str(item.record_id) for item in exc.conflicts],
+            )
+            return 0, [msg_id], []
+        except Exception:
+            log.error(
+                "[RECORDS] Failed to append event",
+                project_id=str(project_id),
+                msg_id=repr(msg_id),
+                exc_info=True,
+            )
+            return 0, [], []
+
+        conflict_ids = set(result.conflicting_record_ids)
+        record_id = msg.record_event.record_id or msg.record_event.producer_id
+        committed_events = [] if record_id in conflict_ids else [msg]
+        return len(result.records), [msg_id], committed_events
+
+    async def _after_commit(
+        self,
+        *,
+        project_id: UUID,
+        events: List[Any],
+    ) -> None:
+        if not events:
+            return
+
+        # Strictly post-append, and BEFORE the relay tee: a client woken by the records
+        # notification below must already see the cancelled gate, not re-render it.
+        await self.reconcile_orphaned_gates(project_id=project_id, events=events)
+
+        # Relay tee (M3): strictly post-append so a notified client that
+        # revalidates always sees the new rows. One publish per distinct
+        # session in the project batch; failures never re-drive the append.
+        if self.watch_publisher is not None:
+            project_id_str = str(project_id)
+            session_ids = {msg.record_event.session_id for msg in events}
+            for session_id in sorted(session_ids):
+                try:
+                    await self.watch_publisher.records_changed(
+                        project_id=project_id_str,
+                        session_id=session_id,
+                    )
+                except Exception:
+                    log.warning(
+                        "[RECORDS] Watch publish failed",
+                        project_id=project_id_str,
+                        session_id=session_id,
+                    )

--- a/api/oss/src/tasks/asyncio/sessions/records_worker.py
+++ b/api/oss/src/tasks/asyncio/sessions/records_worker.py
@@ -7,16 +7,10 @@ from oss.src.core.sessions.interactions.service import SessionInteractionsServic
 from oss.src.core.sessions.records.service import RecordsService
 from oss.src.core.sessions.records.streaming import deserialize_record
 from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterface
-from oss.src.utils.common import is_ee
 from oss.src.utils.logging import get_module_logger
 from oss.src.tasks.asyncio.shared.consumer import StreamConsumer
 
 log = get_module_logger(__name__)
-
-if is_ee():
-    from ee.src.core.access.entitlements.service import check_entitlements, scope_from
-    from ee.src.core.access.entitlements.types import Counter
-
 
 # The runner's terminal per-turn record, and the marker it stamps on that record when the turn
 # stopped to wait for a human instead of finishing (services/runner/src/tracing/otel.ts: the
@@ -55,10 +49,9 @@ class RecordsWorker(StreamConsumer):
     1. Read batch from stream (XREADGROUP) — StreamConsumer
     2. Deserialize messages
     3. Group by project_id
-    4. EE: L2 quota check per org (Counter.RECORDS_INGESTED)
-    5. Append record events to DB
-    6. Reconcile HITL gates orphaned by a finished turn
-    7. ACK + DEL messages — StreamConsumer
+    4. Append record events to DB (session history is quota-exempt)
+    5. Reconcile HITL gates orphaned by a finished turn
+    6. ACK + DEL messages — StreamConsumer
     """
 
     log_prefix = "[RECORDS]"
@@ -151,7 +144,7 @@ class RecordsWorker(StreamConsumer):
         self,
         batch: List[Tuple[bytes, Dict[bytes, bytes]]],
     ) -> Tuple[int, List[bytes]]:
-        """Process batch — deserialize, group by org for EE quota, append to DB."""
+        """Process batch and append session history without tracing quota checks."""
         groups: Dict[UUID, Dict[str, Any]] = {}
         processed_ids: List[bytes] = []
         batch_bytes = 0
@@ -186,54 +179,7 @@ class RecordsWorker(StreamConsumer):
         batches = list(groups.values())
         total_appended = 0
 
-        org_allowed: Dict[UUID, bool] = {}
-        events_per_org: Dict[UUID, int] = {}
-
-        if is_ee():
-            for project_batch in batches:
-                org_id = project_batch["organization_id"]
-                if org_id is None:
-                    continue
-                events_per_org[org_id] = events_per_org.get(org_id, 0) + len(
-                    project_batch["events"]
-                )
-
-            for org_id, delta in events_per_org.items():
-                if delta <= 0:
-                    org_allowed[org_id] = True
-                    continue
-
-                try:
-                    quota_allowed, _, _ = await check_entitlements(  # type: ignore
-                        key=Counter.RECORDS_INGESTED,  # type: ignore
-                        delta=delta,
-                        scope=scope_from(organization_id=org_id),  # type: ignore
-                    )
-                except Exception:
-                    log.error(
-                        "[RECORDS] L2 quota check failed",
-                        organization_id=str(org_id),
-                        exc_info=True,
-                    )
-                    org_allowed[org_id] = False
-                    continue
-
-                if not quota_allowed:
-                    log.warning(
-                        "[RECORDS] Quota exceeded, dropping org batch",
-                        organization_id=str(org_id),
-                        delta=delta,
-                    )
-                    org_allowed[org_id] = False
-                    continue
-
-                org_allowed[org_id] = True
-
         for project_batch in batches:
-            org_id = project_batch["organization_id"]
-            if is_ee() and org_id and not org_allowed.get(org_id, True):
-                continue
-
             try:
                 results = await self.service.append_many(
                     events=[msg.record_event for msg in project_batch["events"]],
@@ -245,6 +191,21 @@ class RecordsWorker(StreamConsumer):
                     project_id=str(project_batch["project_id"]),
                     exc_info=True,
                 )
+                session_ids = sorted(
+                    {msg.record_event.session_id for msg in project_batch["events"]}
+                )
+                try:
+                    await self.service.mark_history_incomplete(
+                        project_id=project_batch["project_id"],
+                        session_ids=session_ids,
+                    )
+                except Exception:
+                    log.error(
+                        "[RECORDS] Failed to mark dropped session history incomplete",
+                        project_id=str(project_batch["project_id"]),
+                        session_ids=session_ids,
+                        exc_info=True,
+                    )
                 continue
 
             # Strictly post-append, and BEFORE the relay tee: a client woken by the records

--- a/api/oss/src/tasks/asyncio/sessions/records_worker.py
+++ b/api/oss/src/tasks/asyncio/sessions/records_worker.py
@@ -5,6 +5,7 @@ from redis.asyncio import Redis
 
 from oss.src.core.sessions.interactions.service import SessionInteractionsService
 from oss.src.core.sessions.records.service import RecordsService
+from oss.src.core.sessions.records.types import RecordContentConflict
 from oss.src.core.sessions.records.streaming import deserialize_record
 from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterface
 from oss.src.utils.logging import get_module_logger
@@ -181,10 +182,17 @@ class RecordsWorker(StreamConsumer):
 
         for project_batch in batches:
             try:
-                results = await self.service.append_many(
+                result = await self.service.append_many(
                     events=[msg.record_event for msg in project_batch["events"]],
                 )
-                total_appended += len(results)
+                total_appended += len(result.records)
+            except RecordContentConflict as exc:
+                log.error(
+                    "[RECORDS] Rejected conflicting stable record ids",
+                    project_id=str(project_batch["project_id"]),
+                    record_ids=[str(item.record_id) for item in exc.conflicts],
+                )
+                continue
             except Exception:
                 log.error(
                     "[RECORDS] Failed to append event batch",

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -1419,6 +1419,10 @@ class SessionsRedisConfig(BaseModel):
     history_retention_days: int | None = _parse_optional_positive_int_env(
         "AGENTA_SESSIONS_HISTORY_RETENTION_DAYS"
     )
+    history_writes: bool = _parse_bool_env(
+        "AGENTA_SESSIONS_HISTORY_WRITES",
+        default=False,
+    )
 
     alive_ttl_seconds: int = (
         _parse_optional_positive_int_env("AGENTA_SESSIONS_REDIS_ALIVE_TTL_SECONDS")

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -1406,12 +1406,19 @@ class RedisConfig(BaseModel):
 
 
 class SessionsRedisConfig(BaseModel):
-    """TTLs and caps for the session coordination-plane Redis keys.
+    """Session history and coordination-plane settings.
 
-    Defaults mirror the golden fixture (services/runner/tests/fixtures/sessions/
-    redis_contract.json) shared with the TypeScript runner. Do not change a default
+    Redis defaults mirror the golden fixture (services/runner/tests/fixtures/sessions/
+    redis_contract.json) shared with the TypeScript runner. Do not change a Redis default
     without updating that fixture and the TS side in lockstep.
     """
+
+    # None means keep session history indefinitely. This is deliberately independent of
+    # tracing-plan retention: records are conversation history even though their table
+    # currently lives in the tracing database.
+    history_retention_days: int | None = _parse_optional_positive_int_env(
+        "AGENTA_SESSIONS_HISTORY_RETENTION_DAYS"
+    )
 
     alive_ttl_seconds: int = (
         _parse_optional_positive_int_env("AGENTA_SESSIONS_REDIS_ALIVE_TTL_SECONDS")

--- a/api/oss/tests/pytest/unit/migrations/test_single_heads.py
+++ b/api/oss/tests/pytest/unit/migrations/test_single_heads.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+
+def test_oss_core_migrations_have_a_single_head():
+    api_root = Path(__file__).resolve().parents[5]
+    migrations = api_root / "oss/databases/postgres/migrations/core_oss"
+    config = Config(str(migrations / "alembic.ini"))
+    config.set_main_option("script_location", str(migrations))
+
+    heads = ScriptDirectory.from_config(config).get_heads()
+
+    assert len(heads) == 1, f"expected one OSS core migration head, found {heads}"

--- a/api/oss/tests/pytest/unit/sessions/test_orphaned_gate_reconciliation.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphaned_gate_reconciliation.py
@@ -27,7 +27,7 @@ from uuid import uuid4
 import pytest
 from orjson import dumps
 
-from oss.src.core.sessions.records.dtos import SessionRecord
+from oss.src.core.sessions.records.dtos import SessionRecord, SessionRecordsAppendResult
 from oss.src.core.sessions.records.service import RecordsService
 from oss.src.tasks.asyncio.sessions.records_worker import (
     RecordsWorker,
@@ -206,10 +206,12 @@ async def test_process_batch_reconciles_after_the_append():
 
     async def _append_many(*, events):
         journal.append("append")
-        return [
-            SessionRecord(record_id=uuid4(), session_id=SESSION, project_id=PROJECT)
-            for _ in events
-        ]
+        return SessionRecordsAppendResult(
+            records=[
+                SessionRecord(record_id=uuid4(), session_id=SESSION, project_id=PROJECT)
+                for _ in events
+            ]
+        )
 
     records_dao.append_many = AsyncMock(side_effect=_append_many)
 

--- a/api/oss/tests/pytest/unit/sessions/test_record_ingest_endpoint.py
+++ b/api/oss/tests/pytest/unit/sessions/test_record_ingest_endpoint.py
@@ -9,9 +9,14 @@ from unittest.mock import AsyncMock, patch
 
 import pytest
 from fastapi import FastAPI, Request
+from fastapi import HTTPException
 
 from oss.src.apis.fastapi.sessions.router import RecordsRouter
 from oss.src.apis.fastapi.sessions.models import SessionRecordIngestRequest
+from oss.src.core.sessions.records.types import (
+    RecordContentConflict,
+    RecordContentConflictDetails,
+)
 
 
 def _make_authed_request(app: FastAPI, project_id, user_id, organization_id) -> Request:
@@ -110,6 +115,7 @@ async def test_record_ingest_threads_turn_id_and_span_id():
     user_id = uuid4()
     organization_id = uuid4()
     session_id = uuid4()
+    producer_id = uuid4()
     # The runner posts a 16-hex OTel span id, NOT a UUID (regression: it was typed as UUID
     # and every ingest 422'd — see FINDING-record-ingest-422.md).
     span_id = uuid4().hex[:16]
@@ -119,6 +125,7 @@ async def test_record_ingest_threads_turn_id_and_span_id():
         record_index=0,
         record_source="agent",
         attributes={"type": "message"},
+        producer_id=producer_id,
         turn_id="turn-abc",
         span_id=span_id,
     )
@@ -143,6 +150,46 @@ async def test_record_ingest_threads_turn_id_and_span_id():
     event = mock_publish.await_args.kwargs["record_event"]
     assert event.turn_id == "turn-abc"
     assert event.span_id == span_id
+    assert event.producer_id == producer_id
+
+
+async def test_record_ingest_maps_record_conflict_to_409():
+    records_service = AsyncMock()
+    router = RecordsRouter(records_service=records_service)
+    project_id = uuid4()
+    record_id = uuid4()
+    request = _make_authed_request(FastAPI(), project_id, uuid4(), uuid4())
+    body = SessionRecordIngestRequest(
+        session_id="sess-conflict",
+        producer_id=record_id,
+    )
+    conflict = RecordContentConflict(
+        [
+            RecordContentConflictDetails(
+                project_id=project_id,
+                record_id=record_id,
+                session_id="sess-conflict",
+            )
+        ]
+    )
+
+    with (
+        patch(
+            "oss.src.apis.fastapi.sessions.router.check_action_access",
+            new_callable=AsyncMock,
+            return_value=True,
+        ),
+        patch(
+            "oss.src.apis.fastapi.sessions.router.publish_record",
+            new_callable=AsyncMock,
+            side_effect=conflict,
+        ),
+        pytest.raises(HTTPException) as exc_info,
+    ):
+        await router.ingest_record_event(request=request, body=body)
+
+    assert exc_info.value.status_code == 409
+    assert exc_info.value.detail == conflict.to_detail()
 
 
 async def test_record_ingest_defaults_turn_id_and_span_id_to_none():

--- a/api/oss/tests/pytest/unit/sessions/test_records_history_durability.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_history_durability.py
@@ -7,14 +7,19 @@ from orjson import dumps
 from sqlalchemy.dialects import postgresql
 
 from ee.src.core.sessions.records.service import RecordsRetentionService
+from oss.src.core.sessions.records.dtos import SessionRecord, SessionRecordsAppendResult
 from oss.src.core.sessions.records.service import RecordsService
+from oss.src.core.sessions.records.types import (
+    RecordContentConflict,
+    RecordContentConflictDetails,
+)
 from oss.src.dbs.postgres.sessions.streams import dao as streams_dao_module
 from oss.src.tasks.asyncio.sessions import records_worker as records_worker_module
 from oss.src.tasks.asyncio.sessions.records_worker import RecordsWorker
 from oss.src.utils.env import env
 
 
-def _payload(*, organization_id, project_id, session_id):
+def _payload(*, organization_id, project_id, session_id, record_id=None):
     return zlib.compress(
         dumps(
             {
@@ -23,6 +28,7 @@ def _payload(*, organization_id, project_id, session_id):
                 "record_event": {
                     "project_id": str(project_id),
                     "session_id": session_id,
+                    "record_id": str(record_id) if record_id else None,
                     "record_index": 0,
                 },
             }
@@ -50,7 +56,17 @@ async def test_records_worker_never_checks_tracing_quota(monkeypatch):
     )
     project_id = uuid4()
     records_dao = AsyncMock()
-    records_dao.append_many = AsyncMock(return_value=[object()])
+    records_dao.append_many = AsyncMock(
+        return_value=SessionRecordsAppendResult(
+            records=[
+                SessionRecord(
+                    record_id=uuid4(),
+                    session_id="sess-quota-exempt",
+                    project_id=project_id,
+                )
+            ]
+        )
+    )
 
     appended, processed = await _worker(records_dao=records_dao).process_batch(
         [
@@ -71,6 +87,101 @@ async def test_records_worker_never_checks_tracing_quota(monkeypatch):
     assert processed == [b"1-0"]
     entitlement_check.assert_not_awaited()
     records_dao.append_many.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_conflicting_duplicates_are_acked_without_marking_history_incomplete():
+    project_id = uuid4()
+    record_id = uuid4()
+    records_dao = AsyncMock()
+    records_dao.append_many = AsyncMock(
+        return_value=SessionRecordsAppendResult(
+            records=[
+                SessionRecord(
+                    record_id=uuid4(),
+                    session_id="sess-valid",
+                    project_id=project_id,
+                )
+            ],
+            conflicting_record_ids=[record_id],
+        )
+    )
+    streams_dao = AsyncMock()
+
+    appended, processed = await _worker(
+        records_dao=records_dao,
+        streams_dao=streams_dao,
+    ).process_batch(
+        [
+            (
+                b"1-0",
+                {
+                    b"data": _payload(
+                        organization_id=uuid4(),
+                        project_id=project_id,
+                        session_id="sess-conflict",
+                        record_id=record_id,
+                    )
+                },
+            ),
+            (
+                b"2-0",
+                {
+                    b"data": _payload(
+                        organization_id=uuid4(),
+                        project_id=project_id,
+                        session_id="sess-valid",
+                    )
+                },
+            ),
+        ]
+    )
+
+    assert appended == 1
+    assert processed == [b"1-0", b"2-0"]
+    streams_dao.mark_history_incomplete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_typed_conflict_never_enters_the_destructive_worker_path():
+    project_id = uuid4()
+    record_id = uuid4()
+    records_dao = AsyncMock()
+    records_dao.append_many = AsyncMock(
+        side_effect=RecordContentConflict(
+            [
+                RecordContentConflictDetails(
+                    project_id=project_id,
+                    record_id=record_id,
+                    session_id="sess-conflict",
+                )
+            ]
+        )
+    )
+    streams_dao = AsyncMock()
+
+    appended, processed = await _worker(
+        records_dao=records_dao,
+        streams_dao=streams_dao,
+    ).process_batch(
+        [
+            (
+                b"1-0",
+                {
+                    b"data": _payload(
+                        organization_id=uuid4(),
+                        project_id=project_id,
+                        session_id="sess-conflict",
+                        record_id=record_id,
+                    )
+                },
+            )
+        ]
+    )
+
+    assert appended == 0
+    assert processed == [b"1-0"]
+    streams_dao.mark_history_incomplete.assert_not_awaited()
 
 
 @pytest.mark.asyncio

--- a/api/oss/tests/pytest/unit/sessions/test_records_history_durability.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_history_durability.py
@@ -185,7 +185,7 @@ async def test_typed_conflict_never_enters_the_destructive_worker_path():
 
 
 @pytest.mark.asyncio
-async def test_dropped_append_marks_every_affected_history_incomplete():
+async def test_failed_append_acknowledges_nothing():
     project_id = uuid4()
     records_dao = AsyncMock()
     records_dao.append_many = AsyncMock(
@@ -223,11 +223,24 @@ async def test_dropped_append_marks_every_affected_history_incomplete():
     )
 
     assert appended == 0
-    assert processed == [b"1-0", b"2-0"]
-    streams_dao.mark_history_incomplete.assert_awaited_once_with(
+    assert processed == []
+    streams_dao.mark_history_incomplete.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_records_service_normalizes_list_returning_dao():
+    project_id = uuid4()
+    record = SessionRecord(
+        record_id=uuid4(),
+        session_id="sess-list-result",
         project_id=project_id,
-        session_ids=["sess-a", "sess-b"],
     )
+    records_dao = AsyncMock()
+    records_dao.append_many = AsyncMock(return_value=[record])
+
+    result = await RecordsService(records_dao=records_dao).append_many(events=[])
+
+    assert result == SessionRecordsAppendResult(records=[record])
 
 
 class _Result:

--- a/api/oss/tests/pytest/unit/sessions/test_records_history_durability.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_history_durability.py
@@ -1,0 +1,199 @@
+from unittest.mock import AsyncMock
+from uuid import uuid4
+import zlib
+
+import pytest
+from orjson import dumps
+from sqlalchemy.dialects import postgresql
+
+from ee.src.core.sessions.records.service import RecordsRetentionService
+from oss.src.core.sessions.records.service import RecordsService
+from oss.src.dbs.postgres.sessions.streams import dao as streams_dao_module
+from oss.src.tasks.asyncio.sessions import records_worker as records_worker_module
+from oss.src.tasks.asyncio.sessions.records_worker import RecordsWorker
+from oss.src.utils.env import env
+
+
+def _payload(*, organization_id, project_id, session_id):
+    return zlib.compress(
+        dumps(
+            {
+                "organization_id": str(organization_id),
+                "project_id": str(project_id),
+                "record_event": {
+                    "project_id": str(project_id),
+                    "session_id": session_id,
+                    "record_index": 0,
+                },
+            }
+        )
+    )
+
+
+def _worker(*, records_dao, streams_dao=None):
+    return RecordsWorker(
+        service=RecordsService(records_dao=records_dao, streams_dao=streams_dao),
+        redis_client=None,
+        stream_name="streams:records",
+        consumer_group="worker-records",
+    )
+
+
+@pytest.mark.asyncio
+async def test_records_worker_never_checks_tracing_quota(monkeypatch):
+    entitlement_check = AsyncMock(return_value=(False, None, None))
+    monkeypatch.setattr(
+        records_worker_module,
+        "check_entitlements",
+        entitlement_check,
+        raising=False,
+    )
+    project_id = uuid4()
+    records_dao = AsyncMock()
+    records_dao.append_many = AsyncMock(return_value=[object()])
+
+    appended, processed = await _worker(records_dao=records_dao).process_batch(
+        [
+            (
+                b"1-0",
+                {
+                    b"data": _payload(
+                        organization_id=uuid4(),
+                        project_id=project_id,
+                        session_id="sess-quota-exempt",
+                    )
+                },
+            )
+        ]
+    )
+
+    assert appended == 1
+    assert processed == [b"1-0"]
+    entitlement_check.assert_not_awaited()
+    records_dao.append_many.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_dropped_append_marks_every_affected_history_incomplete():
+    project_id = uuid4()
+    records_dao = AsyncMock()
+    records_dao.append_many = AsyncMock(
+        side_effect=RuntimeError("database unavailable")
+    )
+    streams_dao = AsyncMock()
+    streams_dao.mark_history_incomplete = AsyncMock(return_value=2)
+
+    appended, processed = await _worker(
+        records_dao=records_dao,
+        streams_dao=streams_dao,
+    ).process_batch(
+        [
+            (
+                b"1-0",
+                {
+                    b"data": _payload(
+                        organization_id=uuid4(),
+                        project_id=project_id,
+                        session_id="sess-a",
+                    )
+                },
+            ),
+            (
+                b"2-0",
+                {
+                    b"data": _payload(
+                        organization_id=uuid4(),
+                        project_id=project_id,
+                        session_id="sess-b",
+                    )
+                },
+            ),
+        ]
+    )
+
+    assert appended == 0
+    assert processed == [b"1-0", b"2-0"]
+    streams_dao.mark_history_incomplete.assert_awaited_once_with(
+        project_id=project_id,
+        session_ids=["sess-a", "sess-b"],
+    )
+
+
+class _Result:
+    rowcount = 2
+
+
+class _Session:
+    def __init__(self):
+        self.statement = None
+
+    async def execute(self, statement):
+        self.statement = statement
+        return _Result()
+
+    async def commit(self):
+        return None
+
+
+class _SessionContext:
+    def __init__(self, session):
+        self.session = session
+
+    async def __aenter__(self):
+        return self.session
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+
+@pytest.mark.asyncio
+async def test_incomplete_marker_is_a_monotonic_bulk_update(monkeypatch):
+    session = _Session()
+    engine = type("Engine", (), {"session": lambda self: _SessionContext(session)})()
+    monkeypatch.setattr(
+        streams_dao_module,
+        "get_transactions_engine",
+        lambda: engine,
+    )
+
+    marked = await streams_dao_module.SessionStreamsDAO().mark_history_incomplete(
+        project_id=uuid4(),
+        session_ids=["sess-a", "sess-b"],
+    )
+
+    sql = str(session.statement.compile(dialect=postgresql.dialect())).lower()
+    assert marked == 2
+    assert "update session_streams" in sql
+    assert "history_incomplete" in sql
+    assert "history_incomplete is not true" in sql
+
+
+@pytest.mark.asyncio
+async def test_records_retention_defaults_to_keep(monkeypatch):
+    monkeypatch.setattr(env.sessions, "history_retention_days", None)
+    dao = AsyncMock()
+
+    await RecordsRetentionService(records_retention_dao=dao).flush_records()
+
+    dao.fetch_projects.assert_not_awaited()
+    dao.delete_records_before_cutoff.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_records_retention_uses_only_session_setting(monkeypatch):
+    monkeypatch.setattr(env.sessions, "history_retention_days", 7)
+    project_id = uuid4()
+    dao = AsyncMock()
+    dao.fetch_projects = AsyncMock(side_effect=[[project_id], []])
+    dao.delete_records_before_cutoff = AsyncMock(return_value=3)
+
+    await RecordsRetentionService(records_retention_dao=dao).flush_records(
+        max_projects_per_batch=10,
+        max_records_per_batch=20,
+    )
+
+    assert dao.fetch_projects.await_count == 2
+    dao.delete_records_before_cutoff.assert_awaited_once()
+    call = dao.delete_records_before_cutoff.await_args.kwargs
+    assert call["project_ids"] == [project_id]
+    assert call["max_records"] == 20

--- a/api/oss/tests/pytest/unit/sessions/test_records_history_writes.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_history_writes.py
@@ -1,4 +1,5 @@
 import uuid
+import os
 from datetime import datetime, timedelta, timezone
 
 import pytest
@@ -66,12 +67,15 @@ def test_exact_in_batch_retry_keeps_the_first_checkpoint():
         "timestamp": now + timedelta(seconds=1),
     }
 
-    deduped = RecordsDAO._dedupe_immutable_values(values_list=[first, second])
+    deduped, conflicts = RecordsDAO._dedupe_immutable_values(
+        values_list=[first, second]
+    )
 
     assert deduped == [first]
+    assert conflicts == []
 
 
-def test_conflicting_in_batch_retry_is_rejected():
+def test_conflicting_in_batch_retry_is_reported_without_dropping_the_first():
     record_id = uuid.uuid4()
     first = RecordsDAO._values(
         event=_event(
@@ -82,14 +86,64 @@ def test_conflicting_in_batch_retry_is_rejected():
     )
     second = {**first, "attributes": {"type": "message", "text": "different"}}
 
-    with pytest.raises(RecordContentConflict) as exc_info:
-        RecordsDAO._dedupe_immutable_values(values_list=[first, second])
+    deduped, conflicts = RecordsDAO._dedupe_immutable_values(
+        values_list=[first, second]
+    )
 
-    assert exc_info.value.conflicts[0].record_id == record_id
+    assert deduped == [first]
+    assert conflicts == [record_id]
+
+
+def test_producer_id_only_replaces_the_legacy_uuid_when_history_writes_are_on(
+    monkeypatch,
+):
+    producer_id = uuid.uuid4()
+    event = _event(
+        record_id=None,
+        timestamp=datetime.now(timezone.utc),
+        attributes={"type": "message", "text": "stable"},
+    ).model_copy(update={"producer_id": producer_id})
+
+    monkeypatch.setattr(env.sessions, "history_writes", False)
+    legacy = RecordsDAO._values(event=event)
+    monkeypatch.setattr(env.sessions, "history_writes", True)
+    immutable = RecordsDAO._values(event=event)
+
+    assert legacy["record_id"] != producer_id
+    assert immutable["record_id"] == producer_id
+
+
+def test_record_content_conflict_is_agent_actionable():
+    record_id = uuid.uuid4()
+    conflict = RecordContentConflict(
+        [
+            RecordsDAO._conflict_details(
+                RecordsDAO._values(
+                    event=_event(
+                        record_id=record_id,
+                        timestamp=datetime.now(timezone.utc),
+                        attributes={"type": "message", "text": "changed"},
+                    )
+                )
+            )
+        ]
+    )
+
+    assert conflict.to_detail() == {
+        "code": "record_conflict",
+        "message": "A stable record ID already exists with different content.",
+        "retryable": False,
+        "next_step": "Use a new record ID or resend the original content unchanged.",
+        "details": {"record_ids": [str(record_id)]},
+    }
 
 
 @pytest.mark.asyncio
 @pytest.mark.integration
+@pytest.mark.skipif(
+    not os.getenv("POSTGRES_URI_CORE"),
+    reason="POSTGRES_URI_CORE is required for the live record-conflict test",
+)
 async def test_database_accepts_exact_retry_and_rejects_changed_content(monkeypatch):
     monkeypatch.setattr(env.sessions, "history_writes", True)
     project_id = uuid.uuid4()
@@ -118,7 +172,16 @@ async def test_database_accepts_exact_retry_and_rejects_changed_content(monkeypa
     retried = await dao.append(event=exact_retry)
     with pytest.raises(RecordContentConflict):
         await dao.append(event=conflict)
+    valid = first.model_copy(
+        update={
+            "record_id": uuid.uuid4(),
+            "record_index": 2,
+            "attributes": {"type": "message", "text": "valid batch peer"},
+        }
+    )
+    batch_result = await dao.append_many(events=[conflict, valid])
     stored = await dao.get_event(project_id=project_id, record_id=record_id)
+    stored_valid = await dao.get_event(project_id=project_id, record_id=valid.record_id)
 
     assert created is not None
     assert retried is not None
@@ -126,3 +189,7 @@ async def test_database_accepts_exact_retry_and_rejects_changed_content(monkeypa
     assert retried.timestamp == timestamp
     assert stored is not None
     assert stored.attributes == {"type": "message", "text": "stable"}
+    assert batch_result.conflicting_record_ids == [record_id]
+    assert [record.record_id for record in batch_result.records] == [valid.record_id]
+    assert stored_valid is not None
+    assert stored_valid.attributes == {"type": "message", "text": "valid batch peer"}

--- a/api/oss/tests/pytest/unit/sessions/test_records_history_writes.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_history_writes.py
@@ -1,0 +1,128 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+import oss.src.dbs.postgres.shared.engine as engine_module
+from oss.src.core.sessions.records.dtos import SessionRecordEvent
+from oss.src.core.sessions.records.types import RecordContentConflict
+from oss.src.dbs.postgres.sessions.records.dao import RecordsDAO
+from oss.src.dbs.postgres.shared.engine import get_analytics_engine
+from oss.src.utils.env import env
+
+
+def _event(*, record_id, timestamp, attributes):
+    return SessionRecordEvent(
+        project_id=uuid.uuid4(),
+        session_id="sess-history",
+        record_id=record_id,
+        record_index=0,
+        timestamp=timestamp,
+        record_type="message",
+        record_source="agent",
+        attributes=attributes,
+        turn_id="turn-1",
+    )
+
+
+@pytest.fixture(autouse=True)
+async def _fresh_engine_per_test():
+    engine_module._analytics_engine = None
+    yield
+    if engine_module._analytics_engine is not None:
+        await engine_module._analytics_engine.close()
+        engine_module._analytics_engine = None
+
+
+def test_history_writes_default_to_the_legacy_upsert_path(monkeypatch):
+    monkeypatch.setattr(env.sessions, "history_writes", False)
+    first = RecordsDAO._values(
+        event=_event(
+            record_id=uuid.uuid4(),
+            timestamp=datetime.now(timezone.utc),
+            attributes={"type": "message", "text": "first"},
+        )
+    )
+    second = {**first, "attributes": {"type": "message", "text": "second"}}
+
+    deduped = RecordsDAO._dedupe_values(values_list=[first, second])
+
+    assert deduped[0]["attributes"]["text"] == "second"
+
+
+def test_exact_in_batch_retry_keeps_the_first_checkpoint():
+    record_id = uuid.uuid4()
+    now = datetime.now(timezone.utc)
+    first = RecordsDAO._values(
+        event=_event(
+            record_id=record_id,
+            timestamp=now,
+            attributes={"type": "message", "text": "same"},
+        )
+    )
+    second = {
+        **first,
+        "record_index": 99,
+        "timestamp": now + timedelta(seconds=1),
+    }
+
+    deduped = RecordsDAO._dedupe_immutable_values(values_list=[first, second])
+
+    assert deduped == [first]
+
+
+def test_conflicting_in_batch_retry_is_rejected():
+    record_id = uuid.uuid4()
+    first = RecordsDAO._values(
+        event=_event(
+            record_id=record_id,
+            timestamp=datetime.now(timezone.utc),
+            attributes={"type": "message", "text": "first"},
+        )
+    )
+    second = {**first, "attributes": {"type": "message", "text": "different"}}
+
+    with pytest.raises(RecordContentConflict) as exc_info:
+        RecordsDAO._dedupe_immutable_values(values_list=[first, second])
+
+    assert exc_info.value.conflicts[0].record_id == record_id
+
+
+@pytest.mark.asyncio
+@pytest.mark.integration
+async def test_database_accepts_exact_retry_and_rejects_changed_content(monkeypatch):
+    monkeypatch.setattr(env.sessions, "history_writes", True)
+    project_id = uuid.uuid4()
+    record_id = uuid.uuid4()
+    timestamp = datetime.now(timezone.utc)
+    first = SessionRecordEvent(
+        project_id=project_id,
+        session_id=f"history-write-{uuid.uuid4().hex[:8]}",
+        record_id=record_id,
+        record_index=0,
+        timestamp=timestamp,
+        record_type="message",
+        record_source="agent",
+        attributes={"type": "message", "text": "stable"},
+        turn_id="turn-1",
+    )
+    exact_retry = first.model_copy(
+        update={"record_index": 1, "timestamp": timestamp + timedelta(seconds=1)}
+    )
+    conflict = first.model_copy(
+        update={"attributes": {"type": "message", "text": "changed"}}
+    )
+    dao = RecordsDAO(engine=get_analytics_engine())
+
+    created = await dao.append(event=first)
+    retried = await dao.append(event=exact_retry)
+    with pytest.raises(RecordContentConflict):
+        await dao.append(event=conflict)
+    stored = await dao.get_event(project_id=project_id, record_id=record_id)
+
+    assert created is not None
+    assert retried is not None
+    assert retried.record_index == 0
+    assert retried.timestamp == timestamp
+    assert stored is not None
+    assert stored.attributes == {"type": "message", "text": "stable"}

--- a/api/oss/tests/pytest/unit/sessions/test_records_worker_batching.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_worker_batching.py
@@ -16,7 +16,11 @@ import zlib
 import pytest
 from orjson import dumps
 
-from oss.src.core.sessions.records.dtos import SessionRecordEvent, SessionRecord
+from oss.src.core.sessions.records.dtos import (
+    SessionRecord,
+    SessionRecordEvent,
+    SessionRecordsAppendResult,
+)
 from oss.src.core.sessions.records.service import RecordsService
 from oss.src.tasks.asyncio.sessions.records_worker import RecordsWorker
 
@@ -40,10 +44,14 @@ async def test_process_batch_appends_once_per_project_not_per_event():
 
     records_dao = AsyncMock()
     records_dao.append_many = AsyncMock(
-        return_value=[
-            SessionRecord(record_id=uuid4(), session_id="sess-1", project_id=project_id)
-            for _ in range(3)
-        ]
+        return_value=SessionRecordsAppendResult(
+            records=[
+                SessionRecord(
+                    record_id=uuid4(), session_id="sess-1", project_id=project_id
+                )
+                for _ in range(3)
+            ]
+        )
     )
     records_dao.append = AsyncMock()
 
@@ -85,7 +93,7 @@ async def test_process_batch_groups_by_project_one_append_many_per_project():
     project_b = uuid4()
 
     records_dao = AsyncMock()
-    records_dao.append_many = AsyncMock(return_value=[])
+    records_dao.append_many = AsyncMock(return_value=SessionRecordsAppendResult())
     records_dao.append = AsyncMock()
 
     service = RecordsService(records_dao=records_dao)

--- a/api/oss/tests/pytest/unit/sessions/test_watch_publish.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watch_publish.py
@@ -20,7 +20,7 @@ from oss.src.core.sessions.records.service import RecordsService
 from oss.src.core.sessions.streams.dtos import SessionStreamHeaderEdit
 from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.core.sessions.watch.interfaces import SessionsWatchPublisherInterface
-from oss.src.core.sessions.records.dtos import SessionRecord
+from oss.src.core.sessions.records.dtos import SessionRecord, SessionRecordsAppendResult
 from oss.src.core.workflows.dtos import Workflow, WorkflowEdit
 from oss.src.core.workflows.service import WorkflowsService
 from oss.src.dbs.redis.sessions.contract import project_watch_channel, watch_channel
@@ -82,12 +82,14 @@ async def test_worker_publishes_once_per_session_after_append():
 
     async def _append_many(*, events):
         journal.append(("append", len(events)))
-        return [
-            SessionRecord(
-                record_id=uuid4(), session_id=e.session_id, project_id=project_id
-            )
-            for e in events
-        ]
+        return SessionRecordsAppendResult(
+            records=[
+                SessionRecord(
+                    record_id=uuid4(), session_id=e.session_id, project_id=project_id
+                )
+                for e in events
+            ]
+        )
 
     records_dao.append_many = AsyncMock(side_effect=_append_many)
 
@@ -148,7 +150,13 @@ async def test_worker_survives_publisher_failure():
     project_id = uuid4()
 
     records_dao = AsyncMock()
-    records_dao.append_many = AsyncMock(return_value=[object()])
+    records_dao.append_many = AsyncMock(
+        return_value=SessionRecordsAppendResult(
+            records=[
+                SessionRecord(record_id=uuid4(), session_id="s", project_id=project_id)
+            ]
+        )
+    )
 
     worker = _worker(records_dao, _RecordingPublisher(fail=True))
 

--- a/api/oss/tests/pytest/unit/sessions/test_watch_publish.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watch_publish.py
@@ -138,11 +138,7 @@ async def test_worker_skips_publish_when_append_fails():
 
     assert total_appended == 0
     assert publisher.calls == []
-    # `process_batch` acknowledges at parse time, before the append, so a failed append is still
-    # acked and dropped by the shared consumer loop. That predates this change and is shared by
-    # every worker on `BaseStreamConsumer`; the relay tee neither causes it nor repairs it. This
-    # assertion pins the tee's scope, not an endorsement of the acknowledgement rule.
-    assert len(processed_ids) == 1
+    assert processed_ids == []
 
 
 @pytest.mark.asyncio

--- a/services/runner/src/sessions/persist.ts
+++ b/services/runner/src/sessions/persist.ts
@@ -24,10 +24,11 @@
  */
 
 import { apiBase } from "../apiBase.ts";
-import { envInt, envTimerMs } from "../env.ts";
+import { randomUUID } from "node:crypto";
+import { envInt } from "../env.ts";
 import type { AgentEvent } from "../protocol.ts";
 import type { Redactor } from "../redaction.ts";
-import { stableRecordId } from "./record-id.ts";
+import { stableRecordId, stableRecordIdForIndex } from "./record-id.ts";
 
 const INGEST_MAX_RETRIES = 3;
 const INGEST_RETRY_BASE_MS = 100;
@@ -87,10 +88,22 @@ async function postEvent(
   recordId?: string,
   turnId?: string,
   spanId?: string,
+  timestamp: string = new Date().toISOString(),
 ): Promise<void> {
   const url = `${apiBase()}/sessions/records/ingest`;
   const durable = durableRecordsEnabled();
   const maxRetries = durable ? durableMaxRetries() : INGEST_MAX_RETRIES;
+  const body = JSON.stringify({
+    session_id: sessionId,
+    ...(recordId ? { record_id: recordId } : {}),
+    record_index: eventIndex,
+    timestamp,
+    record_source: sender,
+    record_type: event.type,
+    attributes: event,
+    ...(turnId ? { turn_id: turnId } : {}),
+    ...(spanId ? { span_id: spanId } : {}),
+  });
   let lastErr: unknown;
   for (let attempt = 1; attempt <= maxRetries; attempt++) {
     try {
@@ -100,21 +113,7 @@ async function postEvent(
           "content-type": "application/json",
           authorization: auth(),
         },
-        body: JSON.stringify({
-          session_id: sessionId,
-          // Present only for tool-family records (stable uuid5); the backend mints a
-          // uuid4 when omitted. A re-sent id upserts the same row.
-          ...(recordId ? { record_id: recordId } : {}),
-          record_index: eventIndex,
-          timestamp: new Date().toISOString(),
-          record_source: sender,
-          record_type: event.type,
-          attributes: event,
-          // Tags the record for turn-grouping; span_id bridges to observability when
-          // the run has one in scope (both forward-fill only, absent is expected).
-          ...(turnId ? { turn_id: turnId } : {}),
-          ...(spanId ? { span_id: spanId } : {}),
-        }),
+        body,
       });
       // Prefixed so a runner-side 401 is distinguishable from a provider refusal; see
       // `RUNNER_INTERNAL_401` in engines/sandbox_agent/errors.ts.
@@ -160,6 +159,7 @@ export function persistEvent(
   redactor?: Redactor,
   turnId?: string,
   spanId?: string,
+  timestamp?: string,
 ): void {
   // Redact at the sink: the durable copy is scrubbed; the live/in-memory event the harness
   // and the client stream still hold is untouched.
@@ -174,6 +174,7 @@ export function persistEvent(
       recordId,
       turnId,
       spanId,
+      timestamp,
     ),
   );
   persistChains.set(sessionId, tail);
@@ -225,16 +226,6 @@ export function recordsIncomplete(sessionId: string): boolean {
 }
 
 /**
- * A tool call streams as many `tool_call` events with a growing partial-args snapshot for
- * one id. Idle window after which an open, un-closed tool call is flushed as-is — the
- * substitute for a close signal the harness may never send (a call that streams then
- * stalls without a `tool_result`).
- */
-const OPEN_TOOL_TTL_MS = envTimerMs("AGENTA_RECORD_TOOL_TTL_MS", 3_000, {
-  log,
-});
-
-/**
  * Build an emitter that persists every event via the ingest chain AND calls the
  * original emitter (for live streaming). Returns a stateful counter so record_index
  * increments per turn (the in-session ordering key; the DB tiebreaks with ingest time).
@@ -242,10 +233,9 @@ const OPEN_TOOL_TTL_MS = envTimerMs("AGENTA_RECORD_TOOL_TTL_MS", 3_000, {
  * Coalescing keeps one durable record per streamed family, while the live stream gets
  * every raw event unchanged:
  *  - message_start/delta/end and thought_* accumulate text, persisted once on *_end.
- *  - tool_call snapshots for one id accumulate (latest args win) into a single open slot,
- *    persisted once when a non-continuation event arrives, the TTL fires, or the turn
- *    drains. The record carries a turn-scoped stable uuid5 id so retries upsert within
- *    one execution without overwriting the same tool call from another execution.
+ *  - tool_call/tool_result snapshots accumulate by tool id (latest payload wins) until the
+ *    turn-end flush. That flush is the complete checkpoint: no partial tool state becomes
+ *    durable. Every record gets a producer-generated id before its first delivery attempt.
  */
 export function buildPersistingEmitter(
   sessionId: string,
@@ -262,35 +252,74 @@ export function buildPersistingEmitter(
   flush: () => Promise<void>;
 } {
   let eventIndex = 0;
+  const recordScope = turnId ?? randomUUID();
   // Coalescing state: accumulate delta families into a single durable event.
   const coalescedMessages = new Map<string, { id: string; text: string }>();
 
-  // At most one open tool call at a time: its index is claimed when the call first
-  // appears (so it sorts ahead of whatever flushes it), args are overwritten in place
-  // while snapshots for the same id keep arriving, and it is persisted exactly once.
-  let openTool: {
+  type PendingToolRecord = {
     id: string;
     index: number;
     event: AgentEvent;
-    timer: NodeJS.Timeout;
-  } | null = null;
+    timestamp: string;
+  };
+  const pendingTools = new Map<string, PendingToolRecord>();
 
-  const flushOpenTool = (): void => {
-    if (!openTool) return;
-    const { id, index, event, timer } = openTool;
-    clearTimeout(timer);
-    openTool = null;
+  const enqueue = (
+    event: AgentEvent,
+    index: number,
+    sender: string = "agent",
+    recordId: string = stableRecordIdForIndex(sessionId, index, recordScope),
+    timestamp: string = new Date().toISOString(),
+  ): void => {
     persistEvent(
       sessionId,
       auth,
       event,
       index,
-      "agent",
-      stableRecordId(sessionId, id, "tool_call", turnId),
+      sender,
+      recordId,
       redactor,
       turnId,
       spanId,
+      timestamp,
     );
+  };
+
+  const stageTool = (event: AgentEvent & { id?: string }): boolean => {
+    if (
+      !event.id ||
+      (event.type !== "tool_call" && event.type !== "tool_result")
+    ) {
+      return false;
+    }
+    const key = `${event.type}:${event.id}`;
+    const pending = pendingTools.get(key);
+    if (pending) {
+      pending.event = event;
+      return true;
+    }
+    pendingTools.set(key, {
+      id: stableRecordId(sessionId, event.id, event.type, recordScope),
+      index: eventIndex++,
+      event,
+      timestamp: new Date().toISOString(),
+    });
+    return true;
+  };
+
+  const flushPendingTools = (): void => {
+    for (const pending of [...pendingTools.values()].sort(
+      (a, b) => a.index - b.index,
+    )) {
+      enqueue(
+        pending.event,
+        pending.index,
+        "agent",
+        pending.id,
+        pending.timestamp,
+      );
+    }
+    pendingTools.clear();
   };
 
   const emit = (event: AgentEvent): void => {
@@ -300,28 +329,11 @@ export function buildPersistingEmitter(
     // Transient data describes the current live turn. It must not become transcript history.
     if (event.type === "data" && event.transient) return;
 
-    // Accumulate tool_call snapshots for one id; flush on any non-continuation below.
-    if (event.type === "tool_call" && event.id) {
-      if (openTool && openTool.id === event.id) {
-        // Continuation: latest args win, push the idle deadline out.
-        openTool.event = event;
-        clearTimeout(openTool.timer);
-        openTool.timer = setTimeout(flushOpenTool, OPEN_TOOL_TTL_MS);
-        return;
-      }
-      // A different call: flush the previous open slot, then open this one.
-      flushOpenTool();
-      openTool = {
-        id: event.id,
-        index: eventIndex++,
-        event,
-        timer: setTimeout(flushOpenTool, OPEN_TOOL_TTL_MS),
-      };
-      return;
-    }
-    // Any other event is a "different step": close the open tool call before it, so the
-    // tool_call record lands (with its earlier index) ahead of this event.
-    flushOpenTool();
+    if (stageTool(event)) return;
+
+    // A terminal event is an explicit complete checkpoint. Queue finalized tool state
+    // first so delivery order agrees with the record ordinals as well as read order.
+    if (event.type === "done") flushPendingTools();
 
     // Coalesce delta families: accumulate text; persist only on *_end.
     if (event.type === "message_start") {
@@ -340,16 +352,9 @@ export function buildPersistingEmitter(
       if (acc) {
         coalescedMessages.delete(event.id);
         // Persist the coalesced message in place of the end marker.
-        persistEvent(
-          sessionId,
-          auth,
+        enqueue(
           { type: "message", text: acc.text },
           eventIndex++,
-          "agent",
-          undefined,
-          redactor,
-          turnId,
-          spanId,
         );
         return;
       }
@@ -370,16 +375,9 @@ export function buildPersistingEmitter(
       const acc = coalescedMessages.get(`thought:${event.id}`);
       if (acc) {
         coalescedMessages.delete(`thought:${event.id}`);
-        persistEvent(
-          sessionId,
-          auth,
+        enqueue(
           { type: "thought", text: acc.text },
           eventIndex++,
-          "agent",
-          undefined,
-          redactor,
-          turnId,
-          spanId,
         );
         return;
       }
@@ -388,58 +386,29 @@ export function buildPersistingEmitter(
     // Related tool and interaction events share correlation ids but need distinct, retry-stable
     // rows, so the record type remains part of the stable id.
     if (
-      (event.type === "tool_result" ||
-        event.type === "interaction_request" ||
+      (event.type === "interaction_request" ||
         event.type === "interaction_response") &&
       event.id
     ) {
-      persistEvent(
-        sessionId,
-        auth,
+      enqueue(
         event,
         eventIndex++,
         "agent",
-        stableRecordId(sessionId, event.id, event.type, turnId),
-        redactor,
-        turnId,
-        spanId,
+        stableRecordId(sessionId, event.id, event.type, recordScope),
       );
       return;
     }
 
     // All other events persist as-is.
-    persistEvent(
-      sessionId,
-      auth,
-      event,
-      eventIndex++,
-      "agent",
-      undefined,
-      redactor,
-      turnId,
-      spanId,
-    );
+    enqueue(event, eventIndex++);
   };
 
   const persist = (event: AgentEvent, sender: string): void => {
-    // Out-of-band records (the inbound user turn) still respect open-tool ordering.
-    flushOpenTool();
-    persistEvent(
-      sessionId,
-      auth,
-      event,
-      eventIndex++,
-      sender,
-      undefined,
-      redactor,
-      turnId,
-      spanId,
-    );
+    enqueue(event, eventIndex++, sender);
   };
 
   const flush = async (): Promise<void> => {
-    // A paused call ends the turn with its slot still open — persist it before draining.
-    flushOpenTool();
+    flushPendingTools();
     await drainPersist(sessionId);
     // Consume the drop signal at the turn-end drain: records that exhausted retries mean the durable
     // log is incomplete, so next turn's reconstruction may be missing context. Reading here also

--- a/services/runner/src/sessions/persist.ts
+++ b/services/runner/src/sessions/persist.ts
@@ -89,6 +89,7 @@ async function postEvent(
   turnId?: string,
   spanId?: string,
   timestamp: string = new Date().toISOString(),
+  producerId?: string,
 ): Promise<void> {
   const url = `${apiBase()}/sessions/records/ingest`;
   const durable = durableRecordsEnabled();
@@ -96,6 +97,7 @@ async function postEvent(
   const body = JSON.stringify({
     session_id: sessionId,
     ...(recordId ? { record_id: recordId } : {}),
+    ...(producerId ? { producer_id: producerId } : {}),
     record_index: eventIndex,
     timestamp,
     record_source: sender,
@@ -160,6 +162,7 @@ export function persistEvent(
   turnId?: string,
   spanId?: string,
   timestamp?: string,
+  producerId?: string,
 ): void {
   // Redact at the sink: the durable copy is scrubbed; the live/in-memory event the harness
   // and the client stream still hold is untouched.
@@ -175,6 +178,7 @@ export function persistEvent(
       turnId,
       spanId,
       timestamp,
+      producerId,
     ),
   );
   persistChains.set(sessionId, tail);
@@ -233,9 +237,10 @@ export function recordsIncomplete(sessionId: string): boolean {
  * Coalescing keeps one durable record per streamed family, while the live stream gets
  * every raw event unchanged:
  *  - message_start/delta/end and thought_* accumulate text, persisted once on *_end.
- *  - tool_call/tool_result snapshots accumulate by tool id (latest payload wins) until the
- *    turn-end flush. That flush is the complete checkpoint: no partial tool state becomes
- *    durable. Every record gets a producer-generated id before its first delivery attempt.
+ *  - tool_call/tool_result snapshots keep one open slot per tool id. A type transition for that
+ *    id, the next non-tool event, or the turn-end flush is its complete checkpoint.
+ *  - Every emitted record keeps its legacy record_id behavior and adds a retry-stable producer_id.
+ *    An older API ignores the additive field; immutable-history mode can consume it.
  */
 export function buildPersistingEmitter(
   sessionId: string,
@@ -257,7 +262,6 @@ export function buildPersistingEmitter(
   const coalescedMessages = new Map<string, { id: string; text: string }>();
 
   type PendingToolRecord = {
-    id: string;
     index: number;
     event: AgentEvent;
     timestamp: string;
@@ -268,8 +272,13 @@ export function buildPersistingEmitter(
     event: AgentEvent,
     index: number,
     sender: string = "agent",
-    recordId: string = stableRecordIdForIndex(sessionId, index, recordScope),
+    recordId?: string,
     timestamp: string = new Date().toISOString(),
+    producerId: string = stableRecordIdForIndex(
+      sessionId,
+      index,
+      recordScope,
+    ),
   ): void => {
     persistEvent(
       sessionId,
@@ -282,6 +291,25 @@ export function buildPersistingEmitter(
       turnId,
       spanId,
       timestamp,
+      producerId,
+    );
+  };
+
+  const flushPendingTool = (toolId: string): void => {
+    const pending = pendingTools.get(toolId);
+    if (!pending) return;
+    pendingTools.delete(toolId);
+    enqueue(
+      pending.event,
+      pending.index,
+      "agent",
+      stableRecordId(
+        sessionId,
+        toolId,
+        pending.event.type,
+        recordScope,
+      ),
+      pending.timestamp,
     );
   };
 
@@ -292,14 +320,15 @@ export function buildPersistingEmitter(
     ) {
       return false;
     }
-    const key = `${event.type}:${event.id}`;
-    const pending = pendingTools.get(key);
+    const pending = pendingTools.get(event.id);
     if (pending) {
-      pending.event = event;
-      return true;
+      if (pending.event.type === event.type) {
+        pending.event = event;
+        return true;
+      }
+      flushPendingTool(event.id);
     }
-    pendingTools.set(key, {
-      id: stableRecordId(sessionId, event.id, event.type, recordScope),
+    pendingTools.set(event.id, {
       index: eventIndex++,
       event,
       timestamp: new Date().toISOString(),
@@ -308,18 +337,11 @@ export function buildPersistingEmitter(
   };
 
   const flushPendingTools = (): void => {
-    for (const pending of [...pendingTools.values()].sort(
-      (a, b) => a.index - b.index,
+    for (const [toolId] of [...pendingTools.entries()].sort(
+      ([, a], [, b]) => a.index - b.index,
     )) {
-      enqueue(
-        pending.event,
-        pending.index,
-        "agent",
-        pending.id,
-        pending.timestamp,
-      );
+      flushPendingTool(toolId);
     }
-    pendingTools.clear();
   };
 
   const emit = (event: AgentEvent): void => {
@@ -331,9 +353,8 @@ export function buildPersistingEmitter(
 
     if (stageTool(event)) return;
 
-    // A terminal event is an explicit complete checkpoint. Queue finalized tool state
-    // first so delivery order agrees with the record ordinals as well as read order.
-    if (event.type === "done") flushPendingTools();
+    // Advancing beyond tool traffic is a complete checkpoint for every open tool id.
+    flushPendingTools();
 
     // Coalesce delta families: accumulate text; persist only on *_end.
     if (event.type === "message_start") {
@@ -404,6 +425,7 @@ export function buildPersistingEmitter(
   };
 
   const persist = (event: AgentEvent, sender: string): void => {
+    flushPendingTools();
     enqueue(event, eventIndex++, sender);
   };
 

--- a/services/runner/src/sessions/record-id.ts
+++ b/services/runner/src/sessions/record-id.ts
@@ -49,3 +49,15 @@ export function stableRecordId(
     RECORD_NAMESPACE,
   );
 }
+
+/** Stable id for a record without its own logical correlation id. */
+export function stableRecordIdForIndex(
+  sessionId: string,
+  recordIndex: number,
+  recordScope: string,
+): string {
+  return uuid5(
+    `${sessionId}:${recordScope}:record-index:${recordIndex}`,
+    RECORD_NAMESPACE,
+  );
+}

--- a/services/runner/tests/unit/session-persist.test.ts
+++ b/services/runner/tests/unit/session-persist.test.ts
@@ -53,7 +53,8 @@ describe("buildPersistingEmitter", () => {
     assert.equal(body["record_type"], "message");
     assert.equal(body["record_index"], 0);
     assert.equal(body["record_source"], "agent");
-    assert.ok(typeof body["record_id"] === "string");
+    assert.equal("record_id" in body, false);
+    assert.ok(typeof body["producer_id"] === "string");
   });
 
   it("forwards transient status data without persisting it", async () => {
@@ -284,7 +285,7 @@ describe("buildPersistingEmitter", () => {
     assert.notEqual(bodies[0]["record_id"], bodies[1]["record_id"]);
   });
 
-  it("a different tool id flushes the previous open call", async () => {
+  it("keeps one open slot per tool id until a complete checkpoint", async () => {
     const { emit, flush } = buildPersistingEmitter(
       "sess-tc2",
       () => "Secret t",
@@ -302,16 +303,18 @@ describe("buildPersistingEmitter", () => {
       name: "read",
       input: { path: "/y" },
     });
+    assert.equal(postedBodies.length, 0);
+    emit({ type: "message", text: "both reads completed" });
     await flush();
 
     const bodies = postedBodies as Array<Record<string, unknown>>;
-    const inputs = bodies.map(
+    const inputs = bodies.slice(0, 2).map(
       (b) => (b["attributes"] as Record<string, unknown>)["input"],
     );
     assert.deepEqual(inputs, [{ path: "/x" }, { path: "/y" }]);
     assert.deepEqual(
       bodies.map((b) => b["record_index"]),
-      [0, 1],
+      [0, 1, 2],
     );
   });
 
@@ -335,6 +338,38 @@ describe("buildPersistingEmitter", () => {
     assert.equal(
       (bodies[0]["attributes"] as Record<string, unknown>)["type"],
       "tool_call",
+    );
+  });
+
+  it("checkpoints a completed tool call before the turn-end flush", async () => {
+    const { emit, flush } = buildPersistingEmitter(
+      "sess-mid-turn",
+      () => "Secret t",
+    );
+
+    emit({
+      type: "tool_call",
+      id: "call-complete",
+      name: "bash",
+      input: { command: "pwd" },
+    });
+    emit({ type: "tool_result", id: "call-complete", output: "/workspace" });
+    await drainPersist("sess-mid-turn");
+
+    assert.deepEqual(
+      (postedBodies as Array<Record<string, unknown>>).map(
+        (body) => (body["attributes"] as Record<string, unknown>)["type"],
+      ),
+      ["tool_call"],
+    );
+
+    emit({ type: "message", text: "The workspace is ready." });
+    await flush();
+    assert.deepEqual(
+      (postedBodies as Array<Record<string, unknown>>).map(
+        (body) => (body["attributes"] as Record<string, unknown>)["type"],
+      ),
+      ["tool_call", "tool_result", "message"],
     );
   });
 
@@ -517,9 +552,10 @@ describe("buildPersistingEmitter API contract", () => {
         assert.match(String(body.span_id), OTEL_SPAN_ID);
       for (const body of accepted)
         assert.match(
-          String(body.record_id),
+          String(body.producer_id),
           /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
         );
+      for (const body of accepted) assert.equal("record_id" in body, false);
     } finally {
       globalThis.fetch = prior;
     }
@@ -656,7 +692,7 @@ describe("durable records (AGENTA_RECORDS_DURABLE)", () => {
 
     assert.equal(attempts.length, 2);
     assert.equal(attempts[0], attempts[1]);
-    assert.ok(JSON.parse(attempts[0]).record_id);
+    assert.ok(JSON.parse(attempts[0]).producer_id);
   });
 });
 

--- a/services/runner/tests/unit/session-persist.test.ts
+++ b/services/runner/tests/unit/session-persist.test.ts
@@ -53,6 +53,7 @@ describe("buildPersistingEmitter", () => {
     assert.equal(body["record_type"], "message");
     assert.equal(body["record_index"], 0);
     assert.equal(body["record_source"], "agent");
+    assert.ok(typeof body["record_id"] === "string");
   });
 
   it("forwards transient status data without persisting it", async () => {
@@ -184,12 +185,11 @@ describe("buildPersistingEmitter", () => {
     await second.flush();
 
     const bodies = postedBodies as Array<Record<string, unknown>>;
-    assert.equal(bodies.length, 3);
-    assert.equal(bodies[0]["record_id"], bodies[1]["record_id"]);
-    assert.notEqual(bodies[0]["record_id"], bodies[2]["record_id"]);
+    assert.equal(bodies.length, 2);
+    assert.notEqual(bodies[0]["record_id"], bodies[1]["record_id"]);
     assert.deepEqual(
       bodies.map((body) => body["turn_id"]),
-      ["turn-a", "turn-a", "turn-b"],
+      ["turn-a", "turn-b"],
     );
   });
 
@@ -338,7 +338,7 @@ describe("buildPersistingEmitter", () => {
     );
   });
 
-  it("flushes an open tool_call when the idle TTL fires", async () => {
+  it("keeps an open tool_call temporary until the complete checkpoint", async () => {
     vi.useFakeTimers();
     try {
       const { emit, flush } = buildPersistingEmitter(
@@ -352,9 +352,11 @@ describe("buildPersistingEmitter", () => {
         name: "bash",
         input: { command: "x" },
       });
-      // Nothing follows; only the TTL can close it.
+      // Time alone is not a complete checkpoint, so partial arguments remain temporary.
       assert.equal(postedBodies.length, 0);
       await vi.advanceTimersByTimeAsync(3000);
+      assert.equal(postedBodies.length, 0);
+      await flush();
       assert.equal(postedBodies.length, 1);
       assert.equal(
         (
@@ -365,10 +367,31 @@ describe("buildPersistingEmitter", () => {
         )["type"],
         "tool_call",
       );
-      await flush();
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("keeps progressive tool results temporary until the complete checkpoint", async () => {
+    const { emit, flush } = buildPersistingEmitter(
+      "sess-tool-result",
+      () => "Secret t",
+      undefined,
+      undefined,
+      "turn-1",
+    );
+
+    emit({ type: "tool_result", id: "call-1", output: "" });
+    emit({ type: "tool_result", id: "call-1", output: "complete" });
+    assert.equal(postedBodies.length, 0);
+    await flush();
+
+    assert.equal(postedBodies.length, 1);
+    const body = postedBodies[0] as Record<string, unknown>;
+    assert.equal(
+      (body["attributes"] as Record<string, unknown>)["output"],
+      "complete",
+    );
   });
 });
 
@@ -492,6 +515,11 @@ describe("buildPersistingEmitter API contract", () => {
       assert.equal(accepted.length, 3);
       for (const body of accepted)
         assert.match(String(body.span_id), OTEL_SPAN_ID);
+      for (const body of accepted)
+        assert.match(
+          String(body.record_id),
+          /^[0-9a-f]{8}-[0-9a-f]{4}-5[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/,
+        );
     } finally {
       globalThis.fetch = prior;
     }
@@ -597,6 +625,38 @@ describe("durable records (AGENTA_RECORDS_DURABLE)", () => {
 
     assert.equal(postedBodies.length, 1); // landed
     assert.equal(takePersistFailures("sess-recover"), 0);
+  });
+
+  it("retries the exact same stable record body", async () => {
+    vi.stubEnv("AGENTA_RECORDS_DURABLE", "true");
+    vi.stubEnv("AGENTA_RECORDS_INGEST_MAX_RETRIES", "2");
+    const attempts: string[] = [];
+    const prior = globalThis.fetch;
+    globalThis.fetch = vi.fn(
+      async (_input: string | URL | Request, init?: RequestInit) => {
+        attempts.push(String(init?.body));
+        return attempts.length === 1
+          ? new Response("retry", { status: 500 })
+          : new Response(JSON.stringify({ ok: true }), { status: 200 });
+      },
+    );
+    try {
+      const { emit, flush } = buildPersistingEmitter(
+        "sess-stable-retry",
+        () => "Secret t",
+        undefined,
+        undefined,
+        "turn-1",
+      );
+      emit({ type: "message", text: "one durable fact" });
+      await flush();
+    } finally {
+      globalThis.fetch = prior;
+    }
+
+    assert.equal(attempts.length, 2);
+    assert.equal(attempts[0], attempts[1]);
+    assert.ok(JSON.parse(attempts[0]).record_id);
   });
 });
 


### PR DESCRIPTION
Session records are conversation history, but today they sit under the tracing quota and retention: the records worker drops an over-quota org's records and marks nothing, so history can vanish silently. This PR is increment 3 of the session-control design (docs/design/session-control-and-live-events on PR #6495): the durable-history producer work that needs no client change.

## What changes

- Session records are exempt from the tracing quota drop in OSS and EE, and from tracing retention. A new session-scoped retention setting lives in `env.py`. When a record is still lost, `session_streams.history_incomplete` is set (additive nullable column, migration `oss000000025`; it was 22, renumbered because PR #6503 uses 22 on the same parent; whichever PR lands second re-points `down_revision` to the new head).
- Behind `AGENTA_SESSIONS_HISTORY_WRITES` (default off): stable record ids that a retry reuses, one open slot per tool id so a completed tool call is durable before the turn ends, and per-record rejection of a retry that carries different content under the same id. The rejection is a typed core exception with code `record_conflict`, 409 at the router. Other records in the batch still commit.
- The runner sends a `producer_id` as an additive field that an older API ignores; with the flag off the API path is unchanged.

Not in this PR: the per-session sequence (open question O1 in the design), snapshot, replay.

## Tests

- `pytest oss/tests/pytest/unit/sessions -q` against Postgres: 539 passed.
- `pnpm test` in `services/runner`: 2,688 passed; `session-persist.test.ts`: 28 passed.
- Reviewed twice by an Opus agent (round 2 verdict: ship). One known leftover: the worker still acknowledges a batch whose transaction failed because `processed_ids` is filled at deserialization; pre-existing, tracked in the durable-history package.


## Known items for review

- The 409 mapping cannot be reached today because the ingest route only writes to Redis; the worker path raises the typed exception.
- With the retention setting unset, no session record is ever deleted. That is the intended default for now; say if you want a bound.
- The column is `history_incomplete`; the design contract names the snapshot field `history_complete`. One of the two should flip before the snapshot ships.

Agent-generated, low weight. Not merged.

https://claude.ai/code/session_01GAqSs7fw6QRi2n1ZJ2tmAV

