### PR TITLE
fix(sessions): preserve active turns when watchdog checks fail

### DIFF
--- a/api/oss/src/core/sessions/commands/service.py
+++ b/api/oss/src/core/sessions/commands/service.py
@@ -1627,10 +1627,16 @@ class SessionCommandsService:
         )
         if (
             execution is not None
-            and (env.agenta.sessions.durable_approvals or env.agenta.sessions.queue)
             and (
-                execution.source_interaction_id is not None
-                or execution.parent_execution_id is not None
+                (
+                    execution.source_interaction_id is not None
+                    and env.agenta.sessions.durable_approvals
+                )
+                or (
+                    execution.source_interaction_id is None
+                    and execution.parent_execution_id is not None
+                    and env.agenta.sessions.queue
+                )
             )
             and execution.terminal_outcome is None
         ):

--- a/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
+++ b/api/oss/src/tasks/asyncio/sessions/orphan_sweep.py
@@ -554,6 +554,8 @@ async def run_orphan_sweep(
                 )
             )
             if completion_failures:
+                deferred.update(completion_failures)
+                unsettled.difference_update(completion_failures)
                 orphan_rows = [
                     row
                     for row in orphan_rows
@@ -653,12 +655,11 @@ async def run_orphan_sweep(
                 },
             )
 
+        unsettled.difference_update(skipped_orphan_turns)
         terminal_winners: Set[Tuple[UUID, str, str]] = set()
         endings_written: Set[Tuple[UUID, str, str]] = set()
         for project_id, session_id, turn_id in sorted(unsettled, key=lambda t: t[1]):
             key = (project_id, session_id, turn_id)
-            if key in skipped_orphan_turns:
-                continue
             if (
                 key not in terminal_turns
                 and env.agenta.sessions.durable_stop

--- a/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
+++ b/api/oss/tests/pytest/unit/sessions/test_execution_watchdog.py
@@ -364,6 +364,9 @@ class _FakeRecordsService:
         self.queries.append(list(keys))
         return {key for key in keys if key in self.settled}
 
+    async def runner_completed_turns(self, *, project_id, keys):
+        return set()
+
 
 @pytest.mark.anyio
 async def test_terminal_record_checks_are_batched_once_per_project(anyio_backend):
@@ -1142,6 +1145,53 @@ async def test_lost_turn_clear_loses_to_a_concurrent_turn_advance(anyio_backend)
     assert redis._store[alive_key] == b"turn-new"
     assert redis._store[running_key] == b"turn-new"
     assert redis._store[owner_key] == b"runner-new"
+
+
+@pytest.mark.anyio
+async def test_completion_lookup_failure_defers_settlement_and_cleanup(
+    anyio_backend, monkeypatch
+):
+    monkeypatch.setattr(env.agenta.sessions, "durable_stop", True)
+    monkeypatch.setattr(env.agenta.sessions, "durable_approvals", True)
+
+    class _FailingCompletionLookup(_FakeRecordsService):
+        async def runner_completed_turns(self, *, project_id, keys):
+            raise RuntimeError("tracing db unreachable")
+
+    stream = _stale_running_row(
+        session_id="sess-completion-lookup", turn_id="turn-current"
+    )
+    commands = _CommandsService()
+    publisher = _Publisher()
+    redis = _FakeRedis()
+    project = str(stream.project_id)
+    alive_key = f"alive:{project}:session:{stream.session_id}"
+    running_key = f"running:{project}:session:{stream.session_id}"
+    owner_key = f"owner:{project}:session:{stream.session_id}"
+    superseded_key = (
+        f"superseded:{project}:session:{stream.session_id}:turn:{stream.turn_id}"
+    )
+    owner = make_owner_value(replica_id="runner-1", turn_id=stream.turn_id).encode()
+    redis._store[alive_key] = stream.turn_id.encode()
+    redis._store[running_key] = stream.turn_id.encode()
+    redis._store[owner_key] = owner
+
+    await run_orphan_sweep(
+        _FakeTransactionsEngine([stream]),
+        redis,
+        records_service=_FailingCompletionLookup(),
+        commands_service=commands,
+        publish=publisher,
+    )
+
+    assert commands.execution_lost_calls == []
+    assert publisher.published == []
+    assert stream.flags["is_alive"] is True
+    assert stream.flags["is_running"] is True
+    assert redis._store[alive_key] == stream.turn_id.encode()
+    assert redis._store[running_key] == stream.turn_id.encode()
+    assert redis._store[owner_key] == owner
+    assert superseded_key not in redis._store
 
 
 @pytest.mark.anyio

--- a/api/oss/tests/pytest/unit/sessions/test_interaction_continuation_admission.py
+++ b/api/oss/tests/pytest/unit/sessions/test_interaction_continuation_admission.py
@@ -979,12 +979,49 @@ async def test_watchdog_does_not_recover_continuation_when_approvals_are_disable
     monkeypatch,
 ):
     monkeypatch.setattr(env.agenta.sessions, "durable_approvals", False)
+    monkeypatch.setattr(env.agenta.sessions, "queue", True)
     project_id = uuid4()
     executions = _Executions(
         project_id=project_id, session_id="session-1", source_id="source-1"
     )
     executions.continuation = executions.continuation.model_copy(
         update={"state": SessionExecutionState.running}
+    )
+    service = SessionCommandsService(
+        commands_dao=_Commands(),
+        streams_service=None,
+        interactions_service=None,
+        lock_engine=None,
+        delivery=_Unreachable(),
+        executions_dao=executions,
+    )
+
+    assert await service.settle_execution_lost(
+        project_id=project_id,
+        session_id="session-1",
+        execution_id="continuation-1",
+        settled_at=datetime.now(timezone.utc),
+    )
+    assert executions.continuation.state == SessionExecutionState.terminal
+    assert executions.continuation.terminal_outcome == SessionCommandOutcome.lost.value
+
+
+@pytest.mark.asyncio
+async def test_watchdog_does_not_recover_input_continuation_when_queue_is_disabled(
+    monkeypatch,
+):
+    monkeypatch.setattr(env.agenta.sessions, "durable_approvals", True)
+    monkeypatch.setattr(env.agenta.sessions, "queue", False)
+    project_id = uuid4()
+    executions = _Executions(
+        project_id=project_id, session_id="session-1", source_id="source-1"
+    )
+    executions.continuation = executions.continuation.model_copy(
+        update={
+            "state": SessionExecutionState.running,
+            "parent_execution_id": "source-1",
+            "source_interaction_id": None,
+        }
     )
     service = SessionCommandsService(
         commands_dao=_Commands(),

--- a/api/oss/tests/pytest/unit/sessions/test_records_mapping_upsert.py
+++ b/api/oss/tests/pytest/unit/sessions/test_records_mapping_upsert.py
@@ -11,6 +11,8 @@ Verifies:
 
 from uuid import UUID, uuid5, NAMESPACE_DNS
 
+import pytest
+
 from oss.src.core.sessions.records.dtos import SessionRecordEvent
 from oss.src.dbs.postgres.sessions.records.mappings import map_record_event_to_dbe
 
@@ -59,6 +61,13 @@ def test_turn_id_and_span_id_default_to_none():
     assert dbe.sequence is None
 
 
+@pytest.fixture
+def legacy_write_mode(monkeypatch):
+    from oss.src.utils.env import env
+
+    monkeypatch.setattr(env.sessions, "sequence_writes", False)
+
+
 class _FakeResult:
     def scalars(self):
         class _S:
@@ -99,7 +108,7 @@ class _FakeEngine:
         return _cm()
 
 
-def test_append_upserts_preserving_index():
+def test_append_upserts_preserving_index(legacy_write_mode):
     """The append statement must be an ON CONFLICT DO UPDATE on (project_id, record_id)
     that overwrites attributes but does not touch record_index."""
     from oss.src.dbs.postgres.sessions.records.dao import RecordsDAO
@@ -137,7 +146,7 @@ def test_append_upserts_preserving_index():
     assert "span_id" in compiled
 
 
-def test_append_commits_when_it_opens_its_own_session():
+def test_append_commits_when_it_opens_its_own_session(legacy_write_mode):
     from oss.src.dbs.postgres.sessions.records.dao import RecordsDAO
     import asyncio
 
@@ -149,7 +158,7 @@ def test_append_commits_when_it_opens_its_own_session():
     assert engine.opened_sessions[0].commit_calls == 1
 
 
-def test_append_does_not_commit_a_caller_supplied_session():
+def test_append_does_not_commit_a_caller_supplied_session(legacy_write_mode):
     """A caller threading its own session through owns the transaction boundary;
     append must flush (so the row is visible in-transaction) but never commit it."""
     from oss.src.dbs.postgres.sessions.records.dao import RecordsDAO


### PR DESCRIPTION
## Context
A failed lookup of runner completion records could let the watchdog mark a session turn lost without first verifying that its heartbeat was still stale. Separately, enabling queueing could keep an approval continuation recoverable even when durable approvals were explicitly disabled.

## Changes
Defer candidates whose completion lookup or reconciliation failed so the watchdog leaves their executions, records, and ownership untouched until a later pass. Also exclude turns whose heartbeat advanced during the sweep from later running-state and lock cleanup. Honor the corresponding feature flag for each continuation type. Keep the legacy record-upsert tests explicitly on the legacy path now that sequencing defaults on.

## Tests
The three affected API test modules passed (55 tests); the hardened lookup-failure and heartbeat-race checks also passed after explicitly setting their flags. Ruff format and lint passed. The full API unit suite passed locally (3,223 passed, 167 skipped) and in GitHub CI (3,222 passed, 168 skipped; run 34112818399). The local run used the SDK from this worktree, matching CI's local SDK installation. Independent review found no remaining issues. This hotfix adds no migration.
