### PR TITLE
[fix] Persist build-kit tool disable across playground reloads [AGE-4251]

### DIFF
--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -16,6 +16,7 @@ import {projectIdAtom, sessionAtom} from "@agenta/shared/state"
 import {createBatchFetcher, stripEmptyCollectionsDeep} from "@agenta/shared/utils"
 import isEqual from "fast-deep-equal"
 import {atom, type Getter} from "jotai"
+import {atomWithStorage} from "jotai/utils"
 import {getDefaultStore} from "jotai/vanilla"
 import {atomFamily} from "jotai-family"
 import {atomWithQuery, queryClientAtom} from "jotai-tanstack-query"
@@ -1457,19 +1458,47 @@ export const workflowAgentTemplateOverlayAtomFamily = atomFamily((revisionId: st
     }),
 )
 
-export const workflowBuildKitEnabledAtomFamily = atomFamily((_revisionId: string) =>
-    atom<boolean>(true),
-)
-
 /** The build kit's UI state: the master on/off plus the platform ops the user switched off. */
 export interface BuildKitUiState {
     enabled: boolean
     disabledOps: string[]
 }
 
-/** Platform ops switched off individually, by `op`. Empty = all on. In-memory like the master flag. */
-export const workflowBuildKitDisabledOpsAtomFamily = atomFamily((_revisionId: string) =>
-    atom<string[]>([]),
+const DEFAULT_BUILD_KIT_UI_STATE: BuildKitUiState = {enabled: true, disabledOps: []}
+
+/**
+ * The build-kit UI state per revision, persisted so an individually switched-off tool (or the
+ * master off) survives a page reload (#6493). One localStorage record keyed by revision id, the
+ * scoped-persistence pattern; the two atom families below expose per-revision read/write access.
+ */
+const buildKitUiStateByRevisionAtom = atomWithStorage<Record<string, BuildKitUiState>>(
+    "agenta:playground:build-kit",
+    {},
+    undefined,
+    {getOnInit: true},
+)
+
+export const workflowBuildKitEnabledAtomFamily = atomFamily((revisionId: string) =>
+    atom(
+        (get) => get(buildKitUiStateByRevisionAtom)[revisionId]?.enabled ?? true,
+        (get, set, next: boolean) => {
+            const all = get(buildKitUiStateByRevisionAtom)
+            const prev = all[revisionId] ?? DEFAULT_BUILD_KIT_UI_STATE
+            set(buildKitUiStateByRevisionAtom, {...all, [revisionId]: {...prev, enabled: next}})
+        },
+    ),
+)
+
+/** Platform ops switched off individually, by `op`. Empty = all on. Persisted like the master flag. */
+export const workflowBuildKitDisabledOpsAtomFamily = atomFamily((revisionId: string) =>
+    atom(
+        (get) => get(buildKitUiStateByRevisionAtom)[revisionId]?.disabledOps ?? [],
+        (get, set, next: string[]) => {
+            const all = get(buildKitUiStateByRevisionAtom)
+            const prev = all[revisionId] ?? DEFAULT_BUILD_KIT_UI_STATE
+            set(buildKitUiStateByRevisionAtom, {...all, [revisionId]: {...prev, disabledOps: next}})
+        },
+    ),
 )
 
 /**

--- a/web/packages/agenta-entities/src/workflow/state/store.ts
+++ b/web/packages/agenta-entities/src/workflow/state/store.ts
@@ -1478,26 +1478,58 @@ const buildKitUiStateByRevisionAtom = atomWithStorage<Record<string, BuildKitUiS
     {getOnInit: true},
 )
 
+/**
+ * Read one revision's UI state, normalizing whatever localStorage held. jotai already falls back to
+ * the default record on invalid JSON, but valid-JSON-of-the-wrong-shape (tampering, a future shape
+ * change) still passes through, so guard each field: a non-array `disabledOps` would otherwise throw
+ * in the switches' `.filter`.
+ */
+const readBuildKitUiState = (get: Getter, revisionId: string): BuildKitUiState => {
+    const entry: unknown = get(buildKitUiStateByRevisionAtom)[revisionId]
+    if (!entry || typeof entry !== "object") return DEFAULT_BUILD_KIT_UI_STATE
+    const {enabled, disabledOps} = entry as Partial<BuildKitUiState>
+    return {
+        enabled: typeof enabled === "boolean" ? enabled : true,
+        disabledOps: Array.isArray(disabledOps)
+            ? disabledOps.filter((op): op is string => typeof op === "string")
+            : [],
+    }
+}
+
+const writeBuildKitUiState = (
+    get: Getter,
+    set: (next: Record<string, BuildKitUiState>) => void,
+    revisionId: string,
+    patch: Partial<BuildKitUiState>,
+) => {
+    const all = get(buildKitUiStateByRevisionAtom)
+    set({...all, [revisionId]: {...readBuildKitUiState(get, revisionId), ...patch}})
+}
+
 export const workflowBuildKitEnabledAtomFamily = atomFamily((revisionId: string) =>
     atom(
-        (get) => get(buildKitUiStateByRevisionAtom)[revisionId]?.enabled ?? true,
-        (get, set, next: boolean) => {
-            const all = get(buildKitUiStateByRevisionAtom)
-            const prev = all[revisionId] ?? DEFAULT_BUILD_KIT_UI_STATE
-            set(buildKitUiStateByRevisionAtom, {...all, [revisionId]: {...prev, enabled: next}})
-        },
+        (get) => readBuildKitUiState(get, revisionId).enabled,
+        (get, set, next: boolean) =>
+            writeBuildKitUiState(
+                get,
+                (value) => set(buildKitUiStateByRevisionAtom, value),
+                revisionId,
+                {enabled: next},
+            ),
     ),
 )
 
 /** Platform ops switched off individually, by `op`. Empty = all on. Persisted like the master flag. */
 export const workflowBuildKitDisabledOpsAtomFamily = atomFamily((revisionId: string) =>
     atom(
-        (get) => get(buildKitUiStateByRevisionAtom)[revisionId]?.disabledOps ?? [],
-        (get, set, next: string[]) => {
-            const all = get(buildKitUiStateByRevisionAtom)
-            const prev = all[revisionId] ?? DEFAULT_BUILD_KIT_UI_STATE
-            set(buildKitUiStateByRevisionAtom, {...all, [revisionId]: {...prev, disabledOps: next}})
-        },
+        (get) => readBuildKitUiState(get, revisionId).disabledOps,
+        (get, set, next: string[]) =>
+            writeBuildKitUiState(
+                get,
+                (value) => set(buildKitUiStateByRevisionAtom, value),
+                revisionId,
+                {disabledOps: next},
+            ),
     ),
 )
 

--- a/web/packages/agenta-entities/tests/unit/agent-build-kit-ui-state-atom.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-build-kit-ui-state-atom.test.ts
@@ -1,0 +1,100 @@
+/**
+ * Regression guard for #6493: an individually switched-off build-kit tool (and the master off)
+ * must survive a page reload. The UI state is persisted to localStorage; a page reload re-evaluates
+ * the store module, whose `getOnInit` storage read seeds the atom from what the previous load wrote.
+ * Here `vi.resetModules()` + a fresh import stands in for that reload.
+ */
+import {createStore} from "jotai"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+// Node test env has no localStorage; a minimal Storage stub lets atomWithStorage persist.
+// jotai's default storage reads `window.localStorage`, so the stub is hung off a stub window.
+// The backing map outlives module resets so a re-import (the "reload") sees prior writes.
+class MemoryStorage {
+    constructor(private store: Map<string, string>) {}
+    get length() {
+        return this.store.size
+    }
+    clear() {
+        this.store.clear()
+    }
+    getItem(key: string) {
+        return this.store.get(key) ?? null
+    }
+    key(index: number) {
+        return [...this.store.keys()][index] ?? null
+    }
+    removeItem(key: string) {
+        this.store.delete(key)
+    }
+    setItem(key: string, value: string) {
+        this.store.set(key, value)
+    }
+}
+
+const REVISION = "rev-agent-1"
+
+type StoreModule = typeof import("../../src/workflow/state/store")
+
+/** Fresh module evaluation against the shared storage — a stand-in for a page load/reload. */
+async function loadStore(backing: Map<string, string>): Promise<StoreModule> {
+    vi.stubGlobal("window", {localStorage: new MemoryStorage(backing)})
+    vi.resetModules()
+    return import("../../src/workflow/state/store")
+}
+
+describe("build-kit UI state persistence", () => {
+    let backing: Map<string, string>
+
+    beforeEach(() => {
+        backing = new Map()
+    })
+
+    afterEach(() => {
+        vi.unstubAllGlobals()
+    })
+
+    it("defaults to enabled with no disabled ops", async () => {
+        const mod = await loadStore(backing)
+        const store = createStore()
+        expect(store.get(mod.workflowBuildKitEnabledAtomFamily(REVISION))).toBe(true)
+        expect(store.get(mod.workflowBuildKitDisabledOpsAtomFamily(REVISION))).toEqual([])
+    })
+
+    it("persists a switched-off tool across a reload", async () => {
+        const first = await loadStore(backing)
+        createStore().set(first.workflowBuildKitDisabledOpsAtomFamily(REVISION), ["read_file"])
+
+        const reloaded = await loadStore(backing)
+        const store = createStore()
+        expect(store.get(reloaded.workflowBuildKitDisabledOpsAtomFamily(REVISION))).toEqual([
+            "read_file",
+        ])
+        // The master flag is untouched by a tool toggle.
+        expect(store.get(reloaded.workflowBuildKitEnabledAtomFamily(REVISION))).toBe(true)
+    })
+
+    it("persists the master off across a reload", async () => {
+        const first = await loadStore(backing)
+        createStore().set(first.workflowBuildKitEnabledAtomFamily(REVISION), false)
+
+        const reloaded = await loadStore(backing)
+        expect(createStore().get(reloaded.workflowBuildKitEnabledAtomFamily(REVISION))).toBe(false)
+    })
+
+    it("keeps each revision's state independent", async () => {
+        const first = await loadStore(backing)
+        const writeStore = createStore()
+        writeStore.set(first.workflowBuildKitDisabledOpsAtomFamily("rev-a"), ["read_file"])
+        writeStore.set(first.workflowBuildKitDisabledOpsAtomFamily("rev-b"), ["write_file"])
+
+        const reloaded = await loadStore(backing)
+        const store = createStore()
+        expect(store.get(reloaded.workflowBuildKitDisabledOpsAtomFamily("rev-a"))).toEqual([
+            "read_file",
+        ])
+        expect(store.get(reloaded.workflowBuildKitDisabledOpsAtomFamily("rev-b"))).toEqual([
+            "write_file",
+        ])
+    })
+})

--- a/web/packages/agenta-entities/tests/unit/agent-build-kit-ui-state-atom.test.ts
+++ b/web/packages/agenta-entities/tests/unit/agent-build-kit-ui-state-atom.test.ts
@@ -82,6 +82,17 @@ describe("build-kit UI state persistence", () => {
         expect(createStore().get(reloaded.workflowBuildKitEnabledAtomFamily(REVISION))).toBe(false)
     })
 
+    it("falls back to defaults when the persisted record is the wrong shape", async () => {
+        backing.set(
+            "agenta:playground:build-kit",
+            JSON.stringify({[REVISION]: {enabled: "yes", disabledOps: "read_file"}}),
+        )
+        const mod = await loadStore(backing)
+        const store = createStore()
+        expect(store.get(mod.workflowBuildKitEnabledAtomFamily(REVISION))).toBe(true)
+        expect(store.get(mod.workflowBuildKitDisabledOpsAtomFamily(REVISION))).toEqual([])
+    })
+
     it("keeps each revision's state independent", async () => {
         const first = await loadStore(backing)
         const writeStore = createStore()


### PR DESCRIPTION
## Context
Disable a "build it" tool in the agent playground, refresh, and the tool is enabled again. The disabled state never survived a reload. The playground held the build-kit UI state (the master on/off plus the ops switched off individually) in plain in-memory Jotai atoms, so every page load re-initialized them to their defaults (`enabled: true`, `disabledOps: []`).

## Changes
Both atom families are now backed by a single `localStorage` record keyed by revision id, so a switched-off tool and the master off both persist across reloads. The two families keep their existing public API, so `useBuildKit`, `AgentTemplateControl`, and the run-request builder need no changes.

Before: `workflowBuildKitDisabledOpsAtomFamily(rev)` was `atom<string[]>([])`, reset on every load.
After: it reads/writes `agenta:playground:build-kit` in `localStorage` (one record, `{[revisionId]: {enabled, disabledOps}}`, hydrated via `getOnInit`).

## Tests
- New unit suite `agent-build-kit-ui-state-atom.test.ts` models a reload with `vi.resetModules()` + a fresh import: a switched-off tool, the master off, and per-revision isolation all survive.
- Existing build-kit overlay atom/api suites and the playground `agentRequest` suite (43 tests) still pass. `tsc --noEmit` and eslint clean on the changed files.

## What to QA
- Open the playground for any agent, expand Advanced, switch off one "build it" tool, then refresh. The tool stays off.
- Switch the whole build kit off and refresh. It stays off.
- Regression: two different agents keep independent tool states. Switching a tool off in one does not change the other.
