### PR TITLE
[6627] fix(hosting): give the api service the runner URL on the gh.local and gh.ssl stacks

### DIFF
--- a/hosting/docker-compose/ee/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/ee/docker-compose.gh.local.yml
@@ -85,6 +85,10 @@ services:
         environment:
             - AGENTA_SERVICES_INTERNAL_KEY=${AGENTA_SERVICES_INTERNAL_KEY:?AGENTA_SERVICES_INTERNAL_KEY is required}
             - SCRIPT_NAME=/api
+            # The api calls the runner directly for Stop (session cancel) and kill (sandbox
+            # teardown): same address and shared token as the `services` container.
+            - AGENTA_RUNNER_INTERNAL_URL=${AGENTA_RUNNER_INTERNAL_URL:-http://runner:8765}
+            - AGENTA_RUNNER_TOKEN=${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
             # Unset leaves the code default (3600s) in place.
             - AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
         # === NETWORK ============================================== #

--- a/hosting/docker-compose/oss/docker-compose.gh.local.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.local.yml
@@ -83,6 +83,10 @@ services:
         environment:
             - AGENTA_SERVICES_INTERNAL_KEY=${AGENTA_SERVICES_INTERNAL_KEY:?AGENTA_SERVICES_INTERNAL_KEY is required}
             - SCRIPT_NAME=/api
+            # The api calls the runner directly for Stop (session cancel) and kill (sandbox
+            # teardown): same address and shared token as the `services` container.
+            - AGENTA_RUNNER_INTERNAL_URL=${AGENTA_RUNNER_INTERNAL_URL:-http://runner:8765}
+            - AGENTA_RUNNER_TOKEN=${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
             # Unset leaves the code default (3600s) in place.
             - AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
         # === NETWORK ============================================== #

--- a/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
+++ b/hosting/docker-compose/oss/docker-compose.gh.ssl.yml
@@ -90,6 +90,10 @@ services:
         environment:
             - AGENTA_SERVICES_INTERNAL_KEY=${AGENTA_SERVICES_INTERNAL_KEY:?AGENTA_SERVICES_INTERNAL_KEY is required}
             - SCRIPT_NAME=/api
+            # The api calls the runner directly for Stop (session cancel) and kill (sandbox
+            # teardown): same address and shared token as the `services` container.
+            - AGENTA_RUNNER_INTERNAL_URL=${AGENTA_RUNNER_INTERNAL_URL:-http://runner:8765}
+            - AGENTA_RUNNER_TOKEN=${AGENTA_RUNNER_TOKEN:?AGENTA_RUNNER_TOKEN is required}
             # Unset leaves the code default (3600s) in place.
             - AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS=${AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS:-}
         # === NETWORK ============================================== #


### PR DESCRIPTION
## Summary

On the `gh.local` (oss and ee) and `gh.ssl` Compose stacks, the `api` service never gets `AGENTA_RUNNER_INTERNAL_URL`. The api calls the runner directly to cancel a turn (Stop) and to tear down a sandbox (kill), so on those stacks every Stop logs `cancel: no runner internal_url/token configured` and is never delivered. After three failed deliveries the sweep closes the healthy turn as lost, evicts the warm sandbox, and the chat shows "The agent stopped responding and the run was closed".

This PR passes the runner URL and token to the `api` service in those three files, the way `gh.yml` and `dev.yml` already do.

## Before

```
$ docker compose exec api printenv AGENTA_RUNNER_INTERNAL_URL
$ docker compose exec services printenv AGENTA_RUNNER_INTERNAL_URL
http://runner:8765
```

Api log on Stop:

```
[WARN.] cancel: no runner internal_url/token configured; command 01a07c17-... cannot be delivered
```

## After

`docker compose config` on each of the three files renders `AGENTA_RUNNER_INTERNAL_URL=http://runner:8765` and the token on the `api` service. An existing stack needs `docker compose up -d --force-recreate api` after the pull.

## Why only these files

`AGENTA_RUNNER_INTERNAL_URL` is commented out in the example env files, so the api only gets it when the compose file sets it. `gh.yml` and `dev.yml` set it on the api since #6287072c0b (direct cancel). The local and ssl variants were not updated.

Closes #6627

https://claude.ai/code/session_015akbm8MYys7pVjkhdP9R9a
