### PR TITLE
[fix] Preserve agent drafts during version restores

### DIFF
--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/AgentVersionHistoryDrawer.tsx
@@ -73,6 +73,11 @@ export const AgentVersionHistoryDrawer = ({
     // Only the button needs this: reverting to a version identical to the head does nothing.
     const latestParams = useAtomValue(workflowMolecule.selectors.configuration(latestRow?.id ?? ""))
 
+    const selectedData = useAtomValue(workflowMolecule.selectors.serverData(selectedId || ""))
+    const latestData = useAtomValue(workflowMolecule.selectors.data(latestRow?.id ?? ""))
+    const selectedSchemas = selectedData?.data?.schemas
+    const latestSchemas = latestData?.data?.schemas
+
     // Opens on the newest version — "what just changed" is the question the drawer is opened with.
     const selectVersionId = useSetAtom(versionHistorySelectedAtomFamily(workflowId))
     const newestId = rows[0]?.id ?? null
@@ -134,8 +139,9 @@ export const AgentVersionHistoryDrawer = ({
         () =>
             !!selectedParams &&
             !!latestParams &&
-            stableStringify(selectedParams) === stableStringify(latestParams),
-        [selectedParams, latestParams],
+            stableStringify(selectedParams) === stableStringify(latestParams) &&
+            stableStringify(selectedSchemas ?? {}) === stableStringify(latestSchemas ?? {}),
+        [selectedParams, latestParams, selectedSchemas, latestSchemas],
     )
     const emptyText = !previousRow
         ? "The first version — there is nothing before it to compare."

--- a/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter.tsx
+++ b/web/packages/agenta-playground-ui/src/components/AgentVersionHistory/RevertFooter.tsx
@@ -58,8 +58,8 @@ export const RevertFooter = ({
         return (
             <div className="flex items-center justify-between gap-4">
                 <span className="text-[11.5px] leading-snug text-[var(--ag-colorError)]">
-                    <strong className="font-semibold">Revert failed.</strong> The commit was
-                    rejected. Your agent is unchanged and no version was created.
+                    <strong className="font-semibold">Revert failed.</strong> Wait for any save to
+                    finish, then try again.
                 </span>
                 <span className="flex shrink-0 gap-2">
                     <Button variant="outline" onClick={onCancel}>

--- a/web/packages/agenta-playground/src/state/execution/agentAutoCommit.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentAutoCommit.ts
@@ -65,6 +65,13 @@ export const registerAgentAutoCommitHandler = (
 
 type Store = ReturnType<typeof getDefaultStore>
 
+/** Check before staging a revert so a busy writer's draft and timer remain untouched. */
+export const isAgentAutoCommitBusy = (revisionId: string): boolean => {
+    if (inFlight.has(revisionId)) return true
+    const selfCommit = getDefaultStore().get(agentSelfCommitSignalAtom)
+    return !!selfCommit && Date.now() - selfCommit.at < SELF_COMMIT_QUIET_MS
+}
+
 /**
  * `skip` not ours · `clean` nothing to save · `busy` transient, try again shortly.
  *
@@ -81,10 +88,7 @@ const flushBlocker = (store: Store, revisionId: string): "skip" | "clean" | "bus
     if (isLocalDraftId(revisionId)) return "skip"
     if (!store.get(workflowMolecule.selectors.isDirty(revisionId))) return "clean"
 
-    if (inFlight.has(revisionId)) return "busy"
-
-    const selfCommit = store.get(agentSelfCommitSignalAtom)
-    if (selfCommit && Date.now() - selfCommit.at < SELF_COMMIT_QUIET_MS) return "busy"
+    if (isAgentAutoCommitBusy(revisionId)) return "busy"
 
     return null
 }
@@ -178,7 +182,8 @@ const runFlush = async (
     }
 
     if (blocker === "busy") {
-        schedule(store, revisionId, DEBOUNCE_MS, isRetry, messageOverride)
+        // Reverts roll their draft back on false; never leave a timer holding their message.
+        if (messageOverride === undefined) schedule(store, revisionId, DEBOUNCE_MS, isRetry)
         return false
     }
 

--- a/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
+++ b/web/packages/agenta-playground/src/state/execution/agentVersionHistory.ts
@@ -19,7 +19,7 @@ import {
 } from "@agenta/entities/workflow"
 import {atom, getDefaultStore} from "jotai"
 
-import {flushAgentAutoCommitAtom} from "./agentAutoCommit"
+import {flushAgentAutoCommitAtom, isAgentAutoCommitBusy} from "./agentAutoCommit"
 
 /** Prefix of a revert's commit message. */
 export const REVERT_MESSAGE_PREFIX = "Revert to v"
@@ -84,9 +84,10 @@ export interface RevertAgentRevisionParams {
  * was never committed. Schemas ride along — the commit sends `data.schemas`, so leaving them
  * behind would restore a configuration the old version never had.
  *
- * All-or-nothing: if the commit does not land, the draft goes back exactly as it was. Staging
+ * If the commit does not land, an untouched draft goes back exactly as it was. Staging
  * OVERWRITES an existing draft, so a pre-existing one is snapshotted and restored rather than
- * discarded, or a failed revert would eat edits it never owned.
+ * discarded, or a failed revert would eat edits it never owned. Edits made while the request
+ * is pending take precedence over this rollback.
  *
  * Resolves to whether a new version landed.
  */
@@ -95,6 +96,9 @@ export const revertAgentRevisionAtom = atom(
     async (get, set, {revisionId, targetRevisionId}: RevertAgentRevisionParams) => {
         if (!revisionId || !targetRevisionId || revisionId === targetRevisionId) return false
 
+        // A deferred flush would outlive our rollback and could commit the wrong draft.
+        if (isAgentAutoCommitBusy(revisionId)) return false
+
         const parameters = get(workflowMolecule.selectors.serverConfiguration(targetRevisionId))
         if (!parameters) return false
         const schemas = get(workflowMolecule.selectors.serverData(targetRevisionId))?.data?.schemas
@@ -102,7 +106,7 @@ export const revertAgentRevisionAtom = atom(
         // Staging overwrites whatever is there, so keep the original to put back on failure.
         const priorDraft = get(workflowDraftAtomFamily(revisionId))
         set(updateWorkflowDraftAtom, revisionId, {
-            data: {parameters, ...(schemas ? {schemas} : {})},
+            data: {parameters, schemas: schemas ?? {}},
         } as Partial<Workflow>)
 
         // Nothing staged means the target already matches the current configuration.
@@ -117,8 +121,10 @@ export const revertAgentRevisionAtom = atom(
             message: target?.message?.trim() || null,
         })
 
+        const stagedDraft = get(workflowDraftAtomFamily(revisionId))
         const landed = await set(flushAgentAutoCommitAtom, {revisionId, commitMessage})
-        if (!landed) {
+        // Draft writes replace the object; a newer one belongs to the edit made while saving.
+        if (!landed && get(workflowDraftAtomFamily(revisionId)) === stagedDraft) {
             if (priorDraft) set(workflowDraftAtomFamily(revisionId), priorDraft)
             else set(discardWorkflowDraftAtom, revisionId)
         }

--- a/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
+++ b/web/packages/agenta-playground/tests/unit/agentVersionHistory.test.ts
@@ -20,6 +20,7 @@ let commitOutcome: {success: boolean; newRevisionId?: string; error?: Error} = {
 const draftWrites: {revisionId: string; updates: any}[] = []
 /** Revisions whose draft was rolled back. */
 const discards: string[] = []
+let commitDelay: Promise<void> | undefined
 
 vi.mock("@agenta/entities/workflow", async (importOriginal) => {
     const actual = (await importOriginal()) as any
@@ -79,6 +80,7 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
                 params: {revisionId: string; commitMessage?: string},
             ) => {
                 commitCalls.push(params)
+                if (commitDelay) await commitDelay
                 if (commitOutcome.success) set(isDirty(params.revisionId), false)
                 return commitOutcome
             },
@@ -86,10 +88,17 @@ vi.mock("@agenta/entities/workflow", async (importOriginal) => {
     }
 })
 
-import {workflowDraftAtomFamily, workflowMolecule} from "@agenta/entities/workflow"
-import {projectIdAtom} from "@agenta/shared/state"
+import {
+    updateWorkflowDraftAtom,
+    workflowDraftAtomFamily,
+    workflowMolecule,
+} from "@agenta/entities/workflow"
+import {agentSelfCommitSignalAtom, projectIdAtom} from "@agenta/shared/state"
 
-import {__resetAgentAutoCommit} from "../../src/state/execution/agentAutoCommit"
+import {
+    __resetAgentAutoCommit,
+    flushAgentAutoCommitAtom,
+} from "../../src/state/execution/agentAutoCommit"
 import {
     buildRevertMessage,
     buildVersionRows,
@@ -131,6 +140,7 @@ function seedRevision(
 }
 
 beforeEach(() => {
+    commitDelay = undefined
     commitCalls.length = 0
     draftWrites.length = 0
     discards.length = 0
@@ -138,10 +148,12 @@ beforeEach(() => {
     __resetAgentAutoCommit()
     store = getDefaultStore()
     store.set(projectIdAtom, "proj-1")
+    store.set(agentSelfCommitSignalAtom, null)
 })
 
 afterEach(() => {
     vi.clearAllTimers()
+    vi.useRealTimers()
 })
 
 describe("buildVersionRows", () => {
@@ -226,6 +238,17 @@ describe("revertAgentRevisionAtom", () => {
         expect(draftWrites[0].updates.data.schemas).toEqual(schemas)
     })
 
+    it("clears schemas when the historical version has none", async () => {
+        const target = seedRevision(nextId(), {version: 2, params: OLD})
+        const current = seedRevision(nextId(), {
+            version: 4,
+            params: NEW,
+            schemas: {outputs: {type: "string"}},
+        })
+        await store.set(revertAgentRevisionAtom, {revisionId: current, targetRevisionId: target})
+        expect(draftWrites[0].updates.data.schemas).toEqual({})
+    })
+
     it("reads the target's SERVER config, so a draft left on an old revision cannot leak in", async () => {
         const target = seedRevision(nextId(), {version: 2, params: OLD})
         // Someone once edited that old revision; the draft must not be what gets restored.
@@ -284,6 +307,79 @@ describe("revertAgentRevisionAtom", () => {
 
         expect(discards).toEqual([])
         expect(store.get(draftOf(current))).toEqual(mine)
+    })
+
+    it.each([false, true])(
+        "preserves edits made during a rejected revert (prior draft: %s)",
+        async (hasPriorDraft) => {
+            commitOutcome = {success: false, error: new Error("rejected")}
+            const target = seedRevision(nextId(), {version: 2, params: OLD})
+            const current = seedRevision(nextId(), {version: 4, params: NEW})
+            if (hasPriorDraft) store.set(draftOf(current), {data: {parameters: NEW}})
+            let finish!: () => void
+            commitDelay = new Promise<void>((resolve) => {
+                finish = resolve
+            })
+            const reverting = store.set(revertAgentRevisionAtom, {
+                revisionId: current,
+                targetRevisionId: target,
+            })
+            const edit = {data: {parameters: {agent: {llm: {model: "newer-edit"}}}}}
+            store.set(updateWorkflowDraftAtom, current, edit as any)
+            finish()
+
+            expect(await reverting).toBe(false)
+            expect(store.get(draftOf(current))).toEqual(edit)
+            expect(discards).toEqual([])
+        },
+    )
+
+    it("rejects a revert during the self-commit quiet window without staging or scheduling it", async () => {
+        vi.useFakeTimers()
+        const target = seedRevision(nextId(), {version: 2, params: OLD})
+        const current = seedRevision(nextId(), {version: 4, params: NEW})
+        const mine = {data: {parameters: {agent: {llm: {model: "my-edit"}}}}}
+        store.set(draftOf(current), mine)
+        put((workflowMolecule as any).selectors.isDirty, current, true)
+        store.set(agentSelfCommitSignalAtom, {at: Date.now()} as any)
+
+        expect(
+            await store.set(revertAgentRevisionAtom, {
+                revisionId: current,
+                targetRevisionId: target,
+            }),
+        ).toBe(false)
+        expect(draftWrites).toEqual([])
+        expect(store.get(draftOf(current))).toEqual(mine)
+        await vi.advanceTimersByTimeAsync(5000)
+        expect(commitCalls).toEqual([])
+        vi.useRealTimers()
+    })
+
+    it("does not overwrite a draft while its auto-commit is in flight", async () => {
+        const target = seedRevision(nextId(), {version: 2, params: OLD})
+        const current = seedRevision(nextId(), {version: 4, params: NEW})
+        const mine = {data: {parameters: NEW}}
+        store.set(draftOf(current), mine)
+        put((workflowMolecule as any).selectors.isDirty, current, true)
+        let finish!: () => void
+        commitDelay = new Promise<void>((resolve) => {
+            finish = resolve
+        })
+        const saving = store.set(flushAgentAutoCommitAtom, {revisionId: current})
+
+        expect(
+            await store.set(revertAgentRevisionAtom, {
+                revisionId: current,
+                targetRevisionId: target,
+            }),
+        ).toBe(false)
+        finish()
+        await saving
+        expect(draftWrites).toEqual([])
+        expect(store.get(draftOf(current))).toEqual(mine)
+        expect(commitCalls).toHaveLength(1)
+        expect(commitCalls[0].commitMessage).toBeUndefined()
     })
 
     it("cancelling is simply never calling it — no draft is staged and nothing commits", () => {


### PR DESCRIPTION
## Context
Reverting an agent version while auto-save was busy could replace the active draft and then roll it back, while a deferred save still held the revert message. A rejected revert could also erase edits made while its request was pending. These paths are new with the version-history feature in release v0.114.8.

## Changes
Reject busy reverts before staging configuration and prevent deferred flushes from keeping a revert message. After a failed request, restore the prior draft only when the user has not edited it in the meantime.

Include schemas when deciding whether a historical version differs from the latest, and explicitly clear schemas when the selected version has none. The failure message now asks the user to retry after saving finishes instead of asserting that the server rejected the commit.

## Tests
248 targeted tests passed across run-request assembly, auto-save/revert, revision ordering, build-kit persistence, configuration diffs and sidebar ordering. Four concurrency regression cases failed before the relevant guards and passed afterward. Scoped frontend lint, formatting and shared UI TypeScript checks passed. Independent code review found no introduced correctness issue.

Live desktop/mobile validation and the session continuity smoke are outstanding: the release PR preview currently returns Application not found, and the available stages run other versions. No live sandbox validation is claimed.

## What to QA
- Revert while a save is in flight or just after an agent self-commit. Existing edits survive; retry after saving creates exactly one historical restore.
- Edit configuration while a revert request is pending, then reject that request. The newer edit remains available.
- Restore a version with different schemas but identical parameters, and one with no schemas. Verify the committed payload and the next agent run use the restored configuration.
- Repeat the version-history flow on desktop and /m.

Prepared by the AI agent for release PR #6526. This PR does not change the runner, Daytona, sandbox lifecycle or chat transport.
