### PR TITLE
[fix] Address CodeRabbit review for milestone 3

### DIFF
--- a/api/oss/src/apis/fastapi/sessions/router.py
+++ b/api/oss/src/apis/fastapi/sessions/router.py
@@ -2730,9 +2730,11 @@ class SessionControlRouter:
 
         resumed = False
         if env.agenta.sessions.durable_approvals:
-            resumed = await self._service.resume_recoverable_continuation(
-                project_id=UUID(str(project_id)),
-                session_id=session_id,
+            resumed = bool(
+                await self._service.resume_recoverable_continuation(
+                    project_id=UUID(str(project_id)),
+                    session_id=session_id,
+                )
             )
         return SessionContinuationResumeResponse(resumed=resumed)
 

--- a/api/oss/src/core/sessions/commands/interfaces.py
+++ b/api/oss/src/core/sessions/commands/interfaces.py
@@ -129,7 +129,7 @@ class SessionCommandsDAOInterface(ABC):
         command_id: UUID,
         input_id: UUID,
         transaction: Optional[Any] = None,
-    ) -> SessionCommand:
+    ) -> Optional[SessionCommand]:
         """Bind the first Steer input to an open Stop command."""
         raise NotImplementedError
 

--- a/api/oss/src/core/sessions/commands/service.py
+++ b/api/oss/src/core/sessions/commands/service.py
@@ -316,15 +316,19 @@ class SessionCommandsService:
                 target_turn_id=target_turn_id,
             )
             if open_command is not None:
-                command = (
-                    await self._dao.bind_steer_input(
+                if steer_input_id is not None:
+                    command = await self._dao.bind_steer_input(
                         project_id=project_id,
                         command_id=open_command.id,
                         input_id=steer_input_id,
                     )
-                    if steer_input_id is not None
-                    else open_command
-                )
+                    if command is None:
+                        raise SessionCommandNotClaimable(
+                            command_id=str(open_command.id),
+                            state="closed or already bound",
+                        )
+                else:
+                    command = open_command
             else:
                 created = await self._insert(
                     project_id=project_id,
@@ -368,16 +372,20 @@ class SessionCommandsService:
                     transaction=transaction,
                 )
                 if open_command is not None:
-                    command = (
-                        await self._dao.bind_steer_input(
+                    if steer_input_id is not None:
+                        command = await self._dao.bind_steer_input(
                             project_id=project_id,
                             command_id=open_command.id,
                             input_id=steer_input_id,
                             transaction=transaction,
                         )
-                        if steer_input_id is not None
-                        else open_command
-                    )
+                        if command is None:
+                            raise SessionCommandNotClaimable(
+                                command_id=str(open_command.id),
+                                state="closed or already bound",
+                            )
+                    else:
+                        command = open_command
                 else:
                     await self._executions.set_state(
                         project_id=project_id,
@@ -412,6 +420,11 @@ class SessionCommandsService:
                             input_id=steer_input_id,
                             transaction=transaction,
                         )
+                        if command is None:
+                            raise SessionCommandNotClaimable(
+                                command_id=str(created.command.id),
+                                state="closed or already bound",
+                            )
                     cancelled_interactions = (
                         await self._interactions.cancel_session_pending(
                             project_id=project_id,

--- a/api/oss/src/core/sessions/commands/service.py
+++ b/api/oss/src/core/sessions/commands/service.py
@@ -804,15 +804,15 @@ class SessionCommandsService:
 
     async def resume_recoverable_continuation(
         self, *, project_id: UUID, session_id: str
-    ) -> bool:
+    ) -> Optional[str]:
         if not (env.agenta.sessions.durable_approvals or env.agenta.sessions.queue):
-            return False
+            return None
         command = await self._dao.fetch_resumable_continuation(
             project_id=project_id,
             session_id=session_id,
         )
         if command is None:
-            return False
+            return None
         if (
             command.kind == SessionCommandKind.continue_interaction
             and not env.agenta.sessions.durable_approvals
@@ -820,17 +820,17 @@ class SessionCommandsService:
             command.kind == SessionCommandKind.continue_input
             and not env.agenta.sessions.queue
         ):
-            return False
+            return None
         execution_id = command.target_turn_id
         if execution_id is None or self._executions is None:
-            return True
+            return execution_id
         execution = await self._executions.fetch_execution(
             project_id=project_id,
             session_id=session_id,
             execution_id=execution_id,
         )
         if execution is None:
-            return True
+            return execution_id
         if execution.state == SessionExecutionState.running:
             # A stale heartbeat is not a fencing token: a partitioned runner can still be
             # executing the approved side effect. Only the watchdog may turn `running` into
@@ -846,10 +846,14 @@ class SessionCommandsService:
             #   * PARKED on its own approval — the continuation raised a new gate and stopped
             #     to wait on the user. Nothing is in flight to destroy, so a Send is a steer
             #     and stays allowed. Allow.
-            return not await self._execution_is_parked_on_a_gate(
-                project_id=project_id,
-                session_id=session_id,
-                execution_id=execution_id,
+            return (
+                None
+                if await self._execution_is_parked_on_a_gate(
+                    project_id=project_id,
+                    session_id=session_id,
+                    execution_id=execution_id,
+                )
+                else execution_id
             )
         if (
             command.state
@@ -888,10 +892,8 @@ class SessionCommandsService:
                 execution=execution,
             )
             if command is None:
-                return True
-            execution_id = command.target_turn_id
-            if execution_id is None:
-                return True
+                return execution_id
+            execution_id = command.target_turn_id or execution_id
         if command.kind == SessionCommandKind.continue_input:
             admission: Any = InputContinuationAdmission(
                 command=command,
@@ -914,7 +916,7 @@ class SessionCommandsService:
             receipt = None
         if receipt is None or receipt.status != "accepted":
             await self._mark_continuation_recoverable(admission, receipt)
-        return True
+        return execution_id
 
     async def _reopen_continuation_attempt(
         self,

--- a/api/oss/src/core/sessions/inputs/service.py
+++ b/api/oss/src/core/sessions/inputs/service.py
@@ -38,7 +38,7 @@ class SessionInputsService:
         inputs_dao: SessionInputsDAOInterface,
         streams_service: SessionStreamsService,
         executions_dao: Optional[SessionExecutionsDAOInterface] = None,
-        continuation_resumer: Optional[Callable[..., Awaitable[bool]]] = None,
+        continuation_resumer: Optional[Callable[..., Awaitable[Optional[str]]]] = None,
     ) -> None:
         self._dao = inputs_dao
         self._streams = streams_service
@@ -75,19 +75,23 @@ class SessionInputsService:
             project_id=project_id, session_id=session_id
         )
         busy = bool(stream and stream.flags and stream.flags.is_running)
+        resumed_execution_id: Optional[str] = None
         if (
             not busy
             and (env.agenta.sessions.durable_approvals or env.agenta.sessions.queue)
             and self._continuation_resumer is not None
         ):
-            busy = await self._continuation_resumer(
+            resumed_execution_id = await self._continuation_resumer(
                 project_id=project_id,
                 session_id=session_id,
             )
+            busy = resumed_execution_id is not None
         if not busy:
             return PendingInputAdmission(action="execute")
 
-        current_execution_id = stream.turn_id if stream else None
+        current_execution_id = resumed_execution_id or (
+            stream.turn_id if stream else None
+        )
         queue_enabled = env.agenta.sessions.queue
         steer_enabled = queue_enabled and env.agenta.sessions.steer
         if policy == "steer" and not steer_enabled:

--- a/api/oss/src/core/sessions/records/events.py
+++ b/api/oss/src/core/sessions/records/events.py
@@ -4,16 +4,23 @@ from pydantic import TypeAdapter, ValidationError
 
 from oss.src.core.sessions.records.dtos import (
     SESSION_DURABLE_EVENT_TYPES,
-    InteractionRequestedEvent,
-    InteractionRespondedEvent,
-    MessageCompletedEvent,
     SessionDurableEvent,
     SessionRecord,
-    ToolCompletedEvent,
 )
 
 
 _EVENT_ADAPTER = TypeAdapter(SessionDurableEvent)
+
+
+def _validated_event(
+    *, base: Dict[str, Any], event_type: str, payload: Dict[str, Any]
+) -> Optional[SessionDurableEvent]:
+    try:
+        return _EVENT_ADAPTER.validate_python(
+            {**base, "type": event_type, "payload": payload}
+        )
+    except ValidationError:
+        return None
 
 
 def _event_base(
@@ -72,12 +79,7 @@ def _direct_event(
     )
     if base is None:
         return None
-    try:
-        return _EVENT_ADAPTER.validate_python(
-            {**base, "type": record.record_type, "payload": payload}
-        )
-    except ValidationError:
-        return None
+    return _validated_event(base=base, event_type=record.record_type, payload=payload)
 
 
 def durable_events_from_records(
@@ -129,42 +131,35 @@ def durable_events_from_records(
                 "interaction_id": entity_id,
                 "kind": attributes.get("kind"),
             }
-            if record.record_type == "interaction_request":
-                events.append(
-                    InteractionRequestedEvent(
-                        **base,
-                        type="interaction.requested",
-                        payload=payload,
-                    )
-                )
-            else:
-                events.append(
-                    InteractionRespondedEvent(
-                        **base,
-                        type="interaction.responded",
-                        payload=payload,
-                    )
-                )
+            event = _validated_event(
+                base=base,
+                event_type=(
+                    "interaction.requested"
+                    if record.record_type == "interaction_request"
+                    else "interaction.responded"
+                ),
+                payload=payload,
+            )
+            if event is not None:
+                events.append(event)
             continue
 
         if record.record_type == "message":
             role = (
                 "assistant" if record.record_source == "agent" else record.record_source
             )
-            events.append(
-                MessageCompletedEvent(
-                    **base,
-                    type="message.completed",
-                    payload={
-                        "message_id": entity_id,
-                        "role": role or "assistant",
-                        "content": attributes.get(
-                            "content", attributes.get("text", "")
-                        ),
-                        "finish_reason": attributes.get("finish_reason"),
-                    },
-                )
+            event = _validated_event(
+                base=base,
+                event_type="message.completed",
+                payload={
+                    "message_id": entity_id,
+                    "role": role or "assistant",
+                    "content": attributes.get("content", attributes.get("text", "")),
+                    "finish_reason": attributes.get("finish_reason"),
+                },
             )
+            if event is not None:
+                events.append(event)
             continue
 
         tool_key = (str(record.turn_id), entity_id)
@@ -177,21 +172,19 @@ def durable_events_from_records(
         call = tool_calls.get(tool_key, {})
         is_error = bool(attributes.get("isError"))
         output = attributes.get("data", attributes.get("output"))
-        events.append(
-            ToolCompletedEvent(
-                **base,
-                type="tool.completed",
-                payload={
-                    "tool_call_id": entity_id,
-                    "name": str(
-                        call.get("name") or attributes.get("name") or "unknown"
-                    ),
-                    "input": call.get("input", attributes.get("input")),
-                    "output": None if is_error else output,
-                    "error": output if is_error else None,
-                    "status": "error" if is_error else "completed",
-                },
-            )
+        event = _validated_event(
+            base=base,
+            event_type="tool.completed",
+            payload={
+                "tool_call_id": entity_id,
+                "name": str(call.get("name") or attributes.get("name") or "unknown"),
+                "input": call.get("input", attributes.get("input")),
+                "output": None if is_error else output,
+                "error": output if is_error else None,
+                "status": "error" if is_error else "completed",
+            },
         )
+        if event is not None:
+            events.append(event)
 
     return events

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -277,12 +277,12 @@ class WorkflowsService:
         self.embeds_service = embeds_service
         self.static_catalog = static_catalog
         self._watch = watch_publisher
-        self._session_continuation_resumer: Optional[Callable[..., Awaitable[bool]]] = (
-            None
-        )
+        self._session_continuation_resumer: Optional[
+            Callable[..., Awaitable[Optional[str]]]
+        ] = None
 
     def set_session_continuation_resumer(
-        self, callback: Callable[..., Awaitable[bool]]
+        self, callback: Callable[..., Awaitable[Optional[str]]]
     ) -> None:
         self._session_continuation_resumer = callback
 
@@ -298,9 +298,11 @@ class WorkflowsService:
             or self._session_continuation_resumer is None
         ):
             return False
-        return await self._session_continuation_resumer(
-            project_id=project_id,
-            session_id=session_id,
+        return bool(
+            await self._session_continuation_resumer(
+                project_id=project_id,
+                session_id=session_id,
+            )
         )
 
     @staticmethod

--- a/api/oss/src/dbs/postgres/sessions/commands/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/commands/dao.py
@@ -261,8 +261,8 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
         command_id: UUID,
         input_id: UUID,
         transaction: Optional[Any] = None,
-    ) -> SessionCommand:
-        async def execute(session: Any) -> SessionCommand:
+    ) -> Optional[SessionCommand]:
+        async def execute(session: Any) -> Optional[SessionCommand]:
             row = (
                 await session.execute(
                     sa_update(SessionCommandDBE)
@@ -270,7 +270,11 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
                         SessionCommandDBE.project_id == project_id,
                         SessionCommandDBE.id == command_id,
                         SessionCommandDBE.state.in_(_OPEN_STATES),
-                        SessionCommandDBE.data["steer_input_id"].astext.is_(None),
+                        or_(
+                            SessionCommandDBE.data["steer_input_id"].astext.is_(None),
+                            SessionCommandDBE.data["steer_input_id"].astext
+                            == str(input_id),
+                        ),
                     )
                     .values(
                         data=cast(
@@ -283,16 +287,7 @@ class SessionCommandsDAO(SessionCommandsDAOInterface):
                     .returning(SessionCommandDBE)
                 )
             ).scalar_one_or_none()
-            if row is None:
-                row = (
-                    await session.execute(
-                        select(SessionCommandDBE).where(
-                            SessionCommandDBE.project_id == project_id,
-                            SessionCommandDBE.id == command_id,
-                        )
-                    )
-                ).scalar_one()
-            return map_command_dbe_to_dto(row)
+            return map_command_dbe_to_dto(row) if row is not None else None
 
         if transaction is not None:
             return await execute(transaction)

--- a/api/oss/src/dbs/redis/sessions/locks.py
+++ b/api/oss/src/dbs/redis/sessions/locks.py
@@ -127,7 +127,14 @@ async def session_heartbeat_guard(
     finally:
         renewal.cancel()
         await asyncio.gather(renewal, return_exceptions=True)
-        await engine.eval(RELEASE_IF_OWNER_LUA, 1, key.encode(), token)
+        try:
+            await engine.eval(RELEASE_IF_OWNER_LUA, 1, key.encode(), token)
+        except Exception:
+            log.warning(
+                "heartbeat guard release failed; lease will expire",
+                session_id=session_id,
+                exc_info=True,
+            )
 
 
 async def acquire_alive(

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -594,18 +594,6 @@ async def run_orphan_sweep(
         # Win the stale stream generation before settling its execution or publishing records.
         # The update and execution settlement share this transaction; an exception rolls both
         # back, while record ids make a publish-before-commit retry idempotent.
-        # A turn this pass is settling as LOST must reach rest even when the row's
-        # `updated_at` moved inside this same pass. The command settlement and the record
-        # publish above both write through this transaction, so the advance can be our own
-        # write rather than a sign of life. The `turn_id` guard still protects a row that
-        # advanced to a NEWER turn, which is the case the timestamp guard exists for.
-        settled_lost = {
-            key
-            for key in unsettled
-            if (env.agenta.sessions.durable_approvals or env.agenta.sessions.queue)
-            and terminal_outcomes.get(key) != "stopped"
-        }
-
         collapsed_flags = SessionStreamFlags(
             is_alive=False, is_running=False, is_attached=False
         ).model_dump(mode="json")
@@ -631,12 +619,11 @@ async def run_orphan_sweep(
                     else SessionStreamDBE.turn_id.is_(None)
                 ),
             ]
-            if (project_uuid, session_id, turn_id) not in settled_lost:
-                conditions.append(
-                    SessionStreamDBE.updated_at == observed_updated_at
-                    if observed_updated_at is not None
-                    else SessionStreamDBE.updated_at.is_(None)
-                )
+            conditions.append(
+                SessionStreamDBE.updated_at == observed_updated_at
+                if observed_updated_at is not None
+                else SessionStreamDBE.updated_at.is_(None)
+            )
             result = await session.execute(
                 sa_update(SessionStreamDBE)
                 .where(*conditions)

--- a/api/oss/tests/pytest/unit/sessions/test_durable_events.py
+++ b/api/oss/tests/pytest/unit/sessions/test_durable_events.py
@@ -113,6 +113,31 @@ def test_maps_interaction_records_to_durable_lifecycle_events():
     assert events[1].payload.kind == "user_approval"
 
 
+def test_invalid_open_wire_strings_do_not_poison_durable_event_projection():
+    records = [
+        _record(
+            sequence=1,
+            record_type="interaction_request",
+            attributes={"id": "interaction-1", "kind": {"invalid": True}},
+        ),
+        _record(
+            sequence=2,
+            record_type="message",
+            attributes={"id": "message-1", "text": "bad", "finish_reason": 42},
+        ),
+        _record(
+            sequence=3,
+            record_type="message",
+            attributes={"id": "message-2", "text": "kept", "finish_reason": "stop"},
+        ),
+    ]
+
+    events = durable_events_from_records(records)
+
+    assert [event.entity_id for event in events] == ["message-2"]
+    assert events[0].payload.finish_reason == "stop"
+
+
 def test_non_dict_payload_reads_as_absent_instead_of_raising():
     """A record whose `payload` attribute is not a dict must not poison the batch.
 

--- a/api/oss/tests/pytest/unit/sessions/test_heartbeat_lock_races.py
+++ b/api/oss/tests/pytest/unit/sessions/test_heartbeat_lock_races.py
@@ -27,7 +27,9 @@ from oss.src.dbs.redis.sessions.locks import (
     get_owner,
     get_running_owner,
     is_turn_superseded,
+    session_heartbeat_guard,
 )
+from oss.src.dbs.redis.sessions.contract import RELEASE_IF_OWNER_LUA
 
 from unit.sessions.test_heartbeat_parked_zombie import _FakeStreamsDAO
 from unit.sessions.test_project_scoped_locks import _FakeRedis
@@ -90,6 +92,35 @@ async def _superseded(lock_engine, turn: str) -> bool:
 # --------------------------------------------------------------------------- #
 # Replica affinity
 # --------------------------------------------------------------------------- #
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_guard_release_failure_does_not_mask_the_body(lock_engine):
+    redis = lock_engine._client()
+    original_eval = redis.eval
+
+    async def fail_release(script, numkeys, *keys_and_args):
+        if script == RELEASE_IF_OWNER_LUA:
+            raise ConnectionError("redis unavailable")
+        return await original_eval(script, numkeys, *keys_and_args)
+
+    with (
+        patch.object(redis, "eval", new=fail_release),
+        patch("oss.src.dbs.redis.sessions.locks.log.warning") as warning,
+    ):
+        async with session_heartbeat_guard(
+            lock_engine,
+            project_id=str(_PROJECT),
+            session_id=_SESSION,
+        ):
+            result = "committed"
+
+    assert result == "committed"
+    warning.assert_called_once_with(
+        "heartbeat guard release failed; lease will expire",
+        session_id=_SESSION,
+        exc_info=True,
+    )
 
 
 @pytest.mark.asyncio

--- a/api/oss/tests/pytest/unit/sessions/test_interaction_continuation_admission.py
+++ b/api/oss/tests/pytest/unit/sessions/test_interaction_continuation_admission.py
@@ -652,7 +652,7 @@ async def test_next_send_resumes_the_same_open_continuation():
         project_id=project_id, session_id="session-1"
     )
 
-    assert resumed is True
+    assert resumed == commands.command.target_turn_id
     assert delivery.delivered[0].id == commands.command.id
     assert delivery.delivered[0].target_turn_id == "continuation-1"
 
@@ -700,7 +700,7 @@ async def test_exhausted_continuation_stays_recoverable(monkeypatch):
     resumed = await service.resume_recoverable_continuation(
         project_id=project_id, session_id="session-1"
     )
-    assert resumed is True
+    assert resumed == commands.command.target_turn_id
     assert commands.command.state == SessionCommandState.pending
     assert delivery.delivered[-1].id == command.id
     assert delivery.delivered[-1].target_turn_id != "continuation-1"
@@ -1226,7 +1226,7 @@ async def test_recovery_hooks_are_disabled_with_durable_approvals(monkeypatch):
         await service.resume_recoverable_continuation(
             project_id=project_id, session_id="session-1"
         )
-        is False
+        is None
     )
     assert await service.settle_abandoned_commands(now=datetime.now(timezone.utc)) == 0
     assert delivery.delivered == []
@@ -1298,7 +1298,7 @@ async def test_a_late_delivery_failure_does_not_demote_a_running_continuation():
         project_id=project_id, session_id="session-1"
     )
 
-    assert resumed is True
+    assert resumed == "continuation-1"
     assert delivery.delivered
     # The turn the runner is already running keeps `running`. The recoverable projection is
     # refused, so the card never asks the user to retry work that is under way.
@@ -1349,7 +1349,7 @@ async def test_a_send_after_the_budget_is_spent_reopens_the_continuation(monkeyp
         project_id=project_id, session_id="session-1"
     )
 
-    assert resumed is True
+    assert resumed == commands.command.target_turn_id
     # The exhausted attempt is recorded as ended and the command now targets a NEW execution:
     # redelivering the old id is what spent the budget in the first place.
     assert commands.command.target_turn_id != spent.target_turn_id

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -352,7 +352,7 @@ async def test_running_row_is_swept_at_the_short_threshold(anyio_backend):
 
 
 @pytest.mark.anyio
-async def test_turn_settled_lost_by_this_pass_collapses_after_timestamp_advance(
+async def test_heartbeat_during_lost_settlement_prevents_collapse(
     anyio_backend,
     monkeypatch,
 ):
@@ -378,7 +378,7 @@ async def test_turn_settled_lost_by_this_pass_collapses_after_timestamp_advance(
         publish=publish,
     )
 
-    assert _swept(row)
+    assert not _swept(row)
 
 
 @pytest.mark.anyio

--- a/api/oss/tests/pytest/unit/sessions/test_pending_inputs_service.py
+++ b/api/oss/tests/pytest/unit/sessions/test_pending_inputs_service.py
@@ -169,7 +169,7 @@ async def test_idle_input_executes_without_being_queued(monkeypatch):
 @pytest.mark.asyncio
 async def test_detached_executing_continuation_keeps_input_in_the_queue(monkeypatch):
     monkeypatch.setattr(env.agenta.sessions, "queue", True)
-    continuation_resumer = AsyncMock(return_value=True)
+    continuation_resumer = AsyncMock(return_value="continuation-1")
     dao = MemoryInputsDAO()
     service = SessionInputsService(
         inputs_dao=dao,
@@ -194,7 +194,7 @@ async def test_detached_executing_continuation_keeps_input_in_the_queue(monkeypa
 @pytest.mark.asyncio
 async def test_parked_continuation_still_allows_input_to_execute(monkeypatch):
     monkeypatch.setattr(env.agenta.sessions, "queue", True)
-    continuation_resumer = AsyncMock(return_value=False)
+    continuation_resumer = AsyncMock(return_value=None)
     dao = MemoryInputsDAO()
     service = SessionInputsService(
         inputs_dao=dao,
@@ -221,7 +221,7 @@ async def test_queue_flag_off_keeps_the_idle_path_without_a_continuation_probe(
 ):
     monkeypatch.setattr(env.agenta.sessions, "queue", False)
     monkeypatch.setattr(env.agenta.sessions, "durable_approvals", False)
-    continuation_resumer = AsyncMock(return_value=True)
+    continuation_resumer = AsyncMock(return_value="continuation-1")
     service = SessionInputsService(
         inputs_dao=MemoryInputsDAO(),
         streams_service=Streams(running=False),
@@ -239,6 +239,37 @@ async def test_queue_flag_off_keeps_the_idle_path_without_a_continuation_probe(
 
     assert admitted.action == "execute"
     continuation_resumer.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_steer_targets_the_execution_reopened_by_continuation_resume(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "queue", True)
+    monkeypatch.setattr(env.agenta.sessions, "steer", True)
+    continuation_resumer = AsyncMock(return_value="continuation-2")
+    executions = SimpleNamespace(
+        lock_for_control=AsyncMock(return_value=SimpleNamespace(terminal_outcome=None))
+    )
+    service = SessionInputsService(
+        inputs_dao=MemoryInputsDAO(),
+        streams_service=Streams(running=False),
+        executions_dao=executions,
+        continuation_resumer=continuation_resumer,
+    )
+
+    admitted = await service.admit(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        session_id="session-1",
+        content={"message": "steer the resumed continuation"},
+        policy="steer",
+        idempotency_key="key-1",
+    )
+
+    assert admitted.execution_id == "continuation-2"
+    assert (
+        executions.lock_for_control.await_args.kwargs["execution_id"]
+        == "continuation-2"
+    )
 
 
 @pytest.mark.asyncio

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_admission.py
@@ -934,6 +934,29 @@ async def test_steer_binds_to_an_already_open_stop(lock_engine):
 
 
 @pytest.mark.asyncio
+async def test_steer_rejects_an_open_stop_that_closes_before_binding(lock_engine):
+    await _run_turn(lock_engine, "turn-A")
+    dao = _FakeCommandsDAO()
+    svc = _service(
+        lock_engine,
+        dao=dao,
+        streams=_FakeStreamsService(
+            _stream("turn-A", datetime.now(timezone.utc) - timedelta(seconds=30))
+        ),
+    )
+    await svc.request_cancel(project_id=_PROJECT, user_id=_USER, session_id=_SESSION)
+    dao.bind_steer_input = AsyncMock(return_value=None)
+
+    with pytest.raises(SessionCommandNotClaimable):
+        await svc.request_cancel(
+            project_id=_PROJECT,
+            user_id=_USER,
+            session_id=_SESSION,
+            steer_input_id=uuid4(),
+        )
+
+
+@pytest.mark.asyncio
 async def test_a_reachable_runner_that_does_not_hold_the_session_settles_at_once(
     lock_engine,
 ):

--- a/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_commands_dao.py
@@ -1256,7 +1256,7 @@ async def test_executing_continuation_refuses_a_competing_send(
             project_id=command_scope["project_id"],
             session_id=command_scope["session_id"],
         )
-        is True
+        == "continuation-live"
     )
 
 
@@ -1276,7 +1276,7 @@ async def test_parked_continuation_still_accepts_a_send(command_scope, monkeypat
             project_id=command_scope["project_id"],
             session_id=command_scope["session_id"],
         )
-        is False
+        is None
     )
 
 

--- a/api/oss/tests/pytest/unit/sessions/test_session_inputs_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_inputs_dao.py
@@ -663,7 +663,20 @@ async def test_steer_stop_promotes_only_the_bound_input(input_scope, monkeypatch
         command_id=command.id,
         input_id=steer.id,
     )
+    assert command is not None
+    rebound = await SessionCommandsDAO(engine=input_scope["engine"]).bind_steer_input(
+        project_id=input_scope["project_id"],
+        command_id=command.id,
+        input_id=steer.id,
+    )
+    rejected = await SessionCommandsDAO(engine=input_scope["engine"]).bind_steer_input(
+        project_id=input_scope["project_id"],
+        command_id=command.id,
+        input_id=older.id,
+    )
     assert command.data == {"steer_input_id": str(steer.id)}
+    assert rebound is not None and rebound.data == command.data
+    assert rejected is None
     service = _settlement_service(input_scope, inputs)
 
     settled = await service.settle(

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.livePreview.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.livePreview.test.tsx
@@ -215,6 +215,7 @@ describe("desktop durable reconnect", () => {
                     busy: false,
                     setMessages,
                     persistMessages: vi.fn(),
+                    clearRunError: vi.fn(),
                     intent: {
                         armJump: vi.fn(),
                         stickRef: {current: false},

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.test.ts
@@ -17,9 +17,18 @@ import {describe, expect, it} from "vitest"
 
 import {
     hasStrandedTail,
+    nextInteractionGatePollDelay,
     shouldProtectRenderedInteraction,
     shouldSkipRecordsRefresh,
 } from "./useSessionHydration"
+
+describe("nextInteractionGatePollDelay", () => {
+    it("backs off and caps long-lived interaction gate polling", () => {
+        expect(nextInteractionGatePollDelay(1_000)).toBe(2_000)
+        expect(nextInteractionGatePollDelay(32_000)).toBe(60_000)
+        expect(nextInteractionGatePollDelay(60_000)).toBe(60_000)
+    })
+})
 
 describe("shouldSkipRecordsRefresh", () => {
     it("does not skip when idle and no settle is pending a resume", () => {

--- a/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useSessionHydration.ts
@@ -44,6 +44,10 @@ const REMOTE_RUN_POLL_MS = 15_000
  * records until it returns) is still followed. */
 const REMOTE_RUN_POLL_MAX_MS = 60_000
 const INTERACTION_GATE_POLL_MS = 1_000
+const INTERACTION_GATE_POLL_MAX_MS = 60_000
+
+export const nextInteractionGatePollDelay = (delay: number): number =>
+    Math.min(delay * 2, INTERACTION_GATE_POLL_MAX_MS)
 
 /** Retry budget for the stranded-first-send record check when the fetch itself fails
  * (`records: null`). Bounded so a down endpoint gets a short burst, not a hammer; when the budget
@@ -628,11 +632,15 @@ export const useSessionHydration = ({
         if (activeSessionId !== sessionId || !interactionGateOpen) return
         let cancelled = false
         let timer: ReturnType<typeof setTimeout> | undefined
+        let delay = INTERACTION_GATE_POLL_MS
         const poll = async () => {
             await refreshFromInteractions()
-            if (!cancelled) timer = setTimeout(poll, INTERACTION_GATE_POLL_MS)
+            if (!cancelled) {
+                delay = nextInteractionGatePollDelay(delay)
+                timer = setTimeout(poll, delay)
+            }
         }
-        timer = setTimeout(poll, INTERACTION_GATE_POLL_MS)
+        timer = setTimeout(poll, delay)
         return () => {
             cancelled = true
             if (timer) clearTimeout(timer)

--- a/web/packages/agenta-chat/src/model/livePreview.ts
+++ b/web/packages/agenta-chat/src/model/livePreview.ts
@@ -158,8 +158,7 @@ export const reduceSessionLivePreview = (
     const current = state.byExecution[frame.execution_id]
     if (current && frame.frame_index <= current.lastFrameIndex) return state
 
-    const expectedFrameIndex = current ? current.lastFrameIndex + 1 : 0
-    if (frame.frame_index !== expectedFrameIndex) {
+    if (current && frame.frame_index !== current.lastFrameIndex + 1) {
         return {...createSessionLivePreviewState(), gapDetected: true}
     }
 

--- a/web/packages/agenta-chat/tests/unit/model/livePreview.test.ts
+++ b/web/packages/agenta-chat/tests/unit/model/livePreview.test.ts
@@ -129,17 +129,17 @@ describe("session live preview reducer", () => {
         expect(sessionLivePreviewMessages(stale)[0].parts).toEqual([{type: "text", text: "newer"}])
     })
 
-    it("suppresses a late join whose first frame index is above zero", () => {
-        const gapped = reduceSessionLivePreview(
+    it("accepts a late join and enforces contiguous indexes after its first frame", () => {
+        const joined = reduceSessionLivePreview(
             createSessionLivePreviewState(),
             frame(2, "text-delta", {delta: "tail"}),
         )
-        const later = reduceSessionLivePreview(gapped, frame(3, "text-delta", {delta: "later"}))
+        const later = reduceSessionLivePreview(joined, frame(3, "text-delta", {delta: " later"}))
 
-        expect(gapped.gapDetected).toBe(true)
-        expect(gapped.executionOrder).toEqual([])
-        expect(sessionLivePreviewMessages(gapped)).toEqual([])
-        expect(later).toBe(gapped)
+        expect(joined.gapDetected).toBe(false)
+        expect(sessionLivePreviewMessages(later)[0].parts).toEqual([
+            {type: "text", text: "tail later"},
+        ])
     })
 
     it("clears and suppresses a preview after an internal frame gap", () => {

--- a/web/packages/agenta-chat/tests/unit/transport/sessionLiveEvents.test.ts
+++ b/web/packages/agenta-chat/tests/unit/transport/sessionLiveEvents.test.ts
@@ -46,7 +46,9 @@ describe("connectSessionLiveEvents", () => {
         const error = vi.spyOn(console, "error").mockImplementation(() => undefined)
         connectSessionLiveEvents({
             sessionId: "session-1",
+            after: 0,
             onFrame,
+            onEvent: vi.fn(),
             onReady: vi.fn(),
             onDisconnect: vi.fn(),
         })


### PR DESCRIPTION
## Context

CodeRabbit identified correctness and reliability gaps in the milestone 3 session-control branch, plus two strict TypeScript test-fixture failures.

## Changes

- Propagate resumed continuation ownership, reject lost steer bindings, and preserve concurrent heartbeat fences.
- Validate open-wire durable events and prevent Redis lease-release failures from masking committed heartbeats.
- Repair strict test inputs, back off long-lived approval polling, and accept live-preview attaches mid-execution.

## Tests

- Core and tracing Alembic legacy and OSS upgrade chains
- API sessions: 864 passed
- @agenta/chat: 819 passed; focused live-preview: 23 passed; types:check; lint
- @agenta/oss: 485 passed, 1 skipped; focused hydration: 12 passed; types:check; lint
- @agenta/entities: 1,556 passed
- @agenta/mobile: 164 passed
- Ruff 0.15.12 format and check

https://claude.ai/code/session_0164kzD6YzYk