### PR TITLE
fix(runner): finish stopped turns before running steered input

### DIFF
--- a/services/runner/src/server.ts
+++ b/services/runner/src/server.ts
@@ -943,6 +943,7 @@ async function runAndStreamWithApiBaseResolved(
   }
 
   let result: AgentRunResult;
+  let teardownCompleted = true;
   try {
     // Not a bare `await run(...)`: an await inside the run that never settles would keep this
     // function parked forever, and with it the terminal record below AND the alive watchdog's
@@ -985,6 +986,7 @@ async function runAndStreamWithApiBaseResolved(
       // The run is still pending and may never settle. Give the turn the ending the runner
       // owes it, and let the abandoned run keep its own teardown if it ever unwinds.
       turnClosed = true;
+      teardownCompleted = false;
       const message = `${ABANDONED_TURN_MARKER}: ${outcome.reason}`;
       process.stderr.write(
         `[sessions] ABANDONED session=${sessionId ?? "-"} turn=${turnId ?? "-"}: ${outcome.reason}\n`,
@@ -1031,7 +1033,7 @@ async function runAndStreamWithApiBaseResolved(
     // Same `finally` as the watchdog release, so a run that threw still leaves the registry
     // clean. Scoped to this turn id, so a turn that finishes after its successor registered
     // cannot unregister the successor.
-    if (sessionOwned) unregisterExecution(sessionId, turnId);
+    if (sessionOwned) unregisterExecution(sessionId, turnId, teardownCompleted);
   }
 
   // Streaming delivered the events live, so don't echo them in the terminal record.

--- a/services/runner/src/sessions/applied-commands.ts
+++ b/services/runner/src/sessions/applied-commands.ts
@@ -23,6 +23,8 @@ export interface AppliedCommand {
   executionId: string | null;
   result: "applied" | "obsolete";
   appliedAt: number;
+  /** Duplicate deliveries must respect the original execution's teardown boundary. */
+  settled?: Promise<void>;
 }
 
 /**

--- a/services/runner/src/sessions/control-channel.ts
+++ b/services/runner/src/sessions/control-channel.ts
@@ -116,6 +116,7 @@ export async function applyCommand(
   if (seen) {
     // A no-op that STILL acknowledges. Aborting a second time could kill a newer turn; not
     // acknowledging would leave the command open until the settlement sweep gave up on it.
+    await seen.settled;
     const outcome: ControlOutcome = {
       result: seen.result,
       execution: {
@@ -139,12 +140,17 @@ export async function applyCommand(
 
   // Remember BEFORE aborting. A duplicate that arrives while the first abort is still settling
   // must find the command already taken, not start a second one.
+  let settleCommand!: () => void;
+  const settled = new Promise<void>((resolve) => {
+    settleCommand = resolve;
+  });
   rememberCommand(
     {
       commandId: command.id,
       executionId: outcome.execution.id,
       executionState: outcome.execution.state,
       result: outcome.result,
+      settled,
     },
     now(),
   );
@@ -156,6 +162,11 @@ export async function applyCommand(
         // ACP `session/cancel` to the harness and lets the environment be PARKED rather than
         // deleted (see `cancel-turn.ts` and `shouldPark`). Stop keeps the session warm.
         live.abort();
+        if ((await live.released) === false) {
+          throw new Error(
+            "Stopped execution did not finish releasing its environment.",
+          );
+        }
         log(
           `aborted command=${command.id} session=${command.sessionId} turn=${live.turnId}`,
         );
@@ -187,10 +198,9 @@ export async function applyCommand(
     }
   }
 
-  // Reported as soon as the abort is issued, not after the harness settles. The command's job
-  // is to deliver the Stop; the turn's own teardown then writes its transcript and parks the
-  // sandbox on its own clock, which can take seconds. Waiting for it would make a Stop that
-  // worked look stuck.
+  settleCommand();
+  // The transport already acknowledged Stop. A stopped outcome may promote Steer, so it
+  // must follow teardown rather than merely issuing the abort.
   await report(command, outcome).catch((error) => {
     log(
       `outcome report failed command=${command.id}: ${

--- a/services/runner/src/sessions/execution-registry.ts
+++ b/services/runner/src/sessions/execution-registry.ts
@@ -53,11 +53,19 @@ export interface LiveExecution {
    * environment that was about to be parked. So the applier reads this flag and does nothing.
    */
   settled?: boolean;
+  /** Resolves after teardown and the final ownership release, not merely prompt settlement. */
+  released?: Promise<boolean>;
   /** Stop the run. Aborting is what makes the turn end `cancelled`. */
   abort: () => void;
 }
 
 const executions = new Map<string, LiveExecution>();
+const releases = new Map<
+  string,
+  { promise: Promise<boolean>; resolve: (safeToContinue: boolean) => void }
+>();
+const releaseKey = (sessionId: string, turnId: string) =>
+  JSON.stringify([sessionId, turnId]);
 
 /**
  * Register a run as live. A second registration for the same session REPLACES the first,
@@ -65,6 +73,17 @@ const executions = new Map<string, LiveExecution>();
  * time a replacement turn starts.
  */
 export function registerExecution(execution: LiveExecution): void {
+  const key = releaseKey(execution.sessionId, execution.turnId);
+  let completion = releases.get(key);
+  if (!completion) {
+    let resolve!: (safeToContinue: boolean) => void;
+    const promise = new Promise<boolean>((done) => {
+      resolve = done;
+    });
+    completion = { promise, resolve };
+    releases.set(key, completion);
+  }
+  execution.released = completion.promise;
   executions.set(execution.sessionId, execution);
 }
 
@@ -98,7 +117,14 @@ export function noteExecutionSettled(sessionId: string, turnId: string): void {
  * Remove a run, but only if it is still the one registered. A turn that finishes after its
  * successor registered must not unregister the successor.
  */
-export function unregisterExecution(sessionId: string, turnId: string): void {
+export function unregisterExecution(
+  sessionId: string,
+  turnId: string,
+  safeToContinue = true,
+): void {
+  const key = releaseKey(sessionId, turnId);
+  releases.get(key)?.resolve(safeToContinue);
+  releases.delete(key);
   const current = executions.get(sessionId);
   if (current && current.turnId === turnId) executions.delete(sessionId);
 }
@@ -129,5 +155,7 @@ export function liveExecutions(): LiveExecution[] {
 
 /** Test seam: drop everything. Never called by the server. */
 export function resetExecutionsForTest(): void {
+  for (const completion of releases.values()) completion.resolve(false);
+  releases.clear();
   executions.clear();
 }

--- a/services/runner/tests/unit/control-command-apply.test.ts
+++ b/services/runner/tests/unit/control-command-apply.test.ts
@@ -643,6 +643,80 @@ describe("applyCommand", () => {
   });
 });
 
+describe("Stop teardown before outcome", () => {
+  it("aborts once immediately but holds original and duplicate outcomes until release", async () => {
+    const { execution, aborts } = liveRun();
+    registerExecution(execution);
+    const { reported, report } = collector();
+    const first = applyCommand(command(), { report });
+    const duplicate = applyCommand(command(), { report });
+    await Promise.resolve();
+    assert.equal(aborts.length, 1);
+    assert.equal(
+      reported.length,
+      0,
+      "Steer cannot promote into the still-busy environment",
+    );
+    noteExecutionSettled(SESSION, TURN);
+    await Promise.resolve();
+    assert.equal(reported.length, 0, "prompt settlement precedes teardown");
+    unregisterExecution(SESSION, TURN);
+    await Promise.all([first, duplicate]);
+    assert.equal(reported.length, 2);
+    assert.ok(
+      reported.every((outcome) => outcome.execution.state === "stopped"),
+    );
+  });
+
+  it("reports failure for an abandoned turn, including an already-waiting duplicate", async () => {
+    registerExecution(liveRun().execution);
+    const { reported, report } = collector();
+    const first = applyCommand(command(), { report });
+    const duplicate = applyCommand(command(), { report });
+    unregisterExecution(SESSION, TURN, false);
+    await Promise.all([first, duplicate]);
+    assert.equal(reported.length, 2);
+    assert.ok(
+      reported.every((outcome) => outcome.execution.state === "failed"),
+    );
+  });
+
+  it("does not strand a duplicate when abort throws before teardown", async () => {
+    registerExecution(
+      liveRun({
+        abort: () => {
+          throw new Error("abort failed");
+        },
+      }).execution,
+    );
+    const { reported, report } = collector();
+    await Promise.all([
+      applyCommand(command(), { report }),
+      applyCommand(command(), { report }),
+    ]);
+    assert.equal(reported.length, 2);
+    assert.ok(
+      reported.every((outcome) => outcome.execution.state === "failed"),
+    );
+    unregisterExecution(SESSION, TURN);
+  });
+
+  it("does not let unregistering an older execution release its successor", async () => {
+    const older = liveRun({ turnId: "older" }).execution;
+    const current = liveRun().execution;
+    registerExecution(older);
+    registerExecution(current);
+    const { reported, report } = collector();
+    const pending = applyCommand(command(), { report });
+    unregisterExecution(SESSION, "older");
+    await Promise.resolve();
+    assert.equal(reported.length, 0);
+    unregisterExecution(SESSION, TURN);
+    await pending;
+    assert.equal(reported.length, 1);
+  });
+});
+
 describe("the execution registry", () => {
   it("refuses a lookup from another project once the scope is known", () => {
     const { execution } = liveRun();

--- a/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
+++ b/services/runner/tests/unit/sandbox-agent-orchestration.test.ts
@@ -57,6 +57,7 @@ import {
 } from "../utils/sandbox-agent-harness.ts";
 import {
   findExecution,
+  unregisterExecution,
   registerExecution,
   resetExecutionsForTest,
 } from "../../src/sessions/execution-registry.ts";
@@ -2698,7 +2699,7 @@ describe("runSandboxAgent default ApprovalResponder wiring", () => {
     );
 
     await pauseTeardownStarted;
-    const outcome = await applyCommand(
+    const stopped = applyCommand(
       {
         id: "command-stop-during-pause-teardown",
         projectId,
@@ -2709,8 +2710,7 @@ describe("runSandboxAgent default ApprovalResponder wiring", () => {
       },
       { report: async () => {} },
     );
-    assert.equal(outcome.execution.state, "stopped");
-
+    assert.equal(controller.signal.aborted, true);
     releasePauseTeardown();
     const result = await turn;
 
@@ -2719,6 +2719,8 @@ describe("runSandboxAgent default ApprovalResponder wiring", () => {
     assert.equal(result.stopReason, "cancelled");
     assert.equal(result.cancelSettled, true);
     assert.equal(findExecution(projectId, sessionId)?.settled, true);
+    unregisterExecution(sessionId, turnId);
+    assert.equal((await stopped).execution.state, "stopped");
   });
 
   it("effective ask with no decision pauses the tool, no harness reply (F-024)", async () => {


### PR DESCRIPTION
## Context
Steer could cancel a running tool and then lose the follow-up with “This session is already running a turn.” The runner reported Stop completion immediately after issuing the abort, allowing the API to promote the saved input while the original environment was still busy.

## Changes
Keep the immediate HTTP acknowledgement, but report the stopped outcome after the execution finishes teardown and releases ownership. Duplicate deliveries wait for that same outcome. An abandoned execution reports failure rather than allowing Steer to enter an environment that may still be busy.

## Tests
- Reproduced with a real running shell: cancellation succeeded, but the promoted input failed before the original turn ended.
- Repeated that exact sequence with the fix: correct execution cancelled, follow-up started after its predecessor ended, one saved agent reply, no error records, empty queue and idle session.
- Control/server/timeout regressions: 91 passed, including immediate abort, delayed outcome, duplicate delivery, abandonment, abort failure and execution identity.
- Full runner suite initially passed 2,902 tests; four failures needed generated tool-shim assets, and an existing pause-teardown test needed to release its mocked teardown before awaiting the final outcome. Both affected suites then passed all 91 tests. Strict typecheck passed.

## What to QA
Start a long shell operation, use Steer while the tool is running, and verify the original stops and the follow-up runs once. Check ordinary Stop still acknowledges immediately and keeps the next message usable.

Stacked on #6591 for release/v0.115.2.
