### PR TITLE
[fix] Update attachment acceptance test for saved chat records

### DIFF
--- a/web/oss/tests/playwright/acceptance/agent-chat/attach-send-render-reload.spec.ts
+++ b/web/oss/tests/playwright/acceptance/agent-chat/attach-send-render-reload.spec.ts
@@ -14,7 +14,7 @@ import {expect} from "@agenta/web-tests/utils"
 import {expectAuthenticatedSession} from "../utils/auth"
 import {buildAcceptanceTags} from "../utils/tags"
 
-import {resumeTextTurn, sseFulfill} from "./assets/elicitationStream"
+import {sseFulfill} from "./assets/elicitationStream"
 import {test} from "./tests"
 
 const tags = buildAcceptanceTags({
@@ -47,12 +47,90 @@ test(
         const appId = await seedAgentChatApp()
         await navigateToAgentPlayground(appId)
 
-        let run = 0
+        let recordsApiUrl = ""
         await page.route("**/invoke*", async (route) => {
-            run += 1
-            await route.fulfill(
-                sseFulfill(resumeTextTurn({messageId: `attachment-run-${run}`, text: "Done."})),
-            )
+            const body = route.request().postDataJSON() as {
+                session_id?: string
+                data?: {
+                    inputs?: {
+                        messages?: {
+                            parts?: Record<string, unknown>[]
+                        }[]
+                    }
+                }
+            }
+            const sessionId = body.session_id
+            const message = body.data?.inputs?.messages?.at(-1)
+            const filePart = message?.parts?.find((part) => part.type === "file")
+            const agenta = (filePart?.providerMetadata as {agenta?: Record<string, unknown>})
+                ?.agenta
+            const attachment = {
+                attachmentId: agenta?.attachmentId,
+                filename: filePart?.filename,
+                mediaType: filePart?.mediaType,
+                size: agenta?.size,
+            }
+            const turnId = `attachment-turn-${Date.now()}`
+
+            expect(sessionId).toBeTruthy()
+            expect(attachment).toMatchObject({
+                attachmentId: expect.any(String),
+                filename: IMAGE_NAME,
+                mediaType: "image/png",
+                size: IMAGE.length,
+            })
+
+            const ingestUrl = new URL(recordsApiUrl)
+            const projectId = new URL(route.request().url()).searchParams.get("project_id")
+            if (projectId) ingestUrl.searchParams.set("project_id", projectId)
+            recordsApiUrl = ingestUrl.toString()
+
+            const records = [
+                {
+                    record_index: 0,
+                    record_source: "user",
+                    record_type: "message",
+                    attributes: {
+                        type: "message",
+                        text: "Describe the attached image.",
+                        attachments: [attachment],
+                    },
+                },
+                {
+                    record_index: 1,
+                    record_source: "agent",
+                    record_type: "message",
+                    attributes: {type: "message", text: "Done."},
+                },
+                {
+                    record_index: 2,
+                    record_source: "agent",
+                    record_type: "done",
+                    attributes: {type: "done", stopReason: "stop"},
+                },
+            ]
+            for (const record of records) {
+                const response = await page.request.post(recordsApiUrl, {
+                    data: {...record, session_id: sessionId, turn_id: turnId},
+                })
+                expect(response.ok()).toBe(true)
+            }
+
+            const chunks = [
+                {type: "start", messageId: `attachment-run-${turnId}`},
+                {type: "start-step"},
+                {
+                    type: "data-session-accepted",
+                    data: {sessionId, turnId, executionId: turnId},
+                    transient: true,
+                },
+                {type: "finish-step"},
+                {type: "finish", finishReason: "stop"},
+            ]
+            const stream =
+                chunks.map((chunk) => `data: ${JSON.stringify(chunk)}\n\n`).join("") +
+                "data: [DONE]\n\n"
+            await route.fulfill(sseFulfill(stream))
         })
 
         let contentReads = 0
@@ -80,7 +158,11 @@ test(
             mimeType: "image/png",
             buffer: IMAGE,
         })
-        expect((await uploadResponsePromise).ok()).toBe(true)
+        const uploadResponse = await uploadResponsePromise
+        expect(uploadResponse.ok()).toBe(true)
+        recordsApiUrl = uploadResponse
+            .url()
+            .replace(/\/sessions\/attachments(?:\?.*)?$/, "/sessions/records/ingest")
         await expect(page.getByAltText(IMAGE_NAME)).toBeVisible()
 
         const runRequestPromise = page.waitForRequest(
@@ -91,15 +173,18 @@ test(
 
         const runRequest = await runRequestPromise
         expect(runRequest.postData() ?? "").not.toContain("data:")
-        // FileCard (@ant-design/x) renders an image attachment as just an <img>, with the
-        // filename only in `alt` — there is no separate visible text caption for images
-        // (unlike the file/audio/video card types, which do render a name label).
-        await expect(page.getByAltText(IMAGE_NAME).last()).toBeVisible()
+        const renderedAttachment = page.locator(
+            `img[alt="${IMAGE_NAME}"][src*="/sessions/attachments/"][src*="/content"]`,
+        )
+        await expect(renderedAttachment.last()).toBeVisible()
+        await expect(renderedAttachment.last()).toHaveJSProperty("naturalWidth", 1)
         await expect.poll(() => contentReads).toBeGreaterThanOrEqual(1)
+        const contentReadsBeforeReload = contentReads
 
         await page.reload({waitUntil: "domcontentloaded"})
 
-        await expect(page.getByAltText(IMAGE_NAME).last()).toBeVisible()
-        await expect.poll(() => contentReads).toBeGreaterThanOrEqual(2)
+        await expect(renderedAttachment.last()).toBeVisible()
+        await expect(renderedAttachment.last()).toHaveJSProperty("naturalWidth", 1)
+        await expect.poll(() => contentReads).toBeGreaterThan(contentReadsBeforeReload)
     },
 )


### PR DESCRIPTION
## Context

The web acceptance job on release PR #6616 fails when it sends an uploaded image in agent chat. The test mocks the invoke response, but chat now renders saved session records rather than message content from that response. The fake turn saves no records, so the image disappears and the content-read assertion times out.

Failing job: https://github.com/Agenta-AI/agenta/actions/runs/34113627381/job/101719146870

## Changes

Update the existing test's fake turn to ingest the submitted attachment reference and a completed reply through the real session-record API. Emit the acceptance control frame expected by the current chat transport.

Keep upload, saved history, attachment retrieval and reload real. Check that the content-backed image decodes, rather than accepting a leftover composer thumbnail, and require a new content request after reload. No production changes, new skips, extra retries or longer timeouts.

## Tests

- Reproduced the original failure against the live PR #6616 preview with retries disabled.
- Updated attachment flow passed three times against that same preview (9.5, 7.7 and 8.5 seconds, no retries).
- Frontend `pnpm lint-fix`: 25 tasks passed. Focused ESLint, Prettier and diff checks passed.
- Independent review found no actionable issues.
- [Full PR CI passed](https://github.com/Agenta-AI/agenta/actions/runs/34120312459): web acceptance 50 passed, 0 failed, 30 existing skips in 7.1 minutes; attachment test passed first attempt in 14 seconds. API acceptance: 757 passed. All other required PR checks are green.

## How to review

The diff changes one acceptance test. Start with the fake invoke handler, then check the image assertions before and after reload. The PR targets `release/v0.115.3`.
