### PR TITLE
test(qa): add the session-control cells to the agent release gate

### DIFF
--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -225,6 +225,8 @@ fallback:
   `~/.agenta-qa-secrets.env`.
 - `QA_OPENAI_API_KEY` — stocked into that account's vault so the `pi_core` and `codex` harnesses
   have a provider key. Lives in `~/.agenta-qa-openai.env`.
+- `ANTHROPIC_API_KEY` — only required for `--harness claude`, stocked into the same vault the
+  same way. Lives in `~/.agenta-qa-secrets.env`. A pi_core- or codex-only run does not need it.
 
 A Daytona run additionally needs a Secrets-capable Daytona key on the runner; the key in most
 session env files returns 403 on the Secrets endpoint, so check that before trusting a Daytona

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -183,7 +183,7 @@ mechanism-blind cell from scratch, to avoid duplicating scaffolding.
 
 ## Session control cells
 
-`resources/session_control.py` is a second, standalone driver: thirteen cells that cover Stop,
+`resources/session_control.py` is a second, standalone driver: fourteen cells that cover Stop,
 durable commands, and the runner's recovery paths (owner release, park/resume, watchdog
 quarantine). It drives the same product endpoint and asserts on the same wire, but it needs its
 own account bootstrap, so it runs as a separate process rather than as `qa_product.py` cells. See
@@ -204,9 +204,9 @@ Run every cell with one line:
 uv run resources/session_control.py --cells all --harness pi_core --sandbox local
 ```
 
-Add `--project <docker-compose project name>` to also run the seven cells that need direct
+Add `--project <docker-compose project name>` to also run the eight cells that need direct
 Docker and Postgres access (`sandbox-gone`, `records-outage`, `restart-after-stop`,
-`post-stop-row`, `codex-child`, `stale-tail`, plus the abort-log check inside
+`runner-gone`, `post-stop-row`, `codex-child`, `stale-tail`, plus the abort-log check inside
 `stop-after-finish`). Without `--project` those cells SKIP with a named reason; the other six
 (`stop-warm`, `double-send`, `stale-stop`, `stop-approval`, `stop-after-finish`,
 `repeat-stop`, `stop-during-completion`) run over HTTP alone against any deployment. Add

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -204,11 +204,12 @@ Run every cell with one line:
 uv run resources/session_control.py --cells all --harness pi_core --sandbox local
 ```
 
-Add `--project <docker-compose project name>` to also run the nine cells that need direct
-Docker and Postgres access (`sandbox-gone`, `records-outage`, `restart-after-stop`,
-`runner-gone`, `runner-gone-late`, `post-stop-row`, `codex-child`, `stale-tail`, plus the
-abort-log check inside `stop-after-finish`). Without `--project` those cells SKIP with a named
-reason; the other eight
+Add `--project <docker-compose project name>` to run the eight cells that need direct Docker and
+Postgres access (`sandbox-gone`, `records-outage`, `restart-after-stop`, `runner-gone`,
+`runner-gone-late`, `post-stop-row`, `codex-child`, `stale-tail`) and the abort-log subcheck inside
+`stop-after-finish`. Without `--project`, those eight cells SKIP with a named reason. The
+`stop-after-finish` HTTP check still runs, but only its abort-log subcheck is unavailable. The
+other eight cells
 (`stop-warm`, `double-send`, `stale-stop`, `stop-approval`, `stop-after-finish`,
 `repeat-stop`, `concurrent-stops`, `stop-during-completion`) run over HTTP alone against any
 deployment. Add
@@ -217,7 +218,9 @@ recorded there is loaded instead of re-run.
 
 Results land in a timestamped folder under `~/agenta-qa-evidence/` (override with
 `AGENTA_QA_RUNS_DIR`), as `results.json` and `summary.md` — the same PASS/FAIL/SKIP shape as the
-rest of the gate.
+rest of the gate. When a release path makes session control mandatory, pass that artifact to the
+standing gate with `--session-control-results <path>`: a missing or incomplete artifact stops the
+gate before the matrix runs, and a recorded FAIL makes the final gate exit nonzero.
 
 **Environment, by name.** Same three-variable discipline as the rest of the gate, no env-file
 fallback:

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -183,7 +183,7 @@ mechanism-blind cell from scratch, to avoid duplicating scaffolding.
 
 ## Session control cells
 
-`resources/session_control.py` is a second, standalone driver: fourteen cells that cover Stop,
+`resources/session_control.py` is a second, standalone driver: fifteen cells that cover Stop,
 durable commands, and the runner's recovery paths (owner release, park/resume, watchdog
 quarantine). It drives the same product endpoint and asserts on the same wire, but it needs its
 own account bootstrap, so it runs as a separate process rather than as `qa_product.py` cells. See
@@ -207,9 +207,10 @@ uv run resources/session_control.py --cells all --harness pi_core --sandbox loca
 Add `--project <docker-compose project name>` to also run the eight cells that need direct
 Docker and Postgres access (`sandbox-gone`, `records-outage`, `restart-after-stop`,
 `runner-gone`, `post-stop-row`, `codex-child`, `stale-tail`, plus the abort-log check inside
-`stop-after-finish`). Without `--project` those cells SKIP with a named reason; the other six
+`stop-after-finish`). Without `--project` those cells SKIP with a named reason; the other eight
 (`stop-warm`, `double-send`, `stale-stop`, `stop-approval`, `stop-after-finish`,
-`repeat-stop`, `stop-during-completion`) run over HTTP alone against any deployment. Add
+`repeat-stop`, `concurrent-stops`, `stop-during-completion`) run over HTTP alone against any
+deployment. Add
 `--resume <path to a prior run's results.json>` to pick a lost run back up: any cell already
 recorded there is loaded instead of re-run.
 

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -183,7 +183,7 @@ mechanism-blind cell from scratch, to avoid duplicating scaffolding.
 
 ## Session control cells
 
-`resources/session_control.py` is a second, standalone driver: fifteen cells that cover Stop,
+`resources/session_control.py` is a second, standalone driver: sixteen cells that cover Stop,
 durable commands, and the runner's recovery paths (owner release, park/resume, watchdog
 quarantine). It drives the same product endpoint and asserts on the same wire, but it needs its
 own account bootstrap, so it runs as a separate process rather than as `qa_product.py` cells. See
@@ -204,10 +204,11 @@ Run every cell with one line:
 uv run resources/session_control.py --cells all --harness pi_core --sandbox local
 ```
 
-Add `--project <docker-compose project name>` to also run the eight cells that need direct
+Add `--project <docker-compose project name>` to also run the nine cells that need direct
 Docker and Postgres access (`sandbox-gone`, `records-outage`, `restart-after-stop`,
-`runner-gone`, `post-stop-row`, `codex-child`, `stale-tail`, plus the abort-log check inside
-`stop-after-finish`). Without `--project` those cells SKIP with a named reason; the other eight
+`runner-gone`, `runner-gone-late`, `post-stop-row`, `codex-child`, `stale-tail`, plus the
+abort-log check inside `stop-after-finish`). Without `--project` those cells SKIP with a named
+reason; the other eight
 (`stop-warm`, `double-send`, `stale-stop`, `stop-approval`, `stop-after-finish`,
 `repeat-stop`, `concurrent-stops`, `stop-during-completion`) run over HTTP alone against any
 deployment. Add

--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -181,6 +181,55 @@ cell, promoted after the platform-guidance fix closed that exact gap; it reuses 
 the same way the separate one-shot benchmark (Tier B) does — check there before writing a new
 mechanism-blind cell from scratch, to avoid duplicating scaffolding.
 
+## Session control cells
+
+`resources/session_control.py` is a second, standalone driver: thirteen cells that cover Stop,
+durable commands, and the runner's recovery paths (owner release, park/resume, watchdog
+quarantine). It drives the same product endpoint and asserts on the same wire, but it needs its
+own account bootstrap, so it runs as a separate process rather than as `qa_product.py` cells. See
+`resources/path_triggers.py` for the exact mandatory-cell mechanism.
+
+**These cells are MANDATORY** — run them, not just the standing gate — whenever the release diff
+touches any of:
+
+- `services/runner/src/sessions/**`
+- `services/runner/src/engines/sandbox_agent/**`
+- `api/oss/src/core/sessions/**`
+- `api/oss/src/tasks/asyncio/sessions/**`
+- `api/oss/src/apis/fastapi/sessions/**`
+
+Run every cell with one line:
+
+```bash
+uv run resources/session_control.py --cells all --harness pi_core --sandbox local
+```
+
+Add `--project <docker-compose project name>` to also run the seven cells that need direct
+Docker and Postgres access (`sandbox-gone`, `records-outage`, `restart-after-stop`,
+`post-stop-row`, `codex-child`, `stale-tail`, plus the abort-log check inside
+`stop-after-finish`). Without `--project` those cells SKIP with a named reason; the other six
+(`stop-warm`, `double-send`, `stale-stop`, `stop-approval`, `stop-after-finish`,
+`repeat-stop`, `stop-during-completion`) run over HTTP alone against any deployment. Add
+`--resume <path to a prior run's results.json>` to pick a lost run back up: any cell already
+recorded there is loaded instead of re-run.
+
+Results land in a timestamped folder under `~/agenta-qa-evidence/` (override with
+`AGENTA_QA_RUNS_DIR`), as `results.json` and `summary.md` — the same PASS/FAIL/SKIP shape as the
+rest of the gate.
+
+**Environment, by name.** Same three-variable discipline as the rest of the gate, no env-file
+fallback:
+
+- `AGENTA_BASE` — the deployment origin.
+- `AGENTA_ADMIN_KEY` — mints the ephemeral account this driver runs under. Lives in
+  `~/.agenta-qa-secrets.env`.
+- `QA_OPENAI_API_KEY` — stocked into that account's vault so the `pi_core` and `codex` harnesses
+  have a provider key. Lives in `~/.agenta-qa-openai.env`.
+
+A Daytona run additionally needs a Secrets-capable Daytona key on the runner; the key in most
+session env files returns 403 on the Secrets endpoint, so check that before trusting a Daytona
+result.
+
 ## When results lie
 
 The runtime **fails open**: a component can break, get logged, and the turn still succeeds with a

--- a/.agents/skills/agent-release-gate/resources/path_triggers.py
+++ b/.agents/skills/agent-release-gate/resources/path_triggers.py
@@ -33,6 +33,12 @@ import subprocess
 # the second kind as required, because a standalone cell is a separate process it cannot observe.
 GATEWAY_TOOLS = ("matrix_gw1_gateway_tools.py",)
 
+# The standing session-control regression cells: Stop, durable commands, and the runner's
+# recovery paths (owner release, park/resume, watchdog quarantine). A separate standalone driver
+# because it needs its own account bootstrap and, for most cells, a docker-compose project name —
+# see resources/session_control.py and SKILL.md "Session control cells".
+SESSION_CONTROL = ("session_control.py",)
+
 # The cells that run a REMOTE sandbox and need no extra flag. A release that touches the sandbox
 # engine or the Daytona provider changes how a cold sandbox gets built and how its credentials are
 # delivered, and the `burst` and `crosstalk` journeys are the only ones that see that path under
@@ -71,8 +77,18 @@ PATH_TRIGGERS: dict[str, tuple[str, ...]] = {
     # A fault here shows up only when many sandboxes start at once, which is what `burst` and
     # `crosstalk` do on these cells. Production hit it as one first message in five failing with
     # a credential error (AGE-4249 / #6485) while the sequential gate stayed green.
-    "services/runner/src/engines/sandbox_agent/**": DAYTONA_CELLS,
+    # A dict literal keeps only the last value for a repeated key, so a glob that already names
+    # DAYTONA_CELLS lists SESSION_CONTROL alongside it in the SAME tuple rather than as a second
+    # entry that would silently drop the Daytona rule.
+    "services/runner/src/engines/sandbox_agent/**": DAYTONA_CELLS + SESSION_CONTROL,
     "services/runner/src/providers/daytona*": DAYTONA_CELLS,
+    # Session control: Stop, durable commands, park/resume, and the owner-release and watchdog
+    # sweeps. A change here can silently break a warm resume or leave a command stuck, and
+    # nothing in the fixed matrix drives Stop at all. See qa-audit-2026-09-03.md section 4.
+    "services/runner/src/sessions/**": SESSION_CONTROL,
+    "api/oss/src/core/sessions/**": SESSION_CONTROL,
+    "api/oss/src/tasks/asyncio/sessions/**": SESSION_CONTROL,
+    "api/oss/src/apis/fastapi/sessions/**": SESSION_CONTROL,
 }
 
 # Glob -> journeys that MUST run when the rule fires. Same matching as PATH_TRIGGERS, kept as a

--- a/.agents/skills/agent-release-gate/resources/qa_product.py
+++ b/.agents/skills/agent-release-gate/resources/qa_product.py
@@ -3118,6 +3118,61 @@ JOURNEYS = {
 }
 
 
+def _load_session_control_result(path: str) -> dict:
+    """Load and summarize a complete standalone session-control result."""
+    result_path = pathlib.Path(path).expanduser()
+    try:
+        payload = json.loads(result_path.read_text())
+    except (OSError, json.JSONDecodeError) as exc:
+        raise SystemExit(
+            f"Cannot read --session-control-results {result_path}: {exc}"
+        ) from exc
+
+    cells = payload.get("cells")
+    if not isinstance(cells, dict):
+        raise SystemExit(
+            f"Invalid session-control result {result_path}: expected a top-level cells object."
+        )
+
+    # Import the standalone driver's registry instead of copying its cell names here. A newly
+    # added session-control cell must become release-mandatory without a second list to update.
+    from session_control import CELLS as session_control_cells
+
+    missing = sorted(set(session_control_cells) - set(cells))
+    if missing:
+        raise SystemExit(
+            f"Incomplete session-control result {result_path}: missing cells: "
+            + ", ".join(missing)
+        )
+
+    statuses: dict[str, str] = {}
+    for name in session_control_cells:
+        entry = cells.get(name)
+        verdict = entry.get("verdict") if isinstance(entry, dict) else None
+        if (
+            not isinstance(verdict, dict)
+            or not isinstance(verdict.get("pass"), bool)
+            or not isinstance(verdict.get("skip"), bool)
+            or (verdict["pass"] and verdict["skip"])
+        ):
+            raise SystemExit(
+                f"Invalid session-control result {result_path}: cell {name!r} has no valid "
+                "PASS/FAIL/SKIP verdict."
+            )
+        statuses[name] = (
+            "SKIP" if verdict["skip"] else ("PASS" if verdict["pass"] else "FAIL")
+        )
+
+    failed = sorted(name for name, status in statuses.items() if status == "FAIL")
+    skipped = sorted(name for name, status in statuses.items() if status == "SKIP")
+    return {
+        "path": str(result_path),
+        "status": "FAIL" if failed else "PASS",
+        "failed": failed,
+        "skipped": skipped,
+    }
+
+
 def main() -> int:
     # Declared here, not beside the assignments below, because the flag help strings read these
     # module defaults and a `global` statement must precede every use of the name in a function.
@@ -3271,6 +3326,13 @@ def main() -> int:
         "--repo",
         help="repository the release diff is read from (default: the current directory)",
     )
+    p.add_argument(
+        "--session-control-results",
+        help=(
+            "results.json written by resources/session_control.py. Required when a path rule "
+            "makes that standalone driver mandatory; all of its cells must be recorded."
+        ),
+    )
     args = p.parse_args()
 
     resolve_credentials(args.env_file)
@@ -3368,6 +3430,16 @@ def main() -> int:
     external_cells = [
         cell for cell in triggered if cell not in CELLS and cell not in missing_cells
     ]
+    session_control_result = None
+    if "session_control.py" in external_cells:
+        if not args.session_control_results:
+            raise SystemExit(
+                "This release makes session_control.py mandatory. Run it separately, then pass "
+                "its results.json with --session-control-results."
+            )
+        session_control_result = _load_session_control_result(
+            args.session_control_results
+        )
     for cell in triggered:
         if cell in CELLS and cell not in cells:
             cells.append(cell)
@@ -3380,7 +3452,11 @@ def main() -> int:
                 else (
                     "MISSING — no such cell exists"
                     if cell in missing_cells
-                    else "run it separately"
+                    else (
+                        f"recorded {session_control_result['status']}"
+                        if cell == "session_control.py" and session_control_result
+                        else "run it separately"
+                    )
                 )
             )
             print(f"  {cell} ({where})")
@@ -3479,9 +3555,19 @@ def main() -> int:
         table += "\n\nMandatory for this release, by path rule:\n\n"
         table += "| cell | run here | because this release changed |\n|---|---|---|\n"
         for cell, why in triggered.items():
-            here = "yes" if cell in CELLS else "no — run it separately"
+            if cell in CELLS:
+                here = "yes"
+            elif cell == "session_control.py" and session_control_result:
+                here = f"recorded {session_control_result['status']}"
+            else:
+                here = "no — run it separately"
             table += f"| {cell} | {here} | {', '.join(why)} |\n"
-        if external_cells:
+        unrecorded_external_cells = [
+            cell
+            for cell in external_cells
+            if not (cell == "session_control.py" and session_control_result)
+        ]
+        if unrecorded_external_cells:
             table += (
                 "\nThis release is NOT green until every cell above marked "
                 "`run it separately` has a recorded result.\n"
@@ -3506,7 +3592,10 @@ def main() -> int:
         for cell in results.values()
         for journey in cell["journeys"].values()
     )
-    return 1 if failed else 0
+    standalone_failed = bool(
+        session_control_result and session_control_result["status"] == "FAIL"
+    )
+    return 1 if failed or standalone_failed else 0
 
 
 if __name__ == "__main__":

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -1,0 +1,1625 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""Session-control regression cells for the agent release gate.
+
+Wire-level scenarios for Stop, durable commands, and the runner's recovery paths. Each cell
+drives the same product endpoint the playground drives (`/services/agent/v0/invoke`) and asserts
+on the SSE frame stream, the durable records, and the command rows. It never asserts on model
+prose.
+
+Ported from the durable-cancel slice's spike driver
+(`~/agenta-qa-evidence/2026-09-03-session-round2/integration-refresh/refresh_live.py`), with four
+changes made so this file can live in the repo and run as a standing check instead of a one-box
+artifact:
+
+1. Reads the SAME env contract as `qa_product.py` (`AGENTA_BASE`), plus `AGENTA_ADMIN_KEY` and
+   `QA_OPENAI_API_KEY`, which this driver needs to mint its own ephemeral account and stock the
+   vault. No env-file fallback: a fallback file is how a green run gets recorded against the
+   wrong deployment.
+2. The Docker- and Postgres-only helpers sit behind one `OperatorHooks` interface
+   (`DockerComposeHooks` / `NullHooks`). Six cells need no shell at all and run against any
+   deployment; the rest need `--project <docker-compose project>` and SKIP with a named reason
+   when it is absent.
+3. Emits the gate's result shape: PASS / FAIL / SKIP per cell with a one-line reason, plus
+   `results.json` and `summary.md` in a timestamped run folder under `~/agenta-qa-evidence/`
+   (override with `AGENTA_QA_RUNS_DIR`).
+4. `--cells` is resumable: pass `--resume <path to a results.json>` and any cell already
+   recorded there is loaded instead of re-run, so a lost agent costs one cell, not the whole run.
+
+    uv run resources/session_control.py --cells all --harness pi_core --sandbox local
+
+See `SKILL.md` for when these cells are mandatory and where the model keys live.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import pathlib
+import subprocess
+import sys
+import threading
+import time
+import uuid
+
+import httpx
+
+REQUIRED_ENV = ("AGENTA_BASE", "AGENTA_ADMIN_KEY", "QA_OPENAI_API_KEY")
+
+# Resolved by resolve_env() before anything runs. Left empty so --help works with no env set.
+BASE = ""
+ADMIN_KEY = ""
+OPENAI_KEY = ""
+
+RUNS = pathlib.Path(
+    os.environ.get(
+        "AGENTA_QA_RUNS_DIR", str(pathlib.Path.home() / "agenta-qa-evidence")
+    )
+).expanduser()
+
+STATE: dict = {}
+RECALL = "What was the codeword I gave you? Reply with just the codeword."
+
+
+def resolve_env() -> None:
+    """Populate BASE/ADMIN_KEY/OPENAI_KEY from the environment only.
+
+    No env-file fallback on purpose: qa-audit-2026-09-03.md section 4 names the file fallback as
+    the mechanism that recorded a green run against the wrong deployment. Every missing variable
+    is named so a Sonnet QA agent does not have to guess.
+    """
+    global BASE, ADMIN_KEY, OPENAI_KEY
+    missing = [name for name in REQUIRED_ENV if not os.environ.get(name)]
+    if missing:
+        raise SystemExit(
+            "Missing environment variables: " + ", ".join(missing) + ".\n"
+            "Set them, e.g.\n"
+            "  export AGENTA_BASE=https://your-stack.example.com\n"
+            "  export AGENTA_ADMIN_KEY=...      # ~/.agenta-qa-secrets.env\n"
+            "  export QA_OPENAI_API_KEY=...     # ~/.agenta-qa-openai.env\n"
+            "There is no env-file fallback: a fallback file is how a green run gets recorded "
+            "against the wrong deployment."
+        )
+    BASE = os.environ["AGENTA_BASE"]
+    ADMIN_KEY = os.environ["AGENTA_ADMIN_KEY"]
+    OPENAI_KEY = os.environ["QA_OPENAI_API_KEY"]
+
+
+# --------------------------------------------------------------------------- #
+# Operator hooks: the only place this file talks to Docker or Postgres.
+# --------------------------------------------------------------------------- #
+
+
+class HooksUnavailable(Exception):
+    """Raised by a NullHooks method. Caught at the cell boundary and turned into a SKIP."""
+
+
+class OperatorHooks:
+    """Interface the cells call through. `available` gates whether shell-only cells can run."""
+
+    available = False
+
+    def dc(self, *args: str, timeout: float = 60.0) -> str:
+        raise HooksUnavailable
+
+    def psql(self, db: str, sql: str) -> list[list[str]]:
+        raise HooksUnavailable
+
+    def runner_log(self, since: float) -> list[str]:
+        raise HooksUnavailable
+
+    def sandbox_procs(self, marker: str) -> list[dict]:
+        raise HooksUnavailable
+
+    def stream_row(self, session_id: str) -> dict:
+        raise HooksUnavailable
+
+    def record_rows(self, session_id: str) -> list[dict]:
+        raise HooksUnavailable
+
+    def command_rows(self, session_id: str) -> list[dict]:
+        raise HooksUnavailable
+
+    def wait_for_runner(self, *, timeout: float = 120.0) -> float | None:
+        raise HooksUnavailable
+
+    def restart_runner(self, grace_seconds: int = 10) -> None:
+        raise HooksUnavailable
+
+    def kill_runner(self) -> None:
+        raise HooksUnavailable
+
+    def pause_runner(self) -> None:
+        raise HooksUnavailable
+
+    def unpause_runner(self) -> None:
+        raise HooksUnavailable
+
+    def stop_postgres(self) -> None:
+        raise HooksUnavailable
+
+    def start_postgres(self) -> None:
+        raise HooksUnavailable
+
+    def kill_sandbox(self) -> list[str]:
+        raise HooksUnavailable
+
+
+class NullHooks(OperatorHooks):
+    """No `--project` was given. Every method raises; cells that need it SKIP with a reason."""
+
+    available = False
+
+
+class DockerComposeHooks(OperatorHooks):
+    """The original refresh_live.py helpers, ported behind the OperatorHooks interface."""
+
+    available = True
+
+    def __init__(self, project: str) -> None:
+        self.project = project
+
+    def dc(self, *args: str, timeout: float = 60.0) -> str:
+        try:
+            out = subprocess.run(
+                ["docker", *args], capture_output=True, text=True, timeout=timeout
+            )
+            return out.stdout
+        except Exception as exc:  # noqa: BLE001
+            return f"<docker failed: {exc}>"
+
+    def psql(self, db: str, sql: str) -> list[list[str]]:
+        raw = self.dc(
+            "exec",
+            f"{self.project}-postgres-1",
+            "psql",
+            "-U",
+            "username",
+            "-d",
+            db,
+            "-At",
+            "-F",
+            "|",
+            "-c",
+            sql,
+        )
+        return [line.split("|") for line in raw.strip().splitlines() if line.strip()]
+
+    def runner_log(self, since: float) -> list[str]:
+        stamp = time.strftime("%Y-%m-%dT%H:%M:%S", time.gmtime(since - 2))
+        try:
+            out = subprocess.run(
+                ["docker", "logs", "-t", "--since", stamp, f"{self.project}-runner-1"],
+                capture_output=True,
+                text=True,
+                timeout=90,
+            )
+            return (out.stdout + out.stderr).splitlines()
+        except Exception as exc:  # noqa: BLE001
+            return [f"<docker logs failed: {exc}>"]
+
+    def sandbox_procs(self, marker: str) -> list[dict]:
+        raw = self.dc(
+            "exec", f"{self.project}-runner-1", "ps", "-eo", "pid,ppid,etimes,args"
+        )
+        hits = []
+        for line in raw.splitlines()[1:]:
+            parts = line.split(None, 3)
+            if len(parts) < 4 or marker not in parts[3]:
+                continue
+            if "ps -eo" in parts[3] or parts[3].startswith("grep"):
+                continue
+            hits.append(
+                {
+                    "pid": parts[0],
+                    "ppid": parts[1],
+                    "etimes": parts[2],
+                    "args": parts[3][:120],
+                }
+            )
+        return hits
+
+    def stream_row(self, session_id: str) -> dict:
+        rows = self.psql(
+            "agenta_ee_core",
+            "select turn_id, coalesce(flags::text,'{}'), coalesce(stopping_turn_id,'') "
+            f"from session_streams where session_id = '{session_id}'",
+        )
+        if not rows:
+            return {}
+        turn, flags, stopping = rows[0]
+        try:
+            flags_obj = json.loads(flags)
+        except Exception:  # noqa: BLE001
+            flags_obj = {"raw": flags}
+        return {
+            "turn_id": turn,
+            "flags": flags_obj,
+            "stopping_turn_id": stopping or None,
+            "read_at": time.time(),
+        }
+
+    def record_rows(self, session_id: str) -> list[dict]:
+        rows = self.psql(
+            "agenta_ee_tracing",
+            "select coalesce(turn_id,''), record_type, "
+            "coalesce(to_char(created_at,'HH24:MI:SS.MS'),''), "
+            "case when quarantined_at is null then '' "
+            "else to_char(quarantined_at,'HH24:MI:SS.MS') end "
+            f"from records where session_id = '{session_id}' order by created_at",
+        )
+        return [
+            {
+                "turn_id": r[0],
+                "type": r[1],
+                "created_at": r[2],
+                "quarantined_at": r[3] or None,
+            }
+            for r in rows
+            if len(r) >= 4
+        ]
+
+    def command_rows(self, session_id: str) -> list[dict]:
+        rows = self.psql(
+            "agenta_ee_core",
+            "select id::text, state, coalesce(outcome,''), claim_count, "
+            "coalesce(target_turn_id,'') from session_commands "
+            f"where session_id = '{session_id}' order by created_at",
+        )
+        return [
+            {
+                "id": r[0],
+                "state": r[1],
+                "outcome": r[2] or None,
+                "claim_count": r[3],
+                "target_turn_id": r[4] or None,
+            }
+            for r in rows
+            if len(r) >= 5
+        ]
+
+    def wait_for_runner(self, *, timeout: float = 120.0) -> float | None:
+        started = time.time()
+        while time.time() - started < timeout:
+            state = self.dc(
+                "inspect", "-f", "{{.State.Health.Status}}", f"{self.project}-runner-1"
+            ).strip()
+            if state == "healthy":
+                return round(time.time() - started, 1)
+            time.sleep(1)
+        return None
+
+    def restart_runner(self, grace_seconds: int = 10) -> None:
+        self.dc(
+            "restart", "-t", str(grace_seconds), f"{self.project}-runner-1", timeout=120
+        )
+
+    def kill_runner(self) -> None:
+        self.dc("restart", "-t", "0", f"{self.project}-runner-1", timeout=60)
+
+    def pause_runner(self) -> None:
+        self.dc("pause", f"{self.project}-runner-1")
+
+    def unpause_runner(self) -> None:
+        self.dc("unpause", f"{self.project}-runner-1")
+
+    def stop_postgres(self) -> None:
+        self.dc("stop", f"{self.project}-postgres-1")
+
+    def start_postgres(self) -> None:
+        self.dc("start", f"{self.project}-postgres-1")
+
+    def kill_sandbox(self) -> list[str]:
+        ps = self.dc(
+            "exec",
+            f"{self.project}-runner-1",
+            "sh",
+            "-c",
+            'ps -eo pid,args | grep "[s]andbox-agent server"',
+        )
+        pids = [line.split()[0] for line in ps.strip().splitlines() if line.strip()]
+        for pid in pids:
+            self.dc(
+                "exec",
+                f"{self.project}-runner-1",
+                "sh",
+                "-c",
+                f"kill -9 -{pid} || kill -9 {pid}",
+            )
+        return pids
+
+
+# --------------------------------------------------------------------------- #
+# HTTP plumbing (unchanged from refresh_live.py, keyed off the resolved env)
+# --------------------------------------------------------------------------- #
+
+HARNESSES = {
+    "pi_core": {
+        "kind": "pi_core",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+        "connection": {"mode": "agenta", "slug": None},
+    },
+    "codex": {
+        "kind": "codex",
+        "model": "gpt-5.6-luna",
+        "provider": "openai",
+        "connection": {"mode": "agenta", "slug": None},
+    },
+}
+
+
+def api(method: str, path: str, *, timeout: float = 120.0, **kw) -> httpx.Response:
+    headers = {
+        "Authorization": STATE["credentials"],
+        "Content-Type": "application/json",
+        **(kw.pop("headers", None) or {}),
+    }
+    params = {"project_id": STATE["project_id"], **(kw.pop("params", None) or {})}
+    return httpx.request(
+        method,
+        f"{BASE}/api{path}",
+        params=params,
+        headers=headers,
+        timeout=timeout,
+        **kw,
+    )
+
+
+def bootstrap() -> None:
+    uid = uuid.uuid4().hex[:12]
+    r = httpx.post(
+        f"{BASE}/api/admin/simple/accounts/",
+        headers={"Authorization": f"Access {ADMIN_KEY}"},
+        json={
+            "accounts": {
+                "user": {
+                    "user": {"email": f"{uid}@test.agenta.ai"},
+                    "options": {
+                        "create_api_keys": True,
+                        "return_api_keys": True,
+                        "seed_defaults": False,
+                    },
+                }
+            }
+        },
+        timeout=120.0,
+    )
+    r.raise_for_status()
+    account = next(iter(r.json()["accounts"].values()))
+    STATE["credentials"] = f"ApiKey {account['api_keys']['key']}"
+    STATE["project_id"] = next(iter(account["projects"].values()))["id"]
+    print(f"[bootstrap] project={STATE['project_id']}", file=sys.stderr)
+
+    r = api(
+        "POST",
+        "/vault/v1/secrets/",
+        json={
+            "header": {"name": "OpenAI", "description": "session-control gate"},
+            "secret": {
+                "kind": "provider_key",
+                "data": {"kind": "openai", "provider": {"key": OPENAI_KEY}},
+            },
+        },
+    )
+    if r.status_code != 200:
+        raise SystemExit(f"vault create HTTP {r.status_code}: {r.text[:400]}")
+    print("[bootstrap] vault stocked with an openai provider key", file=sys.stderr)
+
+
+def agent_config(
+    harness: str, model: str, provider: str, connection: dict, sandbox: str = "local"
+) -> dict:
+    return {
+        "instructions": {"agents_md": "Be terse. Do exactly what is asked."},
+        "llm": {
+            "model": model,
+            "provider": provider,
+            "connection": connection,
+            "extras": {},
+        },
+        "tools": [],
+        "mcps": [],
+        "skills": [],
+        "harness": {"kind": harness},
+        "sandbox": {"kind": sandbox},
+        "runner": {"permissions": {"default": "allow"}},
+    }
+
+
+def create_revision(cfg: dict, tag: str) -> dict:
+    hexid = uuid.uuid4().hex[:8]
+    r = api(
+        "POST",
+        "/workflows/",
+        json={
+            "workflow": {
+                "slug": f"{tag}-{hexid}",
+                "name": f"session-control {hexid}",
+                "flags": {
+                    "is_custom": True,
+                    "is_evaluator": False,
+                    "is_feedback": False,
+                },
+            }
+        },
+    )
+    if r.status_code != 200:
+        raise SystemExit(f"create workflow HTTP {r.status_code}: {r.text[:400]}")
+    wf = r.json()["workflow"]["id"]
+
+    r = api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"{tag}-{hexid}-v",
+                "name": f"session-control {hexid} v",
+                "workflow_id": wf,
+            }
+        },
+    )
+    if r.status_code != 200:
+        raise SystemExit(f"create variant HTTP {r.status_code}: {r.text[:400]}")
+    var = r.json()["workflow_variant"]["id"]
+
+    rev_id = None
+    for step in ("seed", "baseline"):
+        r = api(
+            "POST",
+            "/workflows/revisions/commit",
+            json={
+                "workflow_revision": {
+                    "slug": f"{tag}-{step}-{hexid}",
+                    "name": f"session-control rev {step}",
+                    "message": step,
+                    "data": {
+                        "uri": "agenta:builtin:agent:v0",
+                        "parameters": {"agent": cfg},
+                    },
+                    "workflow_id": wf,
+                    "workflow_variant_id": var,
+                }
+            },
+        )
+        if r.status_code != 200:
+            raise SystemExit(f"commit {step} HTTP {r.status_code}: {r.text[:400]}")
+        rev_id = r.json()["workflow_revision"]["id"]
+
+    return {
+        "application": {"id": wf},
+        "variant": {"id": var},
+        "revision": {"id": rev_id},
+    }
+
+
+def user_msg(text: str) -> dict:
+    return {
+        "id": str(uuid.uuid4()),
+        "role": "user",
+        "parts": [{"type": "text", "text": text}],
+    }
+
+
+def invoke(
+    session_id: str,
+    messages: list,
+    cfg: dict,
+    references: dict,
+    label: str,
+    out: dict | None = None,
+) -> dict:
+    url = f"{BASE}/services/agent/v0/invoke"
+    body = {
+        "session_id": session_id,
+        "references": references,
+        "data": {"inputs": {"messages": messages}, "parameters": {"agent": cfg}},
+    }
+    headers = {
+        "Authorization": STATE["credentials"],
+        "Accept": "text/event-stream",
+        "x-ag-messages-format": "vercel",
+        "Content-Type": "application/json",
+    }
+    out = out if out is not None else {}
+    out.update(
+        {
+            "frames": [],
+            "text": "",
+            "tool_calls": [],
+            "errors": [],
+            "raw": [],
+            "segments": [],
+            "tool_outcomes": {},
+            "tool_payloads": {},
+        }
+    )
+    started = time.time()
+    with httpx.Client(timeout=600.0) as client:
+        with client.stream(
+            "POST",
+            url,
+            params={
+                "project_id": STATE["project_id"],
+                "application_id": references["application"]["id"],
+            },
+            json=body,
+            headers=headers,
+        ) as r:
+            print(f"[{label}] HTTP {r.status_code}", file=sys.stderr)
+            if r.status_code >= 400:
+                out["errors"].append(f"HTTP {r.status_code}: {r.read().decode()[:600]}")
+                return out
+            for line in r.iter_lines():
+                if not line.startswith("data: "):
+                    continue
+                payload = line[6:]
+                if payload == "[DONE]":
+                    break
+                try:
+                    f = json.loads(payload)
+                except json.JSONDecodeError:
+                    continue
+                out["raw"].append(f)
+                t = f.get("type", "?")
+                out["frames"].append(t)
+                if t == "message-metadata":
+                    tid = (f.get("messageMetadata") or {}).get("turnId")
+                    if isinstance(tid, str) and tid:
+                        out["turn_id"] = tid
+                if t == "text-delta":
+                    delta = f.get("delta", "")
+                    out["text"] += delta
+                    if out["segments"] and out["segments"][-1]["kind"] == "text":
+                        out["segments"][-1]["text"] += delta
+                    else:
+                        out["segments"].append({"kind": "text", "text": delta})
+                elif t == "tool-input-available":
+                    call = {
+                        "toolCallId": f.get("toolCallId"),
+                        "name": f.get("toolName"),
+                        "input": f.get("input"),
+                    }
+                    is_new = not any(
+                        c["toolCallId"] == call["toolCallId"] for c in out["tool_calls"]
+                    )
+                    out["tool_calls"] = [
+                        c
+                        for c in out["tool_calls"]
+                        if c["toolCallId"] != call["toolCallId"]
+                    ] + [call]
+                    if is_new:
+                        out["segments"].append(
+                            {"kind": "tool", "id": call["toolCallId"]}
+                        )
+                elif t == "tool-output-available":
+                    out["tool_outcomes"][f.get("toolCallId")] = "available"
+                    out["tool_payloads"][f.get("toolCallId")] = {
+                        "output": f.get("output")
+                    }
+                elif t == "tool-output-error":
+                    out["tool_outcomes"][f.get("toolCallId")] = "error"
+                    out["tool_payloads"][f.get("toolCallId")] = {
+                        "errorText": f.get("errorText")
+                    }
+                elif t == "error":
+                    out["errors"].append(json.dumps(f)[:600])
+    out["elapsed_s"] = round(time.time() - started, 1)
+    print(
+        f"[{label}] frames={out['frames']} elapsed={out['elapsed_s']}s", file=sys.stderr
+    )
+    return out
+
+
+def assistant_message(turn: dict) -> dict:
+    parts: list = []
+    text_buf: list[str] = []
+    for seg in turn["segments"]:
+        if seg["kind"] == "text":
+            text_buf.append(seg["text"])
+            continue
+        if text_buf:
+            parts.append({"type": "text", "text": "".join(text_buf)})
+            text_buf = []
+        call = next(c for c in turn["tool_calls"] if c["toolCallId"] == seg["id"])
+        part = {
+            "type": f"tool-{call['name']}",
+            "toolCallId": call["toolCallId"],
+            "input": call["input"],
+            "state": "input-available",
+        }
+        outcome = turn["tool_outcomes"].get(call["toolCallId"])
+        if outcome == "available":
+            part["state"] = "output-available"
+            part["output"] = (
+                turn["tool_payloads"].get(call["toolCallId"], {}).get("output")
+            )
+        elif outcome == "error":
+            part["state"] = "output-error"
+            part["errorText"] = (
+                turn["tool_payloads"].get(call["toolCallId"], {}).get("errorText")
+            )
+        parts.append(part)
+    if text_buf:
+        parts.append({"type": "text", "text": "".join(text_buf)})
+    return {"id": str(uuid.uuid4()), "role": "assistant", "parts": parts}
+
+
+def session_stream(session_id: str) -> dict:
+    r = api("GET", "/sessions/streams/", params={"session_id": session_id})
+    if r.status_code != 200:
+        return {}
+    return (r.json() or {}).get("stream") or {}
+
+
+def cancel(
+    session_id: str,
+    *,
+    expected: str | None = None,
+    idempotency_key: str | None = None,
+    label: str = "stop",
+) -> dict:
+    headers = {"Idempotency-Key": idempotency_key} if idempotency_key else None
+    body = {"expected_execution_id": expected} if expected else {}
+    sent = time.time()
+    r = api(
+        "POST",
+        f"/sessions/{session_id}/cancel",
+        json=body,
+        headers=headers,
+        timeout=30.0,
+    )
+    got = time.time()
+    try:
+        payload = r.json()
+    except Exception:
+        payload = {"raw": r.text[:400]}
+    record = {
+        "status": r.status_code,
+        "body": payload,
+        "sent_at": sent,
+        "sent_iso": time.strftime("%H:%M:%S", time.localtime(sent))
+        + f".{int((sent % 1) * 1000):03d}",
+        "round_trip_s": round(got - sent, 3),
+    }
+    print(
+        f"[{label}] HTTP {r.status_code} at {record['sent_iso']} rt={record['round_trip_s']}s {json.dumps(payload)[:300]}",
+        file=sys.stderr,
+    )
+    return record
+
+
+def records(session_id: str) -> list:
+    r = api("POST", "/sessions/records/query", json={"session_id": session_id})
+    if r.status_code != 200:
+        return [{"error": f"HTTP {r.status_code}: {r.text[:200]}"}]
+    return (r.json() or {}).get("records") or []
+
+
+def terminal_records(session_id: str, turn_id: str | None = None) -> list:
+    rows = [
+        {
+            "type": rec.get("record_type"),
+            "turn_id": rec.get("turn_id"),
+            "attributes": rec.get("attributes"),
+        }
+        for rec in records(session_id)
+        if rec.get("record_type") in ("error", "done")
+    ]
+    if turn_id:
+        rows = [r for r in rows if r["turn_id"] == turn_id]
+    return rows
+
+
+def interactions(session_id: str) -> list:
+    r = api(
+        "POST",
+        "/sessions/interactions/query",
+        json={"query": {"session_id": session_id}},
+    )
+    if r.status_code != 200:
+        return [{"error": f"HTTP {r.status_code}"}]
+    return [
+        {
+            "id": i.get("id"),
+            "turn_id": i.get("turn_id"),
+            "kind": i.get("kind"),
+            "status": i.get("status"),
+        }
+        for i in ((r.json() or {}).get("interactions") or [])
+    ]
+
+
+def invoke_async(session_id, messages, cfg, references, label) -> dict:
+    live: dict = {}
+    handle: dict = {"out": None, "live": live}
+
+    def go() -> None:
+        handle["out"] = invoke(session_id, messages, cfg, references, label, out=live)
+
+    t = threading.Thread(target=go, daemon=True)
+    t.start()
+    handle["thread"] = t
+    return handle
+
+
+def wait_for_turn(session_id: str, *, timeout: float = 40.0) -> str | None:
+    deadline = time.time() + timeout
+    while time.time() < deadline:
+        stream = session_stream(session_id)
+        turn = stream.get("turn_id")
+        flags = stream.get("flags") or {}
+        if turn and flags.get("is_running"):
+            return turn
+        time.sleep(0.5)
+    return None
+
+
+def wait_for_tool(handle: dict, *, timeout: float = 60.0) -> dict | None:
+    deadline = time.time() + timeout
+    live = handle["live"]
+    while time.time() < deadline:
+        calls = live.get("tool_calls") or []
+        outcomes = live.get("tool_outcomes") or {}
+        open_calls = [c for c in calls if c["toolCallId"] not in outcomes]
+        if open_calls:
+            return open_calls[-1]
+        if handle["out"] is not None:
+            return None
+        time.sleep(0.1)
+    return None
+
+
+def sleep_prompt(marker: str, seconds: int) -> str:
+    return (
+        f"The codeword is {marker}. Run exactly this one shell command and nothing "
+        f"else: sleep {seconds}. Do not write, read or search any files. "
+        "When the command finishes, reply with the single word DONE."
+    )
+
+
+# --------------------------------------------------------------------------- #
+# Cells. Each returns (evidence: dict, verdict: dict) where verdict is
+# {"pass": bool, "skip": bool, "why": str} — the gate's result shape.
+# --------------------------------------------------------------------------- #
+
+Cell = "tuple[dict, dict]"
+
+
+def _pass(why: str) -> dict:
+    return {"pass": True, "skip": False, "why": why}
+
+
+def _fail(why: str) -> dict:
+    return {"pass": False, "skip": False, "why": why}
+
+
+def _skip(why: str) -> dict:
+    return {"pass": False, "skip": True, "why": why}
+
+
+def cell_stop_warm(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Stop under 5 s, park, warm resume that recalls the codeword. Needs no shell."""
+    session_id = str(uuid.uuid4())
+    marker = f"MANGO{uuid.uuid4().hex[:6].upper()}"
+    msgs = [user_msg(sleep_prompt(marker, args.sleep_seconds))]
+    handle = invoke_async(session_id, msgs, cfg, references, "warm-turn1")
+    turn = wait_for_turn(session_id)
+    open_call = wait_for_tool(handle)
+    stop = cancel(session_id, expected=turn, label="stop-warm")
+    handle["thread"].join(timeout=180)
+    t1 = handle["out"] or {}
+    time.sleep(4)
+    msgs2 = msgs + [assistant_message(t1), user_msg(RECALL)]
+    t2 = invoke(session_id, msgs2, cfg, references, "warm-turn2")
+    evidence = {
+        "session_id": session_id,
+        "turn_id": turn,
+        "marker": marker,
+        "stop": stop,
+        "stopped_during_tool": open_call,
+        "turn1_elapsed_s": t1.get("elapsed_s"),
+        "terminal_records": terminal_records(session_id, turn),
+        "resume_recalled_marker": marker in (t2.get("text") or ""),
+        "resume_elapsed_s": t2.get("elapsed_s"),
+    }
+    if stop["status"] != 200:
+        return evidence, _fail(f"Stop returned HTTP {stop['status']}, expected 200")
+    if not evidence["resume_recalled_marker"]:
+        return evidence, _fail("warm resume did not recall the codeword")
+    return evidence, _pass(
+        "Stop returned 200 and the warm resume recalled the codeword"
+    )
+
+
+def cell_double_send(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """A second message during a running turn is refused, and destroys nothing. Needs no shell."""
+    session_id = str(uuid.uuid4())
+    marker = f"KIWI{uuid.uuid4().hex[:6].upper()}"
+    msgs = [user_msg(sleep_prompt(marker, args.sleep_seconds))]
+    handle = invoke_async(session_id, msgs, cfg, references, "double-turn1")
+    turn = wait_for_turn(session_id)
+    time.sleep(5)
+    second_started = time.time()
+    t2 = invoke(
+        session_id, [user_msg("Say hello.")], cfg, references, "double-turn2-refused"
+    )
+    second_elapsed = round(time.time() - second_started, 2)
+    handle["thread"].join(timeout=300)
+    t1 = handle["out"] or {}
+    time.sleep(4)
+    msgs3 = msgs + [assistant_message(t1), user_msg(RECALL)]
+    t3 = invoke(session_id, msgs3, cfg, references, "double-turn3")
+    evidence = {
+        "session_id": session_id,
+        "turn_id": turn,
+        "marker": marker,
+        "second_send": {
+            "frames": t2.get("frames"),
+            "errors": t2.get("errors"),
+            "elapsed_s": second_elapsed,
+        },
+        "turn1_elapsed_s": t1.get("elapsed_s"),
+        "turn1_errors": t1.get("errors"),
+        "third_send_recalled_marker": marker in (t3.get("text") or ""),
+    }
+    refused = bool(t2.get("errors"))
+    if not refused:
+        return evidence, _fail("second Send during a running turn was not refused")
+    if not evidence["third_send_recalled_marker"]:
+        return evidence, _fail(
+            "turn 1 finished but the codeword was not recalled afterwards"
+        )
+    return evidence, _pass(
+        "second Send was refused and the original turn completed cleanly"
+    )
+
+
+def cell_stale_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """A Stop naming a settled turn is refused and tombstones nothing. Needs no shell."""
+    session_id = str(uuid.uuid4())
+    marker = f"PLUM{uuid.uuid4().hex[:6].upper()}"
+    msgs = [
+        user_msg(f"The codeword is {marker}. Reply with just the single word READY.")
+    ]
+    t1 = invoke(session_id, msgs, cfg, references, "stale-turn1")
+    turn1 = session_stream(session_id).get("turn_id")
+    time.sleep(3)
+    msgs2 = msgs + [
+        assistant_message(t1),
+        user_msg(sleep_prompt(marker, args.sleep_seconds)),
+    ]
+    handle = invoke_async(session_id, msgs2, cfg, references, "stale-turn2")
+    turn2 = None
+    deadline = time.time() + 40
+    while time.time() < deadline:
+        candidate = wait_for_turn(session_id, timeout=2)
+        if candidate and candidate != turn1:
+            turn2 = candidate
+            break
+    time.sleep(3)
+    stale = cancel(session_id, expected=turn1, label="stale-stop")
+    time.sleep(3)
+    bare = cancel(session_id, label="bare-stop")
+    handle["thread"].join(timeout=180)
+    t2 = handle["out"] or {}
+    time.sleep(4)
+    msgs3 = msgs2 + [assistant_message(t2), user_msg(RECALL)]
+    t3 = invoke(session_id, msgs3, cfg, references, "stale-turn3")
+    evidence = {
+        "session_id": session_id,
+        "turn1_id": turn1,
+        "turn2_id": turn2,
+        "stale_stop": stale,
+        "bare_stop": bare,
+        "turn2_elapsed_s": t2.get("elapsed_s"),
+        "turn3_recalled_marker": marker in (t3.get("text") or ""),
+    }
+    if stale["status"] not in (400, 404, 409):
+        return evidence, _fail(
+            f"stale Stop returned HTTP {stale['status']}, expected a mismatch status"
+        )
+    if not evidence["turn3_recalled_marker"]:
+        return evidence, _fail("turn 2 did not survive the stale Stop")
+    return evidence, _pass("stale Stop was refused and turn 2 completed and survived")
+
+
+def cell_stop_approval(cfg_ask, references_ask, args, hooks: OperatorHooks) -> Cell:
+    """A parked approval is cancelled by Stop, and a late answer is refused. Needs no shell."""
+    session_id = str(uuid.uuid4())
+    marker = f"PEAR{uuid.uuid4().hex[:6].upper()}"
+    prompt = f"The codeword is {marker}. Run exactly this one shell command and nothing else: echo hello. Then reply DONE."
+    t1 = invoke(
+        session_id, [user_msg(prompt)], cfg_ask, references_ask, "approval-turn"
+    )
+    time.sleep(3)
+    before = interactions(session_id)
+    stream_before = session_stream(session_id)
+    expected = t1.get("turn_id") or stream_before.get("turn_id")
+    stop = cancel(session_id, expected=expected, label="stop-approval-named")
+    time.sleep(3)
+    pending = next((i for i in before if i.get("status") == "pending"), None)
+    late = {"skipped": "no pending interaction was found before the Stop"}
+    if pending:
+        r = api(
+            "POST",
+            f"/sessions/interactions/{pending['id']}/respond",
+            json={"answer": {"approved": True}},
+        )
+        late = {"status": r.status_code, "body": r.text[:300]}
+    denied = assistant_message(t1)
+    for part in denied["parts"]:
+        if (
+            part.get("type", "").startswith("tool-")
+            and part.get("state") == "input-available"
+        ):
+            part["state"] = "output-denied"
+    msgs2 = [user_msg(prompt), denied, user_msg(RECALL)]
+    t2 = invoke(session_id, msgs2, cfg_ask, references_ask, "approval-resume")
+    evidence = {
+        "session_id": session_id,
+        "marker": marker,
+        "expected_execution_id": expected,
+        "stop": stop,
+        "late_answer": late,
+        "resume_recalled_marker": marker in (t2.get("text") or ""),
+    }
+    if pending is None:
+        return evidence, _fail(
+            "no pending approval was seen before the Stop; the race did not land"
+        )
+    if stop["status"] != 200:
+        return evidence, _fail(
+            f"named Stop on a parked approval returned HTTP {stop['status']}, expected 200"
+        )
+    if late.get("status") == 200:
+        return evidence, _fail(
+            "the late approval answer was accepted after the Stop settled it"
+        )
+    if not evidence["resume_recalled_marker"]:
+        return evidence, _fail(
+            "resume after the approval Stop did not recall the codeword"
+        )
+    return evidence, _pass(
+        "Stop cancelled the parked approval, the late answer was refused, resume recalled the codeword"
+    )
+
+
+def cell_sandbox_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Kill the sandbox under a running tool call. Needs shell to find and kill the process."""
+    if not hooks.available:
+        return {}, _skip(
+            "no --project given: killing the sandbox process needs docker exec"
+        )
+    session_id = str(uuid.uuid4())
+    marker = f"OLIVE{uuid.uuid4().hex[:6].upper()}"
+    msgs = [user_msg(sleep_prompt(marker, 240))]
+    handle = invoke_async(session_id, msgs, cfg, references, "sandbox-turn1")
+    turn = wait_for_turn(session_id)
+    time.sleep(12)
+    killed = hooks.kill_sandbox()
+    handle["thread"].join(timeout=300)
+    t1 = handle["out"] or {}
+    time.sleep(5)
+    evidence = {
+        "session_id": session_id,
+        "turn_id": turn,
+        "killed_pids": killed,
+        "turn1_errors": t1.get("errors"),
+        "terminal_records": terminal_records(session_id, turn),
+        "stream_after": session_stream(session_id),
+    }
+    if not killed:
+        return evidence, _fail("no sandbox-agent process was found to kill")
+    flags = (evidence["stream_after"] or {}).get("flags") or {}
+    if flags.get("is_running"):
+        return evidence, _fail(
+            "session still reads is_running after the sandbox process was killed"
+        )
+    if not evidence["terminal_records"]:
+        return evidence, _fail(
+            "no terminal record was written after the sandbox process was killed"
+        )
+    return evidence, _pass(
+        "killing the sandbox process ended the turn and wrote a terminal record"
+    )
+
+
+def cell_records_outage(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Stop Postgres for 20 s during a turn. Every record must land after it returns."""
+    if not hooks.available:
+        return {}, _skip("no --project given: stopping Postgres needs docker")
+    session_id = str(uuid.uuid4())
+    marker = f"CEDAR{uuid.uuid4().hex[:6].upper()}"
+    msgs = [
+        user_msg(
+            f"The codeword is {marker}. Run exactly this one shell command and nothing else: sleep 30. When it finishes, reply with the single word DONE."
+        )
+    ]
+    handle = invoke_async(session_id, msgs, cfg, references, "outage-turn1")
+    wait_for_turn(session_id)
+    time.sleep(6)
+    hooks.stop_postgres()
+    time.sleep(20)
+    hooks.start_postgres()
+    handle["thread"].join(timeout=400)
+    landed = []
+    deadline = time.time() + 180
+    while time.time() < deadline:
+        landed = records(session_id)
+        if "done" in [r.get("record_type") for r in landed]:
+            break
+        time.sleep(5)
+    evidence = {
+        "session_id": session_id,
+        "marker": marker,
+        "record_types": [r.get("record_type") for r in landed],
+        "record_count": len(landed),
+    }
+    if "done" not in evidence["record_types"]:
+        return evidence, _fail(
+            "no done record landed after the Postgres outage recovered"
+        )
+    return evidence, _pass("every record landed after the Postgres outage recovered")
+
+
+def cell_stop_after_finish(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Fire the Stop at the instant the runner settles the prompt. Needs no shell for the core
+    assertion; the [control] aborted check is skipped without --project."""
+    session_id = str(uuid.uuid4())
+    marker = f"ACORN{uuid.uuid4().hex[:6].upper()}"
+    since = time.time()
+    msgs = [
+        user_msg(
+            f"The codeword is {marker}. Run exactly this one shell command and nothing else: sleep 6. When it finishes, reply with the single word DONE."
+        )
+    ]
+    seen: dict = {}
+    watcher_proc = None
+    if hooks.available:
+        watcher_proc = subprocess.Popen(
+            ["docker", "logs", "-f", "--since", "0s", f"{args.project}-runner-1"],
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+
+        def watch() -> None:
+            assert watcher_proc.stdout is not None
+            for line in watcher_proc.stdout:
+                if "prompt stopReason=" in line:
+                    seen["line"] = line.strip()
+                    seen["at"] = time.time()
+                    return
+
+        threading.Thread(target=watch, daemon=True).start()
+
+    handle = invoke_async(session_id, msgs, cfg, references, "finish-turn1")
+    turn = wait_for_turn(session_id)
+    if hooks.available:
+        deadline = time.time() + 180
+        while "at" not in seen and time.time() < deadline:
+            time.sleep(0.02)
+    else:
+        time.sleep(
+            6.5
+        )  # no runner-log watch: fire the Stop right around the natural finish
+    stop = cancel(session_id, expected=turn, label="stop-after-finish")
+    if watcher_proc:
+        try:
+            watcher_proc.kill()
+        except Exception:  # noqa: BLE001
+            pass
+    handle["thread"].join(timeout=180)
+    t1 = handle["out"] or {}
+    time.sleep(6)
+    msgs2 = msgs + [assistant_message(t1), user_msg(RECALL)]
+    t2 = invoke(session_id, msgs2, cfg, references, "finish-turn2")
+    evidence = {
+        "session_id": session_id,
+        "turn_id": t1.get("turn_id") or turn,
+        "settle_line": seen.get("line"),
+        "stop": stop,
+        "resume_recalled_marker": marker in (t2.get("text") or ""),
+        "terminal_records": terminal_records(session_id, turn),
+    }
+    if hooks.available:
+        logs = hooks.runner_log(since)
+        evidence["control_aborted_lines"] = [
+            ln for ln in logs if "[control] aborted" in ln and session_id in ln
+        ]
+    if hooks.available and evidence.get("control_aborted_lines"):
+        return evidence, _fail(
+            "a Stop that lost the race to completion still aborted the settled run"
+        )
+    if not evidence["resume_recalled_marker"]:
+        return evidence, _fail(
+            "the session did not park warm after Stop raced a finished turn"
+        )
+    why = (
+        "no spurious abort and a warm continuation recalled the codeword"
+        if hooks.available
+        else "a warm continuation recalled the codeword (abort-log check skipped: no --project)"
+    )
+    return evidence, _pass(why)
+
+
+def cell_restart_after_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Stop, restart the runner, continue with an EMPTY client transcript."""
+    if not hooks.available:
+        return {}, _skip("no --project given: restarting the runner needs docker")
+    session_id = str(uuid.uuid4())
+    marker = f"BIRCH{uuid.uuid4().hex[:6].upper()}"
+    msgs = [user_msg(sleep_prompt(marker, args.sleep_seconds))]
+    handle = invoke_async(session_id, msgs, cfg, references, "restart-turn1")
+    turn = wait_for_turn(session_id)
+    wait_for_tool(handle)
+    stop = cancel(session_id, expected=turn, label="stop-before-restart")
+    handle["thread"].join(timeout=180)
+    time.sleep(4)
+    restart_at = time.time()
+    hooks.restart_runner(grace_seconds=10)
+    healthy_after = hooks.wait_for_runner()
+    attempts = []
+    admitted = None
+    deadline = time.time() + 240
+    while time.time() < deadline:
+        t = invoke(session_id, [user_msg(RECALL)], cfg, references, "restart-recall")
+        refused = any(
+            "already running a turn" in (e or "") for e in t.get("errors", [])
+        )
+        attempts.append(
+            {
+                "at_s_after_restart": round(time.time() - restart_at, 1),
+                "refused": refused,
+            }
+        )
+        if not refused:
+            admitted = t
+            break
+        time.sleep(5)
+    evidence = {
+        "session_id": session_id,
+        "turn_id": turn,
+        "stop": stop,
+        "runner_healthy_after_s": healthy_after,
+        "attempts": attempts,
+        "admitted_at_s": attempts[-1]["at_s_after_restart"] if admitted else None,
+        "recalled_marker": marker in ((admitted or {}).get("text") or ""),
+    }
+    if healthy_after is None:
+        return evidence, _fail("the runner never reported healthy after the restart")
+    if admitted is None:
+        return evidence, _fail(
+            "the continuation was refused for the whole wait window after the restart"
+        )
+    if not evidence["recalled_marker"]:
+        return evidence, _fail(
+            "the native harness session did not survive the restart: the codeword was not recalled"
+        )
+    return evidence, _pass(
+        "the runner rehydrated the native session across a restart and recalled the codeword"
+    )
+
+
+def cell_post_stop_row(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """After a Stop the row must read is_running: false within a few seconds."""
+    if not hooks.available:
+        return {}, _skip("no --project given: reading the Postgres row needs psql")
+    session_id = str(uuid.uuid4())
+    marker = f"CEDAR{uuid.uuid4().hex[:6].upper()}"
+    msgs = [user_msg(sleep_prompt(marker, args.sleep_seconds))]
+    handle = invoke_async(session_id, msgs, cfg, references, "row-turn1")
+    turn = wait_for_turn(session_id)
+    wait_for_tool(handle)
+    stop = cancel(session_id, expected=turn, label="stop-post-row")
+    first_false_at = None
+    deadline = time.time() + 20
+    while time.time() < deadline:
+        row = hooks.stream_row(session_id)
+        flags = row.get("flags") or {}
+        if flags.get("is_running") is False:
+            first_false_at = round(row.get("read_at", time.time()) - stop["sent_at"], 2)
+            break
+        time.sleep(0.1)
+    handle["thread"].join(timeout=180)
+    evidence = {
+        "session_id": session_id,
+        "turn_id": turn,
+        "stop": stop,
+        "seconds_to_is_running_false": first_false_at,
+    }
+    if first_false_at is None:
+        return evidence, _fail(
+            "the Postgres row never read is_running: false within 20 s of the Stop"
+        )
+    if first_false_at > 5:
+        return evidence, _fail(
+            f"the row took {first_false_at}s to read is_running: false, expected under 5s"
+        )
+    return evidence, _pass(
+        f"the row read is_running: false {first_false_at}s after the Stop"
+    )
+
+
+def cell_codex_child(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """A stopped Codex turn must not leave its shell child alive in the parked sandbox."""
+    if not hooks.available:
+        return {}, _skip(
+            "no --project given: reading the runner's process table needs docker exec"
+        )
+    session_id = str(uuid.uuid4())
+    codeword = f"DELTA{uuid.uuid4().hex[:6].upper()}"
+    marker = f"sleep 300.{uuid.uuid4().int % 900000 + 100000}"
+    msgs = [
+        user_msg(
+            f"The codeword is {codeword}. Run exactly this one shell command and nothing else: {marker}\n"
+            "Run it in the FOREGROUND and wait for it to finish. Never run it in the background and never "
+            "append an ampersand. Do not read, write or search any files. When it finishes, reply with the "
+            "single word DONE."
+        )
+    ]
+    handle = invoke_async(session_id, msgs, cfg, references, "codex-turn1")
+    turn = wait_for_turn(session_id, timeout=90)
+    child_before = []
+    deadline = time.time() + 120
+    while time.time() < deadline:
+        child_before = hooks.sandbox_procs(marker)
+        if child_before:
+            break
+        time.sleep(1)
+    stop = cancel(session_id, expected=turn, label="stop-codex")
+    handle["thread"].join(timeout=180)
+    gone_at = None
+    deadline = time.time() + 45
+    while time.time() < deadline:
+        alive = hooks.sandbox_procs(marker)
+        if not alive:
+            gone_at = round(time.time() - stop["sent_at"], 1)
+            break
+        time.sleep(1)
+    time.sleep(4)
+    t2 = invoke(
+        session_id,
+        msgs + [assistant_message(handle["out"] or {}), user_msg(RECALL)],
+        cfg,
+        references,
+        "codex-turn2",
+    )
+    evidence = {
+        "session_id": session_id,
+        "turn_id": turn,
+        "child_before_stop": child_before,
+        "stop": stop,
+        "seconds_until_child_gone": gone_at,
+        "resume_recalled_marker": codeword in (t2.get("text") or ""),
+    }
+    if not child_before:
+        return evidence, _fail(
+            "never observed the child process before the Stop; the race did not land"
+        )
+    if gone_at is None:
+        return evidence, _fail("the child process was still alive 45s after the Stop")
+    if not evidence["resume_recalled_marker"]:
+        return evidence, _fail(
+            "the parked Codex sandbox did not recall the codeword on resume"
+        )
+    return evidence, _pass(
+        f"the child was reaped {gone_at}s after Stop and the resume recalled the codeword"
+    )
+
+
+def cell_stale_tail(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Freeze the runner past the watchdog threshold, thaw it, and read the late tail."""
+    if not hooks.available:
+        return {}, _skip("no --project given: pausing the runner needs docker")
+    session_id = str(uuid.uuid4())
+    marker = f"ELDER{uuid.uuid4().hex[:6].upper()}"
+    msgs = [
+        user_msg(
+            f"The codeword is {marker}. Run exactly this one shell command and nothing else: sleep 20. When it finishes, reply with the single word DONE."
+        )
+    ]
+    handle = invoke_async(session_id, msgs, cfg, references, "tail-turn1")
+    wait_for_turn(session_id)
+    time.sleep(3)
+    hooks.pause_runner()
+    deadline = time.time() + args.sweep_wait
+    while time.time() < deadline:
+        if any(r["type"] == "done" for r in hooks.record_rows(session_id)):
+            break
+        time.sleep(5)
+    hooks.unpause_runner()
+    handle["thread"].join(timeout=180)
+    time.sleep(20)
+    rows = hooks.record_rows(session_id)
+    quarantined = [r for r in rows if r["quarantined_at"]]
+    endpoint = [r.get("record_type") for r in records(session_id)]
+    evidence = {
+        "session_id": session_id,
+        "quarantined": quarantined,
+        "endpoint_record_types": endpoint,
+    }
+    if not quarantined:
+        return evidence, _fail(
+            "no late record was quarantined after the runner was thawed past the watchdog window"
+        )
+    if "done" not in endpoint and "error" not in endpoint:
+        return evidence, _fail(
+            "the transcript read shows no terminal record after the watchdog fired"
+        )
+    return evidence, _pass(
+        f"{len(quarantined)} late record(s) quarantined and hidden from the transcript read"
+    )
+
+
+def cell_repeat_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Two Stop requests for one execution, 50ms apart. One command effect, one ending."""
+    session_id = str(uuid.uuid4())
+    marker = f"HAZEL{uuid.uuid4().hex[:6].upper()}"
+    msgs = [user_msg(sleep_prompt(marker, args.sleep_seconds))]
+    handle = invoke_async(session_id, msgs, cfg, references, "repeat-turn1")
+    turn = wait_for_turn(session_id)
+    wait_for_tool(handle)
+    results: list = []
+
+    def fire(label: str) -> None:
+        results.append(cancel(session_id, expected=turn, label=label))
+
+    t1 = threading.Thread(target=fire, args=("repeat-stop-a",))
+    t1.start()
+    time.sleep(0.05)
+    t2 = threading.Thread(target=fire, args=("repeat-stop-b",))
+    t2.start()
+    t1.join()
+    t2.join()
+    handle["thread"].join(timeout=180)
+    out = handle["out"] or {}
+    time.sleep(4)
+    t3 = invoke(
+        session_id,
+        msgs + [assistant_message(out), user_msg(RECALL)],
+        cfg,
+        references,
+        "repeat-turn2",
+    )
+    evidence = {
+        "session_id": session_id,
+        "turn_id": turn,
+        "stops": results,
+        "terminal_records": terminal_records(session_id, turn),
+        "resume_recalled_marker": marker in (t3.get("text") or ""),
+    }
+    if hooks.available:
+        evidence["commands"] = hooks.command_rows(session_id)
+    accepted = [r for r in results if r["status"] == 200]
+    if len(accepted) == 0:
+        return evidence, _fail("neither of the two repeated Stops was accepted")
+    if len(evidence["terminal_records"]) != 1:
+        return evidence, _fail(
+            f"expected exactly one terminal record for the turn, saw {len(evidence['terminal_records'])}"
+        )
+    if not evidence["resume_recalled_marker"]:
+        return evidence, _fail(
+            "resume after the repeated Stop did not recall the codeword"
+        )
+    return evidence, _pass(
+        "two Stops 50ms apart produced exactly one terminal record and a warm resume"
+    )
+
+
+def cell_stop_during_completion(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Stop fired at the moment a short (toolless) turn completes naturally. One committed winner:
+    obsolete/not_running, or a clean stopped ending — never both, never neither."""
+    session_id = str(uuid.uuid4())
+    marker = f"IVY{uuid.uuid4().hex[:6].upper()}"
+    msgs = [
+        user_msg(f"The codeword is {marker}. Reply with just the single word READY.")
+    ]
+    handle = invoke_async(session_id, msgs, cfg, references, "completion-turn1")
+    turn = wait_for_turn(session_id)
+    # Race the natural finish: poll the live frame count and fire the instant it stops growing,
+    # which is the closest an HTTP-only driver can land on "while the execution completes".
+    live = handle["live"]
+    last_len = -1
+    stable_since = None
+    deadline = time.time() + 30
+    while time.time() < deadline:
+        n = len(live.get("frames") or [])
+        if n == last_len and n > 0:
+            if stable_since is None:
+                stable_since = time.time()
+            elif time.time() - stable_since > 0.05:
+                break
+        else:
+            stable_since = None
+        last_len = n
+        if handle["out"] is not None:
+            break
+        time.sleep(0.02)
+    stop = cancel(session_id, expected=turn, label="stop-during-completion")
+    handle["thread"].join(timeout=60)
+    out = handle["out"] or {}
+    time.sleep(3)
+    terminal = terminal_records(session_id, turn)
+    stream_after = session_stream(session_id)
+    t2 = invoke(
+        session_id,
+        msgs + [assistant_message(out), user_msg(RECALL)],
+        cfg,
+        references,
+        "completion-turn2",
+    )
+    evidence = {
+        "session_id": session_id,
+        "turn_id": turn,
+        "stop": stop,
+        "terminal_records": terminal,
+        "stream_after_flags": (stream_after or {}).get("flags"),
+        "resume_recalled_marker": marker in (t2.get("text") or ""),
+    }
+    if len(terminal) > 1:
+        return evidence, _fail(
+            f"the race produced {len(terminal)} terminal records for one turn, expected one"
+        )
+    if stop["status"] not in (200, 404, 409):
+        return evidence, _fail(
+            f"Stop-at-completion returned an unexpected HTTP {stop['status']}"
+        )
+    if not evidence["resume_recalled_marker"]:
+        return evidence, _fail(
+            "the session did not survive the completion race cleanly"
+        )
+    return evidence, _pass(
+        "Stop racing a natural finish produced exactly one committed ending and a clean resume"
+    )
+
+
+# (needs_hooks, permission, fn)
+CELLS: dict[str, tuple[bool, str, "object"]] = {
+    "stop-warm": (False, "allow", cell_stop_warm),
+    "double-send": (False, "allow", cell_double_send),
+    "stale-stop": (False, "allow", cell_stale_stop),
+    "stop-approval": (False, "ask", cell_stop_approval),
+    "sandbox-gone": (True, "allow", cell_sandbox_gone),
+    "records-outage": (True, "allow", cell_records_outage),
+    "stop-after-finish": (False, "allow", cell_stop_after_finish),
+    "restart-after-stop": (True, "allow", cell_restart_after_stop),
+    "post-stop-row": (True, "allow", cell_post_stop_row),
+    "codex-child": (True, "allow", cell_codex_child),
+    "stale-tail": (True, "allow", cell_stale_tail),
+    "repeat-stop": (False, "allow", cell_repeat_stop),
+    "stop-during-completion": (False, "allow", cell_stop_during_completion),
+}
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--harness", default="pi_core", choices=sorted(HARNESSES))
+    ap.add_argument("--cells", default="all", help="comma separated, or 'all'")
+    ap.add_argument("--sleep-seconds", type=int, default=45)
+    ap.add_argument("--sweep-wait", type=float, default=240.0)
+    ap.add_argument(
+        "--project",
+        default=None,
+        help="docker-compose project name; enables the shell-only cells",
+    )
+    ap.add_argument("--sandbox", default="local", choices=["local", "daytona"])
+    ap.add_argument(
+        "--resume",
+        default=None,
+        help="path to a prior run's results.json; cells already recorded there are loaded, not re-run",
+    )
+    args = ap.parse_args()
+
+    wanted = (
+        list(CELLS)
+        if args.cells == "all"
+        else [c.strip() for c in args.cells.split(",") if c.strip()]
+    )
+    unknown = [c for c in wanted if c not in CELLS]
+    if unknown:
+        raise SystemExit(f"unknown cells: {unknown}; known: {sorted(CELLS)}")
+
+    resolve_env()
+    hooks: OperatorHooks = (
+        DockerComposeHooks(args.project) if args.project else NullHooks()
+    )
+
+    prior: dict = {}
+    if args.resume:
+        prior_path = pathlib.Path(args.resume).expanduser()
+        if prior_path.exists():
+            prior = json.loads(prior_path.read_text()).get("cells", {})
+            print(
+                f"[resume] loaded {len(prior)} cell result(s) from {prior_path}",
+                file=sys.stderr,
+            )
+
+    bootstrap()
+    spec = HARNESSES[args.harness]
+    base_cfg = agent_config(
+        spec["kind"], spec["model"], spec["provider"], spec["connection"], args.sandbox
+    )
+    built: dict = {}
+
+    def config_for(permission: str):
+        if permission not in built:
+            cfg = json.loads(json.dumps(base_cfg))
+            cfg["runner"] = {"permissions": {"default": permission}}
+            built[permission] = (
+                cfg,
+                create_revision(cfg, f"session-control-{args.sandbox}-{permission}"),
+            )
+        return built[permission]
+
+    stamp = time.strftime("%Y%m%d-%H%M%S")
+    outdir = RUNS / f"{stamp}-session-control"
+    outdir.mkdir(parents=True, exist_ok=True)
+
+    results: dict = {
+        "project_id": STATE["project_id"],
+        "harness": args.harness,
+        "sandbox": args.sandbox,
+        "cells": {},
+    }
+    for name in wanted:
+        if name in prior:
+            print(
+                f"[{name}] resumed from prior run: {prior[name]['verdict']['pass'] and 'PASS' or (prior[name]['verdict']['skip'] and 'SKIP' or 'FAIL')}",
+                file=sys.stderr,
+            )
+            results["cells"][name] = prior[name]
+            (outdir / "results.json").write_text(
+                json.dumps(results, indent=2, default=str)
+            )
+            continue
+        needs_hooks, permission, fn = CELLS[name]
+        cfg, references = config_for(permission)
+        print(f"\n=== cell {name} ===", file=sys.stderr)
+        started = time.time()
+        try:
+            evidence, verdict = fn(cfg, references, args, hooks)
+        except Exception as exc:  # noqa: BLE001
+            import traceback
+
+            evidence = {
+                "driver_error": f"{type(exc).__name__}: {exc}",
+                "traceback": traceback.format_exc()[-1500:],
+            }
+            verdict = _fail(f"driver exception: {type(exc).__name__}: {exc}")
+        elapsed = round(time.time() - started, 1)
+        verdict_str = (
+            "SKIP" if verdict["skip"] else ("PASS" if verdict["pass"] else "FAIL")
+        )
+        print(f"[{name}] {verdict_str} — {verdict['why']}", file=sys.stderr)
+        results["cells"][name] = {
+            "evidence": evidence,
+            "verdict": verdict,
+            "elapsed_s": elapsed,
+        }
+        (outdir / "results.json").write_text(json.dumps(results, indent=2, default=str))
+
+    lines = ["| cell | verdict | why |", "|---|---|---|"]
+    for name, r in results["cells"].items():
+        v = r["verdict"]
+        verdict_str = "SKIP" if v["skip"] else ("PASS" if v["pass"] else "FAIL")
+        lines.append(f"| {name} | {verdict_str} | {v['why']} |")
+    table = "\n".join(lines)
+    (outdir / "summary.md").write_text(table + "\n")
+    print("\n" + table)
+    print(f"\nresults: {outdir}")
+
+    failed = any(
+        not r["verdict"]["skip"] and not r["verdict"]["pass"]
+        for r in results["cells"].values()
+    )
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -61,6 +61,12 @@ ANTHROPIC_KEY = ""
 # local sandbox needs, so every wait that assumes "local" gets this much extra slack.
 SANDBOX_STARTUP_SLACK_S = 0.0
 
+# Set in main() from --client-shape. "full" (default) replays the whole transcript on every
+# send, like this driver always has, so existing results stay comparable. "last-message"
+# reshapes every outbound `messages` list the way the desktop client does — see
+# _client_shape_messages() below.
+CLIENT_SHAPE = "full"
+
 RUNS = pathlib.Path(
     os.environ.get(
         "AGENTA_QA_RUNS_DIR", str(pathlib.Path.home() / "agenta-qa-evidence")
@@ -579,6 +585,48 @@ def user_msg(text: str) -> dict:
     }
 
 
+def _is_answer_part(part: dict) -> bool:
+    """Mirrors `isAnswerPart` in agentRequest.ts (web/packages/agenta-playground/src/state/
+    execution/agentRequest.ts): a non-empty text part, a tool part (`tool-*`), a
+    `dynamic-tool` part, or a `file` part."""
+    t = part.get("type") if isinstance(part, dict) else None
+    if not isinstance(t, str):
+        return False
+    if t == "text":
+        text = part.get("text")
+        return isinstance(text, str) and text.strip() != ""
+    return t.startswith("tool-") or t in ("dynamic-tool", "file")
+
+
+def _has_answer(message: dict) -> bool:
+    """Mirrors `hasAnswer` in agentRequest.ts: a user (non-assistant) message always counts;
+    an assistant message counts only if at least one of its parts is an answer part. Strips an
+    answer-less assistant turn so it cannot cascade into every later turn failing."""
+    if message.get("role") != "assistant":
+        return True
+    parts = message.get("parts")
+    return isinstance(parts, list) and any(_is_answer_part(p) for p in parts)
+
+
+def _client_shape_messages(messages: list) -> list:
+    """Shape the outbound `messages` list the way the desktop client does (agentRequest.ts),
+    when `--client-shape last-message` is selected. A no-op under the default `full`.
+
+    Strip answer-less assistant turns, then send only the trailing message when it is a fresh
+    user turn — the runner rebuilds prior turns from the durable record log. A resume whose
+    trailing turn carries a settled HITL answer (not a user turn) keeps the full history so the
+    answer still binds to its tool call.
+    """
+    if CLIENT_SHAPE != "last-message":
+        return messages
+    history = [m for m in messages if _has_answer(m)]
+    if not history:
+        return history
+    if history[-1].get("role") == "user":
+        return [history[-1]]
+    return history
+
+
 def invoke(
     session_id: str,
     messages: list,
@@ -591,7 +639,10 @@ def invoke(
     body = {
         "session_id": session_id,
         "references": references,
-        "data": {"inputs": {"messages": messages}, "parameters": {"agent": cfg}},
+        "data": {
+            "inputs": {"messages": _client_shape_messages(messages)},
+            "parameters": {"agent": cfg},
+        },
     }
     headers = {
         "Authorization": STATE["credentials"],
@@ -2026,6 +2077,17 @@ def main() -> int:
     )
     ap.add_argument("--sandbox", default="local", choices=["local", "daytona"])
     ap.add_argument(
+        "--client-shape",
+        default="full",
+        choices=["full", "last-message"],
+        help=(
+            "full (default) replays the whole transcript on every send, keeping results "
+            "comparable with prior runs. last-message sends only the new user message on "
+            "every resume and follow-up, the way the desktop client does (agentRequest.ts) — "
+            "use it to catch continuity bugs the full transcript masks."
+        ),
+    )
+    ap.add_argument(
         "--resume",
         default=None,
         help="path to a prior run's results.json; cells already recorded there are loaded, not re-run",
@@ -2048,6 +2110,8 @@ def main() -> int:
     if args.sandbox == "daytona":
         global SANDBOX_STARTUP_SLACK_S
         SANDBOX_STARTUP_SLACK_S = 25.0
+    global CLIENT_SHAPE
+    CLIENT_SHAPE = args.client_shape
 
     prior: dict = {}
     if args.resume:
@@ -2087,6 +2151,7 @@ def main() -> int:
         "project_id": STATE["project_id"],
         "harness": args.harness,
         "sandbox": args.sandbox,
+        "client_shape": args.client_shape,
         "cells": {},
     }
     for name in wanted:

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -208,6 +208,9 @@ class OperatorHooks:
     def wait_for_runner(self, *, timeout: float = 120.0) -> float | None:
         raise HooksUnavailable
 
+    def runner_healthy(self) -> bool:
+        raise HooksUnavailable
+
     def ensure_runner_healthy(self, *, timeout: float = 120.0) -> dict:
         raise HooksUnavailable
 
@@ -410,13 +413,17 @@ class DockerComposeHooks(OperatorHooks):
     def wait_for_runner(self, *, timeout: float = 120.0) -> float | None:
         started = time.time()
         while time.time() - started < timeout:
-            state = self.dc(
-                "inspect", "-f", "{{.State.Health.Status}}", f"{self.project}-runner-1"
-            ).strip()
-            if state == "healthy":
+            if self.runner_healthy():
                 return round(time.time() - started, 1)
             time.sleep(1)
         return None
+
+    def runner_healthy(self) -> bool:
+        """One health check: the runner container's Docker health status reads `healthy`."""
+        state = self.dc(
+            "inspect", "-f", "{{.State.Health.Status}}", f"{self.project}-runner-1"
+        ).strip()
+        return state == "healthy"
 
     def ensure_runner_healthy(self, *, timeout: float = 120.0) -> dict:
         """Recover the runner container to running and healthy, whatever a cell left it in.
@@ -980,6 +987,32 @@ def sandbox_gone_settle_budget_s() -> float:
         + SANDBOX_GONE_SETTLE_SLACK_S
         + SANDBOX_STARTUP_SLACK_S
     )
+
+
+# After the runner-gone-late cell restarts the runner, the recovery Send must not race the
+# runner coming back up: a Send issued mid-restart gets "All connection attempts failed" and is
+# misread as a product failure. Poll the runner's health until it is back, bounded, then send.
+RECOVERY_HEALTH_TIMEOUT_S = 60.0
+RECOVERY_HEALTH_POLL_S = 2.0
+
+
+def _recover_then_send(health_poll, send, *, timeout, poll_interval, clock=time):
+    """Poll `health_poll()` until it returns truthy (bounded by `timeout`), THEN call `send()`.
+
+    `send` runs ONLY once the runner is healthy again, so a recovery Send can never race a runner
+    that is still restarting. Returns `(healthy, result)`; when health never recovers within the
+    budget, `send` is not called and `result` is None. The clock is injectable for tests."""
+    deadline = clock.time() + timeout
+    healthy = False
+    while True:
+        if health_poll():
+            healthy = True
+            break
+        if clock.time() >= deadline:
+            break
+        clock.sleep(poll_interval)
+    result = send() if healthy else None
+    return healthy, result
 
 
 def api(method: str, path: str, *, timeout: float = 120.0, **kw) -> httpx.Response:
@@ -2347,13 +2380,28 @@ def cell_runner_gone_late(cfg, references, args, hooks: OperatorHooks) -> Cell:
     commands = hooks.command_rows(session_id)
     stream_row = hooks.stream_row(session_id)
     stop_command = _match_stop_command(commands, turn)
-    t2 = invoke(
-        session_id,
-        [user_msg(f"The codeword is {marker}. Reply with just the single word READY.")],
-        cfg,
-        references,
-        "gone-late-turn2",
+    # The runner is restarting from the kill above. A recovery Send issued before it is back up
+    # gets "All connection attempts failed" and is misread as a product failure. Wait for the
+    # runner to be healthy again (bounded), THEN send. If it never recovers, do not send a doomed
+    # request — `runner_recovered` records which happened.
+    recover_started = time.time()
+    runner_recovered, t2 = _recover_then_send(
+        health_poll=hooks.runner_healthy,
+        send=lambda: invoke(
+            session_id,
+            [
+                user_msg(
+                    f"The codeword is {marker}. Reply with just the single word READY."
+                )
+            ],
+            cfg,
+            references,
+            "gone-late-turn2",
+        ),
+        timeout=RECOVERY_HEALTH_TIMEOUT_S,
+        poll_interval=RECOVERY_HEALTH_POLL_S,
     )
+    t2 = t2 or {}
     evidence = {
         "session_id": session_id,
         "turn_id": turn,
@@ -2364,9 +2412,16 @@ def cell_runner_gone_late(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "commands": commands,
         "stop_command": stop_command,
         "stream_row": stream_row,
+        "runner_recovered": runner_recovered,
+        "runner_recover_seconds": round(time.time() - recover_started, 1),
         "new_message_ran": bool(t2.get("frames")) and not t2.get("errors"),
         "new_message_errors": t2.get("errors"),
     }
+    if not runner_recovered:
+        return evidence, _fail(
+            f"runner did not become healthy within {RECOVERY_HEALTH_TIMEOUT_S:.0f}s after the "
+            "restart; recovery Send not attempted"
+        )
     return evidence, _judge_runner_gone(evidence)
 
 

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -826,12 +826,14 @@ def cell_stop_warm(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "resume_recalled_marker": marker in (t2.get("text") or ""),
         "resume_elapsed_s": t2.get("elapsed_s"),
     }
-    if stop["status"] != 200:
-        return evidence, _fail(f"Stop returned HTTP {stop['status']}, expected 200")
+    if stop["status"] not in (200, 202):
+        return evidence, _fail(
+            f"Stop returned HTTP {stop['status']}, expected 200 or 202"
+        )
     if not evidence["resume_recalled_marker"]:
         return evidence, _fail("warm resume did not recall the codeword")
     return evidence, _pass(
-        "Stop returned 200 and the warm resume recalled the codeword"
+        f"Stop returned HTTP {stop['status']} and the warm resume recalled the codeword"
     )
 
 
@@ -971,9 +973,9 @@ def cell_stop_approval(cfg_ask, references_ask, args, hooks: OperatorHooks) -> C
         return evidence, _fail(
             "no pending approval was seen before the Stop; the race did not land"
         )
-    if stop["status"] != 200:
+    if stop["status"] not in (200, 202):
         return evidence, _fail(
-            f"named Stop on a parked approval returned HTTP {stop['status']}, expected 200"
+            f"named Stop on a parked approval returned HTTP {stop['status']}, expected 200 or 202"
         )
     if late.get("status") == 200:
         return evidence, _fail(
@@ -1396,7 +1398,7 @@ def cell_repeat_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
     }
     if hooks.available:
         evidence["commands"] = hooks.command_rows(session_id)
-    accepted = [r for r in results if r["status"] == 200]
+    accepted = [r for r in results if r["status"] in (200, 202)]
     if len(accepted) == 0:
         return evidence, _fail("neither of the two repeated Stops was accepted")
     if len(evidence["terminal_records"]) != 1:
@@ -1466,7 +1468,7 @@ def cell_stop_during_completion(cfg, references, args, hooks: OperatorHooks) -> 
         return evidence, _fail(
             f"the race produced {len(terminal)} terminal records for one turn, expected one"
         )
-    if stop["status"] not in (200, 404, 409):
+    if stop["status"] not in (200, 202, 404, 409):
         return evidence, _fail(
             f"Stop-at-completion returned an unexpected HTTP {stop['status']}"
         )

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -39,6 +39,7 @@ import argparse
 import json
 import os
 import pathlib
+import re
 import subprocess
 import sys
 import threading
@@ -112,6 +113,69 @@ class HooksUnavailable(Exception):
     """Raised by a NullHooks method. Caught at the cell boundary and turned into a SKIP."""
 
 
+class WrongSandboxTarget(Exception):
+    """The sandbox-gone cell could not map the tested session to exactly one sandbox-agent
+    daemon it is safe to kill. Raised INSTEAD of killing a guess. Two sessions can share one
+    mount key, and the keep-alive pool keeps other sessions' parked daemons alive in the same
+    runner container, so a blind `ps | grep sandbox-agent` kill hits the wrong process. The cell
+    turns this into a `wrong target` failure rather than a false negative against the product."""
+
+
+# A local sandbox id from the turn ledger is `local/<host>:<port>`; a Daytona id is `daytona/<uuid>`.
+_LOCAL_SANDBOX_ID_RE = re.compile(r"^local/[^:\s]+:(\d+)$")
+
+
+# The runner log line that names the port a session's local sandbox daemon bound to, e.g.
+# `[sandbox-agent] [timing] stage=prepare_workspace ms=0 sandbox=local/127.0.0.1:44831 session=<id>`.
+def _prepare_workspace_port_re(session_id: str) -> re.Pattern[str]:
+    return re.compile(
+        r"stage=prepare_workspace\b.*\bsandbox=local/[^:\s]+:(\d+)\b.*\bsession="
+        + re.escape(session_id)
+    )
+
+
+def _parse_local_sandbox_port(sandbox_id: str | None) -> int | None:
+    """The port from a local ledger sandbox id, or None for a Daytona/empty/foreign id."""
+    if not sandbox_id:
+        return None
+    m = _LOCAL_SANDBOX_ID_RE.match(sandbox_id.strip())
+    return int(m.group(1)) if m else None
+
+
+def _parse_ss_listener_pid(ss_output: str, port: int) -> str | None:
+    """The owning pid of the LISTEN socket on `port`, parsed from `ss -ltnHp` output.
+
+    A line looks like:
+      LISTEN 0 511 127.0.0.1:44831 0.0.0.0:* users:(("node",pid=2170,fd=23))
+    The peer column on a listener is always `0.0.0.0:*`/`[::]:*`, so an exact `:<port>` field
+    match cannot collide with the peer, and `rsplit` guards against a substring port match."""
+    for line in ss_output.splitlines():
+        fields = line.split()
+        if not any(f.rsplit(":", 1)[-1] == str(port) for f in fields if ":" in f):
+            continue
+        m = re.search(r"\bpid=(\d+)", line)
+        if m:
+            return m.group(1)
+    return None
+
+
+# Fallback for a container without `ss`: read the LISTEN socket's inode from /proc/net/tcp{,6},
+# then find the pid whose fd points at that socket. `$1` is the decimal port.
+_PROC_PID_ON_PORT_SH = r"""
+port="$1"
+hp=$(printf '%04X' "$port" 2>/dev/null) || exit 0
+inode=$(awk -v hp="$hp" 'NR>1 && $4=="0A" { split($2,a,":"); if (a[2]==hp) { print $10; exit } }' /proc/net/tcp /proc/net/tcp6 2>/dev/null)
+[ -z "$inode" ] && exit 0
+for fd in /proc/[0-9]*/fd/*; do
+  link=$(readlink "$fd" 2>/dev/null) || continue
+  if [ "$link" = "socket:[$inode]" ]; then
+    echo "$fd" | awk -F/ '{print $3}'
+    exit 0
+  fi
+done
+"""
+
+
 class OperatorHooks:
     """Interface the cells call through. `available` gates whether shell-only cells can run."""
 
@@ -166,6 +230,14 @@ class OperatorHooks:
         raise HooksUnavailable
 
     def kill_sandbox(self, sandbox_id: str | None = None) -> list[str]:
+        raise HooksUnavailable
+
+    def kill_sandbox_for_session(
+        self,
+        session_id: str | None = None,
+        sandbox_id: str | None = None,
+        since: float | None = None,
+    ) -> dict:
         raise HooksUnavailable
 
 
@@ -404,6 +476,119 @@ class DockerComposeHooks(OperatorHooks):
             )
         return pids
 
+    def local_sandbox_port(
+        self,
+        session_id: str,
+        sandbox_id: str | None = None,
+        since: float | None = None,
+    ) -> int | None:
+        """The TCP port THIS session's own local sandbox daemon bound to.
+
+        The source of truth is the runner log's `prepare_workspace` line for this exact session
+        id; the turn ledger's `local/<host>:<port>` sandbox id is a fallback and a cross-check.
+        Two sessions can share one mount key, so a global `ps | grep` cannot tell them apart —
+        this is per-session by construction. When both sources disagree the target is ambiguous
+        and this refuses (raises), rather than guessing which daemon to kill."""
+        log_port = None
+        pat = _prepare_workspace_port_re(session_id)
+        for line in self.runner_log(since if since is not None else time.time() - 600):
+            m = pat.search(line)
+            if m:
+                log_port = int(
+                    m.group(1)
+                )  # last match wins: a rebuild uses a fresh port
+        ledger_port = _parse_local_sandbox_port(sandbox_id)
+        if log_port is not None and ledger_port is not None and log_port != ledger_port:
+            raise WrongSandboxTarget(
+                f"the runner log names port {log_port} for session {session_id} but the turn "
+                f"ledger names {ledger_port}; refusing to kill an ambiguous target"
+            )
+        return log_port if log_port is not None else ledger_port
+
+    def pid_listening_on_port(self, port: int) -> str | None:
+        """The pid of the process listening on `port` inside the runner container.
+
+        Prefers `ss -ltnHp` (the pid is inline); falls back to reading the socket inode from
+        /proc/net/tcp and matching it against /proc/*/fd when the image ships no `ss`."""
+        ss_out = self.dc(
+            "exec",
+            f"{self.project}-runner-1",
+            "sh",
+            "-c",
+            "ss -ltnHp 2>/dev/null || true",
+        )
+        pid = _parse_ss_listener_pid(ss_out, port)
+        if pid:
+            return pid
+        proc_out = self.dc(
+            "exec",
+            f"{self.project}-runner-1",
+            "sh",
+            "-c",
+            _PROC_PID_ON_PORT_SH,
+            "pid-on-port",
+            str(port),
+        )
+        proc_out = proc_out.strip()
+        return proc_out or None
+
+    def process_cmdline(self, pid: str) -> str:
+        """The argv of `pid` inside the runner container, space-joined (nul-separated on disk)."""
+        return self.dc(
+            "exec",
+            f"{self.project}-runner-1",
+            "sh",
+            "-c",
+            f"tr '\\0' ' ' < /proc/{pid}/cmdline 2>/dev/null",
+        ).strip()
+
+    def kill_sandbox_for_session(
+        self,
+        session_id: str | None = None,
+        sandbox_id: str | None = None,
+        since: float | None = None,
+    ) -> dict:
+        """Kill ONLY the local sandbox daemon that belongs to `session_id`.
+
+        Maps the session to its own port, resolves the listening pid, and asserts the pid is a
+        sandbox-agent daemon before killing it. Any gap in that chain raises `WrongSandboxTarget`
+        so the cell fails as `wrong target` instead of killing an unrelated session's parked
+        sandbox (the historical false negative). Returns the port, pid, cmdline, and killed pids
+        as evidence."""
+        if not session_id:
+            raise WrongSandboxTarget("no session id given; refusing to kill a guess")
+        port = self.local_sandbox_port(session_id, sandbox_id=sandbox_id, since=since)
+        if port is None:
+            raise WrongSandboxTarget(
+                f"could not find this session's local sandbox port for {session_id} in the "
+                f"runner log or the turn ledger (ledger id={sandbox_id!r}); refusing to kill a guess"
+            )
+        pid = self.pid_listening_on_port(port)
+        if not pid:
+            raise WrongSandboxTarget(
+                f"nothing is listening on port {port} inside the runner container for session "
+                f"{session_id}; the named sandbox is not here — refusing to kill a guess"
+            )
+        cmdline = self.process_cmdline(pid)
+        if "sandbox-agent" not in cmdline:
+            raise WrongSandboxTarget(
+                f"pid {pid} on port {port} is not a sandbox-agent daemon "
+                f"(cmdline={cmdline[:120]!r}); refusing to kill it"
+            )
+        self.dc(
+            "exec",
+            f"{self.project}-runner-1",
+            "sh",
+            "-c",
+            f"kill -9 -{pid} || kill -9 {pid}",
+        )
+        return {
+            "port": port,
+            "pid": pid,
+            "cmdline": cmdline[:200],
+            "killed": [pid],
+        }
+
 
 class DaytonaAwareHooks(DockerComposeHooks):
     """`DockerComposeHooks` plus a Daytona-provider-aware `kill_sandbox` and `sandbox_procs`.
@@ -484,6 +669,34 @@ class DaytonaAwareHooks(DockerComposeHooks):
             )
             return []
         return [bare]
+
+    def kill_sandbox_for_session(
+        self,
+        session_id: str | None = None,
+        sandbox_id: str | None = None,
+        since: float | None = None,
+    ) -> dict:
+        """Delete THIS session's remote sandbox by the one id its turn ledger observed.
+
+        A Daytona sandbox is a remote machine, addressed by its own uuid, so this path is already
+        per-session targeted and never had the shared-runner ambiguity the local path did. An
+        absent id means there is nothing to end — that is a `wrong target` refusal, not a kill."""
+        if not sandbox_id:
+            raise WrongSandboxTarget(
+                f"no sandbox id observed for session {session_id}; nothing to end"
+            )
+        killed = self.kill_sandbox(sandbox_id=sandbox_id)
+        if not killed:
+            raise WrongSandboxTarget(
+                f"the Daytona delete for sandbox {sandbox_id} did not confirm; refusing to "
+                "claim a kill that did not land"
+            )
+        return {
+            "port": None,
+            "pid": None,
+            "cmdline": None,
+            "killed": killed,
+        }
 
     def sandbox_procs(self, marker: str, sandbox_id: str | None = None) -> list[dict]:
         if not sandbox_id:
@@ -605,6 +818,30 @@ DEFAULT_STREAM_TIMEOUT_S = 600.0
 def stream_timeout_s(cfg: dict) -> float:
     kind = (cfg.get("harness") or {}).get("kind")
     return STREAM_TIMEOUT_S.get(kind, DEFAULT_STREAM_TIMEOUT_S)
+
+
+# The "sandbox-gone" cell runs one slow shell command, kills the tested session's OWN sandbox
+# daemon under it, and expects the runner to end the turn with a terminal record. The settle
+# budget is derived from the runner's sandbox-liveness probe defaults
+# (services/runner/src/engines/sandbox_agent/sandbox-liveness.ts): PROBE_FAILURES consecutive
+# probe failures at PROBE_INTERVAL_S each, after which the turn ends with an error record. The
+# cell waits that budget plus slack, and never less than the slow command itself — so a healthy
+# turn that outlives a mis-targeted kill can never be misread as "still running" before it would
+# even have finished. The command duration is a constant the cell prints in its evidence.
+SANDBOX_GONE_COMMAND_S = 240
+SANDBOX_LIVENESS_PROBE_INTERVAL_S = 30.0
+SANDBOX_LIVENESS_PROBE_FAILURES = 3
+SANDBOX_GONE_SETTLE_SLACK_S = 60.0
+
+
+def sandbox_gone_settle_budget_s() -> float:
+    """Seconds to wait for the runner to end the turn after the sandbox is killed: the probe's
+    three-strikes budget plus slack plus any sandbox-startup slack the run declared."""
+    return (
+        SANDBOX_LIVENESS_PROBE_INTERVAL_S * SANDBOX_LIVENESS_PROBE_FAILURES
+        + SANDBOX_GONE_SETTLE_SLACK_S
+        + SANDBOX_STARTUP_SLACK_S
+    )
 
 
 def api(method: str, path: str, *, timeout: float = 120.0, **kw) -> httpx.Response:
@@ -1501,29 +1738,57 @@ def cell_sandbox_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
         )
     session_id = str(uuid.uuid4())
     marker = f"OLIVE{uuid.uuid4().hex[:6].upper()}"
-    msgs = [user_msg(sleep_prompt(marker, 240))]
+    # `since` bounds the runner-log window used to map THIS session to its own sandbox port.
+    since = time.time()
+    msgs = [user_msg(sleep_prompt(marker, SANDBOX_GONE_COMMAND_S))]
     handle = invoke_async(session_id, msgs, cfg, references, "sandbox-turn1")
     turn = wait_for_turn(session_id)
     time.sleep(12)
-    # The sandbox id this session's own turn ledger observed. On daytona this is the ONE sandbox
-    # `kill_sandbox` is allowed to touch (DaytonaAwareHooks); on local it is unused (a local
-    # sandbox is a subprocess of the runner container, found by ps regardless of id).
+    # The sandbox id this session's own turn ledger observed (`local/<host>:<port>` on local, the
+    # remote uuid on Daytona). Used to derive the port on local and to address the remote sandbox
+    # on Daytona; never a shared `ps | grep`, which cannot tell two sessions apart.
     observed_ids = sandbox_ids(session_id)
     target_sandbox_id = observed_ids[-1] if observed_ids else None
-    killed = hooks.kill_sandbox(sandbox_id=target_sandbox_id)
-    handle["thread"].join(timeout=300)
-    t1 = handle["out"] or {}
-    time.sleep(5)
+    settle_budget = sandbox_gone_settle_budget_s()
     evidence = {
         "session_id": session_id,
         "turn_id": turn,
+        "command_seconds": SANDBOX_GONE_COMMAND_S,
+        "settle_budget_seconds": round(settle_budget, 1),
         "target_sandbox_id": target_sandbox_id,
-        "killed_pids": killed,
-        "turn1_errors": t1.get("errors"),
-        "terminal_records": terminal_records(session_id, turn),
-        "stream_after": session_stream(session_id),
     }
-    if not killed:
+    # Target the tested session's OWN sandbox, assert it is a sandbox-agent daemon, and refuse
+    # (never kill a guess) when the mapping cannot be made.
+    try:
+        target = hooks.kill_sandbox_for_session(
+            session_id, sandbox_id=target_sandbox_id, since=since
+        )
+    except WrongSandboxTarget as exc:
+        evidence["wrong_target"] = str(exc)
+        return evidence, _fail(f"wrong target, refused to kill a guess: {exc}")
+    evidence.update(
+        {
+            "killed_port": target.get("port"),
+            "killed_pid": target.get("pid"),
+            "killed_cmdline": target.get("cmdline"),
+            "killed_pids": target.get("killed"),
+        }
+    )
+    # Wait for the runner to end the turn: the probe's three-strikes budget, and never shorter
+    # than the slow command, so a mis-target could not read as "still running" prematurely. The
+    # thread returns as soon as the stream closes, so a healthy kill settles well inside this.
+    wait_s = max(settle_budget, float(SANDBOX_GONE_COMMAND_S)) + SANDBOX_STARTUP_SLACK_S
+    handle["thread"].join(timeout=wait_s)
+    t1 = handle["out"] or {}
+    time.sleep(5)
+    evidence.update(
+        {
+            "turn1_errors": t1.get("errors"),
+            "terminal_records": terminal_records(session_id, turn),
+            "stream_after": session_stream(session_id),
+        }
+    )
+    if not target.get("killed"):
         return evidence, _fail("no sandbox-agent process was found to kill")
     flags = (evidence["stream_after"] or {}).get("flags") or {}
     if flags.get("is_running"):
@@ -1535,7 +1800,7 @@ def cell_sandbox_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
             "no terminal record was written after the sandbox process was killed"
         )
     return evidence, _pass(
-        "killing the sandbox process ended the turn and wrote a terminal record"
+        "killing the tested session's own sandbox ended the turn and wrote a terminal record"
     )
 
 

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -135,6 +135,9 @@ class OperatorHooks:
     def wait_for_runner(self, *, timeout: float = 120.0) -> float | None:
         raise HooksUnavailable
 
+    def ensure_runner_healthy(self, *, timeout: float = 120.0) -> dict:
+        raise HooksUnavailable
+
     def restart_runner(self, grace_seconds: int = 10) -> None:
         raise HooksUnavailable
 
@@ -300,6 +303,33 @@ class DockerComposeHooks(OperatorHooks):
                 return round(time.time() - started, 1)
             time.sleep(1)
         return None
+
+    def ensure_runner_healthy(self, *, timeout: float = 120.0) -> dict:
+        """Recover the runner container to running and healthy, whatever a cell left it in.
+
+        `run_cell()` calls this in a `finally` block after every cell that needs hooks, so a
+        cell that pauses, stops, or restarts the runner and then raises before its own restore
+        code runs does not strand the runner paused or down for the next cell.
+        """
+        paused = (
+            self.dc(
+                "inspect", "-f", "{{.State.Paused}}", f"{self.project}-runner-1"
+            ).strip()
+            == "true"
+        )
+        if paused:
+            self.unpause_runner()
+        status = self.dc(
+            "inspect", "-f", "{{.State.Status}}", f"{self.project}-runner-1"
+        ).strip()
+        if status != "running":
+            self.restart_runner()
+        healthy_after_s = self.wait_for_runner(timeout=timeout)
+        return {
+            "was_paused": paused,
+            "status_before": status,
+            "healthy_after_s": healthy_after_s,
+        }
 
     def restart_runner(self, grace_seconds: int = 10) -> None:
         self.dc(
@@ -1143,8 +1173,12 @@ def cell_records_outage(cfg, references, args, hooks: OperatorHooks) -> Cell:
     wait_for_turn(session_id)
     time.sleep(6)
     hooks.stop_postgres()
-    time.sleep(20)
-    hooks.start_postgres()
+    try:
+        time.sleep(20)
+    finally:
+        # Restore Postgres even if something above raises: a stopped Postgres left behind
+        # strands every cell that runs after this one, not just this one's own assertions.
+        hooks.start_postgres()
     handle["thread"].join(timeout=400)
     landed = []
     deadline = time.time() + 180
@@ -1523,12 +1557,16 @@ def cell_stale_tail(cfg, references, args, hooks: OperatorHooks) -> Cell:
     wait_for_turn(session_id)
     time.sleep(3)
     hooks.pause_runner()
-    deadline = time.time() + args.sweep_wait
-    while time.time() < deadline:
-        if any(r["type"] == "done" for r in hooks.record_rows(session_id)):
-            break
-        time.sleep(5)
-    hooks.unpause_runner()
+    try:
+        deadline = time.time() + args.sweep_wait
+        while time.time() < deadline:
+            if any(r["type"] == "done" for r in hooks.record_rows(session_id)):
+                break
+            time.sleep(5)
+    finally:
+        # A paused runner left behind strands every cell that runs after this one. Restore it
+        # even if hooks.record_rows() above raises.
+        hooks.unpause_runner()
     handle["thread"].join(timeout=180)
     time.sleep(20)
     rows = hooks.record_rows(session_id)
@@ -1606,6 +1644,106 @@ def cell_repeat_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
         )
     return evidence, _pass(
         "two Stops 50ms apart produced exactly one terminal record and a warm resume"
+    )
+
+
+def cell_concurrent_stops(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Five independent sessions, each with a long turn, all Stopped within one second.
+
+    Every Stop must return HTTP 202, every session must read exactly one terminal record, and
+    every session must recall its own codeword on a warm resume. HTTP-only: needs no shell.
+    """
+    n = 5
+    sessions = []
+    for i in range(n):
+        session_id = str(uuid.uuid4())
+        marker = f"NOVA{i}{uuid.uuid4().hex[:5].upper()}"
+        msgs = [user_msg(sleep_prompt(marker, args.sleep_seconds))]
+        handle = invoke_async(
+            session_id, msgs, cfg, references, f"concurrent-turn1-{i}"
+        )
+        sessions.append(
+            {"session_id": session_id, "marker": marker, "msgs": msgs, "handle": handle}
+        )
+
+    for s in sessions:
+        s["turn_id"] = wait_for_turn(s["session_id"])
+    missing_turn = [s["session_id"] for s in sessions if not s["turn_id"]]
+    if missing_turn:
+        evidence = {"n": n, "missing_turn_sessions": missing_turn}
+        return evidence, _fail(
+            f"{len(missing_turn)} of {n} sessions never reported a running turn"
+        )
+    time.sleep(2)
+
+    def fire(s: dict) -> None:
+        s["stop"] = cancel(
+            s["session_id"],
+            expected=s["turn_id"],
+            label=f"concurrent-stop-{s['marker']}",
+        )
+
+    threads = [threading.Thread(target=fire, args=(s,)) for s in sessions]
+    fired_at = time.time()
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    stop_window_s = round(time.time() - fired_at, 3)
+
+    for s in sessions:
+        s["handle"]["thread"].join(timeout=180)
+        s["out"] = s["handle"]["out"] or {}
+    time.sleep(4)
+
+    for s in sessions:
+        s["terminal_records"] = terminal_records(s["session_id"], s["turn_id"])
+        msgs2 = s["msgs"] + [assistant_message(s["out"]), user_msg(RECALL)]
+        t2 = invoke(
+            s["session_id"], msgs2, cfg, references, f"concurrent-turn2-{s['marker']}"
+        )
+        s["resume_recalled_marker"] = s["marker"] in (t2.get("text") or "")
+        s["resume_text"] = (t2.get("text") or "")[:200]
+
+    evidence = {
+        "n": n,
+        "stop_window_s": stop_window_s,
+        "sessions": [
+            {
+                "session_id": s["session_id"],
+                "turn_id": s["turn_id"],
+                "stop_status": s["stop"]["status"],
+                "stop_round_trip_s": s["stop"]["round_trip_s"],
+                "terminal_record_count": len(s["terminal_records"]),
+                "resume_recalled_marker": s["resume_recalled_marker"],
+            }
+            for s in sessions
+        ],
+    }
+    not_202 = [s["session_id"] for s in sessions if s["stop"]["status"] != 202]
+    if not_202:
+        return evidence, _fail(
+            f"{len(not_202)} of {n} concurrent Stops did not return HTTP 202: {not_202}"
+        )
+    bad_terminal = [
+        s["session_id"] for s in sessions if len(s["terminal_records"]) != 1
+    ]
+    if bad_terminal:
+        return evidence, _fail(
+            f"{len(bad_terminal)} of {n} sessions did not read exactly one terminal record: "
+            f"{bad_terminal}"
+        )
+    not_recalled = [
+        s["session_id"] for s in sessions if not s["resume_recalled_marker"]
+    ]
+    if not_recalled:
+        return evidence, _fail(
+            f"{len(not_recalled)} of {n} sessions did not recall their codeword on resume: "
+            f"{not_recalled}"
+        )
+    return evidence, _pass(
+        f"all {n} concurrent Stops returned HTTP 202 within {stop_window_s}s, each session read "
+        "exactly one terminal record, and each resumed warm with its own codeword"
     )
 
 
@@ -1693,8 +1831,54 @@ CELLS: dict[str, tuple[bool, str, "object"]] = {
     "codex-child": (True, "allow", cell_codex_child),
     "stale-tail": (True, "allow", cell_stale_tail),
     "repeat-stop": (False, "allow", cell_repeat_stop),
+    "concurrent-stops": (False, "allow", cell_concurrent_stops),
     "stop-during-completion": (False, "allow", cell_stop_during_completion),
 }
+
+
+def run_cell(
+    name: str, fn, cfg, references, args, hooks: OperatorHooks, needs_hooks: bool
+) -> dict:
+    """Run one cell and return its `results["cells"][name]` entry.
+
+    A cell that pauses, stops, or restarts the runner restores it itself in its own `finally`
+    block (see `cell_stale_tail` and `cell_records_outage`). This is the second, run-level
+    guarantee: a cell that raises BEFORE its own restore code runs must not strand the runner
+    paused or down for the cell that runs after it, so the recovery check here runs in a
+    `finally` block too, no matter how the cell ends.
+    """
+    started = time.time()
+    try:
+        evidence, verdict = fn(cfg, references, args, hooks)
+    except Exception as exc:  # noqa: BLE001
+        import traceback
+
+        evidence = {
+            "driver_error": f"{type(exc).__name__}: {exc}",
+            "traceback": traceback.format_exc()[-1500:],
+        }
+        verdict = _fail(f"driver exception: {type(exc).__name__}: {exc}")
+    finally:
+        if needs_hooks and hooks.available:
+            try:
+                recovery = hooks.ensure_runner_healthy()
+            except Exception as exc:  # noqa: BLE001
+                print(f"[{name}] runner-health recovery failed: {exc}", file=sys.stderr)
+            else:
+                if (
+                    recovery.get("was_paused")
+                    or recovery.get("status_before") != "running"
+                ):
+                    print(f"[{name}] recovered the runner: {recovery}", file=sys.stderr)
+                if recovery.get("healthy_after_s") is None:
+                    print(
+                        f"[{name}] WARNING: the runner did not report healthy after recovery",
+                        file=sys.stderr,
+                    )
+    elapsed = round(time.time() - started, 1)
+    verdict_str = "SKIP" if verdict["skip"] else ("PASS" if verdict["pass"] else "FAIL")
+    print(f"[{name}] {verdict_str} — {verdict['why']}", file=sys.stderr)
+    return {"evidence": evidence, "verdict": verdict, "elapsed_s": elapsed}
 
 
 def main() -> int:
@@ -1787,27 +1971,9 @@ def main() -> int:
         needs_hooks, permission, fn = CELLS[name]
         cfg, references = config_for(permission)
         print(f"\n=== cell {name} ===", file=sys.stderr)
-        started = time.time()
-        try:
-            evidence, verdict = fn(cfg, references, args, hooks)
-        except Exception as exc:  # noqa: BLE001
-            import traceback
-
-            evidence = {
-                "driver_error": f"{type(exc).__name__}: {exc}",
-                "traceback": traceback.format_exc()[-1500:],
-            }
-            verdict = _fail(f"driver exception: {type(exc).__name__}: {exc}")
-        elapsed = round(time.time() - started, 1)
-        verdict_str = (
-            "SKIP" if verdict["skip"] else ("PASS" if verdict["pass"] else "FAIL")
+        results["cells"][name] = run_cell(
+            name, fn, cfg, references, args, hooks, needs_hooks
         )
-        print(f"[{name}] {verdict_str} — {verdict['why']}", file=sys.stderr)
-        results["cells"][name] = {
-            "evidence": evidence,
-            "verdict": verdict,
-            "elapsed_s": elapsed,
-        }
         (outdir / "results.json").write_text(json.dumps(results, indent=2, default=str))
 
     lines = ["| cell | verdict | why |", "|---|---|---|"]

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -1308,6 +1308,99 @@ def cell_restart_after_stop(cfg, references, args, hooks: OperatorHooks) -> Cell
     )
 
 
+def cell_runner_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Restart the runner right after a Stop is claimed, before it can report the outcome.
+
+    The sweep must settle the command as `lost`, not `claimed`, after the stale threshold and
+    the sweep interval both pass. The session_streams row must then read `is_running: false`,
+    and a Send sent after that must run.
+    """
+    if not hooks.available:
+        return {}, _skip("no --project given: restarting the runner needs docker")
+    session_id = str(uuid.uuid4())
+    marker = f"FIG{uuid.uuid4().hex[:6].upper()}"
+    msgs = [user_msg(sleep_prompt(marker, 240))]
+    handle = invoke_async(session_id, msgs, cfg, references, "gone-turn1")
+    turn = wait_for_turn(session_id)
+    time.sleep(5)
+
+    # Stop first, then take the runner away before it can report the outcome.
+    stop = cancel(session_id, expected=turn, label="stop-then-kill")
+    kill_at = time.time()
+    hooks.kill_runner()
+    print(
+        f"[runner-gone] restarted the runner at {time.strftime('%H:%M:%S')}",
+        file=sys.stderr,
+    )
+    handle["thread"].join(timeout=60)
+
+    # Wait for the sweep. The plan budgets the stale threshold plus the sweep interval, held in
+    # --sweep-wait.
+    settled_at = None
+    terminal: list = []
+    deadline = time.time() + args.sweep_wait
+    while time.time() < deadline:
+        stream = session_stream(session_id)
+        flags = stream.get("flags") or {}
+        terminal = terminal_records(session_id, turn)
+        if terminal and not flags.get("is_running"):
+            settled_at = time.time()
+            break
+        time.sleep(5)
+
+    time.sleep(3)
+    commands = hooks.command_rows(session_id)
+    stream_row = hooks.stream_row(session_id)
+    matching = [c for c in commands if turn and c.get("target_turn_id") == turn]
+    stop_command = matching[-1] if matching else (commands[-1] if commands else None)
+    t2 = invoke(
+        session_id,
+        [user_msg(f"The codeword is {marker}. Reply with just the single word READY.")],
+        cfg,
+        references,
+        "gone-turn2",
+    )
+    evidence = {
+        "session_id": session_id,
+        "turn_id": turn,
+        "stop": stop,
+        "seconds_to_settle": round(settled_at - kill_at, 1) if settled_at else None,
+        "terminal_records": terminal,
+        "stream_after": session_stream(session_id),
+        "commands": commands,
+        "stop_command": stop_command,
+        "stream_row": stream_row,
+        "new_message_ran": bool(t2.get("frames")) and not t2.get("errors"),
+        "new_message_errors": t2.get("errors"),
+    }
+    if settled_at is None:
+        return evidence, _fail(
+            "no terminal record settled within the sweep-wait window after the runner was taken away"
+        )
+    if stop_command is None:
+        return evidence, _fail("no session_commands row was found for the Stop")
+    if stop_command.get("state") not in ("obsolete", "applied"):
+        return evidence, _fail(
+            f"the Stop command read state {stop_command.get('state')!r}, expected obsolete or applied"
+        )
+    if stop_command.get("outcome") != "lost":
+        return evidence, _fail(
+            f"the Stop command read outcome {stop_command.get('outcome')!r}, expected lost, not claimed"
+        )
+    if (stream_row.get("flags") or {}).get("is_running") is not False:
+        return evidence, _fail(
+            "the session_streams row did not read is_running: false after the sweep settled the command"
+        )
+    if not evidence["new_message_ran"]:
+        return evidence, _fail(
+            "the Send sent after the runner recovered did not run cleanly"
+        )
+    return evidence, _pass(
+        "the sweep settled the Stop as lost, the stream row read is_running: false, and the "
+        "next Send ran"
+    )
+
+
 def cell_post_stop_row(cfg, references, args, hooks: OperatorHooks) -> Cell:
     """After a Stop the row must read is_running: false within a few seconds."""
     if not hooks.available:
@@ -1595,6 +1688,7 @@ CELLS: dict[str, tuple[bool, str, "object"]] = {
     "records-outage": (True, "allow", cell_records_outage),
     "stop-after-finish": (False, "allow", cell_stop_after_finish),
     "restart-after-stop": (True, "allow", cell_restart_after_stop),
+    "runner-gone": (True, "allow", cell_runner_gone),
     "post-stop-row": (True, "allow", cell_post_stop_row),
     "codex-child": (True, "allow", cell_codex_child),
     "stale-tail": (True, "allow", cell_stale_tail),

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -915,6 +915,46 @@ def _skip(why: str) -> dict:
     return {"pass": False, "skip": True, "why": why}
 
 
+def _judge_runner_gone(evidence: dict) -> dict:
+    """Shared PASS rule for the runner-gone family (`runner-gone`, `runner-gone-late`).
+
+    The invariant: exactly one effective terminal outcome for the execution, no command left
+    pending or claimed, is_running false, and the next Send succeeds. Two different races can
+    land this — the runner reports the Stop's outcome before it dies (`outcome-reported-then-
+    died`), or it never gets the chance and the sweep settles the command `lost`
+    (`never-reported`) — and both satisfy the invariant, so both PASS. Which one landed is
+    recorded on `evidence["race"]` for visibility, not asserted on. Mutates `evidence` in place.
+    """
+    if not evidence.get("terminal_records"):
+        return _fail("no terminal record settled within the sweep-wait window")
+    stop_command = evidence.get("stop_command")
+    if stop_command is None:
+        return _fail("no session_commands row was found for the Stop")
+    if stop_command.get("state") not in ("obsolete", "applied"):
+        return _fail(
+            f"the Stop command read state {stop_command.get('state')!r}, expected obsolete or applied"
+        )
+    outcome = stop_command.get("outcome")
+    if outcome in (None, "", "pending", "claimed"):
+        return _fail(
+            f"the Stop command was left {outcome!r}: still pending or claimed, never settled"
+        )
+    stream_row = evidence.get("stream_row") or {}
+    if (stream_row.get("flags") or {}).get("is_running") is not False:
+        return _fail(
+            "the session_streams row did not read is_running: false after the sweep settled "
+            "the command"
+        )
+    if not evidence.get("new_message_ran"):
+        return _fail("the Send sent after recovery did not run cleanly")
+    race = "never-reported" if outcome == "lost" else "outcome-reported-then-died"
+    evidence["race"] = race
+    return _pass(
+        f"race {race}: the Stop command settled off pending/claimed, is_running read false, "
+        "and the next Send ran"
+    )
+
+
 def cell_stop_warm(cfg, references, args, hooks: OperatorHooks) -> Cell:
     """Stop under 5 s, park, warm resume that recalls the codeword. Needs no shell."""
     session_id = str(uuid.uuid4())
@@ -1343,14 +1383,18 @@ def cell_restart_after_stop(cfg, references, args, hooks: OperatorHooks) -> Cell
 
 
 def cell_runner_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
-    """Restart the runner right after a Stop is claimed, before it can report the outcome.
+    """Pause the runner BEFORE the Stop, so the command can never be claimed or reported.
 
-    The sweep must settle the command as `lost`, not `claimed`, after the stale threshold and
-    the sweep interval both pass. The session_streams row must then read `is_running: false`,
-    and a Send sent after that must run.
+    Deterministic version of the hard race: hoping a restart lands between the Stop and the
+    runner's own outcome report is timing-dependent and mostly loses the race (see
+    `runner-gone-late`). Pausing first removes the timing dependency: the runner cannot claim
+    or report the command at all, so it must stay `pending` until the stale threshold and the
+    sweep interval both pass (--sweep-wait), at which point the sweep must settle it `lost`
+    (state `obsolete` or `applied`, outcome `lost`) and write the execution's own watchdog
+    `execution_lost` ending. Unpause, confirm healthy, then send the next message.
     """
     if not hooks.available:
-        return {}, _skip("no --project given: restarting the runner needs docker")
+        return {}, _skip("no --project given: pausing the runner needs docker")
     session_id = str(uuid.uuid4())
     marker = f"FIG{uuid.uuid4().hex[:6].upper()}"
     msgs = [user_msg(sleep_prompt(marker, 240))]
@@ -1358,12 +1402,124 @@ def cell_runner_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
     turn = wait_for_turn(session_id)
     time.sleep(5)
 
-    # Stop first, then take the runner away before it can report the outcome.
+    hooks.pause_runner()
+    try:
+        # The runner is paused: it cannot claim or report the Stop. Fire it anyway — the API
+        # accepts and enqueues the command whether or not the runner is reachable.
+        stop = cancel(session_id, expected=turn, label="stop-then-pause")
+        stop_at = time.time()
+
+        # Wait for the sweep. The plan budgets the stale threshold plus the sweep interval,
+        # held in --sweep-wait.
+        settled_at = None
+        terminal: list = []
+        deadline = time.time() + args.sweep_wait
+        while time.time() < deadline:
+            stream = session_stream(session_id)
+            flags = stream.get("flags") or {}
+            terminal = terminal_records(session_id, turn)
+            if terminal and not flags.get("is_running"):
+                settled_at = time.time()
+                break
+            time.sleep(5)
+
+        time.sleep(3)
+        commands = hooks.command_rows(session_id)
+        stream_row = hooks.stream_row(session_id)
+    finally:
+        # Unpause even if the wait above raises: a paused runner left behind strands every
+        # cell that runs after this one.
+        hooks.unpause_runner()
+    healthy_after_s = hooks.wait_for_runner()
+
+    matching = [c for c in commands if turn and c.get("target_turn_id") == turn]
+    stop_command = matching[-1] if matching else (commands[-1] if commands else None)
+
+    handle["thread"].join(timeout=60)
+    t2 = invoke(
+        session_id,
+        [user_msg(f"The codeword is {marker}. Reply with just the single word READY.")],
+        cfg,
+        references,
+        "gone-turn2",
+    )
+    evidence = {
+        "session_id": session_id,
+        "turn_id": turn,
+        "stop": stop,
+        "seconds_to_settle": round(settled_at - stop_at, 1) if settled_at else None,
+        "terminal_records": terminal,
+        "stream_after": session_stream(session_id),
+        "commands": commands,
+        "stop_command": stop_command,
+        "stream_row": stream_row,
+        "healthy_after_unpause_s": healthy_after_s,
+        "new_message_ran": bool(t2.get("frames")) and not t2.get("errors"),
+        "new_message_errors": t2.get("errors"),
+    }
+    if healthy_after_s is None:
+        return evidence, _fail("the runner never reported healthy after the unpause")
+    if settled_at is None:
+        return evidence, _fail(
+            "no terminal record settled within the sweep-wait window while the runner was paused"
+        )
+    if stop_command is None:
+        return evidence, _fail("no session_commands row was found for the Stop")
+    if stop_command.get("state") not in ("obsolete", "applied"):
+        return evidence, _fail(
+            f"the Stop command read state {stop_command.get('state')!r}, expected obsolete or applied"
+        )
+    if stop_command.get("outcome") != "lost":
+        return evidence, _fail(
+            f"the Stop command read outcome {stop_command.get('outcome')!r}, expected lost: a "
+            "paused runner should never have been able to report it"
+        )
+    watchdog_ending = [
+        r
+        for r in terminal
+        if r.get("type") == "error"
+        and (r.get("attributes") or {}).get("code") == "execution_lost"
+        and (r.get("attributes") or {}).get("settled_by") == "watchdog"
+    ]
+    if not watchdog_ending:
+        return evidence, _fail(
+            "no watchdog execution_lost ending was found among the terminal records"
+        )
+    evidence["race"] = "never-reported"
+    if (stream_row.get("flags") or {}).get("is_running") is not False:
+        return evidence, _fail(
+            "the session_streams row did not read is_running: false after the sweep settled the command"
+        )
+    if not evidence["new_message_ran"]:
+        return evidence, _fail("the Send sent after the unpause did not run cleanly")
+    return evidence, _pass(
+        "pausing the runner first deterministically forced the never-reported race: the sweep "
+        "settled the Stop lost with a watchdog execution_lost ending, the stream row read "
+        "is_running: false, and the next Send ran"
+    )
+
+
+def cell_runner_gone_late(cfg, references, args, hooks: OperatorHooks) -> Cell:
+    """Restart the runner right after a Stop is claimed, hoping it lands before the runner can
+    report the outcome. The softer, timing-dependent sibling of `runner-gone`: a restart often
+    loses this race (the runner reports the Stop's outcome before it actually dies), so this
+    cell accepts either race the sweep can produce — see `_judge_runner_gone`.
+    """
+    if not hooks.available:
+        return {}, _skip("no --project given: restarting the runner needs docker")
+    session_id = str(uuid.uuid4())
+    marker = f"FIG{uuid.uuid4().hex[:6].upper()}"
+    msgs = [user_msg(sleep_prompt(marker, 240))]
+    handle = invoke_async(session_id, msgs, cfg, references, "gone-late-turn1")
+    turn = wait_for_turn(session_id)
+    time.sleep(5)
+
+    # Stop first, then take the runner away before it can (maybe) report the outcome.
     stop = cancel(session_id, expected=turn, label="stop-then-kill")
     kill_at = time.time()
     hooks.kill_runner()
     print(
-        f"[runner-gone] restarted the runner at {time.strftime('%H:%M:%S')}",
+        f"[runner-gone-late] restarted the runner at {time.strftime('%H:%M:%S')}",
         file=sys.stderr,
     )
     handle["thread"].join(timeout=60)
@@ -1392,7 +1548,7 @@ def cell_runner_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
         [user_msg(f"The codeword is {marker}. Reply with just the single word READY.")],
         cfg,
         references,
-        "gone-turn2",
+        "gone-late-turn2",
     )
     evidence = {
         "session_id": session_id,
@@ -1407,32 +1563,7 @@ def cell_runner_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "new_message_ran": bool(t2.get("frames")) and not t2.get("errors"),
         "new_message_errors": t2.get("errors"),
     }
-    if settled_at is None:
-        return evidence, _fail(
-            "no terminal record settled within the sweep-wait window after the runner was taken away"
-        )
-    if stop_command is None:
-        return evidence, _fail("no session_commands row was found for the Stop")
-    if stop_command.get("state") not in ("obsolete", "applied"):
-        return evidence, _fail(
-            f"the Stop command read state {stop_command.get('state')!r}, expected obsolete or applied"
-        )
-    if stop_command.get("outcome") != "lost":
-        return evidence, _fail(
-            f"the Stop command read outcome {stop_command.get('outcome')!r}, expected lost, not claimed"
-        )
-    if (stream_row.get("flags") or {}).get("is_running") is not False:
-        return evidence, _fail(
-            "the session_streams row did not read is_running: false after the sweep settled the command"
-        )
-    if not evidence["new_message_ran"]:
-        return evidence, _fail(
-            "the Send sent after the runner recovered did not run cleanly"
-        )
-    return evidence, _pass(
-        "the sweep settled the Stop as lost, the stream row read is_running: false, and the "
-        "next Send ran"
-    )
+    return evidence, _judge_runner_gone(evidence)
 
 
 def cell_post_stop_row(cfg, references, args, hooks: OperatorHooks) -> Cell:
@@ -1827,6 +1958,7 @@ CELLS: dict[str, tuple[bool, str, "object"]] = {
     "stop-after-finish": (False, "allow", cell_stop_after_finish),
     "restart-after-stop": (True, "allow", cell_restart_after_stop),
     "runner-gone": (True, "allow", cell_runner_gone),
+    "runner-gone-late": (True, "allow", cell_runner_gone_late),
     "post-stop-row": (True, "allow", cell_post_stop_row),
     "codex-child": (True, "allow", cell_codex_child),
     "stale-tail": (True, "allow", cell_stale_tail),

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -1054,6 +1054,12 @@ def cell_stop_approval(cfg_ask, references_ask, args, hooks: OperatorHooks) -> C
         "stop": stop,
         "late_answer": late,
         "resume_recalled_marker": marker in (t2.get("text") or ""),
+        # Without the actual reply, a FAIL here cannot be told apart from a driver replay bug
+        # (the reconstructed `output-denied` part shaped wrong) versus the model genuinely not
+        # recalling the codeword -- keep enough of the wire to tell the two apart after the fact.
+        "resume_text": (t2.get("text") or "")[:400],
+        "resume_frames": t2.get("frames", [])[:20],
+        "resume_errors": t2.get("errors"),
     }
     evidence["sandbox_ids"] = sandbox_ids(session_id)
     evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -1015,6 +1015,76 @@ def _recover_then_send(health_poll, send, *, timeout, poll_interval, clock=time)
     return healthy, result
 
 
+def _measure_runner_gone_while_paused(
+    hooks,
+    session_id,
+    turn,
+    do_stop,
+    read_terminal,
+    *,
+    sweep_wait,
+    poll_interval=5.0,
+    clock=time,
+):
+    """Pause the runner, fire the Stop while it is gone, wait for the sweep to settle it lost, and
+    read is_running from the stream row WHILE THE RUNNER IS STILL PAUSED.
+
+    The pause is the whole assertion. "Runner gone" must be measured while the runner is still
+    gone: once it is unpaused it starts a new turn on the same session that legitimately sets
+    is_running true again, so a read after the unpause sees that new turn and misreads a healthy
+    recovery as a failure. Settlement is detected on the durable rows — the Stop command reaching
+    `obsolete`/`applied` with outcome `lost`, or an execution row carrying a terminal outcome —
+    not on the volatile stream. Unpauses on every path. Returns the paused measurements."""
+    stop = None
+    stop_at = None
+    settled_at = None
+    paused_read_at = None
+    stream_row = None
+    stop_command = None
+    commands: list = []
+    executions: list = []
+    terminal: list = []
+    hooks.pause_runner()
+    try:
+        stop = do_stop()
+        stop_at = clock.time()
+        deadline = clock.time() + sweep_wait
+        while True:
+            commands = hooks.command_rows(session_id)
+            stop_command = _match_stop_command(commands, turn)
+            executions = hooks.execution_rows(session_id)
+            command_settled = (
+                stop_command is not None
+                and stop_command.get("state") in ("obsolete", "applied")
+                and stop_command.get("outcome") == "lost"
+            )
+            execution_lost = any(e.get("terminal_outcome") for e in executions)
+            if command_settled or execution_lost:
+                settled_at = clock.time()
+                break
+            if clock.time() >= deadline:
+                break
+            clock.sleep(poll_interval)
+        terminal = read_terminal()
+        # THE gone-and-stays-gone read: is_running, taken while the runner is still paused.
+        stream_row = hooks.stream_row(session_id)
+        paused_read_at = clock.time()
+    finally:
+        # Unpause on every path: a paused runner left behind strands every later cell.
+        hooks.unpause_runner()
+    return {
+        "stop": stop,
+        "stop_at": stop_at,
+        "settled_at": settled_at,
+        "paused_read_at": paused_read_at,
+        "stream_row": stream_row,
+        "stop_command": stop_command,
+        "commands": commands,
+        "executions": executions,
+        "terminal": terminal,
+    }
+
+
 def api(method: str, path: str, *, timeout: float = 120.0, **kw) -> httpx.Response:
     headers = {
         "Authorization": STATE["credentials"],
@@ -2230,7 +2300,13 @@ def cell_runner_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
     or report the command at all, so it must stay `pending` until the stale threshold and the
     sweep interval both pass (--sweep-wait), at which point the sweep must settle it `lost`
     (state `obsolete` or `applied`, outcome `lost`) and write the execution's own watchdog
-    `execution_lost` ending. Unpause, confirm healthy, then send the next message.
+    `execution_lost` ending.
+
+    Every gone-and-stays-gone signal — the settled command, the watchdog ending, and is_running:
+    false — is read WHILE THE RUNNER IS STILL PAUSED. Reading after the unpause is the run-2b bug:
+    the returning runner starts a new turn on the same session that legitimately sets is_running
+    true. The unpause and the Send that follows are only a restore step plus an OPTIONAL, separately
+    recorded resumability check; they are not part of this cell's pass.
     """
     if not hooks.available:
         return {}, _skip("no --project given: pausing the runner needs docker")
@@ -2241,65 +2317,81 @@ def cell_runner_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
     turn = wait_for_turn(session_id)
     time.sleep(5)
 
-    hooks.pause_runner()
-    try:
-        # The runner is paused: it cannot claim or report the Stop. Fire it anyway — the API
-        # accepts and enqueues the command whether or not the runner is reachable.
-        stop = cancel(session_id, expected=turn, label="stop-then-pause")
-        stop_at = time.time()
-
-        # Wait for the sweep. The plan budgets the stale threshold plus the sweep interval,
-        # held in --sweep-wait.
-        settled_at = None
-        terminal: list = []
-        deadline = time.time() + args.sweep_wait
-        while time.time() < deadline:
-            stream = session_stream(session_id)
-            flags = stream.get("flags") or {}
-            terminal = terminal_records(session_id, turn)
-            if terminal and not flags.get("is_running"):
-                settled_at = time.time()
-                break
-            time.sleep(5)
-
-        time.sleep(3)
-        commands = hooks.command_rows(session_id)
-        stream_row = hooks.stream_row(session_id)
-    finally:
-        # Unpause even if the wait above raises: a paused runner left behind strands every
-        # cell that runs after this one.
-        hooks.unpause_runner()
-    healthy_after_s = hooks.wait_for_runner()
-
-    stop_command = _match_stop_command(commands, turn)
-
-    handle["thread"].join(timeout=60)
-    t2 = invoke(
+    # Pause, Stop, settle, and READ is_running all while the runner is still gone. Measuring after
+    # the unpause is the run-2b bug: the returning runner starts a new turn on the same session
+    # that legitimately sets is_running true, and the driver read that true.
+    measured = _measure_runner_gone_while_paused(
+        hooks,
         session_id,
-        [user_msg(f"The codeword is {marker}. Reply with just the single word READY.")],
-        cfg,
-        references,
-        "gone-turn2",
+        turn,
+        do_stop=lambda: cancel(session_id, expected=turn, label="stop-then-pause"),
+        read_terminal=lambda: terminal_records(session_id, turn),
+        sweep_wait=args.sweep_wait,
     )
+    stop = measured["stop"]
+    settled_at = measured["settled_at"]
+    stop_command = measured["stop_command"]
+    terminal = measured["terminal"]
+    stream_row = measured["stream_row"]
+    paused_is_running = (
+        (stream_row.get("flags") or {}).get("is_running") if stream_row else None
+    )
+
+    # The runner is back. Restore health, then run an OPTIONAL, separately-recorded resumability
+    # check — a Send after health. It is NOT part of the runner-gone verdict: a returning runner
+    # starting a new turn is exactly the signal that must not count against "gone".
+    healthy_after_s = hooks.wait_for_runner()
+    resume: dict = {"attempted": False}
+    if healthy_after_s is not None:
+        handle["thread"].join(timeout=60)
+        runner_recovered, t2 = _recover_then_send(
+            health_poll=hooks.runner_healthy,
+            send=lambda: invoke(
+                session_id,
+                [
+                    user_msg(
+                        f"The codeword is {marker}. Reply with just the single word READY."
+                    )
+                ],
+                cfg,
+                references,
+                "gone-turn2",
+            ),
+            timeout=RECOVERY_HEALTH_TIMEOUT_S,
+            poll_interval=RECOVERY_HEALTH_POLL_S,
+        )
+        t2 = t2 or {}
+        resume = {
+            "attempted": True,
+            "runner_recovered": runner_recovered,
+            "ran": bool(t2.get("frames")) and not t2.get("errors"),
+            "errors": t2.get("errors"),
+        }
+
     evidence = {
         "session_id": session_id,
         "turn_id": turn,
         "stop": stop,
-        "seconds_to_settle": round(settled_at - stop_at, 1) if settled_at else None,
+        "settled_at": measured["settled_at"],
+        "paused_read_at": measured["paused_read_at"],
+        "seconds_to_settle": (
+            round(settled_at - measured["stop_at"], 1)
+            if settled_at and measured["stop_at"]
+            else None
+        ),
         "terminal_records": terminal,
-        "stream_after": session_stream(session_id),
-        "commands": commands,
+        "commands": measured["commands"],
+        "executions": measured["executions"],
         "stop_command": stop_command,
-        "stream_row": stream_row,
+        "stream_row_while_paused": stream_row,
+        "is_running_while_paused": paused_is_running,
         "healthy_after_unpause_s": healthy_after_s,
-        "new_message_ran": bool(t2.get("frames")) and not t2.get("errors"),
-        "new_message_errors": t2.get("errors"),
+        "resumability": resume,
     }
-    if healthy_after_s is None:
-        return evidence, _fail("the runner never reported healthy after the unpause")
+    # Gone-and-stays-gone verdict, every signal measured WHILE the runner was still paused.
     if settled_at is None:
         return evidence, _fail(
-            "no terminal record settled within the sweep-wait window while the runner was paused"
+            "the Stop was not settled lost within the sweep-wait window while the runner was paused"
         )
     if stop_command is None:
         return evidence, _fail("no session_commands row was found for the Stop")
@@ -2323,17 +2415,15 @@ def cell_runner_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
         return evidence, _fail(
             "no watchdog execution_lost ending was found among the terminal records"
         )
-    evidence["race"] = "never-reported"
-    if (stream_row.get("flags") or {}).get("is_running") is not False:
+    if paused_is_running is not False:
         return evidence, _fail(
-            "the session_streams row did not read is_running: false after the sweep settled the command"
+            "the session_streams row did not read is_running: false while the runner was still paused"
         )
-    if not evidence["new_message_ran"]:
-        return evidence, _fail("the Send sent after the unpause did not run cleanly")
+    evidence["race"] = "never-reported"
     return evidence, _pass(
-        "pausing the runner first deterministically forced the never-reported race: the sweep "
-        "settled the Stop lost with a watchdog execution_lost ending, the stream row read "
-        "is_running: false, and the next Send ran"
+        "pausing the runner first forced the never-reported race: while the runner was still gone "
+        "the sweep settled the Stop lost with a watchdog execution_lost ending and the stream row "
+        "read is_running: false"
     )
 
 

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -1662,8 +1662,11 @@ def main() -> int:
             )
         return built[permission]
 
+    # PID, not just the second-resolution timestamp: two invocations started in the same second
+    # (e.g. two harnesses smoke-tested in parallel) would otherwise share a folder and the
+    # second writer silently clobbers the first one's results.json mid-run.
     stamp = time.strftime("%Y%m%d-%H%M%S")
-    outdir = RUNS / f"{stamp}-session-control"
+    outdir = RUNS / f"{stamp}-{os.getpid()}-session-control"
     outdir.mkdir(parents=True, exist_ok=True)
 
     results: dict = {

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -585,6 +585,27 @@ HARNESSES = {
     },
 }
 
+# Read timeout for the SSE stream `invoke()` opens, per harness kind (`cfg["harness"]["kind"]`,
+# the same key HARNESSES above sets). Pi is a single in-process model loop; Codex and Claude Code
+# are agentic CLIs behind an ACP bridge and routinely take longer per turn under load, so their
+# budget is about 1.5x Pi's — high enough that a genuinely slow-but-healthy turn does not trip
+# the driver's OWN httpx.ReadTimeout and get misread as a product failure (concurrent-stops hit
+# exactly this on Claude Code). A cell whose Stop settlement is the actual problem is caught by
+# `assert_command_settled` well before this ever fires, at its own fixed 20s budget regardless of
+# harness — this table is about not confusing "the driver gave up too early" with "the product is
+# broken", not about giving a broken product more rope.
+STREAM_TIMEOUT_S = {
+    "pi_core": 600.0,
+    "codex": 900.0,
+    "claude": 900.0,
+}
+DEFAULT_STREAM_TIMEOUT_S = 600.0
+
+
+def stream_timeout_s(cfg: dict) -> float:
+    kind = (cfg.get("harness") or {}).get("kind")
+    return STREAM_TIMEOUT_S.get(kind, DEFAULT_STREAM_TIMEOUT_S)
+
 
 def api(method: str, path: str, *, timeout: float = 120.0, **kw) -> httpx.Response:
     headers = {
@@ -844,7 +865,7 @@ def invoke(
         }
     )
     started = time.time()
-    with httpx.Client(timeout=600.0) as client:
+    with httpx.Client(timeout=stream_timeout_s(cfg)) as client:
         with client.stream(
             "POST",
             url,

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -126,7 +126,7 @@ class OperatorHooks:
     def runner_log(self, since: float) -> list[str]:
         raise HooksUnavailable
 
-    def sandbox_procs(self, marker: str) -> list[dict]:
+    def sandbox_procs(self, marker: str, sandbox_id: str | None = None) -> list[dict]:
         raise HooksUnavailable
 
     def stream_row(self, session_id: str) -> dict:
@@ -162,7 +162,7 @@ class OperatorHooks:
     def start_postgres(self) -> None:
         raise HooksUnavailable
 
-    def kill_sandbox(self) -> list[str]:
+    def kill_sandbox(self, sandbox_id: str | None = None) -> list[str]:
         raise HooksUnavailable
 
 
@@ -219,7 +219,11 @@ class DockerComposeHooks(OperatorHooks):
         except Exception as exc:  # noqa: BLE001
             return [f"<docker logs failed: {exc}>"]
 
-    def sandbox_procs(self, marker: str) -> list[dict]:
+    def sandbox_procs(self, marker: str, sandbox_id: str | None = None) -> list[dict]:
+        # A local sandbox IS a subprocess of the runner container, so `ps` inside the runner
+        # sees it regardless of which session owns it. `sandbox_id` is accepted for interface
+        # parity with the Daytona-aware hook (which needs it to pick a remote sandbox) and
+        # ignored here.
         raw = self.dc(
             "exec", f"{self.project}-runner-1", "ps", "-eo", "pid,ppid,etimes,args"
         )
@@ -357,7 +361,10 @@ class DockerComposeHooks(OperatorHooks):
     def start_postgres(self) -> None:
         self.dc("start", f"{self.project}-postgres-1")
 
-    def kill_sandbox(self) -> list[str]:
+    def kill_sandbox(self, sandbox_id: str | None = None) -> list[str]:
+        # A local sandbox is a subprocess of the runner container: there is only ever one
+        # `sandbox-agent server` process family running there per cell, so `sandbox_id` (accepted
+        # for interface parity with the Daytona-aware hook) is not needed to target it.
         ps = self.dc(
             "exec",
             f"{self.project}-runner-1",
@@ -375,6 +382,158 @@ class DockerComposeHooks(OperatorHooks):
                 f"kill -9 -{pid} || kill -9 {pid}",
             )
         return pids
+
+
+class DaytonaAwareHooks(DockerComposeHooks):
+    """`DockerComposeHooks` plus a Daytona-provider-aware `kill_sandbox` and `sandbox_procs`.
+
+    A local sandbox is a subprocess of the runner container, so the base class's `docker exec ps`
+    sees it. A Daytona sandbox is a remote machine: `docker exec` into the runner container never
+    sees the sandbox's process table, and killing a local process cannot end a remote sandbox. So
+    for `--sandbox daytona` this hook ends the sandbox and lists its processes through the same
+    Daytona REST API the runner itself uses (`services/runner/src/engines/sandbox_agent/
+    daytona-provider.ts`'s `sandbox.delete()`, and the vendored `sandbox-agent/daytona` provider's
+    `runProcess`, which `reap-exec.ts` drives with the identical `ps -eo pid=,ppid=,etimes=,args=`
+    used below).
+
+    Every call is scoped to the ONE sandbox id the cell observed for its own session
+    (`sandbox_ids(session_id)` in the driver, threaded in by the caller) — never a list, never a
+    wildcard. Credentials come from `AGENTA_RUNNER_DAYTONA_API_KEY` / `AGENTA_RUNNER_DAYTONA_API_URL`
+    (export only; never logged, never put in an exception message).
+    """
+
+    def __init__(self, project: str) -> None:
+        super().__init__(project)
+        missing = [
+            name
+            for name in (
+                "AGENTA_RUNNER_DAYTONA_API_KEY",
+                "AGENTA_RUNNER_DAYTONA_API_URL",
+            )
+            if not os.environ.get(name)
+        ]
+        if missing:
+            raise SystemExit(
+                "--sandbox daytona needs " + ", ".join(missing) + " exported (from the "
+                "integration env file's AGENTA_RUNNER_DAYTONA_* block) so sandbox-gone and "
+                "codex-child can reach the Daytona API directly."
+            )
+        self._daytona_api_url = os.environ["AGENTA_RUNNER_DAYTONA_API_URL"].rstrip("/")
+        self._daytona_api_key = os.environ["AGENTA_RUNNER_DAYTONA_API_KEY"]
+
+    @staticmethod
+    def _bare_id(sandbox_id: str) -> str:
+        """`sandbox_ids()` returns ids like `daytona/<uuid>`; the Daytona API wants the bare uuid."""
+        return sandbox_id.split("/", 1)[1] if "/" in sandbox_id else sandbox_id
+
+    def _daytona_get(self, path: str) -> httpx.Response:
+        return httpx.get(
+            f"{self._daytona_api_url}{path}",
+            headers={"Authorization": f"Bearer {self._daytona_api_key}"},
+            timeout=30.0,
+        )
+
+    def _daytona_delete(self, path: str) -> httpx.Response:
+        return httpx.delete(
+            f"{self._daytona_api_url}{path}",
+            headers={"Authorization": f"Bearer {self._daytona_api_key}"},
+            timeout=30.0,
+        )
+
+    def kill_sandbox(self, sandbox_id: str | None = None) -> list[str]:
+        if not sandbox_id:
+            return []
+        bare = self._bare_id(sandbox_id)
+        try:
+            resp = self._daytona_delete(f"/sandbox/{bare}")
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"[daytona] delete sandbox={bare} failed: {exc}",
+                file=sys.stderr,
+            )
+            return []
+        # DELETE /sandbox/{id} is what `sandbox.delete()` calls on this same SDK/API version
+        # (Sandbox.js -> SandboxApi.deleteSandbox); a 404 means it is already gone, also success
+        # for "the sandbox is gone" purposes.
+        if resp.status_code not in (200, 202, 204, 404):
+            print(
+                f"[daytona] delete sandbox={bare} returned {resp.status_code}: "
+                f"{resp.text[:200]}",
+                file=sys.stderr,
+            )
+            return []
+        return [bare]
+
+    def sandbox_procs(self, marker: str, sandbox_id: str | None = None) -> list[dict]:
+        if not sandbox_id:
+            return []
+        bare = self._bare_id(sandbox_id)
+        try:
+            proxy = self._daytona_get(f"/sandbox/{bare}/toolbox-proxy-url")
+            if proxy.status_code != 200:
+                print(
+                    f"[daytona] toolbox-proxy-url sandbox={bare} returned "
+                    f"{proxy.status_code}: {proxy.text[:200]}",
+                    file=sys.stderr,
+                )
+                return []
+            proxy_url = (proxy.json() or {}).get("url")
+            if not proxy_url:
+                print(
+                    f"[daytona] toolbox-proxy-url sandbox={bare} returned no url",
+                    file=sys.stderr,
+                )
+                return []
+            # Same shape as `reap-exec.ts`'s `PS_ARGS` (`-eo pid=,ppid=,etimes=,args=`): the `=`
+            # suffixes drop the header line, so every returned line is a data row.
+            exec_resp = httpx.post(
+                f"{proxy_url.rstrip('/')}/process/execute",
+                json={"command": "ps -eo pid=,ppid=,etimes=,args=", "timeout": 10},
+                timeout=20.0,
+            )
+        except Exception as exc:  # noqa: BLE001
+            print(
+                f"[daytona] process listing sandbox={bare} failed: {exc}",
+                file=sys.stderr,
+            )
+            return []
+        if exec_resp.status_code != 200:
+            print(
+                f"[daytona] process/execute sandbox={bare} returned "
+                f"{exec_resp.status_code}: {exec_resp.text[:200]}",
+                file=sys.stderr,
+            )
+            return []
+        raw = (exec_resp.json() or {}).get("result", "") or ""
+        hits = []
+        for line in raw.splitlines():
+            parts = line.split(None, 3)
+            if len(parts) < 4 or marker not in parts[3]:
+                continue
+            if "ps -eo" in parts[3] or parts[3].startswith("grep"):
+                continue
+            hits.append(
+                {
+                    "pid": parts[0],
+                    "ppid": parts[1],
+                    "etimes": parts[2],
+                    "args": parts[3][:120],
+                }
+            )
+        return hits
+
+
+def select_hooks(project: str | None, sandbox: str) -> OperatorHooks:
+    """The provider switch: no `--project` is NullHooks regardless of `--sandbox`; with a
+    project, `--sandbox daytona` needs the Daytona-aware hook (docker exec cannot see or touch a
+    remote sandbox), everything else gets the plain docker-compose hook. Pulled out of `main()` so
+    it is unit-testable without a live stack.
+    """
+    if not project:
+        return NullHooks()
+    if sandbox == "daytona":
+        return DaytonaAwareHooks(project)
+    return DockerComposeHooks(project)
 
 
 # --------------------------------------------------------------------------- #
@@ -1221,13 +1380,19 @@ def cell_sandbox_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
     handle = invoke_async(session_id, msgs, cfg, references, "sandbox-turn1")
     turn = wait_for_turn(session_id)
     time.sleep(12)
-    killed = hooks.kill_sandbox()
+    # The sandbox id this session's own turn ledger observed. On daytona this is the ONE sandbox
+    # `kill_sandbox` is allowed to touch (DaytonaAwareHooks); on local it is unused (a local
+    # sandbox is a subprocess of the runner container, found by ps regardless of id).
+    observed_ids = sandbox_ids(session_id)
+    target_sandbox_id = observed_ids[-1] if observed_ids else None
+    killed = hooks.kill_sandbox(sandbox_id=target_sandbox_id)
     handle["thread"].join(timeout=300)
     t1 = handle["out"] or {}
     time.sleep(5)
     evidence = {
         "session_id": session_id,
         "turn_id": turn,
+        "target_sandbox_id": target_sandbox_id,
         "killed_pids": killed,
         "turn1_errors": t1.get("errors"),
         "terminal_records": terminal_records(session_id, turn),
@@ -1676,19 +1841,27 @@ def cell_codex_child(cfg, references, args, hooks: OperatorHooks) -> Cell:
     ]
     handle = invoke_async(session_id, msgs, cfg, references, "codex-turn1")
     turn = wait_for_turn(session_id, timeout=90)
+    # The sandbox id this session's turn ledger observed. On daytona, `sandbox_procs` needs this
+    # to know which remote sandbox to list processes on (DaytonaAwareHooks); on local it is
+    # unused (docker exec into the runner container sees every local sandbox subprocess).
+    observed_ids = sandbox_ids(session_id)
+    target_sandbox_id = observed_ids[-1] if observed_ids else None
     child_before = []
     deadline = time.time() + 120
     while time.time() < deadline:
-        child_before = hooks.sandbox_procs(marker)
+        child_before = hooks.sandbox_procs(marker, sandbox_id=target_sandbox_id)
         if child_before:
             break
+        if not target_sandbox_id:
+            observed_ids = sandbox_ids(session_id)
+            target_sandbox_id = observed_ids[-1] if observed_ids else None
         time.sleep(1)
     stop = cancel(session_id, expected=turn, label="stop-codex")
     handle["thread"].join(timeout=180)
     gone_at = None
     deadline = time.time() + 45
     while time.time() < deadline:
-        alive = hooks.sandbox_procs(marker)
+        alive = hooks.sandbox_procs(marker, sandbox_id=target_sandbox_id)
         if not alive:
             gone_at = round(time.time() - stop["sent_at"], 1)
             break
@@ -1704,6 +1877,7 @@ def cell_codex_child(cfg, references, args, hooks: OperatorHooks) -> Cell:
     evidence = {
         "session_id": session_id,
         "turn_id": turn,
+        "target_sandbox_id": target_sandbox_id,
         "child_before_stop": child_before,
         "stop": stop,
         "seconds_until_child_gone": gone_at,
@@ -2104,9 +2278,7 @@ def main() -> int:
         raise SystemExit(f"unknown cells: {unknown}; known: {sorted(CELLS)}")
 
     resolve_env()
-    hooks: OperatorHooks = (
-        DockerComposeHooks(args.project) if args.project else NullHooks()
-    )
+    hooks = select_hooks(args.project, args.sandbox)
     if args.sandbox == "daytona":
         global SANDBOX_STARTUP_SLACK_S
         SANDBOX_STARTUP_SLACK_S = 25.0

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -138,6 +138,9 @@ class OperatorHooks:
     def command_rows(self, session_id: str) -> list[dict]:
         raise HooksUnavailable
 
+    def execution_rows(self, session_id: str) -> list[dict]:
+        raise HooksUnavailable
+
     def wait_for_runner(self, *, timeout: float = 120.0) -> float | None:
         raise HooksUnavailable
 
@@ -301,6 +304,24 @@ class DockerComposeHooks(OperatorHooks):
             }
             for r in rows
             if len(r) >= 5
+        ]
+
+    def execution_rows(self, session_id: str) -> list[dict]:
+        rows = self.psql(
+            "agenta_ee_core",
+            "select execution_id, terminal_outcome, coalesce(settled_by,''), "
+            "coalesce(to_char(settled_at,'HH24:MI:SS.MS'),'') from session_executions "
+            f"where session_id = '{session_id}' order by settled_at",
+        )
+        return [
+            {
+                "execution_id": r[0],
+                "terminal_outcome": r[1] or None,
+                "settled_by": r[2] or None,
+                "settled_at": r[3] or None,
+            }
+            for r in rows
+            if len(r) >= 4
         ]
 
     def wait_for_runner(self, *, timeout: float = 120.0) -> float | None:
@@ -1125,6 +1146,75 @@ def _skip(why: str) -> dict:
     return {"pass": False, "skip": True, "why": why}
 
 
+def _match_stop_command(commands: list[dict], turn_id: str | None) -> dict | None:
+    """The Stop command for a given turn: the last command row targeting it, or (when the turn
+    id is unknown, or nothing targets it) the last command row overall. Shared by every cell that
+    needs to find "the command the Stop I just sent produced" among a session's command rows."""
+    matching = [c for c in commands if turn_id and c.get("target_turn_id") == turn_id]
+    return matching[-1] if matching else (commands[-1] if commands else None)
+
+
+def assert_command_settled(
+    hooks: OperatorHooks, session_id: str, turn_id: str | None, *, timeout: float = 20.0
+) -> dict:
+    """Poll for up to `timeout` seconds after a Stop for the durable settlement invariant every
+    Stop-issuing cell must observe: the session_commands row for the Stop reaches a terminal
+    state (`applied` or `obsolete` — never left `pending` or `claimed`), and exactly one
+    session_executions row exists for the stopped session with a non-empty terminal outcome. This
+    is the check that would have caught the repeat-stop false pass on 2026-09-04 (session
+    190e9118: command stuck `claimed` forever, zero session_executions rows, yet every driver-
+    level assertion — one terminal trace record, a warm resume — still passed).
+
+    Returns a dict with `settled` (bool), `command`, `execution_rows`, and `why` (a one-line
+    reason, only set when `settled` is False). Never raises: a hookless run (`NullHooks`) reads
+    as `settled=True` with `why=None` so a cell that runs without --project is not blocked by a
+    check it has no way to make (the cell's own `hooks.available` guard already SKIPs it).
+    """
+    if not hooks.available:
+        return {"settled": True, "command": None, "execution_rows": [], "why": None}
+    deadline = time.time() + timeout
+    command: dict | None = None
+    executions: list[dict] = []
+    while True:
+        commands = hooks.command_rows(session_id)
+        command = _match_stop_command(commands, turn_id)
+        executions = hooks.execution_rows(session_id)
+        settled_command = command is not None and command.get("state") in (
+            "applied",
+            "obsolete",
+        )
+        settled_execution = len(executions) == 1 and bool(
+            executions[0].get("terminal_outcome")
+        )
+        if settled_command and settled_execution:
+            return {
+                "settled": True,
+                "command": command,
+                "execution_rows": executions,
+                "why": None,
+            }
+        if time.time() >= deadline:
+            break
+        time.sleep(1)
+    if command is None:
+        why = "no session_commands row was found for the Stop"
+    elif command.get("state") not in ("applied", "obsolete"):
+        why = f"the Stop command was left {command.get('state')!r}, expected applied or obsolete"
+    elif len(executions) != 1:
+        why = (
+            "expected exactly one session_executions row for the stopped session, saw "
+            f"{len(executions)}"
+        )
+    else:
+        why = "the session_executions row settled with no terminal outcome"
+    return {
+        "settled": False,
+        "command": command,
+        "execution_rows": executions,
+        "why": why,
+    }
+
+
 def _judge_runner_gone(evidence: dict) -> dict:
     """Shared PASS rule for the runner-gone family (`runner-gone`, `runner-gone-late`).
 
@@ -1174,6 +1264,7 @@ def cell_stop_warm(cfg, references, args, hooks: OperatorHooks) -> Cell:
     turn = wait_for_turn(session_id)
     open_call = wait_for_tool(handle)
     stop = cancel(session_id, expected=turn, label="stop-warm")
+    settle = assert_command_settled(hooks, session_id, turn)
     handle["thread"].join(timeout=180)
     t1 = handle["out"] or {}
     time.sleep(4)
@@ -1189,6 +1280,7 @@ def cell_stop_warm(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "terminal_records": terminal_records(session_id, turn),
         "resume_recalled_marker": marker in (t2.get("text") or ""),
         "resume_elapsed_s": t2.get("elapsed_s"),
+        "command_settled": settle,
     }
     evidence["sandbox_ids"] = sandbox_ids(session_id)
     evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
@@ -1196,6 +1288,8 @@ def cell_stop_warm(cfg, references, args, hooks: OperatorHooks) -> Cell:
         return evidence, _fail(
             f"Stop returned HTTP {stop['status']}, expected 200 or 202"
         )
+    if not settle["settled"]:
+        return evidence, _fail(settle["why"])
     if not evidence["resume_recalled_marker"]:
         return evidence, _fail("warm resume did not recall the codeword")
     return evidence, _pass(
@@ -1274,6 +1368,9 @@ def cell_stale_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
     stale = cancel(session_id, expected=turn1, label="stale-stop")
     time.sleep(3)
     bare = cancel(session_id, label="bare-stop")
+    # The stale Stop (targets turn1, already settled) is expected to be REFUSED, not to produce
+    # a settlement of its own — only `bare` (the real Stop, targets the live turn2) must settle.
+    settle = assert_command_settled(hooks, session_id, turn2)
     handle["thread"].join(timeout=180)
     t2 = handle["out"] or {}
     time.sleep(4)
@@ -1287,6 +1384,7 @@ def cell_stale_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "bare_stop": bare,
         "turn2_elapsed_s": t2.get("elapsed_s"),
         "turn3_recalled_marker": marker in (t3.get("text") or ""),
+        "command_settled": settle,
     }
     evidence["sandbox_ids"] = sandbox_ids(session_id)
     evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
@@ -1294,6 +1392,8 @@ def cell_stale_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
         return evidence, _fail(
             f"stale Stop returned HTTP {stale['status']}, expected a mismatch status"
         )
+    if not settle["settled"]:
+        return evidence, _fail(settle["why"])
     if not evidence["turn3_recalled_marker"]:
         return evidence, _fail("turn 2 did not survive the stale Stop")
     return evidence, _pass("stale Stop was refused and turn 2 completed and survived")
@@ -1312,6 +1412,7 @@ def cell_stop_approval(cfg_ask, references_ask, args, hooks: OperatorHooks) -> C
     stream_before = session_stream(session_id)
     expected = t1.get("turn_id") or stream_before.get("turn_id")
     stop = cancel(session_id, expected=expected, label="stop-approval-named")
+    settle = assert_command_settled(hooks, session_id, expected)
     time.sleep(3)
     pending = next((i for i in before if i.get("status") == "pending"), None)
     late = {"skipped": "no pending interaction was found before the Stop"}
@@ -1344,6 +1445,7 @@ def cell_stop_approval(cfg_ask, references_ask, args, hooks: OperatorHooks) -> C
         "resume_text": (t2.get("text") or "")[:400],
         "resume_frames": t2.get("frames", [])[:20],
         "resume_errors": t2.get("errors"),
+        "command_settled": settle,
     }
     evidence["sandbox_ids"] = sandbox_ids(session_id)
     evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
@@ -1355,6 +1457,8 @@ def cell_stop_approval(cfg_ask, references_ask, args, hooks: OperatorHooks) -> C
         return evidence, _fail(
             f"named Stop on a parked approval returned HTTP {stop['status']}, expected 200 or 202"
         )
+    if not settle["settled"]:
+        return evidence, _fail(settle["why"])
     if late.get("status") == 200:
         return evidence, _fail(
             "the late approval answer was accepted after the Stop settled it"
@@ -1693,8 +1797,7 @@ def cell_runner_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
         hooks.unpause_runner()
     healthy_after_s = hooks.wait_for_runner()
 
-    matching = [c for c in commands if turn and c.get("target_turn_id") == turn]
-    stop_command = matching[-1] if matching else (commands[-1] if commands else None)
+    stop_command = _match_stop_command(commands, turn)
 
     handle["thread"].join(timeout=60)
     t2 = invoke(
@@ -1802,8 +1905,7 @@ def cell_runner_gone_late(cfg, references, args, hooks: OperatorHooks) -> Cell:
     time.sleep(3)
     commands = hooks.command_rows(session_id)
     stream_row = hooks.stream_row(session_id)
-    matching = [c for c in commands if turn and c.get("target_turn_id") == turn]
-    stop_command = matching[-1] if matching else (commands[-1] if commands else None)
+    stop_command = _match_stop_command(commands, turn)
     t2 = invoke(
         session_id,
         [user_msg(f"The codeword is {marker}. Reply with just the single word READY.")],
@@ -1847,12 +1949,14 @@ def cell_post_stop_row(cfg, references, args, hooks: OperatorHooks) -> Cell:
             first_false_at = round(row.get("read_at", time.time()) - stop["sent_at"], 2)
             break
         time.sleep(0.1)
+    settle = assert_command_settled(hooks, session_id, turn)
     handle["thread"].join(timeout=180)
     evidence = {
         "session_id": session_id,
         "turn_id": turn,
         "stop": stop,
         "seconds_to_is_running_false": first_false_at,
+        "command_settled": settle,
     }
     if first_false_at is None:
         return evidence, _fail(
@@ -1862,6 +1966,8 @@ def cell_post_stop_row(cfg, references, args, hooks: OperatorHooks) -> Cell:
         return evidence, _fail(
             f"the row took {first_false_at}s to read is_running: false, expected under 5s"
         )
+    if not settle["settled"]:
+        return evidence, _fail(settle["why"])
     return evidence, _pass(
         f"the row read is_running: false {first_false_at}s after the Stop"
     )
@@ -1902,6 +2008,7 @@ def cell_codex_child(cfg, references, args, hooks: OperatorHooks) -> Cell:
             target_sandbox_id = observed_ids[-1] if observed_ids else None
         time.sleep(1)
     stop = cancel(session_id, expected=turn, label="stop-codex")
+    settle = assert_command_settled(hooks, session_id, turn)
     handle["thread"].join(timeout=180)
     gone_at = None
     deadline = time.time() + 45
@@ -1927,6 +2034,7 @@ def cell_codex_child(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "stop": stop,
         "seconds_until_child_gone": gone_at,
         "resume_recalled_marker": codeword in (t2.get("text") or ""),
+        "command_settled": settle,
     }
     if not child_before:
         return evidence, _fail(
@@ -1934,6 +2042,8 @@ def cell_codex_child(cfg, references, args, hooks: OperatorHooks) -> Cell:
         )
     if gone_at is None:
         return evidence, _fail("the child process was still alive 45s after the Stop")
+    if not settle["settled"]:
+        return evidence, _fail(settle["why"])
     if not evidence["resume_recalled_marker"]:
         return evidence, _fail(
             "the parked Codex sandbox did not recall the codeword on resume"
@@ -2011,6 +2121,7 @@ def cell_repeat_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
     t2.start()
     t1.join()
     t2.join()
+    settle = assert_command_settled(hooks, session_id, turn)
     handle["thread"].join(timeout=180)
     out = handle["out"] or {}
     time.sleep(4)
@@ -2027,6 +2138,7 @@ def cell_repeat_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "stops": results,
         "terminal_records": terminal_records(session_id, turn),
         "resume_recalled_marker": marker in (t3.get("text") or ""),
+        "command_settled": settle,
     }
     evidence["sandbox_ids"] = sandbox_ids(session_id)
     evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
@@ -2039,6 +2151,8 @@ def cell_repeat_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
         return evidence, _fail(
             f"expected exactly one terminal record for the turn, saw {len(evidence['terminal_records'])}"
         )
+    if not settle["settled"]:
+        return evidence, _fail(settle["why"])
     if not evidence["resume_recalled_marker"]:
         return evidence, _fail(
             "resume after the repeated Stop did not recall the codeword"
@@ -2092,6 +2206,17 @@ def cell_concurrent_stops(cfg, references, args, hooks: OperatorHooks) -> Cell:
         t.join()
     stop_window_s = round(time.time() - fired_at, 3)
 
+    def settle(s: dict) -> None:
+        s["command_settled"] = assert_command_settled(
+            hooks, s["session_id"], s["turn_id"]
+        )
+
+    settle_threads = [threading.Thread(target=settle, args=(s,)) for s in sessions]
+    for t in settle_threads:
+        t.start()
+    for t in settle_threads:
+        t.join()
+
     for s in sessions:
         s["handle"]["thread"].join(timeout=180)
         s["out"] = s["handle"]["out"] or {}
@@ -2117,6 +2242,7 @@ def cell_concurrent_stops(cfg, references, args, hooks: OperatorHooks) -> Cell:
                 "stop_round_trip_s": s["stop"]["round_trip_s"],
                 "terminal_record_count": len(s["terminal_records"]),
                 "resume_recalled_marker": s["resume_recalled_marker"],
+                "command_settled": s["command_settled"],
             }
             for s in sessions
         ],
@@ -2125,6 +2251,14 @@ def cell_concurrent_stops(cfg, references, args, hooks: OperatorHooks) -> Cell:
     if not_202:
         return evidence, _fail(
             f"{len(not_202)} of {n} concurrent Stops did not return HTTP 202: {not_202}"
+        )
+    unsettled = [
+        s["session_id"] for s in sessions if not s["command_settled"]["settled"]
+    ]
+    if unsettled:
+        return evidence, _fail(
+            f"{len(unsettled)} of {n} sessions did not settle their Stop command within "
+            f"20s: {unsettled}"
         )
     bad_terminal = [
         s["session_id"] for s in sessions if len(s["terminal_records"]) != 1

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -1541,7 +1541,19 @@ def cell_stop_after_finish(cfg, references, args, hooks: OperatorHooks) -> Cell:
 
 
 def cell_restart_after_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
-    """Stop, restart the runner, continue with an EMPTY client transcript."""
+    """Stop, restart the runner, continue with an EMPTY client transcript.
+
+    The codeword recall alone is not proof of native continuity: when the native session did not
+    truly hydrate, the runner can still answer correctly by reconstructing the conversation from
+    the persisted record log (the `[reconstruct]` / `session/load ... loaded=false` path), and a
+    driver that ever sent more than the trailing message could paper over the same gap from the
+    client side. So this cell forces its resume onto `--client-shape last-message` (the shape the
+    desktop actually sends) regardless of the run's own `--client-shape`, and requires a SECOND,
+    independent signal beyond the recalled codeword: either the sandbox id after the restart is
+    the SAME one the turn ran on before it (true continuity needs no rebuild), or the runner log
+    for the resume shows `session/load ... loaded=true` (a genuine native hydrate, not a
+    reconstruction). Recall without either is a false pass, not a pass.
+    """
     if not hooks.available:
         return {}, _skip("no --project given: restarting the runner needs docker")
     session_id = str(uuid.uuid4())
@@ -1553,27 +1565,44 @@ def cell_restart_after_stop(cfg, references, args, hooks: OperatorHooks) -> Cell
     stop = cancel(session_id, expected=turn, label="stop-before-restart")
     handle["thread"].join(timeout=180)
     time.sleep(4)
+    sandbox_id_before = (sandbox_ids(session_id) or [None])[-1]
     restart_at = time.time()
     hooks.restart_runner(grace_seconds=10)
     healthy_after = hooks.wait_for_runner()
     attempts = []
     admitted = None
-    deadline = time.time() + 240
-    while time.time() < deadline:
-        t = invoke(session_id, [user_msg(RECALL)], cfg, references, "restart-recall")
-        refused = any(
-            "already running a turn" in (e or "") for e in t.get("errors", [])
-        )
-        attempts.append(
-            {
-                "at_s_after_restart": round(time.time() - restart_at, 1),
-                "refused": refused,
-            }
-        )
-        if not refused:
-            admitted = t
-            break
-        time.sleep(5)
+    global CLIENT_SHAPE
+    prior_client_shape = CLIENT_SHAPE
+    CLIENT_SHAPE = "last-message"
+    try:
+        deadline = time.time() + 240
+        while time.time() < deadline:
+            t = invoke(
+                session_id, [user_msg(RECALL)], cfg, references, "restart-recall"
+            )
+            refused = any(
+                "already running a turn" in (e or "") for e in t.get("errors", [])
+            )
+            attempts.append(
+                {
+                    "at_s_after_restart": round(time.time() - restart_at, 1),
+                    "refused": refused,
+                }
+            )
+            if not refused:
+                admitted = t
+                break
+            time.sleep(5)
+    finally:
+        CLIENT_SHAPE = prior_client_shape
+    sandbox_id_after = (sandbox_ids(session_id) or [None])[-1]
+    resume_log = [
+        line
+        for line in hooks.runner_log(restart_at)
+        if session_id in line and "session/load" in line
+    ]
+    loaded_true = any("loaded=true" in line for line in resume_log)
+    same_sandbox = bool(sandbox_id_before) and sandbox_id_before == sandbox_id_after
     evidence = {
         "session_id": session_id,
         "turn_id": turn,
@@ -1582,18 +1611,34 @@ def cell_restart_after_stop(cfg, references, args, hooks: OperatorHooks) -> Cell
         "attempts": attempts,
         "admitted_at_s": attempts[-1]["at_s_after_restart"] if admitted else None,
         "recalled_marker": marker in ((admitted or {}).get("text") or ""),
+        "sandbox_id_before": sandbox_id_before,
+        "sandbox_id_after": sandbox_id_after,
+        "same_sandbox": same_sandbox,
+        "resume_load_log_lines": resume_log,
+        "loaded_true": loaded_true,
     }
-    if healthy_after is None:
-        return evidence, _fail("the runner never reported healthy after the restart")
-    if admitted is None:
-        return evidence, _fail(
+    return evidence, _judge_restart_after_stop(evidence)
+
+
+def _judge_restart_after_stop(evidence: dict) -> dict:
+    """PASS rule for `restart-after-stop`. A recalled codeword alone is not proof of native
+    continuity — the runner can recover it by reconstructing the conversation from persisted
+    records even when the native session did not truly hydrate. Require the recall AND one of:
+    the sandbox was not rebuilt (`same_sandbox`), or the runner log shows a genuine native hydrate
+    (`loaded_true`). See `cell_restart_after_stop`'s docstring for why."""
+    if evidence.get("runner_healthy_after_s") is None:
+        return _fail("the runner never reported healthy after the restart")
+    if evidence.get("admitted_at_s") is None:
+        return _fail(
             "the continuation was refused for the whole wait window after the restart"
         )
-    if not evidence["recalled_marker"]:
-        return evidence, _fail(
+    if not evidence.get("recalled_marker"):
+        return _fail(
             "the native harness session did not survive the restart: the codeword was not recalled"
         )
-    return evidence, _pass(
+    if not (evidence.get("same_sandbox") or evidence.get("loaded_true")):
+        return _fail("native session not resumed, recovered by transcript replay")
+    return _pass(
         "the runner rehydrated the native session across a restart and recalled the codeword"
     )
 

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -662,7 +662,11 @@ def invoke(
 def assistant_message(turn: dict) -> dict:
     parts: list = []
     text_buf: list[str] = []
-    for seg in turn["segments"]:
+    # `turn` can be `{}` when the driver's own wait for the turn timed out (`handle["out"]` was
+    # never set, e.g. because the runner was unhealthy and the stream thread never finished) — a
+    # driver-side timeout, not a reason to crash the cell with a KeyError instead of reporting a
+    # FAIL. Missing segments means no assistant turn to replay.
+    for seg in turn.get("segments") or []:
         if seg["kind"] == "text":
             text_buf.append(seg["text"])
             continue

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -53,6 +53,13 @@ REQUIRED_ENV = ("AGENTA_BASE", "AGENTA_ADMIN_KEY", "QA_OPENAI_API_KEY")
 BASE = ""
 ADMIN_KEY = ""
 OPENAI_KEY = ""
+# Only required when --harness claude is selected; checked in bootstrap(), not resolve_env(),
+# so a pi_core/codex-only run never needs it set.
+ANTHROPIC_KEY = ""
+
+# Set in main() from --sandbox: Daytona sandboxes take 10 to 20s to start, on top of whatever a
+# local sandbox needs, so every wait that assumes "local" gets this much extra slack.
+SANDBOX_STARTUP_SLACK_S = 0.0
 
 RUNS = pathlib.Path(
     os.environ.get(
@@ -86,6 +93,8 @@ def resolve_env() -> None:
     BASE = os.environ["AGENTA_BASE"]
     ADMIN_KEY = os.environ["AGENTA_ADMIN_KEY"]
     OPENAI_KEY = os.environ["QA_OPENAI_API_KEY"]
+    global ANTHROPIC_KEY
+    ANTHROPIC_KEY = os.environ.get("ANTHROPIC_API_KEY", "")
 
 
 # --------------------------------------------------------------------------- #
@@ -349,6 +358,15 @@ HARNESSES = {
         "provider": "openai",
         "connection": {"mode": "agenta", "slug": None},
     },
+    "claude": {
+        # `sonnet` alias, not a full model id: a full id is dropped to the default on the Claude
+        # ACP path (qa_product.py F-007). VAULT key (mode "agenta"), not subscription: this
+        # driver's cells run on Daytona too, and Daytona rejects subscription auth by design.
+        "kind": "claude",
+        "model": "sonnet",
+        "provider": "anthropic",
+        "connection": {"mode": "agenta", "slug": None},
+    },
 }
 
 
@@ -369,7 +387,7 @@ def api(method: str, path: str, *, timeout: float = 120.0, **kw) -> httpx.Respon
     )
 
 
-def bootstrap() -> None:
+def bootstrap(harness: str = "pi_core") -> None:
     uid = uuid.uuid4().hex[:12]
     r = httpx.post(
         f"{BASE}/api/admin/simple/accounts/",
@@ -408,6 +426,33 @@ def bootstrap() -> None:
     if r.status_code != 200:
         raise SystemExit(f"vault create HTTP {r.status_code}: {r.text[:400]}")
     print("[bootstrap] vault stocked with an openai provider key", file=sys.stderr)
+
+    if harness == "claude":
+        # The claude harness's vault connection (agent_config mode "agenta") needs a funded
+        # Anthropic key, the same way the OpenAI key above covers pi_core and codex. Checked
+        # here, not in resolve_env(), so a pi_core/codex-only run never needs it set.
+        if not ANTHROPIC_KEY:
+            raise SystemExit(
+                "Missing environment variable: ANTHROPIC_API_KEY. Required for --harness "
+                "claude (the vault connection needs a funded Anthropic key). "
+                "e.g. export ANTHROPIC_API_KEY=...   # ~/.agenta-qa-secrets.env"
+            )
+        r = api(
+            "POST",
+            "/vault/v1/secrets/",
+            json={
+                "header": {"name": "Anthropic", "description": "session-control gate"},
+                "secret": {
+                    "kind": "provider_key",
+                    "data": {"kind": "anthropic", "provider": {"key": ANTHROPIC_KEY}},
+                },
+            },
+        )
+        if r.status_code != 200:
+            raise SystemExit(f"vault create HTTP {r.status_code}: {r.text[:400]}")
+        print(
+            "[bootstrap] vault stocked with an anthropic provider key", file=sys.stderr
+        )
 
 
 def agent_config(
@@ -648,6 +693,41 @@ def assistant_message(turn: dict) -> dict:
     return {"id": str(uuid.uuid4()), "role": "assistant", "parts": parts}
 
 
+def turn_ledger(session_id: str, limit: int = 20) -> list[dict]:
+    """The session's turn rows, newest first, over HTTP only (no docker needed).
+
+    The runner writes `agent_session_id` and `sandbox_id` on every turn, so this is a STORED
+    outcome, not an echo of what the client sent. Used to check the resume after a Stop landed
+    in the SAME sandbox rather than a rebuilt one.
+    """
+    r = api(
+        "POST",
+        "/sessions/turns/query",
+        json={
+            "query": {"session_id": session_id},
+            "windowing": {"limit": limit, "order": "descending"},
+        },
+    )
+    if r.status_code != 200:
+        return []
+    try:
+        body = r.json()
+    except Exception:  # noqa: BLE001
+        return []
+    turns = body.get("turns") if isinstance(body, dict) else None
+    return turns if isinstance(turns, list) else []
+
+
+def sandbox_ids(session_id: str) -> list[str]:
+    """Distinct sandbox ids across the session's turn ledger.
+
+    ONE id = the resume reused the same sandbox (warm). TWO or more = the sandbox was rebuilt.
+    """
+    return sorted(
+        {r.get("sandbox_id") for r in turn_ledger(session_id) if r.get("sandbox_id")}
+    )
+
+
 def session_stream(session_id: str) -> dict:
     r = api("GET", "/sessions/streams/", params={"session_id": session_id})
     if r.status_code != 200:
@@ -747,7 +827,7 @@ def invoke_async(session_id, messages, cfg, references, label) -> dict:
 
 
 def wait_for_turn(session_id: str, *, timeout: float = 40.0) -> str | None:
-    deadline = time.time() + timeout
+    deadline = time.time() + timeout + SANDBOX_STARTUP_SLACK_S
     while time.time() < deadline:
         stream = session_stream(session_id)
         turn = stream.get("turn_id")
@@ -759,7 +839,7 @@ def wait_for_turn(session_id: str, *, timeout: float = 40.0) -> str | None:
 
 
 def wait_for_tool(handle: dict, *, timeout: float = 60.0) -> dict | None:
-    deadline = time.time() + timeout
+    deadline = time.time() + timeout + SANDBOX_STARTUP_SLACK_S
     live = handle["live"]
     while time.time() < deadline:
         calls = live.get("tool_calls") or []
@@ -826,6 +906,8 @@ def cell_stop_warm(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "resume_recalled_marker": marker in (t2.get("text") or ""),
         "resume_elapsed_s": t2.get("elapsed_s"),
     }
+    evidence["sandbox_ids"] = sandbox_ids(session_id)
+    evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
     if stop["status"] not in (200, 202):
         return evidence, _fail(
             f"Stop returned HTTP {stop['status']}, expected 200 or 202"
@@ -868,6 +950,8 @@ def cell_double_send(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "turn1_errors": t1.get("errors"),
         "third_send_recalled_marker": marker in (t3.get("text") or ""),
     }
+    evidence["sandbox_ids"] = sandbox_ids(session_id)
+    evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
     refused = bool(t2.get("errors"))
     if not refused:
         return evidence, _fail("second Send during a running turn was not refused")
@@ -920,6 +1004,8 @@ def cell_stale_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "turn2_elapsed_s": t2.get("elapsed_s"),
         "turn3_recalled_marker": marker in (t3.get("text") or ""),
     }
+    evidence["sandbox_ids"] = sandbox_ids(session_id)
+    evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
     if stale["status"] not in (400, 404, 409):
         return evidence, _fail(
             f"stale Stop returned HTTP {stale['status']}, expected a mismatch status"
@@ -969,6 +1055,8 @@ def cell_stop_approval(cfg_ask, references_ask, args, hooks: OperatorHooks) -> C
         "late_answer": late,
         "resume_recalled_marker": marker in (t2.get("text") or ""),
     }
+    evidence["sandbox_ids"] = sandbox_ids(session_id)
+    evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
     if pending is None:
         return evidence, _fail(
             "no pending approval was seen before the Stop; the race did not land"
@@ -1129,6 +1217,8 @@ def cell_stop_after_finish(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "resume_recalled_marker": marker in (t2.get("text") or ""),
         "terminal_records": terminal_records(session_id, turn),
     }
+    evidence["sandbox_ids"] = sandbox_ids(session_id)
+    evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
     if hooks.available:
         logs = hooks.runner_log(since)
         evidence["control_aborted_lines"] = [
@@ -1396,6 +1486,8 @@ def cell_repeat_stop(cfg, references, args, hooks: OperatorHooks) -> Cell:
         "terminal_records": terminal_records(session_id, turn),
         "resume_recalled_marker": marker in (t3.get("text") or ""),
     }
+    evidence["sandbox_ids"] = sandbox_ids(session_id)
+    evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
     if hooks.available:
         evidence["commands"] = hooks.command_rows(session_id)
     accepted = [r for r in results if r["status"] in (200, 202)]
@@ -1464,6 +1556,8 @@ def cell_stop_during_completion(cfg, references, args, hooks: OperatorHooks) -> 
         "stream_after_flags": (stream_after or {}).get("flags"),
         "resume_recalled_marker": marker in (t2.get("text") or ""),
     }
+    evidence["sandbox_ids"] = sandbox_ids(session_id)
+    evidence["warm_same_sandbox"] = len(evidence["sandbox_ids"]) <= 1
     if len(terminal) > 1:
         return evidence, _fail(
             f"the race produced {len(terminal)} terminal records for one turn, expected one"
@@ -1531,6 +1625,9 @@ def main() -> int:
     hooks: OperatorHooks = (
         DockerComposeHooks(args.project) if args.project else NullHooks()
     )
+    if args.sandbox == "daytona":
+        global SANDBOX_STARTUP_SLACK_S
+        SANDBOX_STARTUP_SLACK_S = 25.0
 
     prior: dict = {}
     if args.resume:
@@ -1542,7 +1639,7 @@ def main() -> int:
                 file=sys.stderr,
             )
 
-    bootstrap()
+    bootstrap(args.harness)
     spec = HARNESSES[args.harness]
     base_cfg = agent_config(
         spec["kind"], spec["model"], spec["provider"], spec["connection"], args.sandbox

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -1664,13 +1664,29 @@ def assert_command_settled(
     190e9118: command stuck `claimed` forever, zero session_executions rows, yet every driver-
     level assertion — one terminal trace record, a warm resume — still passed).
 
-    Returns a dict with `settled` (bool), `command`, `execution_rows`, and `why` (a one-line
-    reason, only set when `settled` is False). Never raises: a hookless run (`NullHooks`) reads
-    as `settled=True` with `why=None` so a cell that runs without --project is not blocked by a
-    check it has no way to make (the cell's own `hooks.available` guard already SKIPs it).
+    A Stop can also land AFTER the turn already finished naturally — common on a fast Claude Code
+    turn: the valid Stop returns 202, but the runner has nothing to cancel, so the command settles
+    `obsolete`/`not_running` and NO execution row is written. Zero rows is correct there, so a Stop
+    that settled `not_running` is accepted with zero execution rows and `natural_finish=True`. The
+    strict one-row requirement is kept for a Stop the runner applied (`stopped`) or the sweep
+    settled (`lost`). `stop-after-finish` and `stop-during-completion` already accept this shape;
+    routing it through here shares it with every Stop-issuing cell.
+
+    Returns a dict with `settled` (bool), `command`, `execution_rows`, `natural_finish` (bool),
+    `note` (set to "stop landed after a natural finish" on that path, else None), and `why` (a
+    one-line reason, only set when `settled` is False). Never raises: a hookless run (`NullHooks`)
+    reads as `settled=True` so a cell that runs without --project is not blocked by a check it has
+    no way to make (the cell's own `hooks.available` guard already SKIPs it).
     """
     if not hooks.available:
-        return {"settled": True, "command": None, "execution_rows": [], "why": None}
+        return {
+            "settled": True,
+            "command": None,
+            "execution_rows": [],
+            "natural_finish": False,
+            "note": None,
+            "why": None,
+        }
     deadline = time.time() + timeout
     command: dict | None = None
     executions: list[dict] = []
@@ -1682,14 +1698,21 @@ def assert_command_settled(
             "applied",
             "obsolete",
         )
+        outcome = command.get("outcome") if command else None
+        # The Stop landed after a natural finish: obsolete/not_running, no execution row to expect.
+        natural_finish = settled_command and outcome == "not_running"
         settled_execution = len(executions) == 1 and bool(
             executions[0].get("terminal_outcome")
         )
-        if settled_command and settled_execution:
+        if settled_command and (natural_finish or settled_execution):
             return {
                 "settled": True,
                 "command": command,
                 "execution_rows": executions,
+                "natural_finish": natural_finish,
+                "note": "stop landed after a natural finish"
+                if natural_finish
+                else None,
                 "why": None,
             }
         if time.time() >= deadline:
@@ -1710,6 +1733,8 @@ def assert_command_settled(
         "settled": False,
         "command": command,
         "execution_rows": executions,
+        "natural_finish": False,
+        "note": None,
         "why": why,
     }
 

--- a/.agents/skills/agent-release-gate/resources/session_control.py
+++ b/.agents/skills/agent-release-gate/resources/session_control.py
@@ -240,6 +240,17 @@ class OperatorHooks:
     ) -> dict:
         raise HooksUnavailable
 
+    def wait_for_sandbox_ready(
+        self,
+        session_id: str | None = None,
+        ledger_id_getter=None,
+        since: float | None = None,
+        timeout: float | None = None,
+        poll_interval: float | None = None,
+        clock=time,
+    ):
+        raise HooksUnavailable
+
 
 class NullHooks(OperatorHooks):
     """No `--project` was given. Every method raises; cells that need it SKIP with a reason."""
@@ -589,6 +600,75 @@ class DockerComposeHooks(OperatorHooks):
             "killed": [pid],
         }
 
+    def wait_for_local_sandbox_port(
+        self,
+        session_id: str,
+        ledger_id_getter=None,
+        since: float | None = None,
+        timeout: float | None = None,
+        poll_interval: float | None = None,
+        clock=time,
+    ) -> int:
+        """Poll until THIS session's local sandbox port is resolvable, or refuse on timeout.
+
+        A cold acquire writes the `prepare_workspace` line ~35 s after the turn starts, so reading
+        once right after the turn began finds nothing and the cell refused correctly but uselessly.
+        Poll the runner log (and the turn ledger via `ledger_id_getter`) until the port appears.
+        A transient log/ledger disagreement during acquire is retried, not fatal; only its
+        persistence to the deadline raises. When nothing appears within `timeout`, raise
+        WrongSandboxTarget so the cell fails as `wrong target` rather than killing a guess."""
+        timeout = SANDBOX_GONE_RESOLVE_TIMEOUT_S if timeout is None else timeout
+        poll_interval = (
+            SANDBOX_GONE_RESOLVE_POLL_S if poll_interval is None else poll_interval
+        )
+        getter = ledger_id_getter or (lambda: None)
+        deadline = clock.time() + timeout
+        last_error: WrongSandboxTarget | None = None
+        while True:
+            try:
+                ledger_id = getter()
+            except Exception:  # noqa: BLE001
+                ledger_id = None
+            try:
+                port = self.local_sandbox_port(
+                    session_id, sandbox_id=ledger_id, since=since
+                )
+            except WrongSandboxTarget as exc:
+                # A log/ledger disagreement mid-acquire is usually transient; keep polling and
+                # let it raise only if it is still the state at the deadline.
+                last_error = exc
+                port = None
+            if port is not None:
+                return port
+            if clock.time() >= deadline:
+                if last_error is not None:
+                    raise last_error
+                raise WrongSandboxTarget(
+                    f"this session's prepare_workspace line never appeared in the runner log "
+                    f"(and no local ledger sandbox id) within {timeout:.0f}s for session "
+                    f"{session_id}; refusing to kill a guess"
+                )
+            clock.sleep(poll_interval)
+
+    def wait_for_sandbox_ready(
+        self,
+        session_id: str | None = None,
+        ledger_id_getter=None,
+        since: float | None = None,
+        timeout: float | None = None,
+        poll_interval: float | None = None,
+        clock=time,
+    ):
+        """Local: block until this session's own sandbox port is resolvable (returns the port)."""
+        return self.wait_for_local_sandbox_port(
+            session_id,
+            ledger_id_getter=ledger_id_getter,
+            since=since,
+            timeout=timeout,
+            poll_interval=poll_interval,
+            clock=clock,
+        )
+
 
 class DaytonaAwareHooks(DockerComposeHooks):
     """`DockerComposeHooks` plus a Daytona-provider-aware `kill_sandbox` and `sandbox_procs`.
@@ -697,6 +777,39 @@ class DaytonaAwareHooks(DockerComposeHooks):
             "cmdline": None,
             "killed": killed,
         }
+
+    def wait_for_sandbox_ready(
+        self,
+        session_id: str | None = None,
+        ledger_id_getter=None,
+        since: float | None = None,
+        timeout: float | None = None,
+        poll_interval: float | None = None,
+        clock=time,
+    ):
+        """Daytona: block until this session's remote sandbox id is observed (returns the id).
+
+        A remote sandbox is even slower to appear than a local one, so the same poll applies; the
+        target here is the ledger id, not a port. Refuse on timeout rather than deleting a guess."""
+        timeout = SANDBOX_GONE_RESOLVE_TIMEOUT_S if timeout is None else timeout
+        poll_interval = (
+            SANDBOX_GONE_RESOLVE_POLL_S if poll_interval is None else poll_interval
+        )
+        getter = ledger_id_getter or (lambda: None)
+        deadline = clock.time() + timeout
+        while True:
+            try:
+                sandbox_id = getter()
+            except Exception:  # noqa: BLE001
+                sandbox_id = None
+            if sandbox_id:
+                return sandbox_id
+            if clock.time() >= deadline:
+                raise WrongSandboxTarget(
+                    f"no Daytona sandbox id was observed for session {session_id} within "
+                    f"{timeout:.0f}s; refusing to kill a guess"
+                )
+            clock.sleep(poll_interval)
 
     def sandbox_procs(self, marker: str, sandbox_id: str | None = None) -> list[dict]:
         if not sandbox_id:
@@ -828,17 +941,42 @@ def stream_timeout_s(cfg: dict) -> float:
 # cell waits that budget plus slack, and never less than the slow command itself — so a healthy
 # turn that outlives a mis-targeted kill can never be misread as "still running" before it would
 # even have finished. The command duration is a constant the cell prints in its evidence.
-SANDBOX_GONE_COMMAND_S = 240
 SANDBOX_LIVENESS_PROBE_INTERVAL_S = 30.0
 SANDBOX_LIVENESS_PROBE_FAILURES = 3
 SANDBOX_GONE_SETTLE_SLACK_S = 60.0
+
+# A cold acquire on the gate stack takes ~35 s before the sandbox's `prepare_workspace` line is
+# even written (observed `acquire_total ms=34766`), so the cell must POLL for this session's own
+# sandbox to become resolvable rather than reading once right after the turn starts. Poll the
+# runner log and the turn ledger for up to this long, then let the slow command run a moment
+# before the kill. If the line never appears, refuse (never kill a guess).
+SANDBOX_GONE_ACQUIRE_BUDGET_S = 60.0
+SANDBOX_GONE_RESOLVE_TIMEOUT_S = 120.0
+SANDBOX_GONE_RESOLVE_POLL_S = 3.0
+SANDBOX_GONE_RUNNING_SLACK_S = 5.0
+
+# The design window the runner needs to end the turn once the sandbox is dead: PROBE_FAILURES
+# probes at PROBE_INTERVAL_S each.
+_SANDBOX_GONE_DESIGN_WINDOW_S = (
+    SANDBOX_LIVENESS_PROBE_INTERVAL_S * SANDBOX_LIVENESS_PROBE_FAILURES
+)
+
+# The slow command must OUTLAST the whole worst case before the kill lands, plus the design
+# window, so it is still running when the sandbox dies and a failed kill cannot be misread as a
+# healthy completion: acquire budget + the resolve poll window + the probe design window + margin.
+SANDBOX_GONE_COMMAND_S = int(
+    SANDBOX_GONE_ACQUIRE_BUDGET_S
+    + SANDBOX_GONE_RESOLVE_TIMEOUT_S
+    + _SANDBOX_GONE_DESIGN_WINDOW_S
+    + 30
+)
 
 
 def sandbox_gone_settle_budget_s() -> float:
     """Seconds to wait for the runner to end the turn after the sandbox is killed: the probe's
     three-strikes budget plus slack plus any sandbox-startup slack the run declared."""
     return (
-        SANDBOX_LIVENESS_PROBE_INTERVAL_S * SANDBOX_LIVENESS_PROBE_FAILURES
+        _SANDBOX_GONE_DESIGN_WINDOW_S
         + SANDBOX_GONE_SETTLE_SLACK_S
         + SANDBOX_STARTUP_SLACK_S
     )
@@ -1743,22 +1881,39 @@ def cell_sandbox_gone(cfg, references, args, hooks: OperatorHooks) -> Cell:
     msgs = [user_msg(sleep_prompt(marker, SANDBOX_GONE_COMMAND_S))]
     handle = invoke_async(session_id, msgs, cfg, references, "sandbox-turn1")
     turn = wait_for_turn(session_id)
-    time.sleep(12)
-    # The sandbox id this session's own turn ledger observed (`local/<host>:<port>` on local, the
-    # remote uuid on Daytona). Used to derive the port on local and to address the remote sandbox
-    # on Daytona; never a shared `ps | grep`, which cannot tell two sessions apart.
-    observed_ids = sandbox_ids(session_id)
-    target_sandbox_id = observed_ids[-1] if observed_ids else None
     settle_budget = sandbox_gone_settle_budget_s()
     evidence = {
         "session_id": session_id,
         "turn_id": turn,
         "command_seconds": SANDBOX_GONE_COMMAND_S,
+        "resolve_timeout_seconds": SANDBOX_GONE_RESOLVE_TIMEOUT_S,
         "settle_budget_seconds": round(settle_budget, 1),
-        "target_sandbox_id": target_sandbox_id,
     }
-    # Target the tested session's OWN sandbox, assert it is a sandbox-agent daemon, and refuse
-    # (never kill a guess) when the mapping cannot be made.
+    # A cold acquire writes this session's `prepare_workspace` line ~35 s in, so POLL for the
+    # session's own sandbox to become resolvable (up to the resolve timeout) instead of reading
+    # once right after the turn started. Refuse if the line never appears — never kill a guess.
+    # The ledger id (`local/<host>:<port>` on local, the remote uuid on Daytona) is the
+    # cross-check; never a shared `ps | grep`, which cannot tell two sessions apart.
+    resolve_started = time.time()
+    try:
+        hooks.wait_for_sandbox_ready(
+            session_id,
+            ledger_id_getter=lambda: (sandbox_ids(session_id) or [None])[-1],
+            since=since,
+            timeout=SANDBOX_GONE_RESOLVE_TIMEOUT_S,
+        )
+    except WrongSandboxTarget as exc:
+        evidence["wrong_target"] = str(exc)
+        evidence["resolve_seconds"] = round(time.time() - resolve_started, 1)
+        return evidence, _fail(f"wrong target, refused to kill a guess: {exc}")
+    evidence["resolve_seconds"] = round(time.time() - resolve_started, 1)
+    # Let the slow command actually be running before the kill, so the sandbox dies mid-turn.
+    time.sleep(SANDBOX_GONE_RUNNING_SLACK_S)
+    observed_ids = sandbox_ids(session_id)
+    target_sandbox_id = observed_ids[-1] if observed_ids else None
+    evidence["target_sandbox_id"] = target_sandbox_id
+    # Now resolve the pid on the tested session's own port (or the remote id), assert it is a
+    # sandbox-agent daemon, and refuse (never kill a guess) if the mapping cannot be made.
     try:
         target = hooks.kill_sandbox_for_session(
             session_id, sandbox_id=target_sandbox_id, since=since

--- a/.agents/skills/agent-release-gate/resources/test_qa_product_concurrency.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_product_concurrency.py
@@ -17,11 +17,14 @@ works, which is what the live gate is for.
 
 import gzip
 import importlib
+import json
 import os
 import sys
 import threading
 import time
 from pathlib import Path
+
+import pytest
 
 HERE = Path(__file__).resolve().parent
 
@@ -389,9 +392,113 @@ def test_a_runner_path_change_makes_the_journeys_mandatory():
     assert triggers.mandatory_journeys(["web/oss/src/app/page.tsx"]) == {}
 
 
+def _session_control_result(status="PASS"):
+    import session_control
+
+    return {
+        "cells": {
+            name: {
+                "verdict": {
+                    "pass": status == "PASS",
+                    "skip": status == "SKIP",
+                    "why": status.lower(),
+                }
+            }
+            for name in session_control.CELLS
+        }
+    }
+
+
+def test_session_control_result_consumer_accepts_a_complete_pass(tmp_path):
+    path = tmp_path / "results.json"
+    path.write_text(json.dumps(_session_control_result()))
+
+    result = qa._load_session_control_result(str(path))
+
+    assert result["status"] == "PASS"
+    assert result["failed"] == []
+    assert result["skipped"] == []
+
+
+def test_session_control_result_consumer_carries_a_failure(tmp_path):
+    payload = _session_control_result()
+    payload["cells"]["stop-warm"]["verdict"] = {
+        "pass": False,
+        "skip": False,
+        "why": "regression",
+    }
+    path = tmp_path / "results.json"
+    path.write_text(json.dumps(payload))
+
+    result = qa._load_session_control_result(str(path))
+
+    assert result["status"] == "FAIL"
+    assert result["failed"] == ["stop-warm"]
+
+
+def test_session_control_result_consumer_rejects_an_incomplete_run(tmp_path):
+    payload = _session_control_result()
+    del payload["cells"]["stop-warm"]
+    path = tmp_path / "results.json"
+    path.write_text(json.dumps(payload))
+
+    with pytest.raises(SystemExit, match="missing cells: stop-warm"):
+        qa._load_session_control_result(str(path))
+
+
+def test_driver_requires_mandatory_session_control_results(monkeypatch):
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "qa_product.py",
+            "--cell",
+            "C3",
+            "--only",
+            "chat",
+            "--changed-path",
+            "api/oss/src/core/sessions/service.py",
+        ],
+    )
+
+    with pytest.raises(SystemExit, match="session_control.py mandatory"):
+        qa.main()
+
+
+def test_driver_fails_for_a_failed_session_control_result(monkeypatch, tmp_path):
+    payload = _session_control_result()
+    payload["cells"]["stop-warm"]["verdict"] = {
+        "pass": False,
+        "skip": False,
+        "why": "regression",
+    }
+    result_path = tmp_path / "session-control-results.json"
+    result_path.write_text(json.dumps(payload))
+    monkeypatch.setattr(qa, "RUNS", tmp_path / "runs")
+    monkeypatch.setitem(
+        qa.JOURNEYS, "chat", lambda _cell: {"pass": True, "why": "ok"}
+    )
+    monkeypatch.setattr(
+        sys,
+        "argv",
+        [
+            "qa_product.py",
+            "--cell",
+            "C3",
+            "--only",
+            "chat",
+            "--changed-path",
+            "api/oss/src/core/sessions/service.py",
+            "--session-control-results",
+            str(result_path),
+        ],
+    )
+
+    assert qa.main() == 1
+
+
 def test_the_driver_forces_a_mandatory_journey_past_only(tmp_path=None):
     """End to end through main(), with every journey stubbed out."""
-    import json
     import tempfile
 
     _reset()
@@ -408,6 +515,8 @@ def test_the_driver_forces_a_mandatory_journey_past_only(tmp_path=None):
         }
     )
     outdir = tempfile.mkdtemp()
+    session_control_results = Path(outdir) / "session-control-results.json"
+    session_control_results.write_text(json.dumps(_session_control_result()))
     argv = sys.argv
     runs_dir = qa.RUNS
     sys.argv = [
@@ -418,6 +527,8 @@ def test_the_driver_forces_a_mandatory_journey_past_only(tmp_path=None):
         "chat",
         "--changed-path",
         "services/runner/src/engines/sandbox_agent/daytona-secrets.ts",
+        "--session-control-results",
+        str(session_control_results),
     ]
     qa.RUNS = Path(outdir)
     try:

--- a/.agents/skills/agent-release-gate/resources/test_qa_product_concurrency.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_product_concurrency.py
@@ -475,9 +475,7 @@ def test_driver_fails_for_a_failed_session_control_result(monkeypatch, tmp_path)
     result_path = tmp_path / "session-control-results.json"
     result_path.write_text(json.dumps(payload))
     monkeypatch.setattr(qa, "RUNS", tmp_path / "runs")
-    monkeypatch.setitem(
-        qa.JOURNEYS, "chat", lambda _cell: {"pass": True, "why": "ok"}
-    )
+    monkeypatch.setitem(qa.JOURNEYS, "chat", lambda _cell: {"pass": True, "why": "ok"})
     monkeypatch.setattr(
         sys,
         "argv",

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -121,6 +121,7 @@ def test_cell_names_are_stable_and_known():
         "records-outage",
         "stop-after-finish",
         "restart-after-stop",
+        "runner-gone",
         "post-stop-row",
         "codex-child",
         "stale-tail",

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -37,6 +37,7 @@ def test_null_hooks_raises_on_every_method():
         raise AssertionError(f"{method} should raise HooksUnavailable")
     for method in (
         "wait_for_runner",
+        "ensure_runner_healthy",
         "restart_runner",
         "kill_runner",
         "pause_runner",
@@ -126,9 +127,100 @@ def test_cell_names_are_stable_and_known():
         "codex-child",
         "stale-tail",
         "repeat-stop",
+        "concurrent-stops",
         "stop-during-completion",
     }
     assert set(sc.CELLS) == expected
+
+
+def test_run_cell_finally_path_with_null_hooks_does_not_crash():
+    """run_cell()'s runner-health recovery is gated on `needs_hooks and hooks.available`. With
+    NullHooks (no --project), hooks.available is False, so the finally block must skip the
+    recovery call rather than let HooksUnavailable escape through it — even for a needs_hooks
+    cell whose own function raises before it can restore anything itself."""
+
+    class Args:
+        sleep_seconds = 1
+        sweep_wait = 1
+        project = None
+        sandbox = "local"
+
+    def boom(cfg, references, args, hooks):
+        raise RuntimeError("cell blew up before it could restore anything")
+
+    hooks = sc.NullHooks()
+    result = sc.run_cell("boom-cell", boom, {}, {}, Args(), hooks, True)
+    assert result["verdict"]["pass"] is False
+    assert result["verdict"]["skip"] is False
+    assert "driver exception" in result["verdict"]["why"]
+    assert "RuntimeError" in result["evidence"]["driver_error"]
+    assert "elapsed_s" in result
+
+
+def test_run_cell_recovers_the_runner_when_a_cell_raises():
+    """The run-level guarantee: a needs_hooks cell that raises must still trigger the runner
+    recovery check, so a paused or restarted runner does not strand the cell that runs next."""
+
+    class Args:
+        sleep_seconds = 1
+        sweep_wait = 1
+        project = "fake-project"
+        sandbox = "local"
+
+    class StubHooks(sc.OperatorHooks):
+        available = True
+
+        def __init__(self):
+            self.recovered = False
+
+        def ensure_runner_healthy(self, *, timeout: float = 120.0) -> dict:
+            self.recovered = True
+            return {
+                "was_paused": True,
+                "status_before": "running",
+                "healthy_after_s": 1.0,
+            }
+
+    def boom(cfg, references, args, hooks):
+        raise RuntimeError("cell paused the runner and blew up before unpausing it")
+
+    hooks = StubHooks()
+    result = sc.run_cell("boom-cell", boom, {}, {}, Args(), hooks, True)
+    assert hooks.recovered is True
+    assert result["verdict"]["pass"] is False
+
+
+def test_run_cell_skips_recovery_for_cells_that_do_not_need_hooks():
+    """A cell that never touches Docker (needs_hooks=False) must not trigger a recovery check,
+    even when hooks happen to be available."""
+
+    class Args:
+        sleep_seconds = 1
+        sweep_wait = 1
+        project = "fake-project"
+        sandbox = "local"
+
+    class StubHooks(sc.OperatorHooks):
+        available = True
+
+        def __init__(self):
+            self.recovered = False
+
+        def ensure_runner_healthy(self, *, timeout: float = 120.0) -> dict:
+            self.recovered = True
+            return {
+                "was_paused": False,
+                "status_before": "running",
+                "healthy_after_s": 1.0,
+            }
+
+    def ok(cfg, references, args, hooks):
+        return {"session_id": "abc"}, sc._pass("fine")
+
+    hooks = StubHooks()
+    result = sc.run_cell("http-only-cell", ok, {}, {}, Args(), hooks, False)
+    assert hooks.recovered is False
+    assert result["verdict"]["pass"] is True
 
 
 def test_resolve_env_names_every_missing_variable(monkeypatch):

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -44,6 +44,7 @@ def test_null_hooks_raises_on_every_method():
         raise AssertionError(f"{method} should raise HooksUnavailable")
     for method in (
         "wait_for_runner",
+        "runner_healthy",
         "ensure_runner_healthy",
         "restart_runner",
         "kill_runner",
@@ -1092,6 +1093,54 @@ def test_sandbox_gone_command_outlasts_acquire_resolve_and_the_design_window():
         + sc.SANDBOX_GONE_RESOLVE_TIMEOUT_S
         + sc._SANDBOX_GONE_DESIGN_WINDOW_S
     )
+
+
+def test_recover_then_send_waits_for_health_before_sending():
+    """The recovery Send is not issued until the health poll returns healthy: fail twice, then
+    succeed, and the send must fire exactly once and only after the third (healthy) check."""
+    order: list = []
+    calls = {"n": 0}
+
+    def health():
+        calls["n"] += 1
+        order.append(("health", calls["n"]))
+        return calls["n"] >= 3  # unhealthy on the first two polls, healthy on the third
+
+    def send():
+        order.append(("send", None))
+        return {"ok": True}
+
+    clock = _FakeClock()
+    healthy, result = sc._recover_then_send(
+        health, send, timeout=60.0, poll_interval=2.0, clock=clock
+    )
+    assert healthy is True
+    assert result == {"ok": True}
+    assert calls["n"] == 3
+    assert clock.sleeps == [2.0, 2.0]  # slept between the two failed polls only
+    assert order == [
+        ("health", 1),
+        ("health", 2),
+        ("health", 3),
+        ("send", None),
+    ]
+
+
+def test_recover_then_send_does_not_send_when_health_never_recovers():
+    sent = {"n": 0}
+
+    def send():
+        sent["n"] += 1
+        return {"ok": True}
+
+    clock = _FakeClock()
+    healthy, result = sc._recover_then_send(
+        lambda: False, send, timeout=6.0, poll_interval=2.0, clock=clock
+    )
+    assert healthy is False
+    assert result is None
+    assert sent["n"] == 0  # a doomed Send is never attempted
+    assert clock.now >= 6.0
 
 
 def test_sandbox_gone_settle_budget_derives_from_probe_defaults():

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -533,6 +533,20 @@ def test_resolve_env_populates_globals(monkeypatch):
     assert sc.OPENAI_KEY == "sk-test"
 
 
+def test_stream_timeout_s_gives_pi_the_shorter_budget():
+    assert sc.stream_timeout_s({"harness": {"kind": "pi_core"}}) == 600.0
+
+
+def test_stream_timeout_s_gives_codex_and_claude_1_5x_pi():
+    assert sc.stream_timeout_s({"harness": {"kind": "codex"}}) == 900.0
+    assert sc.stream_timeout_s({"harness": {"kind": "claude"}}) == 900.0
+
+
+def test_stream_timeout_s_defaults_for_an_unknown_or_missing_harness():
+    assert sc.stream_timeout_s({"harness": {"kind": "some-future-harness"}}) == 600.0
+    assert sc.stream_timeout_s({}) == 600.0
+
+
 def test_client_shape_messages_full_is_a_noop():
     """--client-shape full (the default) must not touch the outbound messages at all."""
     assert sc.CLIENT_SHAPE == "full"

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -123,6 +123,7 @@ def test_cell_names_are_stable_and_known():
         "stop-after-finish",
         "restart-after-stop",
         "runner-gone",
+        "runner-gone-late",
         "post-stop-row",
         "codex-child",
         "stale-tail",

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -53,6 +53,7 @@ def test_null_hooks_raises_on_every_method():
         "start_postgres",
         "kill_sandbox",
         "kill_sandbox_for_session",
+        "wait_for_sandbox_ready",
     ):
         try:
             getattr(hooks, method)()
@@ -834,15 +835,26 @@ class _FakeLocalHooks(sc.DockerComposeHooks):
     """DockerComposeHooks with the container round-trips (`dc`, `runner_log`) scripted, so the
     port-to-pid mapping and the wrong-target refusals are tested without Docker."""
 
-    def __init__(self, *, log_lines=None, ss="", proc_pid="", cmdlines=None):
+    def __init__(
+        self, *, log_lines=None, log_reads=None, ss="", proc_pid="", cmdlines=None
+    ):
         super().__init__("fake-project")
         self._log_lines = log_lines or []
+        # `log_reads` scripts one return value per `runner_log` call (the last repeats), so a test
+        # can make this session's line appear on, say, the third poll. `log_lines` is the fixed
+        # fallback when no script is given.
+        self._log_reads = log_reads
         self._ss = ss
         self._proc_pid = proc_pid
         self._cmdlines = cmdlines or {}
         self.killed: list[str] = []
+        self.log_read_count = 0
 
     def runner_log(self, since: float) -> list[str]:
+        self.log_read_count += 1
+        if self._log_reads is not None:
+            i = min(self.log_read_count - 1, len(self._log_reads) - 1)
+            return list(self._log_reads[i])
         return list(self._log_lines)
 
     def dc(self, *args: str, timeout: float = 60.0) -> str:
@@ -993,6 +1005,93 @@ def test_daytona_kill_for_session_refuses_without_a_sandbox_id():
         raise AssertionError("expected WrongSandboxTarget")
     finally:
         _restore_env(saved)
+
+
+class _FakeClock:
+    """A clock whose `sleep` advances `time` instantly, so poll loops run without real waiting."""
+
+    def __init__(self):
+        self.now = 0.0
+        self.sleeps: list[float] = []
+
+    def time(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.sleeps.append(seconds)
+        self.now += seconds
+
+
+def test_wait_for_local_sandbox_port_returns_when_the_line_appears_on_the_third_read():
+    sid = "sess"
+    line = (
+        "12:29 [sandbox-agent] [timing] stage=prepare_workspace ms=0 "
+        f"sandbox=local/127.0.0.1:44831 session={sid}"
+    )
+    hooks = _FakeLocalHooks(log_reads=[[], [], [line]])  # empty, empty, then the line
+    clock = _FakeClock()
+    port = hooks.wait_for_local_sandbox_port(
+        sid,
+        ledger_id_getter=lambda: None,
+        since=0.0,
+        timeout=120.0,
+        poll_interval=3.0,
+        clock=clock,
+    )
+    assert port == 44831
+    assert hooks.log_read_count == 3
+    assert clock.sleeps == [3.0, 3.0]  # slept twice before the third read found it
+
+
+def test_wait_for_local_sandbox_port_refuses_when_the_line_never_appears():
+    hooks = _FakeLocalHooks(log_reads=[[]])  # every read is empty
+    clock = _FakeClock()
+    try:
+        hooks.wait_for_local_sandbox_port(
+            "sess",
+            ledger_id_getter=lambda: None,
+            since=0.0,
+            timeout=9.0,
+            poll_interval=3.0,
+            clock=clock,
+        )
+    except sc.WrongSandboxTarget as exc:
+        assert "never appeared" in str(exc)
+        assert clock.now >= 9.0
+        return
+    raise AssertionError("expected WrongSandboxTarget on timeout")
+
+
+def test_wait_for_local_sandbox_port_resolves_from_the_ledger_when_the_log_is_silent():
+    calls = {"n": 0}
+
+    def ledger():
+        calls["n"] += 1
+        return "local/127.0.0.1:44831" if calls["n"] >= 3 else None
+
+    hooks = _FakeLocalHooks(
+        log_reads=[[]]
+    )  # log stays empty; the ledger supplies the port
+    clock = _FakeClock()
+    port = hooks.wait_for_local_sandbox_port(
+        "sess",
+        ledger_id_getter=ledger,
+        since=0.0,
+        timeout=120.0,
+        poll_interval=3.0,
+        clock=clock,
+    )
+    assert port == 44831
+    assert calls["n"] == 3
+
+
+def test_sandbox_gone_command_outlasts_acquire_resolve_and_the_design_window():
+    assert (
+        sc.SANDBOX_GONE_COMMAND_S
+        > sc.SANDBOX_GONE_ACQUIRE_BUDGET_S
+        + sc.SANDBOX_GONE_RESOLVE_TIMEOUT_S
+        + sc._SANDBOX_GONE_DESIGN_WINDOW_S
+    )
 
 
 def test_sandbox_gone_settle_budget_derives_from_probe_defaults():

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -225,6 +225,68 @@ def test_judge_runner_gone_fails_when_the_next_send_did_not_run():
     assert "race" not in evidence
 
 
+def _restart_after_stop_evidence(**overrides) -> dict:
+    base = {
+        "runner_healthy_after_s": 5.0,
+        "admitted_at_s": 12.0,
+        "recalled_marker": True,
+        "same_sandbox": True,
+        "loaded_true": False,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_judge_restart_after_stop_accepts_the_same_sandbox_signal():
+    """Recall plus an unchanged sandbox id is a real native resume: no rebuild happened."""
+    evidence = _restart_after_stop_evidence(same_sandbox=True, loaded_true=False)
+    verdict = sc._judge_restart_after_stop(evidence)
+    assert verdict["pass"] is True
+
+
+def test_judge_restart_after_stop_accepts_the_loaded_true_signal():
+    """Recall plus a genuine native hydrate in the runner log is also a real resume, even when
+    the sandbox itself had to be rebuilt (a new sandbox that loads the OLD native session)."""
+    evidence = _restart_after_stop_evidence(same_sandbox=False, loaded_true=True)
+    verdict = sc._judge_restart_after_stop(evidence)
+    assert verdict["pass"] is True
+
+
+def test_judge_restart_after_stop_fails_when_recall_is_the_only_signal():
+    """The exact false-pass this cell exists to catch: the codeword comes back, but neither the
+    sandbox id nor the runner log backs up a genuine native resume — the runner recovered it by
+    reconstructing the conversation from persisted records, not by resuming the native session."""
+    evidence = _restart_after_stop_evidence(same_sandbox=False, loaded_true=False)
+    verdict = sc._judge_restart_after_stop(evidence)
+    assert verdict["pass"] is False
+    assert (
+        verdict["why"] == "native session not resumed, recovered by transcript replay"
+    )
+
+
+def test_judge_restart_after_stop_fails_without_recall_even_with_both_signals():
+    evidence = _restart_after_stop_evidence(
+        recalled_marker=False, same_sandbox=True, loaded_true=True
+    )
+    verdict = sc._judge_restart_after_stop(evidence)
+    assert verdict["pass"] is False
+    assert "codeword was not recalled" in verdict["why"]
+
+
+def test_judge_restart_after_stop_fails_when_the_runner_never_reported_healthy():
+    evidence = _restart_after_stop_evidence(runner_healthy_after_s=None)
+    verdict = sc._judge_restart_after_stop(evidence)
+    assert verdict["pass"] is False
+    assert "never reported healthy" in verdict["why"]
+
+
+def test_judge_restart_after_stop_fails_when_the_continuation_was_never_admitted():
+    evidence = _restart_after_stop_evidence(admitted_at_s=None)
+    verdict = sc._judge_restart_after_stop(evidence)
+    assert verdict["pass"] is False
+    assert "refused for the whole wait window" in verdict["why"]
+
+
 def test_run_cell_finally_path_with_null_hooks_does_not_crash():
     """run_cell()'s runner-health recovery is gated on `needs_hooks and hooks.available`. With
     NullHooks (no --project), hooks.available is False, so the finally block must skip the

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -400,6 +400,193 @@ def test_client_shape_messages_strips_answerless_assistant_turns_first():
     assert shaped[0] is last
 
 
+class _FakeResponse:
+    """Minimal stand-in for an `httpx.Response` the DaytonaAwareHooks code path reads."""
+
+    def __init__(self, status_code: int, payload=None, text: str = ""):
+        self.status_code = status_code
+        self._payload = payload
+        self.text = text
+
+    def json(self):
+        return self._payload
+
+
+def _set_daytona_env():
+    """Dummy, non-secret env values so `DaytonaAwareHooks.__init__` does not raise. Never a real
+    key — these tests must never touch the network."""
+    import os
+
+    saved = {
+        k: os.environ.get(k)
+        for k in ("AGENTA_RUNNER_DAYTONA_API_KEY", "AGENTA_RUNNER_DAYTONA_API_URL")
+    }
+    os.environ["AGENTA_RUNNER_DAYTONA_API_KEY"] = "test-key-not-real"
+    os.environ["AGENTA_RUNNER_DAYTONA_API_URL"] = "https://daytona.example/api"
+    return saved
+
+
+def _restore_env(saved: dict):
+    import os
+
+    for k, v in saved.items():
+        if v is None:
+            os.environ.pop(k, None)
+        else:
+            os.environ[k] = v
+
+
+def test_daytona_aware_hooks_requires_daytona_env_vars():
+    """Constructing without AGENTA_RUNNER_DAYTONA_API_KEY/URL must fail loudly and by name, the
+    same discipline `resolve_env` uses for the three top-level env vars — never a silent no-op
+    that later fails deep inside an HTTP call."""
+    import os
+
+    saved = {
+        k: os.environ.get(k)
+        for k in ("AGENTA_RUNNER_DAYTONA_API_KEY", "AGENTA_RUNNER_DAYTONA_API_URL")
+    }
+    os.environ.pop("AGENTA_RUNNER_DAYTONA_API_KEY", None)
+    os.environ.pop("AGENTA_RUNNER_DAYTONA_API_URL", None)
+    try:
+        try:
+            sc.DaytonaAwareHooks("fake-project")
+        except SystemExit as exc:
+            assert "AGENTA_RUNNER_DAYTONA_API_KEY" in str(exc)
+            assert "AGENTA_RUNNER_DAYTONA_API_URL" in str(exc)
+        else:
+            raise AssertionError("expected SystemExit without the Daytona env vars")
+    finally:
+        _restore_env(saved)
+
+
+def test_daytona_aware_hooks_kill_sandbox_noop_without_sandbox_id():
+    """No observed sandbox id means nothing to end — must not call the Daytona API at all."""
+    saved = _set_daytona_env()
+    try:
+        hooks = sc.DaytonaAwareHooks("fake-project")
+
+        def boom(*a, **k):
+            raise AssertionError("must not call the network without a sandbox id")
+
+        hooks._daytona_delete = boom
+        assert hooks.kill_sandbox(sandbox_id=None) == []
+    finally:
+        _restore_env(saved)
+
+
+def test_daytona_aware_hooks_kill_sandbox_deletes_only_the_observed_sandbox():
+    """Ends the ONE sandbox id the cell observed, by its bare uuid (the `daytona/` prefix is a
+    driver-internal convention, not part of the Daytona API path)."""
+    saved = _set_daytona_env()
+    try:
+        hooks = sc.DaytonaAwareHooks("fake-project")
+        calls = []
+
+        def fake_delete(path):
+            calls.append(path)
+            return _FakeResponse(200)
+
+        hooks._daytona_delete = fake_delete
+        result = hooks.kill_sandbox(sandbox_id="daytona/abc-123")
+        assert calls == ["/sandbox/abc-123"]
+        assert result == ["abc-123"]
+    finally:
+        _restore_env(saved)
+
+
+def test_daytona_aware_hooks_kill_sandbox_treats_404_as_already_gone():
+    saved = _set_daytona_env()
+    try:
+        hooks = sc.DaytonaAwareHooks("fake-project")
+        hooks._daytona_delete = lambda path: _FakeResponse(404)
+        assert hooks.kill_sandbox(sandbox_id="daytona/abc-123") == ["abc-123"]
+    finally:
+        _restore_env(saved)
+
+
+def test_daytona_aware_hooks_sandbox_procs_noop_without_sandbox_id():
+    saved = _set_daytona_env()
+    try:
+        hooks = sc.DaytonaAwareHooks("fake-project")
+
+        def boom(*a, **k):
+            raise AssertionError("must not call the network without a sandbox id")
+
+        hooks._daytona_get = boom
+        assert hooks.sandbox_procs("marker", sandbox_id=None) == []
+    finally:
+        _restore_env(saved)
+
+
+def test_daytona_aware_hooks_sandbox_procs_matches_the_marker_and_filters_self():
+    """The full happy path: fetch the toolbox proxy URL for the ONE observed sandbox, run the
+    same `ps -eo pid=,ppid=,etimes=,args=` reap-exec.ts uses, and keep only the row matching the
+    driver's own marker — never the `ps` invocation itself or an unrelated process."""
+    saved = _set_daytona_env()
+    try:
+        hooks = sc.DaytonaAwareHooks("fake-project")
+        get_calls = []
+        post_calls = []
+
+        hooks._daytona_get = lambda path: (
+            get_calls.append(path),
+            _FakeResponse(200, {"url": "https://proxy.example/tb/abc-123"}),
+        )[1]
+
+        ps_output = (
+            "  501     1    120 /sbin/init\n"
+            "  777   501     30 sleep 300.123456\n"
+            "  778   777      0 ps -eo pid=,ppid=,etimes=,args=\n"
+        )
+
+        class _FakePost:
+            def __call__(self, url, json=None, timeout=None):
+                post_calls.append((url, json))
+                return _FakeResponse(200, {"result": ps_output, "exitCode": 0})
+
+        import httpx as real_httpx
+
+        saved_post = real_httpx.post
+        real_httpx.post = _FakePost()
+        try:
+            hits = hooks.sandbox_procs("sleep 300.123456", sandbox_id="daytona/abc-123")
+        finally:
+            real_httpx.post = saved_post
+
+        assert get_calls == ["/sandbox/abc-123/toolbox-proxy-url"]
+        assert len(post_calls) == 1
+        url, body = post_calls[0]
+        assert url == "https://proxy.example/tb/abc-123/process/execute"
+        assert body["command"] == "ps -eo pid=,ppid=,etimes=,args="
+        assert len(hits) == 1
+        assert hits[0]["pid"] == "777"
+        assert "sleep 300.123456" in hits[0]["args"]
+    finally:
+        _restore_env(saved)
+
+
+def test_select_hooks_returns_null_hooks_without_project():
+    hooks = sc.select_hooks(None, "local")
+    assert isinstance(hooks, sc.NullHooks)
+    hooks = sc.select_hooks(None, "daytona")
+    assert isinstance(hooks, sc.NullHooks)
+
+
+def test_select_hooks_returns_docker_compose_hooks_for_local_sandbox():
+    hooks = sc.select_hooks("fake-project", "local")
+    assert type(hooks) is sc.DockerComposeHooks  # noqa: E721 -- exact class, not the daytona subclass
+
+
+def test_select_hooks_returns_daytona_aware_hooks_for_daytona_sandbox():
+    saved = _set_daytona_env()
+    try:
+        hooks = sc.select_hooks("fake-project", "daytona")
+        assert isinstance(hooks, sc.DaytonaAwareHooks)
+    finally:
+        _restore_env(saved)
+
+
 if __name__ == "__main__":
     import inspect
 

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -1143,6 +1143,104 @@ def test_recover_then_send_does_not_send_when_health_never_recovers():
     assert clock.now >= 6.0
 
 
+class _RunnerGoneStubHooks(sc.OperatorHooks):
+    """Records the order of pause/read/unpause and DB reads, so the runner-gone measurement can be
+    tested without Docker or Postgres. `settle_on_call` makes the command settle on the Nth poll."""
+
+    available = True
+
+    def __init__(self, *, command, executions, stream, settle_on_call=1):
+        self.calls: list[str] = []
+        self._command = command
+        self._executions = executions
+        self._stream = stream
+        self._settle_on_call = settle_on_call
+        self._cmd_calls = 0
+
+    def pause_runner(self) -> None:
+        self.calls.append("pause")
+
+    def unpause_runner(self) -> None:
+        self.calls.append("unpause")
+
+    def command_rows(self, session_id: str) -> list[dict]:
+        self._cmd_calls += 1
+        self.calls.append("command_rows")
+        return self._command if self._cmd_calls >= self._settle_on_call else []
+
+    def execution_rows(self, session_id: str) -> list[dict]:
+        self.calls.append("execution_rows")
+        return self._executions
+
+    def stream_row(self, session_id: str) -> dict:
+        self.calls.append("stream_row")
+        return self._stream
+
+
+def test_runner_gone_measurement_reads_is_running_while_paused():
+    """The is_running read must happen while the pause is still in effect: pause before the read,
+    unpause after it. Reading after the unpause would catch the returning runner's new turn."""
+    hooks = _RunnerGoneStubHooks(
+        command=[{"state": "applied", "outcome": "lost", "target_turn_id": "t1"}],
+        executions=[{"terminal_outcome": "execution_lost"}],
+        stream={"flags": {"is_running": False}},
+    )
+    stop_calls = []
+    terminal = [
+        {
+            "type": "error",
+            "attributes": {"code": "execution_lost", "settled_by": "watchdog"},
+        }
+    ]
+    clock = _FakeClock()
+    measured = sc._measure_runner_gone_while_paused(
+        hooks,
+        "sess",
+        "t1",
+        do_stop=lambda: (stop_calls.append("stop"), {"status": 202})[1],
+        read_terminal=lambda: terminal,
+        sweep_wait=60.0,
+        poll_interval=5.0,
+        clock=clock,
+    )
+    assert "pause" in hooks.calls and "unpause" in hooks.calls
+    assert (
+        hooks.calls.index("pause")
+        < hooks.calls.index("stream_row")
+        < hooks.calls.index("unpause")
+    )
+    assert measured["stream_row"] == {"flags": {"is_running": False}}
+    assert measured["stream_row"]["flags"]["is_running"] is False
+    assert measured["settled_at"] is not None
+    assert measured["paused_read_at"] is not None
+    assert stop_calls == ["stop"]
+
+
+def test_runner_gone_measurement_unpauses_even_when_it_never_settles():
+    """No settlement within the window still unpauses (never strand the runner) and still takes the
+    is_running read while paused, so the cell can report the timeout honestly."""
+    hooks = _RunnerGoneStubHooks(
+        command=[],
+        executions=[],
+        stream={"flags": {"is_running": True}},
+        settle_on_call=999,
+    )
+    clock = _FakeClock()
+    measured = sc._measure_runner_gone_while_paused(
+        hooks,
+        "sess",
+        "t1",
+        do_stop=lambda: {"status": 202},
+        read_terminal=lambda: [],
+        sweep_wait=6.0,
+        poll_interval=3.0,
+        clock=clock,
+    )
+    assert measured["settled_at"] is None
+    assert "unpause" in hooks.calls
+    assert hooks.calls.index("stream_row") < hooks.calls.index("unpause")
+
+
 def test_sandbox_gone_settle_budget_derives_from_probe_defaults():
     saved = sc.SANDBOX_STARTUP_SLACK_S
     sc.SANDBOX_STARTUP_SLACK_S = 0.0

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -1,0 +1,210 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["httpx>=0.27"]
+# ///
+"""Unit tests for the pure parts of session_control.py: cell selection, resume, and result shape.
+
+No stack, no network, no Docker — these exercise only the argument parsing, the OperatorHooks
+skip path, and the verdict-shape helpers.
+"""
+
+from __future__ import annotations
+
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
+
+import session_control as sc  # noqa: E402
+
+
+def test_cells_registry_is_internally_consistent():
+    for name, (needs_hooks, permission, fn) in sc.CELLS.items():
+        assert isinstance(needs_hooks, bool), name
+        assert permission in ("allow", "ask"), name
+        assert callable(fn), name
+
+
+def test_null_hooks_raises_on_every_method():
+    hooks = sc.NullHooks()
+    assert hooks.available is False
+    for method in ("stream_row", "record_rows", "command_rows", "sandbox_procs"):
+        try:
+            getattr(hooks, method)("x")
+        except sc.HooksUnavailable:
+            continue
+        raise AssertionError(f"{method} should raise HooksUnavailable")
+    for method in (
+        "wait_for_runner",
+        "restart_runner",
+        "kill_runner",
+        "pause_runner",
+        "unpause_runner",
+        "stop_postgres",
+        "start_postgres",
+        "kill_sandbox",
+    ):
+        try:
+            getattr(hooks, method)()
+        except sc.HooksUnavailable:
+            continue
+        raise AssertionError(f"{method} should raise HooksUnavailable")
+
+
+def test_verdict_shape_helpers():
+    p = sc._pass("ok")
+    f = sc._fail("bad")
+    s = sc._skip("no hooks")
+    assert p == {"pass": True, "skip": False, "why": "ok"}
+    assert f == {"pass": False, "skip": False, "why": "bad"}
+    assert s == {"pass": False, "skip": True, "why": "no hooks"}
+    for v in (p, f, s):
+        assert set(v) == {"pass", "skip", "why"}
+
+
+def test_hooks_only_cells_skip_without_project(monkeypatch):
+    """Every cell marked needs_hooks=True must SKIP (not crash, not run) when --project is
+    absent, per qa-audit-2026-09-03.md section 4 change 2."""
+
+    class Args:
+        sleep_seconds = 1
+        sweep_wait = 1
+        project = None
+        sandbox = "local"
+
+    hooks = sc.NullHooks()
+    for name, (needs_hooks, _permission, fn) in sc.CELLS.items():
+        if not needs_hooks:
+            continue
+        evidence, verdict = fn({}, {}, Args(), hooks)
+        assert verdict["skip"] is True, f"{name} should skip without --project"
+        assert evidence == {}, (
+            f"{name} should not run any evidence-gathering without --project"
+        )
+
+
+def test_resume_skips_cells_already_in_prior_results(tmp_path):
+    """Cells present in a prior run's results.json are loaded, not re-executed. This is the
+    resumability property qa-audit-2026-09-03.md section 4 change 4 asks for: a lost agent
+    costs one cell, not the whole run."""
+    prior_results = {
+        "cells": {
+            "stop-warm": {
+                "evidence": {"session_id": "abc"},
+                "verdict": {"pass": True, "skip": False, "why": "ok"},
+                "elapsed_s": 1.0,
+            }
+        }
+    }
+    prior_path = tmp_path / "results.json"
+    prior_path.write_text(json.dumps(prior_results))
+
+    loaded = json.loads(prior_path.read_text()).get("cells", {})
+    assert "stop-warm" in loaded
+    assert loaded["stop-warm"]["verdict"]["pass"] is True
+
+    # The cell-selection logic in main(): a cell present in `prior` is carried forward as-is
+    # rather than re-run. Exercise the same branch condition main() uses.
+    wanted = ["stop-warm", "double-send"]
+    to_run = [c for c in wanted if c not in loaded]
+    assert to_run == ["double-send"]
+
+
+def test_cell_names_are_stable_and_known():
+    expected = {
+        "stop-warm",
+        "double-send",
+        "stale-stop",
+        "stop-approval",
+        "sandbox-gone",
+        "records-outage",
+        "stop-after-finish",
+        "restart-after-stop",
+        "post-stop-row",
+        "codex-child",
+        "stale-tail",
+        "repeat-stop",
+        "stop-during-completion",
+    }
+    assert set(sc.CELLS) == expected
+
+
+def test_resolve_env_names_every_missing_variable(monkeypatch):
+    monkeypatch.delenv("AGENTA_BASE", raising=False)
+    monkeypatch.delenv("AGENTA_ADMIN_KEY", raising=False)
+    monkeypatch.delenv("QA_OPENAI_API_KEY", raising=False)
+    try:
+        sc.resolve_env()
+    except SystemExit as exc:
+        msg = str(exc)
+        assert "AGENTA_BASE" in msg
+        assert "AGENTA_ADMIN_KEY" in msg
+        assert "QA_OPENAI_API_KEY" in msg
+        assert "no env-file fallback" in msg
+    else:
+        raise AssertionError("resolve_env() should raise SystemExit when env is empty")
+
+
+def test_resolve_env_populates_globals(monkeypatch):
+    monkeypatch.setenv("AGENTA_BASE", "https://example.test")
+    monkeypatch.setenv("AGENTA_ADMIN_KEY", "admin-secret")
+    monkeypatch.setenv("QA_OPENAI_API_KEY", "sk-test")
+    sc.resolve_env()
+    assert sc.BASE == "https://example.test"
+    assert sc.ADMIN_KEY == "admin-secret"
+    assert sc.OPENAI_KEY == "sk-test"
+
+
+if __name__ == "__main__":
+    import inspect
+
+    failures = 0
+    tests = [
+        (name, obj)
+        for name, obj in sorted(globals().items())
+        if name.startswith("test_") and callable(obj)
+    ]
+    for name, fn in tests:
+        params = inspect.signature(fn).parameters
+        try:
+            if "monkeypatch" in params or "tmp_path" in params:
+                # Minimal standalone monkeypatch/tmp_path so this file runs without pytest too.
+                import os
+                import tempfile
+
+                class _MonkeyPatch:
+                    def __init__(self):
+                        self._saved = {}
+
+                    def setenv(self, k, v):
+                        self._saved.setdefault(k, os.environ.get(k))
+                        os.environ[k] = v
+
+                    def delenv(self, k, raising=False):
+                        self._saved.setdefault(k, os.environ.get(k))
+                        os.environ.pop(k, None)
+
+                    def restore(self):
+                        for k, v in self._saved.items():
+                            if v is None:
+                                os.environ.pop(k, None)
+                            else:
+                                os.environ[k] = v
+
+                kwargs = {}
+                mp = _MonkeyPatch()
+                if "monkeypatch" in params:
+                    kwargs["monkeypatch"] = mp
+                if "tmp_path" in params:
+                    kwargs["tmp_path"] = pathlib.Path(tempfile.mkdtemp())
+                fn(**kwargs)
+                mp.restore()
+            else:
+                fn()
+            print(f"PASS {name}")
+        except Exception as exc:  # noqa: BLE001
+            failures += 1
+            print(f"FAIL {name}: {exc}")
+    print(f"\n{len(tests) - failures}/{len(tests)} passed")
+    sys.exit(1 if failures else 0)

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -341,6 +341,65 @@ def test_resolve_env_populates_globals(monkeypatch):
     assert sc.OPENAI_KEY == "sk-test"
 
 
+def test_client_shape_messages_full_is_a_noop():
+    """--client-shape full (the default) must not touch the outbound messages at all."""
+    assert sc.CLIENT_SHAPE == "full"
+    messages = [
+        sc.user_msg("first"),
+        {"role": "assistant", "parts": [{"type": "text", "text": "ok"}]},
+        sc.user_msg("last"),
+    ]
+    assert sc._client_shape_messages(messages) == messages
+
+
+def test_client_shape_messages_last_message_produces_exactly_one_message_for_a_user_turn():
+    """The literal contract: under last-message, the outbound messages a fresh user turn
+    produces has exactly one entry, and it is the new user message — not a copy or a rebuild
+    of it."""
+    sc.CLIENT_SHAPE = "last-message"
+    try:
+        first = sc.user_msg("first")
+        reply = {"role": "assistant", "parts": [{"type": "text", "text": "ok"}]}
+        last = sc.user_msg("last")
+        shaped = sc._client_shape_messages([first, reply, last])
+    finally:
+        sc.CLIENT_SHAPE = "full"
+    assert len(shaped) == 1
+    assert shaped[0] is last
+
+
+def test_client_shape_messages_keeps_full_history_for_a_hitl_resume():
+    """A resume whose trailing turn carries a settled HITL answer (an assistant message, not a
+    fresh user turn) must NOT be truncated: the answer has to stay bound to its tool call, the
+    same guard agentRequest.ts applies (`lastMessage?.role === "user"`)."""
+    sc.CLIENT_SHAPE = "last-message"
+    try:
+        first = sc.user_msg("first")
+        settled = {
+            "role": "assistant",
+            "parts": [{"type": "tool-shell", "state": "output-denied"}],
+        }
+        shaped = sc._client_shape_messages([first, settled])
+    finally:
+        sc.CLIENT_SHAPE = "full"
+    assert shaped == [first, settled]
+
+
+def test_client_shape_messages_strips_answerless_assistant_turns_first():
+    """An assistant turn with no answer part (no text, no tool, no dynamic-tool, no file) is
+    stripped before the trailing-user-turn check, mirroring `hasAnswer` in agentRequest.ts."""
+    sc.CLIENT_SHAPE = "last-message"
+    try:
+        first = sc.user_msg("first")
+        empty_assistant = {"role": "assistant", "parts": []}
+        last = sc.user_msg("last")
+        shaped = sc._client_shape_messages([first, empty_assistant, last])
+    finally:
+        sc.CLIENT_SHAPE = "full"
+    assert len(shaped) == 1
+    assert shaped[0] is last
+
+
 if __name__ == "__main__":
     import inspect
 

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -12,6 +12,7 @@ from __future__ import annotations
 
 import json
 import pathlib
+import re
 import sys
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
@@ -51,6 +52,7 @@ def test_null_hooks_raises_on_every_method():
         "stop_postgres",
         "start_postgres",
         "kill_sandbox",
+        "kill_sandbox_for_session",
     ):
         try:
             getattr(hooks, method)()
@@ -791,6 +793,221 @@ def test_select_hooks_returns_daytona_aware_hooks_for_daytona_sandbox():
         assert isinstance(hooks, sc.DaytonaAwareHooks)
     finally:
         _restore_env(saved)
+
+
+# --------------------------------------------------------------------------- #
+# sandbox-gone: per-session sandbox targeting (the driver defect this PR fixes).
+# --------------------------------------------------------------------------- #
+
+
+def test_parse_local_sandbox_port_reads_the_port_from_a_local_ledger_id():
+    assert sc._parse_local_sandbox_port("local/127.0.0.1:44831") == 44831
+    assert sc._parse_local_sandbox_port("local/0.0.0.0:5") == 5
+
+
+def test_parse_local_sandbox_port_ignores_daytona_and_empty_ids():
+    assert sc._parse_local_sandbox_port("daytona/abc-123") is None
+    assert sc._parse_local_sandbox_port(None) is None
+    assert sc._parse_local_sandbox_port("") is None
+
+
+def test_parse_ss_listener_pid_matches_the_exact_port():
+    out = (
+        'LISTEN 0 511 127.0.0.1:44831 0.0.0.0:* users:(("node",pid=2170,fd=23))\n'
+        'LISTEN 0 511 127.0.0.1:34013 0.0.0.0:* users:(("node",pid=1999,fd=23))\n'
+    )
+    assert sc._parse_ss_listener_pid(out, 44831) == "2170"
+    assert sc._parse_ss_listener_pid(out, 34013) == "1999"
+
+
+def test_parse_ss_listener_pid_does_not_match_a_substring_port():
+    out = 'LISTEN 0 511 127.0.0.1:44831 0.0.0.0:* users:(("node",pid=2170,fd=23))\n'
+    assert sc._parse_ss_listener_pid(out, 4483) is None
+    assert sc._parse_ss_listener_pid(out, 831) is None
+
+
+def test_parse_ss_listener_pid_returns_none_when_absent():
+    assert sc._parse_ss_listener_pid("", 44831) is None
+
+
+class _FakeLocalHooks(sc.DockerComposeHooks):
+    """DockerComposeHooks with the container round-trips (`dc`, `runner_log`) scripted, so the
+    port-to-pid mapping and the wrong-target refusals are tested without Docker."""
+
+    def __init__(self, *, log_lines=None, ss="", proc_pid="", cmdlines=None):
+        super().__init__("fake-project")
+        self._log_lines = log_lines or []
+        self._ss = ss
+        self._proc_pid = proc_pid
+        self._cmdlines = cmdlines or {}
+        self.killed: list[str] = []
+
+    def runner_log(self, since: float) -> list[str]:
+        return list(self._log_lines)
+
+    def dc(self, *args: str, timeout: float = 60.0) -> str:
+        joined = " ".join(str(a) for a in args)
+        if "ss -ltnHp" in joined:
+            return self._ss
+        if "socket:[" in joined:  # the /proc/net/tcp fallback resolver script
+            return self._proc_pid
+        if "/cmdline" in joined:
+            m = re.search(r"/proc/(\d+)/cmdline", joined)
+            return self._cmdlines.get(m.group(1) if m else "", "")
+        if "kill -9" in joined:
+            self.killed.append(joined)
+            return ""
+        raise AssertionError(f"unexpected dc call: {args}")
+
+
+def test_local_kill_targets_only_the_tested_sessions_sandbox():
+    """The tested session's port maps to its own pid; the other session's parked daemon on a
+    different port is never touched — the exact defect that produced the false negative."""
+    sid = "sess-under-test"
+    hooks = _FakeLocalHooks(
+        log_lines=[
+            f"12:29 [sandbox-agent] [timing] stage=prepare_workspace ms=0 "
+            f"sandbox=local/127.0.0.1:44831 session={sid}",
+            "12:28 [sandbox-agent] [timing] stage=prepare_workspace ms=0 "
+            "sandbox=local/127.0.0.1:34013 session=other-session",
+        ],
+        ss=(
+            'LISTEN 0 511 127.0.0.1:44831 0.0.0.0:* users:(("node",pid=2170,fd=23))\n'
+            'LISTEN 0 511 127.0.0.1:34013 0.0.0.0:* users:(("node",pid=1999,fd=23))\n'
+        ),
+        cmdlines={
+            "2170": "node /app/node_modules/.bin/sandbox-agent server --port 44831",
+        },
+    )
+    result = hooks.kill_sandbox_for_session(
+        sid, sandbox_id="local/127.0.0.1:44831", since=0.0
+    )
+    assert result["port"] == 44831
+    assert result["pid"] == "2170"
+    assert result["killed"] == ["2170"]
+    assert any("2170" in k for k in hooks.killed)
+    assert not any("1999" in k for k in hooks.killed)
+
+
+def test_local_kill_refuses_when_the_port_cannot_be_mapped():
+    hooks = _FakeLocalHooks(log_lines=[])
+    try:
+        hooks.kill_sandbox_for_session("sess", sandbox_id=None, since=0.0)
+    except sc.WrongSandboxTarget:
+        assert hooks.killed == []
+        return
+    raise AssertionError("expected WrongSandboxTarget")
+
+
+def test_local_kill_refuses_when_nothing_listens_on_the_port():
+    hooks = _FakeLocalHooks(ss="", proc_pid="")
+    try:
+        hooks.kill_sandbox_for_session(
+            "sess", sandbox_id="local/127.0.0.1:44831", since=0.0
+        )
+    except sc.WrongSandboxTarget:
+        assert hooks.killed == []
+        return
+    raise AssertionError("expected WrongSandboxTarget")
+
+
+def test_local_kill_refuses_when_the_pid_is_not_a_sandbox_agent():
+    hooks = _FakeLocalHooks(
+        ss='LISTEN 0 511 127.0.0.1:44831 0.0.0.0:* users:(("postgres",pid=42,fd=7))\n',
+        cmdlines={"42": "postgres: primary process"},
+    )
+    try:
+        hooks.kill_sandbox_for_session(
+            "sess", sandbox_id="local/127.0.0.1:44831", since=0.0
+        )
+    except sc.WrongSandboxTarget:
+        assert hooks.killed == []
+        return
+    raise AssertionError("expected WrongSandboxTarget")
+
+
+def test_local_kill_refuses_when_log_and_ledger_ports_disagree():
+    sid = "sess"
+    hooks = _FakeLocalHooks(
+        log_lines=[
+            f"12:29 [sandbox-agent] [timing] stage=prepare_workspace ms=0 "
+            f"sandbox=local/127.0.0.1:34013 session={sid}",
+        ],
+    )
+    try:
+        hooks.kill_sandbox_for_session(
+            sid, sandbox_id="local/127.0.0.1:44831", since=0.0
+        )
+    except sc.WrongSandboxTarget:
+        assert hooks.killed == []
+        return
+    raise AssertionError("expected WrongSandboxTarget")
+
+
+def test_local_kill_falls_back_to_proc_when_ss_is_absent():
+    """A distroless runner has no `ss`; the /proc resolver supplies the pid instead."""
+    sid = "sess"
+    hooks = _FakeLocalHooks(
+        log_lines=[
+            f"12:29 [sandbox-agent] [timing] stage=prepare_workspace ms=0 "
+            f"sandbox=local/127.0.0.1:44831 session={sid}",
+        ],
+        ss="",
+        proc_pid="2170\n",
+        cmdlines={"2170": "node .../sandbox-agent server"},
+    )
+    result = hooks.kill_sandbox_for_session(
+        sid, sandbox_id="local/127.0.0.1:44831", since=0.0
+    )
+    assert result["pid"] == "2170"
+    assert result["killed"] == ["2170"]
+
+
+def test_daytona_kill_for_session_delegates_to_the_remote_delete():
+    saved = _set_daytona_env()
+    try:
+        hooks = sc.DaytonaAwareHooks("fake-project")
+        hooks._daytona_delete = lambda path: _FakeResponse(200)
+        result = hooks.kill_sandbox_for_session(
+            "sess", sandbox_id="daytona/abc-123", since=0.0
+        )
+        assert result["killed"] == ["abc-123"]
+        assert result["port"] is None
+    finally:
+        _restore_env(saved)
+
+
+def test_daytona_kill_for_session_refuses_without_a_sandbox_id():
+    saved = _set_daytona_env()
+    try:
+        hooks = sc.DaytonaAwareHooks("fake-project")
+
+        def boom(*a, **k):
+            raise AssertionError("must not call the network without a sandbox id")
+
+        hooks._daytona_delete = boom
+        try:
+            hooks.kill_sandbox_for_session("sess", sandbox_id=None, since=0.0)
+        except sc.WrongSandboxTarget:
+            return
+        raise AssertionError("expected WrongSandboxTarget")
+    finally:
+        _restore_env(saved)
+
+
+def test_sandbox_gone_settle_budget_derives_from_probe_defaults():
+    saved = sc.SANDBOX_STARTUP_SLACK_S
+    sc.SANDBOX_STARTUP_SLACK_S = 0.0
+    try:
+        expected = (
+            sc.SANDBOX_LIVENESS_PROBE_INTERVAL_S * sc.SANDBOX_LIVENESS_PROBE_FAILURES
+            + sc.SANDBOX_GONE_SETTLE_SLACK_S
+        )
+        assert sc.sandbox_gone_settle_budget_s() == expected
+        # Never shorter than the slow command's own duration would leave it, per the wait rule.
+        assert sc.SANDBOX_GONE_COMMAND_S > 0
+    finally:
+        sc.SANDBOX_STARTUP_SLACK_S = saved
 
 
 if __name__ == "__main__":

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -134,6 +134,97 @@ def test_cell_names_are_stable_and_known():
     assert set(sc.CELLS) == expected
 
 
+def _runner_gone_evidence(**overrides) -> dict:
+    """A minimal evidence dict shaped the way cell_runner_gone / cell_runner_gone_late build
+    it, with sane defaults that satisfy `_judge_runner_gone` on their own. Tests override just
+    the field(s) under test."""
+    base = {
+        "terminal_records": [
+            {
+                "type": "error",
+                "attributes": {"code": "execution_lost", "settled_by": "watchdog"},
+            },
+            {"type": "done", "attributes": {"settled_by": "watchdog"}},
+        ],
+        "stop_command": {"state": "applied", "outcome": "stopped"},
+        "stream_row": {"flags": {"is_running": False}},
+        "new_message_ran": True,
+    }
+    base.update(overrides)
+    return base
+
+
+def test_judge_runner_gone_accepts_the_never_reported_race():
+    """The hard race: the command settles `lost` because the runner never got to claim or
+    report it. This must PASS and record which race landed."""
+    evidence = _runner_gone_evidence(
+        stop_command={"state": "applied", "outcome": "lost"}
+    )
+    verdict = sc._judge_runner_gone(evidence)
+    assert verdict["pass"] is True
+    assert verdict["skip"] is False
+    assert evidence["race"] == "never-reported"
+
+
+def test_judge_runner_gone_accepts_the_outcome_reported_then_died_race():
+    """The soft race: the runner reports the Stop's outcome before it actually dies. This must
+    ALSO pass — both races satisfy the same invariant — and record the other race label."""
+    evidence = _runner_gone_evidence(
+        stop_command={"state": "obsolete", "outcome": "stopped"}
+    )
+    verdict = sc._judge_runner_gone(evidence)
+    assert verdict["pass"] is True
+    assert verdict["skip"] is False
+    assert evidence["race"] == "outcome-reported-then-died"
+
+
+def test_judge_runner_gone_fails_without_any_terminal_record():
+    evidence = _runner_gone_evidence(terminal_records=[])
+    verdict = sc._judge_runner_gone(evidence)
+    assert verdict["pass"] is False
+    assert "race" not in evidence
+
+
+def test_judge_runner_gone_fails_without_a_stop_command_row():
+    evidence = _runner_gone_evidence(stop_command=None)
+    verdict = sc._judge_runner_gone(evidence)
+    assert verdict["pass"] is False
+    assert "race" not in evidence
+
+
+def test_judge_runner_gone_fails_on_an_unexpected_command_state():
+    evidence = _runner_gone_evidence(
+        stop_command={"state": "claimed", "outcome": "stopped"}
+    )
+    verdict = sc._judge_runner_gone(evidence)
+    assert verdict["pass"] is False
+    assert "race" not in evidence
+
+
+def test_judge_runner_gone_fails_while_the_command_is_still_pending_or_claimed():
+    for outcome in (None, "", "pending", "claimed"):
+        evidence = _runner_gone_evidence(
+            stop_command={"state": "applied", "outcome": outcome}
+        )
+        verdict = sc._judge_runner_gone(evidence)
+        assert verdict["pass"] is False, outcome
+        assert "race" not in evidence, outcome
+
+
+def test_judge_runner_gone_fails_when_is_running_still_reads_true():
+    evidence = _runner_gone_evidence(stream_row={"flags": {"is_running": True}})
+    verdict = sc._judge_runner_gone(evidence)
+    assert verdict["pass"] is False
+    assert "race" not in evidence
+
+
+def test_judge_runner_gone_fails_when_the_next_send_did_not_run():
+    evidence = _runner_gone_evidence(new_message_ran=False)
+    verdict = sc._judge_runner_gone(evidence)
+    assert verdict["pass"] is False
+    assert "race" not in evidence
+
+
 def test_run_cell_finally_path_with_null_hooks_does_not_crash():
     """run_cell()'s runner-health recovery is gated on `needs_hooks and hooks.available`. With
     NullHooks (no --project), hooks.available is False, so the finally block must skip the

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -29,7 +29,13 @@ def test_cells_registry_is_internally_consistent():
 def test_null_hooks_raises_on_every_method():
     hooks = sc.NullHooks()
     assert hooks.available is False
-    for method in ("stream_row", "record_rows", "command_rows", "sandbox_procs"):
+    for method in (
+        "stream_row",
+        "record_rows",
+        "command_rows",
+        "execution_rows",
+        "sandbox_procs",
+    ):
         try:
             getattr(hooks, method)("x")
         except sc.HooksUnavailable:
@@ -285,6 +291,130 @@ def test_judge_restart_after_stop_fails_when_the_continuation_was_never_admitted
     verdict = sc._judge_restart_after_stop(evidence)
     assert verdict["pass"] is False
     assert "refused for the whole wait window" in verdict["why"]
+
+
+def test_match_stop_command_prefers_the_row_targeting_the_turn():
+    commands = [
+        {"id": "old", "target_turn_id": "turn-a", "state": "applied"},
+        {"id": "new", "target_turn_id": "turn-b", "state": "obsolete"},
+    ]
+    assert sc._match_stop_command(commands, "turn-b")["id"] == "new"
+
+
+def test_match_stop_command_falls_back_to_the_last_row_when_nothing_matches():
+    commands = [
+        {"id": "a", "target_turn_id": None},
+        {"id": "b", "target_turn_id": None},
+    ]
+    assert sc._match_stop_command(commands, "turn-x")["id"] == "b"
+    assert sc._match_stop_command(commands, None)["id"] == "b"
+
+
+def test_match_stop_command_returns_none_for_no_commands():
+    assert sc._match_stop_command([], "turn-a") is None
+
+
+class _StubSettlementHooks(sc.OperatorHooks):
+    """A hook stub whose command_rows/execution_rows are scripted per call, so
+    assert_command_settled can be tested without Docker or Postgres."""
+
+    available = True
+
+    def __init__(self, command_sequence, execution_sequence):
+        # Each is a list of return values, one per poll iteration; the last value repeats once
+        # exhausted, so a test can describe "stays this way forever" with one entry.
+        self._commands = command_sequence
+        self._executions = execution_sequence
+        self._i = 0
+
+    def command_rows(self, session_id: str) -> list[dict]:
+        i = min(self._i, len(self._commands) - 1)
+        return self._commands[i]
+
+    def execution_rows(self, session_id: str) -> list[dict]:
+        i = min(self._i, len(self._executions) - 1)
+        result = self._executions[i]
+        self._i += (
+            1  # advance once per poll iteration (execution_rows is always called)
+        )
+        return result
+
+
+def test_assert_command_settled_is_a_noop_without_hooks():
+    """A cell running without --project (NullHooks) must not be blocked by a check it has no
+    way to make — the cell's own hooks.available guard already SKIPs it where needed."""
+    result = sc.assert_command_settled(
+        sc.NullHooks(), "session-1", "turn-1", timeout=5.0
+    )
+    assert result == {
+        "settled": True,
+        "command": None,
+        "execution_rows": [],
+        "why": None,
+    }
+
+
+def test_assert_command_settled_passes_immediately_when_already_settled():
+    hooks = _StubSettlementHooks(
+        command_sequence=[
+            [{"id": "cmd-1", "target_turn_id": "turn-1", "state": "applied"}]
+        ],
+        execution_sequence=[
+            [{"execution_id": "exec-1", "terminal_outcome": "stopped"}]
+        ],
+    )
+    result = sc.assert_command_settled(hooks, "session-1", "turn-1", timeout=5.0)
+    assert result["settled"] is True
+    assert result["why"] is None
+    assert result["command"]["state"] == "applied"
+    assert result["execution_rows"][0]["terminal_outcome"] == "stopped"
+
+
+def test_assert_command_settled_catches_the_repeat_stop_false_pass():
+    """The exact case this function exists to catch (2026-09-04): a command stuck `claimed`
+    forever with zero session_executions rows, even though every OTHER driver assertion (one
+    terminal trace record, a warm resume) would still pass. Must FAIL, fast (timeout=0 -> no
+    retry sleep), with a reason naming the stuck state."""
+    hooks = _StubSettlementHooks(
+        command_sequence=[
+            [
+                {
+                    "id": "cmd-1",
+                    "target_turn_id": "turn-1",
+                    "state": "claimed",
+                    "outcome": None,
+                }
+            ]
+        ],
+        execution_sequence=[[]],
+    )
+    result = sc.assert_command_settled(hooks, "session-1", "turn-1", timeout=0)
+    assert result["settled"] is False
+    assert "claimed" in result["why"]
+
+
+def test_assert_command_settled_fails_when_no_command_row_exists():
+    hooks = _StubSettlementHooks(command_sequence=[[]], execution_sequence=[[]])
+    result = sc.assert_command_settled(hooks, "session-1", "turn-1", timeout=0)
+    assert result["settled"] is False
+    assert "no session_commands row" in result["why"]
+
+
+def test_assert_command_settled_fails_on_more_than_one_execution_row():
+    hooks = _StubSettlementHooks(
+        command_sequence=[
+            [{"id": "cmd-1", "target_turn_id": "turn-1", "state": "applied"}]
+        ],
+        execution_sequence=[
+            [
+                {"execution_id": "exec-1", "terminal_outcome": "stopped"},
+                {"execution_id": "exec-2", "terminal_outcome": "stopped"},
+            ]
+        ],
+    )
+    result = sc.assert_command_settled(hooks, "session-1", "turn-1", timeout=0)
+    assert result["settled"] is False
+    assert "exactly one session_executions row" in result["why"]
 
 
 def test_run_cell_finally_path_with_null_hooks_does_not_crash():

--- a/.agents/skills/agent-release-gate/resources/test_session_control.py
+++ b/.agents/skills/agent-release-gate/resources/test_session_control.py
@@ -354,6 +354,8 @@ def test_assert_command_settled_is_a_noop_without_hooks():
         "settled": True,
         "command": None,
         "execution_rows": [],
+        "natural_finish": False,
+        "note": None,
         "why": None,
     }
 
@@ -418,6 +420,52 @@ def test_assert_command_settled_fails_on_more_than_one_execution_row():
     )
     result = sc.assert_command_settled(hooks, "session-1", "turn-1", timeout=0)
     assert result["settled"] is False
+    assert "exactly one session_executions row" in result["why"]
+
+
+def test_assert_command_settled_accepts_a_stop_after_a_natural_finish():
+    """A valid Stop that lands after the turn already finished settles obsolete/not_running with
+    NO execution row. Zero rows is correct there — accept it, flag it, and note it."""
+    hooks = _StubSettlementHooks(
+        command_sequence=[
+            [
+                {
+                    "id": "cmd-1",
+                    "target_turn_id": "turn-1",
+                    "state": "obsolete",
+                    "outcome": "not_running",
+                }
+            ]
+        ],
+        execution_sequence=[[]],  # zero execution rows, and that is correct here
+    )
+    result = sc.assert_command_settled(hooks, "session-1", "turn-1", timeout=5.0)
+    assert result["settled"] is True
+    assert result["natural_finish"] is True
+    assert result["note"] == "stop landed after a natural finish"
+    assert result["execution_rows"] == []
+    assert result["why"] is None
+
+
+def test_assert_command_settled_still_requires_a_row_for_a_real_stop():
+    """The strict one-row requirement is kept when the runner actually stopped the turn: an
+    obsolete/stopped command with zero execution rows must still FAIL."""
+    hooks = _StubSettlementHooks(
+        command_sequence=[
+            [
+                {
+                    "id": "cmd-1",
+                    "target_turn_id": "turn-1",
+                    "state": "obsolete",
+                    "outcome": "stopped",
+                }
+            ]
+        ],
+        execution_sequence=[[]],
+    )
+    result = sc.assert_command_settled(hooks, "session-1", "turn-1", timeout=0)
+    assert result["settled"] is False
+    assert result["natural_finish"] is False
     assert "exactly one session_executions row" in result["why"]
 
 


### PR DESCRIPTION
The thirteen-cell driver that proved warm Stop on 2 and 3 September lived in an evidence folder outside the repo. This PR moves it into the release-gate skill as a standing check, with two new cells the QA audit asked for: repeated Stop, and Stop racing a natural completion.

## What changes

- `.agents/skills/agent-release-gate/resources/session_control.py`: fifteen cells. Seven run over HTTP alone against any deployment; six that need container or Postgres access sit behind an operator-hooks interface and skip by name without `--project`. Results land as PASS, FAIL, or SKIP with a one-line reason in a timestamped run folder, and `--resume` replays a prior `results.json` so a lost agent costs one cell.
- `path_triggers.py`: the cells become mandatory for any change under the runner sessions and sandbox-agent code or the API sessions core, tasks, and routers.
- `SKILL.md`: the one-line command, the flags, and the three environment variables by name.
- Unit tests for the pure parts (`test_session_control.py`, 8 pass).

## Runs tonight

| Stack | Harness | Provider | Result |
|---|---|---|---|
| integration (7f2ef31307 + sweep fixes) | Pi | local | stop-warm and repeat-stop pass; Stop 105 ms, two Stops 50 ms apart gave one terminal record |
| integration | Claude Code | local | 5 of 7 pass; stop-approval fails because the builtin shell tool never asks; stop-after-finish ambiguous without hooks |
| integration | Pi | Daytona | 6 of 7 pass, every cell in the same sandbox |
| Track A stack (#6503 + #6501 + fixes) | Pi | local, with hooks | 9 of 13 pass; three failures were first-turn 504s on a cold stack, one is the missing #6500 admission |

The stop-approval cell found a real defect on both providers: after a Stop cancels an approval, the next message takes the runner's approval-resume path and the new text never reaches the model. The fix is on PR #6496.


## Added on 2026-09-04
- Cells `runner-gone` (the runner is paused before the Stop, so delivery cannot reach it; the sweep must settle the command lost), `runner-gone-late` (the runner is killed right after the Stop is accepted), and `concurrent-stops` (five sessions stopped within one second). All three found real defects on their first run; the fixes are on PR #6501 and PR #6496.
- Every hook cell restores its container in a `finally` block, and the run ends with the runner running and healthy even when a cell throws (`5ce3d7e982`).
- `--client-shape full|last-message`: `last-message` mirrors the desktop's request semantics from `agentRequest.ts` (send only the trailing user message; keep full history when the trailing turn carries a settled tool answer). The browser pass found a continuity defect the `full` shape hides, so continuity cells must run in both shapes (`3c07ceb242`).
- Run folders carry the process id so concurrent runs never collide; the run records `client_shape`.
Nineteen cells; 23 unit tests.
- Every Stop-issuing cell now asserts settlement within 20 s: the command row reaches applied or obsolete (never left pending or claimed) and exactly one execution row carries a terminal outcome; the false pass seen on repeat-stop (command claimed forever, no execution row) fails now (`d5bbdc3ee6`). Per-harness stream timeouts: Pi 600 s, Codex and Claude Code 900 s (`e33a1aa3ea`). Nineteen cells; 49 unit tests.

Agent-generated, low weight. Not merged.

https://claude.ai/code/session_01GAqSs7fw6QRi2n1ZJ2tmAV




### Update 2026-09-04 afternoon

The sandbox-gone cell killed the wrong process on the local provider: it matched the first sandbox-agent daemon under a shared mount key and hit the parked idle sandbox of another session, while the tested turn ran on and finished. Head a769ce9058 makes the cell target the tested session's own sandbox port from the runner log, verify the pid's command line, refuse a guess as "wrong target", record port and pid in the evidence, and wait the design window (three liveness probe failures at 30 s plus slack, never shorter than the slow command). 63 driver tests pass.



Head f6bf53c5e7 adds the second half: the cell polls the runner log and the turn ledger for the tested session's own sandbox for up to 120 s (a cold acquire on the stack takes about 35 s), waits until the slow command runs, then kills only that daemon; the slow command lasts 300 s so it outlasts the acquire, the poll, and the 90 s probe window. 67 driver tests pass.



Head 74ad9f9bec adds a third cell fix: runner-gone-late polls the runner health (up to 60 s at 2 s) after it restarts the runner and before the recovery Send, so the restart race can no longer read as a product failure. 69 driver tests pass.

Head 4fbfcb6cef adds the fourth cell fix: runner-gone reads is_running from session_streams while the runner is still paused, after the Stop command settles lost, and records the paused-read and settle timestamps. The unpause and the following Send are a separate resumability check, because the returning runner starts a new turn that sets is_running true again. 71 driver tests pass.

Live results on the integration stack (head dfb94a0c85 and later): runner-gone-late passed on 74ad9f9bec, and sandbox-gone passed on f6bf53c5e7 (the tested session's own sandbox died mid-turn and the turn ended with a terminal record). runner-gone re-runs on 4fbfcb6cef.


Head 97b42fd038 adds the fifth cell fix: the shared settlement assertion now accepts a Stop that lands after a natural finish — command obsolete/not_running with zero execution rows — recording "stop landed after a natural finish", while keeping the strict one-row requirement when the outcome is stopped or lost. This is the shape stale-stop hit on a fast Claude Code turn in run 4. Because every Stop-issuing cell routes its settlement check through this one function, they all inherit it. 73 driver tests pass.
