### PR TITLE
[fix] Enable durable Stop by default

### DIFF
--- a/api/oss/src/utils/env.py
+++ b/api/oss/src/utils/env.py
@@ -525,7 +525,7 @@ def _parse_sessions_late_output() -> Literal["quarantine", "reject"]:
 
 
 def _sessions_durable_stop_enabled() -> bool:
-    return (os.getenv("AGENTA_SESSIONS_DURABLE_STOP") or "false").lower() in _TRUTHY
+    return (os.getenv("AGENTA_SESSIONS_DURABLE_STOP") or "true").lower() in _TRUTHY
 
 
 def _parse_sessions_watchdog_stale_heartbeat_seconds() -> int:

--- a/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
+++ b/api/oss/tests/pytest/unit/sessions/test_orphan_sweep_thresholds.py
@@ -329,16 +329,13 @@ async def test_idle_row_is_swept_at_the_long_threshold(anyio_backend):
 
 
 @pytest.mark.anyio
-async def test_the_flag_off_running_threshold_keeps_the_release_baseline(anyio_backend):
-    """300 seconds of heartbeat age, not lease expiry.
+async def test_default_running_threshold_uses_durable_stop(anyio_backend):
+    """Three missed 30-second heartbeats settle a running turn by default.
 
-    The Redis alive/running keys carry a ONE HOUR TTL, so a rule phrased as "shortly after the
-    lease expires" would leave a dead turn running for an hour. The runner beats every 30
-    seconds and mirrors the beat onto `updated_at`, so ten missed beats preserve the baseline.
-    Durable Stop may opt into the 90-second default, but the rollout flag being off preserves
-    the prior 300-second threshold while still writing the missing terminal outcome.
+    Idle sessions retain the 30-minute approval TTL. Explicit flag-off behavior
+    is covered by the session cancellation configuration tests.
     """
-    assert (ORPHAN_THRESHOLD_SECONDS, IDLE_THRESHOLD_SECONDS) == (300, 1800)
+    assert (ORPHAN_THRESHOLD_SECONDS, IDLE_THRESHOLD_SECONDS) == (90, 1800)
 
 
 @pytest.mark.anyio

--- a/api/oss/tests/pytest/unit/sessions/test_session_cancel_feature_flag.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_cancel_feature_flag.py
@@ -31,12 +31,15 @@ def test_unknown_late_output_policy_falls_back_to_quarantine(monkeypatch):
 
 @pytest.mark.parametrize(
     ("durable_stop", "expected"),
-    [("false", 300), ("true", 90)],
+    [(None, 90), ("", 90), ("false", 300), ("true", 90)],
 )
-def test_watchdog_default_preserves_flag_off_threshold(
+def test_watchdog_default_respects_durable_stop_setting(
     monkeypatch, durable_stop, expected
 ):
-    monkeypatch.setenv("AGENTA_SESSIONS_DURABLE_STOP", durable_stop)
+    if durable_stop is None:
+        monkeypatch.delenv("AGENTA_SESSIONS_DURABLE_STOP", raising=False)
+    else:
+        monkeypatch.setenv("AGENTA_SESSIONS_DURABLE_STOP", durable_stop)
     monkeypatch.delenv(
         "AGENTA_SESSIONS_WATCHDOG_STALE_HEARTBEAT_SECONDS", raising=False
     )

--- a/hosting/docker-compose/ee/env.ee.dev.example
+++ b/hosting/docker-compose/ee/env.ee.dev.example
@@ -136,7 +136,7 @@ AGENTA_RUNNER_DEFAULT_SANDBOX_PROVIDER=local
 # Smart truncation preserves the structure of a record whose body exceeds the API size
 # cap (higher-fidelity reconstruction). Still opt-in, default off.
 # AGENTA_RECORDS_SMART_TRUNCATION=true
-# Durable Stop is exercised in development; production keeps the API default off.
+# Durable Stop is enabled by default; set false to use legacy cancellation.
 AGENTA_SESSIONS_DURABLE_STOP=true
 # AGENTA_SESSIONS_LATE_OUTPUT=quarantine
 

--- a/hosting/docker-compose/oss/env.oss.dev.example
+++ b/hosting/docker-compose/oss/env.oss.dev.example
@@ -142,7 +142,7 @@ NEXT_PUBLIC_AGENT_FILE_UPLOADS=true
 # Smart truncation preserves the structure of a record whose body exceeds the API size
 # cap (higher-fidelity reconstruction). Still opt-in, default off.
 # AGENTA_RECORDS_SMART_TRUNCATION=true
-# Durable Stop is exercised in development; production keeps the API default off.
+# Durable Stop is enabled by default; set false to use legacy cancellation.
 AGENTA_SESSIONS_DURABLE_STOP=true
 # AGENTA_SESSIONS_LATE_OUTPUT=quarantine
 


### PR DESCRIPTION
Enable durable Stop when `AGENTA_SESSIONS_DURABLE_STOP` is unset or empty. An explicit `false` still selects legacy cancellation and its 300-second watchdog threshold; the enabled default uses 90 seconds. Update the OSS/EE example comments to match.

## Tests

18 focused cancellation-configuration and orphan-watchdog tests pass. Ruff format/check and diff whitespace checks pass. Existing browser QA already exercised the enabled path on both previews; this changes only the fallback configuration and adds no migration.
