### PR TITLE
fix(api): persist final heartbeat state after execution settlement

### DIFF
--- a/api/oss/src/dbs/postgres/sessions/streams/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/streams/dao.py
@@ -538,6 +538,7 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
                     SessionExecutionDBE.project_id == project_id,
                     SessionExecutionDBE.session_id == session_id,
                     SessionExecutionDBE.execution_id == stream.expected_turn_id,
+                    SessionExecutionDBE.terminal_outcome.is_not(None),
                 )
                 .exists()
             )
@@ -561,7 +562,11 @@ class SessionStreamsDAO(SessionStreamsDAOInterface, TriggerSessionClaimsDAOInter
                         SessionStreamDBE.flags.contains(
                             {"is_alive": True, "is_running": True}
                         ),
-                        ~terminal_execution_exists,
+                        # Final idle beats must persist after settlement; active beats
+                        # must not revive an execution that has already ended.
+                        (~terminal_execution_exists)
+                        if stream.flags is None or stream.flags.is_running
+                        else True,
                     )
                     .values(**values)
                     .returning(SessionStreamDBE)

--- a/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
+++ b/api/oss/tests/pytest/unit/sessions/test_watchdog_collapse_persistence.py
@@ -586,3 +586,78 @@ async def test_c_heartbeat_blocked_on_sweep_cannot_revive_collapsed_row(
         "is_running": False,
         "is_attached": False,
     }
+
+
+@pytest.mark.anyio
+@pytest.mark.parametrize(
+    "settled,is_running,collapsed,replaced,accepted",
+    [
+        (False, True, False, False, True),
+        (True, False, False, False, True),
+        (True, True, False, False, False),
+        (True, False, True, False, False),
+        (True, False, False, True, False),
+    ],
+)
+async def test_heartbeat_mirror_distinguishes_active_and_settled_execution(
+    anyio_backend, wd_engine, settled, is_running, collapsed, replaced, accepted
+):
+    session_id = "wd-" + uuid.uuid4().hex[:12]
+    turn_id = str(uuid.uuid4())
+    project_id = await _seed_scenario(wd_engine, session_id=session_id, turn_id=turn_id)
+    async with wd_engine.session() as transaction:
+        # Use the actual M3 admission writer: active execution rows exist before completion.
+        await SessionExecutionsDAO(wd_engine).create_continuation(
+            project_id=project_id,
+            session_id=session_id,
+            execution_id=turn_id,
+            parent_execution_id="previous-turn",
+            source_interaction_id=None,
+            transaction=transaction,
+        )
+        if settled:
+            await transaction.execute(
+                text(
+                    "UPDATE session_executions SET state='terminal', "
+                    "terminal_outcome='stopped', settled_by='runner', settled_at=NOW() "
+                    "WHERE project_id=:p AND session_id=:s"
+                ),
+                {"p": project_id, "s": session_id},
+            )
+        if collapsed:
+            await transaction.execute(
+                text(
+                    "UPDATE session_streams SET flags="
+                    '\'{"is_alive": false,"is_running": false,"is_attached": false}\'::jsonb '
+                    "WHERE project_id=:p AND session_id=:s"
+                ),
+                {"p": project_id, "s": session_id},
+            )
+        if replaced:
+            await transaction.execute(
+                text(
+                    "UPDATE session_streams SET turn_id='new-turn' WHERE project_id=:p AND session_id=:s"
+                ),
+                {"p": project_id, "s": session_id},
+            )
+        await transaction.commit()
+
+    mirrored = await SessionStreamsDAO(wd_engine).update(
+        project_id=project_id,
+        user_id=None,
+        session_id=session_id,
+        stream=SessionStreamEdit(
+            flags=SessionStreamFlags(
+                is_alive=True, is_running=is_running, is_attached=False
+            ),
+            turn_id=turn_id,
+            expected_turn_id=turn_id,
+        ),
+    )
+    assert (mirrored is not None) is accepted
+    persisted = await SessionStreamsDAO(wd_engine).get_by_session_id(
+        project_id=project_id, session_id=session_id
+    )
+    assert persisted.flags.is_running is (is_running if accepted else not collapsed)
+    assert persisted.flags.is_alive is (not collapsed)
+    assert persisted.turn_id == ("new-turn" if replaced else turn_id)


### PR DESCRIPTION
## Context

After an agent finished, another browser could keep showing activity dots because the project session list still reported it as running. The individual session snapshot already said idle. The heartbeat database guard treated every execution row as terminal, although approval continuations create active rows upfront, and rejected the final idle update after settlement.

## Changes

Treat only execution rows with a terminal outcome as settled. Allow the final non-running heartbeat to mirror completion after settlement, while retaining the same-turn and previously-live row checks. Late running heartbeats still cannot revive a settled execution or a row collapsed by the watchdog.

## Tests

All eight real Postgres tests in the affected persistence suite pass. New cases cover active continuation rows, final idle updates, late running updates, replaced turns, and collapsed rows. The existing blocked-on-watchdog race also passes. Ruff format and lint pass.

A live local browser turn completed a read tool and returned its exact final answer once. The session detail, project list, and snapshot agreed it was idle, and the observer's activity dots disappeared with the frontend unchanged.

## What to QA

Open the same session in two browsers, run a tool and let it finish, and verify both clients settle. Repeat after an approval continuation. Stop and a later turn must still preserve session ownership.
