### PR TITLE
[fix] Keep queued input behind starting approval continuations

### DIFF
--- a/api/oss/src/core/sessions/executions/interfaces.py
+++ b/api/oss/src/core/sessions/executions/interfaces.py
@@ -33,6 +33,16 @@ class SessionExecutionsDAOInterface(ABC):
         """Ensure and row-lock the source execution for Stop/answer arbitration."""
         raise NotImplementedError
 
+    async def lock_active_continuation(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        transaction: Any,
+    ) -> Optional[SessionExecutionSettlement]:
+        """Lock the unsettled continuation that still owns this session."""
+        raise NotImplementedError
+
     async def create_continuation(
         self,
         *,

--- a/api/oss/src/core/sessions/inputs/service.py
+++ b/api/oss/src/core/sessions/inputs/service.py
@@ -174,6 +174,19 @@ class SessionInputsService:
                         if successor is not None
                         else None
                     )
+                    if successor_execution_id is None and self._executions is not None:
+                        # Redis can announce a resumed turn before the durable header moves off
+                        # its terminal parent. Approval children have no promoted input row.
+                        continuation = await self._executions.lock_active_continuation(
+                            project_id=project_id,
+                            session_id=session_id,
+                            transaction=transaction,
+                        )
+                        successor_execution_id = (
+                            continuation.execution_id
+                            if continuation is not None
+                            else None
+                        )
                     if successor_execution_id is None:
                         return PendingInputAdmission(action="execute")
             if not retry_after_interaction:

--- a/api/oss/src/dbs/postgres/sessions/executions/dao.py
+++ b/api/oss/src/dbs/postgres/sessions/executions/dao.py
@@ -97,6 +97,29 @@ class SessionExecutionsDAO(SessionExecutionsDAOInterface):
         ).scalar_one()
         return _to_dto(row)
 
+    async def lock_active_continuation(
+        self,
+        *,
+        project_id: UUID,
+        session_id: str,
+        transaction: Any,
+    ) -> Optional[SessionExecutionSettlement]:
+        row = (
+            await transaction.execute(
+                select(SessionExecutionDBE)
+                .where(
+                    SessionExecutionDBE.project_id == project_id,
+                    SessionExecutionDBE.session_id == session_id,
+                    SessionExecutionDBE.parent_execution_id.is_not(None),
+                    SessionExecutionDBE.terminal_outcome.is_(None),
+                )
+                .order_by(SessionExecutionDBE.execution_id)
+                .limit(1)
+                .with_for_update()
+            )
+        ).scalar_one_or_none()
+        return _to_dto(row) if row is not None else None
+
     async def create_continuation(
         self,
         *,

--- a/api/oss/tests/pytest/unit/sessions/test_session_inputs_dao.py
+++ b/api/oss/tests/pytest/unit/sessions/test_session_inputs_dao.py
@@ -850,3 +850,69 @@ async def test_stop_settlement_wins_before_steer_bind(input_scope, monkeypatch):
         engine=input_scope["engine"]
     ).fetch_command(command_id=command.id)
     assert settled_command.data is None
+
+
+@pytest.mark.parametrize("policy", ["queue", "steer"])
+@pytest.mark.parametrize(
+    "state", ["pending_delivery", "running", "recoverable", "terminal"]
+)
+async def test_admission_follows_approval_continuation_before_stream_header_catches_up(
+    input_scope, monkeypatch, policy, state
+):
+    monkeypatch.setattr(env.agenta.sessions, "queue", True)
+    monkeypatch.setattr(env.agenta.sessions, "steer", True)
+    inputs = SessionInputsDAO(engine=input_scope["engine"])
+    executions = SessionExecutionsDAO(engine=input_scope["engine"])
+    scope = {
+        "project_id": input_scope["project_id"],
+        "session_id": input_scope["session_id"],
+    }
+    async with input_scope["engine"].session() as transaction:
+        await executions.settle(
+            **scope,
+            execution_id="source-turn",
+            terminal_outcome="continued",
+            settled_by="interaction_response",
+            transaction=transaction,
+        )
+        await executions.create_continuation(
+            **scope,
+            execution_id="approved-child",
+            parent_execution_id="source-turn",
+            source_interaction_id=None,
+            transaction=transaction,
+        )
+        if state == "terminal":
+            await executions.settle(
+                **scope,
+                execution_id="approved-child",
+                terminal_outcome="completed",
+                settled_by="runner",
+                transaction=transaction,
+            )
+        else:
+            await executions.set_state(
+                **scope,
+                execution_id="approved-child",
+                state=SessionExecutionState(state),
+                transaction=transaction,
+            )
+    service = SessionInputsService(
+        inputs_dao=inputs,
+        streams_service=_BusyStreams(),
+        executions_dao=executions,
+    )
+    admission = await service.admit(
+        **scope,
+        user_id=input_scope["user_id"],
+        content={"message": "after approved work"},
+        policy=policy,
+        idempotency_key="approval-start-gap",
+    )
+    if state == "terminal":
+        assert admission.action == "execute"
+        assert await inputs.list_pending(**scope) == []
+    else:
+        assert admission.action == "pending"
+        assert admission.execution_id == "approved-child"
+        assert len(await inputs.list_pending(**scope)) == 1


### PR DESCRIPTION
Sending Queue immediately after approving a tool could start a fresh run and cancel the approved work. During continuation startup, Redis can report running while the durable stream header still names the settled parent; the admission recheck previously looked only for successors promoted from queued inputs.

The same locked recheck now also finds and locks an unsettled continuation before allowing fresh execution. Queue remains pending behind the approved run, and Steer targets that continuation. Terminal continuations still allow a fresh run. This adds no schema or configuration changes.

Validation: six new real-Postgres cases reproduced the failure before the fix. All 19 affected database tests and 16 admission service tests pass, including terminal fallback, settlement arbitration, promotion, and idempotency. Ruff formatting/checks pass. Two independent release-agent reviews found no blockers. A targeted live local approval-resume run passed11 assertions: Queue returned202 targeting the approved child, its tool completed, and the queued followup drained without cancellation or error. The startup window was held by temporarily restoring only the disposable session’s old durable header; it was restored immediately after admission. The same paid run supplied final evidence, with no paid rerun.
