### PR TITLE
[feat] Put the Advanced drawer on a section rail

### DIFF
--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -1222,7 +1222,7 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
                 onSave={saveSection}
                 disabled={disabled || !sectionDirty}
                 dirty={sectionDirty}
-                width={880}
+                width={mh.advancedDrawerWidth}
             >
                 <ChangedPathsProvider changes={drawerChangedPaths}>
                     <ModelHarnessSectionBody

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/AgentTemplateControl.tsx
@@ -1217,7 +1217,6 @@ export const AgentTemplateControl = memo(function AgentTemplateControl({
             <SectionDrawer
                 open={openSection === "advanced"}
                 title="Advanced"
-                icon={<SlidersHorizontal size={16} />}
                 onCancel={cancelSection}
                 onSave={saveSection}
                 disabled={disabled || !sectionDirty}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SectionDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SectionDrawer.tsx
@@ -74,9 +74,7 @@ export function SectionDrawer({
                 }
                 // The body itself doesn't scroll — the content (a full-height flex row) gives each
                 // panel its own overflow, so the left and right panels scroll independently.
-                // Tighter side inset than top/bottom: the rail sits right against the left edge,
-                // and 16px there read as a gutter. The vertical 16 is what the rail's `bleed`
-                // negates, so it stays put.
+                // Tighter at the sides; the vertical 16 is what the rail's `bleed` negates.
                 styles={{body: {padding: "16px 12px", overflow: "hidden"}}}
             >
                 {children}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SectionDrawer.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/SectionDrawer.tsx
@@ -4,7 +4,7 @@
  * Right-hand drawer chrome for a whole config SECTION (Model & harness, Advanced) — as opposed to
  * the per-item `ConfigItemDrawer`. The accordion header opens it; the body is whatever the host
  * passes as children. The host owns the draft model (snapshot the config on open, restore on
- * Cancel), so this is pure chrome: header (icon + title), a scrollable body, and Cancel/Save.
+ * Cancel), so this is pure chrome: header (title), a scrollable body, and Cancel/Save.
  *
  * Built on the shared `EnhancedDrawer`.
  */
@@ -24,7 +24,6 @@ export interface SectionDrawerProps {
     // When true, closing via scrim/X asks for confirmation instead of discarding silently.
     dirty?: boolean
     width?: number
-    footerNote?: ReactNode
     children: ReactNode
 }
 
@@ -37,7 +36,6 @@ export function SectionDrawer({
     disabled = false,
     dirty = false,
     width = 720,
-    footerNote = "Draft — applies on save",
     children,
 }: SectionDrawerProps) {
     const [confirmOpen, setConfirmOpen] = useState(false)
@@ -65,23 +63,21 @@ export function SectionDrawer({
                     </div>
                 }
                 footer={
-                    <div className="flex items-center justify-between gap-3">
-                        <span className="min-w-0 truncate text-xs text-[var(--ag-zinc-5)]">
-                            {footerNote}
-                        </span>
-                        <div className="flex shrink-0 items-center gap-2">
-                            <Button variant="outline" onClick={onCancel}>
-                                Cancel
-                            </Button>
-                            <Button onClick={onSave} disabled={disabled}>
-                                Save
-                            </Button>
-                        </div>
+                    <div className="flex items-center justify-end gap-2">
+                        <Button variant="outline" onClick={onCancel}>
+                            Cancel
+                        </Button>
+                        <Button onClick={onSave} disabled={disabled}>
+                            Save
+                        </Button>
                     </div>
                 }
                 // The body itself doesn't scroll — the content (a full-height flex row) gives each
                 // panel its own overflow, so the left and right panels scroll independently.
-                styles={{body: {padding: 16, overflow: "hidden"}}}
+                // Tighter side inset than top/bottom: the rail sits right against the left edge,
+                // and 16px there read as a gutter. The vertical 16 is what the rail's `bleed`
+                // negates, so it stays put.
+                styles={{body: {padding: "16px 12px", overflow: "hidden"}}}
             >
                 {children}
             </EnhancedDrawer>

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection.tsx
@@ -70,6 +70,7 @@ export function BuildKitSection({
                 <div className="flex items-center gap-2">
                     <span className="min-w-0 flex-1 text-xs font-medium">Playground build kit</span>
                     <Switch
+                        size="sm"
                         checked={enabled}
                         onCheckedChange={onEnabledChange}
                         disabled={disabled}
@@ -77,8 +78,8 @@ export function BuildKitSection({
                     />
                 </div>
                 <span className="text-xs leading-snug text-colorTextDescription">
-                    These playground-only tools and permissions help the assistant build and revise
-                    this agent. None of this is part of the published agent.
+                    Tools and permissions the assistant builds with here. None of it reaches the
+                    published agent.
                 </span>
             </div>
             {!enabled ? (

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/BuildKitSection.tsx
@@ -7,11 +7,9 @@
  */
 import type {ReactNode} from "react"
 
-import {ConfigAccordionSection, Tag} from "@agenta/ui/components/presentational"
+import {Tag} from "@agenta/ui/components/presentational"
 import {Switch, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "@agenta/ui/ui"
-import {Warning, Wrench} from "@phosphor-icons/react"
-
-import {RailField} from "../../../drawers/shared/RailField"
+import {Warning} from "@phosphor-icons/react"
 
 import type {ItemDescriptor} from "./itemDescriptors"
 import {ItemRow} from "./ItemRow"
@@ -47,8 +45,6 @@ export interface BuildKitSectionProps {
     onSetAllTools: (next: boolean) => void
     /** Sandbox permission overlay, rendered read-only as `key → value` rows. */
     permissions?: Record<string, unknown> | null
-    /** Collapsed in the app (it is background information); stories open it. @default false */
-    defaultOpen?: boolean
 }
 
 /** The build-kit block. Switchable tools get a switch each; the rest, and permissions, are read-only. */
@@ -60,7 +56,6 @@ export function BuildKitSection({
     onToggleTool,
     onSetAllTools,
     permissions,
-    defaultOpen = false,
 }: BuildKitSectionProps) {
     // Per-tool switches only mean anything while the kit as a whole is on.
     const toolsDisabled = Boolean(disabled) || !enabled
@@ -70,57 +65,45 @@ export function BuildKitSection({
     // Nothing to switch means no bulk action — the button would be a dead control.
     const hasSwitchableTools = tools.some((tool) => tool.toggle)
     return (
-        <ConfigAccordionSection
-            size="compact"
-            defaultOpen={defaultOpen}
-            icon={<Wrench size={15} />}
-            title="Playground build kit"
-            summary={
-                <span className="inline-flex items-center gap-1.5">
-                    <span className="h-1.5 w-1.5 rounded-full bg-[var(--ag-colorWarning)]" />
-                    Removed on commit
+        <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1">
+                <div className="flex items-center gap-2">
+                    <span className="min-w-0 flex-1 text-xs font-medium">Playground build kit</span>
+                    <Switch
+                        checked={enabled}
+                        onCheckedChange={onEnabledChange}
+                        disabled={disabled}
+                        aria-label="Enable the playground build kit"
+                    />
+                </div>
+                <span className="text-xs leading-snug text-colorTextDescription">
+                    These playground-only tools and permissions help the assistant build and revise
+                    this agent. None of this is part of the published agent.
                 </span>
-            }
-            extra={
-                <Switch
-                    checked={enabled}
-                    onCheckedChange={onEnabledChange}
-                    disabled={disabled}
-                    aria-label="Enable the playground build kit"
-                />
-            }
-        >
-            <span className="text-xs leading-snug text-colorTextDescription">
-                These playground-only tools and permissions help the assistant build and revise this
-                agent. None of this is part of the published agent.
-            </span>
+            </div>
             {!enabled ? (
                 <div className="rounded border border-solid border-[var(--ant-color-info-border)] bg-[var(--ant-color-info-bg)] px-2.5 py-2 text-xs leading-snug text-[var(--ant-color-info-text)]">
                     The assistant can no longer create files, run code, or edit the agent here.
                 </div>
             ) : null}
             {tools.length > 0 ? (
-                <RailField
-                    wide
-                    label={
-                        <span className="flex flex-col items-start gap-1">
-                            <span>Tools</span>
-                            <span className="text-[11px] leading-tight text-colorTextDescription">
-                                {enabledCount} of {tools.length} enabled
-                            </span>
-                            {hasSwitchableTools ? (
-                                <button
-                                    type="button"
-                                    disabled={toolsDisabled}
-                                    onClick={() => onSetAllTools(!allEnabled)}
-                                    className="cursor-pointer border-0 bg-transparent p-0 text-[11px] underline underline-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
-                                >
-                                    {allEnabled ? "Disable all" : "Enable all"}
-                                </button>
-                            ) : null}
+                <div className="flex flex-col gap-1.5">
+                    <div className="flex items-baseline gap-2 text-xs text-colorTextDescription">
+                        <span>Tools</span>
+                        <span className="min-w-0 flex-1 text-[11px]">
+                            {enabledCount} of {tools.length} enabled
                         </span>
-                    }
-                >
+                        {hasSwitchableTools ? (
+                            <button
+                                type="button"
+                                disabled={toolsDisabled}
+                                onClick={() => onSetAllTools(!allEnabled)}
+                                className="cursor-pointer border-0 bg-transparent p-0 text-[11px] text-inherit underline underline-offset-2 disabled:cursor-not-allowed disabled:opacity-50"
+                            >
+                                {allEnabled ? "Disable all" : "Enable all"}
+                            </button>
+                        ) : null}
+                    </div>
                     {tools.map(({key, descriptor, toggle}) => (
                         <ItemRow
                             key={`build-kit-tool-${key}`}
@@ -141,10 +124,11 @@ export function BuildKitSection({
                             }
                         />
                     ))}
-                </RailField>
+                </div>
             ) : null}
             {permissions && Object.keys(permissions).length > 0 ? (
-                <RailField wide label="Sandbox permissions">
+                <div className="flex flex-col gap-1.5">
+                    <span className="text-xs text-colorTextDescription">Sandbox permissions</span>
                     <div className="flex flex-col gap-1.5 opacity-70">
                         {Object.entries(permissions).map(([key, value]) => (
                             <div
@@ -162,9 +146,9 @@ export function BuildKitSection({
                             </div>
                         ))}
                     </div>
-                </RailField>
+                </div>
             ) : null}
-        </ConfigAccordionSection>
+        </div>
     )
 }
 

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/ItemRow.tsx
@@ -156,7 +156,7 @@ export function ItemRow({
                 <ItemAvatar descriptor={descriptor} />
                 <div className="min-w-0 flex-1">
                     <div
-                        className={`truncate text-[13px] font-medium ${
+                        className={`truncate text-[13px] font-normal ${
                             descriptor.monoName === false ? "" : "font-mono"
                         }`}
                     >

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx
@@ -7,6 +7,7 @@
  * revision) plus the user's build-kit state — the master on/off and the platform ops switched off
  * individually — and returns:
  *   - `hasBuildKitOverlay`: whether to render the build-kit block / extend the Advanced section,
+ *   - `buildKitEnabled`: the master on/off, for callers that flag the panel while it is live,
  *   - `buildKitSection`: the drawer block (one tool list — platform tools with a switch each, the
  *     Agenta-owned embeds locked on — plus sandbox permissions) under the master enable switch,
  *   - `permissionOverrideHint`: the inline warning to show above SandboxPermissionControl when the
@@ -186,6 +187,8 @@ export function useBuildKit({
 
     return {
         hasBuildKitOverlay,
+        // The master on/off, so the Advanced rail can flag the panel while the overlay is live.
+        buildKitEnabled,
         buildKitSection,
         permissionOverrideHint,
     }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -2,7 +2,7 @@
  * useModelHarness — the Model + Advanced sections (the panel's most stateful part). One
  * hook because the model/connection state feeds both; returns each section's summary + bodies.
  */
-import {useCallback, useEffect, useMemo, type ReactNode} from "react"
+import {useCallback, useEffect, useMemo, useState, type ReactNode} from "react"
 
 import {
     customSecretsAtom,
@@ -21,12 +21,13 @@ import {normalizeProviderFamily} from "@agenta/shared/utils"
 import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
 import {useDrillInUI} from "@agenta/ui/drill-in"
 import {SelectLLMProviderBase} from "@agenta/ui/select-llm-provider"
-import {Cube, ShieldCheck} from "@phosphor-icons/react"
+import {Cube, ShieldCheck, Wrench} from "@phosphor-icons/react"
 import {atom, useAtomValue, useSetAtom} from "jotai"
 
 import {useHasChangedUnder, useRevertUnder} from "../../../drawers/shared/ChangedPathsContext"
 import {useFocusPaths, useHasFocusUnder} from "../../../drawers/shared/FocusPathsContext"
-import {RailField} from "../../../drawers/shared/RailField"
+import {FieldLayoutProvider, RailField} from "../../../drawers/shared/RailField"
+import {SectionRail, type SectionRailItem} from "../../../drawers/shared/SectionRail"
 import {ClaudePermissionsControl} from "../ClaudePermissionsControl"
 import type {PickerSelection} from "../connectionPicker"
 import {
@@ -68,6 +69,13 @@ import {useBuildKit} from "./useBuildKit"
 const vaultLoadedAtom = atom((get) => Array.isArray(get(vaultSecretsQueryAtom).data))
 
 // Shared with the chat composer's model palette so a hidden harness stays hidden everywhere.
+
+/** One Advanced rail panel: its nav item, an optional header, and the controls it shows. */
+interface AdvancedPanel {
+    item: SectionRailItem
+    header?: {title: string; caption: string; extra?: ReactNode}
+    body: ReactNode
+}
 
 export function useModelHarness({
     schema,
@@ -377,12 +385,13 @@ export function useModelHarness({
 
     // Playground-only "build kit" overlay (read-only) shown at the top of Advanced. It also flags
     // sandbox-permission keys the overlay overrides for the user's own permission control below.
-    const {hasBuildKitOverlay, buildKitSection, permissionOverrideHint} = useBuildKit({
-        revisionId: revisionId ?? null,
-        sandboxPermissions: (sandbox.permissions as Record<string, unknown> | null) ?? null,
-        disabled,
-        stateOverride: buildKitOverride,
-    })
+    const {hasBuildKitOverlay, buildKitEnabled, buildKitSection, permissionOverrideHint} =
+        useBuildKit({
+            revisionId: revisionId ?? null,
+            sandboxPermissions: (sandbox.permissions as Record<string, unknown> | null) ?? null,
+            disabled,
+            stateOverride: buildKitOverride,
+        })
 
     // Which Advanced sub-sections own an uncommitted change (see `ChangedPathsProvider`). Drives
     // `defaultOpen` so a drawer opened from a "something changed" indicator lands with the changed
@@ -755,12 +764,110 @@ export function useModelHarness({
         </>
     )
 
-    // The stacked sections carry their own dividers; drop the trailing one on whichever section
-    // renders last (they're conditional, so target the last child rather than a fixed section).
-    const advancedDrawerBody = (
+    // Rail panels: one per Advanced group, in the order the drawer nav lists them. Schema-gated, so
+    // a template without a group shows neither the rail item nor its panel.
+    const advancedPanels: AdvancedPanel[] = (
+        [
+            hasPermissionsGroup && {
+                item: {
+                    value: "permissions",
+                    label: "Permissions",
+                    icon: <ShieldCheck size={14} />,
+                    status: permissionsChanged ? ("warning" as const) : undefined,
+                },
+                header: {
+                    title: "Permissions",
+                    caption: "What the agent may do on its own before it must ask.",
+                    extra: revertAction(permissionsChanged ? revertPermissions : null),
+                },
+                body: permissionsBody,
+            },
+            hasExecutionGroup && {
+                item: {
+                    value: "execution",
+                    label: "Execution",
+                    icon: <Cube size={14} />,
+                    status: sandboxChanged ? ("warning" as const) : undefined,
+                },
+                header: {
+                    title: "Execution environment",
+                    caption:
+                        "Where the agent's tools and code run, and what that sandbox may touch.",
+                    extra: revertAction(revertSandbox),
+                },
+                body: executionBody,
+            },
+            hasBuildKitOverlay && {
+                // Amber while the kit is on, for the same reason the group carried "Removed on commit":
+                // what this panel adds is playground-only and never reaches the committed agent.
+                item: {
+                    value: "build-kit",
+                    label: "Build kit",
+                    icon: <Wrench size={14} />,
+                    status: buildKitEnabled ? ("warning" as const) : undefined,
+                },
+                // The block carries its own title + enable switch, so it needs no panel header.
+                body: buildKitSection,
+            },
+        ] as (AdvancedPanel | false)[]
+    ).filter((panel): panel is AdvancedPanel => Boolean(panel))
+
+    // Land on the first panel that owns an uncommitted change, else the first one.
+    const initialAdvancedPanel =
+        advancedPanels.find((panel) => panel.item.status === "warning" && panel.header)?.item
+            .value ??
+        advancedPanels[0]?.item.value ??
+        ""
+    const [advancedPanelValue, setAdvancedPanelValue] = useState(initialAdvancedPanel)
+    const activeAdvancedPanel =
+        advancedPanels.find((panel) => panel.item.value === advancedPanelValue) ?? advancedPanels[0]
+
+    const activeAdvancedPanelBody = (
+        <div className="flex min-h-0 flex-1 flex-col gap-3 overflow-y-auto pb-3 pr-1">
+            {activeAdvancedPanel?.header ? (
+                <div className="flex items-start gap-2">
+                    <div className="flex min-w-0 flex-1 flex-col gap-0.5">
+                        <span className="text-xs font-medium">
+                            {activeAdvancedPanel.header.title}
+                        </span>
+                        <span className="text-xs leading-snug text-colorTextDescription">
+                            {activeAdvancedPanel.header.caption}
+                        </span>
+                    </div>
+                    {activeAdvancedPanel.header.extra}
+                </div>
+            ) : null}
+            {activeAdvancedPanel?.body}
+        </div>
+    )
+
+    // One panel needs no nav — a single-item rail is chrome around nothing.
+    const advancedRailBody =
+        advancedPanels.length > 1 ? (
+            <SectionRail
+                fill
+                // Wider than the default rail: these labels carry an icon as well.
+                railWidth="w-[132px]"
+                items={advancedPanels.map((panel) => panel.item)}
+                value={activeAdvancedPanel?.item.value ?? ""}
+                onChange={setAdvancedPanelValue}
+            >
+                {activeAdvancedPanelBody}
+            </SectionRail>
+        ) : (
+            activeAdvancedPanelBody
+        )
+
+    // A focus filter narrows the body to the changed properties, where a nav would be noise — that
+    // path keeps the flat/grouped stack. Otherwise the rail is the drawer's shape.
+    const advancedDrawerBody = focus.active ? (
         <div className="flex h-full flex-col overflow-y-auto [&>*:last-child]:!border-b-0">
             {advancedControls}
         </div>
+    ) : (
+        <FieldLayoutProvider layout="stacked">
+            <div className="flex h-full min-h-0 flex-col">{advancedRailBody}</div>
+        </FieldLayoutProvider>
     )
 
     return {
@@ -779,5 +886,7 @@ export function useModelHarness({
         hasAdvanced,
         advancedSummary,
         advancedDrawerBody,
+        // Rail + one panel at a time: no wider than the Model drawer.
+        advancedDrawerWidth: 560,
     }
 }

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -763,8 +763,7 @@ export function useModelHarness({
         </>
     )
 
-    // Rail panels: one per Advanced group, in the order the drawer nav lists them. Schema-gated, so
-    // a template without a group shows neither the rail item nor its panel.
+    // One rail panel per Advanced group, schema-gated: no group, no rail item and no panel.
     const advancedPanels: AdvancedPanel[] = (
         [
             hasPermissionsGroup && {
@@ -856,8 +855,7 @@ export function useModelHarness({
             activeAdvancedPanelBody
         )
 
-    // A focus filter narrows the body to the changed properties, where a nav would be noise — that
-    // path keeps the flat/grouped stack. Otherwise the rail is the drawer's shape.
+    // Under a focus filter the body is already narrowed, so it keeps the stack over the rail.
     const advancedDrawerBody = focus.active ? (
         <div className="flex h-full flex-col overflow-y-auto [&>*:last-child]:!border-b-0">
             {advancedControls}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -845,7 +845,7 @@ export function useModelHarness({
                 // The drawer body is the rail's only host, so the divider runs its full height.
                 bleed
                 // Wider than the default rail: these labels carry an icon as well.
-                railWidth="w-[132px]"
+                railWidth="w-[148px]"
                 items={advancedPanels.map((panel) => panel.item)}
                 value={activeAdvancedPanel?.item.value ?? ""}
                 onChange={setAdvancedPanelValue}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -385,13 +385,12 @@ export function useModelHarness({
 
     // Playground-only "build kit" overlay (read-only) shown at the top of Advanced. It also flags
     // sandbox-permission keys the overlay overrides for the user's own permission control below.
-    const {hasBuildKitOverlay, buildKitEnabled, buildKitSection, permissionOverrideHint} =
-        useBuildKit({
-            revisionId: revisionId ?? null,
-            sandboxPermissions: (sandbox.permissions as Record<string, unknown> | null) ?? null,
-            disabled,
-            stateOverride: buildKitOverride,
-        })
+    const {hasBuildKitOverlay, buildKitSection, permissionOverrideHint} = useBuildKit({
+        revisionId: revisionId ?? null,
+        sandboxPermissions: (sandbox.permissions as Record<string, unknown> | null) ?? null,
+        disabled,
+        stateOverride: buildKitOverride,
+    })
 
     // Which Advanced sub-sections own an uncommitted change (see `ChangedPathsProvider`). Drives
     // `defaultOpen` so a drawer opened from a "something changed" indicator lands with the changed
@@ -798,13 +797,10 @@ export function useModelHarness({
                 body: executionBody,
             },
             hasBuildKitOverlay && {
-                // Amber while the kit is on, for the same reason the group carried "Removed on commit":
-                // what this panel adds is playground-only and never reaches the committed agent.
                 item: {
                     value: "build-kit",
                     label: "Build kit",
                     icon: <Wrench size={14} />,
-                    status: buildKitEnabled ? ("warning" as const) : undefined,
                 },
                 // The block carries its own title + enable switch, so it needs no panel header.
                 body: buildKitSection,
@@ -846,6 +842,8 @@ export function useModelHarness({
         advancedPanels.length > 1 ? (
             <SectionRail
                 fill
+                // The drawer body is the rail's only host, so the divider runs its full height.
+                bleed
                 // Wider than the default rail: these labels carry an icon as well.
                 railWidth="w-[132px]"
                 items={advancedPanels.map((panel) => panel.item)}

--- a/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
@@ -146,13 +146,13 @@ export function RailField({label, align = "top", path, wide, children}: RailFiel
     const labelNode = changed ? (
         <Popover>
             <PopoverTrigger asChild>
-                {/* role=button makes the Radix aria-haspopup/expanded attrs valid here. */}
-                <span
-                    role="button"
-                    className="cursor-pointer underline decoration-[var(--ag-colorInfo)] decoration-dotted underline-offset-4"
+                {/* A real button, so the keyboard can reach the change detail and its Restore. */}
+                <button
+                    type="button"
+                    className="cursor-pointer border-0 bg-transparent p-0 font-[inherit] text-inherit underline decoration-[var(--ag-colorInfo)] decoration-dotted underline-offset-4 outline-none focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-focus-ring"
                 >
                     {label}
-                </span>
+                </button>
             </PopoverTrigger>
             {/* antd Popover chrome: elevated panel with 12px inner padding. */}
             <PopoverContent side="top" align="start" className="p-3">

--- a/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
@@ -27,8 +27,7 @@ import {ArrowCounterClockwise, Info} from "@phosphor-icons/react"
 import {useChangedDetail, useChangedPath, useRevertPath} from "./ChangedPathsContext"
 import {useIsPathVisible} from "./FocusPathsContext"
 
-/** How a {@link RailField} lays its label out: the two-column rail rhythm, or label-above-control
- * for panels too narrow to spare the 116px column. Context, like the two filters RailField reads. */
+/** How a {@link RailField} lays its label out: two-column rail, or label above the control. */
 const FieldLayoutContext = createContext<"rail" | "stacked">("rail")
 
 export function FieldLayoutProvider({

--- a/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/RailField.tsx
@@ -9,7 +9,7 @@
  * The content is capped at `max-w-prose` so inputs in a section panel keep a readable width instead
  * of stretching the full drawer. Styling uses antd semantic tokens (`--ag-color*`) only — dark-safe.
  */
-import type {ReactNode} from "react"
+import {createContext, useContext, type ReactNode} from "react"
 
 import {cn} from "@agenta/ui/styles"
 import {
@@ -26,6 +26,20 @@ import {ArrowCounterClockwise, Info} from "@phosphor-icons/react"
 
 import {useChangedDetail, useChangedPath, useRevertPath} from "./ChangedPathsContext"
 import {useIsPathVisible} from "./FocusPathsContext"
+
+/** How a {@link RailField} lays its label out: the two-column rail rhythm, or label-above-control
+ * for panels too narrow to spare the 116px column. Context, like the two filters RailField reads. */
+const FieldLayoutContext = createContext<"rail" | "stacked">("rail")
+
+export function FieldLayoutProvider({
+    layout,
+    children,
+}: {
+    layout: "rail" | "stacked"
+    children: ReactNode
+}) {
+    return <FieldLayoutContext.Provider value={layout}>{children}</FieldLayoutContext.Provider>
+}
 
 export interface RailFieldProps {
     label: ReactNode
@@ -120,12 +134,53 @@ function ChangedDetail({
 }
 
 export function RailField({label, align = "top", path, wide, children}: RailFieldProps) {
+    const layout = useContext(FieldLayoutContext)
     const changed = useChangedPath(path)
     const detail = useChangedDetail(path)
     const revert = useRevertPath(path)
     // Focus filter (see FocusPathsContext): each row self-filters on its own `path`.
     const visible = useIsPathVisible(path)
     if (!visible) return null
+    const stacked = layout === "stacked"
+    // The change shows as emphasis + a colorInfo dotted underline, so both states share one box.
+    const labelNode = changed ? (
+        <Popover>
+            <PopoverTrigger asChild>
+                {/* role=button makes the Radix aria-haspopup/expanded attrs valid here. */}
+                <span
+                    role="button"
+                    className="cursor-pointer underline decoration-[var(--ag-colorInfo)] decoration-dotted underline-offset-4"
+                >
+                    {label}
+                </span>
+            </PopoverTrigger>
+            {/* antd Popover chrome: elevated panel with 12px inner padding. */}
+            <PopoverContent side="top" align="start" className="p-3">
+                <ChangedDetail before={detail?.before} onRevert={revert} />
+            </PopoverContent>
+        </Popover>
+    ) : (
+        label
+    )
+
+    // Stacked = the trigger drawers' flat field stack; `align`/`wide` are rail-only knobs.
+    if (stacked) {
+        return (
+            <div className="flex flex-col gap-1.5">
+                <span
+                    className={`text-xs ${
+                        changed
+                            ? "text-[var(--ag-colorText)]"
+                            : "text-[var(--ag-colorTextDescription)]"
+                    }`}
+                >
+                    {labelNode}
+                </span>
+                <div className="flex min-w-0 flex-col">{children}</div>
+            </div>
+        )
+    }
+
     return (
         <div className="flex gap-3">
             <div
@@ -133,28 +188,7 @@ export function RailField({label, align = "top", path, wide, children}: RailFiel
                     align === "center" ? "self-center" : "pt-1.5"
                 } ${changed ? "text-[var(--ag-colorText)]" : "text-[var(--ag-colorTextSecondary)]"}`}
             >
-                {/* The label carries the change via emphasis (colorTextSecondary → colorText) plus a
-                    colorInfo dotted underline — no marker glyph, so changed and unchanged rows share
-                    the same box. */}
-                {changed ? (
-                    <Popover>
-                        <PopoverTrigger asChild>
-                            {/* role=button makes the Radix aria-haspopup/expanded attrs valid here. */}
-                            <span
-                                role="button"
-                                className="cursor-pointer underline decoration-[var(--ag-colorInfo)] decoration-dotted underline-offset-4"
-                            >
-                                {label}
-                            </span>
-                        </PopoverTrigger>
-                        {/* antd Popover chrome: elevated panel with 12px inner padding. */}
-                        <PopoverContent side="top" align="start" className="p-3">
-                            <ChangedDetail before={detail?.before} onRevert={revert} />
-                        </PopoverContent>
-                    </Popover>
-                ) : (
-                    label
-                )}
+                {labelNode}
             </div>
             <div
                 className={cn(

--- a/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
@@ -40,6 +40,12 @@ export interface SectionRailProps {
      * internally-scrolling child. @default false (content-flow, natural height — the drawer case).
      */
     fill?: boolean
+    /**
+     * Run the divider past the host's 16px top/bottom body padding so it meets the drawer's header
+     * and footer rules instead of floating between them. The padding is restored inside the panel,
+     * so the content sits where it did. @default false
+     */
+    bleed?: boolean
     /** Right-hand content panel; separated from the rail by a left border. */
     children: ReactNode
 }
@@ -51,10 +57,11 @@ export function SectionRail({
     railWidth = "w-[116px]",
     disabled = false,
     fill = false,
+    bleed = false,
     children,
 }: SectionRailProps) {
     return (
-        <div className={clsx("flex gap-3", fill && "min-h-0 flex-1")}>
+        <div className={clsx("flex gap-2", fill && "min-h-0 flex-1")}>
             <div className={`flex ${railWidth} shrink-0 flex-col gap-0.5`}>
                 {items.map((item) => {
                     const active = item.value === value
@@ -64,7 +71,7 @@ export function SectionRail({
                             variant="ghost"
                             disabled={disabled}
                             onClick={() => onChange(item.value)}
-                            className={`h-8 w-full rounded-md px-2.5 text-xs transition-colors ${
+                            className={`h-8 w-full rounded-md px-2 text-xs transition-colors ${
                                 item.count != null || item.status
                                     ? "flex items-center justify-between"
                                     : "justify-start"
@@ -99,7 +106,12 @@ export function SectionRail({
                     )
                 })}
             </div>
-            <div className="flex min-w-0 flex-1 flex-col gap-1.5 border-0 border-l border-solid border-[var(--ag-colorBorder)] pl-4">
+            <div
+                className={clsx(
+                    "flex min-w-0 flex-1 flex-col gap-1.5 border-0 border-l border-solid border-[var(--ag-colorBorder)] pl-4",
+                    bleed && "-my-4 py-4",
+                )}
+            >
                 {children}
             </div>
         </div>

--- a/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
@@ -40,11 +40,7 @@ export interface SectionRailProps {
      * internally-scrolling child. @default false (content-flow, natural height — the drawer case).
      */
     fill?: boolean
-    /**
-     * Run the divider past the host's 16px top/bottom body padding so it meets the drawer's header
-     * and footer rules instead of floating between them. The padding is restored inside the panel,
-     * so the content sits where it did. @default false
-     */
+    /** Bleed the divider past the host's 16px vertical padding, onto its rules. @default false */
     bleed?: boolean
     /** Right-hand content panel; separated from the rail by a left border. */
     children: ReactNode

--- a/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/SectionRail.tsx
@@ -16,6 +16,8 @@ import clsx from "clsx"
 export interface SectionRailItem {
     value: string
     label: string
+    /** Optional leading glyph, sized by the caller (14-15px matches the drawer rails). */
+    icon?: ReactNode
     /** Optional trailing count (e.g. a schema's field count). */
     count?: number
     /**
@@ -74,7 +76,14 @@ export function SectionRail({
                                     : "text-[var(--ag-colorTextSecondary)] hover:bg-[var(--ag-colorFillTertiary)] hover:text-[var(--ag-colorText)] disabled:text-[var(--ag-colorTextSecondary)]"
                             }`}
                         >
-                            <span className="truncate">{item.label}</span>
+                            <span className="flex min-w-0 items-center gap-1.5">
+                                {item.icon ? (
+                                    <span className="flex shrink-0 items-center opacity-75">
+                                        {item.icon}
+                                    </span>
+                                ) : null}
+                                <span className="truncate">{item.label}</span>
+                            </span>
                             {item.status ? (
                                 <span
                                     className={`h-1.5 w-1.5 shrink-0 rounded-full ${

--- a/web/packages/agenta-entity-ui/src/drawers/shared/index.ts
+++ b/web/packages/agenta-entity-ui/src/drawers/shared/index.ts
@@ -3,7 +3,7 @@
  * config drawers. Re-exported here so app-layer drawers (e.g. the agent-home template setup drawer)
  * can share the exact same field/rail layout instead of re-implementing it.
  */
-export {RailField, railInfoLabel, type RailFieldProps} from "./RailField"
+export {RailField, FieldLayoutProvider, railInfoLabel, type RailFieldProps} from "./RailField"
 export {SectionRail, type SectionRailItem, type SectionRailProps} from "./SectionRail"
 export {DrawerFooter} from "./DrawerFooter"
 export {RowRemoveButton} from "./RowRemoveButton"

--- a/web/packages/agenta-entity-ui/src/gatewayTool/components/schemaFormControls.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTool/components/schemaFormControls.tsx
@@ -7,7 +7,7 @@
  * Every control takes plain `value`/`onChange`/`disabled` so it works both under antd
  * `Form.Item` cloning and as an explicitly controlled leaf.
  */
-import {useId, useRef, useState} from "react"
+import {useEffect, useId, useMemo, useRef, useState} from "react"
 
 import {dayjs} from "@agenta/shared/utils"
 import {
@@ -19,6 +19,9 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
     Input,
+    Popover,
+    PopoverAnchor,
+    PopoverContent,
     Switch,
     Select,
     SelectContent,
@@ -234,8 +237,14 @@ export function MultiSelect({
 }
 
 /**
- * Free chip input (antd `Select mode="tags"` with `open={false}`): type + Enter adds a
- * chip, Backspace on an empty input removes the last one.
+ * Free chip input (antd `Select mode="tags"`): type + Enter adds a chip, Backspace on an empty
+ * input removes the last one.
+ *
+ * `options` are SUGGESTIONS, not a closed set — the field still takes any typed value. They used
+ * to ride on a native `<datalist>`, which renders an unstyled OS popup, opens only on some
+ * gestures and can't be keyboard-driven from our own markup. So the suggestion list is built here
+ * on the same Popover + `role=listbox` + `aria-activedescendant` pattern as `Combobox`, and looks
+ * like every other dropdown in the form.
  */
 export function ChipsInput({
     value,
@@ -250,16 +259,50 @@ export function ChipsInput({
     placeholder?: string
     disabled?: boolean
     id?: string
-    /** Suggested values, offered as native datalist completions (antd tags-mode `options`). */
+    /** Suggested values, offered in a dropdown. Typing a value not in the list still works. */
     options?: string[]
 }) {
     const [draft, setDraft] = useState("")
-    const listId = useId()
+    const [open, setOpen] = useState(false)
+    const [activeIndex, setActiveIndex] = useState(0)
+    const boxRef = useRef<HTMLDivElement>(null)
     const inputRef = useRef<HTMLInputElement>(null)
+    const listRef = useRef<HTMLDivElement>(null)
     const selected = value ?? []
 
-    const commit = () => {
-        const trimmed = draft.trim()
+    // Stable ids so the input's aria-controls/aria-activedescendant can point at the listbox and
+    // the active row (WAI-ARIA combobox), the way `Combobox` does.
+    const rid = useId()
+    const listId = `${rid}-listbox`
+    const optionId = (index: number) => `${rid}-opt-${index}`
+
+    // What's left to suggest: never a value already chipped, narrowed by what's typed so far.
+    const matches = useMemo(() => {
+        const taken = value ?? []
+        const q = draft.trim().toLowerCase()
+        return (options ?? []).filter(
+            (o) => !taken.includes(o) && (!q || o.toLowerCase().includes(q)),
+        )
+    }, [options, value, draft])
+
+    const hasSuggestions = Boolean(options?.length)
+    const showList = open && !disabled && matches.length > 0
+
+    /** Did this dismiss attempt come from the field itself (the anchor), rather than off it? */
+    const fromBox = (e: {detail: {originalEvent: Event}}) => {
+        const target = e.detail.originalEvent.target
+        return target instanceof Node && Boolean(boxRef.current?.contains(target))
+    }
+
+    // A fresh query re-aims at the first row; the old index could point past the new list.
+    useEffect(() => setActiveIndex(0), [draft, open])
+    useEffect(() => {
+        if (showList)
+            listRef.current?.querySelector("[data-active=true]")?.scrollIntoView({block: "nearest"})
+    }, [activeIndex, showList])
+
+    const add = (raw: string) => {
+        const trimmed = raw.trim()
         setDraft("")
         if (!trimmed || selected.includes(trimmed)) return
         onChange?.([...selected, trimmed])
@@ -269,13 +312,26 @@ export function ChipsInput({
         onChange?.(next.length ? next : undefined)
     }
 
-    return (
+    const box = (
         <div
+            ref={boxRef}
             data-slot="chips-input"
-            onClick={() => inputRef.current?.focus()}
+            onMouseDown={(e) => {
+                if (disabled) return
+                // Focus by hand off the box chrome (Combobox does the same): letting the browser
+                // do it mid-gesture opens the list on a `focus` the rest of the click then
+                // reads as an interaction outside, and the list shuts again on mouseup.
+                if (e.target !== inputRef.current) {
+                    e.preventDefault()
+                    inputRef.current?.focus()
+                }
+                if (hasSuggestions) setOpen(true)
+            }}
             className={cn(
                 selectTriggerVariants({variant: "default", size: "default"}),
                 MULTI_BOX_CLS,
+                // The right inset only exists to clear the caret; without suggestions there is none.
+                !hasSuggestions && "pr-1",
                 "cursor-text",
                 disabled &&
                     "cursor-not-allowed bg-disabled-bg text-disabled border-disabled-border",
@@ -296,33 +352,101 @@ export function ChipsInput({
                 variant="ghost"
                 disabled={disabled}
                 aria-label={placeholder}
+                role={hasSuggestions ? "combobox" : undefined}
+                aria-expanded={hasSuggestions ? showList : undefined}
+                aria-controls={hasSuggestions ? listId : undefined}
+                aria-autocomplete={hasSuggestions ? "list" : undefined}
+                aria-activedescendant={showList ? optionId(activeIndex) : undefined}
                 placeholder={selected.length === 0 ? placeholder : undefined}
                 value={draft}
-                onChange={(e) => setDraft(e.target.value)}
+                onChange={(e) => {
+                    setDraft(e.target.value)
+                    if (hasSuggestions) setOpen(true)
+                }}
+                onFocus={() => hasSuggestions && setOpen(true)}
                 onKeyDown={(e) => {
-                    if (e.key === "Enter") {
+                    if (hasSuggestions && (e.key === "ArrowDown" || e.key === "ArrowUp")) {
                         e.preventDefault()
-                        commit()
+                        if (!showList) return setOpen(true)
+                        const dir = e.key === "ArrowDown" ? 1 : -1
+                        setActiveIndex((i) => (i + dir + matches.length) % matches.length)
+                    } else if (e.key === "Enter") {
+                        e.preventDefault()
+                        add(showList ? (matches[activeIndex] ?? draft) : draft)
+                        setOpen(false)
+                    } else if (e.key === "Escape" && showList) {
+                        // Swallowed, or the drawer hosting the field would close along with the list.
+                        e.preventDefault()
+                        e.stopPropagation()
+                        setOpen(false)
                     } else if (e.key === "Backspace" && draft === "" && selected.length > 0) {
                         removeAt(selected[selected.length - 1])
                     }
                 }}
-                onBlur={commit}
-                list={options?.length ? listId : undefined}
+                onBlur={() => {
+                    add(draft)
+                    setOpen(false)
+                }}
                 // antd's tags-mode search input is width-auto; an 80px floor pushed the caret
                 // onto a second line as soon as the chips filled the row.
                 className="h-6 min-w-[4px] flex-1 px-1"
             />
-            {options?.length ? (
-                <datalist id={listId}>
-                    {options
-                        .filter((o) => !selected.includes(o))
-                        .map((o) => (
-                            <option key={o} value={o} />
-                        ))}
-                </datalist>
-            ) : null}
+            {hasSuggestions && (
+                <CaretDown
+                    size={12}
+                    className="absolute right-[11px] top-1/2 -translate-y-1/2 text-placeholder"
+                />
+            )}
         </div>
+    )
+
+    if (!hasSuggestions) return box
+
+    return (
+        <Popover open={showList} onOpenChange={setOpen}>
+            <PopoverAnchor asChild>{box}</PopoverAnchor>
+            <PopoverContent
+                align="start"
+                aria-label="Suggestions"
+                // Focus stays in the input — the list is driven by aria-activedescendant.
+                onOpenAutoFocus={(e) => e.preventDefault()}
+                onCloseAutoFocus={(e) => e.preventDefault()}
+                // The input lives in the ANCHOR, so every click and focus inside the field reads
+                // as "outside the layer" to Radix and would dismiss the list the moment it opened.
+                onPointerDownOutside={(e) => fromBox(e) && e.preventDefault()}
+                onFocusOutside={(e) => fromBox(e) && e.preventDefault()}
+                className="w-[var(--radix-popover-trigger-width)] p-1 font-portal"
+            >
+                <div
+                    id={listId}
+                    ref={listRef}
+                    role="listbox"
+                    aria-label="Suggestions"
+                    className="max-h-[300px] overflow-y-auto"
+                >
+                    {matches.map((o, index) => (
+                        <div
+                            key={o}
+                            id={optionId(index)}
+                            role="option"
+                            aria-selected={index === activeIndex}
+                            data-active={index === activeIndex}
+                            onMouseEnter={() => setActiveIndex(index)}
+                            // Keeps the input focused, so `onBlur` doesn't chip the draft first.
+                            onMouseDown={(e) => e.preventDefault()}
+                            onClick={() => {
+                                add(o)
+                                setOpen(false)
+                                inputRef.current?.focus()
+                            }}
+                            className="box-border flex min-h-control w-full cursor-pointer select-none items-center rounded-control-sm px-3 py-1 text-field-md data-[active=true]:bg-muted"
+                        >
+                            {o}
+                        </div>
+                    ))}
+                </div>
+            </PopoverContent>
+        </Popover>
     )
 }
 

--- a/web/packages/agenta-entity-ui/src/gatewayTool/components/schemaFormControls.tsx
+++ b/web/packages/agenta-entity-ui/src/gatewayTool/components/schemaFormControls.tsx
@@ -237,14 +237,10 @@ export function MultiSelect({
 }
 
 /**
- * Free chip input (antd `Select mode="tags"`): type + Enter adds a chip, Backspace on an empty
- * input removes the last one.
+ * Free chip input (antd `Select mode="tags"`): type + Enter chips, Backspace on an empty input
+ * removes the last. `options` suggest; any typed value still lands.
  *
- * `options` are SUGGESTIONS, not a closed set — the field still takes any typed value. They used
- * to ride on a native `<datalist>`, which renders an unstyled OS popup, opens only on some
- * gestures and can't be keyboard-driven from our own markup. So the suggestion list is built here
- * on the same Popover + `role=listbox` + `aria-activedescendant` pattern as `Combobox`, and looks
- * like every other dropdown in the form.
+ * Suggestions use the `Combobox` pattern, not a `<datalist>` the keyboard can't reach.
  */
 export function ChipsInput({
     value,
@@ -270,8 +266,7 @@ export function ChipsInput({
     const listRef = useRef<HTMLDivElement>(null)
     const selected = value ?? []
 
-    // Stable ids so the input's aria-controls/aria-activedescendant can point at the listbox and
-    // the active row (WAI-ARIA combobox), the way `Combobox` does.
+    // Stable ids for the input's aria-controls/aria-activedescendant (WAI-ARIA combobox).
     const rid = useId()
     const listId = `${rid}-listbox`
     const optionId = (index: number) => `${rid}-opt-${index}`
@@ -318,9 +313,7 @@ export function ChipsInput({
             data-slot="chips-input"
             onMouseDown={(e) => {
                 if (disabled) return
-                // Focus by hand off the box chrome (Combobox does the same): letting the browser
-                // do it mid-gesture opens the list on a `focus` the rest of the click then
-                // reads as an interaction outside, and the list shuts again on mouseup.
+                // Focus by hand: browser focus opens a list the same click dismisses.
                 if (e.target !== inputRef.current) {
                     e.preventDefault()
                     inputRef.current?.focus()
@@ -387,8 +380,7 @@ export function ChipsInput({
                     add(draft)
                     setOpen(false)
                 }}
-                // antd's tags-mode search input is width-auto; an 80px floor pushed the caret
-                // onto a second line as soon as the chips filled the row.
+                // Width-auto like antd's tags input: a min-width floor wraps the caret.
                 className="h-6 min-w-[4px] flex-1 px-1"
             />
             {hasSuggestions && (
@@ -411,8 +403,7 @@ export function ChipsInput({
                 // Focus stays in the input — the list is driven by aria-activedescendant.
                 onOpenAutoFocus={(e) => e.preventDefault()}
                 onCloseAutoFocus={(e) => e.preventDefault()}
-                // The input lives in the ANCHOR, so every click and focus inside the field reads
-                // as "outside the layer" to Radix and would dismiss the list the moment it opened.
+                // The input is in the ANCHOR, so Radix reads clicks in the field as outside.
                 onPointerDownOutside={(e) => fromBox(e) && e.preventDefault()}
                 onFocusOutside={(e) => fromBox(e) && e.preventDefault()}
                 className="w-[var(--radix-popover-trigger-width)] p-1 font-portal"

--- a/web/storybook/stories/entity-ui/BuildKitSection.stories.tsx
+++ b/web/storybook/stories/entity-ui/BuildKitSection.stories.tsx
@@ -1,7 +1,5 @@
 import {useState} from "react"
 
-import {RailField} from "@agenta/entity-ui/drawers/shared"
-import {ConfigAccordionSection} from "@agenta/ui/components/presentational"
 import {Warning, Wrench} from "@phosphor-icons/react"
 import type {Meta, StoryObj} from "@storybook/nextjs"
 import {Switch as AntSwitch, Tag as AntTag, Tooltip as AntTooltip, Typography} from "antd"
@@ -28,7 +26,7 @@ import {ItemRow} from "../../../packages/agenta-entity-ui/src/DrillInView/Schema
 //
 // The antd half replays the pre-migration markup from
 // `git show feat/storybook-data-seam:web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useBuildKit.tsx`
-// inside the same (already-migrated) `ConfigAccordionSection` / `RailField` / `ItemRow` chrome.
+// inside the same (already-migrated) plain-panel / `ItemRow` chrome.
 const meta = {
     title: "@agenta/entity-ui/DrillIn/BuildKitSection",
     component: BuildKitSection,
@@ -97,33 +95,33 @@ const AntdBuildKitSection = ({
     enabled?: boolean
     disabled?: boolean
 }) => (
-    <ConfigAccordionSection
-        size="compact"
-        defaultOpen
-        icon={<Wrench size={15} />}
-        title="Playground build kit"
-        summary={
-            <span className="inline-flex items-center gap-1.5">
-                <span className="h-1.5 w-1.5 rounded-full bg-[var(--ag-colorWarning)]" />
-                Removed on commit
-            </span>
-        }
-        extra={<AntSwitch checked={enabled} disabled={disabled} />}
-    >
-        <Typography.Text type="secondary" className="text-[11px] leading-snug">
-            {CAPTION}
-        </Typography.Text>
+    <div className="flex flex-col gap-3">
+        <div className="flex flex-col gap-1">
+            <div className="flex items-center gap-2">
+                <span className="min-w-0 flex-1 text-xs font-medium">Playground build kit</span>
+                <AntSwitch checked={enabled} disabled={disabled} />
+            </div>
+            <Typography.Text type="secondary" className="text-[11px] leading-snug">
+                {CAPTION}
+            </Typography.Text>
+        </div>
         {!enabled ? (
             <div className="rounded border border-solid border-[var(--ant-color-info-border)] bg-[var(--ant-color-info-bg)] px-2.5 py-2 text-[11.5px] leading-snug text-[var(--ant-color-info-text)]">
                 {DISABLED_NOTE}
             </div>
         ) : null}
-        <RailField label="Platform tools">
+        <div className="flex flex-col gap-1.5">
+            <Typography.Text type="secondary" className="text-xs">
+                Platform tools
+            </Typography.Text>
             {PLATFORM_OPS.map((op) => (
                 <ItemRow key={`platform-${op}`} descriptor={platformDescriptor(op)} locked />
             ))}
-        </RailField>
-        <RailField label="Sandbox permissions">
+        </div>
+        <div className="flex flex-col gap-1.5">
+            <Typography.Text type="secondary" className="text-xs">
+                Sandbox permissions
+            </Typography.Text>
             <div className="flex flex-col gap-1.5 opacity-70">
                 {Object.entries(PERMISSIONS).map(([key, value]) => (
                     <div
@@ -137,8 +135,8 @@ const AntdBuildKitSection = ({
                     </div>
                 ))}
             </div>
-        </RailField>
-    </ConfigAccordionSection>
+        </div>
+    </div>
 )
 
 /** Pre-migration antd markup for the override hint. */
@@ -156,8 +154,6 @@ const BASE = {
     onToggleTool: () => undefined,
     onSetAllTools: () => undefined,
     permissions: PERMISSIONS,
-    // The app renders this collapsed; every story opens it so the body is visible/measured.
-    defaultOpen: true,
 }
 
 const Live = ({
@@ -228,13 +224,11 @@ export const PermissionsOnly: Story = {
         onToggleTool: () => undefined,
         onSetAllTools: () => undefined,
         permissions: PERMISSIONS,
-        defaultOpen: true,
     },
     render: () => (
         <div className="max-w-[560px]">
             <BuildKitSection
                 enabled
-                defaultOpen
                 onEnabledChange={() => undefined}
                 tools={[]}
                 onToggleTool={() => undefined}


### PR DESCRIPTION
## Context

The Advanced drawer stacked its three groups (Permissions, Execution, Build kit) as accordions in an 880px drawer, so auditing a configuration meant opening and closing them one at a time. Design 1a replaces that with the same section rail the tool and trigger drawers already use.

Two things surfaced while building it. The drawer's chrome kept restating what the panel already showed, and the permission fields offered their suggestions through a native `<datalist>`, which the browser draws in its own style and opens on its own terms.

## Changes

**The rail.** Permissions / Execution / Build kit now sit in a left rail beside one panel at a time, in a 560px drawer. `RailField` gains a stacked layout, selected through a context, so the sandbox, Claude and Pi permission controls keep rendering their own rows unchanged. The build-kit block drops its accordion chrome for a plain panel with the enable switch in its header.

`SectionRail` also gains a `bleed` prop that runs the divider past the drawer's vertical body padding, so it meets the header and footer rules instead of floating between them.

**The chrome.** Dropped the header icon, the "Draft — applies on save" footer note and the Build kit rail's amber dot. Each restated something already on screen. The drawer's side inset goes from 16px to 12px, the rail-to-divider gap from 12px to 8px, and the rail toggles' side padding from 10px to 8px. The footer note came off `SectionDrawer`'s default, so the Model drawer loses it and takes the same insets.

**The chip inputs.** `ChipsInput` offered its suggestions through a native `<datalist>`. That draws an unstyled OS popup, opens on the browser's terms rather than the field's, and cannot be driven from our own keyboard handling. The box also reserved 24px on the right for a caret it never drew.

Before:

```
<input list={listId} />
<datalist id={listId}>{options.map(o => <option value={o} />)}</datalist>
```

After: a `Popover` with a `role=listbox` panel and `aria-activedescendant`, the same pattern `Combobox` uses. It opens on focus, filters as you type, hides values already chipped, and takes arrows, Enter and Escape.

One trap worth naming for the reviewer. The input lives in the popover's *anchor*, not its content, so every click and focus inside the field reads to Radix as an interaction outside the layer. Without a guard, the list dismissed on the tail of the very click that opened it. `onPointerDownOutside` and `onFocusOutside` now check whether the event came from the field, and the input is focused by hand on mousedown rather than by the browser mid-gesture.

Free text still chips on Enter. The options are suggestions, not a closed set.

**Row typography.** `ItemRow`'s name drops from semibold to normal weight; at 13px it read as a heading in a list of them. The build kit's enable switch was the default size while every per-tool switch under it is small, so they now match. The build-kit caption goes from three lines to two.

`ItemRow` is shared, so the tools, subagents, skills and MCP lists take the lighter name too.

## Tests

- `pnpm lint-fix` and `tsc --noEmit` on `@agenta/entity-ui` are both clean.
- Verified every change in the running app, not a component harness. The rail divider measures exactly onto the header rule and the footer rule. The suggestion list opens on click and stays open, dismisses on an outside click, closes on Escape while leaving the drawer open, narrows to Read / Write / Grep when you type `r`, and produces chips from both a clicked suggestion and free text.
- No unit tests added. These are presentational changes plus one interaction rebuilt on an existing primitive pattern.
- Demo capture is outstanding. I confirmed all of the above against the local dev server but cannot export screenshots from the in-app browser.

## What to QA

- Open an agent's configuration and click Advanced. The three groups are a left rail showing one panel at a time, and the divider between rail and panel runs from the header rule to the footer rule with no gap at either end.
- On Permissions, click the Allow field. The suggestion list opens in the app's own dropdown style and stays open. Type `r` and it narrows. Click a suggestion and it becomes a chip.
- Type a value that is not in the list, such as `Bash(npm run:*)`, and press Enter. It still becomes a chip.
- Press Escape with the list open. The list closes and the drawer stays open.
- Open Build kit. The master switch is the same size as the per-tool switches, and the tool names are normal weight.
- Regression: open the Model drawer. It has lost the "Draft — applies on save" note and takes the same side insets, but is otherwise unchanged.
- Regression: the commit modal and the trigger drawers' Pinned/Deployed axis use the same `SectionRail`. Their toggles are 2px tighter on each side but should otherwise look and behave as before.


## Preview

<img width="700"  alt="image" src="https://github.com/user-attachments/assets/098c4406-236a-44b7-b019-f1ae71b1fde4" />

