### PR TITLE
[fix] Stop local mount polling after geesefs exits

### DIFF
--- a/services/runner/src/engines/sandbox_agent/mount.ts
+++ b/services/runner/src/engines/sandbox_agent/mount.ts
@@ -244,6 +244,32 @@ function credEnv(creds: MountCredentials): Record<string, string> {
   return env;
 }
 
+function waitForExitOrDelay(exited: Promise<void>, ms: number): Promise<void> {
+  return new Promise((resolve) => {
+    const timeout = setTimeout(resolve, ms);
+    void exited.then(() => {
+      clearTimeout(timeout);
+      resolve();
+    });
+  });
+}
+
+export async function waitForLocalMount(
+  isAlive: () => Promise<boolean>,
+  hasExited: () => boolean,
+  exited: Promise<void>,
+  attempts = 30,
+  delayMs = 500,
+): Promise<boolean> {
+  for (let i = 0; i < attempts; i++) {
+    if (hasExited()) return false;
+    if (await isAlive()) return true;
+    if (hasExited()) return false;
+    await waitForExitOrDelay(exited, delayMs);
+  }
+  return false;
+}
+
 /**
  * True only when `cwd` is a mountpoint AND the FUSE backend still serves I/O.
  *
@@ -358,10 +384,11 @@ export async function mountStorage(
       child.unref();
       // Poll up to ~15s for the mountpoint to serve I/O; geesefs logs "successfully mounted"
       // within ~1s normally. Resolve as soon as it's alive; the caller re-verifies after.
-      for (let i = 0; i < 30; i++) {
-        if (await isMounted(cwd, () => {})) break;
-        await new Promise((r) => setTimeout(r, 500));
-      }
+      await waitForLocalMount(
+        () => isMounted(cwd, () => {}),
+        () => processExited,
+        exited,
+      );
       return {
         stop: async () => {
           const waitForExit = async (): Promise<boolean> => {

--- a/services/runner/tests/unit/sandbox-agent-mount.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-mount.test.ts
@@ -16,6 +16,7 @@ import {
   mountStorage,
   unmountStorage,
   mountpointFailureState,
+  waitForLocalMount,
   discoverTunnelEndpoint,
   mountStorageRemote,
   harnessSessionMounts,
@@ -243,6 +244,35 @@ function notMountedThenAlive(): (cwd: string) => Promise<boolean> {
     return calls > 1;
   };
 }
+
+describe("waitForLocalMount", () => {
+  it("stops polling when geesefs exits before the mount is alive", async () => {
+    let probes = 0;
+    let exited = false;
+    let resolveExit!: () => void;
+    const exitPromise = new Promise<void>((resolve) => {
+      resolveExit = () => {
+        exited = true;
+        resolve();
+      };
+    });
+
+    const ok = await waitForLocalMount(
+      async () => {
+        probes += 1;
+        resolveExit();
+        return false;
+      },
+      () => exited,
+      exitPromise,
+      30,
+      1_000,
+    );
+
+    assert.equal(ok, false);
+    assert.equal(probes, 1);
+  });
+});
 
 describe("mountStorage", () => {
   it("builds the geesefs command with creds in env, not argv", async () => {


### PR DESCRIPTION
## Summary
Fixes #6559.

The local geesefs startup poll now stops as soon as the foreground child exits instead of continuing through the full 30x500ms budget. The existing 15s ceiling still applies while the child stays alive.

## Testing
### Verified locally
- `pnpm --dir services/runner exec vitest run --project unit tests/unit/sandbox-agent-mount.test.ts`
- `pnpm --dir services/runner run typecheck`
- `pnpm --dir services/runner run build:extension`
- `pnpm --dir services/runner run test:unit`
- `git diff --check`

### Added or updated tests
- Added a unit case for the local mount poll returning after the geesefs exit promise resolves.

### QA follow-up
N/A; runner mount timing is unit-covered. I did not reproduce the SeaweedFS multipart panic locally.

## Demo
N/A; runner-only change.

## Checklist
- [x] Demo shows the real app running this branch (not a mock-up or recreated UI), or is marked N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me
