### PR TITLE
fix(sdk): retain builder configuration for approval resumes

### DIFF
--- a/sdks/python/agenta/sdk/agents/utils/effective_config.py
+++ b/sdks/python/agenta/sdk/agents/utils/effective_config.py
@@ -19,8 +19,8 @@ Two guards run before a config becomes durable:
   replayed run re-resolves the same credentials from the project vault. The cost is
   deliberate: an author who inlines a static header into an MCP connection loses that header
   on a replayed resume rather than having it persisted in a second place.
-- **Size cap.** Measured over the dev corpus (n=326 revisions with parameters): avg 761 B,
-  p90 1.4 KB, max 20 KB — the large ones are entirely tool JSON-Schema. Anything over
+- **Size cap.** The playground builder config includes its tool catalog and measured
+  147 KB in live QA, larger than saved agent revisions. Anything over
   :data:`MAX_STAMPED_BYTES` is dropped WHOLE with a warning (a truncated blob would be
   invalid JSON, and a silently truncated config is worse than none); the resume then degrades
   to today's references-only hydration.
@@ -35,8 +35,8 @@ from agenta.sdk.utils.logging import get_module_logger
 
 log = get_module_logger(__name__)
 
-# 3x the largest config measured in the dev corpus. Over this the blob is not stamped at all.
-MAX_STAMPED_BYTES = 64 * 1024
+# Keep normal builder turns (147 KB observed) resumable while bounding durable config size.
+MAX_STAMPED_BYTES = 256 * 1024
 
 # Keys that can hold a raw credential VALUE on a tool/MCP entry or its connection descriptor.
 # `credentials` is deliberately NOT here: it holds vault key names, which the replay needs.

--- a/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/test_wire_contract.py
@@ -775,6 +775,36 @@ def test_effective_parameters_preserve_tool_input_schema_properties():
     assert payload["effectiveParameters"]["agent"]["tools"][0] == tool
 
 
+def test_effective_parameters_preserve_builder_sized_configuration():
+    # The normal playground builder measured 147,209 bytes with 18 tools. Dropping
+    # that config silently resumes against the saved agent, which has no builder tools.
+    parameters = {
+        "agent": {
+            "instructions": {"agents_md": "Build and update the current agent."},
+            "tools": [
+                {
+                    "name": "commit_revision"
+                    if index == 0
+                    else f"builder_tool_{index}",
+                    "description": "Builder operation schema documentation. " * 210,
+                    "inputSchema": {"type": "object", "properties": {}},
+                }
+                for index in range(18)
+            ],
+        }
+    }
+    assert 147_209 <= len(json.dumps(parameters).encode("utf-8")) <= 160_000
+    payload = request_to_wire(
+        harness=HarnessKind.PI,
+        sandbox="local",
+        config=PiAgentTemplate(),
+        messages=[Message(role="user", content="Configure this agent")],
+        session_id="sess-builder",
+        effective_parameters=parameters,
+    )
+    assert payload["effectiveParameters"] == parameters
+
+
 def test_effective_parameters_over_the_cap_are_dropped_whole():
     # A truncated config is invalid JSON and a silently-truncated one is worse than none, so an
     # oversize blob is not stamped at all (the resume degrades to reference hydration).


### PR DESCRIPTION
## Context

Approving a configuration change in the playground builder could resume an agent without its configuration tools, leaving the approved change unapplied. The normal builder configuration measured 147 KB, exceeding the SDK's 64 KiB persistence limit and silently falling back to the saved agent revision during approval resume.

## Changes

Raise the bounded effective-configuration limit to 256 KiB so ordinary builder turns retain their tools and instructions across approval. Credential redaction and whole-config rejection above the limit stay in place.

## Tests

The new 18-tool, 153 KB wire regression fails with the old limit and passes with this change. All 63 wire-contract tests pass, including credential redaction and oversized-config rejection. Ruff format and lint pass. The failed live playground approval was rerun after the fix: its configuration tool returned `committed`, version 2 contained the requested instructions, and the resumed execution ended idle.

## What to QA

Create or configure an agent in the playground, approve its configuration change, and verify the new revision is saved and the requested instructions are applied.
