### PR TITLE
[fix] Keep the flag-off session path unchanged in milestone 3

### DIFF
--- a/web/mobile/src/features/chat/Composer.tsx
+++ b/web/mobile/src/features/chat/Composer.tsx
@@ -71,6 +71,7 @@ export const Composer = ({
     const stoppable = isComposerRunStoppable({
         localStreaming: streaming,
         serverBusy: inputBusy,
+        serverControlEnabled: queueEnabled,
         waitingOnUser,
     })
 

--- a/web/mobile/tests/unit/turnStatus.test.ts
+++ b/web/mobile/tests/unit/turnStatus.test.ts
@@ -1,3 +1,4 @@
+import {isComposerRunStoppable} from "@agenta/chat/assets"
 import {describe, expect, it} from "vitest"
 
 import {
@@ -98,5 +99,19 @@ describe("showRunningElsewhere", () => {
 
     it("keeps a locally parked gate from being labeled remote", () => {
         expect(showRunningElsewhere({running: true, localStatus: "awaiting"})).toBe(false)
+    })
+
+    it("renders exactly one Stop for a flag-off remote run", () => {
+        const stripStop = showRunningElsewhere({running: true, localStatus: "idle"})
+        const composerStop = isComposerRunStoppable({
+            localStreaming: false,
+            serverBusy: true,
+            serverControlEnabled: false,
+            waitingOnUser: false,
+        })
+
+        expect([stripStop, composerStop].filter(Boolean)).toHaveLength(1)
+        expect(stripStop).toBe(true)
+        expect(composerStop).toBe(false)
     })
 })

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -377,8 +377,13 @@ const AgentConversation = ({
         onExecuted: revalidate,
     })
 
+    const previousServerInputsStatusRef = useRef(status)
     useEffect(() => {
-        if (status === "ready" || status === "error") void serverInputs.refresh()
+        const previousStatus = previousServerInputsStatusRef.current
+        previousServerInputsStatusRef.current = status
+        if (previousStatus !== status && (status === "ready" || status === "error")) {
+            void serverInputs.refresh()
+        }
     }, [status, serverInputs.refresh])
 
     // Send one released queued message. Stable (only depends on `sendMessage`) so the queue's

--- a/web/oss/src/components/AgentChatSlice/assets/composerRunState.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/composerRunState.test.ts
@@ -1,0 +1,26 @@
+import {isComposerRunStoppable} from "@agenta/chat/assets"
+import {describe, expect, it} from "vitest"
+
+describe("desktop composer run state", () => {
+    it("does not expose Stop for another browser's run when capabilities are absent", () => {
+        expect(
+            isComposerRunStoppable({
+                localStreaming: false,
+                serverBusy: true,
+                serverControlEnabled: false,
+                waitingOnUser: false,
+            }),
+        ).toBe(false)
+    })
+
+    it("keeps this browser's legacy stream stoppable when capabilities are absent", () => {
+        expect(
+            isComposerRunStoppable({
+                localStreaming: true,
+                serverBusy: false,
+                serverControlEnabled: false,
+                waitingOnUser: false,
+            }),
+        ).toBe(true)
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/AgentComposerDock.tsx
@@ -153,6 +153,7 @@ const AgentComposerDock = ({
     const stoppable = isComposerRunStoppable({
         localStreaming: busy,
         serverBusy: queue.serverBusy,
+        serverControlEnabled: queueEnabled,
         waitingOnUser: hitlPending,
     })
     const {

--- a/web/packages/agenta-chat/src/assets/composerRunState.ts
+++ b/web/packages/agenta-chat/src/assets/composerRunState.ts
@@ -1,9 +1,11 @@
 export const isComposerRunStoppable = ({
     localStreaming,
     serverBusy,
+    serverControlEnabled,
     waitingOnUser,
 }: {
     localStreaming: boolean
     serverBusy: boolean
+    serverControlEnabled: boolean
     waitingOnUser: boolean
-}): boolean => (localStreaming || serverBusy) && !waitingOnUser
+}): boolean => (localStreaming || (serverBusy && serverControlEnabled)) && !waitingOnUser

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -671,8 +671,13 @@ export const useAgentConversation = ({
         },
     })
 
+    const previousServerInputsStatusRef = useRef(status)
     useEffect(() => {
-        if (status === "ready" || status === "error") void serverInputs.refresh()
+        const previousStatus = previousServerInputsStatusRef.current
+        previousServerInputsStatusRef.current = status
+        if (previousStatus !== status && (status === "ready" || status === "error")) {
+            void serverInputs.refresh()
+        }
     }, [status, serverInputs.refresh])
 
     // Queue messages typed while a turn is streaming or paused on a HITL approval; released

--- a/web/packages/agenta-chat/src/hooks/useServerSessionInputs.ts
+++ b/web/packages/agenta-chat/src/hooks/useServerSessionInputs.ts
@@ -1,6 +1,10 @@
 import {useCallback, useEffect, useRef, useState} from "react"
 
-import {fetchSessionSnapshotAtom, removePendingSessionInputAtom} from "@agenta/entities/session"
+import {
+    fetchSessionCapabilitiesAtom,
+    fetchSessionSnapshotAtom,
+    removePendingSessionInputAtom,
+} from "@agenta/entities/session"
 import {buildAgentRequest} from "@agenta/playground/agent-chat"
 import type {UIMessage} from "ai"
 import {useSetAtom} from "jotai"
@@ -35,6 +39,7 @@ export const useServerSessionInputs = ({
     onExecuted?: () => void
 }): ServerSessionInputs => {
     const fetchSnapshot = useSetAtom(fetchSessionSnapshotAtom)
+    const fetchCapabilities = useSetAtom(fetchSessionCapabilitiesAtom)
     const removeInput = useSetAtom(removePendingSessionInputAtom)
     const [viewState, setViewState] = useState<{sessionId: string; view: SessionPendingInputView}>(
         () => ({sessionId, view: emptyView}),
@@ -43,26 +48,49 @@ export const useServerSessionInputs = ({
     const messagesRef = useRef(messages)
     const entityIdRef = useRef(entityId)
     const onExecutedRef = useRef(onExecuted)
+    const loadInFlightRef = useRef<{
+        sessionId: string
+        promise: Promise<SessionPendingInputView | null>
+    } | null>(null)
     messagesRef.current = messages
     entityIdRef.current = entityId
     onExecutedRef.current = onExecuted
 
+    const load = useCallback((): Promise<SessionPendingInputView | null> => {
+        if (loadInFlightRef.current?.sessionId === sessionId) {
+            return loadInFlightRef.current.promise
+        }
+        const promise = (async () => {
+            const capabilities = await fetchCapabilities(sessionId)
+            if (!capabilities.queue) return emptyView
+            const snapshot = await fetchSnapshot(sessionId)
+            return snapshot ? reduceSessionPendingInputs(snapshot) : null
+        })()
+        const entry = {sessionId, promise}
+        loadInFlightRef.current = entry
+        const clear = () => {
+            if (loadInFlightRef.current === entry) loadInFlightRef.current = null
+        }
+        void promise.then(clear, clear)
+        return promise
+    }, [fetchCapabilities, fetchSnapshot, sessionId])
+
     const refresh = useCallback(async () => {
-        const snapshot = await fetchSnapshot(sessionId)
-        if (snapshot) setViewState({sessionId, view: reduceSessionPendingInputs(snapshot)})
-    }, [fetchSnapshot, sessionId])
+        const next = await load()
+        if (next) setViewState({sessionId, view: next})
+    }, [load, sessionId])
 
     useEffect(() => {
         let cancelled = false
-        void fetchSnapshot(sessionId).then((snapshot) => {
-            if (!cancelled && snapshot) {
-                setViewState({sessionId, view: reduceSessionPendingInputs(snapshot)})
+        void load().then((next) => {
+            if (!cancelled && next) {
+                setViewState({sessionId, view: next})
             }
         })
         return () => {
             cancelled = true
         }
-    }, [fetchSnapshot, sessionId])
+    }, [load, sessionId])
 
     // Pending-input events arrive in a later increment. Until then, a small capability-gated
     // snapshot poll gives every mounted browser the same durable order.

--- a/web/packages/agenta-chat/tests/unit/ChatComposer.runControls.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/ChatComposer.runControls.test.tsx
@@ -29,11 +29,13 @@ const attachments = {
 const renderComposer = async ({
     localStreaming,
     serverBusy = false,
+    serverControlEnabled = false,
     queued = false,
     busyActions,
 }: {
     localStreaming: boolean
     serverBusy?: boolean
+    serverControlEnabled?: boolean
     queued?: boolean
     busyActions?: {label: string; onSubmit: (text: string) => void}[]
 }) => {
@@ -41,6 +43,7 @@ const renderComposer = async ({
     const streaming = isComposerRunStoppable({
         localStreaming,
         serverBusy,
+        serverControlEnabled,
         waitingOnUser: false,
     })
     render(
@@ -87,6 +90,7 @@ describe("ChatComposer running controls", () => {
         const onStop = await renderComposer({
             localStreaming: false,
             serverBusy: true,
+            serverControlEnabled: true,
             queued: true,
             busyActions: [
                 {label: "Queue", onSubmit: vi.fn()},
@@ -100,5 +104,28 @@ describe("ChatComposer running controls", () => {
         expect(screen.getByRole("button", {name: "Stop"})).toBeTruthy()
         fireEvent.keyDown(document, {key: "Escape"})
         expect(onStop).toHaveBeenCalledOnce()
+    })
+
+    it("keeps a flag-off remote run out of the desktop composer controls", () => {
+        const onStop = vi.fn()
+        const streaming = isComposerRunStoppable({
+            localStreaming: false,
+            serverBusy: true,
+            serverControlEnabled: false,
+            waitingOnUser: false,
+        })
+
+        render(
+            <ChatComposer
+                onSubmit={vi.fn()}
+                attachments={attachments}
+                streaming={streaming}
+                onStop={onStop}
+            />,
+        )
+
+        expect(screen.queryByRole("button", {name: "Stop"})).toBeNull()
+        fireEvent.keyDown(document, {key: "Escape"})
+        expect(onStop).not.toHaveBeenCalled()
     })
 })

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
@@ -21,7 +21,8 @@ import type {UIMessage} from "ai"
 import {createStore, Provider} from "jotai"
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
 
-const {snapshotViaAtom, resumeContinuation} = vi.hoisted(() => ({
+const {capabilitiesViaAtom, snapshotViaAtom, resumeContinuation} = vi.hoisted(() => ({
+    capabilitiesViaAtom: vi.fn(),
     snapshotViaAtom: vi.fn(),
     resumeContinuation: vi.fn(),
 }))
@@ -54,10 +55,14 @@ vi.mock("@agenta/entities/session", async (importOriginal) => {
         fetchSessionInteractionStatesAtom: atom(null, () => new Map()),
         fetchSessionSnapshot: vi.fn(),
         querySessionTranscript: vi.fn(),
+        fetchSessionCapabilitiesAtom: atom(null, (_get, _set, sessionId: string) =>
+            capabilitiesViaAtom(sessionId),
+        ),
         fetchSessionSnapshotAtom: atom(null, (_get, _set, sessionId: string) =>
             snapshotViaAtom(sessionId),
         ),
         resumeSessionContinuationAtom: atom(null, () => resumeContinuation()),
+        sessionDurableApprovalsCapabilityAtom: atom(null, () => false),
     }
 })
 
@@ -283,6 +288,8 @@ beforeEach(() => {
     vi.mocked(querySessionTranscript).mockResolvedValue([])
     snapshotViaAtom.mockReset()
     snapshotViaAtom.mockResolvedValue(null)
+    capabilitiesViaAtom.mockReset()
+    capabilitiesViaAtom.mockResolvedValue({durableApprovals: false, queue: false, steer: false})
     resumeContinuation.mockReset()
     resumeContinuation.mockResolvedValue(false)
     vi.mocked(buildAgentRequest).mockClear()
@@ -299,6 +306,11 @@ afterEach(() => vi.useRealTimers())
 
 describe("useAgentConversation", () => {
     it("keeps a Steer draft when durable admission is refused", async () => {
+        capabilitiesViaAtom.mockResolvedValue({
+            durableApprovals: true,
+            queue: true,
+            steer: true,
+        })
         snapshotViaAtom.mockResolvedValue({
             session: {
                 id: "11111111-1111-4111-8111-111111111111",

--- a/web/packages/agenta-chat/tests/unit/hooks/useServerSessionInputs.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useServerSessionInputs.test.ts
@@ -15,8 +15,9 @@ import {useAgentChatQueue} from "../../../src/hooks/useAgentChatQueue"
 import type {useComposerAttachments} from "../../../src/hooks/useComposerAttachments"
 import {useServerSessionInputs} from "../../../src/hooks/useServerSessionInputs"
 
-const {buildAgentRequest, fetchSnapshot, removeInput} = vi.hoisted(() => ({
+const {buildAgentRequest, fetchCapabilities, fetchSnapshot, removeInput} = vi.hoisted(() => ({
     buildAgentRequest: vi.fn(),
+    fetchCapabilities: vi.fn(),
     fetchSnapshot: vi.fn(),
     removeInput: vi.fn(),
 }))
@@ -24,6 +25,9 @@ const {buildAgentRequest, fetchSnapshot, removeInput} = vi.hoisted(() => ({
 vi.mock("@agenta/entities/session", async () => {
     const {atom} = await import("jotai")
     return {
+        fetchSessionCapabilitiesAtom: atom(null, (_get, _set, sessionId: string) =>
+            fetchCapabilities(sessionId),
+        ),
         fetchSessionSnapshotAtom: atom(null, (_get, _set, sessionId: string) =>
             fetchSnapshot(sessionId),
         ),
@@ -64,6 +68,8 @@ beforeAll(() => {
 
 beforeEach(() => {
     buildAgentRequest.mockReset()
+    fetchCapabilities.mockReset()
+    fetchCapabilities.mockResolvedValue({durableApprovals: true, queue: true, steer: true})
     fetchSnapshot.mockReset()
     removeInput.mockReset()
     fetchMock.mockReset()
@@ -269,6 +275,28 @@ const setupRunningElsewhereAdmission = async ({refuse = false}: {refuse?: boolea
 }
 
 describe("useServerSessionInputs", () => {
+    it("does not request a queue snapshot when the capability is absent", async () => {
+        fetchCapabilities.mockResolvedValue({
+            durableApprovals: false,
+            queue: false,
+            steer: false,
+        })
+
+        const {result} = renderHook(() =>
+            useServerSessionInputs({
+                entityId: "revision-1",
+                sessionId: "session-1",
+                messages: [] as UIMessage[],
+                locallyBusy: false,
+            }),
+        )
+
+        await waitFor(() => expect(fetchCapabilities).toHaveBeenCalledOnce())
+        expect(fetchSnapshot).not.toHaveBeenCalled()
+        expect(result.current.capabilities).toEqual({queue: false, steer: false})
+        expect(result.current.busy).toBe(false)
+    })
+
     it("enables Queue from a snapshot without reconnect data", async () => {
         fetchSnapshot.mockResolvedValue({
             session: null,
@@ -289,8 +317,38 @@ describe("useServerSessionInputs", () => {
         )
 
         await waitFor(() => expect(result.current.capabilities.queue).toBe(true))
+        expect(fetchSnapshot).toHaveBeenCalledOnce()
         expect(result.current.capabilities.steer).toBe(true)
         expect(result.current.executionState).toBe("idle")
+    })
+
+    it("shares the mount load with an immediate ready-state refresh", async () => {
+        let resolveSnapshot!: (snapshot: ReturnType<typeof runningSnapshot>) => void
+        fetchSnapshot.mockImplementation(
+            () =>
+                new Promise((resolve) => {
+                    resolveSnapshot = resolve
+                }),
+        )
+
+        const {result} = renderHook(() =>
+            useServerSessionInputs({
+                entityId: "revision-1",
+                sessionId: "session-1",
+                messages: [] as UIMessage[],
+                locallyBusy: false,
+            }),
+        )
+
+        await waitFor(() => expect(fetchSnapshot).toHaveBeenCalledOnce())
+        await act(async () => {
+            const refresh = result.current.refresh()
+            resolveSnapshot(runningSnapshot())
+            await refresh
+        })
+
+        expect(fetchSnapshot).toHaveBeenCalledOnce()
+        expect(result.current.executionState).toBe("running")
     })
 
     it("reads queue support from the snapshot and submits durable admission", async () => {

--- a/web/packages/agenta-chat/tests/unit/hooks/useServerSessionInputs.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useServerSessionInputs.test.ts
@@ -161,6 +161,7 @@ const RunningElsewhereAdmissionHarness = ({
     const stoppable = isComposerRunStoppable({
         localStreaming: false,
         serverBusy: server.busy,
+        serverControlEnabled: queue.queueEnabled,
         waitingOnUser: false,
     })
 

--- a/web/packages/agenta-entities/src/session/api/api.ts
+++ b/web/packages/agenta-entities/src/session/api/api.ts
@@ -198,7 +198,7 @@ export async function removePendingSessionInput({
 const SESSION_CAPABILITY_TIMEOUT_SECONDS = 2
 const SESSION_CAPABILITY_NEGATIVE_RETRY_MS = 30_000
 
-interface SessionFeatureCapabilities {
+export interface SessionFeatureCapabilities {
     durableApprovals: boolean
     queue: boolean
     steer: boolean
@@ -242,7 +242,7 @@ const cachedSessionCapabilities = (key: string): SessionFeatureCapabilities | nu
     return null
 }
 
-const negotiateSessionCapabilities = async ({
+export const fetchSessionCapabilities = async ({
     sessionId,
     projectId,
     appId,
@@ -819,7 +819,7 @@ export async function fetchSessionDurableApprovalsCapability({
     const cached = cachedSessionCapabilities(key)
     if (cached) return cached.durableApprovals
 
-    void negotiateSessionCapabilities({sessionId, projectId, appId, abortSignal})
+    void fetchSessionCapabilities({sessionId, projectId, appId, abortSignal})
     return false
 }
 

--- a/web/packages/agenta-entities/src/session/api/api.ts
+++ b/web/packages/agenta-entities/src/session/api/api.ts
@@ -195,7 +195,27 @@ export async function removePendingSessionInput({
     return !!data
 }
 
-const durableApprovalsCapabilityCache = new Map<string, Promise<boolean>>()
+const SESSION_CAPABILITY_TIMEOUT_SECONDS = 2
+const SESSION_CAPABILITY_NEGATIVE_RETRY_MS = 30_000
+
+interface SessionFeatureCapabilities {
+    durableApprovals: boolean
+    queue: boolean
+    steer: boolean
+}
+
+interface SessionCapabilityCacheEntry {
+    result?: SessionFeatureCapabilities
+    retryAt?: number
+    request?: Promise<SessionFeatureCapabilities>
+}
+
+const noSessionCapabilities: SessionFeatureCapabilities = {
+    durableApprovals: false,
+    queue: false,
+    steer: false,
+}
+const durableApprovalsCapabilityCache = new Map<string, SessionCapabilityCacheEntry>()
 
 const durableApprovalsCapabilityKey = ({projectId, sessionId}: SessionScopedParams): string =>
     JSON.stringify([projectId, sessionId])
@@ -208,6 +228,77 @@ export function invalidateSessionDurableApprovalsCapability(
         return
     }
     durableApprovalsCapabilityCache.delete(durableApprovalsCapabilityKey(params))
+}
+
+const hasSessionCapability = (capabilities: SessionFeatureCapabilities): boolean =>
+    capabilities.durableApprovals || capabilities.queue || capabilities.steer
+
+const cachedSessionCapabilities = (key: string): SessionFeatureCapabilities | null => {
+    const cached = durableApprovalsCapabilityCache.get(key)
+    if (!cached?.result) return null
+    if (hasSessionCapability(cached.result) || Date.now() < (cached.retryAt ?? 0)) {
+        return cached.result
+    }
+    return null
+}
+
+const negotiateSessionCapabilities = async ({
+    sessionId,
+    projectId,
+    appId,
+    abortSignal,
+}: SessionScopedParams): Promise<SessionFeatureCapabilities> => {
+    if (!projectId || !sessionId) return noSessionCapabilities
+
+    const key = durableApprovalsCapabilityKey({projectId, sessionId})
+    const cached = cachedSessionCapabilities(key)
+    if (cached) return cached
+
+    const existing = durableApprovalsCapabilityCache.get(key)
+    if (existing?.request) return existing.request
+
+    const entry: SessionCapabilityCacheEntry = {}
+    const request = (async () => {
+        let capabilities = noSessionCapabilities
+        try {
+            const data = await callFern("[fetchSessionDurableApprovalsCapability]", () =>
+                getSessionsClient().fetchSessionStream(
+                    {session_id: sessionId},
+                    {
+                        ...projectScopedRequest(projectId, appId, abortSignal),
+                        timeoutInSeconds: SESSION_CAPABILITY_TIMEOUT_SECONDS,
+                        maxRetries: 0,
+                    },
+                ),
+            )
+            const validated = data
+                ? safeParseWithLogging(
+                      sessionStreamResponseSchema,
+                      data,
+                      "[fetchSessionDurableApprovalsCapability]",
+                  )
+                : null
+            capabilities = {
+                durableApprovals: validated?.capabilities.durable_approvals ?? false,
+                queue: validated?.capabilities.queue ?? false,
+                steer: validated?.capabilities.steer ?? false,
+            }
+        } catch {
+            capabilities = noSessionCapabilities
+        }
+
+        if (durableApprovalsCapabilityCache.get(key) === entry) {
+            entry.result = capabilities
+            entry.retryAt = hasSessionCapability(capabilities)
+                ? undefined
+                : Date.now() + SESSION_CAPABILITY_NEGATIVE_RETRY_MS
+            entry.request = undefined
+        }
+        return capabilities
+    })()
+    entry.request = request
+    durableApprovalsCapabilityCache.set(key, entry)
+    return request
 }
 
 export interface QueryInteractionsParams extends Omit<SessionScopedParams, "sessionId"> {
@@ -725,32 +816,11 @@ export async function fetchSessionDurableApprovalsCapability({
     if (!projectId || !sessionId) return false
 
     const key = durableApprovalsCapabilityKey({projectId, sessionId})
-    const cached = durableApprovalsCapabilityCache.get(key)
-    if (cached) return cached
+    const cached = cachedSessionCapabilities(key)
+    if (cached) return cached.durableApprovals
 
-    let request: Promise<boolean> | undefined
-    request = (async () => {
-        const data = await callFern("[fetchSessionDurableApprovalsCapability]", () =>
-            getSessionsClient().fetchSessionStream(
-                {session_id: sessionId},
-                projectScopedRequest(projectId, appId, abortSignal),
-            ),
-        )
-        if (!data) {
-            if (durableApprovalsCapabilityCache.get(key) === request) {
-                durableApprovalsCapabilityCache.delete(key)
-            }
-            return false
-        }
-        const validated = safeParseWithLogging(
-            sessionStreamResponseSchema,
-            data,
-            "[fetchSessionDurableApprovalsCapability]",
-        )
-        return validated?.capabilities.durable_approvals ?? false
-    })()
-    durableApprovalsCapabilityCache.set(key, request)
-    return request
+    void negotiateSessionCapabilities({sessionId, projectId, appId, abortSignal})
+    return false
 }
 
 export interface CommandSessionStreamParams extends SessionScopedParams {

--- a/web/packages/agenta-entities/src/session/core/schema.ts
+++ b/web/packages/agenta-entities/src/session/core/schema.ts
@@ -319,9 +319,11 @@ export const sessionStreamResponseSchema = z.object({
     capabilities: z
         .object({
             durable_approvals: z.boolean().optional().default(false),
+            queue: z.boolean().optional().default(false),
+            steer: z.boolean().optional().default(false),
         })
         .optional()
-        .default({durable_approvals: false}),
+        .default({durable_approvals: false, queue: false, steer: false}),
 })
 
 /** Control-call result for the prompt × force command matrix. */

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -19,6 +19,7 @@ export {
     querySessions,
     setSessionHeader,
     fetchSessionStream,
+    fetchSessionCapabilities,
     fetchSessionDurableApprovalsCapability,
     removePendingSessionInput,
     invalidateSessionDurableApprovalsCapability,
@@ -44,6 +45,7 @@ export {
     type QuerySessionsPageParams,
     type QuerySessionsParams,
     type SessionScopedParams,
+    type SessionFeatureCapabilities,
     type QueryInteractionsParams,
     type InteractionScopedParams,
     type RespondInteractionParams,
@@ -102,7 +104,11 @@ export {
     type MountFile,
     type Mount,
 } from "./core/schema"
-export {fetchSessionSnapshotAtom, removePendingSessionInputAtom} from "./state/pendingInputs"
+export {
+    fetchSessionCapabilitiesAtom,
+    fetchSessionSnapshotAtom,
+    removePendingSessionInputAtom,
+} from "./state/pendingInputs"
 export {
     deriveStreamNest,
     deriveSessionLifecycle,

--- a/web/packages/agenta-entities/src/session/state/pendingInputs.ts
+++ b/web/packages/agenta-entities/src/session/state/pendingInputs.ts
@@ -1,7 +1,12 @@
 import {projectIdAtom} from "@agenta/shared/state"
 import {atom} from "jotai"
 
-import {fetchSessionSnapshot, removePendingSessionInput} from "../api/api"
+import {fetchSessionCapabilities, fetchSessionSnapshot, removePendingSessionInput} from "../api/api"
+
+export const fetchSessionCapabilitiesAtom = atom(null, async (get, _set, sessionId: string) => {
+    const projectId = get(projectIdAtom) ?? ""
+    return fetchSessionCapabilities({projectId, sessionId})
+})
 
 export const fetchSessionSnapshotAtom = atom(null, async (get, _set, sessionId: string) => {
     const projectId = get(projectIdAtom) ?? ""

--- a/web/packages/agenta-entities/tests/unit/session-continuation-resume-api.test.ts
+++ b/web/packages/agenta-entities/tests/unit/session-continuation-resume-api.test.ts
@@ -14,6 +14,7 @@ vi.mock("@agenta/sdk/resources", () => ({
 }))
 
 import {
+    fetchSessionCapabilities,
     fetchSessionDurableApprovalsCapability,
     invalidateSessionDurableApprovalsCapability,
     resumeSessionContinuation,
@@ -82,6 +83,26 @@ describe("fetchSessionDurableApprovalsCapability", () => {
             {session_id: "session-1"},
             expect.objectContaining({timeoutInSeconds: 2, maxRetries: 0}),
         )
+    })
+
+    it("returns queue capabilities from the same cached negotiation", async () => {
+        fetchStream.mockResolvedValue({
+            stream: null,
+            capabilities: {durable_approvals: false, queue: true, steer: true},
+        })
+        const scope = {projectId: "project-1", sessionId: "session-1"}
+
+        await expect(fetchSessionCapabilities(scope)).resolves.toEqual({
+            durableApprovals: false,
+            queue: true,
+            steer: true,
+        })
+        await expect(fetchSessionCapabilities(scope)).resolves.toEqual({
+            durableApprovals: false,
+            queue: true,
+            steer: true,
+        })
+        expect(fetchStream).toHaveBeenCalledOnce()
     })
 
     it("shares one request per session until the session reconnects", async () => {

--- a/web/packages/agenta-entities/tests/unit/session-continuation-resume-api.test.ts
+++ b/web/packages/agenta-entities/tests/unit/session-continuation-resume-api.test.ts
@@ -72,12 +72,16 @@ describe("fetchSessionDurableApprovalsCapability", () => {
             capabilities: {durable_approvals: true},
         })
 
-        await expect(
-            fetchSessionDurableApprovalsCapability({
-                projectId: "project-1",
-                sessionId: "session-1",
-            }),
-        ).resolves.toBe(true)
+        const scope = {projectId: "project-1", sessionId: "session-1"}
+
+        await expect(fetchSessionDurableApprovalsCapability(scope)).resolves.toBe(false)
+        await vi.waitFor(() =>
+            expect(fetchSessionDurableApprovalsCapability(scope)).resolves.toBe(true),
+        )
+        expect(fetchStream).toHaveBeenCalledWith(
+            {session_id: "session-1"},
+            expect.objectContaining({timeoutInSeconds: 2, maxRetries: 0}),
+        )
     })
 
     it("shares one request per session until the session reconnects", async () => {
@@ -91,6 +95,7 @@ describe("fetchSessionDurableApprovalsCapability", () => {
             fetchSessionDurableApprovalsCapability(scope),
             fetchSessionDurableApprovalsCapability(scope),
         ])
+        await vi.waitFor(() => expect(fetchStream).toHaveBeenCalledTimes(1))
         await fetchSessionDurableApprovalsCapability(scope)
 
         expect(fetchStream).toHaveBeenCalledTimes(1)
@@ -113,5 +118,34 @@ describe("fetchSessionDurableApprovalsCapability", () => {
                 sessionId: "session-1",
             }),
         ).resolves.toBe(false)
+    })
+
+    it("does not delay a legacy send while capability negotiation is slow", async () => {
+        fetchStream.mockImplementation(() => new Promise(() => undefined))
+        const prepare = vi.fn().mockResolvedValue("legacy send")
+
+        const capability = await fetchSessionDurableApprovalsCapability({
+            projectId: "project-1",
+            sessionId: "session-1",
+        })
+        const result = capability ? "durable path" : await prepare()
+
+        expect(result).toBe("legacy send")
+        expect(prepare).toHaveBeenCalledOnce()
+        expect(fetchStream).toHaveBeenCalledOnce()
+    })
+
+    it("caches a failed negotiation instead of retrying it on every send", async () => {
+        const error = vi.spyOn(console, "error").mockImplementation(() => undefined)
+        fetchStream.mockRejectedValue(new Error("route unavailable"))
+        const scope = {projectId: "project-1", sessionId: "session-1"}
+
+        await fetchSessionDurableApprovalsCapability(scope)
+        await vi.waitFor(() => expect(error).toHaveBeenCalledOnce())
+        await fetchSessionDurableApprovalsCapability(scope)
+        await fetchSessionDurableApprovalsCapability(scope)
+
+        expect(fetchStream).toHaveBeenCalledOnce()
+        error.mockRestore()
     })
 })


### PR DESCRIPTION
## Context

With milestone 3 session flags disabled, capability discovery could delay legacy sends and approvals, remote lifecycle state could expose extra Stop controls, and opening a conversation could load the queue snapshot twice. These paths must preserve the milestone 1 and 2 flag-off behavior.

## Changes

- Probe session capabilities in the background with a 2-second request timeout, no transport retries, and cached positive or negative results. Unknown or failed negotiation takes the legacy send and approval path immediately.
- Treat server-only busy state as composer-stoppable only when queue control is advertised. Desktop no longer exposes remote Stop or Escape with capabilities absent, and mobile keeps one strip Stop for one remote run.
- Negotiate queue support before loading queue state, share concurrent mount refreshes, and refresh after real transitions into `ready` or `error`. Flag-off conversations make no queue snapshot request.

## Tests

- `@agenta/chat`: 819 passed.
- `@agenta/oss`: 485 passed, 1 skipped.
- `@agenta/entities`: 1,556 passed.
- `@agenta/mobile`: 164 passed.
- `types:check` passed for chat, OSS, entities, and mobile.
- `pnpm lint-fix` and `pnpm lint` passed for the web workspace. Mobile reports three unchanged warnings and no errors.
- API sessions tests were not run because this PR does not change API code.

https://claude.ai/code/session_0164kzT6ttwpBtzvcDC6YzYk