### PR TITLE
[fix] Keep outage-backlog records and split batches only per record

### DIFF
--- a/api/oss/src/tasks/asyncio/sessions/records_worker.py
+++ b/api/oss/src/tasks/asyncio/sessions/records_worker.py
@@ -193,7 +193,6 @@ class RecordsWorker(StreamConsumer):
                         {f"{row.session_id}:{row.turn_id}" for row in quarantined}
                     ),
                 )
-            self.mark_committed()
             return len(results), True
         except Exception:
             log.error(

--- a/api/oss/src/tasks/asyncio/sessions/records_worker.py
+++ b/api/oss/src/tasks/asyncio/sessions/records_worker.py
@@ -2,6 +2,7 @@ from typing import Any, Dict, List, Optional, Tuple
 from uuid import UUID
 
 from redis.asyncio import Redis
+from sqlalchemy.exc import DataError, IntegrityError
 
 from oss.src.core.sessions.interactions.service import SessionInteractionsService
 from oss.src.core.sessions.records.dtos import TERMINAL_RECORD_TYPE
@@ -23,6 +24,7 @@ if is_ee():
 # human instead of finishing (services/runner/src/tracing/otel.ts: the field is written ONLY
 # for a pause and omitted on every other stop reason).
 PAUSED_STOP_REASON = "paused"
+ROW_REJECTION_ERRORS = (DataError, IntegrityError)
 
 
 def finished_turns_in_batch(events: List[Any]) -> Dict[str, str]:
@@ -104,6 +106,7 @@ class RecordsWorker(StreamConsumer):
         # Absent disables gate reconciliation (minimal test compositions), which only loses the
         # safety net — never the append.
         self.interactions_service = interactions_service
+        self._permanent_failure_ids: set[bytes] = set()
 
     async def reconcile_orphaned_gates(
         self,
@@ -167,13 +170,20 @@ class RecordsWorker(StreamConsumer):
         except Exception:
             return None
 
+    def is_permanent_failure(
+        self,
+        msg_id: bytes,
+        data: Dict[bytes, bytes],
+    ) -> bool:
+        return msg_id in self._permanent_failure_ids
+
     async def _append(
         self,
         *,
         project_id: UUID,
         entries: List[Tuple[bytes, Any]],
-    ) -> Tuple[int, bool]:
-        """One `append_many` call. Returns the rows written and whether it committed."""
+    ) -> Tuple[int, Optional[Exception]]:
+        """One `append_many` call. Returns rows written and any failure."""
         try:
             results = await self.service.append_many(
                 events=[msg.record_event for _, msg in entries],
@@ -193,15 +203,15 @@ class RecordsWorker(StreamConsumer):
                         {f"{row.session_id}:{row.turn_id}" for row in quarantined}
                     ),
                 )
-            return len(results), True
-        except Exception:
+            return len(results), None
+        except Exception as exc:
             log.error(
                 "[RECORDS] Failed to append event batch",
                 project_id=str(project_id),
                 size=len(entries),
                 exc_info=True,
             )
-            return 0, False
+            return 0, exc
 
     async def _append_committed(
         self,
@@ -211,17 +221,23 @@ class RecordsWorker(StreamConsumer):
     ) -> Tuple[int, List[bytes]]:
         """Write a project group and report the message ids that are durable.
 
-        `append_many` is one statement in one transaction, so a single record Postgres rejects
-        takes the whole group down with it. The retry writes the group one record at a time so
-        the unrelated records still land. One record at a time rather than a binary split: the
-        split is cheaper only when the failure is a lone poison record, and it is more expensive
-        when Postgres itself is down, which is the common case.
+        `append_many` is one statement in one transaction, so a row-specific database rejection
+        takes the whole group down with it. Only that failure class triggers one-record writes to
+        isolate the rejected row. Connection, timeout, and unknown failures leave the entire
+        group pending for Redis reclaim instead of multiplying calls during an outage.
         """
-        appended, committed = await self._append(project_id=project_id, entries=entries)
-        if committed:
+        appended, failure = await self._append(project_id=project_id, entries=entries)
+        if failure is None:
+            self._permanent_failure_ids.difference_update(
+                msg_id for msg_id, _ in entries
+            )
             return appended, [msg_id for msg_id, _ in entries]
 
+        if not isinstance(failure, ROW_REJECTION_ERRORS):
+            return 0, []
+
         if len(entries) == 1:
+            self._permanent_failure_ids.add(entries[0][0])
             return 0, []
 
         log.warning(
@@ -233,10 +249,15 @@ class RecordsWorker(StreamConsumer):
         total_appended = 0
         committed_ids: List[bytes] = []
         for entry in entries:
-            appended, ok = await self._append(project_id=project_id, entries=[entry])
-            if ok:
+            appended, failure = await self._append(
+                project_id=project_id, entries=[entry]
+            )
+            if failure is None:
                 total_appended += appended
                 committed_ids.append(entry[0])
+                self._permanent_failure_ids.discard(entry[0])
+            elif isinstance(failure, ROW_REJECTION_ERRORS):
+                self._permanent_failure_ids.add(entry[0])
 
         log.warning(
             "[RECORDS] Retry finished",

--- a/api/oss/src/tasks/asyncio/shared/consumer.py
+++ b/api/oss/src/tasks/asyncio/shared/consumer.py
@@ -76,7 +76,6 @@ class StreamConsumer:
         #: Messages this process gave up on. Only ever grows; read by tests and logs.
         self.dropped_messages = 0
         self._last_reclaim_at = 0.0
-        self._last_commit_at = 0.0
 
     async def create_consumer_group(self):
         """Create consumer group if it doesn't exist. Safe to call multiple times (idempotent)."""
@@ -160,32 +159,22 @@ class StreamConsumer:
         """Subclass hook: a short identity for a dropped message, for the loss log."""
         return None
 
-    def mark_committed(self) -> None:
-        """Subclasses call this after a durable write. See `write_path_is_healthy`."""
-        self._last_commit_at = time.monotonic()
-
-    def write_path_is_healthy(self) -> bool:
-        """Has anything at all been written recently?
-
-        The delivery counter alone cannot tell a message the write path will never accept apart
-        from a write path that is simply down: both fail every delivery. Dropping on the count
-        alone therefore deletes every message in flight whenever an outage lasts longer than
-        `max_deliveries` windows, which is the loss this worker exists to prevent. So the drop
-        only applies while other messages are committing.
-        """
-        if self._last_commit_at == 0.0:
-            return False
-        window_ms = max(self.reclaim_min_idle_ms, 1_000) * 2
-        return (time.monotonic() - self._last_commit_at) * 1000 <= window_ms
+    def is_permanent_failure(
+        self,
+        msg_id: bytes,
+        data: Dict[bytes, bytes],
+    ) -> bool:
+        """Subclass hook: whether this exact message is known not to succeed on retry."""
+        return False
 
     async def reclaim_batch(self) -> List[Tuple[bytes, Dict[bytes, bytes]]]:
-        """Re-deliver entries an earlier pass left unacknowledged, and drop the ones that never
-        write.
+        """Re-deliver entries an earlier pass left unacknowledged.
 
         `read_batch` only ever asks Redis for `>`, so an entry that is never acknowledged is
         invisible to every later read of this group. Without this pass, "skip the ACK so Redis
-        retries it" means "lose it quietly with a growing pending list". Redis' own per-entry
-        delivery counter bounds the retry, so one poison entry cannot hold the group forever.
+        retries it" means "lose it quietly with a growing pending list". Redis' delivery count
+        bounds retries only for a message the subclass has identified as permanently invalid;
+        it cannot distinguish a poison message from a transient write-path outage.
         """
         if not self.reclaim_pending:
             return []
@@ -233,7 +222,6 @@ class StreamConsumer:
 
         # XCLAIM returns nothing for an entry whose stream payload is already gone (MAXLEN
         # trim), and removes it from the pending list itself.
-        healthy = self.write_path_is_healthy()
         retry: List[Tuple[bytes, Dict[bytes, bytes]]] = []
         expired: List[Tuple[bytes, Dict[bytes, bytes]]] = []
         over_budget = 0
@@ -242,7 +230,7 @@ class StreamConsumer:
                 continue
             if deliveries.get(msg_id, 1) >= self.max_deliveries:
                 over_budget += 1
-                if healthy:
+                if self.is_permanent_failure(msg_id, data):
                     expired.append((msg_id, data))
                     continue
             retry.append((msg_id, data))
@@ -251,7 +239,7 @@ class StreamConsumer:
             await self.drop_expired(expired)
         elif over_budget:
             log.warning(
-                f"{self.log_prefix} Keeping over-budget messages: nothing is writing",
+                f"{self.log_prefix} Keeping over-budget messages: failure is not known to be permanent",
                 stream=self.stream_name,
                 group=self.consumer_group,
                 count=over_budget,

--- a/api/oss/tests/pytest/unit/sessions/test_records_worker_durability.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_worker_durability.py
@@ -377,6 +377,55 @@ async def test_nothing_is_dropped_while_the_write_path_is_down():
 
 
 @pytest.mark.asyncio
+async def test_recovery_with_new_traffic_keeps_the_over_budget_backlog():
+    project_id = uuid4()
+    old_record, new_record = uuid4(), uuid4()
+    redis_client = fakeredis.FakeRedis()
+    await _seed(
+        redis_client,
+        [_payload(project_id=project_id, session_id="s", record_id=old_record)],
+    )
+
+    dao = FakeRecordsDAO(fail_calls=99)
+    worker = _worker(dao, redis_client=redis_client, max_deliveries=2)
+
+    old_batch = await worker.read_batch()
+    await worker.process_batch(old_batch)
+    for _ in range(3):
+        await asyncio.sleep(0.01)
+        reclaimed = await worker.reclaim_batch()
+        assert [msg_id for msg_id, _ in reclaimed] == [
+            msg_id for msg_id, _ in old_batch
+        ]
+        await worker.process_batch(reclaimed)
+
+    dao.fail_calls = 0
+    await redis_client.xadd(
+        name=STREAM,
+        fields={
+            "data": _payload(
+                project_id=project_id,
+                session_id="s",
+                record_id=new_record,
+            )
+        },
+    )
+    new_batch = await worker.read_batch()
+    _, acked_ids = await worker.process_batch(new_batch)
+    await worker.ack_and_delete(acked_ids)
+
+    await asyncio.sleep(0.01)
+    reclaimed = await worker.reclaim_batch()
+    assert [msg_id for msg_id, _ in reclaimed] == [msg_id for msg_id, _ in old_batch]
+    _, acked_ids = await worker.process_batch(reclaimed)
+    await worker.ack_and_delete(acked_ids)
+
+    assert dao.committed == [str(new_record), str(old_record)]
+    assert worker.dropped_messages == 0
+    assert await redis_client.xlen(STREAM) == 0
+
+
+@pytest.mark.asyncio
 async def test_describe_message_survives_an_undecodable_payload():
     assert _worker(FakeRecordsDAO()).describe_message({b"data": b"not-zlib"}) is None
 

--- a/api/oss/tests/pytest/unit/sessions/test_records_worker_durability.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_worker_durability.py
@@ -27,6 +27,7 @@ from uuid import uuid4
 import fakeredis.aioredis as fakeredis
 import pytest
 from orjson import dumps
+from sqlalchemy.exc import IntegrityError
 
 from oss.src.core.sessions.records.dtos import SessionRecord
 from oss.src.core.sessions.records.service import RecordsService
@@ -55,20 +56,21 @@ def _payload(*, project_id, session_id, record_id, record_type="message", turn_i
 class FakeRecordsDAO:
     """Records what committed, and fails the events the caller names."""
 
-    def __init__(self, *, poison_ids=(), fail_calls=0):
+    def __init__(self, *, poison_ids=(), fail_calls=0, transient_error=None):
         self.poison_ids = {str(record_id) for record_id in poison_ids}
         self.fail_calls = fail_calls
+        self.transient_error = transient_error or ConnectionError("postgres is down")
         self.calls = 0
         self.committed: list[str] = []
 
     async def append_many(self, *, events):
         self.calls += 1
         if self.calls <= self.fail_calls:
-            raise RuntimeError("postgres is down")
+            raise self.transient_error
         if any(str(event.record_id) in self.poison_ids for event in events):
             # `append_many` is one statement in one transaction: a rejected row takes the
             # whole call with it, and nothing in the call commits.
-            raise RuntimeError("record rejected")
+            raise IntegrityError("INSERT records", {}, ValueError("record rejected"))
         for event in events:
             self.committed.append(str(event.record_id))
         return [
@@ -122,6 +124,21 @@ async def test_failed_batch_acknowledges_nothing():
     # every id this list carries.
     assert acked_ids == []
     assert dao.committed == []
+    assert dao.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_timeout_leaves_the_whole_batch_pending_without_single_row_retries():
+    project_id = uuid4()
+    dao = FakeRecordsDAO(fail_calls=99, transient_error=asyncio.TimeoutError())
+
+    appended, acked_ids = await _worker(dao).process_batch(
+        _batch(project_id=project_id, record_ids=[uuid4(), uuid4(), uuid4()])
+    )
+
+    assert appended == 0
+    assert acked_ids == []
+    assert dao.calls == 1
 
 
 @pytest.mark.asyncio
@@ -129,8 +146,8 @@ async def test_redelivered_batch_is_acknowledged_once_and_written_once():
     project_id = uuid4()
     record_ids = [uuid4(), uuid4()]
     batch = _batch(project_id=project_id, record_ids=record_ids)
-    # The whole-batch call fails, then the per-record retry fails twice, then Postgres is back.
-    dao = FakeRecordsDAO(fail_calls=3)
+    # The whole batch stays pending on the connection failure, then Postgres is back.
+    dao = FakeRecordsDAO(fail_calls=1)
     worker = _worker(dao)
 
     _, first_acked = await worker.process_batch(batch)

--- a/web/packages/agenta-chat/tests/unit/assets/agentTurn.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/agentTurn.test.ts
@@ -45,15 +45,11 @@ describe("latestTurnId", () => {
     })
 
     it("does not fall back when the newest assistant has no id", () => {
-        expect(
-            latestTurnId([assistant("a1", {turnId: "turn-1"}), assistant("a2")]),
-        ).toBeNull()
+        expect(latestTurnId([assistant("a1", {turnId: "turn-1"}), assistant("a2")])).toBeNull()
     })
 
     it("does not cross a trailing user message into an older turn", () => {
-        expect(
-            latestTurnId([assistant("a1", {turnId: "turn-A"}), user("u2")]),
-        ).toBeNull()
+        expect(latestTurnId([assistant("a1", {turnId: "turn-A"}), user("u2")])).toBeNull()
     })
 })
 


### PR DESCRIPTION
## Context

PR #6553's durable session-record path had two recovery gaps. Recovery could discard valid records after they exhausted their delivery budget during an outage, and a database connection failure split the failed batch into sequential per-record writes.

## Changes

- Retryable record failures remain pending during outage recovery. Only a failure classified as permanent for that exact record can be discarded.
- Connection, timeout, and unknown batch failures leave the whole batch pending. Only row-specific data or integrity rejections fall back to per-record isolation.
- Direct Stop delivery remains on the feature branch's proven two-hop acknowledgement and outcome-report path. The single-round-trip change is deferred until after the release because it needs safe old-API/new-runner rollout behavior and bounded settlement for parked Stops.

Before, an outage could exhaust a record's delivery budget and make recovery acknowledge it without persistence. A failed database batch could also fan out into one call per record. After, retryable failures stay pending, and only an exact row rejection is isolated.

## Tests / notes

- API sessions: 695 passed with 9 warnings on the dedicated increment-7 databases.
- API tasks-specific unit suite: 22 passed with 3 warnings. This feature cut has no `unit/tasks/` directory.
- Runner typecheck passed.
- Runner unit: 169 files and 2,867 tests passed with `--maxWorkers=3`.
- `@agenta/chat`: 60 files and 653 tests passed; typecheck and lint passed.
- Ruff 0.15.12 format: 1,492 files unchanged. Ruff check passed.
- Migration reached the dedicated core database. It was already stamped at `oss000000027`, while this feature cut contains migrations through `oss000000026`, so Alembic refused the older source tree and no downgrade was attempted.

Agent-generated, low weight.
https://claude.ai/code/session_0164kzT6ttwpBtzvcDC6YzYk