### PR TITLE
[fix] Stop accepted shared session executions

### DIFF
--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
@@ -12,6 +12,7 @@ const state = vi.hoisted(() => ({
     capturedHooks: undefined as
         | {
               prepareRequest: (args: {messages: UIMessage[]; id?: string}) => Promise<unknown>
+              onData: (part: {type: string; data?: unknown}) => void
               onError: () => void
               sendAutomaticallyWhen: (args: {messages: UIMessage[]}) => boolean
           }
@@ -82,6 +83,8 @@ vi.mock("@agenta/chat/state", () => ({
     sessionRecordCountsReadAtom: "record-counts",
     setSessionStatusAtom: "set-session-status",
     setSessionTurnId: (sessionId: string, turnId: string) => state.turnIds.set(sessionId, turnId),
+    setAcceptedSessionTurnId: (sessionId: string, turnId: string) =>
+        state.turnIds.set(sessionId, turnId),
     stampMessagesCreatedAtAtom: "stamp-created-at",
     startTurnClockAtom: "start-turn-clock",
     turnDeliverySourceBySession: state.turnDeliverySourceBySession,
@@ -278,6 +281,43 @@ describe("useAgentChatSession execution guard", () => {
             })
             await Promise.resolve()
         })
+        act(() => root.unmount())
+    })
+
+    it("stops an accepted shared turn before transcript metadata arrives", async () => {
+        state.busy = true
+        state.cancelSessionExecution.mockResolvedValue({
+            accepted: true,
+            conflict: false,
+            execution: {id: "accepted-turn", state: "stopping"},
+        })
+        let result: ReturnType<typeof useAgentChatSession> | undefined
+        const container = document.createElement("div")
+        const root = createRoot(container)
+        const Probe = () => {
+            result = useAgentChatSession({
+                entityId: "revision-1",
+                sessionId: "session-1",
+                initialMessages: [],
+                intent: {} as never,
+            })
+            return null
+        }
+        act(() => root.render(createElement(Probe)))
+        await act(() => state.capturedHooks!.prepareRequest({messages: [], id: "session-1"}))
+        act(() =>
+            state.capturedHooks!.onData({
+                type: "data-session-accepted",
+                data: {executionId: "accepted-turn"},
+            }),
+        )
+        await act(async () => result!.handleStop())
+        expect(state.cancelSessionExecution).toHaveBeenCalledWith({
+            sessionId: "session-1",
+            projectId: "project-id",
+            expectedExecutionId: "accepted-turn",
+        })
+        expect(state.resolveStopExecution).not.toHaveBeenCalled()
         act(() => root.unmount())
     })
 

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -36,6 +36,7 @@ import {
     sessionRecordCountsReadAtom,
     setSessionStatusAtom,
     setSessionTurnId,
+    setAcceptedSessionTurnId,
     type SessionChatHooks,
 } from "@agenta/chat/state"
 import {
@@ -208,6 +209,9 @@ export const useAgentChatSession = ({
                 const data = part.data as {executionId?: unknown} | undefined
                 acceptedExecutionIdRef.current =
                     typeof data?.executionId === "string" ? data.executionId : null
+                if (acceptedExecutionIdRef.current) {
+                    setAcceptedSessionTurnId(sessionId, acceptedExecutionIdRef.current)
+                }
                 acceptedRunBySession.set(sessionId, acceptedExecutionIdRef.current)
                 setAcceptedRunPending(true)
             }

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -76,6 +76,7 @@ import {
     composerDraftBySession,
     isSessionFresh,
     setSessionTurnId,
+    setAcceptedSessionTurnId,
     turnDeliverySourceBySession,
     type TurnDeliverySource,
 } from "../state/sessionEphemera"
@@ -344,6 +345,9 @@ export const useAgentConversation = ({
                 const data = part.data as {executionId?: unknown} | undefined
                 acceptedExecutionIdRef.current =
                     typeof data?.executionId === "string" ? data.executionId : null
+                if (acceptedExecutionIdRef.current) {
+                    setAcceptedSessionTurnId(sessionId, acceptedExecutionIdRef.current)
+                }
                 acceptedRunBySession.set(sessionId, acceptedExecutionIdRef.current)
                 setAcceptedRunPending(true)
             }

--- a/web/packages/agenta-chat/src/state/sessionEphemera.ts
+++ b/web/packages/agenta-chat/src/state/sessionEphemera.ts
@@ -30,6 +30,13 @@ export const setSessionTurnId = (sessionId: string, turnId: string) => {
     turnIdBySession.set(sessionId, turnId)
 }
 
+/** The runner may accept the same execution again when an approval resumes it. */
+export const setAcceptedSessionTurnId = (sessionId: string, turnId: string) => {
+    if (!turnId.trim()) return
+    supersededTurnIdsBySession.get(sessionId)?.delete(turnId)
+    turnIdBySession.set(sessionId, turnId)
+}
+
 export const getSessionTurnId = (sessionId: string): string | undefined =>
     turnIdBySession.get(sessionId)
 

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
@@ -747,6 +747,9 @@ describe("useAgentConversation", () => {
             expect(result.current.turns.some((turn) => turn.status.isError)).toBe(false)
         })
 
+        // Stop must target the accepted execution even before any transcript turnId arrives.
+        expect(getSessionTurnId(sessionId)).toBe("turn-1")
+
         // Durable: only the user turn. Nothing here can repaint the failure after a reload, and
         // the count the adoption guard compares stays equal to what the log holds.
         await waitFor(() => {

--- a/web/packages/agenta-chat/tests/unit/state/sessionEphemera.test.ts
+++ b/web/packages/agenta-chat/tests/unit/state/sessionEphemera.test.ts
@@ -12,6 +12,7 @@ import {
     isSessionFresh,
     markSessionFresh,
     setSessionTurnId,
+    setAcceptedSessionTurnId,
 } from "../../../src/state/sessionEphemera"
 
 const attachment = (uid: string): PendingAttachment => ({
@@ -55,6 +56,20 @@ describe("fresh-session marker", () => {
 })
 
 describe("turn id freshness", () => {
+    it("restores a resumed execution only after authoritative acceptance", () => {
+        setSessionTurnId("s1", "older-turn")
+        clearSessionTurnId("s1")
+        setSessionTurnId("s1", "approval-turn")
+        clearSessionTurnId("s1")
+        setSessionTurnId("s1", "approval-turn")
+        expect(getSessionTurnId("s1")).toBeUndefined()
+
+        setAcceptedSessionTurnId("s1", "approval-turn")
+        expect(getSessionTurnId("s1")).toBe("approval-turn")
+        setSessionTurnId("s1", "older-turn")
+        expect(getSessionTurnId("s1")).toBe("approval-turn")
+    })
+
     it("does not resurrect the superseded turn while a resumed execution is starting", () => {
         setSessionTurnId("s1", "turn-parked")
         clearSessionTurnId("s1")


### PR DESCRIPTION
## Context
With shared session delivery enabled, clicking Stop after approving a shell command could leave the command running. The browser received the accepted execution ID, but Stop waited for transcript metadata that the detached sender never receives.

## Changes
The desktop and shared chat hooks now cache the execution ID as soon as the runner accepts the turn. Approval resumes can explicitly reaccept the same execution ID; stale transcript metadata still cannot restore a superseded ID.

## How to review
Start with the accepted-ID setter in `sessionEphemera.ts`, then its two acceptance callbacks. The desktop regression asserts that Stop immediately sends cancellation with the accepted ID before transcript metadata arrives. Shared-hook and cache regressions cover detached delivery and same-execution approval resumes.

## Tests
- Reproduced on OSS preview twice: Stop issued no cancellation request and the shell completed.
- New regression assertions failed before the fix and passed afterward.
- Desktop session hook: 10 passed. Chat package: 761 passed. Chat TypeScript check passed.
- Frontend `pnpm lint-fix`: all 25 tasks passed.
- Candidate live browser capture is pending while the isolated local frontend is prepared; deployment QA will verify desktop and mobile Stop before release signoff.

## What to QA
- With shared delivery enabled, approve a long shell command and click Stop in desktop and mobile. The browser sends cancellation for the current execution and the command stops.
- Resume another approval, then Stop again. Reaccepting the same execution must work; stale metadata must not target an older run.
