### PR TITLE
[fix] Prevent approval resume after Stop

### DIFF
--- a/web/mobile/src/features/chat/LiveConversation.tsx
+++ b/web/mobile/src/features/chat/LiveConversation.tsx
@@ -173,7 +173,7 @@ export const LiveConversation = ({
     const takePendingTask = useSetAtom(takePendingTaskAtom)
     const sentPendingTaskFor = useRef<string | null>(null)
     const [pendingTaskError, setPendingTaskError] = useState<string | null>(null)
-    const {isHydrating, revalidate, send, stop} = conversation
+    const {isHydrating, revalidate, send, stop, voidPendingResume} = conversation
     useEffect(() => {
         const decision = pendingTaskDecision({
             sessionId,
@@ -279,6 +279,8 @@ export const LiveConversation = ({
     // Composer Stop cancels on the server before changing local presentation.
     const stopHere = useCallback(() => {
         if (stopping) return
+        // Fence a delayed approval release even when cancellation cannot be requested yet.
+        voidPendingResume()
         if (!projectId || !sessionId) return
         setStoppingHere(true)
         const wasParked = !streamingHereRef.current && conversation.hitlPending
@@ -385,7 +387,15 @@ export const LiveConversation = ({
                         : "Could not stop the run. It may still be running.",
                 )
             })
-    }, [projectId, sessionId, stop, stopping, conversation.hitlPending, settleParkedStop])
+    }, [
+        projectId,
+        sessionId,
+        stop,
+        stopping,
+        conversation.hitlPending,
+        settleParkedStop,
+        voidPendingResume,
+    ])
 
     const interactionAvailability = getInteractionAvailability({
         stopped: conversation.stopped,

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
@@ -10,9 +10,12 @@ const state = vi.hoisted(() => ({
     capturedHooks: undefined as
         | {
               prepareRequest: (args: {messages: UIMessage[]; id?: string}) => Promise<unknown>
+              onError: () => void
+              sendAutomaticallyWhen: (args: {messages: UIMessage[]}) => boolean
           }
         | undefined,
     messages: [] as UIMessage[],
+    projectId: "project-id" as string | null,
     latestTurnId: undefined as string | undefined,
     hitlPending: false,
     sessionTurnId: null as string | null,
@@ -96,7 +99,8 @@ vi.mock("@agenta/entities/workflow", () => ({
 }))
 
 vi.mock("@agenta/playground", () => ({
-    agentShouldResumeAfterApproval: () => true,
+    agentShouldResumeAfterApproval: ({liveInteraction}: {liveInteraction?: unknown}) =>
+        liveInteraction !== null,
     approvalResolution: vi.fn(),
     buildAgentRequest: vi.fn(async () => ({
         invocationUrl: "https://agent.test/invoke",
@@ -133,7 +137,7 @@ vi.mock("@tanstack/react-query", () => ({
 }))
 
 vi.mock("jotai", () => ({
-    useAtomValue: () => "project-id",
+    useAtomValue: () => state.projectId,
     useSetAtom: () => vi.fn(),
     useStore: () => ({
         get: (atom: string) => {
@@ -188,6 +192,7 @@ describe("useAgentChatSession execution guard", () => {
             const executionId = readExecutionId()
             return executionId ? {status: "resolved", executionId} : {status: "settled"}
         })
+        state.projectId = "project-id"
         state.latestTurnId = undefined
         state.hitlPending = false
         state.sessionTurnId = null
@@ -223,6 +228,73 @@ describe("useAgentChatSession execution guard", () => {
         state.turnIds.set(sessionId, "turn-before-auto-resume")
         await act(() => state.capturedHooks!.prepareRequest({messages: [], id: sessionId}))
         expect(state.turnIds.get(sessionId)).toBeUndefined()
+
+        act(() => root.unmount())
+    })
+
+    it("voids an approval resume before cancellation settles or its stream errors", async () => {
+        const sessionId = "session-1"
+        let resolveCancel: ((value: unknown) => void) | undefined
+        state.cancelSessionExecution.mockReturnValue(
+            new Promise((resolve) => {
+                resolveCancel = resolve
+            }),
+        )
+
+        let result: ReturnType<typeof useAgentChatSession> | undefined
+        const container = document.createElement("div")
+        const root = createRoot(container)
+        const Probe = () => {
+            result = useAgentChatSession({
+                entityId: "revision-1",
+                sessionId,
+                initialMessages: [],
+                intent: {} as never,
+            })
+            return null
+        }
+        act(() => root.render(createElement(Probe)))
+
+        act(() => result!.markLiveGate({kind: "approval", id: "approval-1"}))
+        act(() => result!.handleStop())
+        act(() => state.capturedHooks!.onError())
+
+        expect(state.capturedHooks!.sendAutomaticallyWhen({messages: []})).toBe(false)
+
+        await act(async () => {
+            resolveCancel?.({
+                accepted: true,
+                conflict: false,
+                execution: {id: "turn-1", state: "stopping"},
+            })
+            await Promise.resolve()
+        })
+        act(() => root.unmount())
+    })
+
+    it("keeps the approval resume void when Stop cannot load the project", () => {
+        state.projectId = null
+        const sessionId = "session-1"
+        let result: ReturnType<typeof useAgentChatSession> | undefined
+        const container = document.createElement("div")
+        const root = createRoot(container)
+        const Probe = () => {
+            result = useAgentChatSession({
+                entityId: "revision-1",
+                sessionId,
+                initialMessages: [],
+                intent: {} as never,
+            })
+            return null
+        }
+        act(() => root.render(createElement(Probe)))
+
+        act(() => result!.markLiveGate({kind: "approval", id: "approval-1"}))
+        act(() => result!.handleStop())
+        act(() => state.capturedHooks!.onError())
+
+        expect(state.cancelSessionExecution).not.toHaveBeenCalled()
+        expect(state.capturedHooks!.sendAutomaticallyWhen({messages: []})).toBe(false)
 
         act(() => root.unmount())
     })

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -212,13 +212,10 @@ export const useAgentChatSession = ({
             if (!mountedRef.current) setSessionStatus({id: sessionId, status: "idle"})
         },
         onError: () => {
-            // Clear the marker but do NOT void the resume. A gateway approval is answered while the
-            // stream is still open, so the SDK skips its own dispatch and only re-evaluates when the
-            // stream ends — often by erroring, right here. `null` made that last evaluation return
-            // false and stranded the answer; `undefined` lets the tail heuristics decide.
-            // Adoption is unaffected: the hydration guard reads this ref as a boolean.
-            // The registry logs the error for the dev overlay (F-033) before calling this.
-            liveGateInteractionRef.current = undefined
+            // Preserve null after resume/Stop; only a live marker may fall back to tail detection.
+            if (liveGateInteractionRef.current !== null) {
+                liveGateInteractionRef.current = undefined
+            }
         },
     }
 
@@ -557,6 +554,8 @@ export const useAgentChatSession = ({
 
     const handleStop = useCallback(() => {
         if (stopping) return
+        // Fence delayed approval release even when cancellation cannot be requested yet.
+        liveGateInteractionRef.current = null
         const wasParked = !busyRef.current && isHitlPending(messagesRef.current)
         const stopAttempt = ++stopAttemptRef.current
         dispatchStop({type: "request"})
@@ -574,7 +573,6 @@ export const useAgentChatSession = ({
                         dispatchStop(
                             wasParked ? {type: "cancelled", parked: true} : {type: "accepted"},
                         )
-                        liveGateInteractionRef.current = null
                         queryClient.invalidateQueries({queryKey: ["session-liveness"]})
                         // Refresh an open Inspector so it reflects the kill immediately.
                         void invalidateSessionInspector(queryClient, sessionId)
@@ -644,7 +642,6 @@ export const useAgentChatSession = ({
                         stop()
                         dispatchStop({type: "terminal"})
                     }
-                    liveGateInteractionRef.current = null
                     queryClient.invalidateQueries({queryKey: ["session-liveness"]})
                     return
                 }

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -139,6 +139,8 @@ export interface AgentConversation {
     turns: TurnViewModel[]
     /** Send a user message (routes through the queue: sends now, or holds while busy/paused). */
     send: (input: SendInput) => Promise<void>
+    /** Prevent an approval decision still being recorded from starting its delayed resume. */
+    voidPendingResume: () => void
     /** Abort the in-flight stream and tag the last assistant turn as user-stopped. */
     stop: () => void
     /** Re-run an assistant turn by message id (also the "Resend" action after a stop). */
@@ -310,13 +312,10 @@ export const useAgentConversation = ({
             }
         },
         onError: () => {
-            // Clear the marker but do NOT void the resume. A gateway approval is answered while the
-            // stream is still open, so the SDK skips its own dispatch and only re-evaluates when the
-            // stream ends — often by erroring, right here. `null` made that last evaluation return
-            // false and stranded the answer; `undefined` lets the tail heuristics decide.
-            // Adoption is unaffected: the hydration guard reads this ref as a boolean.
-            // The registry logs the error for the dev overlay (F-033) before calling this.
-            liveGateInteractionRef.current = undefined
+            // Preserve null after resume/Stop; only a live marker may fall back to tail detection.
+            if (liveGateInteractionRef.current !== null) {
+                liveGateInteractionRef.current = undefined
+            }
         },
     }
 
@@ -723,15 +722,20 @@ export const useAgentConversation = ({
         void loadSessionMessages(sessionId, adoptServerTranscript).then(adoptServerTranscript)
     }, [adoptServerTranscript, sessionId])
 
+    // Fence a delayed approval release before the host's durable cancel request settles.
+    const voidPendingResume = useCallback(() => {
+        liveGateInteractionRef.current = null
+    }, [])
+
     // ── DT3 cancelled state: wrap stop() to mark the in-flight assistant turn ──
     const handleStop = useCallback(() => {
         const last = messagesRef.current[messagesRef.current.length - 1]
         if (last && last.role === "assistant") setStopped(true)
         // A stop voids the pending gate (same rule the queue applies), so the marker must go too —
         // otherwise it outlives the abandoned resume and blocks this mount's records adoption.
-        liveGateInteractionRef.current = null
+        voidPendingResume()
         stop()
-    }, [stop])
+    }, [stop, voidPendingResume])
 
     // ── D9 teardown: `useSessionChat` releases this mount's claim on the session's chat ──
     // No `stop()` here: a streaming run is preserved past the unmount on purpose (#5724), and
@@ -832,6 +836,7 @@ export const useAgentConversation = ({
         error: parsedError,
         turns,
         send,
+        voidPendingResume,
         stop: handleStop,
         regenerate: regenerateTurn,
         rewind,

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
@@ -14,6 +14,11 @@ import type {UIMessage} from "ai"
 import {createStore, Provider} from "jotai"
 import {beforeEach, describe, expect, it, vi} from "vitest"
 
+const approvalRecord = vi.hoisted(() => ({
+    defer: false,
+    resolve: undefined as (() => void) | undefined,
+}))
+
 vi.mock("@agenta/playground/agent-chat", async (importOriginal) => {
     const actual = await importOriginal<typeof import("@agenta/playground/agent-chat")>()
     return {
@@ -37,6 +42,12 @@ vi.mock("@agenta/entities/session", async (importOriginal) => {
         ...actual,
         revalidateSessionMountsAtom: atom(null, () => {}),
         revalidateSessionRecordsAtom: atom(null, () => {}),
+        recordInteractionAnswerAtom: atom(null, async () => {
+            if (!approvalRecord.defer) return
+            await new Promise<void>((resolve) => {
+                approvalRecord.resolve = resolve
+            })
+        }),
         // The hydration seam's records fetch: "no server history" for these tests.
         fetchSessionRecordsAtom: atom(null, () => ({records: null, refreshed: null})),
         fetchSessionInteractionStatesAtom: atom(null, () => new Map()),
@@ -113,6 +124,8 @@ const mount = (store: ReturnType<typeof createStore>, entityId: string, sessionI
     )
 
 beforeEach(() => {
+    approvalRecord.defer = false
+    approvalRecord.resolve = undefined
     fetchMock.mockReset()
     vi.mocked(buildAgentRequest).mockClear()
     // Restore the ready-workflow build: one test replaces it with a not-yet-loaded one, and
@@ -211,6 +224,33 @@ describe("useAgentConversation", () => {
 
         await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2), {timeout: 5000})
         expect(getSessionTurnId(sessionId)).toBeUndefined()
+    })
+
+    it("voids an approval resume before its delayed interaction write releases", async () => {
+        approvalRecord.defer = true
+        fetchMock
+            .mockResolvedValueOnce(approvalResponse())
+            .mockResolvedValueOnce(streamResponse("unexpected resume"))
+        const store = createStore()
+        const sessionId = nextSessionId()
+        markSessionFresh(sessionId)
+        const {result} = mount(store, "rev-1", sessionId)
+
+        await act(async () => {
+            await result.current.send({text: "needs approval"})
+        })
+        await waitFor(() => expect(result.current.approvals.open).toBe(true), {timeout: 5000})
+
+        act(() => result.current.approvals.respond(true))
+        await waitFor(() => expect(approvalRecord.resolve).toBeTypeOf("function"), {timeout: 5000})
+        act(() => result.current.voidPendingResume())
+        await act(async () => {
+            approvalRecord.resolve?.()
+            await Promise.resolve()
+        })
+        await new Promise((resolve) => setTimeout(resolve, 100))
+
+        expect(fetchMock).toHaveBeenCalledTimes(1)
     })
 
     it("survives a revision switch mid-stream instead of aborting the turn", async () => {


### PR DESCRIPTION
## Context
On mobile, approving a tool and immediately pressing Stop could still start the approved command. The Stop request fenced and cancelled the parked execution, but the approval response could release its automatic resume while that cancel request was in flight, creating a new execution after the user had stopped.

## Changes
The mobile Stop path now voids any pending approval resume synchronously before it sends the durable cancel request. The shared conversation hook exposes that marker-only action separately from aborting the local stream, so the UI can preserve its server-first cancellation flow.

Both conversation hosts also preserve an explicitly consumed or voided approval marker when a stream errors. This prevents an error update from making an already stopped approval eligible for automatic resume again.

## Tests
- `pnpm lint-fix` (24 tasks passed across the full web lint graph)
- `pnpm --filter @agenta/chat exec vitest run tests/unit/hooks/useAgentConversation.test.ts` (12 passed)
- `pnpm --filter @agenta/oss exec vitest run src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts` (8 passed)
- Normal local browser flows passed on mobile and desktop. The long-running command was stopped, the composer returned to Send, and the next message completed.
- Controlled mobile and desktop browser races held both the real approval transition and cancel responses, released approval while cancel remained in flight, and observed only the initial invoke before an explicit next message.

## What to QA
- On mobile, approve a long-running command and press Stop as soon as the approval closes. The command must not finish, and the composer must return to Send.
- Repeat while delaying the approval transition response until after Stop. Releasing the response must not issue another invoke.
- On desktop, repeat approve then immediate Stop and confirm the next message sends normally.
