### PR TITLE
[5512] feat(api): catalog provider adapters (GitHub behind a registry)

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -130,6 +130,10 @@ from oss.src.apis.fastapi.workflows.router import WorkflowsRouter
 from oss.src.apis.fastapi.skills.router import SkillsRouter
 from oss.src.core.skills.service import SkillsService
 from oss.src.core.skills.import_service import SkillImportService
+from oss.src.core.skills.providers import (
+    GitHubProvider as GitHubSkillProvider,
+    ProviderRegistry as SkillProviderRegistry,
+)
 from oss.src.apis.fastapi.workflows.router import SimpleWorkflowsRouter
 from oss.src.apis.fastapi.evaluators.router import EvaluatorsRouter
 from oss.src.apis.fastapi.evaluators.router import SimpleEvaluatorsRouter
@@ -1061,6 +1065,7 @@ skills_service = SkillsService(
 
 skill_import_service = SkillImportService(
     simple_workflows_service=simple_workflows_service,
+    providers=SkillProviderRegistry([GitHubSkillProvider()]),
 )
 
 skills = SkillsRouter(

--- a/api/oss/src/apis/fastapi/skills/models.py
+++ b/api/oss/src/apis/fastapi/skills/models.py
@@ -21,13 +21,16 @@ class SkillsResponse(BaseModel):
 
 
 class SkillSourceScanRequest(BaseModel):
-    repo_url: str
+    source_url: str
     ref: Optional[str] = None
+    # Narrow resolution to one registered catalog provider; default = ask each.
+    provider: Optional[str] = None
 
 
 class SkillSourceImportRequest(BaseModel):
-    repo_url: str
+    source_url: str
     ref: Optional[str] = None
+    provider: Optional[str] = None
     # Paths (from a prior scan) to import; omitted = every valid candidate.
     paths: Optional[List[str]] = None
 

--- a/api/oss/src/apis/fastapi/skills/router.py
+++ b/api/oss/src/apis/fastapi/skills/router.py
@@ -371,7 +371,7 @@ class SkillsRouter:
         scan_request: SkillSourceScanRequest,
     ) -> SourceScanResult:
         """
-        Preview a repo/marketplace as skill candidates — no writes.
+        Preview a catalog source as skill candidates — no writes.
 
         Detects the layout (Claude marketplace manifest, single skill, or a
         multi-skill tree), parses every candidate, and reports per-candidate
@@ -387,8 +387,9 @@ class SkillsRouter:
 
         return await self.import_service.scan_source(
             project_id=UUID(request.state.project_id),
-            repo_url=scan_request.repo_url,
+            source_url=scan_request.source_url,
             ref=scan_request.ref,
+            provider=scan_request.provider,
         )
 
     @intercept_exceptions()
@@ -417,8 +418,9 @@ class SkillsRouter:
             project_id=UUID(request.state.project_id),
             user_id=UUID(request.state.user_id),
             #
-            repo_url=import_request.repo_url,
+            source_url=import_request.source_url,
             ref=import_request.ref,
+            provider=import_request.provider,
             paths=import_request.paths,
         )
 

--- a/api/oss/src/core/skills/fetcher.py
+++ b/api/oss/src/core/skills/fetcher.py
@@ -1,9 +1,7 @@
-"""Source fetching for skill imports: a GitHub repo/marketplace → an
-extracted temp directory + the commit sha it represents.
-
-Snapshot-only by design: the tarball endpoint needs no git binary and no
-clone; the extracted tree is handed to the parser and deleted afterwards.
-Tests (and the archive-upload path later) inject their own fetcher.
+"""Shared archive safety rails for catalog providers: bounded tarball
+extraction (path-traversal rejection, member-count and uncompressed-size
+ceilings) and the scan workdir. Provider-specific fetching lives in
+`providers/` — this module knows nothing about where an archive came from.
 """
 
 import io
@@ -11,105 +9,12 @@ import re
 import tarfile
 import tempfile
 from pathlib import Path
-from typing import Optional, Protocol
+from typing import Optional
 
-import httpx
-from pydantic import BaseModel
-
-from oss.src.utils.env import env
 from oss.src.core.skills.exceptions import (
     SkillSourceFetchError,
-    SkillSourceInvalidURLError,
     SkillSourceTooLargeError,
 )
-
-_GITHUB_URL = re.compile(
-    r"^(?:https?://)?github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+?)(?:\.git)?/?$"
-)
-
-
-class FetchedSource(BaseModel):
-    root: Path  # extracted tree root (inside a caller-owned temp dir)
-    commit_sha: Optional[str] = None
-
-    model_config = {"arbitrary_types_allowed": True}
-
-
-class SourceFetcher(Protocol):
-    async def fetch(
-        self, *, repo_url: str, ref: Optional[str], dest: Path
-    ) -> FetchedSource: ...
-
-
-def parse_github_url(repo_url: str) -> tuple[str, str]:
-    match = _GITHUB_URL.match(repo_url.strip())
-    if not match:
-        raise SkillSourceInvalidURLError(
-            f"Not a GitHub repository URL: {repo_url!r}.",
-            next_step="Pass a URL like github.com/<owner>/<repo>.",
-        )
-    return match.group("owner"), match.group("repo")
-
-
-class GitHubTarballFetcher:
-    """Public-repo fetch via the REST tarball endpoint. No auth in v1."""
-
-    async def fetch(
-        self, *, repo_url: str, ref: Optional[str], dest: Path
-    ) -> FetchedSource:
-        owner, repo = parse_github_url(repo_url)
-        target = f"https://api.github.com/repos/{owner}/{repo}/tarball/{ref or ''}"
-        max_bytes = env.agenta.api.skills_import.max_tarball_mb * 1024 * 1024
-
-        try:
-            async with httpx.AsyncClient(
-                follow_redirects=True,
-                timeout=env.agenta.api.skills_import.fetch_timeout_seconds,
-            ) as client:
-                async with client.stream("GET", target) as response:
-                    if response.status_code == 404:
-                        raise SkillSourceFetchError(
-                            f"GitHub returned 404 for {owner}/{repo}"
-                            + (f"@{ref}" if ref else "")
-                            + " — the repository (or ref) does not exist or is private.",
-                            next_step="Check the URL; private repositories are not supported yet.",
-                        )
-                    if response.status_code == 403:
-                        raise SkillSourceFetchError(
-                            "GitHub rate limit hit while fetching the repository.",
-                            next_step="Wait a few minutes and try again.",
-                        )
-                    if response.status_code >= 400:
-                        raise SkillSourceFetchError(
-                            f"GitHub returned HTTP {response.status_code} for {owner}/{repo}.",
-                        )
-
-                    # Enforce the cap WHILE streaming, so an oversized repository is
-                    # cut off at the limit instead of buffered whole and then rejected.
-                    chunks: list[bytes] = []
-                    received = 0
-                    async for chunk in response.aiter_bytes():
-                        received += len(chunk)
-                        if received > max_bytes:
-                            raise SkillSourceTooLargeError(
-                                f"The repository tarball exceeds the "
-                                f"{env.agenta.api.skills_import.max_tarball_mb} MB import cap.",
-                            )
-                        chunks.append(chunk)
-                    payload = b"".join(chunks)
-        except httpx.HTTPError as e:
-            raise SkillSourceFetchError(
-                f"Could not reach GitHub for {owner}/{repo}: {e.__class__.__name__}.",
-                next_step="Check the URL and try again.",
-            ) from e
-
-        return FetchedSource(
-            root=extract_tarball(payload, dest=dest),
-            # GitHub encodes the resolved sha in the tarball's top-level dir
-            # (<owner>-<repo>-<sha>); extract_tarball surfaces it via the dir name.
-            commit_sha=_sha_from_extracted_root(extracted=dest),
-        )
-
 
 # Decompression-bomb bounds: the download cap limits COMPRESSED bytes only, so
 # expansion gets its own ceilings before anything touches the disk.
@@ -157,7 +62,7 @@ def extract_tarball(payload: bytes, *, dest: Path) -> Path:
     return dest
 
 
-def _sha_from_extracted_root(*, extracted: Path) -> Optional[str]:
+def sha_from_extracted_root(*, extracted: Path) -> Optional[str]:
     entries = [p for p in extracted.iterdir() if p.is_dir()]
     if len(entries) == 1:
         tail = entries[0].name.rsplit("-", 1)[-1]

--- a/api/oss/src/core/skills/import_service.py
+++ b/api/oss/src/core/skills/import_service.py
@@ -166,8 +166,11 @@ class SkillImportService:
 
     async def _origin_index(
         self, *, project_id: UUID
-    ) -> Dict[Tuple[str, str], Dict[str, Any]]:
-        """(repository, path) → artifact origin, over every live skill workflow.
+    ) -> Dict[Tuple[str, str, str], Dict[str, Any]]:
+        """(provider, repository, path) → artifact origin, over every live skill.
+
+        The provider is part of the identity: two catalogs can name the same
+        repository string, and only the triple identifies one imported item.
 
         Two bounded queries: the head-revision query yields the project's skill
         set (revision-level `is_skill`), a batched artifact fetch yields meta.
@@ -190,14 +193,19 @@ class SkillImportService:
             workflow_refs=[Reference(id=artifact_id) for artifact_id in artifact_ids],
         )
 
-        index: Dict[Tuple[str, str], Dict[str, Any]] = {}
+        index: Dict[Tuple[str, str, str], Dict[str, Any]] = {}
         for artifact in artifacts:
             origin = read_origin(getattr(artifact, "meta", None))
             locator = origin_locator(origin)
+            provider = (origin or {}).get("provider")
             repository = locator.get("repository")
             path = locator.get("path")
-            if isinstance(repository, str) and isinstance(path, str):
-                index[(repository, path)] = {
+            if (
+                isinstance(provider, str)
+                and isinstance(repository, str)
+                and isinstance(path, str)
+            ):
+                index[(provider, repository, path)] = {
                     "workflow_id": artifact.id,
                     "origin": origin,
                 }
@@ -224,7 +232,7 @@ class SkillImportService:
             already = [
                 c.path_in_repo
                 for c in scan.candidates
-                if (locator.repository, c.path_in_repo) in index
+                if (adapter.provider, locator.repository, c.path_in_repo) in index
             ]
 
         return SourceScanResult(
@@ -284,7 +292,7 @@ class SkillImportService:
                 continue
 
             skill = candidate.skill
-            if (repository, candidate.path_in_repo) in index:
+            if (adapter.provider, repository, candidate.path_in_repo) in index:
                 result.skipped.append(
                     SkippedSkill(
                         path_in_repo=candidate.path_in_repo,

--- a/api/oss/src/core/skills/import_service.py
+++ b/api/oss/src/core/skills/import_service.py
@@ -28,12 +28,11 @@ from oss.src.core.skills.exceptions import (
     SkillNotFoundError,
     SkillOriginMissingError,
 )
-from oss.src.core.skills.fetcher import (
-    FetchedSource,
-    GitHubTarballFetcher,
-    SourceFetcher,
-    make_workdir,
-    parse_github_url,
+from oss.src.core.skills.fetcher import make_workdir
+from oss.src.core.skills.providers import (
+    CatalogProvider,
+    ProviderRegistry,
+    SourceLocator,
 )
 from oss.src.core.skills.parser import (
     ScanCandidate,
@@ -65,7 +64,8 @@ log = get_module_logger(__name__)
 
 
 class SourceScanResult(BaseModel):
-    repo_url: str
+    source_url: str
+    provider: Optional[str] = None
     ref: Optional[str] = None
     commit_sha: Optional[str] = None
     scan: ScanResult
@@ -86,7 +86,8 @@ class SkippedSkill(BaseModel):
 
 
 class ImportResult(BaseModel):
-    repo_url: str
+    source_url: str
+    provider: Optional[str] = None
     commit_sha: Optional[str] = None
     imported: List[ImportedSkill] = []
     skipped: List[SkippedSkill] = []
@@ -154,10 +155,10 @@ class SkillImportService:
         self,
         *,
         simple_workflows_service,
-        fetcher: Optional[SourceFetcher] = None,
+        providers: ProviderRegistry,
     ):
         self.simple_workflows_service = simple_workflows_service
-        self.fetcher = fetcher or GitHubTarballFetcher()
+        self.providers = providers
 
     @property
     def workflows_service(self):
@@ -205,31 +206,32 @@ class SkillImportService:
     async def scan_source(
         self,
         *,
-        repo_url: str,
+        source_url: str,
         ref: Optional[str] = None,
+        provider: Optional[str] = None,
         project_id=None,
     ) -> SourceScanResult:
+        adapter, locator = self.providers.resolve(
+            source_url, provider=provider, ref=ref
+        )
         with make_workdir() as workdir:
-            fetched = await self.fetcher.fetch(
-                repo_url=repo_url, ref=ref, dest=Path(workdir)
-            )
-            scan = scan_tree(fetched.root)
+            snapshot = await adapter.fetch_snapshot(locator, dest=Path(workdir))
+            scan = scan_tree(snapshot.root)
 
         already: List[str] = []
         if project_id is not None:
-            owner, repo = parse_github_url(repo_url)
-            repository = f"{owner}/{repo}"
             index = await self._origin_index(project_id=project_id)
             already = [
                 c.path_in_repo
                 for c in scan.candidates
-                if (repository, c.path_in_repo) in index
+                if (locator.repository, c.path_in_repo) in index
             ]
 
         return SourceScanResult(
-            repo_url=repo_url,
+            source_url=source_url,
+            provider=adapter.provider,
             ref=ref,
-            commit_sha=fetched.commit_sha,
+            commit_sha=snapshot.resolved_version,
             scan=scan,
             already_imported_paths=already,
         )
@@ -240,15 +242,17 @@ class SkillImportService:
         project_id,
         user_id,
         #
-        repo_url: str,
+        source_url: str,
         ref: Optional[str] = None,
+        provider: Optional[str] = None,
         paths: Optional[List[str]] = None,
     ) -> ImportResult:
+        adapter, locator = self.providers.resolve(
+            source_url, provider=provider, ref=ref
+        )
         with make_workdir() as workdir:
-            fetched: FetchedSource = await self.fetcher.fetch(
-                repo_url=repo_url, ref=ref, dest=Path(workdir)
-            )
-            scan = scan_tree(fetched.root)
+            snapshot = await adapter.fetch_snapshot(locator, dest=Path(workdir))
+            scan = scan_tree(snapshot.root)
 
         # None = every valid candidate; an explicit empty list imports NOTHING.
         selected = {p.rstrip("/") for p in paths} if paths is not None else None
@@ -256,15 +260,18 @@ class SkillImportService:
             c for c in scan.candidates if selected is None or c.path_in_repo in selected
         ]
 
-        owner, repo = parse_github_url(repo_url)
-        repository = f"{owner}/{repo}"
+        repository = locator.repository
 
         # Idempotency rides import provenance, not the name: re-importing a path
         # this repo already delivered is a skip, while an unrelated name clash just
         # gets a fresh suffixed slug (display names may collide, like agents).
         index = await self._origin_index(project_id=project_id)
 
-        result = ImportResult(repo_url=repo_url, commit_sha=fetched.commit_sha)
+        result = ImportResult(
+            source_url=source_url,
+            provider=adapter.provider,
+            commit_sha=snapshot.resolved_version,
+        )
 
         for candidate in candidates:
             if not candidate.valid or not candidate.skill:
@@ -301,22 +308,31 @@ class SkillImportService:
             # One meta for the create call: the artifact keeps `origin`, the v1
             # revision keeps `provenance` — the simple create stamps both records
             # with the same dict, and both halves are true of each record.
+            item_url = adapter.item_url(
+                locator,
+                path=candidate.path_in_repo,
+                resolved_version=snapshot.resolved_version,
+            )
             meta = merge_ag_meta(
                 None,
                 {
                     "origin": build_origin(
+                        provider=adapter.provider,
                         repository=repository,
                         ref=ref,
                         path=candidate.path_in_repo,
-                        resolved_version=fetched.commit_sha,
+                        resolved_version=snapshot.resolved_version,
                         content_hash=candidate_hash,
+                        url=item_url,
                     ),
                     "provenance": build_provenance(
                         operation="import",
+                        provider=adapter.provider,
                         repository=repository,
                         path=candidate.path_in_repo,
-                        resolved_version=fetched.commit_sha,
+                        resolved_version=snapshot.resolved_version,
                         content_hash=candidate_hash,
+                        url=item_url,
                     ),
                 },
             )
@@ -386,9 +402,9 @@ class SkillImportService:
                 f"Skill workflow {workflow_id} was not found in this project.",
             )
         origin = read_origin(getattr(workflow, "meta", None))
-        locator = origin_locator(origin)
-        repository = locator.get("repository")
-        path = locator.get("path")
+        stored_locator = origin_locator(origin)
+        repository = stored_locator.get("repository")
+        path = stored_locator.get("path")
         if not isinstance(repository, str) or not isinstance(path, str):
             raise SkillOriginMissingError(
                 "This skill has no import origin — only imported skills can be "
@@ -402,16 +418,20 @@ class SkillImportService:
             workflow_ref=Reference(id=workflow_id),
         )
 
+        adapter: CatalogProvider = self.providers.get(
+            str((origin or {}).get("provider"))
+        )
+        locator = SourceLocator(
+            provider=adapter.provider,
+            repository=repository,
+            ref=stored_locator.get("ref"),
+        )
         with make_workdir() as workdir:
-            fetched = await self.fetcher.fetch(
-                repo_url=f"github.com/{repository}",
-                ref=locator.get("ref"),
-                dest=Path(workdir),
-            )
-            scan = scan_tree(fetched.root)
+            snapshot = await adapter.fetch_snapshot(locator, dest=Path(workdir))
+            scan = scan_tree(snapshot.root)
 
         candidate = next((c for c in scan.candidates if c.path_in_repo == path), None)
-        return workflow, origin, head_revision, fetched, candidate
+        return workflow, origin, head_revision, adapter, locator, snapshot, candidate
 
     @staticmethod
     def _classify(
@@ -454,7 +474,9 @@ class SkillImportService:
             workflow,
             origin,
             head_revision,
-            fetched,
+            _,
+            _,
+            snapshot,
             candidate,
         ) = await self._load_update_context(
             project_id=project_id, workflow_id=workflow_id
@@ -468,7 +490,7 @@ class SkillImportService:
         return UpdateCheckResult(
             workflow_id=str(workflow_id),
             status=status,
-            resolved_version=fetched.commit_sha,
+            resolved_version=snapshot.resolved_version,
             issues=issues,
         )
 
@@ -486,7 +508,9 @@ class SkillImportService:
             workflow,
             origin,
             head_revision,
-            fetched,
+            adapter,
+            locator,
+            snapshot,
             candidate,
         ) = await self._load_update_context(
             project_id=project_id, workflow_id=workflow_id
@@ -502,15 +526,17 @@ class SkillImportService:
             return UpdateApplyResult(
                 workflow_id=str(workflow_id),
                 status=status,
-                resolved_version=fetched.commit_sha,
+                resolved_version=snapshot.resolved_version,
                 issues=issues,
             )
 
         skill = candidate.skill  # type: ignore[union-attr]  # classified above
-        locator = origin_locator(origin)
-        repository = str(locator.get("repository"))
-        path = str(locator.get("path"))
+        repository = locator.repository
+        path = str(origin_locator(origin).get("path"))
         new_hash = content_hash(candidate)  # type: ignore[arg-type]
+        item_url = adapter.item_url(
+            locator, path=path, resolved_version=snapshot.resolved_version
+        )
 
         try:
             outcome = await self.workflows_service.commit_workflow_revision_checked(
@@ -521,16 +547,18 @@ class SkillImportService:
                     slug=uuid4().hex[-12:],
                     name=skill.name,
                     description=skill.description,
-                    message=f"sync: {repository}@{fetched.commit_sha}",
+                    message=f"sync: {repository}@{snapshot.resolved_version}",
                     meta=merge_ag_meta(
                         None,
                         {
                             "provenance": build_provenance(
                                 operation="update",
+                                provider=adapter.provider,
                                 repository=repository,
                                 path=path,
-                                resolved_version=fetched.commit_sha,
+                                resolved_version=snapshot.resolved_version,
                                 content_hash=new_hash,
+                                url=item_url,
                             )
                         },
                     ),
@@ -548,7 +576,7 @@ class SkillImportService:
             return UpdateApplyResult(
                 workflow_id=str(workflow_id),
                 status="conflict",
-                resolved_version=fetched.commit_sha,
+                resolved_version=snapshot.resolved_version,
             )
 
         # Advance the checkpoint via the merge helper — foreign meta keys survive.
@@ -564,11 +592,13 @@ class SkillImportService:
                     getattr(workflow, "meta", None),
                     {
                         "origin": build_origin(
+                            provider=adapter.provider,
                             repository=repository,
-                            ref=locator.get("ref"),
+                            ref=locator.ref,
                             path=path,
-                            resolved_version=fetched.commit_sha,
+                            resolved_version=snapshot.resolved_version,
                             content_hash=new_hash,
+                            url=item_url,
                         )
                     },
                 ),
@@ -582,5 +612,5 @@ class SkillImportService:
             workflow_id=str(workflow_id),
             status="updated",
             revision_id=revision_id,
-            resolved_version=fetched.commit_sha,
+            resolved_version=snapshot.resolved_version,
         )

--- a/api/oss/src/core/skills/provenance.py
+++ b/api/oss/src/core/skills/provenance.py
@@ -16,19 +16,20 @@ from typing import Any, Dict, Optional
 AG_META_KEY = "_ag"
 
 ORIGIN_KIND_CATALOG = "catalog"
-PROVIDER_GITHUB = "github"
 
 
 def build_origin(
     *,
+    provider: str,
     repository: str,
     ref: Optional[str],
     path: str,
     resolved_version: Optional[str],
     content_hash: str,
-    provider: str = PROVIDER_GITHUB,
+    url: Optional[str] = None,
 ) -> Dict[str, Any]:
-    """The artifact-side origin: nested, identity above the mutable checkpoint."""
+    """The artifact-side origin: nested, identity above the mutable checkpoint.
+    `url` is provider-supplied (CatalogProvider.item_url) — no provider shapes here."""
     return {
         "kind": ORIGIN_KIND_CATALOG,
         "provider": provider,
@@ -37,7 +38,7 @@ def build_origin(
         "last_imported": {
             "resolved_version": resolved_version,
             "content_hash": content_hash,
-            "url": _github_url(repository, resolved_version, path),
+            "url": url,
         },
     }
 
@@ -45,11 +46,12 @@ def build_origin(
 def build_provenance(
     *,
     operation: str,  # "import" | "update"
+    provider: str,
     repository: str,
     path: str,
     resolved_version: Optional[str],
     content_hash: str,
-    provider: str = PROVIDER_GITHUB,
+    url: Optional[str] = None,
 ) -> Dict[str, Any]:
     """The revision-side provenance: flat, one immutable event."""
     return {
@@ -58,7 +60,7 @@ def build_provenance(
         "identifier": f"{repository}/{path}",
         "resolved_version": resolved_version,
         "content_hash": content_hash,
-        "url": _github_url(repository, resolved_version, path),
+        "url": url,
     }
 
 
@@ -133,11 +135,3 @@ def last_imported_hash(origin: Optional[Dict[str, Any]]) -> Optional[str]:
         return None
     value = checkpoint.get("content_hash")
     return value if isinstance(value, str) else None
-
-
-def _github_url(
-    repository: str, resolved_version: Optional[str], path: str
-) -> Optional[str]:
-    if not resolved_version:
-        return None
-    return f"https://github.com/{repository}/tree/{resolved_version}/{path}"

--- a/api/oss/src/core/skills/providers/__init__.py
+++ b/api/oss/src/core/skills/providers/__init__.py
@@ -1,0 +1,15 @@
+from oss.src.core.skills.providers.base import (
+    CatalogProvider,
+    SourceLocator,
+    SourceSnapshot,
+)
+from oss.src.core.skills.providers.github import GitHubProvider
+from oss.src.core.skills.providers.registry import ProviderRegistry
+
+__all__ = [
+    "CatalogProvider",
+    "GitHubProvider",
+    "ProviderRegistry",
+    "SourceLocator",
+    "SourceSnapshot",
+]

--- a/api/oss/src/core/skills/providers/base.py
+++ b/api/oss/src/core/skills/providers/base.py
@@ -1,0 +1,60 @@
+"""The catalog-provider contract (skill-registry plan, Mahmoud's direction #4).
+
+A provider turns an external skill catalog into a local snapshot the parser
+can scan. Everything outside a provider module speaks only these shapes — no
+repo, ref, or tarball vocabulary leaks past the adapter. The stored
+`meta._ag.origin.locator` keeps the shared keys `repository` (the
+provider-scoped source identity — for GitHub, `owner/repo`), `ref`, and
+`path`; a provider may add its own extras.
+"""
+
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional
+
+from pydantic import BaseModel, ConfigDict
+
+
+class SourceLocator(BaseModel):
+    """One external source, provider-scoped: WHERE skills come from."""
+
+    provider: str
+    # The source identity used for grouping and provenance (GitHub: "owner/repo").
+    repository: str
+    ref: Optional[str] = None
+
+
+class SourceSnapshot(BaseModel):
+    """A materialized source tree, ready for `scan_tree`."""
+
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
+    root: Path
+    # The provider's immutable version of this snapshot (GitHub: the commit sha).
+    resolved_version: Optional[str] = None
+
+
+class CatalogProvider(ABC):
+    """One external catalog kind. Register instances on the ProviderRegistry."""
+
+    provider: str
+
+    @abstractmethod
+    def claims(self, source_url: str) -> Optional[SourceLocator]:
+        """The locator, if this provider recognizes the reference — else None."""
+
+    @abstractmethod
+    async def fetch_snapshot(
+        self, locator: SourceLocator, *, dest: Path
+    ) -> SourceSnapshot:
+        """Materialize the source into `dest` (raises SkillSourceFetchError family)."""
+
+    @abstractmethod
+    def item_url(
+        self,
+        locator: SourceLocator,
+        *,
+        path: str,
+        resolved_version: Optional[str],
+    ) -> Optional[str]:
+        """A human-facing link to one item at one version, for provenance display."""

--- a/api/oss/src/core/skills/providers/github.py
+++ b/api/oss/src/core/skills/providers/github.py
@@ -1,0 +1,112 @@
+"""The GitHub catalog adapter — the only registered provider in v1.
+
+Everything GitHub-specific lives here: URL recognition, the REST tarball
+fetch (public repos, no auth), and the provenance link shape. The shared
+extraction safety rails (streamed size cap, decompression-bomb ceilings,
+path-traversal rejection) stay in `fetcher.py` — they serve any provider
+that ships archives.
+"""
+
+import re
+from pathlib import Path
+from typing import Optional
+
+import httpx
+
+from oss.src.utils.env import env
+
+from oss.src.core.skills.exceptions import (
+    SkillSourceFetchError,
+    SkillSourceTooLargeError,
+)
+from oss.src.core.skills.fetcher import extract_tarball, sha_from_extracted_root
+from oss.src.core.skills.providers.base import (
+    CatalogProvider,
+    SourceLocator,
+    SourceSnapshot,
+)
+
+_GITHUB_URL = re.compile(
+    r"^(?:https?://)?github\.com/(?P<owner>[\w.-]+)/(?P<repo>[\w.-]+?)(?:\.git)?/?$"
+)
+
+
+class GitHubProvider(CatalogProvider):
+    provider = "github"
+
+    def claims(self, source_url: str) -> Optional[SourceLocator]:
+        match = _GITHUB_URL.match((source_url or "").strip())
+        if not match:
+            return None
+        return SourceLocator(
+            provider=self.provider,
+            repository=f"{match.group('owner')}/{match.group('repo')}",
+        )
+
+    async def fetch_snapshot(
+        self, locator: SourceLocator, *, dest: Path
+    ) -> SourceSnapshot:
+        repository = locator.repository
+        ref = locator.ref
+        target = f"https://api.github.com/repos/{repository}/tarball/{ref or ''}"
+        max_bytes = env.agenta.api.skills_import.max_tarball_mb * 1024 * 1024
+
+        try:
+            async with httpx.AsyncClient(
+                follow_redirects=True,
+                timeout=env.agenta.api.skills_import.fetch_timeout_seconds,
+            ) as client:
+                async with client.stream("GET", target) as response:
+                    if response.status_code == 404:
+                        raise SkillSourceFetchError(
+                            f"GitHub returned 404 for {repository}"
+                            + (f"@{ref}" if ref else "")
+                            + " — the repository (or ref) does not exist or is private.",
+                            next_step="Check the URL; private repositories are not supported yet.",
+                        )
+                    if response.status_code == 403:
+                        raise SkillSourceFetchError(
+                            "GitHub rate limit hit while fetching the repository.",
+                            next_step="Wait a few minutes and try again.",
+                        )
+                    if response.status_code >= 400:
+                        raise SkillSourceFetchError(
+                            f"GitHub returned HTTP {response.status_code} for {repository}.",
+                        )
+
+                    # Enforce the cap WHILE streaming, so an oversized repository is
+                    # cut off at the limit instead of buffered whole and then rejected.
+                    chunks: list[bytes] = []
+                    received = 0
+                    async for chunk in response.aiter_bytes():
+                        received += len(chunk)
+                        if received > max_bytes:
+                            raise SkillSourceTooLargeError(
+                                f"The repository tarball exceeds the "
+                                f"{env.agenta.api.skills_import.max_tarball_mb} MB import cap.",
+                            )
+                        chunks.append(chunk)
+                    payload = b"".join(chunks)
+        except httpx.HTTPError as e:
+            raise SkillSourceFetchError(
+                f"Could not reach GitHub for {repository}: {e.__class__.__name__}.",
+                next_step="Check the URL and try again.",
+            ) from e
+
+        return SourceSnapshot(
+            root=extract_tarball(payload, dest=dest),
+            # GitHub encodes the resolved sha in the tarball's top-level dir
+            # (<owner>-<repo>-<sha>); extract_tarball surfaces it via the dir name.
+            resolved_version=sha_from_extracted_root(extracted=dest),
+        )
+
+    def item_url(
+        self,
+        locator: SourceLocator,
+        *,
+        path: str,
+        resolved_version: Optional[str],
+    ) -> Optional[str]:
+        if not resolved_version:
+            return None
+        return f"https://github.com/{locator.repository}/tree/{resolved_version}/{path}"

--- a/api/oss/src/core/skills/providers/github.py
+++ b/api/oss/src/core/skills/providers/github.py
@@ -10,6 +10,7 @@ that ships archives.
 import re
 from pathlib import Path
 from typing import Optional
+from urllib.parse import quote
 
 import httpx
 
@@ -109,4 +110,7 @@ class GitHubProvider(CatalogProvider):
     ) -> Optional[str]:
         if not resolved_version:
             return None
-        return f"https://github.com/{locator.repository}/tree/{resolved_version}/{path}"
+        # Paths come from the repo tree and may hold spaces or `#`; encode them
+        # (keeping separators) so the link stays valid.
+        safe_path = quote(path, safe="/")
+        return f"https://github.com/{locator.repository}/tree/{resolved_version}/{safe_path}"

--- a/api/oss/src/core/skills/providers/registry.py
+++ b/api/oss/src/core/skills/providers/registry.py
@@ -1,0 +1,54 @@
+"""The adapter registry: `provider name → CatalogProvider`.
+
+Adding a catalog kind later (GitLab, a marketplace, an internal registry)
+means writing one adapter and registering it here — the import service,
+routes, and frontend never change. Wired in `entrypoints/`.
+"""
+
+from typing import List, Optional, Tuple
+
+from oss.src.core.skills.exceptions import (
+    SkillSourceFetchError,
+    SkillSourceInvalidURLError,
+)
+from oss.src.core.skills.providers.base import CatalogProvider, SourceLocator
+
+
+class ProviderRegistry:
+    def __init__(self, providers: List[CatalogProvider]):
+        self._providers = {p.provider: p for p in providers}
+
+    def get(self, provider: str) -> CatalogProvider:
+        adapter = self._providers.get(provider or "")
+        if adapter is None:
+            # A stored origin naming an unregistered provider: the record is fine,
+            # this deployment just cannot serve it.
+            raise SkillSourceFetchError(
+                f"No catalog provider {provider!r} is registered.",
+            )
+        return adapter
+
+    def resolve(
+        self,
+        source_url: str,
+        *,
+        provider: Optional[str] = None,
+        ref: Optional[str] = None,
+    ) -> Tuple[CatalogProvider, SourceLocator]:
+        """The adapter + locator for a source reference.
+
+        By default every adapter is asked whether it recognizes the URL; an
+        explicit `provider` narrows the question to one adapter."""
+        candidates = (
+            [self.get(provider)] if provider else list(self._providers.values())
+        )
+        for adapter in candidates:
+            locator = adapter.claims(source_url)
+            if locator is not None:
+                if ref is not None:
+                    locator = locator.model_copy(update={"ref": ref})
+                return adapter, locator
+        raise SkillSourceInvalidURLError(
+            f"No catalog provider recognizes {source_url!r}.",
+            next_step="Pass a URL like github.com/<owner>/<repo>.",
+        )

--- a/api/oss/tests/pytest/unit/skills/test_import_service.py
+++ b/api/oss/tests/pytest/unit/skills/test_import_service.py
@@ -13,10 +13,15 @@ from uuid import uuid4
 import pytest
 
 from oss.src.core.skills.exceptions import SkillOriginMissingError
-from oss.src.core.skills.fetcher import FetchedSource
 from oss.src.core.skills.import_service import (
     SkillImportService,
     skill_content_hash,
+)
+from oss.src.core.skills.providers import (
+    CatalogProvider,
+    ProviderRegistry,
+    SourceLocator,
+    SourceSnapshot,
 )
 from oss.src.core.skills.provenance import (
     merge_ag_meta,
@@ -28,17 +33,32 @@ PROJECT_ID = uuid4()
 USER_ID = uuid4()
 
 
-class LocalFetcher:
+class LocalProvider(CatalogProvider):
+    """A filesystem adapter registered like any real one — the registry itself
+    is exercised by every test."""
+
+    provider = "local"
+
     def __init__(self, fixture_root: Path, commit_sha: str = "abc1234"):
         self.fixture_root = fixture_root
         self.commit_sha = commit_sha
 
-    async def fetch(
-        self, *, repo_url: str, ref: Optional[str], dest: Path
-    ) -> FetchedSource:
+    def claims(self, source_url: str) -> Optional[SourceLocator]:
+        if not source_url.startswith("local:"):
+            return None
+        return SourceLocator(
+            provider=self.provider, repository=source_url.removeprefix("local:")
+        )
+
+    async def fetch_snapshot(
+        self, locator: SourceLocator, *, dest: Path
+    ) -> SourceSnapshot:
         root = dest / "tree"
         shutil.copytree(self.fixture_root, root)
-        return FetchedSource(root=root, commit_sha=self.commit_sha)
+        return SourceSnapshot(root=root, resolved_version=self.commit_sha)
+
+    def item_url(self, locator, *, path, resolved_version):
+        return f"local://{locator.repository}/{path}@{resolved_version}"
 
 
 class _Workflow:
@@ -174,10 +194,12 @@ def fixture_tree(tmp_path: Path) -> Path:
 
 def _service(fixture_tree: Path, **kwargs):
     simple = _StubSimpleWorkflowsService(**kwargs)
+    provider = LocalProvider(fixture_tree)
     service = SkillImportService(
         simple_workflows_service=simple,
-        fetcher=LocalFetcher(fixture_tree),
+        providers=ProviderRegistry([provider]),
     )
+    service.test_provider = provider
     return service, simple
 
 
@@ -185,7 +207,7 @@ async def _import_all(service):
     return await service.import_from_source(
         project_id=PROJECT_ID,
         user_id=USER_ID,
-        repo_url="github.com/acme/skills",
+        source_url="local:acme/skills",
     )
 
 
@@ -199,7 +221,7 @@ def _workflow_named(simple, name):
 @pytest.mark.asyncio
 async def test_scan_source_reports_candidates(fixture_tree):
     service, _ = _service(fixture_tree)
-    result = await service.scan_source(repo_url="github.com/acme/skills")
+    result = await service.scan_source(source_url="local:acme/skills")
 
     assert result.commit_sha == "abc1234"
     by_path = {c.path_in_repo: c for c in result.scan.candidates}
@@ -212,23 +234,23 @@ async def test_scan_source_reports_candidates(fixture_tree):
 async def test_scan_marks_already_imported_paths(fixture_tree):
     service, _ = _service(fixture_tree)
     fresh = await service.scan_source(
-        repo_url="github.com/acme/skills", project_id=PROJECT_ID
+        source_url="local:acme/skills", project_id=PROJECT_ID
     )
     assert fresh.already_imported_paths == []
 
     await service.import_from_source(
         project_id=PROJECT_ID,
         user_id=USER_ID,
-        repo_url="github.com/acme/skills",
+        source_url="local:acme/skills",
         paths=["skills/alpha"],
     )
 
     rescan = await service.scan_source(
-        repo_url="github.com/acme/skills", project_id=PROJECT_ID
+        source_url="local:acme/skills", project_id=PROJECT_ID
     )
     assert rescan.already_imported_paths == ["skills/alpha"]
     # Without project context (pure repo preview) the marker stays empty.
-    anonymous = await service.scan_source(repo_url="github.com/acme/skills")
+    anonymous = await service.scan_source(source_url="local:acme/skills")
     assert anonymous.already_imported_paths == []
 
 
@@ -246,12 +268,13 @@ async def test_import_creates_workflows_with_provenance_meta(fixture_tree):
     alpha = _workflow_named(simple, "alpha")
     origin = read_origin(alpha.meta)
     assert origin["kind"] == "catalog"
-    assert origin["provider"] == "github"
+    assert origin["provider"] == "local"
     assert origin["locator"] == {
         "repository": "acme/skills",
         "ref": None,
         "path": "skills/alpha",
     }
+    assert origin["last_imported"]["url"] == "local://acme/skills/skills/alpha@abc1234"
     checkpoint = origin["last_imported"]
     assert checkpoint["resolved_version"] == "abc1234"
     assert checkpoint["content_hash"] == skill_content_hash(alpha.payload)
@@ -270,7 +293,7 @@ async def test_import_with_empty_paths_imports_nothing(fixture_tree):
     result = await service.import_from_source(
         project_id=PROJECT_ID,
         user_id=USER_ID,
-        repo_url="github.com/acme/skills",
+        source_url="local:acme/skills",
         paths=[],
     )
     assert result.imported == []
@@ -382,7 +405,7 @@ async def test_apply_commits_and_advances_the_checkpoint(fixture_tree):
     (fixture_tree / "skills/alpha/SKILL.md").write_text(
         "---\nname: alpha\ndescription: A test skill named alpha.\n---\n\nUpstream change.\n"
     )
-    service.fetcher.commit_sha = "def5678"
+    service.test_provider.commit_sha = "def5678"
 
     outcome = await service.apply_update(
         project_id=PROJECT_ID, user_id=USER_ID, workflow_id=alpha.id
@@ -474,7 +497,7 @@ async def test_check_recovers_from_a_lost_checkpoint_write(fixture_tree):
     (fixture_tree / "skills/alpha/SKILL.md").write_text(
         "---\nname: alpha\ndescription: A test skill named alpha.\n---\n\nUpstream change.\n"
     )
-    service.fetcher.commit_sha = "def5678"
+    service.test_provider.commit_sha = "def5678"
     await service.apply_update(
         project_id=PROJECT_ID, user_id=USER_ID, workflow_id=alpha.id
     )

--- a/api/oss/tests/pytest/unit/skills/test_import_service.py
+++ b/api/oss/tests/pytest/unit/skills/test_import_service.py
@@ -533,3 +533,16 @@ async def test_recovery_never_rescues_a_hand_edited_head(fixture_tree):
 
     check = await service.check_update(project_id=PROJECT_ID, workflow_id=alpha.id)
     assert check.status == "detached"
+
+
+@pytest.mark.asyncio
+async def test_identity_key_includes_the_provider(fixture_tree):
+    """Two catalogs may name the same repository string; only provider +
+    repository + path identifies one imported item."""
+    service, simple = _service(fixture_tree)
+    await _import_all(service)
+
+    index = await service._origin_index(project_id=PROJECT_ID)
+    assert ("local", "acme/skills", "skills/alpha") in index
+    # The same repo/path under a different provider is a DIFFERENT item.
+    assert ("github", "acme/skills", "skills/alpha") not in index

--- a/api/oss/tests/pytest/unit/skills/test_providers.py
+++ b/api/oss/tests/pytest/unit/skills/test_providers.py
@@ -43,6 +43,18 @@ def test_registry_rejects_an_unregistered_provider_name():
         registry.get("gitlab")
 
 
+def test_github_item_url_encodes_the_path():
+    provider = GitHubProvider()
+    locator = provider.claims("github.com/obra/superpowers")
+    url = provider.item_url(
+        locator, path="skills/my skill#1", resolved_version="abc123"
+    )
+    # Separators survive; the unsafe characters do not.
+    assert url == (
+        "https://github.com/obra/superpowers/tree/abc123/skills/my%20skill%231"
+    )
+
+
 def test_github_item_url_shape():
     provider = GitHubProvider()
     locator = provider.claims("github.com/obra/superpowers")

--- a/api/oss/tests/pytest/unit/skills/test_providers.py
+++ b/api/oss/tests/pytest/unit/skills/test_providers.py
@@ -1,0 +1,55 @@
+"""The catalog-provider registry and the GitHub adapter's URL contract."""
+
+import pytest
+
+from oss.src.core.skills.exceptions import (
+    SkillSourceFetchError,
+    SkillSourceInvalidURLError,
+)
+from oss.src.core.skills.providers import GitHubProvider, ProviderRegistry
+
+
+def test_github_claims_its_url_shapes():
+    provider = GitHubProvider()
+    for url in (
+        "github.com/obra/superpowers",
+        "https://github.com/obra/superpowers",
+        "https://github.com/obra/superpowers.git",
+        "github.com/obra/superpowers/",
+    ):
+        locator = provider.claims(url)
+        assert locator is not None and locator.repository == "obra/superpowers"
+    assert provider.claims("gitlab.com/obra/superpowers") is None
+    assert provider.claims("not a url") is None
+
+
+def test_registry_resolves_by_claim_and_threads_the_ref():
+    registry = ProviderRegistry([GitHubProvider()])
+    adapter, locator = registry.resolve("github.com/acme/skills", ref="release-2")
+    assert adapter.provider == "github"
+    assert locator.repository == "acme/skills"
+    assert locator.ref == "release-2"
+
+
+def test_registry_rejects_an_unrecognized_source():
+    registry = ProviderRegistry([GitHubProvider()])
+    with pytest.raises(SkillSourceInvalidURLError):
+        registry.resolve("sourcehut.org/acme/skills")
+
+
+def test_registry_rejects_an_unregistered_provider_name():
+    registry = ProviderRegistry([GitHubProvider()])
+    with pytest.raises(SkillSourceFetchError):
+        registry.get("gitlab")
+
+
+def test_github_item_url_shape():
+    provider = GitHubProvider()
+    locator = provider.claims("github.com/obra/superpowers")
+    assert (
+        provider.item_url(
+            locator, path="skills/brainstorming", resolved_version="abc123"
+        )
+        == "https://github.com/obra/superpowers/tree/abc123/skills/brainstorming"
+    )
+    assert provider.item_url(locator, path="x", resolved_version=None) is None

--- a/docs/design/agent-workflows/projects/skill-registry/plan-meta-provenance.md
+++ b/docs/design/agent-workflows/projects/skill-registry/plan-meta-provenance.md
@@ -121,6 +121,18 @@ review (tables vs meta, feature-by-feature, reversibility asymmetry).
 - Shared per-repo facts are N copies that can disagree after a partial
   refresh; the UI derives group state and shows per-skill truth.
 
+## Provider adapters (added 2026-09-07)
+
+Direction #4 is implemented (`core/skills/providers/`): a `CatalogProvider`
+contract (claims / fetch_snapshot / item_url), neutral `SourceLocator` /
+`SourceSnapshot` DTOs, and a `ProviderRegistry` wired in `entrypoints/` with
+GitHub as the only registered adapter. The import service, routes
+(`source_url` + optional `provider`), and frontend are provider-neutral;
+provenance URLs are adapter-supplied. The tests register a filesystem
+provider, so the registry always runs with n≥1 real lookups. The shared
+archive rails (size caps, bomb ceilings, traversal rejection) stay in
+`fetcher.py` for any provider that ships archives.
+
 ## Later triggers for reintroducing a table
 
 Credentials for private repos, scheduled sync, webhooks, org-level catalog

--- a/web/packages/agenta-api-client/src/generated/api/resources/skills/client/Client.ts
+++ b/web/packages/agenta-api-client/src/generated/api/resources/skills/client/Client.ts
@@ -23,7 +23,7 @@ export class SkillsClient {
     }
 
     /**
-     * Preview a repo/marketplace as skill candidates — no writes.
+     * Preview a catalog source as skill candidates — no writes.
      *
      * Detects the layout (Claude marketplace manifest, single skill, or a
      * multi-skill tree), parses every candidate, and reports per-candidate
@@ -37,7 +37,7 @@ export class SkillsClient {
      *
      * @example
      *     await client.skills.scanSkillSource({
-     *         repo_url: "repo_url"
+     *         source_url: "source_url"
      *     })
      */
     public scanSkillSource(
@@ -274,7 +274,7 @@ export class SkillsClient {
      *
      * @example
      *     await client.skills.importSkillSource({
-     *         repo_url: "repo_url"
+     *         source_url: "source_url"
      *     })
      */
     public importSkillSource(

--- a/web/packages/agenta-api-client/src/generated/api/resources/skills/client/requests/SkillSourceImportRequest.ts
+++ b/web/packages/agenta-api-client/src/generated/api/resources/skills/client/requests/SkillSourceImportRequest.ts
@@ -3,11 +3,12 @@
 /**
  * @example
  *     {
- *         repo_url: "repo_url"
+ *         source_url: "source_url"
  *     }
  */
 export interface SkillSourceImportRequest {
-    repo_url: string;
+    source_url: string;
     ref?: string | null;
+    provider?: string | null;
     paths?: string[] | null;
 }

--- a/web/packages/agenta-api-client/src/generated/api/resources/skills/client/requests/SkillSourceScanRequest.ts
+++ b/web/packages/agenta-api-client/src/generated/api/resources/skills/client/requests/SkillSourceScanRequest.ts
@@ -3,10 +3,11 @@
 /**
  * @example
  *     {
- *         repo_url: "repo_url"
+ *         source_url: "source_url"
  *     }
  */
 export interface SkillSourceScanRequest {
-    repo_url: string;
+    source_url: string;
     ref?: string | null;
+    provider?: string | null;
 }

--- a/web/packages/agenta-api-client/src/generated/api/types/ImportResult.ts
+++ b/web/packages/agenta-api-client/src/generated/api/types/ImportResult.ts
@@ -3,7 +3,8 @@
 import type * as AgentaApi from "../index.js";
 
 export interface ImportResult {
-    repo_url: string;
+    source_url: string;
+    provider?: (string | null) | undefined;
     commit_sha?: (string | null) | undefined;
     imported?: AgentaApi.ImportedSkill[] | undefined;
     skipped?: AgentaApi.SkippedSkill[] | undefined;

--- a/web/packages/agenta-api-client/src/generated/api/types/SourceScanResult.ts
+++ b/web/packages/agenta-api-client/src/generated/api/types/SourceScanResult.ts
@@ -3,7 +3,8 @@
 import type * as AgentaApi from "../index.js";
 
 export interface SourceScanResult {
-    repo_url: string;
+    source_url: string;
+    provider?: (string | null) | undefined;
     ref?: (string | null) | undefined;
     commit_sha?: (string | null) | undefined;
     scan: AgentaApi.ScanResult;

--- a/web/packages/agenta-skills-ui/src/registrySections.ts
+++ b/web/packages/agenta-skills-ui/src/registrySections.ts
@@ -38,7 +38,8 @@ export const toSkillListItem = (
 /** Provenance the drawer and picker rows show for an imported skill. */
 export const toSourceInfo = (origin: SkillOriginInfo): SkillSourceInfo => ({
     label: origin.repository ?? "Imported",
-    repoUrl: origin.repository ? `https://github.com/${origin.repository}` : undefined,
+    // Provider-supplied provenance link — the frontend never builds provider URLs.
+    repoUrl: origin.imported_at_url ?? undefined,
     commitSha: origin.resolved_version ?? undefined,
     detached: origin.detached ?? undefined,
 })

--- a/web/packages/agenta-skills-ui/tests/unit/registrySections.test.ts
+++ b/web/packages/agenta-skills-ui/tests/unit/registrySections.test.ts
@@ -41,11 +41,18 @@ describe("toSkillListItem", () => {
 })
 
 describe("toSourceInfo", () => {
-    it("labels an import by its repository and carries the resolved version", () => {
+    it("renders the provider-supplied link rather than building one", () => {
         const info = toSourceInfo(origin())
         expect(info.label).toBe("obra/superpowers")
-        expect(info.repoUrl).toBe("https://github.com/obra/superpowers")
+        // The adapter owns the URL shape; the frontend never assembles a provider link.
+        expect(info.repoUrl).toBe(
+            "https://github.com/obra/superpowers/tree/b36e082/skills/brainstorming",
+        )
         expect(info.commitSha).toBe("b36e082")
+    })
+
+    it("has no link when the provider supplied none", () => {
+        expect(toSourceInfo(origin({imported_at_url: null})).repoUrl).toBeUndefined()
     })
 
     it("falls back to a neutral label without a repository", () => {

--- a/web/packages/agenta-skills/src/api/index.ts
+++ b/web/packages/agenta-skills/src/api/index.ts
@@ -126,6 +126,8 @@ export interface ScanSkillSourceParams {
     projectId: string
     repoUrl: string
     ref?: string
+    /** Narrow resolution to one catalog provider; omitted = the server asks each. */
+    provider?: string
 }
 
 /** `POST /skills/sources/scan` — fetch + parse a GitHub repo without importing. Throws on HTTP errors. */
@@ -133,11 +135,12 @@ export async function scanSkillSource({
     projectId,
     repoUrl,
     ref,
+    provider,
 }: ScanSkillSourceParams): Promise<SkillSourceScanResponse | null> {
     if (!projectId || !repoUrl) return null
 
     const data = await getSkillsClient().scanSkillSource(
-        {source_url: repoUrl, ...(ref ? {ref} : {})},
+        {source_url: repoUrl, ...(ref ? {ref} : {}), ...(provider ? {provider} : {})},
         {queryParams: {project_id: projectId}},
     )
 
@@ -150,6 +153,7 @@ export interface ImportSkillSourceParams {
     ref?: string
     /** `path_in_repo` values from a prior scan; omitted = every valid candidate. */
     paths?: string[]
+    provider?: string
 }
 
 /** `POST /skills/sources` — import the selected candidates as skill workflows. Throws on HTTP errors. */
@@ -158,6 +162,7 @@ export async function importSkillSource({
     repoUrl,
     ref,
     paths,
+    provider,
 }: ImportSkillSourceParams): Promise<SkillSourceImportResponse | null> {
     if (!projectId || !repoUrl) return null
 
@@ -166,6 +171,7 @@ export async function importSkillSource({
             source_url: repoUrl,
             ...(ref ? {ref} : {}),
             ...(paths ? {paths} : {}),
+            ...(provider ? {provider} : {}),
         },
         {queryParams: {project_id: projectId}},
     )

--- a/web/packages/agenta-skills/src/api/index.ts
+++ b/web/packages/agenta-skills/src/api/index.ts
@@ -137,7 +137,7 @@ export async function scanSkillSource({
     if (!projectId || !repoUrl) return null
 
     const data = await getSkillsClient().scanSkillSource(
-        {repo_url: repoUrl, ...(ref ? {ref} : {})},
+        {source_url: repoUrl, ...(ref ? {ref} : {})},
         {queryParams: {project_id: projectId}},
     )
 
@@ -163,7 +163,7 @@ export async function importSkillSource({
 
     const data = await getSkillsClient().importSkillSource(
         {
-            repo_url: repoUrl,
+            source_url: repoUrl,
             ...(ref ? {ref} : {}),
             ...(paths ? {paths} : {}),
         },

--- a/web/packages/agenta-skills/src/core/schema.ts
+++ b/web/packages/agenta-skills/src/core/schema.ts
@@ -169,7 +169,8 @@ export type ScanCandidate = z.infer<typeof scanCandidateSchema>
 
 export const skillSourceScanResponseSchema = z
     .object({
-        repo_url: z.string().optional().nullable(),
+        source_url: z.string().optional().nullable(),
+        provider: z.string().optional().nullable(),
         ref: z.string().optional().nullable(),
         commit_sha: z.string().optional().nullable(),
         scan: z
@@ -188,7 +189,8 @@ export type SkillSourceScanResponse = z.infer<typeof skillSourceScanResponseSche
 
 export const skillSourceImportResponseSchema = z
     .object({
-        repo_url: z.string().optional().nullable(),
+        source_url: z.string().optional().nullable(),
+        provider: z.string().optional().nullable(),
         commit_sha: z.string().optional().nullable(),
         imported: z
             .array(


### PR DESCRIPTION
## Context
The last piece of the backend review's requested direction (#4): import was GitHub-specific end to end — URL parsing, the tarball API, and provenance link shapes leaked through the import service, routes, and frontend. Adding any second catalog kind meant touching all of them.

## Changes
New `core/skills/providers/` package:
- `CatalogProvider` contract: `claims(source_url) -> Locator | None`, `fetch_snapshot(locator) -> Snapshot`, `item_url(...)`.
- Neutral `SourceLocator` / `SourceSnapshot` DTOs; the stored `origin.locator` keeps the shared `repository`/`ref`/`path` keys (matching the review's canonical schema).
- `ProviderRegistry` (`resolve` by URL claim with an optional explicit `provider`; `get` by stored provider name), wired in `entrypoints/` with **GitHub as the only registered adapter**.

Everything GitHub-specific moved into `providers/github.py`; the shared archive rails (streamed size cap, decompression-bomb ceilings, traversal rejection) stay in `fetcher.py` for any archive-shipping provider. Update check/apply look the adapter up from the stored origin's `provider` — the field now does real work. Wire: `repo_url` → `source_url` plus optional `provider` on scan/import (nothing shipped, so no aliasing). The frontend no longer builds provider URLs — it renders the adapter-supplied provenance link.

Before:
```
import_service → GitHubTarballFetcher → github.com hardcoded in update flows + FE
```
After:
```
import_service → registry.resolve(url) / registry.get(origin.provider) → adapter
```

Adding GitLab or a marketplace later = one adapter file + one registry entry.

## Tests
- 5 new provider/registry tests (URL claiming shapes, ref threading, unrecognized source, unregistered provider, item-url shape).
- The import suite's fetcher stub became a registered filesystem provider, so every import test now exercises the registry too. Full API suite 3270; all web typechecks green.
- Live on /m: scan, import markers (14/14 already imported), and per-section Check updates all running through the adapter path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)