### PR TITLE
[AGE-4067] docs(agents): Plan custom secret setup and delivery

### DIFF
--- a/docs/design/agent-custom-secrets/README.md
+++ b/docs/design/agent-custom-secrets/README.md
@@ -1,0 +1,32 @@
+# Custom secrets for agent runs
+
+Users can save custom secrets and select them for HTTP MCP authentication. They cannot
+attach an arbitrary saved token to an agent's shell or skills. This plan adds that flow
+for internal use, then adds host-restricted delivery as a separate milestone.
+
+## Reading order
+
+1. [Context](context.md): current behavior, intended outcome, and milestone boundaries.
+2. [Plan](plan.md): implementation order and the complete request-card lifecycle.
+3. [Contracts](contracts.md): proposed configuration, runtime, and tool interfaces.
+4. [Research](research.md): verified implementation entry points and remaining checks.
+5. [Simplification](simplification.md): scope reductions and their tradeoffs.
+6. [QA](qa.md): observable acceptance criteria before enabling the feature.
+7. [Status](status.md): decisions, verification, and handoff.
+
+## Terms
+
+The **vault** stores encrypted project secrets. A **binding** assigns a saved secret to
+an environment-variable name. The **runner** starts and manages an agent execution.
+A **harness** is the coding agent it drives, such as Pi, Claude, or Codex. A **sandbox**
+is the local or Daytona execution environment. An **MCP server** exposes tools through
+the Model Context Protocol. A **paused turn** has stopped execution while waiting for
+a user interaction. A **workflow revision** is a saved version of the agent configuration.
+
+## Tracking
+
+[Issue #5703](https://github.com/Agenta-AI/agenta/issues/5703), also
+[AGE-4067](https://linear.app/agenta/issue/AGE-4067), tracks custom-secret delivery.
+This design depends on [PR #6365](https://github.com/Agenta-AI/agenta/pull/6365), which
+introduces shared platform instructions. The child implementation must include the
+secret-handling guidance described here. This PR changes design documents only.

--- a/docs/design/agent-custom-secrets/context.md
+++ b/docs/design/agent-custom-secrets/context.md
@@ -1,0 +1,56 @@
+# Context and scope
+
+## Current behavior
+
+Settings stores text and flat JSON custom secrets with stable project slugs. HTTP MCP
+configuration can reference a text secret, and its setup drawer can create one. These
+features do not provide a general environment-variable attachment for shell commands
+or skills. A user who saves a GitHub token still cannot make it available as
+`GITHUB_TOKEN` to such an agent through a supported attachment flow.
+
+The runner already distinguishes credential values from normal configuration and
+hides model and HTTP MCP credentials through Daytona Secrets. The missing custom
+consumer must not repurpose those model or MCP fields.
+
+## Milestone one: internal readable delivery
+
+An authorized user selects or creates a text secret, assigns its environment-variable
+name, and saves the binding on the agent. The backend resolves selected values and the
+runner injects them into that agent's environment. An agent can request a missing
+credential through a card that opens the same attachment flow.
+
+The user sees: "This secret is available to the agent's scripts and shell commands."
+The value goes directly from the secret form to the vault API, never through chat or
+the tool result. Shared platform guidance tells the model to use credentials without
+inspecting or exposing their values. This is behavioral guidance, not host enforcement
+or a claim that the process cannot read the value.
+
+Milestone one includes local and Daytona delivery, the existing supported Pi, Claude,
+and Codex harnesses, save-and-resume correctness, removal and rotation behavior,
+redaction, validation, and permission checks. Start rollout on an internal deployment.
+Do not weaken existing model/MCP hiding or add an unrelated public rollout flag.
+
+The desktop agent editor and its chat request card are the first UI surfaces. Shared
+components must support OSS and EE. If mobile can receive the new interaction, it must
+render the same action flow or explicitly keep the tool unavailable there; a paused
+card with no action is not supported. Headless runs can use preconfigured bindings but
+must not advertise a browser-only setup tool without an interaction handler.
+
+## Milestone two: host-restricted delivery policy
+
+Add a vault-owned policy for readable use or hidden HTTP delivery with exact allowed
+HTTPS hosts. An agent author cannot widen that policy. Daytona creates placeholders
+for hidden credentials and substitutes values only at permitted destinations. Hidden
+credentials must never fall back to readable delivery. Local execution must reject a
+hidden-only binding with a clear explanation.
+
+Specify normalization, disallowed hosts and URL forms, policy-change reconciliation,
+and hidden-delivery verification in this milestone. Preserve milestone-one bindings
+as explicitly readable; do not silently change their delivery when upgrading.
+
+## Exclusions
+
+Neither milestone commits to JSON expansion, secret files, per-skill permissions,
+a generic secret-manager plugin interface, or a new durable cleanup service. Durable
+Daytona resource reconciliation remains [#6438](https://github.com/Agenta-AI/agenta/issues/6438).
+The existing vault and agent revision stores are sufficient for milestone one.

--- a/docs/design/agent-custom-secrets/contracts.md
+++ b/docs/design/agent-custom-secrets/contracts.md
@@ -1,0 +1,135 @@
+# Proposed contracts
+
+Current agent configuration has no general custom-secret bindings. The following shapes
+are proposals for implementation, not examples of endpoints already available.
+
+## Saved configuration
+
+Put bindings under the sandbox configuration, which owns the process environment:
+
+```json
+{
+  "agent": {
+    "sandbox": {
+      "kind": "daytona",
+      "credentials": [
+        {
+          "secret": { "slug": "github-token" },
+          "binding": { "type": "env", "name": "GITHUB_TOKEN" }
+        }
+      ]
+    }
+  }
+}
+```
+
+This is the `parameters.agent` fragment. The SDK flattens it into its runtime model
+using the existing template parser. Omitted credentials and an empty list are identical.
+There is one environment binding per entry. Milestone one supports only `env` bindings
+and text custom secrets; it adds no delivery-mode picker.
+
+| Field                                       | Role and owner                                                   | Lifetime                         |
+| ------------------------------------------- | ---------------------------------------------------------------- | -------------------------------- |
+| `secret.slug`                               | Credential reference selected by the user in the current project | Saved agent revision             |
+| `binding.type`, `binding.name`              | Environment binding configuration selected by the user           | Saved agent revision             |
+| Secret content                              | Credential material owned by the vault                           | Until value rotation or deletion |
+| Project, agent, session, tool-call identity | Existing authenticated execution context                         | Request or paused interaction    |
+| Future allowed hosts and delivery mode      | Policy owned by the vault secret                                 | Until an authorized policy edit  |
+
+The agent suggests a variable name; the user approves it. Slugs and variable names are
+different identifiers. Do not derive the final variable name from the slug.
+
+Validate names with `^[A-Za-z_][A-Za-z0-9_]*$`. Reject duplicate bindings, platform-reserved
+names, provider/MCP collisions, and environment-control names such as `PATH`, `HOME`,
+`LD_PRELOAD`, `NODE_OPTIONS`, and `PYTHONPATH`. Use one canonical validation rule set with
+Python/TypeScript parity cases, including runner-owned environment names. Do not silently
+overwrite any existing environment owner.
+
+Resolve only the referenced project secrets. Reject missing, deleted, wrong-kind, JSON,
+and empty text values before invoking the harness. Preserve nonempty text verbatim.
+The attachment flow requires the existing secret-edit permission and agent-edit permission;
+execution still requires run permission and project-scoped runtime resolution. The backend
+must enforce attachment permissions for every configuration write path, including agent
+commit tools, rather than relying on the form. This deliberately uses existing permissions
+for internal use; it does not add a new secret-use RBAC system.
+
+## Runner input
+
+Add a typed `sandboxCredentials` collection to the internal run request. Each entry
+contains an environment binding and resolved credential value. It contains no vault
+access token and grants the runner no whole-vault lookup capability. Reuse the existing
+binding primitive and redaction treatment where compatible, but do not put these values
+inside `modelConnection` or an MCP connection.
+
+The authored reference is resolved before this transport boundary. The SDK serializer,
+Python wire model, TypeScript protocol, runner validator, and wire fixtures change together.
+Values must be redacted before request/error logging and tracing. Existing protected
+transport carries plaintext credential material to the runner, as it does for readable
+credentials today. A raw transport capture can contain credentials; saved diagnostic
+snapshots must be redacted. Never describe an unredacted internal request as value-free.
+
+The runner adds the collection to its environment composition and credential-change
+tracking. Binding structure participates in both existing configuration identity views;
+values participate in the existing credential epoch, never a public configuration hash.
+No generic arbitrary environment override or global change to Daytona hiding is needed.
+
+## Agent request tool
+
+Add `request_secret` as a reserved platform client tool, following the static catalog
+and existing browser-fulfilled interaction mechanism. Do not overload OAuth-oriented
+`request_connection` inputs with unrelated fields.
+
+Proposed input:
+
+```json
+{
+  "name": "GitHub token",
+  "env_var": "GITHUB_TOKEN",
+  "reason": "Authenticate the requested repository operation"
+}
+```
+
+`name` and `reason` are display metadata. `env_var` is suggested binding configuration.
+The schema has no value field, project selector, agent selector, or destination policy.
+The host derives the target from the paused interaction and authenticated session.
+Only advertise this tool where the host can fulfill it; guidance must account for its
+absence. The agent receives configured variable names through safe configuration/tool
+metadata, so it need not run `printenv` to discover them.
+
+Successful setup returns a reference and the committed revision, not a value:
+
+```json
+{
+  "status": "configured",
+  "secret": { "slug": "github-token" },
+  "env_var": "GITHUB_TOKEN",
+  "revision_id": "019d952f-0000-0000-0000-000000000000"
+}
+```
+
+Cancellation returns `{"status":"cancelled"}`. Other terminal failures use a bounded
+safe reason. `configured` means the binding was saved. The runtime must apply it before
+the resumed harness receives that result. Browser output is not authorization: the
+backend checks the saved revision, project, permissions, and requested binding again.
+
+## Platform instructions
+
+Extend `AGENTA_PLATFORM_BASE` in the module introduced by #6365 as part of milestone
+one's child implementation. Do not edit the parent PR or ship a second prompt composer.
+The required text is:
+
+> Use configured credential variables only to authenticate the requested operation.
+> Do not inspect, print, enumerate, or include their values in messages or files.
+> If a required credential is unavailable and `request_secret` is available, use it
+> to open the secret setup flow. Otherwise explain that the user must configure the
+> credential in Agenta. Never ask the user to paste a credential into chat.
+
+Scripts and libraries may read variables for authentication. The restriction concerns
+exposing values to the model or other outputs. Review existing instructions that direct
+all credentials to `request_connection`: distinguish integration connections from custom
+shell credentials and keep generic `request_input` value-free.
+
+#6365 delivers text at environment build through Pi append-system text or Claude/Codex
+instruction files. It does not promise a fresh system message on every turn. The rollout
+must build fresh environments before enabling custom bindings; a warm environment created
+before the guidance was deployed must not begin consuming custom secrets without it.

--- a/docs/design/agent-custom-secrets/plan.md
+++ b/docs/design/agent-custom-secrets/plan.md
@@ -1,0 +1,132 @@
+# Implementation plan
+
+## Milestone one: readable custom secrets and setup cards
+
+### Bind, resolve, and inject
+
+Add the contract in [contracts.md](contracts.md) to the agent template, schema inspection,
+configuration validation, SDK parsing, and internal run wire. Resolve text values through
+the existing project-scoped runtime vault path. Write-only values require the existing
+runtime `secret-resolve` grant; do not relax public vault reads or put that grant in the
+browser or sandbox.
+
+Add custom credentials to runner redaction and collision checks before environment
+composition. Inject only selected values into the target environment. Support local
+and Daytona without changing existing model/MCP credential policy or using a global
+`os.environ` mutation in a shared worker.
+
+Include the shared platform instructions in this implementation, using #6365's module.
+Keep stable behavior rules there. Obtain the current attached variable names from current
+configuration metadata, rather than depending on a generated list that can become stale.
+
+### Add one attachment flow
+
+Reuse the existing text secret form and vault mutations in a shared attachment drawer.
+The user selects an existing text secret or creates one, chooses the variable name, and
+sees the readable-delivery explanation before saving. Settings and the agent request
+card enter this same flow. Existing JSON vault storage stays supported elsewhere.
+
+The shared secret UI belongs in `@agenta/entity-ui`; vault and workflow data operations
+belong in `@agenta/entities`. The playground owns the run target and resume orchestration.
+Pass that capability into the shared UI rather than importing playground state from it.
+Register the interaction in the existing shared client-tool registry and chat rendering.
+Do not copy the connection dock's state machine or create another polling service.
+
+Save attachments as an ordinary agent revision through the existing commit operation
+with `base_revision_id`. This publishes configuration on that agent variant, not a new
+production deployment. The form must name the agent/variant being changed. It must not
+silently include unrelated unsaved editor changes: require the user to save or discard
+those edits through the existing editor flow before attachment.
+
+### Complete the request card and resume
+
+Example: an agent needs `GITHUB_TOKEN` while processing a repository request.
+
+1. The agent calls `request_secret` with a name, proposed variable, and reason. The
+   runner emits the existing client-tool interaction and ends the turn paused.
+2. The host displays a pending card with Configure and Cancel actions. Configure opens
+   the attachment drawer for the originating agent/variant, even if the user switches
+   the editor selection. Navigation never changes which agent receives the binding.
+3. The user chooses an existing secret or creates a text secret. A successful create
+   returns its reference. Clear raw form content after submission or dismissal; do not
+   store it in local storage, conversation state, analytics, or interaction records.
+4. Save the binding through the existing revision commit with the revision the form read.
+   A concurrent edit produces the existing conflict response. Refresh and ask the user
+   to review the attachment again; do not overwrite newer configuration.
+5. Read the committed revision into the host's run configuration. Only then settle the
+   original tool call once with `status: configured`, the reference, and revision ID.
+   Use the existing interaction identity and settlement mechanism for duplicate clicks
+   and multiple mounted views. The browser reports saved configuration, not runtime readiness.
+6. The existing automatic-resume path submits the same conversation/session with the
+   committed revision. It must not reuse an old draft or a pinned previous revision.
+   The backend validates that revision in the authenticated project and resolves its
+   bindings again; it never trusts a value or arbitrary target from the tool result.
+7. Before the next harness turn, reconcile the environment with the new binding set.
+   If applying credentials fails, end with a visible runtime error and keep the saved
+   configuration. Do not let the model continue under the old environment.
+8. After successful application, deliver the pending tool result and continue the same
+   conversation. The model can use `GITHUB_TOKEN` without seeing its value in the result.
+
+No separate "apply secret" API or frontend polling loop is required. The existing next
+run request is the runtime application boundary. If the host cannot submit the updated
+revision, report that limitation instead of claiming the attachment is ready.
+
+### Recover interrupted setup
+
+| Interruption                                   | Required behavior                                                                                                                                               |
+| ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| User cancels before saving a binding           | Settle cancellation once. No automatic repeated request for the same declined need.                                                                             |
+| Secret creation succeeds, binding commit fails | Keep the saved vault entry and show "Saved in vault; not attached". Retry attachment using its reference, without creating again.                               |
+| Create response is lost                        | Check the intended unique slug in the current project before retrying. Let the user select the resulting entry; do not overwrite it automatically.              |
+| Binding commit response is lost                | Read current revision. If the exact binding is present, use it; otherwise retry from the current revision with user confirmation on conflict.                   |
+| Browser reloads before settlement              | Recover the pending interaction from existing session state, read the saved binding, and offer Continue if configured. Never recreate the secret automatically. |
+| Resume request fails after settlement          | Keep the configured result and expose the existing run retry. Retry the same saved revision, without another create/attach transaction.                         |
+| Runtime resolution or application fails        | Stop before model execution. Show a safe error; retry or edit the saved binding.                                                                                |
+
+The vault entry and agent revision are separate resources. Do not add a distributed
+transaction or automatically delete a successfully created secret after an attachment
+failure; another consumer may already use it.
+
+### Apply changes between turns
+
+Resolve configured values on each run boundary. Reuse the runner's existing credential
+change tracking and session reconciliation. Add, replace, remove, and value rotation must
+all take effect before the next execution. Removed or replaced values must not survive in
+reused daemon or child-process environments.
+
+For milestone one, choose correctness over a new live-patching mechanism: use the existing
+supported reopen/rebuild path when a process cannot update its environment. Preserve the
+session ID, conversation, and durable files. Changes may restart running processes and
+lose transient process state; show that consequence in configuration UI. Do not mutate
+credentials in the middle of an active turn. A request already executing finishes under
+its original binding set; this version promises updates at the next run boundary.
+
+Implementation must prove environment refresh and transcript continuity separately for
+Pi, Claude, and Codex on local and Daytona. If a backend cannot satisfy both, block that
+configuration explicitly rather than silently executing stale credentials. No new session
+lifecycle engine is part of this plan.
+
+## Milestone two: host-restricted delivery
+
+Extend the vault with readable or hidden HTTP delivery policy and normalized exact HTTPS
+hosts. Keep agent attachments as references plus bindings; policy remains on the secret.
+
+Add hidden custom credentials to the existing Daytona Secret allocation and cleanup
+mechanism. Cover exact-host substitution, no plaintext fallback, local rejection of hidden
+policy, and policy changes before execution. Carry forward #5703's host-validation and
+rotation requirements. Existing readable attachments keep that meaning until an explicit
+policy change. A policy change that makes a running configuration unsupported must fail
+closed at the next run boundary.
+
+## Implementation order and review
+
+1. Finish and land #6365, or implement on a child branch based on its reviewed head.
+2. Add the milestone-one bindings, validation, resolution, runner handling, and shared
+   guidance together with contract and runtime tests.
+3. Add the shared drawer, persisted attachment flow, and request tool. Validate the full
+   interrupted setup and resume cases before enabling the tool.
+4. Run [QA](qa.md) against the complete feature on an internal deployment.
+5. Design the exact vault policy changes for milestone two after the readable flow works.
+
+The current PR contains the plan only. It does not implement the prompt text or the tool,
+and it must not close #5703 as completed work.

--- a/docs/design/agent-custom-secrets/qa.md
+++ b/docs/design/agent-custom-secrets/qa.md
@@ -1,0 +1,68 @@
+# Acceptance checks
+
+These checks are required for implementation. They have not run for this documentation PR.
+Use dummy credentials and test endpoints for injection checks; do not print real secrets.
+
+## Configuration and permissions
+
+- Select an existing text secret and create a new one through the same drawer. Both save
+  the expected binding on the named agent variant. JSON entries cannot be attached.
+- Invalid, reserved, duplicate, or colliding variables fail clearly. Existing model/MCP
+  environment owners retain their values and policies.
+- Missing, deleted, wrong-project, wrong-kind, empty, and unreadable secrets fail before
+  harness execution. API writes enforce the same permission rule as the editor.
+- A moved `base_revision_id` produces a conflict without overwriting another edit. Retry
+  confirms the selected binding against the current revision.
+
+## Card completion and recovery
+
+- Request a secret, configure it, and resume the same conversation. The resumed request
+  uses the committed revision, and an authentication test proves the process received it.
+- Cancel or decline the card. It settles once and the agent does not automatically repeat
+  the same request. Duplicate clicks and dock/inline renders do not double-settle.
+- Reload after secret creation, after binding commit, and after settlement. Each case
+  resumes from the persisted vault/revision/interaction state without duplicate creation.
+- Lose each save response and retry. Existing slug and exact binding checks recover the
+  completed write without overwriting unrelated state.
+- Switch agents while the card is open. It still targets the originating agent/variant.
+- Fail runtime resolution or application after successful configuration. No next model
+  turn executes with stale credentials; ordinary retry uses the already-saved binding.
+
+## Runtime and guidance
+
+Run the critical flow on Pi, Claude, and Codex with both local and Daytona environments.
+For each, cover a fresh run, a previously warm conversation, value rotation, replacement,
+and removal. Verify the conversation and durable files survive any reopen/rebuild, and
+old values no longer exist in processes used for the next execution.
+
+Verify two independent runs never inherit each other's custom credential bindings. Local
+execution keeps its existing host isolation limits; this test checks injection ownership,
+not protection against deliberate host inspection.
+
+Verify the new guidance reaches fresh environments and environments upgraded before the
+feature is enabled. Check presence in the delivered instruction channel, and separately
+exercise a model request that would otherwise print credentials. Model behavior is useful
+QA evidence but is not proof of a security boundary.
+
+Check traces, tool arguments/results, validation failures, analytics, saved diagnostics,
+and browser persistence for raw values. Injection travels as credential material over the
+protected internal transport; redact diagnostic copies of that request.
+
+## Supported hosts and regressions
+
+Desktop OSS/EE can configure and fulfill the card. Mobile either fulfills the same flow or
+does not advertise the tool. Headless clients can run saved bindings without becoming stuck
+on an unsupported browser interaction. Regress existing MCP secret selection/creation,
+write-only vault reads, connection cards, and permission approvals.
+
+Use the repository's SDK, service, runner, and frontend test suites for these behaviors,
+then the agent release gate for live wire assertions. A green unit suite does not complete
+the harness/backend matrix.
+
+## Milestone-two additions
+
+Verify hidden placeholders cannot authenticate at an unlisted host, can authenticate at
+an exact permitted HTTPS host, and never fall back after policy or allocation failures.
+Reject hidden policy locally. Check policy/value changes at the next run boundary and
+cleanup using the existing Daytona resource lifecycle. An echo endpoint alone is not proof
+of failed substitution because Daytona can scrub credential values in responses.

--- a/docs/design/agent-custom-secrets/research.md
+++ b/docs/design/agent-custom-secrets/research.md
@@ -1,0 +1,63 @@
+# Codebase research
+
+## Current user-facing behavior
+
+Custom-secret storage merged in [#4882](https://github.com/Agenta-AI/agenta/pull/4882).
+HTTP MCP secret resolution merged in [#5296](https://github.com/Agenta-AI/agenta/pull/5296),
+and inline secret creation merged in [#6143](https://github.com/Agenta-AI/agenta/pull/6143).
+Old local-tools documents that call all custom secrets storage-only are historical.
+
+Daytona credential delivery merged in
+[#5670](https://github.com/Agenta-AI/agenta/pull/5670) and became default-on in
+[#5705](https://github.com/Agenta-AI/agenta/pull/5705). Those paths handle model and HTTP
+MCP consumers. They do not implement general agent environment attachments.
+
+## Relevant implementation entry points
+
+Paths below were inspected on refreshed `origin/main`, except the platform-instruction
+module, which was read from #6365's remote head. These are implementation locations,
+not promises that the proposed fields already exist.
+
+| Responsibility               | Existing path and finding                                                                                                                                                                                                                 |
+| ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Secret shape                 | `api/oss/src/core/secrets/dtos.py`: custom secret settings contain `format` and `content`; no delivery policy.                                                                                                                            |
+| Vault access                 | `api/oss/src/apis/fastapi/vault/router.py`: project-scoped CRUD; `_for_caller` reveals write-only values only with `secret-resolve`.                                                                                                      |
+| Runtime grant                | `api/oss/src/apis/fastapi/access/router.py`: `_run_credential_grants` requires platform-runtime proof or an existing verified grant.                                                                                                      |
+| Named resolution             | `sdks/python/agenta/sdk/agents/platform/secrets.py`: explicit slug reads, text-only extraction; unresolved values currently return a partial map. New attachment caller must require every binding.                                       |
+| Agent template               | `sdks/python/agenta/sdk/agents/dtos.py`: `AgentTemplate.from_params` parses `parameters.agent` and validates known shape. New nested credentials need schema/parser support.                                                              |
+| Wire types                   | `sdks/python/agenta/sdk/agents/wire_models.py`, `utils/wire.py`, `services/runner/src/protocol.ts`: Python/TypeScript serialization boundary.                                                                                             |
+| Daytona composition          | `services/runner/src/engines/sandbox_agent/daytona-secret-plan.ts`: separate typed model/MCP consumers, collisions, and restricted local-use provider bindings. Arbitrary custom secrets cannot be inserted into those provider bindings. |
+| Runtime identity             | `services/runner/src/lifecycle/desired-state.ts` and `engines/sandbox_agent/session-identity.ts`: structure and credential material have separate tracking. Both identity views must stay consistent.                                     |
+| Existing secret form         | `web/packages/agenta-entity-ui/src/secret/SecretForm/` and `CreateSecretDrawer.tsx`: reuse text creation and vault mutations.                                                                                                             |
+| Existing client interaction  | `services/runner/src/engines/sandbox_agent/client-tools.ts`: common pause/correlation mechanism for browser-fulfilled tools.                                                                                                              |
+| Existing connection flow     | `web/packages/agenta-entity-ui/src/clientTools/useConnectFlow.ts`: reference-only results, single settlement, explicit cancellation and failure. OAuth details do not belong in the custom-secret flow.                                   |
+| Tool catalog                 | `api/oss/src/core/workflows/static_catalog.py` and `sdks/python/agenta/sdk/agents/platform/workflow.py`: reserved platform client-tool definitions and resolution.                                                                        |
+| Host resume                  | `web/packages/agenta-playground/src/state/execution/agentApprovalResume.ts` and `agentRequest.ts`: client-tool resume eligibility and the run's configuration target.                                                                     |
+| Revision conflict protection | `api/oss/src/core/workflows/service.py`: ordered commits require `base_revision_id` and reject a moved variant head. Reuse this for attachment writes.                                                                                    |
+
+## Platform-instruction dependency
+
+[#6365](https://github.com/Agenta-AI/agenta/pull/6365) at
+`ecb28ea14b3664f64da010948b8bf621db0fa0b9` introduces
+`sdks/python/agenta/sdk/agents/platform_instructions.py`. Its base currently tells the
+agent to use documented tools and never invent results. It has no secret-handling rule.
+
+Its runner composes the shared text before author text at environment build. Pi uses
+append-system text; Claude and Codex use instruction files. Generated instructions stay
+outside lifecycle identity, so warm environments retain their previous text. Its reported
+live QA covers Pi; the full local/Daytona and harness matrix remains unverified.
+
+## Implementation checks still required
+
+Confirm the caller's runtime grant reaches custom-secret resolution in all hosted run
+paths. Public standalone vault reads cannot reveal write-only values and must not be
+weakened to make that case work.
+
+Trace the revision selected after client-tool settlement in desktop, EE, and mobile.
+An existing `request_connection` reference-only result does not prove that a new agent
+revision will be selected automatically. The feature needs an explicit host update.
+
+Measure the existing reopen/rebuild behavior for changed process credentials and restored
+conversation history. A documented lifecycle hook is not proof that each harness reloads
+its environment. These checks are implementation acceptance gates, not evidence collected
+by this design PR.

--- a/docs/design/agent-custom-secrets/simplification.md
+++ b/docs/design/agent-custom-secrets/simplification.md
@@ -1,0 +1,60 @@
+# Simplification review
+
+The desired outcome is that an agent can request a credential, the user configures it
+once, and the same conversation continues with the credential available. The following
+suggestions are incorporated in the plan.
+
+## One readable delivery mode first
+
+**Suggestion (non-blocking):** defer hidden delivery and host controls to milestone two.
+This removes policy storage, a mode selector, host validation, custom Daytona Secret
+allocation, and their combinations from the first implementation. Users give up host
+enforcement and protection against a process reading the value. Shared instructions
+reduce accidental exposure but do not replace those controls.
+
+Keep explicit typed credentials and bindings now. Those inexpensive boundaries let later
+policy resolution choose the transport without changing how an agent selects a secret.
+
+## One form and one saved binding list
+
+**Suggestion (non-blocking):** settings and the request card share the same attachment
+flow and ordinary agent revisions. Do not add session-scoped grants, a second attachment
+table, or per-skill secret collections. Users give up temporary one-conversation bindings;
+an attachment persists on the selected agent variant until removed. The UI must say so.
+
+Reuse the existing secret form instead of copying it. Keep the request tool distinct from
+OAuth connection setup because their inputs and completion conditions differ. Share the
+client-tool interaction mechanism, not the OAuth-specific controller.
+
+## Resume is the application boundary
+
+**Suggestion (non-blocking):** resolve and apply credentials in the next run, before the
+harness continues. Remove the proposed need for a separate apply endpoint, readiness poll,
+or browser-owned "injected" flag. The tool result reports configured state; runtime
+success is established by the existing run pipeline.
+
+This keeps one owner for runtime changes and handles runner restarts without another
+coordinator. A failed resume becomes a visible run error with normal retry, not a second
+secret-creation attempt.
+
+## Recover partial saves without a transaction framework
+
+**Suggestion (non-blocking):** preserve a successfully created vault entry if attaching it
+fails. Re-read the unique slug and current agent revision before retrying. Reuse existing
+revision conflicts and interaction identity. Remove distributed rollback, automatic vault
+delete, new durable setup records, and competing retry loops.
+
+The tradeoff is visible partial completion: the user may see "Saved in vault; not attached"
+and need to retry attachment. That is less work than re-entering a lost credential and
+avoids deleting a secret another consumer might already use.
+
+## Use existing restart behavior before live environment patching
+
+**Suggestion (non-blocking):** permit a supported reopen/rebuild at the next run boundary
+when process environments cannot update live. Preserve the conversation and durable files,
+but do not promise uninterrupted subprocesses. Add live patching only if measured restart
+cost or a concrete workflow makes this limitation unacceptable.
+
+Validation, runtime authorization, collision protection, redaction, cancellation, and
+no-stale-credential execution stay in the first milestone. Removing them would shift
+routine failures and recovery work onto the user.

--- a/docs/design/agent-custom-secrets/status.md
+++ b/docs/design/agent-custom-secrets/status.md
@@ -1,0 +1,49 @@
+# Status
+
+## Current phase
+
+Planning complete; implementation has not started. The design is prepared as a child of
+#6365. Neither the secret-handling prompt text nor runtime behavior changes in this PR.
+
+## Decisions
+
+- The user approved two milestones: internal readable delivery first, host-restricted
+  policy second.
+- Milestone one includes explicit bindings, backend resolution, runner injection, a shared
+  select/create/attach flow, and an agent request card with correct save/resume behavior.
+- The child implementation includes guidance in #6365's shared platform module.
+- Text-only bindings, variable validation, redaction, failure handling, and conversation
+  continuity remain requirements of milestone one.
+- The simplification pass keeps ordinary agent revisions and the existing client-tool and
+  run lifecycle. It adds no apply endpoint, readiness polling, setup service, or new tables.
+
+## Review decisions
+
+The plan recommends persistent agent-variant bindings, permission to edit secrets as a
+requirement for attaching readable credentials, and a controlled reopen/rebuild when
+needed. Review those tradeoffs together with the card completion flow. The high-level
+milestone split and shared-guidance dependency are already agreed.
+
+## Evidence and validation
+
+Research inspected `origin/main` at `770b566e5e0e280c95088a591315da9c0af19375`, current GitHub issue/PR records, and #6365
+head `ecb28ea14b3664f64da010948b8bf621db0fa0b9`. Runtime and UI paths were read, not
+executed. See research.md for the remaining implementation checks and qa.md for exit gates.
+
+Publication checks cover relative documentation links, whitespace, style, and the exact
+child diff. Runtime tests do not apply to this documentation-only change.
+
+## Workspace handoff
+
+The local parent contains an older design revision than the remote #6365 implementation.
+GitButler's remote-update dry run failed while merging workspace bases. GitButler writes
+were frozen; no workspace repair is part of this task. Publish through the recovery
+runbook's temporary-index path with the remote #6365 head as the exact parent. Do not
+push or rewrite the parent PR. The published child branch is not an applied local lane.
+
+## Next work
+
+Review the design PR. After approval, implement milestone one in the order in plan.md.
+Update #5703's milestone wording when implementation tracking is reorganized; do not mark
+the issue complete on the strength of this plan. Milestone two needs its own detailed
+policy contract after the readable flow is working.


### PR DESCRIPTION
## Context

Users can save custom secrets and select them for HTTP MCP authentication, but cannot attach an arbitrary saved token to an agent's shell or skills. A setup card also needs to carry the user all the way from creating a secret to continuing the same conversation with the saved binding applied.

## Changes

This design splits #5703 / AGE-4067 into two milestones. The first delivers explicitly readable text credentials for internal use, with saved environment bindings, backend resolution, runner injection, and one shared select/create/attach flow for settings and an agent request card. Its implementation includes secret-handling guidance in the shared platform module introduced by #6365. The second adds vault-owned host restrictions and hidden Daytona delivery.

After setup, the card reports a saved binding and revision, never a value. The next run resolves that revision and applies its credentials before the harness continues. The plan covers partial saves, revision conflicts, reloads, cancellation, runtime failure, replacement, and removal.

The simplification pass removes a separate apply endpoint, readiness polling, session-only attachment storage, distributed rollback, and a new runtime lifecycle system. It reuses agent revisions, the vault form, client-tool settlement, and supported reopen/rebuild behavior. The tradeoffs are persistent agent-variant bindings, readable process credentials, and possible process restarts between turns.

This is a design-only child of #6365, based directly on its remote head `ecb28ea14b`. No runtime code or prompt text changes in this PR. References #5703; does not close it.

## How to review

1. Read `context.md` for the milestone boundary, then `plan.md` for the card-to-resume sequence and interrupted setup.
2. Check `contracts.md` for ownership, permission checks, proposed shapes, and the required shared guidance.
3. Read `simplification.md` for the removed machinery and tradeoffs, then `qa.md` for the implementation acceptance checks. `research.md` records current code entry points.

## Tests

- Checked relative documentation links, whitespace, and absence of em dashes.
- Prettier formatting checked on all eight planning files.
- The published child diff is restricted to `docs/design/agent-custom-secrets/` and scanned with gitleaks.
- Runtime tests and live QA have not run; their required coverage is documented for implementation.

The shared GitButler workspace could not preview updating its stale local parent because of a base-merge conflict. Publication uses the documented temporary-index fallback against #6365's remote head. It does not rewrite the parent PR or apply a new local lane.
