### PR TITLE
[fix] Keep the flag-off watchdog and late-output defaults unchanged

### DIFF
--- a/api/oss/src/core/sessions/records/service.py
+++ b/api/oss/src/core/sessions/records/service.py
@@ -139,7 +139,10 @@ class RecordsService:
         A failed lookup quarantines nothing and appends everything. Losing a record is worse
         than showing one that should have been hidden, and the next delivery gets another go.
         """
-        if self.executions_dao is not None and env.agenta.sessions.durable_stop:
+        if not env.agenta.sessions.durable_stop:
+            return events
+
+        if self.executions_dao is not None:
             return await self._handle_by_execution_state(events=events)
 
         candidates: Dict[UUID, Set[Tuple[str, str]]] = {}

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -78,7 +78,8 @@ log = get_module_logger(__name__)
 # keys carry a one-hour TTL (`env.sessions.alive_ttl_seconds`), so waiting for a lease to
 # expire would mean waiting an hour. The runner beats every 30 seconds and the beat is
 # mirrored onto `session_streams.updated_at`, so the age of that column is what actually says
-# whether anyone is still running the turn. 90 seconds is three missed beats.
+# whether anyone is still running the turn. Durable Stop uses three missed beats (90 seconds);
+# flag-off deployments retain the pre-milestone ten-beat threshold (300 seconds).
 #
 # Raise AGENTA_SESSIONS_WATCHDOG_STALE_HEARTBEAT_SECONDS if healthy turns are being settled.
 ORPHAN_THRESHOLD_SECONDS: int = env.agenta.sessions.watchdog.stale_heartbeat_seconds
@@ -91,8 +92,8 @@ ORPHAN_THRESHOLD_SECONDS: int = env.agenta.sessions.watchdog.stale_heartbeat_sec
 # It does NOT decide whether such a row owes its turn an ending. It used to, on the premise that
 # a not-running row's last turn had already reached a terminal record — a premise a durable Stop
 # broke, because settlement clears `is_running` before the runner has written that record. The
-# ending is now decided by asking the records plane, on the ninety-second clock. See the second
-# selection in `run_orphan_sweep`.
+# ending is now decided by asking the records plane on the configured stale-heartbeat clock. See
+# the second selection in `run_orphan_sweep`.
 IDLE_THRESHOLD_SECONDS: int = env.agenta.sessions.watchdog.idle_grace_seconds
 
 # How often the watchdog runs.

--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -524,6 +524,19 @@ def _parse_sessions_late_output() -> Literal["quarantine", "reject"]:
     return "quarantine"
 
 
+def _sessions_durable_stop_enabled() -> bool:
+    return (os.getenv("AGENTA_SESSIONS_DURABLE_STOP") or "false").lower() in _TRUTHY
+
+
+def _parse_sessions_watchdog_stale_heartbeat_seconds() -> int:
+    configured = _parse_optional_positive_int_env(
+        "AGENTA_SESSIONS_WATCHDOG_STALE_HEARTBEAT_SECONDS"
+    )
+    if configured is not None:
+        return configured
+    return 90 if _sessions_durable_stop_enabled() else 300
+
+
 class SessionsRecordsConfig(BaseModel):
     """Durable session-record ingest tuning (server-side history reconstruction)."""
 
@@ -600,8 +613,8 @@ class SessionWatchdogConfig(BaseModel):
     onto `session_streams.updated_at`, so the age of that column is the real liveness signal.
 
     A turn is declared lost when its stream row still claims `is_running` and its last
-    heartbeat is older than `stale_heartbeat_seconds`. The default of 90 seconds is three
-    missed beats.
+    heartbeat is older than `stale_heartbeat_seconds`. Durable Stop uses 90 seconds (three
+    missed beats); flag-off deployments retain the pre-milestone 300-second default.
 
     Only a turn that still claims `is_running` is eligible. A turn parked for a human sends a
     final beat with `is_running: false` and then stops beating on purpose; that state is
@@ -612,12 +625,7 @@ class SessionWatchdogConfig(BaseModel):
     """
 
     # Maximum age of the last heartbeat before a RUNNING turn is declared lost.
-    stale_heartbeat_seconds: int = (
-        _parse_optional_positive_int_env(
-            "AGENTA_SESSIONS_WATCHDOG_STALE_HEARTBEAT_SECONDS"
-        )
-        or 90
-    )
+    stale_heartbeat_seconds: int = _parse_sessions_watchdog_stale_heartbeat_seconds()
 
     # How long an ALIVE-but-not-running row (between turns, or parked awaiting a human) is left
     # alone before it is RECLAIMED. That state is resumable, so it is keyed to the 30-minute
@@ -694,9 +702,7 @@ class SessionsCommandsConfig(BaseModel):
 class SessionsConfig(BaseModel):
     """Agenta sessions sub-namespace."""
 
-    durable_stop: bool = (
-        os.getenv("AGENTA_SESSIONS_DURABLE_STOP") or "false"
-    ).lower() in _TRUTHY
+    durable_stop: bool = _sessions_durable_stop_enabled()
     late_output: Literal["quarantine", "reject"] = _parse_sessions_late_output()
     attachments: SessionAttachmentsConfig = SessionAttachmentsConfig()
     commands: SessionsCommandsConfig = SessionsCommandsConfig()

--- a/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
+++ b/api/oss/tests/pytest/unit/sessions/test_late_record_quarantine.py
@@ -19,6 +19,8 @@ from datetime import datetime, timezone
 from typing import Dict, List, Optional, Sequence, Set, Tuple
 from uuid import UUID, uuid4
 
+import pytest
+
 from oss.src.core.sessions.records.dtos import (
     RECORD_SETTLED_BY_ATTRIBUTE,
     SETTLED_BY_WATCHDOG,
@@ -37,6 +39,11 @@ from oss.src.utils.env import env
 _PROJECT = UUID("00000000-0000-0000-0000-0000000000aa")
 _SESSION = "sess-late-tail"
 _TURN = "turn-abc"
+
+
+@pytest.fixture(autouse=True)
+def _durable_stop_enabled(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
 
 
 class _StubDAO(RecordsDAOInterface):
@@ -182,7 +189,7 @@ def _quarantined(dao: _StubDAO) -> List[SessionRecordEvent]:
 # --------------------------------------------------------------------------- #
 
 
-async def test_a_thawed_runners_tail_is_quarantined_with_durable_stop_off(
+async def test_a_thawed_runners_tail_remains_visible_with_durable_stop_off(
     monkeypatch,
 ):
     """The live defect, in one test: four records land after the watchdog's ending."""
@@ -201,11 +208,10 @@ async def test_a_thawed_runners_tail_is_quarantined_with_durable_stop_off(
     ]
     results = await service.append_many(events=tail)
 
-    # Every record is still written — quarantine keeps the evidence — and every one of them
-    # is marked, so no read that rebuilds the transcript will show it.
+    # Flag-off retains the pre-milestone presentation: every late record remains visible.
     assert len(results) == 4
-    assert len(_quarantined(dao)) == 4
-    assert all(row.quarantined_at is not None for row in results)
+    assert _quarantined(dao) == []
+    assert all(row.quarantined_at is None for row in results)
 
 
 async def test_reject_policy_drops_a_late_tail(monkeypatch):

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -329,16 +329,16 @@ async def test_idle_row_is_swept_at_the_long_threshold(anyio_backend):
 
 
 @pytest.mark.anyio
-async def test_the_running_threshold_is_three_missed_heartbeats(anyio_backend):
-    """90 seconds of heartbeat age, not lease expiry.
+async def test_the_flag_off_running_threshold_keeps_the_release_baseline(anyio_backend):
+    """300 seconds of heartbeat age, not lease expiry.
 
     The Redis alive/running keys carry a ONE HOUR TTL, so a rule phrased as "shortly after the
     lease expires" would leave a dead turn running for an hour. The runner beats every 30
-    seconds and mirrors the beat onto `updated_at`, so three missed beats is the signal. The
-    old value was 300s, which was defensible while the sweep only collapsed flags and nobody
-    ever saw the result; it is too long now that the sweep writes a real ending.
+    seconds and mirrors the beat onto `updated_at`, so ten missed beats preserve the baseline.
+    Durable Stop may opt into the 90-second default, but the rollout flag being off preserves
+    the prior 300-second threshold while still writing the missing terminal outcome.
     """
-    assert (ORPHAN_THRESHOLD_SECONDS, IDLE_THRESHOLD_SECONDS) == (90, 1800)
+    assert (ORPHAN_THRESHOLD_SECONDS, IDLE_THRESHOLD_SECONDS) == (300, 1800)
 
 
 @pytest.mark.anyio

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_feature_flag.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_feature_flag.py
@@ -13,6 +13,7 @@ from oss.src.core.sessions.commands.dtos import SessionCommandState
 from oss.src.core.sessions.streams.dtos import CommandMode, SessionStreamCommandResponse
 from oss.src.utils.env import env
 from oss.src.utils.env import _parse_sessions_late_output
+from oss.src.utils.env import _parse_sessions_watchdog_stale_heartbeat_seconds
 
 
 _PROJECT = UUID("00000000-0000-0000-0000-0000000000aa")
@@ -26,6 +27,21 @@ def test_unknown_late_output_policy_falls_back_to_quarantine(monkeypatch):
         value = _parse_sessions_late_output()
 
     assert value == "quarantine"
+
+
+@pytest.mark.parametrize(
+    ("durable_stop", "expected"),
+    [("false", 300), ("true", 90)],
+)
+def test_watchdog_default_preserves_flag_off_threshold(
+    monkeypatch, durable_stop, expected
+):
+    monkeypatch.setenv("AGENTA_SESSIONS_DURABLE_STOP", durable_stop)
+    monkeypatch.delenv(
+        "AGENTA_SESSIONS_WATCHDOG_STALE_HEARTBEAT_SECONDS", raising=False
+    )
+
+    assert _parse_sessions_watchdog_stale_heartbeat_seconds() == expected
 
 
 def _request():

--- a/web/mobile/src/features/chat/LiveConversation.tsx
+++ b/web/mobile/src/features/chat/LiveConversation.tsx
@@ -331,6 +331,7 @@ export const LiveConversation = ({
                         parkedAtResponse: !streamingHereRef.current && hitlPendingRef.current,
                         streaming: streamingHereRef.current,
                         retry: isRetry,
+                        executionState: outcome.execution.state,
                     })
                     if (action === "settle-parked") {
                         settleParkedStop()
@@ -341,7 +342,7 @@ export const LiveConversation = ({
                         expectedStopExecutionIdRef.current = undefined
                         return
                     }
-                    if (action === "abort-retry") {
+                    if (action === "abort-settled" || action === "abort-retry") {
                         stop()
                         setStoppingHere(false)
                         expectedStopExecutionIdRef.current = undefined

--- a/web/mobile/src/features/chat/stopHereState.ts
+++ b/web/mobile/src/features/chat/stopHereState.ts
@@ -1,4 +1,9 @@
-export type CancelledStopAction = "settle-parked" | "settle-idle" | "abort-retry" | "await-terminal"
+export type CancelledStopAction =
+    | "settle-parked"
+    | "settle-idle"
+    | "abort-settled"
+    | "abort-retry"
+    | "await-terminal"
 
 /** Choose the local follow-up after the server confirms a turn cancellation. */
 export const cancelledStopAction = ({
@@ -6,14 +11,17 @@ export const cancelledStopAction = ({
     parkedAtResponse,
     streaming,
     retry,
+    executionState,
 }: {
     parkedAtRequest: boolean
     parkedAtResponse: boolean
     streaming: boolean
     retry: boolean
+    executionState: "stopping" | "idle"
 }): CancelledStopAction => {
     if (parkedAtRequest || parkedAtResponse) return "settle-parked"
     if (!streaming) return "settle-idle"
+    if (executionState === "idle") return "abort-settled"
     if (retry) return "abort-retry"
     return "await-terminal"
 }

--- a/web/mobile/tests/unit/stopHereState.test.ts
+++ b/web/mobile/tests/unit/stopHereState.test.ts
@@ -10,6 +10,7 @@ describe("mobile local Stop state", () => {
                 parkedAtResponse: true,
                 streaming: false,
                 retry: false,
+                executionState: "stopping",
             }),
         ).toBe("settle-parked")
     })
@@ -21,6 +22,7 @@ describe("mobile local Stop state", () => {
                 parkedAtResponse: true,
                 streaming: false,
                 retry: false,
+                executionState: "stopping",
             }),
         ).toBe("settle-parked")
     })
@@ -32,6 +34,7 @@ describe("mobile local Stop state", () => {
                 parkedAtResponse: false,
                 streaming: true,
                 retry: false,
+                executionState: "stopping",
             }),
         ).toBe("await-terminal")
     })
@@ -43,7 +46,20 @@ describe("mobile local Stop state", () => {
                 parkedAtResponse: false,
                 streaming: true,
                 retry: true,
+                executionState: "stopping",
             }),
         ).toBe("abort-retry")
+    })
+
+    it("settles an acknowledged legacy Stop without waiting for the client deadline", () => {
+        expect(
+            cancelledStopAction({
+                parkedAtRequest: false,
+                parkedAtResponse: false,
+                streaming: true,
+                retry: false,
+                executionState: "idle",
+            }),
+        ).toBe("abort-settled")
     })
 })

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
@@ -24,6 +24,7 @@ const state = vi.hoisted(() => ({
     sendMessage: vi.fn(() => Promise.resolve()),
     turnIds: new Map<string, string>(),
     busy: false,
+    stop: vi.fn(),
 }))
 
 vi.mock("@agenta/chat/assets", () => ({
@@ -125,7 +126,7 @@ vi.mock("@ai-sdk/react", () => ({
         sendMessage: state.sendMessage,
         setMessages: vi.fn(),
         status: "ready",
-        stop: vi.fn(),
+        stop: state.stop,
     }),
 }))
 vi.mock("@tanstack/react-query", () => ({
@@ -184,6 +185,7 @@ describe("useAgentChatSession execution guard", () => {
         state.regenerate.mockClear()
         state.cancelSessionExecution.mockReset()
         state.resolveStopExecution.mockReset()
+        state.stop.mockReset()
         state.resolveStopExecution.mockImplementation(async ({readExecutionId}) => {
             const executionId = readExecutionId()
             return executionId ? {status: "resolved", executionId} : {status: "settled"}
@@ -274,6 +276,45 @@ describe("useAgentChatSession execution guard", () => {
         expect(result!.stopping).toBe(false)
 
         act(() => remountRoot.unmount())
+    })
+
+    it("settles an acknowledged legacy Stop without entering the retry deadline", async () => {
+        vi.useFakeTimers()
+        const sessionId = "session-1"
+        state.busy = true
+        state.turnIds.set(sessionId, "turn-1")
+        state.cancelSessionExecution.mockResolvedValue({
+            accepted: true,
+            conflict: false,
+            execution: {id: "turn-1", state: "idle"},
+        })
+
+        let result: ReturnType<typeof useAgentChatSession> | undefined
+        const container = document.createElement("div")
+        const root = createRoot(container)
+        const Probe = () => {
+            result = useAgentChatSession({
+                entityId: "revision-1",
+                sessionId,
+                initialMessages: [],
+                intent: {} as never,
+            })
+            return null
+        }
+        act(() => root.render(createElement(Probe)))
+
+        await act(async () => {
+            result!.handleStop()
+            await Promise.resolve()
+        })
+        act(() => vi.advanceTimersByTime(30_000))
+
+        expect(state.stop).toHaveBeenCalledOnce()
+        expect(state.cancelSessionExecution).toHaveBeenCalledOnce()
+        expect(result!.stopping).toBe(false)
+
+        act(() => root.unmount())
+        vi.useRealTimers()
     })
 
     it("drops a stale retry fence after conflict so the next Stop targets the observed run", async () => {

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -640,7 +640,8 @@ export const useAgentChatSession = ({
                 void invalidateSessionInspector(queryClient, sessionId)
                 if (outcome?.accepted) {
                     dispatchStop({type: "cancelled", parked: wasParked})
-                    if (abortAfterAcceptedRef.current) {
+                    const legacyStopSettled = outcome.execution.state === "idle"
+                    if (legacyStopSettled || abortAfterAcceptedRef.current) {
                         stop()
                         dispatchStop({type: "terminal"})
                     }


### PR DESCRIPTION
## Context

With durable Stop disabled, the milestone changed two production defaults: stale running sessions closed after 90 seconds instead of the release baseline of 300 seconds, and late runner output was hidden in quarantine. The milestone also made clients retry a successful legacy Stop after 30 seconds even though the unchanged heartbeat path can take almost 30 seconds to notice Redis displacement before the new harness-cancel work begins.

## Changes

- Keep the watchdog settlement active in both flag states, but default its stale-heartbeat threshold to 300 seconds when durable Stop is off and 90 seconds when it is on. An explicit watchdog threshold still overrides either default.
- Leave late runner output visible when durable Stop is off. Keep quarantine and reject handling on the durable path.
- Treat the legacy HTTP-200 cancellation response as locally settled on desktop and mobile. The clients abort their local stream after the API confirms displacement, while durable Stops continue waiting for terminal evidence.

## Tests

- `pytest oss/tests/pytest/unit/sessions -q -o addopts=''`: 731 passed on the milestone-2 databases.
- Ruff 0.15.12 format and check: passed for all changed API files.
- Desktop Stop hook: 7 passed. Mobile Stop state: 5 passed.
- Targeted desktop and mobile ESLint: passed.
- Full web typechecks remain unavailable in this worktree because its shared dependency tree is incomplete and stale; the failures are missing modules and unrelated existing type errors.

https://claude.ai/code/session_0164kzT6ttwpBtzvcDC6YzYk
