### PR TITLE
[fix] Address CodeRabbit review for milestone 2 live events

### DIFF
--- a/api/oss/src/apis/fastapi/sessions/models.py
+++ b/api/oss/src/apis/fastapi/sessions/models.py
@@ -153,6 +153,14 @@ class SessionStreamsResponse(BaseModel):
 
 
 class SessionTranscriptWindowing(BaseModel):
+    """Deliberate exception to the shared cursor `Windowing`.
+
+    `through_sequence` pins the snapshot, so offset paging over an append-only log inside that
+    bound is stable: a concurrent append raises `latest_sequence`, never the page contents. The
+    transcript reader also needs to seek within one pinned snapshot, which a forward-only cursor
+    cannot express.
+    """
+
     offset: int = Field(default=0, ge=0)
     limit: int = Field(default=100, ge=1, le=200)
     through_sequence: int = Field(ge=0)

--- a/api/oss/src/core/sessions/records/events.py
+++ b/api/oss/src/core/sessions/records/events.py
@@ -51,7 +51,10 @@ def _direct_event(
         return None
     attributes = dict(record.attributes or {})
     payload = attributes.pop("payload", None)
-    if payload is None:
+    # `attributes` is an open dict filled from the ingest wire, so `payload` can be any JSON
+    # value. A non-dict one must read as absent: `.get` on it raises outside the try below,
+    # and that failure poisons the whole batch on every redelivery.
+    if not isinstance(payload, dict):
         attributes.pop("type", None)
         attributes.pop("execution_id", None)
         payload = attributes

--- a/api/oss/src/core/sessions/records/streaming.py
+++ b/api/oss/src/core/sessions/records/streaming.py
@@ -101,10 +101,12 @@ async def trim_live_stream(redis) -> None:
         )
         * 1000
     )
+    # Approximate: the frames are disposable, so a few extra entries per listpack cost nothing
+    # and exact trimming makes every call O(N) in the evicted entries.
     await redis.xtrim(
         LIVE_FRAME_STREAM_NAME,
         minid=f"{age_boundary}-0",
-        approximate=False,
+        approximate=True,
     )
 
 
@@ -152,7 +154,8 @@ async def _append_live_relay_message(redis, *, message: dict) -> None:
         name=LIVE_FRAME_STREAM_NAME,
         fields={"data": zlib.compress(dumps(message, default=_orjson_default))},
         maxlen=env.sessions.live_stream_maxlen,
-        approximate=False,
+        # Approximate for the same reason as `trim_live_stream`: this runs on every relay write.
+        approximate=True,
     )
 
 

--- a/api/oss/tests/pytest/integration/sessions/test_records_sequence_postgres.py
+++ b/api/oss/tests/pytest/integration/sessions/test_records_sequence_postgres.py
@@ -21,6 +21,10 @@ pytestmark = [pytest.mark.asyncio, pytest.mark.integration]
 @pytest.fixture(autouse=True)
 async def _fresh_analytics_engine(monkeypatch):
     monkeypatch.setattr(env.sessions, "sequence_writes", True)
+    # Close whatever an earlier module left behind; teardown only knows this fixture's engine.
+    previous = engine_module._analytics_engine
+    if previous is not None:
+        await previous.close()
     engine_module._analytics_engine = None
     yield
     if engine_module._analytics_engine is not None:

--- a/api/oss/tests/pytest/unit/sessions/test_durable_events.py
+++ b/api/oss/tests/pytest/unit/sessions/test_durable_events.py
@@ -111,3 +111,38 @@ def test_maps_interaction_records_to_durable_lifecycle_events():
     assert events[0].payload.interaction_id == "interaction-1"
     assert events[0].payload.kind == "client_tool"
     assert events[1].payload.kind == "user_approval"
+
+
+def test_non_dict_payload_reads_as_absent_instead_of_raising():
+    """A record whose `payload` attribute is not a dict must not poison the batch.
+
+    `attributes` is an open dict filled from the ingest wire. Before this guard, a string or
+    list `payload` raised `AttributeError` outside the projection's `try`, so the whole batch
+    failed after its rows were committed and the same record returned on every redelivery.
+    """
+    records = [
+        _record(
+            sequence=1,
+            record_type="execution.started",
+            attributes={
+                "payload": "not-a-dict",
+                "started_at": datetime.now(timezone.utc).isoformat(),
+            },
+        ),
+        _record(
+            sequence=2,
+            record_type="execution.started",
+            attributes={
+                "payload": ["also", "not", "a", "dict"],
+                "started_at": datetime.now(timezone.utc).isoformat(),
+            },
+        ),
+    ]
+
+    events = durable_events_from_records(records)
+
+    assert [event.type for event in events] == [
+        "execution.started",
+        "execution.started",
+    ]
+    assert [event.sequence for event in events] == [1, 2]

--- a/api/oss/tests/pytest/unit/sessions/test_live_frame_ingest.py
+++ b/api/oss/tests/pytest/unit/sessions/test_live_frame_ingest.py
@@ -261,8 +261,10 @@ async def test_publish_frame_uses_dedicated_bounded_stream():
     assert xadd["name"] == LIVE_FRAME_STREAM_NAME
     assert isinstance(xadd["fields"]["data"], bytes)
     assert xadd["maxlen"] == 4
-    assert xadd["approximate"] is False
+    # The live stream carries disposable frames, so trimming is approximate on the hot path.
+    assert xadd["approximate"] is True
     redis.xtrim.assert_awaited_once()
+    assert redis.xtrim.await_args.kwargs["approximate"] is True
 
 
 async def test_publish_durable_event_uses_dedicated_bounded_stream():
@@ -294,7 +296,7 @@ async def test_publish_durable_event_uses_dedicated_bounded_stream():
     assert xadd["name"] == LIVE_FRAME_STREAM_NAME
     assert xadd["name"] != RECORD_STREAM_NAME
     assert xadd["maxlen"] == 4
-    assert xadd["approximate"] is False
+    assert xadd["approximate"] is True
 
 
 async def test_publish_record_preserves_flag_off_retention_bound():

--- a/docs/design/session-control-and-live-events/contracts/events.md
+++ b/docs/design/session-control-and-live-events/contracts/events.md
@@ -2,8 +2,9 @@
 
 > **AGENT-GENERATED, low weight.**
 
-This file separates the live-frame contract shipped in the current increment from the durable-event
-contract planned for later increments. The target section does not describe current behavior.
+This file describes the shipped session event contracts. Milestone 1 shipped the disposable
+live-frame relay. Milestone 2 shipped the durable-event contract: replay with sequences and
+watermarks over `GET /sessions/{session_id}/events`, and browser fan-out to a second reader.
 
 ## Shipped live-frame contract
 
@@ -13,10 +14,11 @@ The initiating browser continues to render the invoke response. A second browser
 session event route only when the session advertises `shared_reader` and the run belongs to another
 browser. The global environment switch controls both the route and the advertised capability.
 
-The event route sends a `ready` event after subscribing, then sends live frames as unnamed SSE data
-events. It does not send durable events, sequences, watermarks, or replayed Postgres rows. The
-existing watch SSE continues to send low-frequency notices such as `records-changed`; clients use
-those notices to reload completed records.
+The event route replays durable events after the client's `after` cursor, then sends a `ready`
+event carrying the replay watermark, then follows live frames and durable events as they are
+published. Live frames are unnamed SSE data events. The existing watch SSE continues to send
+low-frequency notices such as `records-changed`; clients use those notices to reload completed
+records.
 
 Each execution must start at `frame_index: 0`, and each later frame must increment the index by one.
 The client ignores duplicate and older indices. If the first index is above zero or a later index
@@ -92,22 +94,19 @@ uses `Cache-Control: no-store` and disables proxy buffering.
 Logs contain identifiers and reason codes only. They do not contain message content, tool payloads,
 or tokens.
 
-## Target durable-event contract
-
-> **Not shipped in this increment.** The sections below define the target for later sender and
-> replay increments.
+## Durable-event contract
 
 ### Sender on the shared path
 
-For `x-ag-session-response: shared`, invoke will emit one transient `data-session-accepted` event
-with `{sessionId, turnId, executionId}`. The target contract uses the same ID for the turn and
-execution. The sender will consume invoke only for this acceptance, protocol lifecycle, and errors.
-It will render text, reasoning, and tool progress from the session event route.
+For `x-ag-session-response: shared`, invoke emits one transient `data-session-accepted` event with
+`{sessionId, turnId, executionId}`, and emits it only after the runner admits the turn. The same ID
+serves as the turn and the execution. The sender consumes invoke only for this acceptance, protocol
+lifecycle, and errors. It renders text, reasoning, and tool progress from the session event route.
 
 ### Durable event envelope
 
-Temporary frames and durable events will reuse the records ingest HTTP endpoint while continuing to
-use separate Redis Streams. `kind` will distinguish the two versioned shapes.
+Temporary frames and durable events reuse the records ingest HTTP endpoint while continuing to use
+separate Redis Streams. `kind` distinguishes the two versioned shapes.
 
 ```text
 version
@@ -128,21 +127,21 @@ when kind = event:
   watermark
 ```
 
-- `sequence` will be the database-assigned per-session record cursor. It can skip values because
-  every record receives a sequence while the relay exposes only the typed events.
-- `watermark` will be the session's latest committed record sequence when the event is published or
-  replayed. On a live event it will be the highest sequence committed in the publishing batch. On
-  the replay's final `ready` event it will be the session cursor after replay.
+- `sequence` is the database-assigned per-session record cursor. It can skip values because every
+  record receives a sequence while the relay exposes only the typed events.
+- `watermark` is the session's latest committed record sequence when the event is published or
+  replayed. On a live event it is the highest sequence committed in the publishing batch. On the
+  replay's final `ready` event it is the session cursor after replay.
 
-Clients will apply durable events whose `sequence` is greater than the last event they applied and
-discard duplicate or older events. They will not wait for a contiguous durable sequence. After
-applying an event, they will advance the event-deduplication cursor to `sequence` and track the
-greater of `sequence` and `watermark` separately as the reconnect cursor. A replay's final `ready`
-event can advance both cursors after every event through its watermark has been applied.
+Clients apply durable events whose `sequence` is greater than the last event they applied, and
+discard duplicate or older events. They do not wait for a contiguous durable sequence. After
+applying an event, they advance the event-deduplication cursor to `sequence` and track the greater
+of `sequence` and `watermark` separately as the reconnect cursor. A replay's final `ready` event can
+advance both cursors after every event through its watermark has been applied.
 
 ### Durable event types
 
-The target contract defines these event types and payloads:
+The contract defines these event types and payloads:
 
 | Type | Typed payload |
 |---|---|
@@ -155,20 +154,20 @@ The target contract defines these event types and payloads:
 | `interaction.requested` | `{interaction_id, kind?}` |
 | `interaction.responded` | `{interaction_id, kind?}` |
 
-The envelope will carry session, execution, entity, sequence, and creation fields, so payloads will
-not repeat them. The reducer will ignore an unknown event type and continue from the next sequence.
+The envelope carries session, execution, entity, sequence, and creation fields, so payloads do not
+repeat them. The reducer ignores an unknown event type and continues from the next sequence.
 Interaction events carry no answer data. Readers use them to refresh records and the current
 interaction state.
 
 ### Replay and live handoff
 
-The target event endpoint will subscribe to the wake-up source before its first history query. It
-will query Postgres after the supplied sequence, send rows in order, and query again when a
-notification arrives. Notifications will carry no durable truth.
+The event endpoint subscribes to the wake-up source before its first history query. It queries
+Postgres after the supplied sequence, sends rows in order, and queries again when a notification
+arrives. Notifications carry no durable truth.
 
-Each replay will be bounded by the current database watermark. Replayed events will carry that
-watermark. The replay's final `ready` event will also carry it, including when no typed event follows
-the supplied sequence.
+Each replay is bounded by the current database watermark. Replayed events carry that watermark. The
+replay's final `ready` event also carries it, including when no typed event follows the supplied
+sequence.
 
-If a reader falls behind, the API will close the connection. The reader will then reload the durable
-snapshot and resume from its durable sequence.
+If a reader falls behind, the API closes the connection. The reader then reloads the durable
+snapshot and resumes from its durable sequence.

--- a/docs/design/session-control-and-live-events/contracts/events.md
+++ b/docs/design/session-control-and-live-events/contracts/events.md
@@ -66,19 +66,22 @@ Repeated tool input snapshots keep one `toolCallId`, so the reducer updates one 
 ### Storage and retention
 
 The runner publishes frames asynchronously through a bounded 256-frame buffer. Publication errors
-and buffer overflow do not block the run. Frames enter `streams:session-live-frames`, which has an
-exact 100,000-entry count limit across the deployment and a 15-minute age limit. Concurrent sessions
-share the count limit because frames are disposable.
+and buffer overflow do not block the run. Frames reach the records ingest HTTP route, where the API
+appends frame relay envelopes to `streams:session-live-frames`. The stream has a 15-minute age limit
+and an approximate 100,000-entry count bound by default. Redis may temporarily retain more entries
+because both count and age trimming use `MAXLEN ~` and `MINID ~`. Concurrent sessions share the
+count bound because relay messages are disposable.
 
-The relay worker reads only the live-frame stream. It discards expired frames, publishes accepted
-frames to the project-and-session Pub/Sub channel, then acknowledges and deletes them. The measured
-long case reached 3,161 frames and 201,056 SSE bytes in one turn. At the highest measured average
-rate, the 100,000-entry count bound would fill in about 22 minutes for one active run, but the
-15-minute age limit caps effective retention at 15 minutes.
+The relay worker reads only the live relay stream. It discards expired envelopes, publishes accepted
+frames and durable events to the project-and-session Pub/Sub channel, then acknowledges and deletes
+them. The measured long case reached 3,161 frames and 201,056 SSE bytes in one turn. At the highest
+measured average rate, the default 100,000-entry trim threshold represents about 22 minutes for one
+active run, but the 15-minute age limit caps effective relay retention at 15 minutes.
 
-Durable records remain on `streams:records`. Publication preserves the existing approximate
-100,000-entry retention bound. The records worker persists, acknowledges, and deletes those entries.
-The live relay does not inspect or coordinate with the durable stream.
+Only durable records enter `streams:records`. Publication preserves the existing approximate
+100,000-entry retention bound. After the records worker commits those records, it projects durable
+events and appends their relay envelopes to `streams:session-live-frames`. It then acknowledges and
+deletes the durable-record entries. The live relay never reads `streams:records`.
 
 ### Authorization and reader limits
 
@@ -105,8 +108,11 @@ lifecycle, and errors. It renders text, reasoning, and tool progress from the se
 
 ### Durable event envelope
 
-Temporary frames and durable events reuse the records ingest HTTP endpoint while continuing to use
-separate Redis Streams. `kind` distinguishes the two versioned shapes.
+Temporary frames and durable records reuse the records ingest HTTP endpoint. The API appends frame
+relay envelopes directly, while the records worker projects durable events only after their records
+commit. Both paths call `_append_live_relay_message` to append relay envelopes to
+`streams:session-live-frames`, where `kind` distinguishes the two versioned shapes. Only durable
+records use the separate `streams:records` path.
 
 ```text
 version

--- a/docs/design/session-control-and-live-events/decisions.md
+++ b/docs/design/session-control-and-live-events/decisions.md
@@ -243,7 +243,8 @@ Do not add a sequence column to mutable upserts and call the result append-only.
 **Status:** Stream layout and retention settled on 2026-09-04.
 
 Temporary frames use a dedicated deployment-wide Redis Stream bounded to 15 minutes and 100,000
-frames. Redaction and browser fan-out remain part of the later shared-reader package.
+frames. Trimming is approximate on both the publish and the sweep path, because the frames are
+disposable. Browser fan-out shipped in milestone 2. Redaction remains open.
 
 ### O-005: Stable record-ID semantics spike
 

--- a/sdks/python/oss/tests/pytest/integration/agents/_fake_runner_backend.py
+++ b/sdks/python/oss/tests/pytest/integration/agents/_fake_runner_backend.py
@@ -58,6 +58,7 @@ class FakeRunnerSession(Session):
         trace: Optional[TraceContext],
         run_context: Optional[RunContext],
         session_id: Optional[str],
+        detached: bool = False,
         effective_parameters: Optional[Dict[str, Any]] = None,
         gateway_policy: Optional[ResolvedGatewayPolicy] = None,
     ) -> None:
@@ -67,6 +68,7 @@ class FakeRunnerSession(Session):
         self._trace = trace
         self._run_context = run_context
         self._session_id = session_id
+        self._detached = detached
         self._effective_parameters = effective_parameters
         self._gateway_policy = gateway_policy
 
@@ -84,6 +86,7 @@ class FakeRunnerSession(Session):
             trace=self._trace,
             run_context=self._run_context,
             session_id=self._session_id,
+            detached=self._detached,
             effective_parameters=self._effective_parameters,
             gateway_policy=self._gateway_policy,
         )
@@ -172,6 +175,7 @@ class FakeRunnerBackend(Backend):
             trace=trace,
             run_context=run_context,
             session_id=session_id,
+            detached=detached,
             effective_parameters=effective_parameters,
             gateway_policy=gateway_policy,
         )

--- a/sdks/python/oss/tests/pytest/unit/agents/conftest.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/conftest.py
@@ -158,6 +158,7 @@ class FakeBackend(Backend):
                 "trace": trace,
                 "run_context": run_context,
                 "session_id": session_id,
+                "detached": detached,
                 "effective_parameters": effective_parameters,
                 "gateway_policy": gateway_policy,
             }

--- a/services/oss/tests/pytest/unit/agent/conftest.py
+++ b/services/oss/tests/pytest/unit/agent/conftest.py
@@ -101,6 +101,7 @@ class FakeBackend(Backend):
         self.created_session_ids: list[Optional[str]] = []
         self.created_secrets: list[Optional[Mapping[str, str]]] = []
         self.created_run_contexts: list = []
+        self.created_detached: list = []
 
     async def setup(self) -> None:
         self.setup_calls += 1
@@ -131,6 +132,7 @@ class FakeBackend(Backend):
         self.created_session_ids.append(session_id)
         self.created_secrets.append(secrets)
         self.created_run_contexts.append(run_context)
+        self.created_detached.append(detached)
         return _FakeSession(self._result)
 
 

--- a/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
+++ b/services/oss/tests/pytest/unit/agent/test_invoke_handler.py
@@ -44,15 +44,19 @@ def _first_allowed_provider(harness):
     return HARNESS_CONNECTION_CAPABILITIES[harness].providers[0]
 
 
-def _request(*, stream=None, session_id=None):
+def _request(*, stream=None, session_id=None, detached=None):
     """Build the request `_agent` reads stream/session_id off of.
 
     `_agent` now sources the stream decision from `request.flags.stream` and the
     session id from `request.session_id` (both set at the route/normalizer edge),
     instead of receiving them as handler params.
     """
-    flags = {"stream": stream} if stream is not None else None
-    return WorkflowServiceRequest(flags=flags, session_id=session_id)
+    flags = {}
+    if stream is not None:
+        flags["stream"] = stream
+    if detached is not None:
+        flags["detached"] = detached
+    return WorkflowServiceRequest(flags=flags or None, session_id=session_id)
 
 
 def _patch_handler(monkeypatch, backend, *, tool_specs=(), tool_callback=None):
@@ -247,6 +251,24 @@ async def test_messages_session_id_reaches_session_config(patched):
     )
 
     assert backend.created_session_ids == ["sess_request"]
+    assert backend.created_detached == [False]
+
+
+async def test_detached_flag_reaches_the_backend_session(patched):
+    """The shared-delivery flag rides the same edge as the session id.
+
+    Nothing else in the service asserts it at this boundary, so a handler that stopped
+    forwarding `flags.detached` would still pass every other invoke test.
+    """
+    backend, _ = patched
+
+    await app._agent(
+        request=_request(session_id="sess_detached", detached=True),
+        messages=[{"role": "user", "content": "hi"}],
+        parameters={"agent": {"harness": {"kind": "pi_core"}}},
+    )
+
+    assert backend.created_detached == [True]
 
 
 async def test_invoke_cross_harness_same_body_divergent_configs(

--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -526,16 +526,21 @@ async function runAndStreamWithApiBaseResolved(
     res.write(JSON.stringify(record) + "\n");
   };
   const liveEmit: EmitEvent = (event) => writeRecord({ kind: "event", event });
-  if (detached) {
-    // The invoke stream's sole positive payload in shared mode: correlation/acceptance. Live
-    // text and tools arrive through /sessions/{id}/events and are filtered from invoke client-side.
+  // The invoke stream's sole positive payload in shared mode: correlation/acceptance. Live text
+  // and tools arrive through /sessions/{id}/events and are filtered from invoke client-side.
+  //
+  // Emitted only from the admission path below, never here: it switches the client to shared
+  // delivery, and a turn the runner is about to refuse (bad attachments, a competing turn already
+  // holding the session) must not move the client off its local stream first.
+  const emitSessionAccepted = () => {
+    if (!detached) return;
     liveEmit({
       type: "data",
       name: "session-accepted",
       data: { sessionId, turnId, executionId: turnId },
       transient: true,
     });
-  }
+  };
   const turn = currentUserTurn(request);
   const attachmentError = attachmentCountError(turn.attachments.length);
   if (attachmentError) {
@@ -668,6 +673,10 @@ async function runAndStreamWithApiBaseResolved(
       //
       // Deliberately on `liveEmit`, not the persisting emitter that replaces it below: this is
       // transport correlation, not conversation, and it must never become a session record.
+      //
+      // Acceptance rides the same frame for the same reason, and lands here rather than at the
+      // top of the request so it can never precede the admission verdict.
+      emitSessionAccepted();
       liveEmit({ type: "turn", turnId });
 
       // A new turn supersedes any prior turn's unanswered gate: cancel stale pending

--- a/services/runner/src/sessions/live-frames.ts
+++ b/services/runner/src/sessions/live-frames.ts
@@ -6,6 +6,10 @@ export const LIVE_FRAME_BUFFER_CAPACITY = 256;
 export const LIVE_FRAME_FLUSH_INTERVAL_MS = 150;
 export const LIVE_FRAME_BATCH_CAPACITY = 50;
 export const LIVE_FRAME_BATCH_MAX_BYTES = 64 * 1024;
+// A stalled ingest POST would keep `pump()` pending, and `flush()` waits on `whenIdle()` — so an
+// unbounded post delays turn completion. A timed-out batch counts as dropped, like any other
+// send failure.
+export const LIVE_FRAME_POST_TIMEOUT_MS = 5_000;
 
 export interface LiveFrameEnvelope {
   version: 1;
@@ -41,6 +45,7 @@ interface LiveFramePublisherOptions {
   batchCapacity?: number;
   maxBatchBytes?: number;
   send?: (frames: LiveFrameEnvelope[]) => Promise<void>;
+  postTimeoutMs?: number;
   now?: () => string;
   log?: (message: string) => void;
 }
@@ -56,9 +61,11 @@ function envEnabled(): boolean {
 async function postFrames(
   auth: () => string,
   frames: LiveFrameEnvelope[],
+  timeoutMs: number = LIVE_FRAME_POST_TIMEOUT_MS,
 ): Promise<void> {
   const response = await fetch(`${apiBase()}/sessions/records/ingest`, {
     method: "POST",
+    signal: AbortSignal.timeout(timeoutMs),
     headers: {
       "content-type": "application/json",
       authorization: auth(),
@@ -200,8 +207,13 @@ export class LiveFramePublisher {
     );
     this.sessionId = options.sessionId;
     this.executionId = options.executionId;
+    const postTimeoutMs = Math.max(
+      1,
+      options.postTimeoutMs ?? LIVE_FRAME_POST_TIMEOUT_MS,
+    );
     this.send =
-      options.send ?? ((frames) => postFrames(options.auth, frames));
+      options.send ??
+      ((frames) => postFrames(options.auth, frames, postTimeoutMs));
     this.now = options.now ?? (() => new Date().toISOString());
     this.log =
       options.log ??

--- a/services/runner/tests/unit/live-frames.test.ts
+++ b/services/runner/tests/unit/live-frames.test.ts
@@ -181,4 +181,43 @@ describe("LiveFramePublisher", () => {
 
     assert.equal(calls, 0);
   });
+  it("drops a batch whose ingest POST never answers, instead of hanging the turn", async () => {
+    // `persist.ts` flush() awaits whenIdle(), so an ingest that stalls before response headers
+    // would hold turn completion open for as long as the socket stayed alive.
+    const realFetch = globalThis.fetch;
+    const signals: AbortSignal[] = [];
+    globalThis.fetch = ((_url: unknown, init?: { signal?: AbortSignal }) => {
+      const signal = init?.signal;
+      if (signal) signals.push(signal);
+      return new Promise((_resolve, reject) => {
+        signal?.addEventListener("abort", () => reject(signal.reason));
+      });
+    }) as typeof fetch;
+    const logs: string[] = [];
+    try {
+      const publisher = new LiveFramePublisher({
+        sessionId: "session-stall",
+        executionId: "execution-stall",
+        auth: () => "Secret test",
+        enabled: true,
+        postTimeoutMs: 25,
+        log: (message) => logs.push(message),
+      });
+
+      publisher.emit({ type: "message_start", id: "message-1" });
+      publisher.emit({ type: "message_delta", id: "message-1", delta: "hi" });
+      await publisher.whenIdle();
+
+      assert.equal(signals.length, 1, "the ingest POST carries an abort signal");
+      assert.equal(signals[0].aborted, true, "and the signal fired on the deadline");
+      assert.equal(
+        publisher.reportDrops(),
+        2,
+        "a timed-out batch counts as dropped, like any other send failure",
+      );
+      assert.ok(logs.some((line) => line.startsWith("DROPPED ")));
+    } finally {
+      globalThis.fetch = realFetch;
+    }
+  });
 });

--- a/services/runner/tests/unit/session-admission.test.ts
+++ b/services/runner/tests/unit/session-admission.test.ts
@@ -137,7 +137,13 @@ function sessionRequest(
 
 interface StreamRecord {
   kind: string;
-  event?: { type: string; message?: string; code?: string; turnId?: string };
+  event?: {
+    type: string;
+    message?: string;
+    code?: string;
+    turnId?: string;
+    name?: string;
+  };
   result?: { ok: boolean; error?: string };
 }
 
@@ -558,6 +564,72 @@ describe("runner admission: the admitted turn id reaches the client", () => {
       assert.ok(
         !records.some((r) => r.kind === "event" && r.event?.type === "turn"),
         "a refused turn must not hand out an id: it runs nothing and there is nothing to stop",
+      );
+    } finally {
+      await runner.close();
+      await api.close();
+    }
+  });
+  it("emits NO session-accepted for a refused detached turn", async () => {
+    // `session-accepted` is what switches the client to shared delivery: live text stops coming
+    // from the invoke stream and starts coming from /sessions/{id}/events. A refused turn serves
+    // no frames on either channel, so a client that already switched renders nothing at all and
+    // waits out its acceptance deadline instead of showing the refusal.
+    const api = await startFakeApi(() => false);
+    process.env[INTERNAL_ENV] = api.url;
+    const runner = await startRunner(async () => ({
+      ok: true,
+      output: "",
+      events: [],
+    }));
+    try {
+      const { records } = await postRun(
+        runner.url,
+        sessionRequest({ detached: true } as Partial<AgentRunRequest>),
+      );
+
+      assert.ok(
+        !records.some(
+          (r) => r.kind === "event" && r.event?.name === "session-accepted",
+        ),
+        "acceptance must never precede the admission verdict",
+      );
+      const error = records.find(
+        (r) => r.kind === "event" && r.event?.type === "error",
+      );
+      assert.ok(error, "the refusal still reaches the client as an error event");
+      assert.equal(error!.event!.code, SESSION_TURN_IN_USE_CODE);
+    } finally {
+      await runner.close();
+      await api.close();
+    }
+  });
+
+  it("emits session-accepted for an admitted detached turn, before the turn event", async () => {
+    const api = await startFakeApi(() => true);
+    process.env[INTERNAL_ENV] = api.url;
+    const runner = await startRunner(async () => ({
+      ok: true,
+      output: "answered",
+      events: [],
+    }));
+    try {
+      const { records } = await postRun(
+        runner.url,
+        sessionRequest({ detached: true } as Partial<AgentRunRequest>),
+      );
+
+      const accepted = records.findIndex(
+        (r) => r.kind === "event" && r.event?.name === "session-accepted",
+      );
+      const turnEvent = records.findIndex(
+        (r) => r.kind === "event" && r.event?.type === "turn",
+      );
+      assert.ok(accepted >= 0, "an admitted detached turn still announces itself");
+      assert.ok(turnEvent >= 0, "and still hands out its execution id");
+      assert.ok(
+        accepted < turnEvent,
+        "acceptance stays the first positive frame the shared client reads",
       );
     } finally {
       await runner.close();

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -291,6 +291,9 @@ export const useAgentConversation = ({
     )
     // Tracks `busy` for callbacks that outlive a render (the preserve verdict at unmount).
     const busyRef = useRef(false)
+    // Only a stream THIS client renders. A shared-delivered turn renders from the live frames,
+    // so the durable snapshot behind them stays adoptable — see the adoption guard below.
+    const localRenderBusyRef = useRef(false)
     const messagesRef = useRef(initialMessages)
     const sharedSenderReadyRef = useRef(false)
 
@@ -433,6 +436,7 @@ export const useAgentConversation = ({
     // (`rewind`, the hydration/revalidation adoption guards) read them through refs instead.
     messagesRef.current = messages
     busyRef.current = busy || acceptedRunPending
+    localRenderBusyRef.current = busy && !acceptedRunPending
 
     useEffect(() => {
         dispatchStopped({type: "transcript", messages})
@@ -484,7 +488,11 @@ export const useAgentConversation = ({
                     sequenceCursor === undefined
                         ? recordWatermarkRef.current
                         : sequenceWatermarkRef.current,
-                busy: busyRef.current,
+                // NOT `busyRef`: that one also covers an accepted shared turn, whose content this
+                // client never streams. Blocking adoption there stalls `hydrateAndOpen`, which
+                // reconnects instead of opening the events stream — so a shared turn that drops
+                // mid-run can never come back until it settles.
+                busy: localRenderBusyRef.current,
             })
             if (!adopt) return false
             serverMsgs.forEach((m) => restoredIdsRef.current.add(m.id))

--- a/web/packages/agenta-chat/tests/unit/assets/loadSession.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/loadSession.test.ts
@@ -20,6 +20,7 @@ const record = (id: string, payload: Record<string, unknown>, sender = "agent"):
     id,
     session_id: "session-1",
     project_id: "project-1",
+    sequence: null,
     event_index: null,
     sender,
     session_update: String(payload.type),

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
@@ -720,6 +720,64 @@ describe("useAgentConversation", () => {
     })
 
     /**
+     * An accepted shared turn is NOT a local stream. Its content arrives on the session events
+     * channel, so the durable snapshot behind those frames stays adoptable — and it has to be,
+     * because `hydrateAndOpen` only opens the events stream once `revalidate` adopts or confirms
+     * the bounded transcript. Treating `acceptedRunPending` as busy refused both, so a shared turn
+     * whose stream dropped mid-run reconnected forever and never came back.
+     */
+    it("adopts the durable transcript while a shared turn is accepted but disconnected", async () => {
+        vi.mocked(buildAgentRequest).mockImplementation(async (_entityId, _messages, opts) => ({
+            invocationUrl: "https://agent.test/invoke",
+            headers: {
+                Accept: "text/event-stream",
+                "content-type": "application/json",
+                "x-ag-session-response": "shared",
+            },
+            requestBody: {session_id: opts?.sessionId},
+        }))
+        fetchMock.mockResolvedValue(sharedDroppedStreamResponse())
+        const store = createStore()
+        const sessionId = nextSessionId()
+        markSessionFresh(sessionId)
+        const {result} = mount(store, "rev-1", sessionId)
+
+        await act(async () => {
+            await result.current.send({text: "Draft the release note."})
+        })
+        await waitFor(() => {
+            expect(result.current.acceptedRunPending).toBe(true)
+            expect(result.current.status).not.toBe("streaming")
+        })
+
+        const serverMessages: UIMessage[] = [
+            {
+                id: "srv-user",
+                role: "user",
+                parts: [{type: "text", text: "Draft the release note."}],
+            },
+            {id: "srv-assistant", role: "assistant", parts: [{type: "text", text: "Here it is."}]},
+        ]
+        const revalidate = result.current.revalidate as unknown as (
+            transcript: unknown,
+        ) => Promise<boolean>
+        let adopted = false
+        await act(async () => {
+            adopted = await revalidate({
+                messages: serverMessages,
+                recordCount: 2,
+                sequenceCursor: 2,
+            })
+        })
+
+        expect(adopted).toBe(true)
+        await waitFor(() => {
+            const persisted = store.get(sessionMessagesAtom)[sessionId]
+            expect(persisted.map((message) => message.id)).toEqual(["srv-user", "srv-assistant"])
+        })
+    })
+
+    /**
      * The other half of the rule. A stream that dies BEFORE the acceptance may describe a turn that
      * never started, so that card is the only signal the user gets and it has to survive the
      * reload.

--- a/web/packages/agenta-chat/tests/unit/hooks/useSessionLivePreview.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/hooks/useSessionLivePreview.test.tsx
@@ -44,6 +44,7 @@ const record = (id: string, payload: Record<string, unknown>): SessionRecord => 
     id,
     session_id: "session-1",
     project_id: "project-1",
+    sequence: null,
     event_index: null,
     sender: "agent",
     session_update: String(payload.type),


### PR DESCRIPTION
## Context

CodeRabbit left 13 unresolved review threads on the milestone 2 draft PR #6572. This branch
answers all 13: nine changes and four declines.

## Changes

Defects, each with a regression test that fails without the fix:

- **A non-dict record `payload` crashed the durable-event projection.** `attributes` is an open
  dict filled from the ingest wire, so `payload.get(...)` raised outside the projection's try
  block. That failed the whole batch after its rows were committed, so the same record came
  back on every redelivery and blocked the consumer.
- **The runner emitted `session-accepted` before admission.** That frame switches the client to
  shared delivery, so a turn the runner was about to refuse moved the client onto a channel
  that would serve it nothing. Acceptance now rides the same admission path as the `turn` event.
- **The live-frame ingest POST had no timeout.** A stall before response headers left `pump()`
  pending, and `flush()` waits on `whenIdle()`, so turn completion waited on the socket.
- **An accepted shared turn could not adopt the durable transcript.** `busyRef` folds
  `acceptedRunPending` into `busy`, and the adoption guard read it, so `revalidate` could
  neither adopt nor confirm. `hydrateAndOpen` opens the events stream only after one of those
  succeeds, so a shared turn whose stream dropped mid-run reconnected on a growing backoff and
  never came back until it settled.

Smaller items:

- Approximate trimming on both live-frame stream paths. Exact trimming is O(N) in the evicted
  entries and sits on the producer's hot path; the frames are disposable.
- The sequence fixture now closes an analytics engine an earlier module left behind.
- The transcript window records why it pages by offset instead of using the shared cursor.
- Three test doubles now carry `detached` instead of dropping it, and the service handler gains
  a direct assertion for it.
- The events contract describes durable replay and browser fan-out as shipped, in the present
  tense.

Declined, with the reason on each thread: the mobile transcript refactor to `atomWithQuery`
(heavy lift, no defect), and the two comment-length threads (the flagged comments document
ordering and transport constraints, which the same rule permits).

## Tests

| Suite | Result |
|---|---|
| API sessions unit (m2 databases) | 762 passed |
| API sessions integration (m2 databases) | 18 passed |
| Runner typecheck and unit | 2888 passed |
| `@agenta/chat` unit, types:check, lint | 753 passed, clean |
| SDK agents unit | 1202 passed, 4 skipped |
| Service unit | 163 passed |
| `uvx ruff@0.15.12` format and check | clean |
| `pnpm run format` | clean |

https://claude.ai/code/session_0164kzT6ttwpBtzvcDC6YzYk
