### PR TITLE
fix(agents): resume queued turns after questionnaire answers

### DIFF
--- a/api/oss/src/tasks/asyncio/sessions/interactions_dispatcher.py
+++ b/api/oss/src/tasks/asyncio/sessions/interactions_dispatcher.py
@@ -9,8 +9,8 @@ session's durable records into wire messages and appends the approval envelope
 ``session-identity.ts`` ``approvalDecisionForToolCall``). The client payload
 stays minimal: ``{approved: bool, tool_call_id?, message?}``.
 
-Every other interaction kind keeps the original passthrough contract
-(``data.inputs = answer``).
+Agent ``client_tool`` answers replay the same conversation with their structured output or
+error as the tool result. Other interaction kinds retain ``data.inputs = answer``.
 
 The resume also carries the gated turn's own config when the runner stamped one on the row
 (``data.parameters``): sending it inline suppresses reference hydration in the SDK resolver,
@@ -233,6 +233,18 @@ def _gated_call_shape(
     return {"name": request.tool, "args": request.args}
 
 
+def _is_agent_interaction_answer(interaction: SessionInteraction, answer: Any) -> bool:
+    if not isinstance(answer, dict):
+        return False
+    return (
+        interaction.kind == SessionInteractionKind.user_approval
+        and isinstance(answer.get("approved"), bool)
+    ) or (
+        interaction.kind == SessionInteractionKind.client_tool
+        and answer.get("outcome") in ("completed", "error")
+    )
+
+
 def compose_approval_messages(
     records: List[SessionRecord],
     interaction: SessionInteraction,
@@ -288,14 +300,18 @@ def compose_approval_messages_many(
                 gated_call["input"] = shape["args"]
             messages.append({"role": "assistant", "content": [gated_call]})
 
-        envelope = {
-            "type": "tool_result",
-            "toolCallId": gated_id,
-            "output": {
+        envelope: Dict[str, Any] = {"type": "tool_result", "toolCallId": gated_id}
+        if interaction.kind == SessionInteractionKind.client_tool:
+            is_error = answer.get("outcome") == "error"
+            envelope["output"] = (
+                answer.get("error") if is_error else answer.get("output", {})
+            )
+            envelope["isError"] = is_error
+        else:
+            envelope["output"] = {
                 "approved": bool(answer.get("approved")),
                 "interactionToken": interaction.token,
-            },
-        }
+            }
         gated_name = gated_call.get("toolName") or shape.get("name")
         if gated_name:
             envelope["toolName"] = gated_name
@@ -347,11 +363,7 @@ class InteractionsDispatcher:
         interaction: SessionInteraction,
         answer: Any,
     ) -> Dict[str, Any]:
-        if (
-            interaction.kind == SessionInteractionKind.user_approval
-            and isinstance(answer, dict)
-            and isinstance(answer.get("approved"), bool)
-        ):
+        if _is_agent_interaction_answer(interaction, answer):
             records: List[SessionRecord] = []
             if self.records_service is not None:
                 try:
@@ -418,12 +430,7 @@ class InteractionsDispatcher:
         selector = (
             data.selector.model_dump(mode="json") if data and data.selector else None
         )
-        if all(
-            item.kind == SessionInteractionKind.user_approval
-            and isinstance(answer, dict)
-            and isinstance(answer.get("approved"), bool)
-            for item, answer in resolved
-        ):
+        if all(_is_agent_interaction_answer(item, answer) for item, answer in resolved):
             records: List[SessionRecord] = []
             if self.records_service is not None:
                 try:

--- a/api/oss/tests/pytest/unit/sessions/test_interactions_dispatcher.py
+++ b/api/oss/tests/pytest/unit/sessions/test_interactions_dispatcher.py
@@ -6,6 +6,8 @@ from uuid import uuid4
 
 from unittest.mock import AsyncMock, MagicMock
 
+import pytest
+
 from oss.src.apis.fastapi.sessions.models import SessionInteractionCreateRequest
 from oss.src.core.sessions.interactions.dtos import SessionInteractionKind
 from oss.src.core.sessions.records.dtos import SessionRecord
@@ -984,3 +986,75 @@ def test_keyed_references_drops_families_the_invoke_does_not_accept():
     assert keyed_references([SessionReference(key="application", slug="app-1")]) == {
         "application": {"slug": "app-1"}
     }
+
+
+@pytest.mark.parametrize("outcome", ["completed", "error"])
+async def test_client_tool_answer_replays_questionnaire_result(outcome):
+    project_id = uuid4()
+    interaction = _make_interaction(
+        kind=SessionInteractionKind.client_tool,
+        request={
+            "tool": "__ag__request_input",
+            "tool_call_id": "form-call",
+            "args": {"title": "Choose"},
+        },
+    )
+    records = [
+        _record(
+            project_id,
+            source="user",
+            rtype="message",
+            attributes={"text": "ask a questionnaire"},
+        ),
+        _record(
+            project_id,
+            rtype="tool_call",
+            attributes={
+                "id": "form-call",
+                "name": "__ag__request_input",
+                "input": {"title": "Choose"},
+            },
+            index=1,
+        ),
+    ]
+    answer = {
+        "tool_call_id": "form-call",
+        "tool_name": "__ag__request_input",
+        "outcome": outcome,
+    }
+    result = {"action": "accept", "content": {"selected": "blue", "default": "UTC"}}
+    if outcome == "error":
+        answer["error"] = "Questionnaire could not be rendered"
+    else:
+        answer["output"] = result
+    dispatch_fn = AsyncMock()
+    dispatcher = _dispatcher_with(interaction, records, dispatch_fn)
+    execution_id = str(uuid4())
+    await dispatcher.respond(
+        project_id=project_id,
+        user_id=uuid4(),
+        interaction_id=interaction.id,
+        answer=answer,
+        continuation_execution_id=execution_id,
+    )
+    request = dispatch_fn.await_args.kwargs["request"]
+    assert dispatch_fn.await_args.kwargs["run_id"] == execution_id
+    messages = request.data.inputs["messages"]
+    assert messages[0] == {"role": "user", "content": "ask a questionnaire"}
+    assert messages[-1]["role"] == "assistant"
+    assert messages[-1]["content"][-1] == {
+        "type": "tool_result",
+        "toolCallId": "form-call",
+        "toolName": "__ag__request_input",
+        "output": answer["error"] if outcome == "error" else result,
+        "isError": outcome == "error",
+    }
+    assert (
+        sum(
+            block.get("type") == "tool_call"
+            for m in messages
+            if isinstance(m.get("content"), list)
+            for block in m["content"]
+        )
+        == 1
+    )

--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -156,7 +156,7 @@ const AgentConversation = ({
         stopping,
         setStopped,
         handleStop,
-        handleClientToolOutput,
+        handleClientToolOutput: answerClientTool,
         markLiveGate,
         answerApproval,
         answerApprovals,
@@ -495,6 +495,18 @@ const AgentConversation = ({
             return outcome
         },
         [answerApproval, markLiveGate, submit],
+    )
+
+    const handleClientToolOutput = useCallback(
+        async (args: Parameters<typeof answerClientTool>[0]) => {
+            approvalResponseOwnerRef.current = args.toolCallId
+            const outcome = await answerClientTool(args)
+            if (approvalResponseOwnerRef.current === args.toolCallId) {
+                setRecoverableContinuation(outcome.recoverable)
+                setContinuationExecutionId(outcome.executionId ?? null)
+            }
+        },
+        [answerClientTool],
     )
 
     const handleApprovalResponses = useCallback(

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.test.ts
@@ -41,6 +41,9 @@ const state = vi.hoisted(() => ({
     busy: false,
     stop: vi.fn(),
     switchEntity: vi.fn(),
+    respondAnswer: vi.fn(),
+    addToolOutput: vi.fn(),
+    durableCapability: false,
     setCommitSignal: vi.fn(),
     invalidateCommit: vi.fn(),
 }))
@@ -58,7 +61,30 @@ vi.mock("@agenta/chat/assets", () => ({
     ) => build(),
     resolveStopExecution: state.resolveStopExecution,
     startupLabelFromDataPart: () => undefined,
-    submitApprovalForCapability: vi.fn(),
+    submitApprovalForCapability: async ({
+        durableApprovals,
+        submitDurable,
+        retireDurable,
+        recordLegacy,
+        releaseLegacy,
+    }: {
+        durableApprovals: boolean
+        submitDurable: () => Promise<unknown>
+        retireDurable: () => void
+        recordLegacy: () => Promise<void>
+        releaseLegacy: () => void
+    }) => {
+        if (durableApprovals) {
+            try {
+                return await submitDurable()
+            } finally {
+                retireDurable()
+            }
+        }
+        await recordLegacy()
+        releaseLegacy()
+        return {durable: false, recoverable: false}
+    },
 }))
 
 vi.mock("@agenta/chat/hooks", () => ({
@@ -155,7 +181,7 @@ vi.mock("@agenta/ui/app-message", () => ({message: {warning: vi.fn()}}))
 vi.mock("@ai-sdk/react", () => ({
     useChat: () => ({
         addToolApprovalResponse: vi.fn(),
-        addToolOutput: vi.fn(),
+        addToolOutput: state.addToolOutput,
         error: undefined,
         messages: state.messages,
         regenerate: state.regenerate,
@@ -172,11 +198,15 @@ vi.mock("@tanstack/react-query", () => ({
 vi.mock("jotai", () => ({
     useAtomValue: () => state.projectId,
     useSetAtom: (atom: string) =>
-        atom === "switch-entity"
-            ? state.switchEntity
-            : atom === "commit-signal"
-              ? state.setCommitSignal
-              : vi.fn(),
+        atom === "respond-interaction-answer"
+            ? state.respondAnswer
+            : atom === "session-durable-approvals-capability"
+              ? () => Promise.resolve(state.durableCapability)
+              : atom === "switch-entity"
+                ? state.switchEntity
+                : atom === "commit-signal"
+                  ? state.setCommitSignal
+                  : vi.fn(),
     useStore: () => ({
         get: (atom: string) => {
             if (atom === "record-counts" || atom === "session-messages") return {}
@@ -227,6 +257,13 @@ describe("useAgentChatSession execution guard", () => {
         state.acceptedRunBySession.clear()
         state.turnDeliverySourceBySession.clear()
         state.turnIds.clear()
+        state.respondAnswer.mockReset().mockResolvedValue({
+            durable: true,
+            recoverable: false,
+            executionId: "questionnaire-child",
+        })
+        state.addToolOutput.mockReset().mockResolvedValue(undefined)
+        state.durableCapability = false
         state.sendMessage.mockClear()
         state.regenerate.mockClear()
         state.cancelSessionExecution.mockReset()
@@ -247,6 +284,49 @@ describe("useAgentChatSession execution guard", () => {
         state.stoppingTurnId = null
         state.stopStateLoading = false
         state.busy = false
+    })
+
+    it("answers a queued questionnaire through server ownership without SDK auto-resume", async () => {
+        state.durableCapability = true
+        let result: ReturnType<typeof useAgentChatSession> | undefined
+        const root = createRoot(document.createElement("div"))
+        const Probe = () => {
+            result = useAgentChatSession({
+                entityId: "revision-1",
+                sessionId: "session-1",
+                initialMessages: [],
+                intent: {} as never,
+            })
+            return null
+        }
+        act(() => root.render(createElement(Probe)))
+        const output = {action: "accept", content: {goal: "Correctness"}}
+        await act(async () => {
+            await expect(
+                result!.handleClientToolOutput({
+                    toolName: "request_input",
+                    toolCallId: "questionnaire",
+                    output,
+                }),
+            ).resolves.toEqual({
+                durable: true,
+                recoverable: false,
+                executionId: "questionnaire-child",
+            })
+        })
+        expect(state.respondAnswer).toHaveBeenCalledWith({
+            sessionId: "session-1",
+            toolCallId: "questionnaire",
+            resolution: {
+                tool_call_id: "questionnaire",
+                tool_name: "request_input",
+                outcome: "completed",
+                output,
+            },
+        })
+        expect(state.addToolOutput).not.toHaveBeenCalled()
+        expect(state.capturedHooks!.sendAutomaticallyWhen({messages: []})).toBe(false)
+        act(() => root.unmount())
     })
 
     it("deduplicates live-reader and native commit notifications through the same config switch", () => {

--- a/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
+++ b/web/oss/src/components/AgentChatSlice/hooks/useAgentChatSession.ts
@@ -63,7 +63,6 @@ import {
     isHitlPending,
     isResumeSend,
     playgroundController,
-    recordAnswerThenRelease,
     type LiveAgentInteraction,
 } from "@agenta/playground"
 import {agentSelfCommitSignalAtom} from "@agenta/shared/state"
@@ -498,30 +497,30 @@ export const useAgentChatSession = ({
         if (isResumeSend({from, to: status})) liveGateInteractionRef.current = null
     }, [status])
 
-    // Settle a parked client tool (#4920). The dispatcher calls this from a widget (e.g. the connect
-    // widget) with the structured reference; `addToolOutput` matches the part by `toolCallId` on the
-    // last turn and the resume predicate auto-resends. `tool` is only the typed-tools key — matching
-    // is by id — so a cast onto the untyped UIMessage tool map is safe.
-    const handleClientToolOutput = useCallback<ClientToolOutputHandler>(
-        ({toolName, toolCallId, output, errorText}) => {
-            // Set synchronously: it holds off transcript adoption for the whole ordered window.
+    // Durable gates resume on the server; legacy gates still release the local SDK.
+    const handleClientToolOutput = useCallback(
+        async ({
+            toolName,
+            toolCallId,
+            output,
+            errorText,
+        }: Parameters<ClientToolOutputHandler>[0]) => {
             liveGateInteractionRef.current = {kind: "client_tool", id: toolCallId}
-            // Ordered, not raced — the resume starts a turn whose sweep cancels every `pending`
-            // row, so the answer has to be durable first. Capped inside the helper.
-            void recordAnswerThenRelease({
-                record: () =>
-                    recordInteractionAnswer({
-                        sessionId,
-                        toolCallId,
-                        resolution: {
-                            tool_call_id: toolCallId,
-                            tool_name: toolName,
-                            ...(errorText !== undefined
-                                ? {outcome: "error", error: errorText}
-                                : {outcome: "completed", output: output ?? {}}),
-                        },
-                    }),
-                release: () => {
+            const resolution = {
+                tool_call_id: toolCallId,
+                tool_name: toolName,
+                ...(errorText !== undefined
+                    ? {outcome: "error", error: errorText}
+                    : {outcome: "completed", output: output ?? {}}),
+            }
+            const outcome = await submitApprovalForCapability({
+                durableApprovals: await supportsDurableApprovals(sessionId),
+                submitDurable: () => respondInteractionAnswer({sessionId, toolCallId, resolution}),
+                retireDurable: () => {
+                    liveGateInteractionRef.current = null
+                },
+                recordLegacy: () => recordInteractionAnswer({sessionId, toolCallId, resolution}),
+                releaseLegacy: () => {
                     if (errorText !== undefined) {
                         addToolOutput({
                             state: "output-error",
@@ -538,8 +537,15 @@ export const useAgentChatSession = ({
                     }
                 },
             })
+            return outcome
         },
-        [addToolOutput, recordInteractionAnswer, sessionId],
+        [
+            addToolOutput,
+            recordInteractionAnswer,
+            respondInteractionAnswer,
+            sessionId,
+            supportsDurableApprovals,
+        ],
     )
 
     // Orphan detection for the queue's pre-resume hold: the tail is a RESTORED message (this

--- a/web/packages/agenta-chat/src/clientTools/ClientToolPart.tsx
+++ b/web/packages/agenta-chat/src/clientTools/ClientToolPart.tsx
@@ -53,13 +53,13 @@ const ClientToolPart = ({
     const settle = useCallback(
         (args: {output: Record<string, unknown>} | {errorText: string}) => {
             if ("errorText" in args) {
-                onOutput({
+                return onOutput({
                     toolName: meta.toolName,
                     toolCallId: meta.toolCallId,
                     errorText: args.errorText,
                 })
             } else {
-                onOutput({
+                return onOutput({
                     toolName: meta.toolName,
                     toolCallId: meta.toolCallId,
                     output: args.output,

--- a/web/packages/agenta-chat/src/clientTools/ClientToolPart.tsx
+++ b/web/packages/agenta-chat/src/clientTools/ClientToolPart.tsx
@@ -18,13 +18,13 @@ import {canonicalToolName, resolveClientToolWidget, resolveToolDisplay} from "..
 import {clientToolMeta} from "./meta"
 import UnhandledClientTool from "./UnhandledClientTool"
 
-/** Settle a parked client tool. The panel maps this onto `addToolOutput` (success or error). */
+/** Settle a parked client tool; await durable submission when the host owns it. */
 export type ClientToolOutputHandler = (args: {
     toolName: string
     toolCallId: string
     output?: Record<string, unknown>
     errorText?: string
-}) => void
+}) => void | Promise<void>
 
 const ClientToolPart = ({
     part,

--- a/web/packages/agenta-chat/src/components/ConnectionDock.tsx
+++ b/web/packages/agenta-chat/src/components/ConnectionDock.tsx
@@ -469,13 +469,13 @@ const ConnectBody = ({
     const settle = useCallback<SettleClientTool>(
         (args) => {
             if ("errorText" in args) {
-                onOutput({
+                return onOutput({
                     toolName: meta.toolName,
                     toolCallId: meta.toolCallId,
                     errorText: args.errorText,
                 })
             } else {
-                onOutput({
+                return onOutput({
                     toolName: meta.toolName,
                     toolCallId: meta.toolCallId,
                     output: args.output,
@@ -537,7 +537,7 @@ const ConnectBody = ({
                         Connecting {name}… finish signing in from the popup window.
                     </span>
                 </div>
-            ) : phase === "error" ? (
+            ) : phase === "error" || errorText ? (
                 <span className="text-xs text-colorError" title={errorText ?? undefined}>
                     {errorText ?? "Connection failed."}
                 </span>

--- a/web/packages/agenta-chat/src/components/ConnectionDock.tsx
+++ b/web/packages/agenta-chat/src/components/ConnectionDock.tsx
@@ -560,6 +560,7 @@ const ConnectBody = ({
                             variant="ghost"
                             className={`text-colorTextSecondary ${touchCls}`}
                             onClick={decline}
+                            disabled={Boolean(errorText)}
                         >
                             Not now
                         </Button>
@@ -573,7 +574,7 @@ const ConnectBody = ({
                             }
                             onClick={() => runConnect(true)}
                         >
-                            {phase === "error" ? "Retry" : "Connect"}
+                            {phase === "error" || errorText ? "Retry" : "Connect"}
                         </Button>
                     </>
                 )}

--- a/web/packages/agenta-chat/src/components/ElicitationDock.tsx
+++ b/web/packages/agenta-chat/src/components/ElicitationDock.tsx
@@ -16,7 +16,7 @@
  * Escape here does NOT settle, unlike `ApprovalCard` and `ConnectionDock`. This card owns a text
  * field, and Escape-to-back-out-of-typing is the stronger expectation; dismissing is the header ✕.
  */
-import {useCallback, useEffect, useMemo, useRef} from "react"
+import {useCallback, useEffect, useMemo, useRef, useState} from "react"
 
 import {
     buildAcceptResult,
@@ -119,11 +119,27 @@ const ElicitationCard = ({
     // One settle per card. `meta.settled` only flips after the host's durable write resolves, so the
     // buttons stay live in between without this latch.
     const settledRef = useRef(false)
+    const [submissionError, setSubmissionError] = useState<string | null>(null)
     const settle = useCallback(
         (output: Record<string, unknown>) => {
             if (settledRef.current) return
             settledRef.current = true
-            onOutput({toolName: meta.toolName, toolCallId: meta.toolCallId, output})
+            setSubmissionError(null)
+            const failed = (error: unknown) => {
+                settledRef.current = false
+                setSubmissionError(
+                    error instanceof Error
+                        ? error.message
+                        : "Could not submit your answer. Try again.",
+                )
+            }
+            try {
+                void Promise.resolve(
+                    onOutput({toolName: meta.toolName, toolCallId: meta.toolCallId, output}),
+                ).catch(failed)
+            } catch (error) {
+                failed(error)
+            }
         },
         [onOutput, meta.toolName, meta.toolCallId],
     )
@@ -146,6 +162,7 @@ const ElicitationCard = ({
             active={active}
             shortcutsEnabled={shortcutsEnabled}
             settle={settle}
+            submissionError={submissionError}
         />
     )
 }
@@ -206,6 +223,7 @@ const LiveCard = ({
     active,
     shortcutsEnabled,
     settle,
+    submissionError,
 }: {
     payload: ElicitationRequestPayload
     meta: ClientToolMeta
@@ -214,6 +232,7 @@ const LiveCard = ({
     active: boolean
     shortcutsEnabled: boolean
     settle: (output: Record<string, unknown>) => void
+    submissionError?: string | null
 }) => {
     const cardRef = useRef<HTMLDivElement>(null)
     const form = useMemo(() => buildElicitationSteps(payload), [payload])
@@ -506,10 +525,12 @@ const LiveCard = ({
                 <span
                     aria-live="polite"
                     className={`mr-auto truncate text-xs ${
-                        stepper.error ? "text-colorError" : "text-colorTextTertiary"
+                        submissionError || stepper.error
+                            ? "text-colorError"
+                            : "text-colorTextTertiary"
                     }`}
                 >
-                    {stepper.error ?? stepper.hold ?? ""}
+                    {submissionError ?? stepper.error ?? stepper.hold ?? ""}
                 </span>
             </div>
         </div>

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -38,7 +38,6 @@ import {
     approvalResolution,
     buildAgentRequest,
     isResumeSend,
-    recordAnswerThenRelease,
     type LiveAgentInteraction,
 } from "@agenta/playground/agent-chat"
 import {generateId} from "@agenta/shared/utils"
@@ -212,7 +211,7 @@ export interface AgentConversation {
     /** Headless approval-dock state wired to the live-gate-aware response path. */
     approvals: ApprovalDock
     /** Settle a parked client tool part (widgets call this; the resume predicate auto-resends). */
-    sendToolOutput: (args: ToolOutputSettleInput) => void
+    sendToolOutput: (args: ToolOutputSettleInput) => Promise<void>
     /** Re-fetch the durable records and adopt the server transcript under the same guards as
      * revalidate-on-open (never mid-stream, only when strictly ahead). Wire push signals — a
      * session watch relay, a foreground event — to this. */
@@ -857,29 +856,26 @@ export const useAgentConversation = ({
         }
     }, [pendingApprovalId])
 
-    // Settle a parked client tool (#4920). A widget calls this with the structured reference;
-    // `addToolOutput` matches the part by `toolCallId` on the last turn and the resume predicate
-    // auto-resends. `tool` is only the typed-tools key — matching is by id — so a cast onto the
-    // untyped UIMessage tool map is safe.
+    // Durable gates resume on the server; legacy gates still release the local SDK.
     const sendToolOutput = useCallback(
-        ({toolName, toolCallId, output, errorText}: ToolOutputSettleInput) => {
+        async ({toolName, toolCallId, output, errorText}: ToolOutputSettleInput) => {
+            approvalResponseOwnerRef.current = toolCallId
             liveGateInteractionRef.current = {kind: "client_tool", id: toolCallId}
-            // Ordered like the approval half: the resume starts a turn whose sweep cancels every
-            // `pending` row, so the answer has to be durable first. Capped inside the helper.
-            void recordAnswerThenRelease({
-                record: () =>
-                    recordInteractionAnswer({
-                        sessionId,
-                        toolCallId,
-                        resolution: {
-                            tool_call_id: toolCallId,
-                            tool_name: toolName,
-                            ...(errorText !== undefined
-                                ? {outcome: "error", error: errorText}
-                                : {outcome: "completed", output: output ?? {}}),
-                        },
-                    }),
-                release: () => {
+            const resolution = {
+                tool_call_id: toolCallId,
+                tool_name: toolName,
+                ...(errorText !== undefined
+                    ? {outcome: "error", error: errorText}
+                    : {outcome: "completed", output: output ?? {}}),
+            }
+            const outcome = await submitApprovalForCapability({
+                durableApprovals: await supportsDurableApprovals(sessionId),
+                submitDurable: () => respondInteractionAnswer({sessionId, toolCallId, resolution}),
+                retireDurable: () => {
+                    liveGateInteractionRef.current = null
+                },
+                recordLegacy: () => recordInteractionAnswer({sessionId, toolCallId, resolution}),
+                releaseLegacy: () => {
                     if (errorText !== undefined) {
                         addToolOutput({
                             state: "output-error",
@@ -896,8 +892,18 @@ export const useAgentConversation = ({
                     }
                 },
             })
+            if (approvalResponseOwnerRef.current === toolCallId) {
+                setRecoverableContinuation(outcome.recoverable)
+                setContinuationExecutionId(outcome.executionId ?? null)
+            }
         },
-        [addToolOutput, recordInteractionAnswer, sessionId],
+        [
+            addToolOutput,
+            recordInteractionAnswer,
+            respondInteractionAnswer,
+            sessionId,
+            supportsDurableApprovals,
+        ],
     )
 
     // Publish this session's run state (single source of truth for session-list status dots).

--- a/web/packages/agenta-chat/tests/unit/components/elicitationDockSettle.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/components/elicitationDockSettle.test.tsx
@@ -631,3 +631,15 @@ describe("the controls the dialect grew", () => {
         expect(screen.getByText("Region")).toBeTruthy()
     })
 })
+
+it("shows a failed durable answer and permits retry without a second in-flight submission", async () => {
+    const {onOutput} = setup(ONE_QUESTION)
+    onOutput
+        .mockRejectedValueOnce(new Error("Answer could not be saved"))
+        .mockResolvedValue(undefined)
+    fireEvent.click(screen.getByRole("button", {name: "Send answers"}))
+    await waitFor(() => expect(screen.getByText("Answer could not be saved")).toBeTruthy())
+    fireEvent.click(screen.getByRole("button", {name: "Send answers"}))
+    await waitFor(() => expect(onOutput).toHaveBeenCalledTimes(2))
+    expect(screen.queryByText("Answer could not be saved")).toBeNull()
+})

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentConversation.test.ts
@@ -21,10 +21,18 @@ import type {UIMessage} from "ai"
 import {createStore, Provider} from "jotai"
 import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
 
-const {capabilitiesViaAtom, snapshotViaAtom, resumeContinuation} = vi.hoisted(() => ({
+const {
+    capabilitiesViaAtom,
+    snapshotViaAtom,
+    resumeContinuation,
+    durableApprovalCapability,
+    respondAnswer,
+} = vi.hoisted(() => ({
     capabilitiesViaAtom: vi.fn(),
     snapshotViaAtom: vi.fn(),
     resumeContinuation: vi.fn(),
+    durableApprovalCapability: vi.fn(),
+    respondAnswer: vi.fn(),
 }))
 
 const approvalRecord = vi.hoisted(() => ({
@@ -73,7 +81,8 @@ vi.mock("@agenta/entities/session", async (importOriginal) => {
             snapshotViaAtom(sessionId),
         ),
         resumeSessionContinuationAtom: atom(null, () => resumeContinuation()),
-        sessionDurableApprovalsCapabilityAtom: atom(null, () => false),
+        sessionDurableApprovalsCapabilityAtom: atom(null, () => durableApprovalCapability()),
+        respondInteractionAnswerAtom: atom(null, (_get, _set, args) => respondAnswer(args)),
     }
 })
 
@@ -309,6 +318,10 @@ const mount = (store: ReturnType<typeof createStore>, entityId: string, sessionI
     )
 
 beforeEach(() => {
+    durableApprovalCapability.mockReset().mockResolvedValue(false)
+    respondAnswer
+        .mockReset()
+        .mockResolvedValue({durable: true, recoverable: false, executionId: "questionnaire-child"})
     approvalRecord.defer = false
     approvalRecord.resolve = undefined
     FakeEventSource.instances = []
@@ -1153,4 +1166,41 @@ describe("useAgentConversation", () => {
             expect(last.status.isError).toBe(true)
         })
     })
+})
+
+describe("server-owned client-tool answers", () => {
+    it.each([false, true])(
+        "submits client-tool answer durably without a competing local resume (error=%s)",
+        async (failed) => {
+            durableApprovalCapability.mockResolvedValue(true)
+            resumeContinuation.mockResolvedValue(true)
+            const store = createStore()
+            const sessionId = nextSessionId()
+            markSessionFresh(sessionId)
+            const {result} = mount(store, "rev-1", sessionId)
+            const output = {action: "accept", content: {goal: "Correctness"}}
+
+            await act(async () => {
+                await result.current.sendToolOutput({
+                    toolName: "request_input",
+                    toolCallId: "questionnaire",
+                    ...(failed ? {errorText: "Questionnaire could not be rendered"} : {output}),
+                })
+            })
+
+            expect(respondAnswer).toHaveBeenCalledWith({
+                sessionId,
+                toolCallId: "questionnaire",
+                resolution: {
+                    tool_call_id: "questionnaire",
+                    tool_name: "request_input",
+                    ...(failed
+                        ? {outcome: "error", error: "Questionnaire could not be rendered"}
+                        : {outcome: "completed", output}),
+                },
+            })
+            expect(resumeContinuation).not.toHaveBeenCalled()
+            expect(fetchMock).not.toHaveBeenCalled()
+        },
+    )
 })

--- a/web/packages/agenta-entities/src/session/state/interactionAnswer.ts
+++ b/web/packages/agenta-entities/src/session/state/interactionAnswer.ts
@@ -58,7 +58,7 @@ export const sessionDurableApprovalsCapabilityAtom = atom(
 )
 
 /**
- * Submit an approval through the response endpoint and preserve its failure for the card.
+ * Submit a gate answer through the response endpoint and preserve its failure for the card.
  * HTTP 202 means the server durably owns continuation; HTTP 200 is the flag-off server dispatcher
  * path. Both are server-owned, so callers never also release the local AI SDK gate.
  */
@@ -70,10 +70,13 @@ export const respondInteractionAnswerAtom = atom(
         params: {
             sessionId: string
             toolCallId: string
-            approved: boolean
-        },
+        } & ({approved: boolean} | {resolution: Record<string, unknown>}),
     ): Promise<{durable: boolean; recoverable: boolean; executionId?: string}> => {
-        const {sessionId, toolCallId, approved} = params
+        const {sessionId, toolCallId} = params
+        const answer =
+            "resolution" in params
+                ? params.resolution
+                : {approved: params.approved, tool_call_id: toolCallId}
         const projectId = get(projectIdAtom) ?? ""
         if (!projectId || !sessionId) throw new Error("Approval has no project or session scope.")
 
@@ -91,9 +94,12 @@ export const respondInteractionAnswerAtom = atom(
         const result = await respondInteraction({
             interactionId: row.id,
             projectId,
-            answer: {approved, tool_call_id: toolCallId},
+            answer,
             expectedExecutionId: row.turnId,
-            idempotencyKey: `approval:${row.id}:${approved ? "approve" : "deny"}`,
+            idempotencyKey:
+                "resolution" in params
+                    ? `client-tool:${row.id}`
+                    : `approval:${row.id}:${params.approved ? "approve" : "deny"}`,
         })
         if (!result) throw new Error("Approval could not be submitted.")
         await queryClient.invalidateQueries({queryKey: rowsQueryKey})

--- a/web/packages/agenta-entities/tests/unit/session-interaction-answer.test.ts
+++ b/web/packages/agenta-entities/tests/unit/session-interaction-answer.test.ts
@@ -1,0 +1,86 @@
+import {projectIdAtom} from "@agenta/shared/state"
+import {QueryClient} from "@tanstack/react-query"
+import {createStore} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+import {beforeEach, expect, it, vi} from "vitest"
+const {respond, transition} = vi.hoisted(() => ({respond: vi.fn(), transition: vi.fn()}))
+vi.mock("../../src/session/api/api", () => ({
+    respondInteraction: respond,
+    transitionInteraction: transition,
+    fetchSessionDurableApprovalsCapability: vi.fn(),
+    resumeSessionContinuation: vi.fn(),
+}))
+vi.mock("../../src/session/state/interactionStatus", async () => {
+    const {atom} = await import("jotai")
+    return {
+        sessionInteractionRowsQueryKey: () => ["interaction-rows"],
+        fetchSessionInteractionStatesAtom: atom(
+            null,
+            () =>
+                new Map([
+                    [
+                        "questionnaire",
+                        {
+                            id: "interaction-id",
+                            toolCallId: "questionnaire",
+                            token: "token",
+                            turnId: "queued-parent",
+                        },
+                    ],
+                ]),
+        ),
+    }
+})
+import {respondInteractionAnswerAtom} from "../../src/session/state/interactionAnswer"
+beforeEach(() => {
+    respond
+        .mockReset()
+        .mockResolvedValue({
+            accepted: true,
+            execution: {id: "answer-child", state: "pending_delivery"},
+        })
+    transition.mockReset()
+})
+it("preserves questionnaire content and stable retry identity without legacy transition", async () => {
+    const store = createStore()
+    store.set(projectIdAtom, "project-id")
+    store.set(queryClientAtom, new QueryClient())
+    const resolution = {
+        tool_call_id: "questionnaire",
+        tool_name: "request_input",
+        outcome: "completed",
+        output: {action: "accept", content: {goal: "Correctness", unchangedDefault: "yes"}},
+    }
+    const args = {sessionId: "session-id", toolCallId: "questionnaire", resolution}
+    expect(await store.set(respondInteractionAnswerAtom, args)).toEqual({
+        durable: true,
+        recoverable: false,
+        executionId: "answer-child",
+    })
+    await store.set(respondInteractionAnswerAtom, args)
+    expect(respond).toHaveBeenNthCalledWith(1, {
+        projectId: "project-id",
+        interactionId: "interaction-id",
+        answer: resolution,
+        expectedExecutionId: "queued-parent",
+        idempotencyKey: "client-tool:interaction-id",
+    })
+    expect(respond.mock.calls[1]).toEqual(respond.mock.calls[0])
+    expect(transition).not.toHaveBeenCalled()
+})
+it("preserves native approval answer and retry identity", async () => {
+    const store = createStore()
+    store.set(projectIdAtom, "project-id")
+    store.set(queryClientAtom, new QueryClient())
+    await store.set(respondInteractionAnswerAtom, {
+        sessionId: "session-id",
+        toolCallId: "questionnaire",
+        approved: false,
+    })
+    expect(respond).toHaveBeenCalledWith(
+        expect.objectContaining({
+            answer: {approved: false, tool_call_id: "questionnaire"},
+            idempotencyKey: "approval:interaction-id:deny",
+        }),
+    )
+})

--- a/web/packages/agenta-entities/tests/unit/session-interaction-answer.test.ts
+++ b/web/packages/agenta-entities/tests/unit/session-interaction-answer.test.ts
@@ -33,12 +33,10 @@ vi.mock("../../src/session/state/interactionStatus", async () => {
 })
 import {respondInteractionAnswerAtom} from "../../src/session/state/interactionAnswer"
 beforeEach(() => {
-    respond
-        .mockReset()
-        .mockResolvedValue({
-            accepted: true,
-            execution: {id: "answer-child", state: "pending_delivery"},
-        })
+    respond.mockReset().mockResolvedValue({
+        accepted: true,
+        execution: {id: "answer-child", state: "pending_delivery"},
+    })
     transition.mockReset()
 })
 it("preserves questionnaire content and stable retry identity without legacy transition", async () => {

--- a/web/packages/agenta-entity-ui/src/clientTools/useConnectFlow.ts
+++ b/web/packages/agenta-entity-ui/src/clientTools/useConnectFlow.ts
@@ -209,6 +209,7 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     // One-shot guard so THIS instance settles the parked call at most once, plus shared cleanup for
     // the running popup's listener/poll/timeout. `meta.settled` covers the OTHER instance's settle.
     const settledRef = useRef(false)
+    const pendingAnswerRef = useRef<ConnectOutput | {errorText: string} | null>(null)
     const activeRef = useRef(active)
     activeRef.current = active
     const popupRef = useRef<Window | null>(null)
@@ -230,8 +231,8 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
             setPhase("idle")
             setErrorText(null)
             const onSubmissionError = (error: unknown) => {
-                // The connection may exist, but the parked answer has not been saved. Keep
-                // the live action retryable instead of treating it as a settled manual retry.
+                // Retry the same answer without creating the connection again.
+                pendingAnswerRef.current = result
                 settledRef.current = false
                 setOutcome(null)
                 setErrorText(
@@ -250,7 +251,9 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
                         ? {connected: false, reason: result.errorText}
                         : {connected: result.connected === true, reason: result.reason},
                 )
-                void Promise.resolve(submission).catch(onSubmissionError)
+                void Promise.resolve(submission).then(() => {
+                    pendingAnswerRef.current = null
+                }, onSubmissionError)
             } catch (error) {
                 onSubmissionError(error)
             }
@@ -281,6 +284,10 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
             if (phase === "connecting") return
             if (settleParkedCall && (!activeRef.current || settledRef.current || meta.settled))
                 return
+            if (settleParkedCall && pendingAnswerRef.current) {
+                finish(pendingAnswerRef.current)
+                return
+            }
             // The integration-detail lookup that picks the real auth mode hasn't resolved yet —
             // proceeding here would send the agent's raw (possibly wrong, e.g. "oauth" for a
             // toolkit that only supports api_key) hint. The button is disabled for this same
@@ -410,6 +417,7 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     // Explicit cancel while the popup is open: settle the parked call as cancelled (or, when the
     // call is already settled — a manual retry — just stop).
     const cancel = useCallback(() => {
+        if (pendingAnswerRef.current) return
         teardown()
         if (!settledRef.current && !meta.settled)
             finish({connected: false, integration, slug, reason: "cancelled"})
@@ -420,7 +428,7 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
     // can respond gracefully / offer an alternative. Distinct from "cancelled" (abandoned popup) so
     // the agent can tell an explicit decline from a mishap.
     const decline = useCallback(() => {
-        if (settledRef.current || meta.settled) return
+        if (settledRef.current || meta.settled || pendingAnswerRef.current) return
         finish({connected: false, integration, slug, reason: "declined"})
     }, [finish, integration, slug, meta.settled])
 

--- a/web/packages/agenta-entity-ui/src/clientTools/useConnectFlow.ts
+++ b/web/packages/agenta-entity-ui/src/clientTools/useConnectFlow.ts
@@ -228,12 +228,31 @@ export const useConnectFlow = (meta: ClientToolMeta, settle: SettleClientTool, a
             teardown()
             // Leave "connecting" and record the terminal result so the chip paints now.
             setPhase("idle")
-            if ("errorText" in result) {
-                setOutcome({connected: false, reason: result.errorText})
-                settle({errorText: result.errorText})
-            } else {
-                setOutcome({connected: result.connected === true, reason: result.reason})
-                settle({output: result as Record<string, unknown>})
+            setErrorText(null)
+            const onSubmissionError = (error: unknown) => {
+                // The connection may exist, but the parked answer has not been saved. Keep
+                // the live action retryable instead of treating it as a settled manual retry.
+                settledRef.current = false
+                setOutcome(null)
+                setErrorText(
+                    error instanceof Error
+                        ? error.message
+                        : "Could not save the answer. Try again.",
+                )
+            }
+            try {
+                const submission =
+                    "errorText" in result
+                        ? settle({errorText: result.errorText})
+                        : settle({output: result as Record<string, unknown>})
+                setOutcome(
+                    "errorText" in result
+                        ? {connected: false, reason: result.errorText}
+                        : {connected: result.connected === true, reason: result.reason},
+                )
+                void Promise.resolve(submission).catch(onSubmissionError)
+            } catch (error) {
+                onSubmissionError(error)
             }
         },
         [settle, teardown],

--- a/web/packages/agenta-entity-ui/tests/unit/useConnectFlow.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/useConnectFlow.test.ts
@@ -12,10 +12,12 @@ import {act, createElement} from "react"
 import {createRoot} from "react-dom/client"
 import {describe, expect, it, vi} from "vitest"
 
+const {handleCreate} = vi.hoisted(() => ({handleCreate: vi.fn(async () => ({connection: {}}))}))
+
 vi.mock("@agenta/entities/gatewayTool", () => ({
     useToolIntegrationDetail: () => ({integration: {auth_schemes: ["oauth"]}, isLoading: false}),
     useToolsConnections: () => ({
-        handleCreate: async () => ({connection: {}}),
+        handleCreate,
         invalidate: vi.fn(),
     }),
 }))
@@ -143,10 +145,16 @@ describe("durable connection answer", () => {
         expect(flow.outcome).toBeNull()
         expect(flow.phase).toBe("idle")
         await act(async () => {
+            flow.decline()
+            flow.cancel()
+        })
+        expect(settle).toHaveBeenCalledTimes(1)
+        await act(async () => {
             await flow.runConnect(true)
         })
         expect(flow.outcome?.connected).toBe(true)
         expect(flow.errorText).toBeNull()
+        expect(handleCreate).toHaveBeenCalledTimes(1)
         expect(settle).toHaveBeenCalledTimes(2)
         expect(settle).toHaveBeenLastCalledWith({
             output: {connected: true, integration: "github", slug: "github"},

--- a/web/packages/agenta-entity-ui/tests/unit/useConnectFlow.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/useConnectFlow.test.ts
@@ -8,12 +8,20 @@
  * error surfaced anywhere — see the ConnectToolWidget KNOWN_CONNECT_REASONS branch this
  * message feeds).
  */
-import {describe, expect, it} from "vitest"
+import {act, createElement} from "react"
+import {createRoot} from "react-dom/client"
+import {describe, expect, it, vi} from "vitest"
+
+vi.mock("@agenta/entities/gatewayTool", () => ({
+    useToolIntegrationDetail: () => ({integration: {auth_schemes: ["oauth"]}, isLoading: false}),
+    useToolsConnections: () => ({handleCreate: async () => ({connection: {}}), invalidate: vi.fn()}),
+}))
 
 import {
     extractConnectErrorMessage,
     isConnectModeResolving,
     resolveConnectMode,
+    useConnectFlow,
 } from "../../src/clientTools/useConnectFlow"
 
 describe("resolveConnectMode", () => {
@@ -100,5 +108,30 @@ describe("extractConnectErrorMessage", () => {
             "Connection failed. Please try again.",
         )
         expect(extractConnectErrorMessage(null)).toBe("Connection failed. Please try again.")
+    })
+})
+
+
+describe("durable connection answer", () => {
+    it("keeps a rejected parked answer retryable instead of reporting connected", async () => {
+        const settle = vi.fn().mockRejectedValueOnce(new Error("Answer was not saved")).mockResolvedValue(undefined)
+        const meta = {toolCallId: "connect-1", input: {integration: "github"}, settled: false} as Parameters<typeof useConnectFlow>[0]
+        vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true)
+        const host = document.createElement("div")
+        const root = createRoot(host)
+        let flow!: ReturnType<typeof useConnectFlow>
+        const Probe = () => { flow = useConnectFlow(meta, settle); return null }
+        await act(async () => { root.render(createElement(Probe)) })
+        await act(async () => { await flow.runConnect(true) })
+        expect(flow.errorText).toBe("Answer was not saved")
+        expect(flow.outcome).toBeNull()
+        expect(flow.phase).toBe("idle")
+        await act(async () => { await flow.runConnect(true) })
+        expect(flow.outcome?.connected).toBe(true)
+        expect(flow.errorText).toBeNull()
+        expect(settle).toHaveBeenCalledTimes(2)
+        expect(settle).toHaveBeenLastCalledWith({output: {connected: true, integration: "github", slug: "github"}})
+        await act(async () => { root.unmount() })
+        vi.unstubAllGlobals()
     })
 })

--- a/web/packages/agenta-entity-ui/tests/unit/useConnectFlow.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/useConnectFlow.test.ts
@@ -14,7 +14,10 @@ import {describe, expect, it, vi} from "vitest"
 
 vi.mock("@agenta/entities/gatewayTool", () => ({
     useToolIntegrationDetail: () => ({integration: {auth_schemes: ["oauth"]}, isLoading: false}),
-    useToolsConnections: () => ({handleCreate: async () => ({connection: {}}), invalidate: vi.fn()}),
+    useToolsConnections: () => ({
+        handleCreate: async () => ({connection: {}}),
+        invalidate: vi.fn(),
+    }),
 }))
 
 import {
@@ -111,27 +114,46 @@ describe("extractConnectErrorMessage", () => {
     })
 })
 
-
 describe("durable connection answer", () => {
     it("keeps a rejected parked answer retryable instead of reporting connected", async () => {
-        const settle = vi.fn().mockRejectedValueOnce(new Error("Answer was not saved")).mockResolvedValue(undefined)
-        const meta = {toolCallId: "connect-1", input: {integration: "github"}, settled: false} as Parameters<typeof useConnectFlow>[0]
+        const settle = vi
+            .fn()
+            .mockRejectedValueOnce(new Error("Answer was not saved"))
+            .mockResolvedValue(undefined)
+        const meta = {
+            toolCallId: "connect-1",
+            input: {integration: "github"},
+            settled: false,
+        } as Parameters<typeof useConnectFlow>[0]
         vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true)
         const host = document.createElement("div")
         const root = createRoot(host)
         let flow!: ReturnType<typeof useConnectFlow>
-        const Probe = () => { flow = useConnectFlow(meta, settle); return null }
-        await act(async () => { root.render(createElement(Probe)) })
-        await act(async () => { await flow.runConnect(true) })
+        const Probe = () => {
+            flow = useConnectFlow(meta, settle)
+            return null
+        }
+        await act(async () => {
+            root.render(createElement(Probe))
+        })
+        await act(async () => {
+            await flow.runConnect(true)
+        })
         expect(flow.errorText).toBe("Answer was not saved")
         expect(flow.outcome).toBeNull()
         expect(flow.phase).toBe("idle")
-        await act(async () => { await flow.runConnect(true) })
+        await act(async () => {
+            await flow.runConnect(true)
+        })
         expect(flow.outcome?.connected).toBe(true)
         expect(flow.errorText).toBeNull()
         expect(settle).toHaveBeenCalledTimes(2)
-        expect(settle).toHaveBeenLastCalledWith({output: {connected: true, integration: "github", slug: "github"}})
-        await act(async () => { root.unmount() })
+        expect(settle).toHaveBeenLastCalledWith({
+            output: {connected: true, integration: "github", slug: "github"},
+        })
+        await act(async () => {
+            root.unmount()
+        })
         vi.unstubAllGlobals()
     })
 })

--- a/web/packages/agenta-shared/src/clientTools/index.ts
+++ b/web/packages/agenta-shared/src/clientTools/index.ts
@@ -94,8 +94,8 @@ export interface ClientToolMeta {
 
 /** Settle the parked part. Mirrors OSS `SettleClientTool`: exactly one of `output`/`errorText`. */
 export interface SettleClientTool {
-    (args: {output: Record<string, unknown>}): void
-    (args: {errorText: string}): void
+    (args: {output: Record<string, unknown>}): void | Promise<void>
+    (args: {errorText: string}): void | Promise<void>
 }
 
 /** Props every client-tool widget receives — mirrors OSS `ClientToolHandlerProps`. */


### PR DESCRIPTION
## Context

Submitting a questionnaire from a queued agent turn saved the answer but left the run stuck. The browser then tried to resume the runner directly; the server correctly refused because the queued continuation still owned the session. The UI showed “A saved approval is resuming,” and later messages remained queued. This was reproduced with two local browser tabs.

## Changes

Desktop and mobile now submit client-tool answers through the existing server-owned response path when durable approvals are enabled. The answer keeps its structured values and a stable retry identity, and the returned execution ID holds the queue until continuation finishes. Servers without that capability keep the existing ordered local resume.

The dispatcher reconstructs client-tool history and the answered tool result before invoking the continuation, preserving successful output and error results. Native approvals and generic user-input pass-through keep their existing behavior. A failed questionnaire submission appears in the form’s existing error line and can be retried without starting a competing local resume. Connection answers likewise preserve rejected submission promises and retry the saved answer without creating another connection.

## Tests

The real two-tab failure and a focused shared-hook regression failed before the fix. Afterward, 30 dispatcher tests, 64 shared hook/form/ownership tests, 14 desktop hook tests five entity/API tests and 12 connection tests pass. Shared chat, entity and entity-UI TypeScript checks and full frontend lint-fix pass (25 tasks).

## Demo

The corrected dispatcher also resumed the previously stuck local questionnaire through the canonical response endpoint: one continuation finished with the selected answer and the queue cleared. The baked questionnaire frontend passed local two-tab and mobile checks: the second tab submitted Visual polish with the untouched Daily default, one continuation completed, both tabs settled, and the next message completed. Mobile submitted Yes through one durable response and returned to idle. Saved records confirm one exact answer and one terminal for each run; screenshots were visually inspected. These images match the questionnaire implementation; the later connection-retry-only correction has focused regression, type and lint coverage. The exact final source also passed staging: a questionnaire queued behind a running turn was answered on mobile through one durable response, its exact answer and terminal were saved, and a normal follow-up completed with an empty queue. A separate first-send capability initialization finding is retained for follow-up, outside this fix. The original reproduction and final captures are retained in private QA evidence.

## What to QA

While one turn runs, queue a questionnaire request. Answer it from a second tab, keeping one default value unchanged. Confirm one continuation receives the exact answers, both tabs settle, and the next queued message completes. Repeat one questionnaire submission on mobile.
