### PR TITLE
fix(frontend): negotiate shared responses for durable chat inputs

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -388,6 +388,7 @@ const AgentConversation = ({
         sessionId,
         messages,
         locallyBusy: busy,
+        isSharedReaderReady: () => readerReady,
         onExecuted: revalidate,
     })
 

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -691,6 +691,7 @@ export const useAgentConversation = ({
         sessionId,
         messages,
         locallyBusy: busy,
+        isSharedReaderReady: () => sharedSenderReadyRef.current,
         onExecuted: () => {
             void loadSessionMessages(sessionId, adoptServerTranscript).then(adoptServerTranscript)
         },

--- a/web/packages/agenta-chat/src/hooks/useServerSessionInputs.ts
+++ b/web/packages/agenta-chat/src/hooks/useServerSessionInputs.ts
@@ -30,12 +30,15 @@ export const useServerSessionInputs = ({
     sessionId,
     messages,
     locallyBusy,
+    isSharedReaderReady,
     onExecuted,
 }: {
     entityId: string
     sessionId: string
     messages: UIMessage[]
     locallyBusy: boolean
+    /** Read current transport readiness when admitting input, including after reconnect. */
+    isSharedReaderReady?: () => boolean
     onExecuted?: () => void
 }): ServerSessionInputs => {
     const fetchSnapshot = useSetAtom(fetchSessionSnapshotAtom)
@@ -48,6 +51,7 @@ export const useServerSessionInputs = ({
     const messagesRef = useRef(messages)
     const entityIdRef = useRef(entityId)
     const onExecutedRef = useRef(onExecuted)
+    const isSharedReaderReadyRef = useRef(isSharedReaderReady)
     const loadInFlightRef = useRef<{
         sessionId: string
         promise: Promise<SessionPendingInputView | null>
@@ -55,6 +59,7 @@ export const useServerSessionInputs = ({
     messagesRef.current = messages
     entityIdRef.current = entityId
     onExecutedRef.current = onExecuted
+    isSharedReaderReadyRef.current = isSharedReaderReady
 
     const load = useCallback((): Promise<SessionPendingInputView | null> => {
         if (loadInFlightRef.current?.sessionId === sessionId) {
@@ -113,7 +118,10 @@ export const useServerSessionInputs = ({
             const request = await buildAgentRequest(
                 entityIdRef.current,
                 [...messagesRef.current, outbound],
-                {sessionId},
+                {
+                    sessionId,
+                    ...(isSharedReaderReadyRef.current?.() ? {sharedResponse: true} : {}),
+                },
             )
             if (!request) throw new Error("The agent is not ready to accept input.")
 

--- a/web/packages/agenta-chat/tests/unit/hooks/useServerSessionInputs.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useServerSessionInputs.test.ts
@@ -348,6 +348,46 @@ describe("useServerSessionInputs", () => {
         expect(result.current.executionState).toBe("running")
     })
 
+    it.each(["queue", "steer"] as const)(
+        "negotiates the current reader readiness for %s admission",
+        async (policy) => {
+            fetchSnapshot.mockResolvedValue(runningSnapshot())
+            buildAgentRequest.mockResolvedValue({
+                invocationUrl: "https://agent.test/invoke",
+                headers: {},
+                requestBody: {},
+            })
+            fetchMock.mockImplementation(async () => new Response(null, {status: 202}))
+            const {result, rerender} = renderHook(
+                ({ready}) =>
+                    useServerSessionInputs({
+                        entityId: "revision-1",
+                        sessionId: "session-1",
+                        messages: [],
+                        locallyBusy: false,
+                        isSharedReaderReady: () => ready,
+                    }),
+                {initialProps: {ready: false}},
+            )
+            await waitFor(() => expect(result.current.capabilities.queue).toBe(true))
+            const submit = result.current.submit
+            await act(() => submit({id: "before-ready", text: "first", source: "local"}, policy))
+            expect(buildAgentRequest.mock.calls.at(-1)?.[2]).toEqual({sessionId: "session-1"})
+            rerender({ready: true})
+            await act(() => submit({id: "ready", text: "next", source: "local"}, policy))
+            expect(buildAgentRequest.mock.calls.at(-1)?.[2]).toEqual({
+                sessionId: "session-1",
+                sharedResponse: true,
+            })
+            rerender({ready: false})
+            await act(() => submit({id: "disconnected", text: "last", source: "local"}, policy))
+            expect(buildAgentRequest.mock.calls.at(-1)?.[2]).toEqual({sessionId: "session-1"})
+            expect(
+                fetchMock.mock.calls.map(([, init]) => JSON.parse(String(init?.body)).on_busy),
+            ).toEqual([policy, policy, policy])
+        },
+    )
+
     it("reads queue support from the snapshot and submits durable admission", async () => {
         fetchSnapshot.mockResolvedValue({
             session: {


### PR DESCRIPTION
## Context

Queue-enabled chats bypass the chat transport when submitting input. That admission path omitted shared-response negotiation even when the session reader was ready, so the server streamed the full native response and the browser discarded it while rendering the shared transcript.

## Changes

Both desktop and mobile admission now read the current shared-reader readiness before building each Queue or Steer request. A ready reader negotiates shared acceptance and detached execution; a disconnected or unavailable reader keeps the existing response fallback. Queued 202 responses and background consumption of fresh 200 responses are unchanged.

## Tests

The new regression failed for both Queue and Steer before the fix. The input-hook suite passes all 12 tests, including readiness changing from false to true and back through a retained submit callback. The existing fresh-200 background-drain test and all 33 queue tests also pass (45 total). Shared TypeScript and the required full frontend lint-fix pass (25 tasks).

The original omission was captured in a real browser: a native EventSource ready event preceded an invoke without the shared-response header. Exact-image local browser QA passed: natural shared header plus detached flag and authoritative acceptance ID; approval resume followed by Stop returned 202 and persisted a cancelled terminal; a subsequent fresh run survived sender reload while running and completed once across desktop sender, desktop observer and mobile. A mobile sender also negotiated the shared header and detached flag naturally, received acceptance, and completed with the final reply visible across clients. The server still emits native SSE after acceptance, which this path drains in the background; this change does not compact that response.

## What to QA

With the shared reader ready, send from an idle session and confirm the request negotiates shared acceptance while the answer and tool results arrive normally. Check Queue and Steer during a run, then Stop and continue after reload.
