### PR TITLE
fix(api): keep queued messages behind pending approvals

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -1183,6 +1183,7 @@ session_commands_service = SessionCommandsService(
 )
 session_inputs_service = SessionInputsService(
     inputs_dao=session_inputs_dao,
+    interactions_dao=interactions_dao,
     streams_service=session_streams_service,
     executions_dao=session_executions_dao,
     continuation_resumer=session_commands_service.resume_recoverable_continuation,

--- a/api/oss/src/core/sessions/inputs/service.py
+++ b/api/oss/src/core/sessions/inputs/service.py
@@ -16,6 +16,10 @@ from oss.src.core.sessions.inputs.types import (
     SessionInputNotFound,
     SessionInputNotRemovable,
 )
+from oss.src.core.sessions.interactions.dtos import SessionInteractionStatus
+from oss.src.core.sessions.interactions.interfaces import (
+    SessionInteractionsDAOInterface,
+)
 from oss.src.core.sessions.executions.interfaces import SessionExecutionsDAOInterface
 from oss.src.core.sessions.streams.service import SessionStreamsService
 from oss.src.utils.env import env
@@ -38,11 +42,13 @@ class SessionInputsService:
         inputs_dao: SessionInputsDAOInterface,
         streams_service: SessionStreamsService,
         executions_dao: Optional[SessionExecutionsDAOInterface] = None,
+        interactions_dao: Optional[SessionInteractionsDAOInterface] = None,
         continuation_resumer: Optional[Callable[..., Awaitable[Optional[str]]]] = None,
     ) -> None:
         self._dao = inputs_dao
         self._streams = streams_service
         self._executions = executions_dao
+        self._interactions = interactions_dao
         self._continuation_resumer = continuation_resumer
 
     async def admit(
@@ -75,6 +81,19 @@ class SessionInputsService:
             project_id=project_id, session_id=session_id
         )
         busy = bool(stream and stream.flags and stream.flags.is_running)
+        # A parked approval has no running heartbeat but still owns Queue.
+        queued_behind_interaction = bool(
+            policy == "queue"
+            and env.agenta.sessions.queue
+            and stream
+            and stream.turn_id
+            and await self._has_pending_interaction(
+                project_id=project_id,
+                session_id=session_id,
+                execution_id=stream.turn_id,
+            )
+        )
+        busy = busy or queued_behind_interaction
         resumed_execution_id: Optional[str] = None
         if (
             not busy
@@ -101,6 +120,7 @@ class SessionInputsService:
         if not idempotency_key:
             raise ValueError("Idempotency-Key is required when queueing input.")
 
+        retry_after_interaction = False
         async with self._dao.transaction() as transaction:
             source_execution = None
             successor_execution_id = None
@@ -128,38 +148,87 @@ class SessionInputsService:
             if (
                 source_execution is not None
                 and source_execution.terminal_outcome is not None
+                and not (
+                    queued_behind_interaction
+                    and await self._has_pending_interaction(
+                        project_id=project_id,
+                        session_id=session_id,
+                        execution_id=current_execution_id,
+                        transaction=transaction,
+                    )
+                )
             ):
-                successor = await self._dao.fetch_active_successor(
-                    project_id=project_id,
-                    session_id=session_id,
+                if queued_behind_interaction:
+                    # An approval can win while Queue waits for the execution lock.
+                    # Re-enter admission outside this transaction so its continuation,
+                    # rather than a fresh run, owns the queued message.
+                    retry_after_interaction = True
+                else:
+                    successor = await self._dao.fetch_active_successor(
+                        project_id=project_id,
+                        session_id=session_id,
+                        transaction=transaction,
+                    )
+                    successor_execution_id = (
+                        successor.promoted_execution_id
+                        if successor is not None
+                        else None
+                    )
+                    if successor_execution_id is None:
+                        return PendingInputAdmission(action="execute")
+            if not retry_after_interaction:
+                item = await self._dao.create_input(
+                    user_id=user_id,
+                    pending_input=PendingInputCreate(
+                        project_id=project_id,
+                        session_id=session_id,
+                        content=content,
+                        policy=policy,
+                        idempotency_key=idempotency_key,
+                        request_fingerprint=fingerprint,
+                    ),
+                    prioritize=policy == "steer",
                     transaction=transaction,
                 )
-                successor_execution_id = (
-                    successor.promoted_execution_id if successor is not None else None
-                )
-                if successor_execution_id is None:
-                    return PendingInputAdmission(action="execute")
-            item = await self._dao.create_input(
+                # `create_input` rechecks under the session transaction lock, so a concurrent
+                # admission can return the row that won after our optimistic read above.
+                if item.request_fingerprint != fingerprint:
+                    raise SessionInputIdempotencyConflict()
+        if retry_after_interaction:
+            return await self.admit(
+                project_id=project_id,
                 user_id=user_id,
-                pending_input=PendingInputCreate(
-                    project_id=project_id,
-                    session_id=session_id,
-                    content=content,
-                    policy=policy,
-                    idempotency_key=idempotency_key,
-                    request_fingerprint=fingerprint,
-                ),
-                prioritize=policy == "steer",
-                transaction=transaction,
+                session_id=session_id,
+                content=content,
+                policy=policy,
+                idempotency_key=idempotency_key,
             )
-            # `create_input` rechecks under the session transaction lock, so a concurrent
-            # admission can return the row that won after our optimistic read above.
-            if item.request_fingerprint != fingerprint:
-                raise SessionInputIdempotencyConflict()
         return PendingInputAdmission(
             action="pending",
             input=item,
             execution_id=successor_execution_id or current_execution_id,
+        )
+
+    async def _has_pending_interaction(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        execution_id: str,
+        transaction: Optional[Any] = None,
+    ) -> bool:
+        if self._interactions is None:
+            return False
+        interactions = await self._interactions.fetch_turn_interactions(
+            project_id=project_id,
+            session_id=session_id,
+            turn_id=execution_id,
+            transaction=transaction,
+            for_update=transaction is not None,
+        )
+        return any(
+            interaction.status == SessionInteractionStatus.pending
+            for interaction in interactions
         )
 
     async def list_pending(

--- a/api/oss/tests/pytest/unit/sessions/test_pending_inputs_service.py
+++ b/api/oss/tests/pytest/unit/sessions/test_pending_inputs_service.py
@@ -6,6 +6,7 @@ from uuid import uuid4
 
 import pytest
 
+from oss.src.core.sessions.interactions.dtos import SessionInteractionStatus
 from oss.src.core.sessions.inputs.dtos import PendingInput, PendingInputState
 from oss.src.core.sessions.inputs.service import SessionInputsService
 from oss.src.core.sessions.inputs.types import (
@@ -192,7 +193,7 @@ async def test_detached_executing_continuation_keeps_input_in_the_queue(monkeypa
 
 
 @pytest.mark.asyncio
-async def test_parked_continuation_still_allows_input_to_execute(monkeypatch):
+async def test_no_recoverable_continuation_keeps_idle_input_executable(monkeypatch):
     monkeypatch.setattr(env.agenta.sessions, "queue", True)
     continuation_resumer = AsyncMock(return_value=None)
     dao = MemoryInputsDAO()
@@ -206,7 +207,7 @@ async def test_parked_continuation_still_allows_input_to_execute(monkeypatch):
         project_id=uuid4(),
         user_id=uuid4(),
         session_id="session-1",
-        content={"message": "steer the parked turn"},
+        content={"message": "normal idle input"},
         policy="queue",
         idempotency_key="key-1",
     )
@@ -356,3 +357,146 @@ async def test_steer_is_saved_ahead_of_queued_input(monkeypatch):
     pending = await service.list_pending(project_id=project_id, session_id="session-1")
     assert [item.id for item in pending] == [steered.input.id, queued.input.id]
     assert steered.execution_id == "execution-1"
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize("terminal_outcome", [None, "completed"])
+async def test_queue_waits_for_unanswered_approval_even_after_execution_settles(
+    monkeypatch, terminal_outcome
+):
+    monkeypatch.setattr(env.agenta.sessions, "queue", True)
+    pending = SimpleNamespace(status=SessionInteractionStatus.pending)
+    interactions = SimpleNamespace(
+        fetch_turn_interactions=AsyncMock(return_value=[pending])
+    )
+    executions = SimpleNamespace(
+        lock_for_control=AsyncMock(
+            return_value=SimpleNamespace(terminal_outcome=terminal_outcome)
+        )
+    )
+    resumer = AsyncMock(return_value=None)
+    dao = MemoryInputsDAO()
+    service = SessionInputsService(
+        inputs_dao=dao,
+        streams_service=Streams(running=False),
+        executions_dao=executions,
+        interactions_dao=interactions,
+        continuation_resumer=resumer,
+    )
+    admitted = await service.admit(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        session_id="session-1",
+        content={"message": "after approval"},
+        policy="queue",
+        idempotency_key="queued-1",
+    )
+    assert admitted.action == "pending"
+    assert admitted.input == dao.items[0]
+    assert admitted.execution_id == "execution-1"
+    assert pending.status == SessionInteractionStatus.pending
+    resumer.assert_not_awaited()
+    if terminal_outcome:
+        assert (
+            interactions.fetch_turn_interactions.await_args.kwargs["for_update"] is True
+        )
+
+
+@pytest.mark.asyncio
+async def test_steer_can_replace_unanswered_approval(monkeypatch):
+    monkeypatch.setattr(env.agenta.sessions, "queue", True)
+    monkeypatch.setattr(env.agenta.sessions, "steer", True)
+    interactions = SimpleNamespace(fetch_turn_interactions=AsyncMock())
+    dao = MemoryInputsDAO()
+    service = SessionInputsService(
+        inputs_dao=dao,
+        streams_service=Streams(running=False),
+        interactions_dao=interactions,
+        continuation_resumer=AsyncMock(return_value=None),
+    )
+    admitted = await service.admit(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        session_id="session-1",
+        content={"message": "replace this"},
+        policy="steer",
+        idempotency_key="steer-1",
+    )
+    assert admitted.action == "execute"
+    assert dao.items == []
+    interactions.fetch_turn_interactions.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "status", [SessionInteractionStatus.resolved, SessionInteractionStatus.cancelled]
+)
+async def test_idle_queue_does_not_wait_on_old_answered_approval(monkeypatch, status):
+    monkeypatch.setattr(env.agenta.sessions, "queue", True)
+    interactions = SimpleNamespace(
+        fetch_turn_interactions=AsyncMock(return_value=[SimpleNamespace(status=status)])
+    )
+    service = SessionInputsService(
+        inputs_dao=MemoryInputsDAO(),
+        streams_service=Streams(running=False),
+        interactions_dao=interactions,
+        continuation_resumer=AsyncMock(return_value=None),
+    )
+    admitted = await service.admit(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        session_id="session-1",
+        content={"message": "now"},
+        policy="queue",
+        idempotency_key="idle-1",
+    )
+    assert admitted.action == "execute"
+
+
+@pytest.mark.asyncio
+async def test_approval_winning_queue_lock_keeps_input_behind_its_continuation(
+    monkeypatch,
+):
+    monkeypatch.setattr(env.agenta.sessions, "queue", True)
+    interactions = SimpleNamespace(
+        fetch_turn_interactions=AsyncMock(
+            side_effect=[
+                [SimpleNamespace(status=SessionInteractionStatus.pending)],
+                [SimpleNamespace(status=SessionInteractionStatus.responded)],
+                [SimpleNamespace(status=SessionInteractionStatus.responded)],
+            ]
+        )
+    )
+    executions = SimpleNamespace(
+        lock_for_control=AsyncMock(
+            side_effect=[
+                SimpleNamespace(terminal_outcome="completed"),
+                SimpleNamespace(terminal_outcome=None),
+            ]
+        )
+    )
+    resumer = AsyncMock(return_value="approved-continuation")
+    dao = MemoryInputsDAO()
+    service = SessionInputsService(
+        inputs_dao=dao,
+        streams_service=Streams(running=False),
+        interactions_dao=interactions,
+        executions_dao=executions,
+        continuation_resumer=resumer,
+    )
+    admitted = await service.admit(
+        project_id=uuid4(),
+        user_id=uuid4(),
+        session_id="session-1",
+        content={"message": "after the approved tool"},
+        policy="queue",
+        idempotency_key="queue-approval-race",
+    )
+    assert admitted.action == "pending"
+    assert admitted.execution_id == "approved-continuation"
+    assert len(dao.items) == 1
+    resumer.assert_awaited_once()
+    assert (
+        executions.lock_for_control.await_args.kwargs["execution_id"]
+        == "approved-continuation"
+    )


### PR DESCRIPTION
## Context

Sending a queued message while an agent waited for approval started a new run and cancelled the unanswered approval. Admission treated the paused session as idle because its running heartbeat had stopped.

## Changes

Queue now checks the current execution's durable pending interactions and saves the message as a pending input while the approval remains unanswered. It rechecks after acquiring the execution lock; if another client has approved in the meantime, admission resumes outside the transaction so the approved continuation retains ownership. Steer and ordinary idle Send retain their existing behavior.

## Tests

- 16 focused admission tests passed, including Queue behind a settled approval, Steer, ordinary idle input, and approval winning the Queue lock.
- Real local native-approval journey passed: Queue returned 202, preserved the same approval, created one pending input, and started no replacement execution. Explicit approval completed the tool, then the queued follow-up completed and the session returned idle.
- Durable records confirmed paused, resumed-completed, then queued-completed execution terminals. The original harness expected three legacy turn projection rows; that assertion was corrected against retained durable records without repeating the paid run.
- Ruff formatting/lint and independent reviews passed.

## What to QA

Open a session with a pending native approval in two clients. Queue a follow-up from the observer: the approval must remain answerable and the follow-up must appear in the queue. Approve the tool and verify it finishes before the queued follow-up runs. Repeat with approval and Queue submitted close together from separate clients.
