### PR TITLE
fix(frontend): refresh configuration after live agent commits

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -166,6 +166,7 @@ const AgentConversation = ({
         runningElsewhere: livenessRunningElsewhere,
         sharedReaderAdvertised,
         refreshFromRecords,
+        onCommittedRevision,
         revalidate,
         setSharedSenderReady,
     } = useAgentChatSession({entityId, sessionId, initialMessages, intent: scrollIntent})
@@ -182,6 +183,7 @@ const AgentConversation = ({
         onReadyChange: setSharedSenderReady,
         onExecutionSettled: settleSharedTurn,
         onDisconnect: refreshFromRecords,
+        onCommittedRevision,
     })
     const livenessUpdatedAt = useAtomValue(sessionLivenessUpdatedAtAtom)
     const refreshLiveness = useSetAtom(refreshSessionLivenessAtom)

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
@@ -40,6 +40,9 @@ const state = vi.hoisted(() => ({
     hydrationBusyRef: undefined as {current: boolean} | undefined,
     busy: false,
     stop: vi.fn(),
+    switchEntity: vi.fn(),
+    setCommitSignal: vi.fn(),
+    invalidateCommit: vi.fn(),
 }))
 
 vi.mock("@agenta/chat/assets", () => ({
@@ -122,7 +125,7 @@ vi.mock("@agenta/entities/session", () => ({
 
 vi.mock("@agenta/entities/trace", () => ({markTraceAsFresh: vi.fn()}))
 vi.mock("@agenta/entities/workflow", () => ({
-    invalidateAgentCommittedRevisionCache: vi.fn(),
+    invalidateAgentCommittedRevisionCache: state.invalidateCommit,
     workflowMolecule: {
         selectors: {configuration: () => "workflow-configuration"},
     },
@@ -168,7 +171,12 @@ vi.mock("@tanstack/react-query", () => ({
 
 vi.mock("jotai", () => ({
     useAtomValue: () => state.projectId,
-    useSetAtom: () => vi.fn(),
+    useSetAtom: (atom: string) =>
+        atom === "switch-entity"
+            ? state.switchEntity
+            : atom === "commit-signal"
+              ? state.setCommitSignal
+              : vi.fn(),
     useStore: () => ({
         get: (atom: string) => {
             if (atom === "record-counts" || atom === "session-messages") return {}
@@ -224,6 +232,10 @@ describe("useAgentChatSession execution guard", () => {
         state.cancelSessionExecution.mockReset()
         state.resolveStopExecution.mockReset()
         state.stop.mockReset()
+        state.switchEntity.mockClear()
+        state.setCommitSignal.mockClear()
+        state.invalidateCommit.mockClear()
+        state.messages = []
         state.resolveStopExecution.mockImplementation(async ({readExecutionId}) => {
             const executionId = readExecutionId()
             return executionId ? {status: "resolved", executionId} : {status: "settled"}
@@ -235,6 +247,46 @@ describe("useAgentChatSession execution guard", () => {
         state.stoppingTurnId = null
         state.stopStateLoading = false
         state.busy = false
+    })
+
+    it("deduplicates live-reader and native commit notifications through the same config switch", () => {
+        let result: ReturnType<typeof useAgentChatSession> | undefined
+        const root = createRoot(document.createElement("div"))
+        const Probe = () => {
+            result = useAgentChatSession({
+                entityId: "revision-1",
+                sessionId: "session-1",
+                initialMessages: [],
+                intent: {} as never,
+            })
+            return null
+        }
+        act(() => root.render(createElement(Probe)))
+        const revision = {revisionId: "revision-2", version: "2"}
+        act(() => {
+            result!.onCommittedRevision(revision)
+            result!.onCommittedRevision(revision)
+        })
+        state.messages = [
+            {
+                id: "commit",
+                role: "assistant",
+                parts: [{type: "data-committed-revision", data: revision}],
+            } as UIMessage,
+        ]
+        act(() => root.render(createElement(Probe)))
+        expect(state.invalidateCommit).toHaveBeenCalledOnce()
+        expect(state.switchEntity).toHaveBeenCalledExactlyOnceWith({
+            currentEntityId: "revision-1",
+            newEntityId: "revision-2",
+        })
+        expect(state.setCommitSignal).toHaveBeenCalledExactlyOnceWith({
+            revisionId: "revision-2",
+            version: "2",
+            prevParameters: null,
+            at: expect.any(Number),
+        })
+        act(() => root.unmount())
     })
 
     it("allows durable hydration for an accepted shared sender while protecting local streaming", async () => {

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -659,33 +659,33 @@ export const useAgentChatSession = ({
     // config. Deduped by revision id so a re-render (token stream) doesn't re-invalidate.
     const committedRevisionsSeenRef = useRef<Set<string>>(new Set())
     const setAgentCommitSignal = useSetAtom(agentSelfCommitSignalAtom)
+    const onCommittedRevision = useCallback(
+        (data?: {revisionId?: string; version?: string}) => {
+            const key = data?.revisionId ?? JSON.stringify(data ?? {}) ?? "committed"
+            if (committedRevisionsSeenRef.current.has(key)) return
+            committedRevisionsSeenRef.current.add(key)
+            invalidateAgentCommittedRevisionCache()
+            if (data?.revisionId && data.revisionId !== entityId) {
+                const prevParameters = store.get(workflowMolecule.selectors.configuration(entityId))
+                setAgentCommitSignal({
+                    revisionId: data.revisionId,
+                    version: data.version,
+                    prevParameters: prevParameters ?? null,
+                    at: Date.now(),
+                })
+                switchEntity({currentEntityId: entityId, newEntityId: data.revisionId})
+            }
+        },
+        [entityId, switchEntity, store, setAgentCommitSignal],
+    )
     useEffect(() => {
         for (const message of messages) {
             for (const part of message.parts) {
                 if ((part as {type?: string}).type !== "data-committed-revision") continue
-                const data = (part as {data?: {revisionId?: string; version?: string}}).data
-                // A stable key per commit: prefer the revision id, fall back to the whole payload.
-                const key = data?.revisionId ?? JSON.stringify(data ?? {}) ?? "committed"
-                if (committedRevisionsSeenRef.current.has(key)) continue
-                committedRevisionsSeenRef.current.add(key)
-                invalidateAgentCommittedRevisionCache()
-                if (data?.revisionId && data.revisionId !== entityId) {
-                    // Capture the OUTGOING revision's parameters before switching, so the config
-                    // panel can show what the agent changed (per-section indicators + summary).
-                    const prevParameters = store.get(
-                        workflowMolecule.selectors.configuration(entityId),
-                    )
-                    setAgentCommitSignal({
-                        revisionId: data.revisionId,
-                        version: data.version,
-                        prevParameters: prevParameters ?? null,
-                        at: Date.now(),
-                    })
-                    switchEntity({currentEntityId: entityId, newEntityId: data.revisionId})
-                }
+                onCommittedRevision((part as {data?: {revisionId?: string; version?: string}}).data)
             }
         }
-    }, [messages, entityId, switchEntity, store, setAgentCommitSignal])
+    }, [messages, onCommittedRevision])
 
     const projectId = useAtomValue(projectIdAtom)
     const expectedStopExecutionIdRef = useRef<string | undefined>(undefined)
@@ -912,6 +912,7 @@ export const useAgentChatSession = ({
         runningElsewhere,
         sharedReaderAdvertised,
         refreshFromRecords,
+        onCommittedRevision,
         setSharedSenderReady,
         revalidate,
         stopped,

--- a/web/packages/agenta-chat/src/assets/committedRevisions.ts
+++ b/web/packages/agenta-chat/src/assets/committedRevisions.ts
@@ -1,0 +1,65 @@
+import type {SessionRecord} from "@agenta/entities/session"
+import {canonicalClientToolName} from "@agenta/shared/clientTools"
+
+export interface CommittedRevision {
+    variantId: string
+    revisionId: string
+    version: string
+}
+
+const committedRevisionData = (output: unknown): CommittedRevision | null => {
+    let value = output
+    if (typeof value === "string") {
+        try {
+            value = JSON.parse(value)
+        } catch {
+            return null
+        }
+    }
+    if (!value || typeof value !== "object") return null
+    const payload = value as Record<string, unknown>
+    if (payload.status !== "committed" && !payload.count) return null
+    if (!payload.workflow_revision || typeof payload.workflow_revision !== "object") return null
+    const revision = payload.workflow_revision as Record<string, unknown>
+    const variantId = revision.workflow_variant_id ?? revision.variant_id
+    const revisionId = revision.id ?? revision.workflow_revision_id ?? revision.revision_id
+    const version = revision.version
+    if (
+        typeof variantId !== "string" ||
+        !variantId ||
+        typeof revisionId !== "string" ||
+        !revisionId ||
+        (typeof version !== "string" && typeof version !== "number") ||
+        !String(version)
+    )
+        return null
+    return {variantId, revisionId, version: String(version)}
+}
+
+/** Notifications learned during this mounted reader, never historical side effects. */
+export const liveCommittedRevisions = (
+    records: SessionRecord[],
+    afterSequence?: number,
+): CommittedRevision[] => {
+    if (afterSequence === undefined) return []
+    const names = new Map<string, string>()
+    const revisions = new Map<string, CommittedRevision>()
+    for (const row of records) {
+        const payload = row.payload
+        if (!payload || typeof payload.id !== "string") continue
+        if (payload.type === "tool_call" && typeof payload.name === "string")
+            names.set(payload.id, canonicalClientToolName(payload.name))
+        if (
+            payload.type !== "tool_result" ||
+            payload.isError ||
+            payload.denied ||
+            typeof row.sequence !== "number" ||
+            row.sequence <= afterSequence ||
+            names.get(payload.id) !== "commit_revision"
+        )
+            continue
+        const revision = committedRevisionData(payload.data ?? payload.output)
+        if (revision) revisions.set(revision.revisionId, revision)
+    }
+    return [...revisions.values()]
+}

--- a/web/packages/agenta-chat/src/assets/index.ts
+++ b/web/packages/agenta-chat/src/assets/index.ts
@@ -16,3 +16,5 @@ export * from "./composerRunState"
 export {startupLabelFromDataPart} from "./startupPhases"
 export {getMessageTurnId, latestTurnId} from "./agentTurn"
 export * from "./resolveStopExecution"
+
+export {liveCommittedRevisions, type CommittedRevision} from "./committedRevisions"

--- a/web/packages/agenta-chat/src/hooks/useSessionLivePreview.ts
+++ b/web/packages/agenta-chat/src/hooks/useSessionLivePreview.ts
@@ -12,6 +12,7 @@ import {projectIdAtom} from "@agenta/shared/state"
 import type {UIMessage} from "ai"
 import {useAtom, useAtomValue, useSetAtom} from "jotai"
 
+import {liveCommittedRevisions, type CommittedRevision} from "../assets/committedRevisions"
 import type {SessionTranscript} from "../assets/loadSession"
 import {transcriptToMessages} from "../assets/transcriptToMessages"
 import {
@@ -43,6 +44,7 @@ export const useSessionLivePreview = ({
     runningElsewhere,
     sender,
     onReadyChange,
+    onCommittedRevision,
     onExecutionSettled,
     onDisconnect,
 }: {
@@ -53,6 +55,8 @@ export const useSessionLivePreview = ({
     runningElsewhere: boolean
     /** Subscribe before this browser sends its next turn. */
     sender?: boolean
+    /** Reports commits learned after initial hydration, once their transcript is adopted. */
+    onCommittedRevision?: (revision: CommittedRevision) => void
     /** Non-reactive request-pipeline signal: true only while the shared event route is ready. */
     onReadyChange?: (ready: boolean) => void
     /** Reports the shared path's durable terminal verdict for the current execution. */
@@ -73,6 +77,8 @@ export const useSessionLivePreview = ({
     const [runningFromSnapshot, setRunningFromSnapshot] = useState(false)
     const [readerReady, setReaderReady] = useState(false)
     const [sharedSettledAt, setSharedSettledAt] = useState(0)
+    const onCommittedRevisionRef = useRef(onCommittedRevision)
+    onCommittedRevisionRef.current = onCommittedRevision
     const onDisconnectRef = useRef(onDisconnect)
     onDisconnectRef.current = onDisconnect
     const retryHydrationRef = useRef<() => void>(() => undefined)
@@ -106,6 +112,7 @@ export const useSessionLivePreview = ({
         let reconnectDelayMs = RECONNECT_INITIAL_DELAY_MS
         let generation = 0
         let durable = createSessionDurableEventState()
+        let liveBaselineSequence: number | undefined
 
         const close = () => {
             connection?.close()
@@ -136,7 +143,11 @@ export const useSessionLivePreview = ({
 
         const readBoundedTranscript = async (
             throughSequence: number,
-        ): Promise<{transcript: SessionTranscript; coveredEntityIds: Set<string>} | null> => {
+        ): Promise<{
+            transcript: SessionTranscript
+            coveredEntityIds: Set<string>
+            committedRevisions: CommittedRevision[]
+        } | null> => {
             if (!projectId) return null
             const [records, interactionRowStates] = await Promise.all([
                 querySessionTranscript({sessionId, projectId, throughSequence}),
@@ -164,6 +175,7 @@ export const useSessionLivePreview = ({
                     interactionRows: interactionRowStates,
                 },
                 coveredEntityIds,
+                committedRevisions: liveCommittedRevisions(records, liveBaselineSequence),
             }
         }
 
@@ -207,6 +219,9 @@ export const useSessionLivePreview = ({
                         scheduleReconnect()
                         return
                     }
+                    for (const revision of bounded.committedRevisions)
+                        onCommittedRevisionRef.current?.(revision)
+                    liveBaselineSequence ??= snapshot.read.latest_sequence
                     if (!snapshotRunning) clearPreview(sessionId)
                     else
                         setPreview((current) => ({
@@ -278,6 +293,8 @@ export const useSessionLivePreview = ({
                             const adopted = transcript ? await adoptTranscript(transcript) : false
                             if (disposed || currentGeneration !== generation) return
                             if (adopted) {
+                                for (const revision of bounded?.committedRevisions ?? [])
+                                    onCommittedRevisionRef.current?.(revision)
                                 setPreview((current) =>
                                     retireSessionLivePreview(
                                         bounded && previewBoundary

--- a/web/packages/agenta-chat/tests/unit/assets/committedRevisions.test.ts
+++ b/web/packages/agenta-chat/tests/unit/assets/committedRevisions.test.ts
@@ -1,0 +1,75 @@
+import type {SessionRecord} from "@agenta/entities/session"
+import {describe, expect, it} from "vitest"
+import {liveCommittedRevisions} from "../../../src/assets/committedRevisions"
+
+const output = {
+    status: "committed",
+    workflow_revision: {
+        id: "01a0740f-777a-79e3-90cf-da5cf00adba7",
+        workflow_variant_id: "01a07403-a0b6-7b03-ab5a-a8380ddc80ea",
+        version: "2",
+    },
+}
+const row = (sequence: number, payload: Record<string, unknown>): SessionRecord => ({
+    id: `row-${sequence}`,
+    session_id: "session-1",
+    project_id: "project-1",
+    sequence,
+    event_index: sequence,
+    sender: "agent",
+    session_update: String(payload.type),
+    payload,
+    created_at: null,
+})
+const records = (
+    name = "commit_revision",
+    result: Record<string, unknown> = {output: JSON.stringify(output)},
+) => [
+    row(24, {type: "tool_call", id: "call-1", name, input: {}}),
+    row(25, {type: "tool_result", id: "call-1", ...result}),
+]
+
+describe("liveCommittedRevisions", () => {
+    it.each([
+        "commit_revision",
+        "mcp__agenta-tools__commit_revision",
+        "mcp.agenta-tools.commit_revision",
+    ])("projects the captured successful output for %s", (name) => {
+        expect(liveCommittedRevisions(records(name), 23)).toEqual([
+            {
+                revisionId: output.workflow_revision.id,
+                variantId: output.workflow_revision.workflow_variant_id,
+                version: "2",
+            },
+        ])
+    })
+    it("keeps initial and reopened history inert", () => {
+        expect(liveCommittedRevisions(records())).toEqual([])
+        expect(liveCommittedRevisions(records(), 25)).toEqual([])
+    })
+    it("ignores failed, denied, malformed and unrelated tool results", () => {
+        for (const result of [
+            {output, isError: true},
+            {output, denied: true},
+            {output: "invalid json"},
+            {output: {status: "committed"}},
+        ])
+            expect(liveCommittedRevisions(records("commit_revision", result), 23)).toEqual([])
+        expect(liveCommittedRevisions(records("other_tool"), 23)).toEqual([])
+    })
+    it("supports the legacy successful result and deduplicates a revision", () => {
+        const legacy = {
+            count: 1,
+            workflow_revision: {revision_id: "rev-2", variant_id: "var-1", version: 2},
+        }
+        expect(
+            liveCommittedRevisions(
+                [
+                    ...records("commit_revision", {data: legacy}),
+                    ...records("commit_revision", {data: legacy}),
+                ],
+                23,
+            ),
+        ).toEqual([{revisionId: "rev-2", variantId: "var-1", version: "2"}])
+    })
+})

--- a/web/packages/agenta-chat/tests/unit/hooks/useSessionLivePreview.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/hooks/useSessionLivePreview.test.tsx
@@ -66,6 +66,125 @@ describe("useSessionLivePreview", () => {
         vi.unstubAllGlobals()
     })
 
+    it.each(["live", "reconnect", "history"])(
+        "delivers live commit callbacks after confirmed adoption without replaying history (%s)",
+        async (mode) => {
+            const output = {
+                status: "committed",
+                workflow_revision: {
+                    id: "revision-2",
+                    workflow_variant_id: "variant-1",
+                    version: "2",
+                },
+            }
+            const rows = [
+                {
+                    ...record("call", {
+                        type: "tool_call",
+                        id: "commit-1",
+                        name: "commit_revision",
+                        input: {},
+                    }),
+                    sequence: 1,
+                },
+                {
+                    ...record("result", {
+                        type: "tool_result",
+                        id: "commit-1",
+                        output: JSON.stringify(output),
+                    }),
+                    sequence: 2,
+                },
+            ]
+            mocks.fetchSessionSnapshot.mockResolvedValue({
+                session: {flags: {is_running: true}},
+                read: {latest_sequence: mode === "history" ? 2 : 0},
+            })
+            mocks.querySessionTranscript.mockResolvedValue(mode === "history" ? rows : [])
+            // A watch may already have adopted this watermark: confirmation returns true
+            // without replacing messages. The notification must still reach the host.
+            const onDisconnect = vi.fn().mockResolvedValue(true)
+            const onCommittedRevision = vi.fn()
+            const store = createStore()
+            store.set(projectIdAtom, "project-1")
+            const wrapper = ({children}: {children: ReactNode}) =>
+                createElement(Provider, {store}, children)
+            renderHook(
+                () =>
+                    useSessionLivePreview({
+                        sessionId: "session-1",
+                        sharedReaderAdvertised: true,
+                        runningElsewhere: false,
+                        sender: true,
+                        onDisconnect,
+                        onCommittedRevision,
+                    }),
+                {wrapper},
+            )
+            await waitFor(() => expect(mocks.connectSessionLiveEvents).toHaveBeenCalledOnce())
+            const notificationParts = () =>
+                onCommittedRevision.mock.calls.map(([revision]) => revision)
+            expect(notificationParts()).toEqual([])
+            if (mode === "history") return
+
+            mocks.querySessionTranscript.mockResolvedValue(rows)
+            const connection = mocks.connectSessionLiveEvents.mock.calls[0][0]
+            const event = {
+                version: 1,
+                kind: "event",
+                session_id: "session-1",
+                execution_id: "turn-1",
+                frame_or_event_id: "result",
+                sequence: 2,
+                watermark: 2,
+                type: "tool.completed",
+                payload: {tool_call_id: "commit-1", name: "commit_revision", output},
+                created_at: "2026-09-06T00:00:00Z",
+            }
+            if (mode === "live") act(() => connection.onEvent(event))
+            else {
+                mocks.fetchSessionSnapshot.mockResolvedValue({
+                    session: {flags: {is_running: false}},
+                    read: {latest_sequence: 2},
+                })
+                act(() => {
+                    connection.onDisconnect({reason: "connection_lost", reconnect: true})
+                    document.dispatchEvent(new Event("visibilitychange"))
+                })
+            }
+            await waitFor(() => expect(notificationParts()).toHaveLength(1))
+            expect(notificationParts()[0]).toEqual({
+                revisionId: "revision-2",
+                variantId: "variant-1",
+                version: "2",
+            })
+            const current = mocks.connectSessionLiveEvents.mock.calls.at(-1)![0]
+            act(() => current.onEvent(event))
+            await act(async () => Promise.resolve())
+            expect(notificationParts()).toHaveLength(1)
+            // A later terminal adoption must not lose the live commit; host revision-ID dedup
+            // handles repeated notifications while transcript messages remain side-effect-free.
+            act(() =>
+                current.onEvent({
+                    ...event,
+                    sequence: 3,
+                    watermark: 3,
+                    frame_or_event_id: "done",
+                    type: "execution.stopped",
+                    payload: {},
+                }),
+            )
+            await waitFor(() => expect(notificationParts()).toHaveLength(2))
+            for (const [transcript] of onDisconnect.mock.calls) {
+                expect(
+                    transcript.messages
+                        .flatMap((message: {parts: {type: string}[]}) => message.parts)
+                        .some((part: {type: string}) => part.type === "data-committed-revision"),
+                ).toBe(false)
+            }
+        },
+    )
+
     it("keeps the flag-off path snapshot-free", async () => {
         const store = createStore()
         store.set(projectIdAtom, "project-1")


### PR DESCRIPTION
## Context

When an agent saved a new revision through the shared session reader, the playground kept showing and running the old configuration. The saved tool result reached the transcript, but the configuration refresh signal existed only on the original invoke stream.

## Changes

Read successful `commit_revision` results from the live reader's adopted transcript and notify the existing configuration switch handler. Initial history stays inert. Reconnect catch-up and an already-adopted transcript still deliver the notification, while revision-ID deduplication prevents repeated switches. Native stream notifications use the same handler.

## Tests

41 focused tests pass, covering initial history, live and reconnect delivery, confirmed adoption, repeated notifications, wrapped tool names, invalid results, and the desktop configuration switch. Shared package TypeScript, shared and desktop ESLint, and formatting pass.

Live browser regression and mobile smoke are pending a frontend image containing this change. The original failure was reproduced in the real playground: the agent saved v2 while the selected configuration stayed on v1.

## What to QA

Create an agent, approve its configuration commit, and confirm the playground selects the saved revision with the new settings. Repeat with another client reconnecting during the commit. Reopening an old session must not switch the selected revision merely from historical tool results.
