### PR TITLE
[fix] Return the newest testset revision, not an arbitrary one

### DIFF
--- a/web/packages/agenta-entities/src/testset/api/api.ts
+++ b/web/packages/agenta-entities/src/testset/api/api.ts
@@ -175,8 +175,8 @@ export async function fetchLatestRevision({
  * Batch fetch latest revisions for multiple testsets
  * Returns a Map of testsetId -> latest Revision
  *
- * Uses per-ref limit feature (ReferenceWithLimit) to get exactly 1 revision per testset.
- * The API uses SQL window functions to partition by testset and return top N per partition.
+ * The API has no per-parent limit yet (agenta#6563), so this asks for newest-first and
+ * keeps the first revision seen per testset.
  */
 export async function fetchLatestRevisionsBatch(
     projectId: string,
@@ -189,8 +189,9 @@ export async function fetchLatestRevisionsBatch(
     const response = await axios.post(
         `${getAgentaApiUrl()}/testsets/revisions/query`,
         {
-            // Use per-ref limit to get exactly 1 revision per testset
-            testset_refs: testsetIds.map((id) => ({id, limit: 1})),
+            testset_refs: testsetIds.map((id) => ({id})),
+            // Without this the API applies no ORDER BY and "latest" is arbitrary.
+            windowing: {order: "descending"},
             include_testcases: false,
         },
         {params: {project_id: projectId}},
@@ -203,14 +204,22 @@ export async function fetchLatestRevisionsBatch(
     )
     if (!validated) return results
 
-    // Map revisions by testset_id
+    // Newest first, so the first revision seen for a testset is its latest.
+    const v0Fallback = new Map<string, Revision>()
     for (const raw of validated.testset_revisions) {
         try {
             const revision = normalizeRevision(raw)
-            results.set(revision.testset_id, revision)
+            // v0 is an auto-created empty placeholder; use it only if nothing else exists.
+            const target = revision.version === 0 ? v0Fallback : results
+            if (!target.has(revision.testset_id)) {
+                target.set(revision.testset_id, revision)
+            }
         } catch (e) {
             console.error("[fetchLatestRevisionsBatch] Failed to normalize revision:", e, raw)
         }
+    }
+    for (const [testsetId, revision] of v0Fallback) {
+        if (!results.has(testsetId)) results.set(testsetId, revision)
     }
 
     return results


### PR DESCRIPTION
## Context

`fetchLatestRevisionsBatch` returns the latest revision of each testset. It did not. It returned an arbitrary one.

The call sent no `windowing`, and `GitDAO.query_revisions` adds an `ORDER BY` only when windowing is present. With no ordering, Postgres returned the rows in whatever order it liked, and the loop overwrote the map on every row, so the last row to arrive won. It looked correct only because a small unmodified table tends to return rows in insertion order. After updates or a vacuum, it would not.

Two smaller problems sat on top. The call sent `{id, limit: 1}` inside a `Reference`. `Reference` is `class Reference(Identifier, Slug, Version)` with no `model_config`, so pydantic drops unknown keys and the limit never applied. Checked on a running API:

```
Reference(**{"id": "...", "limit": 1})
  -> version=None slug=None id=UUID('...')
  -> dumped: {'id': UUID('...')}
```

The docstring also described a `ReferenceWithLimit` feature that uses SQL window functions to return the top N per testset. That name appears in exactly one place in the repository: that comment. The feature does not exist.

## Changes

The request now asks for newest first. The loop keeps the first revision it sees for each testset and prefers a configured revision over an auto-created version 0 placeholder. That last rule matches the sibling fetcher in `web/oss/src/state/entities/testset/revisionEntity.ts`, so the two agree on what "latest" means.

Before:

```ts
testset_refs: testsetIds.map((id) => ({id, limit: 1})),   // limit silently dropped
// no windowing, so no ORDER BY
results.set(revision.testset_id, revision)                // last row wins
```

After:

```ts
testset_refs: testsetIds.map((id) => ({id})),
windowing: {order: "descending"},                          // newest first
// first row per testset wins, v0 only as a fallback
```

This does not stop the over-fetch. See the next section.

## Why the over-fetch is not fixed here

The API cannot express "the latest revision of each of these parents", so this batch still reads every revision of every testset. Six endpoints share that gap. The design for the API change is in #6569, and the incident it caused is issue #6563. This PR is independent of both and can merge on its own.

## Tests

- `tsc --noEmit` on `@agenta/entities` passes.
- eslint with the package's own config passes on the changed file. Prettier reports it formatted.
- Verified the `Reference` drop and the missing `ORDER BY` against a running API and its Postgres, not from reading alone.

## What to QA

- Open a project whose testsets have several revisions each. The testset list shows the newest revision of each, and its version matches the newest committed one.
- Edit a testset to create a new revision. The list picks up the new revision rather than an older one.
- Regression: open a project with a brand new testset that only has a version 0 placeholder. It still appears in the list rather than dropping out.
