### PR TITLE
[fix] Repair web acceptance tests and shorten preview CI

### DIFF
--- a/.github/workflows/44-railway-tests.yml
+++ b/.github/workflows/44-railway-tests.yml
@@ -630,9 +630,8 @@ jobs:
       checks: write
       pull-requests: write
       contents: read
-    # 30 min was too tight: retries on slow tests (e.g. the 7-minute trace test x3
-    # attempts) plus real fixes need headroom before the job gets cut off mid-run.
-    timeout-minutes: 45
+    # Reserve time around Playwright's 20-minute limit for setup and artifacts.
+    timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
@@ -708,7 +707,7 @@ jobs:
           # run-tests.ts runs every source for the layer (package vitest, then
           # playwright) and resolves the playwright dir from --layer itself,
           # skipping internally when that dir is empty. No pre-guard needed.
-          CMD=(pnpm exec tsx playwright/scripts/run-tests.ts --layer "${{ matrix.layer }}" --reporter=html,github)
+          CMD=(pnpm exec tsx playwright/scripts/run-tests.ts --layer "${{ matrix.layer }}")
 
           if [ -n "${{ inputs.coverage }}" ]; then CMD+=(--coverage "${{ inputs.coverage }}"); fi
           if [ -n "${{ inputs.lens }}" ]; then CMD+=(--lens "${{ inputs.lens }}"); fi
@@ -749,11 +748,12 @@ jobs:
       - name: Upload test results
         id: upload_results
         uses: actions/upload-artifact@v4
-        if: failure()
+        if: always()
         with:
           name: playwright-results-${{ matrix.layer }}
           path: |
             web/tests/results/oss/
+            !web/tests/results/oss/state.json
             web/packages/*/test-results/
           retention-days: 7
 
@@ -772,7 +772,7 @@ jobs:
             echo "| --- | --- | --- |"
             echo "| Workflow run | [Open run](${RUN_URL}) | Current run |"
             echo "| Playwright report | ${REPORT_URL:+[Artifact](${REPORT_URL})} | Layer: \`${{ matrix.layer }}\` |"
-            echo "| Playwright results | ${RESULTS_URL:+[Artifact](${RESULTS_URL})} | Uploaded on failures only |"
+            echo "| Playwright results | ${RESULTS_URL:+[Artifact](${RESULTS_URL})} | Includes interrupted runs |"
             echo "| AGENTA_WEB_URL | \`${AGENTA_WEB_URL}\` | |"
             echo "| AGENTA_API_URL | \`${AGENTA_API_URL}\` | |"
             echo "| AGENTA_SERVICES_URL | \`${AGENTA_SERVICES_URL}\` | |"

--- a/api/oss/tests/pytest/acceptance/evaluations/test_evaluation_scenarios_basics.py
+++ b/api/oss/tests/pytest/acceptance/evaluations/test_evaluation_scenarios_basics.py
@@ -179,7 +179,7 @@ class TestEvaluationScenariosBasics:
         assert response.status_code == 200
         response = response.json()
         assert response["count"] == 2
-        assert response["scenario_ids"] == scenario_ids
+        assert sorted(response["scenario_ids"]) == sorted(scenario_ids)
         # ----------------------------------------------------------------------
 
         # ACT ------------------------------------------------------------------

--- a/web/oss/tests/playwright/acceptance/agent-chat/attach-send-render-reload.spec.ts
+++ b/web/oss/tests/playwright/acceptance/agent-chat/attach-send-render-reload.spec.ts
@@ -38,11 +38,12 @@ const IMAGE = Buffer.from(
 test(
     "an uploaded attachment renders after send and after reload",
     {tag: tags},
-    async ({page, seedAgentChatApp, navigateToAgentPlayground}) => {
+    async ({page, seedAgentChatApp, navigateToAgentPlayground, testProviderHelpers}) => {
         // API seeding + 2 navigations + file upload + SSE-mocked run + reload is heavier
         // than the 60s default (siblings that do less than this already bump to 120s+, #5695).
         test.setTimeout(120000)
         await expectAuthenticatedSession(page)
+        await testProviderHelpers.ensureTestProvider()
         const appId = await seedAgentChatApp()
         await navigateToAgentPlayground(appId)
 
@@ -62,7 +63,9 @@ test(
         })
 
         const composer = page.getByRole("textbox").last()
-        await page.getByRole("button", {name: "Attach files"}).click()
+        const attachButton = page.getByRole("button", {name: "Attach files"})
+        await expect(attachButton).toBeEnabled()
+        await attachButton.click()
 
         const uploadResponsePromise = page.waitForResponse((response) => {
             const url = new URL(response.url())

--- a/web/oss/tests/playwright/acceptance/app/test.ts
+++ b/web/oss/tests/playwright/acceptance/app/test.ts
@@ -156,32 +156,28 @@ const testWithAppFixtures = baseTest.extend<AppFixtures>({
             // 5. Click the "Create" button. CommitVariantChangesButton shows "Create"
             //    (not "Commit") for ephemeral local-* entities. Clicking it opens
             //    CommitVariantChangesModal (EntityCommitModal with actionLabel="Create").
-            await uiHelpers.clickButton("Create", drawer)
-            // The confirmation modal opens — accept it. Wait for the submit
-            // button before clicking; isVisible() is an immediate snapshot and
-            // can race the modal render.
-            // Match the dialog by role, not by a component-library class:
-            // `EntityCommitModal` renders through `EnhancedModal`, now a facade over
-            // the @agenta/ui (Radix) `Dialog`, so no `.ant-modal-wrap` exists here.
-            // Radix `aria-hidden`s the launching antd drawer while the modal is open,
-            // so exactly one dialog resolves.
-            const confirmModal = page
-                .getByRole("dialog")
-                .filter({has: page.getByRole("button", {name: "Create", exact: true})})
-                .last()
-            const confirmButton = confirmModal.getByRole("button", {
-                name: "Create",
+            const confirmModal = page.getByRole("dialog", {
+                name: "Create changes",
                 exact: true,
             })
-            await expect(confirmModal).toBeVisible({timeout: 15000})
-            await expect(confirmButton).toBeVisible({timeout: 15000})
-            await expect(confirmButton).toBeEnabled({timeout: 15000})
-            await confirmButton.click({force: true})
+            const [createAppResponse] = await Promise.all([
+                createAppPromise,
+                (async () => {
+                    await uiHelpers.clickButton("Create", drawer)
+                    const confirmButton = confirmModal.getByRole("button", {
+                        name: "Create",
+                        exact: true,
+                    })
+                    await expect(confirmModal).toBeVisible({timeout: 15000})
+                    await expect(confirmButton).toBeVisible({timeout: 15000})
+                    await expect(confirmButton).toBeEnabled({timeout: 15000})
+                    await confirmButton.click({force: true})
+                })(),
+            ])
 
             // 6. Wait for the create response and for the confirmation modal
             //    to close. The current create flow returns to /apps; callers
             //    assert the created app is visible there.
-            const createAppResponse = await createAppPromise
             expect(createAppResponse.ok()).toBe(true)
 
             const response = (await createAppResponse.json()) as CreateAppResponse

--- a/web/oss/tests/playwright/acceptance/auto-evaluation/tests.ts
+++ b/web/oss/tests/playwright/acceptance/auto-evaluation/tests.ts
@@ -191,20 +191,22 @@ const selectAutoEvaluationModalTableInput = async ({
         : activePane.locator("[data-row-key]").first()
     await expect(targetRow).toBeVisible({timeout: 30000})
 
-    const targetRowKey = await targetRow.getAttribute("data-row-key")
-    const stableRow = targetRowKey
-        ? modal.locator(`[data-row-key="${targetRowKey}"]`).first()
-        : targetRow
-    const selectionControl = stableRow
-        .getByRole("checkbox", {includeHidden: true})
-        .or(stableRow.getByRole("radio", {includeHidden: true}))
+    const selectedTabId = await modal.getByRole("tab", {selected: true}).getAttribute("id")
+    const selectionControl = targetRow
+        .getByRole("checkbox")
+        .or(targetRow.getByRole("radio"))
         .first()
-    await expect(stableRow).toBeVisible({timeout: 30000})
 
     if (!(await selectionControl.isChecked())) {
         await selectionControl.click()
     }
-    await expect(selectionControl).toBeChecked({timeout: 30000})
+    // Selection can advance the tab and replace grouped rows. Check the persisted summary.
+    await expect(
+        modal.locator(`[id="${selectedTabId}"]`).getByRole("img", {name: "check-circle"}),
+    ).toBeVisible({timeout: 30000})
+    if (rowText) {
+        await expect(modal.locator(`[id="${selectedTabId}"]`)).toContainText(rowText)
+    }
 }
 
 const waitForAutoResultsPage = async (page: Page, appId: string) => {

--- a/web/oss/tests/playwright/acceptance/auto-evaluation/tests.ts
+++ b/web/oss/tests/playwright/acceptance/auto-evaluation/tests.ts
@@ -173,11 +173,6 @@ const selectAutoEvaluationModalTableInput = async ({
 }) => {
     const activePane = modal.locator(".ant-tabs-tabpane-active").last()
     const searchInput = activePane.locator('input[placeholder="Search"]').first()
-    const inputSelector =
-        'input[type="checkbox"], input[type="radio"], .ant-checkbox-input, .ant-radio-input'
-    const controlSelector =
-        '.ant-checkbox, .ant-checkbox-wrapper, .ant-radio, .ant-radio-wrapper, [role="checkbox"], [role="radio"]'
-    const selectedTags = modal.locator(".ant-tabs-tab .ant-tag")
 
     if (rowText && (await pollLocatorState(() => searchInput.isVisible()))) {
         await typeIntoLocator(searchInput, rowText)
@@ -200,41 +195,16 @@ const selectAutoEvaluationModalTableInput = async ({
     const stableRow = targetRowKey
         ? modal.locator(`[data-row-key="${targetRowKey}"]`).first()
         : targetRow
+    const selectionControl = stableRow
+        .getByRole("checkbox", {includeHidden: true})
+        .or(stableRow.getByRole("radio", {includeHidden: true}))
+        .first()
     await expect(stableRow).toBeVisible({timeout: 30000})
 
-    const isSelected = async () => {
-        const rowClassName = await stableRow.getAttribute("class").catch(() => null)
-        if (rowClassName?.includes("ant-table-row-selected")) {
-            return true
-        }
-
-        const ariaSelected = await stableRow.getAttribute("aria-selected").catch(() => null)
-        if (ariaSelected === "true") {
-            return true
-        }
-
-        const selectionInput = stableRow.locator(inputSelector).first()
-        if ((await selectionInput.count().catch(() => 0)) > 0) {
-            return await pollLocatorState(() => selectionInput.isChecked())
-        }
-
-        if (typeof rowText === "string") {
-            return (await selectedTags.filter({hasText: rowText}).count()) > 0
-        }
-
-        return false
+    if (!(await selectionControl.isChecked())) {
+        await selectionControl.click()
     }
-
-    if (!(await isSelected())) {
-        const selectionControl = stableRow.locator(controlSelector).first()
-        if ((await selectionControl.count().catch(() => 0)) > 0) {
-            await selectionControl.click({force: true})
-        } else {
-            await stableRow.click({force: true})
-        }
-    }
-
-    await expect.poll(isSelected, {timeout: 30000}).toBe(true)
+    await expect(selectionControl).toBeChecked({timeout: 30000})
 }
 
 const waitForAutoResultsPage = async (page: Page, appId: string) => {

--- a/web/oss/tests/playwright/acceptance/human-annotation/tests.ts
+++ b/web/oss/tests/playwright/acceptance/human-annotation/tests.ts
@@ -548,11 +548,6 @@ const selectHumanEvaluationModalTableInput = async ({
 }) => {
     const activePane = getActiveHumanEvaluationPane(modal)
     const searchInput = activePane.locator('input[placeholder="Search"]').first()
-    const inputSelector =
-        'input[type="checkbox"], input[type="radio"], .ant-checkbox-input, .ant-radio-input'
-    const controlSelector =
-        '.ant-checkbox, .ant-checkbox-wrapper, .ant-radio, .ant-radio-wrapper, [role="checkbox"], [role="radio"]'
-    const selectedTags = modal.locator(".ant-tabs-tab .ant-tag")
 
     if (typeof rowText === "string" && (await pollLocatorState(() => searchInput.isVisible()))) {
         await typeIntoLocator(searchInput, rowText)
@@ -571,62 +566,19 @@ const selectHumanEvaluationModalTableInput = async ({
         : activePane.locator("[data-row-key]").first()
     await expect(targetRow).toBeVisible({timeout: 30000})
     const targetRowKey = await targetRow.getAttribute("data-row-key")
-    const stableSelectionInput = targetRowKey
-        ? modal.locator(`[data-row-key="${targetRowKey}"]`).locator(inputSelector).first()
-        : targetRow.locator(inputSelector).first()
     const stableRow = targetRowKey
         ? modal.locator(`[data-row-key="${targetRowKey}"]`).first()
         : targetRow
+    const selectionControl = stableRow
+        .getByRole("checkbox", {includeHidden: true})
+        .or(stableRow.getByRole("radio", {includeHidden: true}))
+        .first()
     await expect(stableRow).toBeVisible({timeout: 30000})
 
-    const isSelected = async () => {
-        const rowClassName = await stableRow.getAttribute("class").catch(() => null)
-        if (rowClassName?.includes("ant-table-row-selected")) {
-            return true
-        }
-
-        const ariaSelected = await stableRow.getAttribute("aria-selected").catch(() => null)
-        if (ariaSelected === "true") {
-            return true
-        }
-
-        if ((await stableSelectionInput.count().catch(() => 0)) > 0) {
-            return await pollLocatorState(() => stableSelectionInput.isChecked())
-        }
-
-        if (typeof rowText === "string") {
-            return (await selectedTags.filter({hasText: rowText}).count()) > 0
-        }
-
-        return false
+    if (!(await selectionControl.isChecked())) {
+        await selectionControl.click()
     }
-
-    if (!(await isSelected())) {
-        const selectionControl = stableRow.locator(controlSelector).first()
-        if ((await selectionControl.count().catch(() => 0)) > 0) {
-            await selectionControl.click({force: true})
-        } else {
-            await stableRow.click({force: true})
-        }
-    }
-
-    if (_inputType === "radio" && typeof rowText === "string") {
-        await expect
-            .poll(
-                async () => {
-                    if (await isSelected()) {
-                        return true
-                    }
-
-                    return (await selectedTags.filter({hasText: rowText}).count()) > 0
-                },
-                {timeout: 30000},
-            )
-            .toBe(true)
-        return
-    }
-
-    await expect.poll(isSelected, {timeout: 30000}).toBe(true)
+    await expect(selectionControl).toBeChecked({timeout: 30000})
 }
 
 const waitForHumanEvaluatorPane = async (modal: Locator) => {

--- a/web/oss/tests/playwright/acceptance/human-annotation/tests.ts
+++ b/web/oss/tests/playwright/acceptance/human-annotation/tests.ts
@@ -565,20 +565,19 @@ const selectHumanEvaluationModalTableInput = async ({
         ? activePane.locator("[data-row-key]").filter({hasText: rowText}).first()
         : activePane.locator("[data-row-key]").first()
     await expect(targetRow).toBeVisible({timeout: 30000})
-    const targetRowKey = await targetRow.getAttribute("data-row-key")
-    const stableRow = targetRowKey
-        ? modal.locator(`[data-row-key="${targetRowKey}"]`).first()
-        : targetRow
-    const selectionControl = stableRow
-        .getByRole("checkbox", {includeHidden: true})
-        .or(stableRow.getByRole("radio", {includeHidden: true}))
+    const selectedTabId = await modal.getByRole("tab", {selected: true}).getAttribute("id")
+    const selectionControl = targetRow
+        .getByRole("checkbox")
+        .or(targetRow.getByRole("radio"))
         .first()
-    await expect(stableRow).toBeVisible({timeout: 30000})
 
     if (!(await selectionControl.isChecked())) {
         await selectionControl.click()
     }
-    await expect(selectionControl).toBeChecked({timeout: 30000})
+    // Selection can advance the tab and replace grouped rows. Check the persisted summary.
+    await expect(
+        modal.locator(`[id="${selectedTabId}"]`).getByRole("img", {name: "check-circle"}),
+    ).toBeVisible({timeout: 30000})
 }
 
 const waitForHumanEvaluatorPane = async (modal: Locator) => {
@@ -615,59 +614,7 @@ const ensureSingleHumanEvaluatorSelection = async ({
     modal: Locator
     evaluatorName?: string
 }) => {
-    const activePane = await waitForHumanEvaluatorPane(modal)
-
-    if (!evaluatorName) {
-        const firstEvaluatorRow = activePane.locator("[data-row-key]").first()
-        const hasSelectedEvaluator = async () => {
-            // evaluateAll runs over every matched row regardless of count, so it can never
-            // throw a strict-mode violation — pollLocatorState would add nothing here.
-            const selectedRows = await activePane
-                .locator("[data-row-key]")
-                .evaluateAll((rows) =>
-                    rows.some(
-                        (row) =>
-                            row.className.includes("ant-table-row-selected") ||
-                            row.getAttribute("aria-selected") === "true",
-                    ),
-                )
-                .catch(() => false)
-
-            if (selectedRows) {
-                return true
-            }
-
-            return (
-                (await activePane
-                    .locator('input[type="checkbox"]:checked, input[type="radio"]:checked')
-                    .count()) > 0
-            )
-        }
-
-        await expect(firstEvaluatorRow).toBeVisible({timeout: 30000})
-
-        await expect
-            .poll(
-                async () => {
-                    if (await hasSelectedEvaluator()) return true
-
-                    const checkboxes = activePane.getByRole("checkbox")
-                    if ((await checkboxes.count()) > 1) {
-                        await checkboxes
-                            .nth(1)
-                            .click({force: true})
-                            .catch(() => null)
-                    } else {
-                        await firstEvaluatorRow.click({force: true}).catch(() => null)
-                    }
-
-                    return hasSelectedEvaluator()
-                },
-                {timeout: 30000},
-            )
-            .toBe(true)
-        return
-    }
+    await waitForHumanEvaluatorPane(modal)
 
     await selectHumanEvaluationModalTableInput({
         modal,

--- a/web/oss/tests/playwright/acceptance/observability/index.ts
+++ b/web/oss/tests/playwright/acceptance/observability/index.ts
@@ -254,7 +254,7 @@ const observabilityTests = () => {
             )
 
             // Use the search input to filter by content
-            const searchInput = page.getByRole("searchbox").first()
+            const searchInput = page.getByLabel("Search observability data")
             await expect(searchInput).toBeVisible({timeout: 10000})
 
             // Typing a search term narrows the table; press Enter to apply
@@ -302,6 +302,11 @@ const observabilityTests = () => {
                 // Click the first data row to open the trace drawer. The virtual table body
                 // does not expose stable cell tags, but the row click handler is the behavior
                 // users rely on.
+                const selectedSpanName = await getFirstTraceRow(page)
+                    .locator("span[title]")
+                    .first()
+                    .getAttribute("title")
+                expect(selectedSpanName).toBeTruthy()
                 await clickFirstTraceRow(page)
 
                 // TraceDrawer renders through EnhancedDrawer, a facade over the @agenta/ui
@@ -315,10 +320,12 @@ const observabilityTests = () => {
                 const treeSearchInput = drawer.getByPlaceholder("Search in tree")
                 await expect(treeSearchInput).toBeVisible({timeout: 10000})
 
-                // Each span in the tree renders a square avatar (AvatarTreeContent → antd Avatar
-                // shape="square"). At least one confirms the tree has nodes.
-                const spanAvatar = drawer.locator(".ant-avatar-square").first()
-                await expect(spanAvatar).toBeVisible({timeout: 10000})
+                await expect(
+                    drawer
+                        .getByTestId("trace-tree")
+                        .getByText(selectedSpanName!, {exact: true})
+                        .first(),
+                ).toBeVisible({timeout: 10000})
             },
         )
     })
@@ -336,33 +343,24 @@ const observabilityTests = () => {
                 testProviderHelpers,
             )
 
-            // The three trace-type tabs are AntD Radio.Buttons: Root | LLM | All
-            const rootTab = page
-                .locator(".ant-radio-button-wrapper")
-                .filter({hasText: "Root"})
-                .first()
-            const llmTab = page
-                .locator(".ant-radio-button-wrapper")
-                .filter({hasText: "LLM"})
-                .first()
-            const allTab = page
-                .locator(".ant-radio-button-wrapper")
-                .filter({hasText: "All"})
-                .first()
+            const traceProjection = page.getByRole("radiogroup", {name: "Trace projection"})
+            const rootTab = traceProjection.getByRole("radio", {name: "Root", exact: true})
+            const llmTab = traceProjection.getByRole("radio", {name: "LLM", exact: true})
+            const allTab = traceProjection.getByRole("radio", {name: "All", exact: true})
 
             await expect(rootTab).toBeVisible({timeout: 10000})
 
             // Switch to LLM
             await llmTab.click()
-            await expect(llmTab).toHaveClass(/ant-radio-button-wrapper-checked/, {timeout: 5000})
+            await expect(llmTab).toBeChecked({timeout: 5000})
 
             // Switch to All
             await allTab.click()
-            await expect(allTab).toHaveClass(/ant-radio-button-wrapper-checked/, {timeout: 5000})
+            await expect(allTab).toBeChecked({timeout: 5000})
 
             // Switch back to Root
             await rootTab.click()
-            await expect(rootTab).toHaveClass(/ant-radio-button-wrapper-checked/, {timeout: 5000})
+            await expect(rootTab).toBeChecked({timeout: 5000})
         },
     )
 

--- a/web/oss/tests/playwright/acceptance/playground/tests.ts
+++ b/web/oss/tests/playwright/acceptance/playground/tests.ts
@@ -350,10 +350,7 @@ const testWithVariantFixtures = baseTest.extend<VariantFixtures>({
                 }
 
                 // 1. Click on the save button
-                const commitButton = page
-                    .locator("button.ant-btn-primary")
-                    .filter({hasText: "Commit"})
-                    .first()
+                const commitButton = page.getByRole("button", {name: "Commit", exact: true})
                 const isCommitButtonDisabled = await commitButton.isDisabled()
 
                 if (!isCommitButtonDisabled) {

--- a/web/oss/tests/playwright/acceptance/prompts/test.ts
+++ b/web/oss/tests/playwright/acceptance/prompts/test.ts
@@ -79,30 +79,31 @@ const testWithPromptsFixtures = baseTest.extend<PromptsFixtures>({
                 return payload.includes(promptName)
             })
 
-            const createButton = drawer.getByRole("button", {name: "Create", exact: true}).first()
-            await expect(createButton).toBeVisible({timeout: 15000})
-            await expect(createButton).toBeEnabled({timeout: 15000})
-            await createButton.click()
-
-            // Match the dialog by role, not by a component-library class:
-            // `EntityCommitModal` renders through `EnhancedModal`, now a facade over
-            // the @agenta/ui (Radix) `Dialog`, so no `.ant-modal-wrap` exists here.
-            // Radix `aria-hidden`s the launching antd drawer while the modal is open,
-            // so exactly one dialog resolves.
-            const confirmModal = page
-                .getByRole("dialog")
-                .filter({has: page.getByRole("button", {name: "Create", exact: true})})
-                .last()
-            const confirmButton = confirmModal.getByRole("button", {
-                name: "Create",
+            const confirmModal = page.getByRole("dialog", {
+                name: "Create changes",
                 exact: true,
             })
-            await expect(confirmModal).toBeVisible({timeout: 15000})
-            await expect(confirmButton).toBeVisible({timeout: 15000})
-            await expect(confirmButton).toBeEnabled({timeout: 15000})
-            await confirmButton.click({force: true})
+            const [createPromptResponse] = await Promise.all([
+                createPromptPromise,
+                (async () => {
+                    const createButton = drawer
+                        .getByRole("button", {name: "Create", exact: true})
+                        .first()
+                    await expect(createButton).toBeVisible({timeout: 15000})
+                    await expect(createButton).toBeEnabled({timeout: 15000})
+                    await createButton.click()
 
-            const createPromptResponse = await createPromptPromise
+                    const confirmButton = confirmModal.getByRole("button", {
+                        name: "Create",
+                        exact: true,
+                    })
+                    await expect(confirmModal).toBeVisible({timeout: 15000})
+                    await expect(confirmButton).toBeVisible({timeout: 15000})
+                    await expect(confirmButton).toBeEnabled({timeout: 15000})
+                    await confirmButton.click({force: true})
+                })(),
+            ])
+
             expect(createPromptResponse.ok()).toBe(true)
             await expect(confirmModal).toBeHidden({timeout: 15000})
         })

--- a/web/oss/tests/playwright/acceptance/testsset/testset-management.ts
+++ b/web/oss/tests/playwright/acceptance/testsset/testset-management.ts
@@ -209,10 +209,7 @@ const testsetTests = () => {
                     })
 
                     // Click a data row cell to open the TestcaseEditDrawer
-                    const cell = page
-                        .locator(".ant-table-cell")
-                        .filter({hasText: "original value"})
-                        .first()
+                    const cell = page.getByRole("cell", {name: "original value", exact: true})
                     await expect(cell).toBeVisible({timeout: 10000})
                     await cell.click()
 
@@ -308,9 +305,9 @@ const testsetTests = () => {
                     await expect(page.locator("th").filter({hasText: "input"}).first()).toBeVisible(
                         {timeout: 10000},
                     )
-                    await expect(page.locator(".ant-table-tbody")).toContainText("existing row", {
-                        timeout: 10000,
-                    })
+                    await expect(
+                        page.getByRole("row").filter({hasText: "existing row"}).first(),
+                    ).toBeVisible({timeout: 10000})
 
                     // Add a new row (auto-opens the edit drawer for the new row)
                     await page.getByRole("button", {name: "Add row"}).click()
@@ -339,11 +336,10 @@ const testsetTests = () => {
                         page.locator("[data-row-key]").filter({hasText: "new-row-value"}).first(),
                     ).toBeVisible({timeout: 5000})
 
-                    // Add a new column — the button has a PlusOutlined (anticon-plus) icon and
-                    // sits in the table header before the column-visibility gear button.
-                    // ant-table-cell-fix-right may not be applied without horizontal scroll,
-                    // so locate by the AntD icon class which is unique in the thead.
-                    await page.locator(".ant-table-thead .anticon-plus").click()
+                    await page
+                        .getByRole("columnheader")
+                        .getByRole("button", {name: "plus", exact: true})
+                        .click()
 
                     const addColumnModal = page
                         .locator(".ant-modal")

--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -124,13 +124,12 @@ const openVariantUseApiDrawer = async (page: any) => {
     // so select the first row explicitly when nothing is checked.
     // Scoped to the registry table's BODY rows: the header select-all and any checkbox
     // outside the table must neither satisfy the check nor receive the click.
-    const checkedRow = page.locator(".ant-table-tbody .ant-checkbox-checked").first()
-    if (!(await checkedRow.isVisible().catch(() => false))) {
-        const firstRowCheckbox = page.locator(".ant-table-tbody .ant-checkbox-input").first()
-        await expect(firstRowCheckbox).toBeVisible({timeout: 15000})
+    const firstRowCheckbox = page.getByRole("checkbox", {name: /^Select row /}).first()
+    await expect(firstRowCheckbox).toBeVisible({timeout: 15000})
+    if (!(await firstRowCheckbox.isChecked())) {
         await firstRowCheckbox.click()
     }
-    await expect(checkedRow).toBeVisible({timeout: 15000})
+    await expect(firstRowCheckbox).toBeChecked({timeout: 15000})
     const useApiButton = page.locator('[data-tour="api-code-button"]')
     await expect(useApiButton).toBeVisible({timeout: 15000})
     await expect(useApiButton).toBeEnabled({timeout: 5000})

--- a/web/oss/tests/playwright/unit/api-helpers.spec.ts
+++ b/web/oss/tests/playwright/unit/api-helpers.spec.ts
@@ -36,6 +36,15 @@ test("latest revision flags classify prompt apps", () => {
     expect(appMatchesType(artifact, "custom", {flags: {is_custom: true}})).toBe(true)
 })
 
+test("an app with only a seed revision is not reused as a completion prompt", () => {
+    const artifact = app({is_application: true})
+    const revisions = selectLatestAppRevisions([
+        {workflow_id: artifact.id, version: "0", flags: {is_agent: true}},
+    ])
+
+    expect(appMatchesType(artifact, "completion", revisions.get(artifact.id))).toBe(false)
+})
+
 test("latest revision selection ignores v0 records", () => {
     const latestByAppId = selectLatestAppRevisions([
         {

--- a/web/packages/agenta-observability-ui/src/traceDrawer/TraceTree.tsx
+++ b/web/packages/agenta-observability-ui/src/traceDrawer/TraceTree.tsx
@@ -90,7 +90,7 @@ const TraceTree = ({activeTrace: active, activeTraceId, selected, setSelected}: 
     }
 
     return (
-        <div className={"h-full overflow-hidden flex flex-col"}>
+        <div data-testid="trace-tree" className={"h-full overflow-hidden flex flex-col"}>
             <div
                 className={clsx(
                     "flex items-center justify-between h-[43px] pl-2 pr-2",

--- a/web/tests/playwright.config.ts
+++ b/web/tests/playwright.config.ts
@@ -42,11 +42,14 @@ export default defineConfig({
     // overrides this for targeted local runs where the developer controls scope.
     fullyParallel: false,
     forbidOnly: !!process.env.CI,
-    retries: process.env.CI ? 2 : process.env.RETRIES ? parseInt(process.env.RETRIES) : 0,
+    retries: process.env.CI ? 1 : process.env.RETRIES ? parseInt(process.env.RETRIES) : 0,
+    maxFailures: process.env.CI ? 5 : 0,
+    globalTimeout: process.env.CI ? 20 * 60 * 1000 : 0,
     workers: process.env.PLAYWRIGHT_WORKERS ? parseInt(process.env.PLAYWRIGHT_WORKERS) : 1,
     reporter: [
         ["html", {outputFolder: getReportDir()}],
         ["junit", {outputFile: getJunitPath()}],
+        ...(process.env.CI ? ([["github"]] as [["github"]]) : []),
         [require.resolve("./playwright/live-reporter.ts")],
     ],
     outputDir: getOutputDir(),

--- a/web/tests/tests/fixtures/base.fixture/apiHelpers/index.ts
+++ b/web/tests/tests/fixtures/base.fixture/apiHelpers/index.ts
@@ -451,6 +451,7 @@ export const appMatchesType = (
     type: APP_TYPE,
     latestRevision?: {flags?: ListAppsItem["flags"]},
 ): boolean => {
+    if (!latestRevision) return false
     const flags = {...(app.flags ?? {}), ...(latestRevision?.flags ?? {})}
     if (flags.is_agent) return false
     if (type === "chat") return !!flags.is_chat

--- a/web/tests/tests/fixtures/base.fixture/apiHelpers/index.ts
+++ b/web/tests/tests/fixtures/base.fixture/apiHelpers/index.ts
@@ -214,12 +214,7 @@ const confirmCreateEntityModal = async (page: Page) => {
     // (Radix) `Dialog`, so no `.ant-modal-wrap` exists in this tree any more. Radix
     // `aria-hidden`s the rest of the document while the modal is open (including the
     // antd drawer that launched it), so exactly one dialog resolves here.
-    const confirmModal = page
-        .getByRole("dialog")
-        .filter({
-            has: page.getByRole("button", {name: "Create", exact: true}),
-        })
-        .last()
+    const confirmModal = page.getByRole("dialog", {name: "Create changes", exact: true})
     const confirmButton = confirmModal.getByRole("button", {
         name: "Create",
         exact: true,
@@ -367,34 +362,28 @@ async function createApp(page: Page, type: APP_TYPE): Promise<ListAppsItem> {
             response.request().method() === "POST",
         2,
     )
+    const [workflowResponse, variantResponse, revisionResponses] = await Promise.all([
+        createWorkflowPromise,
+        createVariantPromise,
+        revisionCommitsPromise,
+        (async () => {
+            const createButton = drawer.getByRole("button", {name: "Create", exact: true}).first()
+            await expect(createButton).toBeEnabled({timeout: 15000})
+            await createButton.click()
+            await confirmCreateEntityModal(page)
+        })(),
+    ])
 
-    // CommitVariantChangesButton shows "Create" (not "Commit") for ephemeral local-* entities.
-    // Use exact:true + drawer scope to avoid matching "Create New Prompt" in the background.
-    const createButton = drawer.getByRole("button", {name: "Create", exact: true}).first()
-    await expect(createButton).toBeVisible({timeout: 15000})
-    await expect(createButton).toBeEnabled({timeout: 15000})
-    await createButton.click()
-
-    // Clicking "Create" opens CommitVariantChangesModal (EntityCommitModal with
-    // actionLabel="Create"). Wait for the modal submit button before clicking:
-    // Locator.isVisible() is an immediate snapshot and can race the antd modal render.
-    await confirmCreateEntityModal(page)
-
-    // Wait for workflow creation
-    const workflowResponse = await createWorkflowPromise
     expect(workflowResponse.ok()).toBe(true)
     const createdApp = (await workflowResponse.json()) as {workflow: ListAppsItem}
     const createdWorkflow = createdApp.workflow
     expect(createdWorkflow.id).toBeTruthy()
 
-    // Wait for variant creation
-    const variantResponse = await createVariantPromise
     expect(variantResponse.ok()).toBe(true)
     const variantData = await variantResponse.json()
     expect(variantData.workflow_variant?.id).toBeTruthy()
 
-    // Wait for both revision commits
-    const [seedResponse, dataResponse] = await revisionCommitsPromise
+    const [seedResponse, dataResponse] = revisionResponses
     expect(seedResponse.ok()).toBe(true)
     expect(dataResponse.ok()).toBe(true)
 


### PR DESCRIPTION
## Context

Preview web acceptance tests repeatedly waited for controls that changed during the UI migration. Retries consumed the 45-minute job limit, and cancellation left us without the browser traces needed to diagnose the failures.

## Changes

Use accessible control names and checked states instead of old Ant Design classes. Configure the existing mock provider before the attachment test, and make app-creation waits target the actual confirmation dialog.

Do not reuse seed-only agents as completion prompts. Keep the configured-revision requirement and cover the cross-test fixture bug with a regression test. Check evaluation selection summaries after the dialog advances to the next tab.

Compare deleted scenario IDs without assuming database return order. This fixes the API acceptance failure while preserving the ID, count, and repeated-delete checks.

Keep all acceptance tests, with one retry instead of two. Stop after five failures or 20 minutes of browser tests, inside a 30-minute job. Preserve the configured HTML/JUnit reporters and upload raw results even for interrupted runs, excluding browser authentication state.

## Tests

- Acceptance discovery: 80 tests across 21 files.
- Frontend lint: all 25 tasks passed. Pre-commit formatting, lint, and secret scan passed.
- Observability UI package build and lint passed.
- Fixture regression: failed before the fix, then all 5 helper unit tests passed.
- Targeted browser checks against the live preview passed for attachment upload, prompt creation, human/auto evaluation, testset editing and row/column changes, and both API snippet flows.
- Full web acceptance on final commit `e2741843bb`: 50 passed, 0 failed, 30 skipped; no retries needed. Browser tests took 12.4 minutes. No tests were removed or newly skipped by this PR.
- API acceptance: 757 passed, 30 skipped, zero failures.
- All CI checks are green on the final commit, including the [complete preview build, deployment, and test matrix](https://github.com/Agenta-AI/agenta/actions/runs/33955629181).

## How to review

Start with the acceptance helpers and selectors, then review the Playwright limits and Railway reporting changes. This PR starts from `release/v0.114.8` and does not change application behavior.
