### PR TITLE
[fix] Scope web-test cleanup and render messages once

### DIFF
--- a/web/ee/tests/playwright/acceptance/members/index.ts
+++ b/web/ee/tests/playwright/acceptance/members/index.ts
@@ -32,6 +32,23 @@ const lightFastTags = buildAcceptanceTags({
 const createInviteEmail = (scope: string) =>
     `${scope}-${Date.now()}-${Math.random().toString(36).slice(2, 8)}@agenta.test`
 
+const waitForResendResponse = async (page: any) => {
+    const response = await page.waitForResponse(
+        (res: any) =>
+            res.request().method() === "POST" &&
+            res.url().includes("/workspaces/") &&
+            res.url().includes("/invite/resend") &&
+            ![301, 302, 303, 307, 308].includes(res.status()),
+        {timeout: 15000},
+    )
+
+    if (!response.ok()) {
+        throw new Error(
+            `Resend invitation request failed (${response.status()}): ${await response.text()}`,
+        )
+    }
+}
+
 const waitForRemoveResponse = async (page: any) => {
     const response = await page.waitForResponse(
         (res: any) =>
@@ -101,20 +118,9 @@ const submitInviteMembersModal = async (inviteModal: any) => {
     await expect(inviteModal).not.toBeVisible({timeout: 30000})
 }
 
-/**
- * Invite a member via the EE flow (email sent) and wait for their row to appear
- * in the members table with "Invitation Pending" status.
- * Returns the invited email so callers can locate the row.
- */
-/**
- * A row in the members table.
- *
- * The table is virtualised: the semantic `<table>` carries only the `<thead>` and each
- * body row is a `[data-row-key]` node outside it, so `locator("tr")` only ever matches
- * the header.
- */
+/** A member row rendered by the current semantic table. */
 const memberRow = (page: any, email: string) =>
-    page.locator("[data-row-key]").filter({hasText: email}).first()
+    page.getByRole("row").filter({hasText: email}).first()
 
 /**
  * Closes the "Invited user link" dialog that opens after a successful invite.
@@ -128,6 +134,7 @@ const dismissInvitedUserLinkDialog = async (page: any) => {
     await expect(dialog).toBeHidden({timeout: 10000})
 }
 
+/** Invites a member and waits for its Pending row state. */
 const invitePendingMember = async (page: any, apiHelpers: any, uiHelpers: any): Promise<string> => {
     const testEmail = createInviteEmail("test-member")
 
@@ -159,7 +166,9 @@ const invitePendingMember = async (page: any, apiHelpers: any, uiHelpers: any): 
     // refreshed at all — which is why callers then failed to find the row. Close it
     // first, then wait for the row itself.
     await dismissInvitedUserLinkDialog(page)
-    await expect(memberRow(page, testEmail)).toBeVisible({timeout: 15000})
+    const row = memberRow(page, testEmail)
+    await expect(row).toBeVisible({timeout: 15000})
+    await expect(row.getByText("Pending", {exact: true})).toBeVisible({timeout: 15000})
 
     return testEmail
 }
@@ -263,14 +272,16 @@ const membersTests = () => {
             })
 
             await scenarios.and("the user clicks Resend invitation", async () => {
-                await page
-                    .locator(".ant-dropdown-menu-item")
-                    .filter({hasText: "Resend invitation"})
-                    .click()
+                await Promise.all([
+                    waitForResendResponse(page),
+                    page.getByRole("menuitem", {name: "Resend invitation", exact: true}).click(),
+                ])
             })
 
             await scenarios.then("a success confirmation is shown", async () => {
-                await expect(page.getByText("Invitation sent!")).toBeVisible({timeout: 10000})
+                await expect(page.getByText("Invitation sent!", {exact: true})).toBeVisible({
+                    timeout: 10000,
+                })
             })
         },
     )
@@ -301,11 +312,8 @@ const membersTests = () => {
             })
 
             await scenarios.and("the user clicks Remove and confirms", async () => {
-                await page.locator(".ant-dropdown-menu-item").filter({hasText: "Remove"}).click()
+                await page.getByRole("menuitem", {name: "Remove", exact: true}).click()
 
-                // `AlertPopup` calls `modal.confirm` from `@agenta/ui/app-message`, which
-                // renders a Radix `AlertDialog`. Its content carries role="alertdialog",
-                // a distinct role from "dialog" — so `getByRole("dialog")` never matches.
                 const confirmDialog = page.getByRole("alertdialog", {name: "Remove member"})
                 await expect(confirmDialog).toBeVisible({timeout: 10000})
                 await Promise.all([

--- a/web/oss/src/components/Layout/Layout.tsx
+++ b/web/oss/src/components/Layout/Layout.tsx
@@ -4,7 +4,6 @@ import {NotFoundScreen} from "@agenta/auth-ui"
 import {workflowLatestRevisionQueryAtomFamily} from "@agenta/entities/workflow"
 import {SETTINGS_SIDEBAR_SCOPE_ID} from "@agenta/navigation"
 import {ProjectWatch} from "@agenta/sessions/watch"
-import AppMessageContext from "@agenta/ui/app-message"
 import {useVisualViewportHeight} from "@agenta/ui/hooks"
 import {ConfigProvider, Layout, Modal, theme} from "antd"
 import clsx from "clsx"
@@ -449,7 +448,6 @@ const App: React.FC<LayoutProps> = ({children}) => {
     return (
         <>
             <PostHogThemeCapture />
-            <AppMessageContext />
             {typeof window === "undefined" ? null : isBareRoute ? (
                 <Layout className={classes.layout}>
                     <ErrorBoundary FallbackComponent={ErrorFallback}>

--- a/web/tests/README.md
+++ b/web/tests/README.md
@@ -33,7 +33,7 @@ Auth behavior in global setup:
 - If the frontend renders password auth, a password must be available (see below).
 - If the frontend renders OTP auth, Testmail envs must be available.
 
-Teardown cleans up the ephemeral project and model hub secrets created by the run.
+Teardown deletes the ephemeral project created by the run.
 
 ---
 

--- a/web/tests/playwright/global-setup.ts
+++ b/web/tests/playwright/global-setup.ts
@@ -1006,7 +1006,7 @@ async function maybeCreateEphemeralProject(page: Page, baseURL: string): Promise
             console.log(
                 "[global-setup] Ephemeral project disabled (AGENTA_TEST_EPHEMERAL_PROJECT=false)",
             )
-            writeProjectMetadata(projectMetadataPath, defaultProject, page, null)
+            writeProjectMetadata(projectMetadataPath, defaultProject, page, null, false)
             return
         }
 
@@ -1022,7 +1022,7 @@ async function maybeCreateEphemeralProject(page: Page, baseURL: string): Promise
             console.warn(
                 `[global-setup] Failed to create ephemeral project (${response.status()}): ${text}`,
             )
-            writeProjectMetadata(projectMetadataPath, defaultProject, page, null)
+            writeProjectMetadata(projectMetadataPath, defaultProject, page, null, false)
             return
         }
 
@@ -1031,12 +1031,12 @@ async function maybeCreateEphemeralProject(page: Page, baseURL: string): Promise
             `[global-setup] Created ephemeral project: ${projectName} (${project.project_id})`,
         )
 
-        writeProjectMetadata(projectMetadataPath, project, page, originalDefaultProjectId)
+        writeProjectMetadata(projectMetadataPath, project, page, originalDefaultProjectId, true)
     } catch (error) {
         console.warn("[global-setup] Failed to create ephemeral project, using default:", error)
         try {
             const projectMetadataPath = getProjectMetadataPath()
-            writeProjectMetadata(projectMetadataPath, null, page, null)
+            writeProjectMetadata(projectMetadataPath, null, page, null, false)
         } catch (writeError) {
             console.warn("[global-setup] Could not write fallback project metadata:", writeError)
         }
@@ -1048,6 +1048,7 @@ function writeProjectMetadata(
     project: any,
     page: Page,
     originalDefaultProjectId: string | null,
+    ephemeral: boolean,
 ): void {
     let metadata: Record<string, unknown> | null = null
 
@@ -1056,6 +1057,7 @@ function writeProjectMetadata(
             project_id: project.project_id,
             project_name: project.project_name ?? null,
             workspace_id: project.workspace_id,
+            ephemeral,
             ...(originalDefaultProjectId !== null
                 ? {original_default_project_id: originalDefaultProjectId}
                 : {}),
@@ -1070,6 +1072,7 @@ function writeProjectMetadata(
                 metadata = {
                     workspace_id: match[1],
                     project_id: match[2],
+                    ephemeral,
                     created_at: new Date().toISOString(),
                 }
                 console.log("[global-setup] Derived project metadata from page URL")

--- a/web/tests/playwright/global-teardown.test.ts
+++ b/web/tests/playwright/global-teardown.test.ts
@@ -1,0 +1,92 @@
+import assert from "node:assert/strict"
+import {existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync} from "node:fs"
+import {tmpdir} from "node:os"
+import {join} from "node:path"
+import {afterEach, describe, it} from "node:test"
+
+import {deleteEphemeralProject} from "./global-teardown.ts"
+
+const roots: string[] = []
+
+function fixture(metadata: Record<string, unknown>) {
+    const root = mkdtempSync(join(tmpdir(), "agenta-global-teardown-"))
+    roots.push(root)
+    const projectPath = join(root, "test-project.json")
+    const statePath = join(root, "state.json")
+    writeFileSync(projectPath, JSON.stringify(metadata))
+    writeFileSync(
+        statePath,
+        JSON.stringify({cookies: [{name: "sAccessToken", value: "test-session"}]}),
+    )
+    return {projectPath, statePath}
+}
+
+afterEach(() => {
+    for (const root of roots.splice(0)) rmSync(root, {recursive: true, force: true})
+})
+
+describe("deleteEphemeralProject", () => {
+    it("never deletes a fallback or default project", async () => {
+        const paths = fixture({
+            project_id: "persistent-project",
+            workspace_id: "workspace",
+            ephemeral: false,
+        })
+        let requestCount = 0
+
+        await deleteEphemeralProject("https://example.test/api", {
+            ...paths,
+            fetchFn: async () => {
+                requestCount += 1
+                return new Response(null, {status: 204})
+            },
+        })
+
+        assert.equal(requestCount, 0)
+        assert.equal(existsSync(paths.projectPath), false)
+    })
+
+    it("deletes an owned ephemeral project and removes its metadata", async () => {
+        const paths = fixture({
+            project_id: "ephemeral-project",
+            project_name: "e2e-test",
+            workspace_id: "workspace",
+            ephemeral: true,
+        })
+        const requests: Array<{url: string; method?: string}> = []
+
+        await deleteEphemeralProject("https://example.test/api", {
+            ...paths,
+            fetchFn: async (input, init) => {
+                requests.push({url: String(input), method: init?.method})
+                return new Response(null, {status: 204})
+            },
+        })
+
+        assert.deepEqual(requests, [
+            {
+                url: "https://example.test/api/projects/ephemeral-project",
+                method: "DELETE",
+            },
+        ])
+        assert.equal(existsSync(paths.projectPath), false)
+    })
+
+    it("retains owned-project metadata when deletion fails", async () => {
+        const metadata = {
+            project_id: "ephemeral-project",
+            project_name: "e2e-test",
+            workspace_id: "workspace",
+            ephemeral: true,
+        }
+        const paths = fixture(metadata)
+
+        await deleteEphemeralProject("https://example.test/api", {
+            ...paths,
+            fetchFn: async () => new Response("temporary failure", {status: 503}),
+        })
+
+        assert.equal(existsSync(paths.projectPath), true)
+        assert.deepEqual(JSON.parse(readFileSync(paths.projectPath, "utf8")), metadata)
+    })
+})

--- a/web/tests/playwright/global-teardown.ts
+++ b/web/tests/playwright/global-teardown.ts
@@ -1,10 +1,4 @@
-/**
- * This script cleans up after Playwright tests.
- * Deletes the ephemeral project created during global-setup (if any),
- * then cleans up model hub secrets.
- */
-
-import {StandardSecretDTO} from "../../oss/src/lib/Types"
+/** Deletes the ephemeral project created during global setup. */
 
 import {existsSync, readFileSync, unlinkSync} from "fs"
 
@@ -22,11 +16,6 @@ function getSessionToken(statePath: string): string | null {
     return state.cookies?.find((c: any) => c.name === "sAccessToken")?.value ?? null
 }
 
-/**
- * Runs after tests complete.
- * 1. Deletes the ephemeral project created during setup (if any).
- * 2. Cleans up model hub secrets (OpenAI keys added during tests).
- */
 /**
  * Derives the API base URL from AGENTA_WEB_URL.
  * The web app may live at a subpath (e.g. /w) but the API is always at /api on the origin.
@@ -49,28 +38,43 @@ async function globalTeardown() {
     const apiURL = getApiURL(baseURL)
     console.log(`[global-teardown] Using api-url: ${apiURL}`)
 
-    // --- Phase 1: Delete ephemeral project ---
     await deleteEphemeralProject(apiURL)
-
-    // --- Phase 2: Clean up model hub secrets ---
-    await cleanupModelHubSecrets(apiURL)
 }
 
 /**
- * Deletes the ephemeral project created during global-setup.
- * Reads project metadata from the runtime metadata file, calls DELETE /api/projects/{id},
- * then removes the metadata file.
+ * Deletes a project only when setup explicitly marked it as ephemeral.
+ * Keeps the metadata after a failed deletion so a later teardown can retry.
  */
-async function deleteEphemeralProject(apiURL: string): Promise<void> {
-    const projectPath = getProjectMetadataPath()
+interface DeleteEphemeralProjectOptions {
+    projectPath?: string
+    statePath?: string
+    fetchFn?: typeof fetch
+}
+
+export async function deleteEphemeralProject(
+    apiURL: string,
+    options: DeleteEphemeralProjectOptions = {},
+): Promise<void> {
+    const projectPath = options.projectPath ?? getProjectMetadataPath()
+    const statePath = options.statePath ?? getStorageStatePath()
+    const fetchFn = options.fetchFn ?? fetch
 
     if (!existsSync(projectPath)) {
         console.log("[global-teardown] No test project metadata found, skipping project cleanup")
         return
     }
 
+    let removeMetadata = false
+
     try {
         const projectData = JSON.parse(readFileSync(projectPath, "utf8"))
+
+        if (projectData.ephemeral !== true) {
+            console.log("[global-teardown] Project is not marked ephemeral, skipping cleanup")
+            removeMetadata = true
+            return
+        }
+
         const projectId = projectData.project_id
         const projectName = projectData.project_name
 
@@ -81,7 +85,6 @@ async function deleteEphemeralProject(apiURL: string): Promise<void> {
 
         console.log(`[global-teardown] Deleting ephemeral project: ${projectName} (${projectId})`)
 
-        const statePath = getStorageStatePath()
         const sessionToken = getSessionToken(statePath)
 
         if (!sessionToken) {
@@ -102,7 +105,7 @@ async function deleteEphemeralProject(apiURL: string): Promise<void> {
             console.log(
                 `[global-teardown] Restoring original default project: ${originalDefaultId}`,
             )
-            const patchResponse = await fetch(`${apiURL}/projects/${originalDefaultId}`, {
+            const patchResponse = await fetchFn(`${apiURL}/projects/${originalDefaultId}`, {
                 method: "PATCH",
                 headers: authHeaders,
                 body: JSON.stringify({make_default: true}),
@@ -113,17 +116,19 @@ async function deleteEphemeralProject(apiURL: string): Promise<void> {
                 console.warn(
                     `[global-teardown] Failed to restore default project (${patchResponse.status})`,
                 )
+                return
             }
         }
 
         // Now delete the ephemeral project
-        const response = await fetch(`${apiURL}/projects/${projectId}`, {
+        const response = await fetchFn(`${apiURL}/projects/${projectId}`, {
             method: "DELETE",
             headers: authHeaders,
         })
 
-        if (response.ok) {
+        if (response.ok || response.status === 404) {
             console.log(`[global-teardown] Deleted ephemeral project: ${projectName}`)
+            removeMetadata = true
         } else {
             const text = await response.text()
             console.warn(
@@ -133,64 +138,18 @@ async function deleteEphemeralProject(apiURL: string): Promise<void> {
     } catch (error) {
         console.warn("[global-teardown] Error deleting ephemeral project:", error)
     } finally {
-        // Always clean up the metadata file
-        try {
-            unlinkSync(projectPath)
-            console.log("[global-teardown] Removed test project metadata")
-        } catch {
-            // Ignore if already deleted
-        }
-    }
-}
-
-/**
- * Cleans up OpenAI model hub secrets that were added during test runs.
- */
-async function cleanupModelHubSecrets(apiURL: string): Promise<void> {
-    try {
-        console.log("[global-teardown] Deleting model hub secrets...")
-        const statePath = getStorageStatePath()
-        const sessionToken = getSessionToken(statePath)
-
-        if (!sessionToken) {
-            console.log(
-                "[global-teardown] No session token in storage state, skipping model hub cleanup",
-            )
-            return
-        }
-
-        console.log(
-            `[teardown] Extracted session token from storage state: ${sessionToken ? "present" : "absent"}`,
-        )
-
-        const secretsResp = await fetch(`${apiURL}/secrets/`, {
-            headers: {Authorization: `Bearer ${sessionToken}`},
-        })
-
-        if (!secretsResp.ok) {
-            console.error("[global-teardown] Failed to fetch secrets", await secretsResp.text())
-            return
-        }
-
-        const secrets = (await secretsResp.json()) as StandardSecretDTO[]
-
-        const openaiSecrets = secrets.filter((s) =>
-            s?.header?.name?.toLowerCase().includes("openai"),
-        )
-
-        for (const secret of openaiSecrets) {
+        if (removeMetadata) {
             try {
-                await fetch(`${apiURL}/secrets/${secret.id}`, {
-                    method: "DELETE",
-                    headers: {Authorization: `Bearer ${sessionToken}`},
-                })
-                console.log(`[global-teardown] Deleted model hub secret ${secret.id}`)
-            } catch (err) {
-                console.error(`[global-teardown] Failed to delete secret ${secret.id}`, err)
+                unlinkSync(projectPath)
+                console.log("[global-teardown] Removed test project metadata")
+            } catch {
+                // Ignore if already deleted
             }
+        } else {
+            console.warn(
+                `[global-teardown] Retained test project metadata for a later cleanup attempt: ${projectPath}`,
+            )
         }
-    } catch (err) {
-        console.error("[global-teardown] Error cleaning up model hub key", err)
     }
 }
 


### PR DESCRIPTION
## Context

The web acceptance teardown restored the account's persistent default project, deleted its ephemeral test project, then listed secrets without a project scope and deleted every provider whose name contained `openai`. A release QA run therefore deleted a persistent browser QA credential after the test project was already gone. Setup could also record a fallback default project in the same metadata shape as an ephemeral project, while teardown treated every recorded ID as test-owned.

The Members acceptance cases depended on removed Ant Design classes. Once those selectors were corrected, the focused browser run exposed two identical success toasts and two identical destructive confirmation dialogs. The desktop app mounted the global app-message outlet in both `_app` and `Layout`, although the outlet contract requires one mount.

## Changes

Setup now records whether a project is ephemeral. Teardown sends DELETE only for an explicitly owned ephemeral project, relies on project deletion to cascade its secrets, and retains metadata after a failed deletion so a later run can retry. It no longer scans or deletes credentials in the restored project.

The Members cases select rows and actions by accessible roles, wait for the exact resend and remove responses, and require one toast and one alert dialog. The app keeps the original `_app` message outlet and removes the newer duplicate from `Layout`.

Before, teardown could issue `DELETE /secrets/<persistent-id>` after restoring the original project, and one `message` or `modal` call rendered twice. After this change, its only remote cleanup is an owned `DELETE /projects/<ephemeral-id>`, and each app-message action has one renderer.

## How to review

1. Read the setup metadata writer and confirm only a successfully created project gets `ephemeral: true`.
2. Read teardown and confirm it guards DELETE on that marker and retains metadata when cleanup fails.
3. Check that `_app` remains the sole app-message outlet and `Layout` no longer adds another.
4. Check the Members locators and response waits against the actions they prove.
5. Confirm the README describes the remaining teardown behavior.

## Tests

- `pnpm exec tsx --test tests/playwright/global-teardown.test.ts` (3/3 passed)
- `pnpm lint-fix` (25/25 tasks passed)
- `git diff --check`
- Focused staging run before the source fix: invite passed in 2.5 seconds; resend passed in 3.7 seconds; remove exposed two identical dialogs and identified the duplicate outlets.
- Exact-source local browser run after the fix: invite reached Pending, resend returned HTTP 200, remove showed exactly one alert dialog, DELETE returned HTTP 200, and the row disappeared. The strict staging 3/3 rerun follows the preview deploy.
