### PR TITLE
[fix] Keep the sandbox warm on a browser Stop and park a first turn's gated sibling call

### DIFF
--- a/docs/design/session-control-and-live-events/spike-a-sandbox-cancel.md
+++ b/docs/design/session-control-and-live-events/spike-a-sandbox-cancel.md
@@ -258,9 +258,9 @@ Two deliberate non-changes:
 A Stop asks a different question from an ordinary idle park. The ordinary window asks how long a
 conversation might keep going by itself. A Stop is a button the user just pressed, so the answer is
 known: they are about to type. On the 60 second local idle window the sandbox can be thrown away
-while they are still writing, which is the cold start this whole change exists to remove. That is
-an argument for a longer window, not a decision this spike should make on its own, so the window is
-now its own named setting and the value is unchanged.
+while they are still writing, which is the cold start this change exists to remove. Mahmoud decided
+on 2026-09-05 that a settled Stop uses the same 600 second window as an approval card on both
+providers. A stopped Daytona sandbox can therefore remain billed for up to ten minutes.
 
 Current windows, all from `services/runner/src/engines/sandbox_agent/session-identity.ts`:
 
@@ -268,17 +268,11 @@ Current windows, all from `services/runner/src/engines/sandbox_agent/session-ide
 | --- | --- | --- | --- |
 | Idle (a clean finished turn) | 60 s | 120 s | `AGENTA_RUNNER_SESSION_TTL_MS`, `AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS` |
 | Awaiting approval | 600 s | 120 s | `AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS` |
-| Stopped by the user (new) | 60 s, recommended 600 s | 120 s | `AGENTA_RUNNER_SESSION_STOPPED_TTL_MS` |
+| Stopped by the user (new) | 600 s | 600 s | `AGENTA_RUNNER_SESSION_STOPPED_TTL_MS` |
 
-**The stopped window ships defaulting to the ordinary idle window, so this change alters no timing
-on its own.** It exists so the value is one named field with one env var when somebody decides to
-move it.
-
-**The recommendation, which is Mahmoud's call: make it the approval window on the local provider,
-600 seconds.** The approval window already encodes "a human is about to act", which is the same
-situation. Daytona should not follow: a parked Daytona sandbox is billed compute, and its 120 second
-idle window is already that decision. Try it with `AGENTA_RUNNER_SESSION_STOPPED_TTL_MS`, which was
-exercised live at 600 s and logged `park-cancelled key=... ttl=600000ms`.
+The stopped window has its own environment override so operators can choose a different retention
+and billing trade-off without changing the ordinary idle or approval windows. The 600 second value
+was exercised live and logged `park-cancelled key=... ttl=600000ms`.
 
 ## The settlement timeout (RFC D-016)
 
@@ -410,21 +404,18 @@ scenario must log `settled=false` and `no-park:cancelled`. That proves the guard
 ## Open questions for Mahmoud
 
 1. **A stopped Codex turn leaves its shell command running in the parked sandbox. Ship anyway, or
-   hold Codex back?** Recommendation: ship, and fix the bridge next. The orphan dies when the idle
-   window closes, the window is 120 s on Daytona where the compute is billed, and holding Codex back
-   means Codex users keep paying a cold start on every Stop. The alternative, an env flag that
-   excludes one harness from parking, is machinery for a decision we would reverse within the week.
-2. **Move the local stopped-session window from 60 s to 600 s?** It ships on 60 s, the ordinary
-   idle window, so nothing changed yet. Recommendation: move it. It would match the approval
-   window, which already encodes "a human is about to act", and the local provider is host memory
-   rather than billed compute. Daytona should keep its 120 s either way.
-3. **Ten seconds for the settle budget?** Recommendation: yes, ship it. The measured cost is
+   hold Codex back?** Recommendation: ship, and fix the bridge next. The orphan dies when the stopped
+   window closes. The stopped window is 600 s on Daytona, where the compute is billed, and holding
+   Codex back means Codex users keep paying a cold start on every Stop. The alternative, an env flag
+   that excludes one harness from parking, is machinery for a decision we would reverse within the
+   week.
+2. **Ten seconds for the settle budget?** Recommendation: yes, ship it. The measured cost is
    14 to 31 ms, so the budget is not a latency cost in the normal case, and it only ever delays a
    Stop that is already going badly.
-4. **Should the Stop also settle the turn ledger row, rather than leaving the turn incomplete?**
+3. **Should the Stop also settle the turn ledger row, rather than leaving the turn incomplete?**
    Recommendation: yes, in work package C. The terminal record now says `cancelled`, so a reader can
    tell a Stop from a completion, but the ledger row still looks like a turn that never finished.
-5. **Do we test Claude and Daytona before the RFC is accepted, or at the release gate?**
+4. **Do we test Claude and Daytona before the RFC is accepted, or at the release gate?**
    Recommendation: at the release gate, with the cell above. Blocking the design on an Anthropic key
    tonight buys little, because the cancel is one protocol request shared by every harness, and the
    Codex result shows the interesting variation is in what the harness does with it, not whether it

--- a/services/runner/src/engines/sandbox_agent/engine.ts
+++ b/services/runner/src/engines/sandbox_agent/engine.ts
@@ -30,25 +30,37 @@ import {
  *  - `result.stopReason === "cancelled"` — did the TURN actually end as a cancel?
  *  - `result.cancelSettled` — did the HARNESS confirm it stopped? See `cancel-turn.ts`.
  *
- * Every other abort leaves the environment in an unknown state and still destroys. The
- * `clientGone` check moved ABOVE the abort check so a disconnect keeps destroying exactly as it
- * did before, whatever the abort says.
+ * Every other abort leaves the environment in an unknown state and still destroys.
+ *
+ * A SETTLED USER STOP IS CHECKED BEFORE `clientGone`, AND THAT ORDER IS THE WHOLE POINT.
+ * `clientGone` used to be read first, which read well and broke the product on every real Stop.
+ * The browser's Stop button aborts its own chat stream in the SAME tick it sends the durable
+ * cancel command (`web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts`,
+ * `handleStop`), so the disconnect and the labelled abort always arrive together. With the
+ * disconnect read first, every Stop fell into the destroy branch: the sandbox was deleted, the
+ * native harness session went with it, and the next message replayed cold. Observed on the
+ * increment-6 stack on 2026-09-04, three Stops, three evictions, no warm park.
+ *
+ * The disconnect rule loses nothing it was written for. It exists so an UNATTENDED session is
+ * never kept warm on a guess, and a Stop is not a guess: it is an authenticated command the API
+ * recorded durably, from a user who is still on the page and about to type. Every other
+ * disconnect — mid-turn tab close, a dropped connection, a failed turn — still destroys, and the
+ * parked entry still expires on its own TTL.
  */
 export function shouldPark(
   result: AgentRunResult,
   signal: AbortSignal | undefined,
   clientGone: (() => boolean) | undefined,
 ): boolean {
+  // The harness is idle and the sandbox is worth keeping warm, whatever the stream did.
+  const settledUserStop =
+    isUserStopAbort(signal) &&
+    result.ok === true &&
+    result.stopReason === "cancelled" &&
+    result.cancelSettled === true;
+  if (settledUserStop) return true;
   if (clientGone?.()) return false; // client disconnected mid-turn: destroy, do not park
-  if (signal?.aborted) {
-    // A settled user Stop: the harness is idle and the sandbox is worth keeping warm.
-    return (
-      isUserStopAbort(signal) &&
-      result.ok === true &&
-      result.stopReason === "cancelled" &&
-      result.cancelSettled === true
-    );
-  }
+  if (signal?.aborted) return false; // any other abort: unknown state, destroy
   if (!result.ok) return false; // failed turn: teardown as today
   if (result.stopReason === "paused") return false; // a plain pause never parks
   return true;

--- a/services/runner/src/engines/sandbox_agent/run-turn.ts
+++ b/services/runner/src/engines/sandbox_agent/run-turn.ts
@@ -1297,11 +1297,19 @@ export async function runTurn(
       const openAllowedExecutions = openToolCallIds().filter(
         (id) => pause.isAllowedExecution(id) && !pause.isPausedToolCall(id),
       );
+      // NOT scoped to a resume. Pi batches on the FIRST turn too, and the first turn is where a
+      // user meets it: the model asks for a Read and a Bash together, the Read answers `allow`
+      // and the Bash parks, and the allowed Read then never closes because Pi will not execute
+      // any call in the batch while a sibling gate is open. With `opts.resume` in this predicate
+      // that turn took the wait below and sat on the 30-minute per-tool-call bound. It never
+      // parked, never emitted `done`, and its alive watchdog kept beating `running=true`, so
+      // every durable continuation aimed at the next turn was refused for want of ownership.
+      // (Browser pass 2026-09-04, sessions d66e2920 at 17:32Z and 6d06f624 at 17:57Z. A healthy
+      // gated turn shows the Read's `tool_result` BEFORE the Bash gate — sequential, so nothing
+      // is open at pause time. The two failures show the two gates back to back with no result
+      // between them, which is the parallel batch.)
       const piBatchBlockedByApproval = Boolean(
-        opts.resume &&
-        plan.isPi &&
-        opts.approvalParkMode &&
-        env.parkedApprovals.size > 0,
+        plan.isPi && opts.approvalParkMode && env.parkedApprovals.size > 0,
       );
       if (piBatchBlockedByApproval) {
         // Pi prepares every call in a parallel batch before it executes any of them. While a

--- a/services/runner/src/engines/sandbox_agent/session-identity.ts
+++ b/services/runner/src/engines/sandbox_agent/session-identity.ts
@@ -29,20 +29,10 @@ export interface KeepaliveConfig {
   /**
    * The idle window for a session PARKED BY A USER STOP.
    *
-   * DEFAULTS TO THE ORDINARY IDLE WINDOW, so this change alters no timing on its own. It exists
-   * so the value is one named field with one env var when somebody decides to move it.
-   *
-   * THE OPEN RECOMMENDATION, for Mahmoud. Make it the APPROVAL window instead
-   * (`DEFAULT_APPROVAL_TTL_MS`, 600 s local). The ordinary idle window asks "how long might a
-   * conversation keep going by itself". A Stop asks a different question and the answer is
-   * known: the user just pressed a button and is about to type. On the 60 s local window the
-   * sandbox can be thrown away while they are still writing, which is the cold start the Stop
-   * change exists to remove. The approval window already encodes "a human is about to act",
-   * which is the same situation. Set AGENTA_RUNNER_SESSION_STOPPED_TTL_MS to try it, or change
-   * the fallback below to `positiveIntEnv(APPROVAL_TTL_ENV, DEFAULT_APPROVAL_TTL_MS)`.
-   *
-   * The counter-argument, and why Daytona would not follow: a parked Daytona sandbox is billed
-   * compute, and its 120 s idle window is already the compute-budget decision.
+   * Defaults to 600 s for both providers, matching the local approval window because both waits
+   * begin when a human is about to act. This deliberately differs from the ordinary 60 s local
+   * and 120 s Daytona idle windows. The trade-off is that a stopped Daytona sandbox can remain
+   * billed for up to ten minutes. Override with AGENTA_RUNNER_SESSION_STOPPED_TTL_MS.
    *
    * Optional so a hand-built config (every test fixture) keeps meaning what it always meant:
    * omitted reads as "same as the idle window". `readKeepaliveConfig`, the only production
@@ -70,6 +60,7 @@ const DEFAULT_TTL_MS = 60_000;
 // (never fails the turn), and an awaiting_approval entry keeps holding a pool slot — override
 // via AGENTA_RUNNER_SESSION_APPROVAL_TTL_MS if warm slots are contended.
 const DEFAULT_APPROVAL_TTL_MS = 600_000;
+const DEFAULT_STOPPED_TTL_MS = 600_000;
 const DEFAULT_POOL_MAX = 8;
 const DAYTONA_TTL_ENV = "AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS";
 const DAYTONA_POOL_MAX_ENV = "AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM";
@@ -121,9 +112,9 @@ export function readKeepaliveConfig(
       // pool never sees an awaiting_approval park for Daytona today because parkedApproval is
       // only set by ACP gates.
       approvalTtlMs: ttlMs,
-      // A stopped Daytona session holds a BILLED sandbox, and the 120 s idle window is already
-      // the compute-budget decision, so it stays on that window unless an operator opts out.
-      stoppedTtlMs: nonNegativeIntEnv(STOPPED_TTL_ENV, ttlMs),
+      // A stopped Daytona session is deliberately held for the same human-response window as a
+      // local one, even though the sandbox remains billed. Zero remains a valid operator override.
+      stoppedTtlMs: nonNegativeIntEnv(STOPPED_TTL_ENV, DEFAULT_STOPPED_TTL_MS),
       // This budgets billed compute (idle warm sandboxes), deliberately separate from the local
       // pool's host-memory budget; Slice 4 adds the strict warm-slot accounting semantics.
       poolMax: positiveIntEnv(DAYTONA_POOL_MAX_ENV, DEFAULT_DAYTONA_POOL_MAX),
@@ -133,12 +124,8 @@ export function readKeepaliveConfig(
     enabled: boolEnv(KEEPALIVE_ENV, true),
     ttlMs: positiveIntEnv(TTL_ENV, DEFAULT_TTL_MS),
     approvalTtlMs: positiveIntEnv(APPROVAL_TTL_ENV, DEFAULT_APPROVAL_TTL_MS),
-    // Defaults to the ordinary idle window: this field changes no timing until somebody
-    // decides it should. See the recommendation on `KeepaliveConfig.stoppedTtlMs`.
-    stoppedTtlMs: positiveIntEnv(
-      STOPPED_TTL_ENV,
-      positiveIntEnv(TTL_ENV, DEFAULT_TTL_MS),
-    ),
+    // A settled Stop gets the same ten-minute human-response window as a pending approval.
+    stoppedTtlMs: positiveIntEnv(STOPPED_TTL_ENV, DEFAULT_STOPPED_TTL_MS),
     poolMax: positiveIntEnv(POOL_MAX_ENV, DEFAULT_POOL_MAX),
   };
 }

--- a/services/runner/tests/unit/harness-cancel-park.test.ts
+++ b/services/runner/tests/unit/harness-cancel-park.test.ts
@@ -180,13 +180,30 @@ describe("shouldPark on a user Stop", () => {
     assert.equal(shouldPark(runLimitTrip, userStopSignal(), undefined), false);
   });
 
-  it("keeps destroying on client disconnect, settled cancel or not", () => {
+  it("parks a settled Stop even though the client dropped its stream", () => {
+    // The case the product actually produces. The browser's Stop button aborts the chat stream
+    // in the same tick it sends the durable cancel command, so a real Stop ALWAYS reaches this
+    // predicate with the client already gone. This assertion used to read `false`, and reading
+    // the disconnect first is what deleted the sandbox on every Stop.
     assert.equal(
       shouldPark(cancelledTurn(true), userStopSignal(), () => true),
+      true,
+    );
+  });
+
+  it("keeps destroying on every disconnect that is not a settled Stop", () => {
+    // A disconnect with no Stop behind it, an unlabelled abort, and an unconfirmed cancel all
+    // leave a session nobody asked to keep. The rule the disconnect check exists for is intact.
+    assert.equal(
+      shouldPark({ ok: true, stopReason: "end_turn" }, undefined, () => true),
       false,
     );
     assert.equal(
-      shouldPark({ ok: true, stopReason: "end_turn" }, undefined, () => true),
+      shouldPark(cancelledTurn(true), abortedSignal(), () => true),
+      false,
+    );
+    assert.equal(
+      shouldPark(cancelledTurn(false), userStopSignal(), () => true),
       false,
     );
   });

--- a/services/runner/tests/unit/harness-cancel-park.test.ts
+++ b/services/runner/tests/unit/harness-cancel-park.test.ts
@@ -239,29 +239,30 @@ describe("the cancelled teardown reason", () => {
 });
 
 describe("the stopped-session park window", () => {
-  // The field exists so the value is one named setting when somebody moves it. It defaults to
-  // the ordinary idle window, so introducing it changed no timing. The open recommendation is
-  // the 600 s approval window on the local provider, because a user who stops is about to type.
-  it("defaults a local stopped session to the ordinary idle window", () => {
+  // A settled Stop gets the same ten-minute human-response window on both providers. The
+  // ordinary idle windows remain shorter and continue to govern clean completed turns.
+  it("defaults a local stopped session to the approval window", () => {
     const config = readKeepaliveConfig("local");
     assert.equal(config.ttlMs, 60_000);
-    assert.equal(config.stoppedTtlMs, 60_000);
-    // The recommended alternative, for the reader who comes to change it.
+    assert.equal(config.stoppedTtlMs, 600_000);
     assert.equal(config.approvalTtlMs, 600_000);
   });
 
-  it("defaults a Daytona stopped session to its billed idle window", () => {
+  it("defaults a Daytona stopped session to the ten-minute human-response window", () => {
     const config = readKeepaliveConfig("daytona");
     assert.equal(config.ttlMs, 120_000);
-    assert.equal(config.stoppedTtlMs, 120_000);
+    assert.equal(config.stoppedTtlMs, 600_000);
   });
 
   it("moves with its own env var, without touching the ordinary idle window", () => {
-    process.env.AGENTA_RUNNER_SESSION_STOPPED_TTL_MS = "600000";
+    process.env.AGENTA_RUNNER_SESSION_STOPPED_TTL_MS = "300000";
     try {
-      const config = readKeepaliveConfig("local");
-      assert.equal(config.stoppedTtlMs, 600_000);
-      assert.equal(config.ttlMs, 60_000);
+      const local = readKeepaliveConfig("local");
+      const daytona = readKeepaliveConfig("daytona");
+      assert.equal(local.stoppedTtlMs, 300_000);
+      assert.equal(local.ttlMs, 60_000);
+      assert.equal(daytona.stoppedTtlMs, 300_000);
+      assert.equal(daytona.ttlMs, 120_000);
     } finally {
       delete process.env.AGENTA_RUNNER_SESSION_STOPPED_TTL_MS;
     }

--- a/services/runner/tests/unit/session-keepalive-approval.test.ts
+++ b/services/runner/tests/unit/session-keepalive-approval.test.ts
@@ -3646,6 +3646,117 @@ describe("runTurn: real approval park + respondPermission resume", () => {
     }
   });
 
+  it("parks a FIRST-turn Pi batch whose allowed sibling can never close", async () => {
+    // The browser pass of 2026-09-04, sessions d66e2920 (17:32Z) and 6d06f624 (17:57Z). The model
+    // asked for a Read and a Bash in ONE parallel batch. The Read answered `allow`; the Bash
+    // parked. Pi will not execute any call in a batch while a sibling gate is open, so the
+    // allowed Read never closed. This is the FIRST turn, and the carry-and-park branch used to
+    // require a resume, so the turn took the closure wait instead and sat on the 30-minute
+    // per-tool-call bound. It never parked, never emitted `done`, and its alive watchdog kept
+    // beating `running=true`, so every durable continuation aimed at the next turn was refused
+    // with "Continuation could not establish alive ownership".
+    //
+    // A healthy gated turn from the same hour shows the Read's `tool_result` BEFORE the Bash
+    // gate. Sequential calls leave nothing open at pause time, which is why this only bites a
+    // parallel batch.
+    const batch: PiBatchCall[] = [
+      {
+        permissionId: "permission-read",
+        toolCallId: "tool-read",
+        toolName: "reader",
+        args: { path: "notes.md" },
+        output: "read output",
+      },
+      {
+        permissionId: "permission-bash",
+        toolCallId: "tool-bash",
+        toolName: "runner",
+        args: { command: "echo one" },
+        output: "bash output",
+      },
+    ];
+    const { deps } = pausableHarness({ piBatching: batch });
+    deps.createOtel = createSandboxAgentOtel as any;
+    // The real responder, so the plan below actually decides. The fake one pends every gate and
+    // would never mark an allowed execution, which is the whole precondition here.
+    delete (deps as { responderFactory?: unknown }).responderFactory;
+    const closureWaitMs = 271_828;
+    deps.resolveRunLimits = () => ({
+      totalMs: 1_000_000,
+      idleMs: 500_000,
+      ttfbMs: 500_000,
+      toolCallMs: closureWaitMs,
+    });
+    deps.createRunLimits = () => ({
+      onTrip() {},
+      noteToolCallStart() {},
+      noteToolCallEnd() {},
+      wrapEmit: (emit: (event: any) => void) => emit,
+      notePaused() {},
+      dispose() {},
+    });
+    // Count the closure waits by their bound, and let one that IS armed fire at once, so the red
+    // is an assertion rather than a 30-minute hang.
+    const realSetTimeout = globalThis.setTimeout;
+    let closureWaitCount = 0;
+    const timeoutSpy = vi.spyOn(globalThis, "setTimeout").mockImplementation(((
+      handler: (...args: any[]) => void,
+      timeout?: number,
+      ...args: any[]
+    ) => {
+      if (timeout === closureWaitMs) {
+        closureWaitCount += 1;
+        return realSetTimeout(handler, 0, ...args);
+      }
+      return realSetTimeout(handler, timeout, ...args);
+    }) as typeof setTimeout);
+    let env: SessionEnvironment | undefined;
+
+    try {
+      const piRequest: AgentRunRequest = {
+        ...engineReq,
+        harness: "pi_agenta",
+        permissions: { default: "ask" },
+        customTools: [
+          { name: "reader", permission: "allow" },
+          { name: "runner", permission: "ask" },
+        ],
+        messages: [{ role: "user", content: "read the file then echo" }],
+      };
+      const acquired = await acquireEnvironment(piRequest, deps);
+      assert.equal(acquired.ok, true);
+      if (!acquired.ok) return;
+      env = acquired.env;
+
+      const result = await runTurn(env, piRequest, undefined, undefined, {
+        approvalParkMode: true,
+      });
+
+      assert.equal(
+        result.stopReason,
+        "paused",
+        "the gated first turn must END as paused, not hang in terminalization",
+      );
+      assert.equal(
+        closureWaitCount,
+        0,
+        "an allowed sibling of a pending Pi gate can never close, so the turn must not wait",
+      );
+      assert.deepEqual(
+        [...(env.parkedApprovedExecutions?.keys() ?? [])],
+        ["tool-read"],
+        "the allowed call is carried so the resume re-announces it",
+      );
+      assert.ok(
+        env.parkedApprovals.has("tool-bash"),
+        "the gated call is parked for the human to answer",
+      );
+    } finally {
+      timeoutSpy.mockRestore();
+      if (env) await env.destroy();
+    }
+  });
+
   it("records the non-retry sentinel when an approved result misses the bound", async () => {
     const { calls, deps, captured } = pausableHarness();
     deps.resolveRunLimits = () => ({

--- a/services/runner/tests/unit/session-keepalive-dispatch.test.ts
+++ b/services/runner/tests/unit/session-keepalive-dispatch.test.ts
@@ -27,6 +27,7 @@ import {
   type KeepaliveEngine,
 } from "../../src/server.ts";
 import { SessionPool } from "../../src/engines/sandbox_agent/session-pool.ts";
+import { USER_STOP_ABORT_REASON } from "../../src/sessions/stop-signal.ts";
 import {
   configFingerprint,
   mountExpiryMs,
@@ -776,6 +777,75 @@ describe("runWithKeepalive: never-park rules", () => {
       "the disconnected client's session is destroyed, not parked",
     );
     assert.equal(ctx.pool.size(), 0);
+  });
+
+  it("a durable Stop re-parks the warm session even though the browser dropped its stream", async () => {
+    // The regression this file exists to prevent, replayed end to end at the dispatch seam.
+    //
+    // Increment 6, 2026-09-04: a warm Daytona session was Stopped from the browser and the next
+    // message came back cold on a NEW sandbox. The runner log read `[control] aborted` ->
+    // `harness_cancel sent=true settled=true` -> `prompt stopReason=cancelled` ->
+    // `[keepalive] evict reason=no-park:cancelled`. Every ingredient of a warm park was present
+    // and the sandbox was deleted anyway, because `handleStop` aborts the chat stream in the same
+    // tick it sends the durable cancel, and the park predicate read the disconnect first.
+    //
+    // So this test asserts BOTH halves land together: the client is gone AND the run signal
+    // carries the user-Stop label. Drop either one and it stops describing the product.
+    let gone = false;
+    const controller = new AbortController();
+    const { engine, calls } = makeEngine({
+      turnResults: [
+        { ok: true, output: "hi", stopReason: "complete" },
+        // What `run-turn.ts` returns for a Stop the harness confirmed.
+        {
+          ok: true,
+          output: "partial",
+          stopReason: "cancelled",
+          cancelSettled: true,
+        },
+      ],
+    });
+    const ctx = makeCtx(engine, {}, () => gone);
+    const key = "proj-1:stop-warm";
+
+    // Turn 1: an ordinary turn, parked warm for the next message.
+    await runWithKeepalive(
+      turn1("stop-warm"),
+      undefined,
+      controller.signal,
+      ctx,
+    );
+    await flush();
+    assert.equal(ctx.pool.get(key)?.state, "idle", "turn 1 parked warm");
+    const warmEnv = calls.acquiredEnvs[0];
+
+    // Turn 2: continues on the SAME environment, and the user presses Stop mid-turn.
+    const origRunTurn = engine.runTurn.bind(engine);
+    engine.runTurn = async (env, request, emit, signal, opts) => {
+      gone = true; // the browser aborted its own chat stream
+      controller.abort(USER_STOP_ABORT_REASON); // the durable command reached this run
+      return origRunTurn(env, request, emit, signal, opts);
+    };
+    const stopped = await runWithKeepalive(
+      turn2("stop-warm"),
+      undefined,
+      controller.signal,
+      ctx,
+    );
+    await flush();
+
+    assert.equal(stopped.stopReason, "cancelled");
+    assert.equal(calls.acquire, 1, "the Stop ran on the warm environment");
+    assert.equal(
+      warmEnv.destroyed,
+      0,
+      "a settled user Stop never destroys the sandbox",
+    );
+    assert.equal(
+      ctx.pool.get(key)?.state,
+      "idle",
+      "re-parked warm, so the next message resumes instead of replaying cold",
+    );
   });
 });
 

--- a/services/runner/tests/unit/session-pool.test.ts
+++ b/services/runner/tests/unit/session-pool.test.ts
@@ -184,16 +184,14 @@ describe("readKeepaliveConfig", () => {
     }
   });
 
-  it("defaults: on, 60s idle, 10m approval, cap 8", () => {
-    // The approval window is the pending-interaction park: 10 minutes so a phone-latency
-    // answer warm-resumes instead of cold-replaying (mobile approvals plan §4b-4).
+  it("defaults: on, 60s idle, 10m approval and stopped, cap 8", () => {
+    // Both human-response windows last 10 minutes so the next action warm-resumes instead of
+    // cold-replaying (mobile approvals plan §4b-4 and Mahmoud's 2026-09-05 Stop decision).
     assert.deepEqual(readKeepaliveConfig("local"), {
       enabled: true,
       ttlMs: 60_000,
       approvalTtlMs: 600_000,
-      // Defaults to the idle window, so the stopped-session field changes no timing on its own.
-      // The open recommendation is to move it to the approval window; Mahmoud picks.
-      stoppedTtlMs: 60_000,
+      stoppedTtlMs: 600_000,
       poolMax: 8,
     });
   });
@@ -232,8 +230,8 @@ describe("readKeepaliveConfig", () => {
     assert.deepEqual(readKeepaliveConfig("daytona"), {
       enabled: true,
       ttlMs: 120_000,
-      // Daytona keeps its billed idle window for a stopped session unless an operator opts in.
-      stoppedTtlMs: 120_000,
+      // The stopped sandbox remains billed for this ten-minute human-response window.
+      stoppedTtlMs: 600_000,
       approvalTtlMs: 120_000,
       poolMax: 20,
     });
@@ -244,7 +242,7 @@ describe("readKeepaliveConfig", () => {
       enabled: false,
       ttlMs: 0,
       approvalTtlMs: 0,
-      stoppedTtlMs: 0,
+      stoppedTtlMs: 600_000,
       poolMax: 20,
     });
     process.env.AGENTA_RUNNER_DAYTONA_SESSION_IDLE_TTL_MS = "45000";
@@ -252,7 +250,7 @@ describe("readKeepaliveConfig", () => {
       enabled: true,
       ttlMs: 45_000,
       approvalTtlMs: 45_000,
-      stoppedTtlMs: 45_000,
+      stoppedTtlMs: 600_000,
       poolMax: 20,
     });
     process.env.AGENTA_RUNNER_DAYTONA_SESSION_MAX_WARM = "7";


### PR DESCRIPTION
## Context

Pressing Stop in the browser sends the durable cancel command and aborts the chat stream in the same tick. The runner saw the browser disconnect first and destroyed the sandbox even after the harness had settled the user Stop, while the driver kept its stream attached and therefore preserved the warm sandbox.

On a first Pi turn, a parallel batch with one allowed tool and one gated tool could remain running instead of parking. The carry-and-park path only recognized resumed turns, so the allowed sibling never closed and the gated turn never emitted `done`.

## Changes

- Treat a settled user Stop as safe to park before applying the client-disconnect teardown rule. Other disconnects and unsettled aborts still destroy the sandbox.
- Apply the Pi parallel-batch carry-and-park predicate on first turns as well as resumed turns.
- Add regression coverage for browser-style Stop disconnects and first-turn allowed-plus-gated sibling calls.

## Tests

- `nice -n 19 pnpm run typecheck`
- `nice -n 19 pnpm run test:unit -- --maxWorkers=3` (169 files, 2,870 tests passed)

## What to QA

- On Daytona, start a browser chat and note the sandbox id. Press Stop during a turn, then send another message. The next turn must reuse the same sandbox id.
- Run the first-turn parallel sibling case with one allowed call and one gated call. The allowed call must settle, the approval must park, and the turn must emit `done`.

Agent-generated, low weight.
https://claude.ai/code/session_0164kzT6ttwpBtzvcDC6YzYk

Mahmoud's 2026-09-05 product decision is now reflected here: after a settled user Stop, local and Daytona sessions stay parked for 600 seconds by default, matching the approval-card window. `AGENTA_RUNNER_SESSION_STOPPED_TTL_MS` remains available; the trade-off is that a stopped Daytona sandbox can remain billed for up to ten minutes.
