### PR TITLE
[fix] Avoid stale app responses in playground test setup

### DIFF
--- a/web/oss/tests/playwright/acceptance/playground/assets/secretPropagation.ts
+++ b/web/oss/tests/playwright/acceptance/playground/assets/secretPropagation.ts
@@ -1,0 +1,12 @@
+export const isSecretPropagationFailure = (response: Record<string, any> | null): boolean => {
+    // A newly recreated fixture connection may precede the service's cached inventory.
+    if (
+        response?.status?.code === 400 &&
+        response.status.type === "https://agenta.ai/docs/misc/errors#v0:schemas:unknown-connection"
+    ) {
+        return true
+    }
+
+    const raw = JSON.stringify(response ?? {}).toLowerCase()
+    return raw.includes("invalid-secrets") || raw.includes("no api key found for model")
+}

--- a/web/oss/tests/playwright/acceptance/playground/tests.ts
+++ b/web/oss/tests/playwright/acceptance/playground/tests.ts
@@ -2,15 +2,11 @@ import {test as baseTest} from "@agenta/web-tests/tests/fixtures/base.fixture"
 import {getKnownLatestRevisionId} from "@agenta/web-tests/tests/fixtures/base.fixture/apiHelpers"
 import {expect, pollLocatorState} from "@agenta/web-tests/utils"
 
+import {isSecretPropagationFailure} from "./assets/secretPropagation"
 import {RoleType, VariantFixtures} from "./assets/types"
 
 const SECRET_PROPAGATION_TIMEOUT_MS = 65_000
 const SECRET_PROPAGATION_POLL_MS = 5_000
-
-const isSecretPropagationFailure = (response: Record<string, any> | null): boolean => {
-    const raw = JSON.stringify(response ?? {}).toLowerCase()
-    return raw.includes("invalid-secrets") || raw.includes("no api key found for model")
-}
 
 const waitForSuccessfulRun = async (
     triggerRun: () => Promise<void>,

--- a/web/oss/tests/playwright/unit/api-helpers.spec.ts
+++ b/web/oss/tests/playwright/unit/api-helpers.spec.ts
@@ -1,12 +1,13 @@
 import {
     appMatchesType,
+    getApp,
     selectLatestAppRevisions,
 } from "@agenta/web-tests/tests/fixtures/base.fixture/apiHelpers"
 import type {
     APP_TYPE,
     ListAppsItem,
 } from "@agenta/web-tests/tests/fixtures/base.fixture/apiHelpers/types"
-import {expect, test} from "@playwright/test"
+import {expect, test, type Page} from "@playwright/test"
 
 const app = (flags: ListAppsItem["flags"]): ListAppsItem =>
     ({
@@ -84,4 +85,51 @@ test("latest revision selection keeps records with a missing version", () => {
     const latest = latestByAppId.get("app-id")
     expect(latest?.version).toBeUndefined()
     expect(latest?.flags?.is_agent).toBe(true)
+})
+
+test("app lookup ignores an old document response during navigation", async () => {
+    const artifact = app({is_application: true})
+    let navigationFinished = false
+    const requestedUrls: string[] = []
+    const fakePage = {
+        url: () => "https://example.test/w/workspace/p/project/settings?tab=llms",
+        goto: async () => {
+            navigationFinished = true
+        },
+        waitForURL: async () => {},
+        // A settings-page query can finish while goto replaces its document. Its
+        // status is valid, but Chromium no longer owns the response body.
+        waitForResponse: async () => ({
+            ok: () => true,
+            text: async () => {
+                throw new Error("Network.getResponseBody: No resource with given identifier found")
+            },
+        }),
+        request: {
+            post: async (url: string) => {
+                expect(navigationFinished).toBe(true)
+                requestedUrls.push(url)
+                return {
+                    ok: () => true,
+                    json: async () =>
+                        url.includes("/revisions/query")
+                            ? {
+                                  workflow_revisions: [
+                                      {
+                                          workflow_id: artifact.id,
+                                          version: "1",
+                                          flags: {is_chat: true},
+                                      },
+                                  ],
+                              }
+                            : {workflows: [artifact], count: 1},
+                }
+            },
+        },
+    } as unknown as Page
+
+    expect(await getApp(fakePage, "chat")).toEqual(artifact)
+    expect(requestedUrls).toHaveLength(2)
+    expect(new URL(requestedUrls[0]).pathname).toMatch(/\/workflows\/query$/)
+    expect(new URL(requestedUrls[0]).searchParams.get("project_id")).toBe("project")
 })

--- a/web/oss/tests/playwright/unit/secret-propagation.spec.ts
+++ b/web/oss/tests/playwright/unit/secret-propagation.spec.ts
@@ -1,0 +1,30 @@
+import {expect, test} from "@playwright/test"
+
+import {isSecretPropagationFailure} from "../acceptance/playground/assets/secretPropagation"
+
+test("retries a stale named connection inventory without masking ordinary run errors", () => {
+    expect(
+        isSecretPropagationFailure({
+            status: {
+                code: 400,
+                type: "https://agenta.ai/docs/misc/errors#v0:schemas:unknown-connection",
+                message: "No provider connection named 'replacement'. Known connections: previous.",
+            },
+        }),
+    ).toBe(true)
+    expect(isSecretPropagationFailure({status: {code: 500, message: "unknown-connection"}})).toBe(
+        false,
+    )
+    expect(
+        isSecretPropagationFailure({status: {code: 400, type: "other:unknown-connection"}}),
+    ).toBe(false)
+    expect(isSecretPropagationFailure({status: {code: 429, message: "Rate limit exceeded"}})).toBe(
+        false,
+    )
+    expect(isSecretPropagationFailure({status: {code: 200}, data: "unknown-connection"})).toBe(
+        false,
+    )
+    expect(isSecretPropagationFailure(null)).toBe(false)
+    expect(isSecretPropagationFailure({status: {type: "#v0:schemas:invalid-secrets"}})).toBe(true)
+    expect(isSecretPropagationFailure({status: {message: "No API key found for model"}})).toBe(true)
+})

--- a/web/tests/tests/fixtures/base.fixture/apiHelpers/index.ts
+++ b/web/tests/tests/fixtures/base.fixture/apiHelpers/index.ts
@@ -460,16 +460,17 @@ export const appMatchesType = (
 }
 
 export const getApp = async (page: Page, type: APP_TYPE = "completion") => {
-    const appsResponse = waitForApiResponse<{workflows: ListAppsItem[]; count: number}>(page, {
-        route: "/workflows/query",
-        method: "POST",
-    })
-
     const projectBasePath = getProjectScopedBasePath(page)
     await page.goto(`${projectBasePath}/prompts`, {waitUntil: "domcontentloaded"})
     await page.waitForURL("**/prompts", {waitUntil: "domcontentloaded"})
 
-    const data = await appsResponse
+    // A background query from the previous document can finish during navigation.
+    // Read fixture data through the request context, whose response survives that navigation.
+    const queryUrl = new URL(`${getApiURL(page)}/workflows/query`)
+    queryUrl.searchParams.set("project_id", getProjectId(page))
+    const response = await page.request.post(queryUrl.toString(), {data: {}})
+    expect(response.ok()).toBe(true)
+    const data = (await response.json()) as {workflows: ListAppsItem[]; count: number}
     const apps = data.workflows ?? []
 
     expect(Array.isArray(apps)).toBe(true)


### PR DESCRIPTION
Playground acceptance setup could read a response from the document it had just navigated away from, causing Chromium to reject the response body before the chat test started. App lookup now queries through the authenticated request context after navigation and explicitly scopes the request to the active project.

A separate recorded retry reached the run but saw the service’s previous provider inventory immediately after the fixture recreated its mock connection. The existing 65-second propagation retry now also recognizes the exact HTTP 400 unknown-connection status. Other errors and the final visible-error assertion remain unchanged.

Validation: both regressions failed before their respective fixes; 7 focused helper tests pass. The single previously failing chat acceptance passed against Railway with the mock provider after each correction (latest 38.8s). Required frontend lint passed across 25 tasks. Root and an independent release agent reviewed the changes.
