### PR TITLE
fix(frontend): retire tool previews when approvals take over

### DIFF
--- a/web/packages/agenta-chat/src/model/livePreview.ts
+++ b/web/packages/agenta-chat/src/model/livePreview.ts
@@ -333,6 +333,18 @@ export const retireCoveredSessionLivePreview = (
             message.parts.flatMap((part) => (part.type === "reasoning" ? [part.text] : [])),
         ),
     )
+    const durableToolIds = new Set(
+        adoptedMessages.flatMap((message) =>
+            message.parts.flatMap((part) =>
+                (part.type === "dynamic-tool" || part.type.startsWith("tool-")) &&
+                "toolCallId" in part &&
+                "state" in part &&
+                part.state !== "input-streaming"
+                    ? [part.toolCallId]
+                    : [],
+            ),
+        ),
+    )
     const byExecution = {...state.byExecution}
     for (const executionId of boundary.executionOrder) {
         const captured = boundary.byExecution[executionId]
@@ -343,6 +355,9 @@ export const retireCoveredSessionLivePreview = (
             if (!entity || current.byEntity[id]?.part !== entity.part) return false
             return (
                 coveredEntityIds.has(id) ||
+                ((entity.part.state === "input-streaming" ||
+                    entity.part.state === "input-available") &&
+                    durableToolIds.has(String(entity.part.toolCallId))) ||
                 (entity.complete === true &&
                     entity.part.type === "reasoning" &&
                     durableReasoning.has(String(entity.part.text)))

--- a/web/packages/agenta-chat/tests/unit/hooks/useSessionLivePreview.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/hooks/useSessionLivePreview.test.tsx
@@ -185,6 +185,97 @@ describe("useSessionLivePreview", () => {
         },
     )
 
+    it("retires an old approval preview when recovery adopts a newer running turn", async () => {
+        mocks.fetchSessionSnapshot.mockResolvedValue({
+            session: {flags: {is_running: false}},
+            execution: null,
+            read: {latest_sequence: 0},
+        })
+        mocks.querySessionTranscript.mockResolvedValue([])
+        const onDisconnect = vi.fn().mockResolvedValue(true)
+        const store = createStore()
+        store.set(projectIdAtom, "project-1")
+        const wrapper = ({children}: {children: ReactNode}) =>
+            createElement(Provider, {store}, children)
+        const {result} = renderHook(
+            () =>
+                useSessionLivePreview({
+                    sessionId: "session-1",
+                    sharedReaderAdvertised: true,
+                    runningElsewhere: true,
+                    onDisconnect,
+                }),
+            {wrapper},
+        )
+        await waitFor(() => expect(mocks.connectSessionLiveEvents).toHaveBeenCalledOnce())
+        const first = mocks.connectSessionLiveEvents.mock.calls[0][0]
+        const tool = {
+            type: "tool_call",
+            id: "bash-call",
+            name: "bash",
+            input: {command: "sleep 12"},
+        }
+        mocks.querySessionTranscript.mockResolvedValue([record("call", tool)])
+        onDisconnect.mockResolvedValueOnce(false)
+        act(() => {
+            first.onFrame({
+                version: 1,
+                kind: "frame",
+                session_id: "session-1",
+                execution_id: "old-turn",
+                frame_or_event_id: "old:0",
+                frame_index: 0,
+                entity_id: "bash-call",
+                type: "tool-input-available",
+                payload: {toolCallId: "bash-call", toolName: "bash", input: tool.input},
+                created_at: "2026-09-06T00:00:00Z",
+            })
+            first.onEvent({
+                version: 1,
+                kind: "event",
+                session_id: "session-1",
+                execution_id: "old-turn",
+                frame_or_event_id: "paused",
+                sequence: 2,
+                watermark: 2,
+                type: "execution.stopped",
+                payload: {reason: "paused"},
+                created_at: "2026-09-06T00:00:01Z",
+            })
+        })
+        await waitFor(() => expect(onDisconnect).toHaveBeenCalledTimes(2))
+        expect(result.current.messages[0].parts).toMatchObject([{toolCallId: "bash-call"}])
+        mocks.fetchSessionSnapshot.mockResolvedValue({
+            session: {flags: {is_running: true}},
+            execution: {turn_id: "new-turn", end_time: null},
+            read: {latest_sequence: 3},
+        })
+        act(() => {
+            first.onDisconnect({reason: "connection_lost", reconnect: true})
+            document.dispatchEvent(new Event("visibilitychange"))
+        })
+        await waitFor(() => expect(mocks.connectSessionLiveEvents).toHaveBeenCalledTimes(2))
+        expect(result.current.messages).toEqual([])
+        const second = mocks.connectSessionLiveEvents.mock.calls[1][0]
+        act(() =>
+            second.onFrame({
+                version: 1,
+                kind: "frame",
+                session_id: "session-1",
+                execution_id: "new-turn",
+                frame_or_event_id: "new:0",
+                frame_index: 0,
+                entity_id: "new-answer",
+                type: "text-delta",
+                payload: {delta: "New answer stays visible"},
+                created_at: "2026-09-06T00:00:02Z",
+            }),
+        )
+        expect(result.current.messages[0].parts).toEqual([
+            {type: "text", text: "New answer stays visible"},
+        ])
+    })
+
     it("keeps the flag-off path snapshot-free", async () => {
         const store = createStore()
         store.set(projectIdAtom, "project-1")

--- a/web/packages/agenta-chat/tests/unit/model/livePreview.test.ts
+++ b/web/packages/agenta-chat/tests/unit/model/livePreview.test.ts
@@ -7,6 +7,7 @@ import {
     isSessionSnapshotRunning,
     reduceSessionLivePreview,
     retireSessionLivePreview,
+    retireCoveredSessionLivePreview,
     markSessionLivePreviewTerminal,
     sessionLivePreviewMessages,
     shouldRefreshLegacyObserverLiveness,
@@ -33,6 +34,60 @@ const frame = (
 })
 
 describe("session live preview reducer", () => {
+    it("hands a paused tool preview to its durable approval without leaving running dots", () => {
+        const toolCallId = "native-bash-call"
+        const state = reduceSessionLivePreview(
+            createSessionLivePreviewState(),
+            frame(
+                0,
+                "tool-input-available",
+                {toolCallId, toolName: "bash", input: {command: "sleep 12"}},
+                toolCallId,
+            ),
+        )
+        const durable = [
+            {
+                id: "saved-approval",
+                role: "assistant" as const,
+                parts: [
+                    {
+                        type: "tool-bash" as const,
+                        toolCallId,
+                        state: "approval-requested" as const,
+                        input: {command: "sleep 12"},
+                        approval: {id: "approval-1"},
+                    },
+                ],
+            },
+        ]
+        const retired = retireCoveredSessionLivePreview(state, state, new Set(), durable)
+        expect(sessionLivePreviewMessages(retired)).toEqual([])
+        expect(durable[0].parts[0].state).toBe("approval-requested")
+
+        const completedWhileReading = reduceSessionLivePreview(
+            state,
+            frame(1, "tool-output-error", {toolCallId, errorText: "tool failed"}, toolCallId),
+        )
+        const preserved = retireCoveredSessionLivePreview(
+            completedWhileReading,
+            state,
+            new Set(),
+            durable,
+        )
+        expect(sessionLivePreviewMessages(preserved)[0].parts).toMatchObject([
+            {state: "output-error"},
+        ])
+        const alreadyCompleted = retireCoveredSessionLivePreview(
+            completedWhileReading,
+            completedWhileReading,
+            new Set(),
+            durable,
+        )
+        expect(sessionLivePreviewMessages(alreadyCompleted)[0].parts).toMatchObject([
+            {state: "output-error"},
+        ])
+    })
+
     it("removes the control-only invoke message but preserves an invoke error", () => {
         const accepted = {
             id: "accepted",


### PR DESCRIPTION
## Context
A tool waiting for approval could remain visible as a second running tool after its saved approval row appeared. If terminal transcript adoption was deferred to protect the approval, that temporary preview could survive recovery into the next turn and leave activity dots after completion.

## Changes
Hand an unchanged input preview to the saved tool with the same call ID when the bounded transcript is adopted. Keep newer tool outputs and errors, and keep text that the saved transcript does not cover. The existing approval card remains the source of the approval state.

## How to review
Start with the tool ownership check in `retireCoveredSessionLivePreview`, then the reducer regression and the hook recovery scenario. This PR is stacked on #6596 so one frontend image can verify both corrections.

## Tests
The new reducer regression fails before the correction. All 61 combined reader, preview, and commit-notification tests pass after stacking; TypeScript and all 25 frontend lint tasks pass. Independent review passed. The original defect was captured in a real OSS preview session; fixed-image desktop/mobile browser verification is pending the combined image build.

## What to QA
With the shared reader enabled, pause on a tool approval, then resume or cancel it and continue with another turn. Each tool should have one visible row, and completed turns should leave no running preview or activity dots. Newer streamed text and tool errors must stay visible during saved-transcript updates.
