### PR TITLE
[fix] Release held messages on mobile when queue capabilities are absent

### DIFF
--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
@@ -10,7 +10,18 @@ const state = vi.hoisted(() => ({
     acceptedRunBySession: new Map<string, string | null>(),
     turnDeliverySourceBySession: new Map<string, "legacy" | "shared">(),
     capturedHooks: undefined as
-        | {prepareRequest: (args: {messages: UIMessage[]; id?: string}) => Promise<unknown>}
+        | {
+              prepareRequest: (args: {messages: UIMessage[]; id?: string}) => Promise<unknown>
+              onData: (part: {type: string; data?: unknown}) => void
+              onFinish: (args: {
+                  message: UIMessage
+                  messages: UIMessage[]
+                  finishReason?: string
+                  isAbort?: boolean
+                  isDisconnect?: boolean
+                  isError?: boolean
+              }) => void
+          }
         | undefined,
     messages: [] as UIMessage[],
     latestTurnId: undefined as string | undefined,
@@ -188,6 +199,42 @@ describe("useAgentChatSession execution guard", () => {
         state.sessionTurnId = null
         state.stoppingTurnId = null
         state.stopStateLoading = false
+    })
+
+    it("settles a desktop accepted turn when its shared invoke stream finishes", () => {
+        const sessionId = "session-1"
+        let result: ReturnType<typeof useAgentChatSession> | undefined
+        const container = document.createElement("div")
+        const root = createRoot(container)
+        const Probe = () => {
+            result = useAgentChatSession({
+                entityId: "revision-1",
+                sessionId,
+                initialMessages: [],
+                intent: {} as never,
+            })
+            return null
+        }
+        act(() => root.render(createElement(Probe)))
+
+        act(() =>
+            state.capturedHooks!.onData({
+                type: "data-session-accepted",
+                data: {executionId: "turn-1"},
+            }),
+        )
+        expect(result!.acceptedRunPending).toBe(true)
+
+        act(() =>
+            state.capturedHooks!.onFinish({
+                message: {id: "assistant-1", role: "assistant", parts: []},
+                messages: [],
+            }),
+        )
+        expect(result!.acceptedRunPending).toBe(false)
+        expect(state.acceptedRunBySession.has(sessionId)).toBe(false)
+
+        act(() => root.unmount())
     })
 
     it("clears the previous turn before sends, regeneration, and SDK automatic requests", async () => {

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -179,6 +179,18 @@ export const useAgentChatSession = ({
     const [turnDeliverySource, setTurnDeliverySource] = useState<TurnDeliverySource | null>(
         () => turnDeliverySourceBySession.get(sessionId) ?? null,
     )
+    const settleSharedTurn = useCallback(
+        (executionId?: string) => {
+            const acceptedExecutionId = acceptedExecutionIdRef.current
+            if (executionId && acceptedExecutionId && acceptedExecutionId !== executionId) return
+            acceptedExecutionIdRef.current = null
+            acceptedRunBySession.delete(sessionId)
+            setAcceptedRunPending(false)
+            turnDeliverySourceBySession.delete(sessionId)
+            setTurnDeliverySource(null)
+        },
+        [sessionId],
+    )
     const sharedSenderReadyRef = useRef(false)
     const setSharedSenderReady = useCallback((ready: boolean) => {
         sharedSenderReadyRef.current = ready
@@ -253,7 +265,16 @@ export const useAgentChatSession = ({
         // `is_running: true` outlived the answer by up to 15s (#5844). Safe to refetch immediately —
         // the runner awaits its `is_running: false` heartbeat BEFORE closing this stream
         // (services/runner/src/server.ts `aliveWatchdog.release()`), so the flag is already cleared.
-        onFinish: ({message, messages: finishedMessages, finishReason}) => {
+        onFinish: ({
+            message,
+            messages: finishedMessages,
+            finishReason,
+            isAbort,
+            isDisconnect,
+            isError,
+        }) => {
+            // A clean shared invoke close is terminal; a disconnect still waits for the durable event.
+            if (!isAbort && !isDisconnect && !isError) settleSharedTurn()
             dispatchStopped({
                 type: "stream-terminal",
                 messages: finishedMessages,
@@ -821,15 +842,7 @@ export const useAgentChatSession = ({
         connectionWarning: errorBoundary.connectionWarning,
         acceptedRunPending,
         turnDeliverySource,
-        settleSharedTurn: (executionId?: string) => {
-            const acceptedExecutionId = acceptedExecutionIdRef.current
-            if (executionId && acceptedExecutionId && acceptedExecutionId !== executionId) return
-            acceptedExecutionIdRef.current = null
-            acceptedRunBySession.delete(sessionId)
-            setAcceptedRunPending(false)
-            turnDeliverySourceBySession.delete(sessionId)
-            setTurnDeliverySource(null)
-        },
+        settleSharedTurn,
         sendMessage: sendMessageWithFreshGuard,
         regenerate: regenerateWithFreshGuard,
         setMessages,

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -329,6 +329,18 @@ export const useAgentConversation = ({
     const [turnDeliverySource, setTurnDeliverySource] = useState<TurnDeliverySource | null>(
         () => turnDeliverySourceBySession.get(sessionId) ?? null,
     )
+    const settleAcceptedRun = useCallback(
+        (executionId?: string) => {
+            const acceptedExecutionId = acceptedExecutionIdRef.current
+            if (executionId && acceptedExecutionId && acceptedExecutionId !== executionId) return
+            acceptedExecutionIdRef.current = null
+            acceptedRunBySession.delete(sessionId)
+            setAcceptedRunPending(false)
+            turnDeliverySourceBySession.delete(sessionId)
+            setTurnDeliverySource(null)
+        },
+        [sessionId],
+    )
     // Tracks `busy` for callbacks that outlive a render (the preserve verdict at unmount).
     const busyRef = useRef(false)
     // Only a stream THIS client renders. A shared-delivered turn renders from the live frames,
@@ -392,7 +404,16 @@ export const useAgentConversation = ({
             const label = startupLabelFromDataPart(part)
             if (label) setTurnStartupLabel(sessionId, label)
         },
-        onFinish: ({message, messages: finishedMessages, finishReason}) => {
+        onFinish: ({
+            message,
+            messages: finishedMessages,
+            finishReason,
+            isAbort,
+            isDisconnect,
+            isError,
+        }) => {
+            // A clean shared invoke close is terminal; a disconnect still waits for the durable event.
+            if (!isAbort && !isDisconnect && !isError) settleAcceptedRun()
             dispatchStopped({
                 type: "stream-terminal",
                 messages: finishedMessages,
@@ -1024,15 +1045,7 @@ export const useAgentConversation = ({
         onReadyChange: (ready) => {
             sharedSenderReadyRef.current = ready
         },
-        onExecutionSettled: (executionId?: string) => {
-            const acceptedExecutionId = acceptedExecutionIdRef.current
-            if (executionId && acceptedExecutionId && acceptedExecutionId !== executionId) return
-            acceptedExecutionIdRef.current = null
-            acceptedRunBySession.delete(sessionId)
-            setAcceptedRunPending(false)
-            turnDeliverySourceBySession.delete(sessionId)
-            setTurnDeliverySource(null)
-        },
+        onExecutionSettled: settleAcceptedRun,
         onDisconnect: revalidate,
     })
     const includePreview = turnDeliverySource !== "legacy"

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
@@ -252,6 +252,35 @@ const controlledLegacyResponse = () => {
     return {response, finish: () => finish()}
 }
 
+const controlledSharedResponse = (sessionId: string) => {
+    const encoder = new TextEncoder()
+    let finish = () => {}
+    const response = new Response(
+        new ReadableStream({
+            start(controller) {
+                for (const chunk of [
+                    {type: "start", messageId: "shared-assistant"},
+                    {type: "start-step"},
+                    {
+                        type: "data-session-accepted",
+                        data: {sessionId, turnId: "turn-1", executionId: "turn-1"},
+                        transient: true,
+                    },
+                ])
+                    controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`))
+                finish = () => {
+                    for (const chunk of [{type: "finish-step"}, {type: "finish"}])
+                        controller.enqueue(encoder.encode(`data: ${JSON.stringify(chunk)}\n\n`))
+                    controller.enqueue(encoder.encode("data: [DONE]\n\n"))
+                    controller.close()
+                }
+            },
+        }),
+        {status: 200, headers: {"content-type": "text/event-stream"}},
+    )
+    return {response, finish: () => finish()}
+}
+
 const fetchMock = vi.fn<typeof globalThis.fetch>()
 vi.stubGlobal("fetch", fetchMock)
 
@@ -305,6 +334,55 @@ beforeEach(() => {
 afterEach(() => vi.useRealTimers())
 
 describe("useAgentConversation", () => {
+    it("releases one mobile-held message after a flag-off shared turn finishes", async () => {
+        const store = createStore()
+        store.set(projectIdAtom, "project-1")
+        const sessionId = nextSessionId()
+        markSessionFresh(sessionId)
+        const first = controlledSharedResponse(sessionId)
+        const second = controlledSharedResponse(sessionId)
+        fetchMock.mockResolvedValueOnce(first.response).mockResolvedValueOnce(second.response)
+        vi.mocked(buildAgentRequest).mockImplementation(async (_entityId, _messages, opts) => ({
+            invocationUrl: "https://agent.test/invoke",
+            headers: {
+                Accept: "text/event-stream",
+                "content-type": "application/json",
+                ...(opts?.sharedResponse ? {"x-ag-session-response": "shared"} : {}),
+            },
+            requestBody: {session_id: opts?.sessionId},
+        }))
+        const {result} = renderHook(
+            () =>
+                useAgentConversation({
+                    entityId: "rev-1",
+                    sessionId,
+                    sharedReaderAdvertised: true,
+                }),
+            {
+                wrapper: ({children}: {children: ReactNode}) =>
+                    createElement(Provider, {store}, children),
+            },
+        )
+
+        await waitFor(() => expect(FakeEventSource.instances).toHaveLength(1))
+        act(() => FakeEventSource.instances[0].ready())
+        await waitFor(() => expect(result.current.readerReady).toBe(true))
+
+        act(() => void result.current.send({text: "start"}))
+        await waitFor(() => expect(result.current.acceptedRunPending).toBe(true))
+        act(() => void result.current.send({text: "held on mobile"}))
+        expect(result.current.queued.map((message) => message.text)).toEqual(["held on mobile"])
+        expect(fetchMock).toHaveBeenCalledTimes(1)
+
+        act(() => first.finish())
+
+        await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+        expect(result.current.queued).toHaveLength(0)
+        act(() => second.finish())
+        await waitFor(() => expect(result.current.acceptedRunPending).toBe(false))
+        expect(fetchMock).toHaveBeenCalledTimes(2)
+    })
+
     it("keeps a Steer draft when durable admission is refused", async () => {
         capabilitiesViaAtom.mockResolvedValue({
             durableApprovals: true,


### PR DESCRIPTION
## Context

With durable queue capabilities disabled, mobile held a message typed during an active turn but never released it after the turn completed. The accepted shared-turn latch waited only for a durable terminal event, even when this browser's invoke stream had already finished cleanly.

## Changes

- Clear accepted shared-turn ownership when the sender stream finishes cleanly, using the same settlement helper as the durable event path.
- Preserve the ownership latch across disconnects, aborts, and errors so recovery still waits for durable confirmation.
- Cover the flag-off mobile hold-and-release flow and desktop settlement parity.

## Tests

- `pnpm --filter @agenta/mobile exec vitest run --maxWorkers=2` (21 files, 164 tests passed)
- `pnpm --filter @agenta/chat exec vitest run --maxWorkers=2` (77 files, 820 tests passed)
- `pnpm --filter @agenta/oss exec vitest run --maxWorkers=2` (57 files, 486 tests passed, 1 skipped)
- `pnpm --filter @agenta/mobile types:check`
- `pnpm --filter @agenta/chat types:check`
- `pnpm --filter @agenta/oss types:check`
- `pnpm --filter @agenta/mobile lint` (0 errors, 3 existing warnings)
- `pnpm --filter @agenta/chat lint`
- `pnpm --filter @agenta/oss lint`
- `pnpm lint-fix`

https://claude.ai/code/session_0164kzT6ttwpBtzvcDC6YzYk
