### PR TITLE
[fix] Point the watchdog collapse test at its own database

### DIFF
--- a/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
@@ -200,6 +200,7 @@ async def wd_engine(monkeypatch):
     monkeypatch.setattr(env.postgres, "uri_core", _sqlalchemy_url_for(db_name))
     engine = TransactionsEngine()
     try:
+        engine._wd_db_name = db_name
         yield engine
     finally:
         await engine.close()
@@ -474,7 +475,9 @@ async def test_c_heartbeat_blocked_on_sweep_cannot_revive_collapsed_row(
     project_id = await _seed_scenario(wd_engine, session_id=session_id, turn_id=turn_id)
 
     parsed = urlparse(env.postgres.uri_core)
-    dsn = urlunparse(("postgresql", parsed.netloc, parsed.path, "", "", ""))
+    dsn = urlunparse(
+        ("postgresql", parsed.netloc, f"/{wd_engine._wd_db_name}", "", "", "")
+    )
     sweep = await asyncpg.connect(dsn=dsn)
     observer = await asyncpg.connect(dsn=dsn)
     sweep_transaction = sweep.transaction()


### PR DESCRIPTION
## Context

test_c opened its raw sweep connections against the base database instead of the fixture-created database. This could pollute operator data and made the heartbeat wait time out. The fixture now exposes its generated database name, and the raw sweep and observer connections use it directly.

## Tests

- The full watchdog collapse persistence test file passes: 3 tests in 3.59 seconds.
- test_c completes its call phase in 0.09 seconds.
- Base session table counts stayed unchanged, and no scratch database remained.

https://claude.ai/code/session_0164kzT6ttwpBtzvcDC6YzYk