### PR TITLE
[6629] docs(self-host): the api needs the runner URL for Stop, plus the matching troubleshooting entry

### DIFF
--- a/docs/docs/self-host/concepts/01-architecture.mdx
+++ b/docs/docs/self-host/concepts/01-architecture.mdx
@@ -129,7 +129,7 @@ selector (for example, `AGENTA_WORKER_STREAMS=spans` on its own).
 - **Port**: 8765 (internal)
 - **Purpose**: Executes agent workflows on behalf of the Services API
 
-The runner receives `/run` requests from the Services API (routed via `AGENTA_RUNNER_INTERNAL_URL`) and starts harness processes (Pi, Claude Code, Codex, or other supported adapters) in local or remote sandboxes. It mounts durable working directories from the store into each sandbox and relays server-side tools back to the Services API without exposing the full stack environment to the harness.
+The runner receives `/run` requests from the Services API, and Stop and kill calls from the platform API (both routed via `AGENTA_RUNNER_INTERNAL_URL`), and starts harness processes (Pi, Claude Code, Codex, or other supported adapters) in local or remote sandboxes. It mounts durable working directories from the store into each sandbox and relays server-side tools back to the Services API without exposing the full stack environment to the harness.
 
 The runner runs each harness in a sandbox: the local runner container (`local`, the default) or a
 Daytona cloud sandbox (`daytona`, enabled by adding `daytona` to

--- a/docs/docs/self-host/concepts/02-how-agents-run.mdx
+++ b/docs/docs/self-host/concepts/02-how-agents-run.mdx
@@ -15,8 +15,13 @@ Services does not run agent code. It sends each agent run to one runner service 
 URL and a shared token:
 
 ```text
-Services  --(AGENTA_RUNNER_INTERNAL_URL, AGENTA_RUNNER_TOKEN)-->  Runner
+Services  --(AGENTA_RUNNER_INTERNAL_URL, AGENTA_RUNNER_TOKEN)-->  Runner   run a turn
+API       --(AGENTA_RUNNER_INTERNAL_URL, AGENTA_RUNNER_TOKEN)-->  Runner   Stop a turn, kill a session
 ```
+
+The platform API uses the same two values for its own calls to the runner. It cancels a turn when a
+user presses Stop, and it tears down a sandbox on the session `kill` verb. Both containers need
+both values.
 
 The runner owns sandbox execution. It receives a run request, starts a harness process inside a
 sandbox, streams results back, and relays server-side tools. A deployment has one logical runner.

--- a/docs/docs/self-host/reference/01-configuration.mdx
+++ b/docs/docs/self-host/reference/01-configuration.mdx
@@ -235,12 +235,13 @@ run multiple runners, use the Daytona provider, whose sessions any runner can re
 
 These locate the runner and authenticate the call. Two of the three are caller-side: the Services
 API and its SDK read them, not the runner. The platform API also reads the locator and token
-directly, for the session `kill` verb's sandbox teardown (`POST /kill` on the runner) — a second,
-independent caller of the same runner HTTP surface, not routed through Services.
+directly. It calls the runner to cancel a turn when a user presses Stop (`POST /cancel`), and to tear down a sandbox
+for the session `kill` verb (`POST /kill` on the runner). It is a second, independent caller of the
+same runner HTTP surface, not routed through Services, so both containers need both values.
 
 | Variable | Role | Read by | Default | Secret | Helm |
 |---|---|---|---|---|---|
-| `AGENTA_RUNNER_INTERNAL_URL` | Runner locator | Services API and the platform API (both caller-side) | Compose: `http://runner:8765` | no | `agentRunner.externalUrl`, else derived from `agentRunner.enabled` |
+| `AGENTA_RUNNER_INTERNAL_URL` | Runner locator | Services API and the platform API (both caller-side) | Compose: `http://runner:8765` on both callers (the `gh.local` and `gh.ssl` files set it on `api` from v0.115.3) | no | `agentRunner.externalUrl`, else derived from `agentRunner.enabled` |
 | `AGENTA_RUNNER_TOKEN` | Shared request credential | Services and the platform API send it; runner verifies it | **Required — no default** | yes | `agenta.runnerToken`, or `agentRunner.auth.tokenSecretRef` to source it from your own Secret |
 | `AGENTA_RUNNER_TIMEOUT_SECONDS` | Idle timeout the caller allows on the run request | Services API and SDK (caller-side) | `360` | no | n/a |
 
@@ -566,13 +567,34 @@ docker compose exec services python -c \
 
 A `200` confirms the hop.
 
+#### Stop does nothing, and minutes later the run is closed as "stopped responding"
+
+**Cause:** `AGENTA_RUNNER_INTERNAL_URL` is unset on the platform API. The api delivers a Stop to
+the runner directly. Without the locator it logs
+`cancel: no runner internal_url/token configured; command <id> cannot be delivered`, retries for a
+few minutes, and then closes the healthy turn as lost. The chat shows "The agent stopped responding
+and the run was closed", and the warm sandbox is gone. Before v0.115.3 the `gh.local` (oss and ee)
+and `gh.ssl` Compose files set the locator on `services` only, so the `services` check above passes
+while the api has no value.
+
+**Solution:** Set the locator and the token on the `api` container and recreate it:
+
+```bash
+docker compose exec api printenv AGENTA_RUNNER_INTERNAL_URL   # empty means this entry
+docker compose up -d --force-recreate api
+```
+
+On a Compose file older than v0.115.3, add both lines to the `api` service's `environment` block,
+the way the `services` block has them. On the next Stop the api log must not show the
+`cannot be delivered` line.
+
 #### The API cannot reach the runner, or the runner rejects its calls
 
 **Cause:** `AGENTA_RUNNER_INTERNAL_URL` does not point at the runner, or `AGENTA_RUNNER_TOKEN` is
 set on only one side.
 
-**Solution:** Check the URL, and set the same token value on the API and on the runner or on
-neither.
+**Solution:** Check the URL, and set the same token value on the api, on services, and on the
+runner.
 
 #### A self-managed local run fails because the harness has no login
 

--- a/docs/docs/self-host/reference/02-networking.mdx
+++ b/docs/docs/self-host/reference/02-networking.mdx
@@ -87,6 +87,7 @@ API Container:
 ├── → postgres:5432 (Database operations)
 ├── → redis-volatile:6379, redis-durable:6381 (queues, streams, caching)
 ├── → supertokens:3567 (Authentication)
+├── → runner:8765 (Stop and kill via AGENTA_RUNNER_INTERNAL_URL)
 └── → worker pool (Task delegation via queues/streams)
 
 Services API Container:
@@ -135,7 +136,7 @@ These variables configure how containers communicate internally. Use `REDIS_URI`
 | `REDIS_URI_VOLATILE` | Redis for caches/channels | `redis://redis-volatile:6379/0` | Falls back to `REDIS_URI` |
 | `REDIS_URI_DURABLE` | Redis for queues/streams | `redis://redis-durable:6381/0` | Falls back to `REDIS_URI` |
 | `SUPERTOKENS_CONNECTION_URI` | Auth service | `http://supertokens:3567` | SuperTokens service URL |
-| `AGENTA_RUNNER_INTERNAL_URL` | Runner URL | `http://runner:8765` | Points the Services API at the agent runner; default in compose, generated from `agentRunner.*` in Helm |
+| `AGENTA_RUNNER_INTERNAL_URL` | Runner URL | `http://runner:8765` | Points the Services API (runs) and the platform API (Stop, kill) at the agent runner; default in compose, generated from `agentRunner.*` in Helm |
 
 :::note Daytona sandboxes and the store tunnel
 Compose deployments using Daytona remote sandboxes require the `with-tunnel` compose profile, which starts an ngrok tunnel (it needs an `NGROK_AUTHTOKEN`). The remote sandbox mounts durable storage over the public internet, so the store endpoint must be reachable. Railway and Kubernetes deployments expose the store endpoint publicly and do not need ngrok.

--- a/docs/docs/self-host/upgrade-and-migrate/02-runner-and-store.mdx
+++ b/docs/docs/self-host/upgrade-and-migrate/02-runner-and-store.mdx
@@ -36,7 +36,10 @@ existing self-hosted Agenta deployment that predates the runner and store featur
    `docker compose logs runner`.
 
 4. The `AGENTA_RUNNER_INTERNAL_URL=http://runner:8765` value is included in the updated Compose
-   files by default. If you maintain a custom env file, add it there.
+   files by default. If you maintain a custom env file, add it there. Both the `services` and the
+   `api` service need it; the api uses it to deliver Stop. The `gh.local` and `gh.ssl` files set it
+   on the api from v0.115.3, so on an older copy of those files add it to the `api` service's
+   `environment` block.
 
 5. (Optional) Enable durable agent workspaces. Set the store credentials in your env file:
 


### PR DESCRIPTION
## Summary

The platform API calls the runner directly to cancel a turn (Stop) and to tear down a sandbox (kill). The self-host docs described the runner hop as Services-only, claimed every Compose file sets `AGENTA_RUNNER_INTERNAL_URL` on both callers, and had no troubleshooting entry for a Stop that never lands. A self-hoster on the `gh.local` or `gh.ssl` stack hits exactly that (#6627) and finds nothing in the docs that matches.

## What changed

- **Configuration reference.** The routing paragraph now names both api calls (Stop and kill). The table's default column says which Compose files set the value on the api and from which version. A new troubleshooting entry keys on the api log line `cancel: no runner internal_url/token configured` and the "stopped responding" card, with the `printenv` check and the recreate step. The generic "API cannot reach the runner" entry no longer suggests leaving the token unset on both sides, since the token is required.
- **How agents run.** The diagram shows the api hop next to the Services hop, with one sentence on what each carries.
- **Networking.** The API container's outbound list gains the runner hop, and the variable row names both callers.
- **Architecture and upgrade guide.** One sentence each: the runner also receives Stop and kill from the api, and the api service needs the value on the local and ssl files.

## Before

A reader with a broken Stop finds "The bundled Compose files already default to this value" and a `services` check that passes.

## After

The reader finds the log line, runs `docker compose exec api printenv AGENTA_RUNNER_INTERNAL_URL`, sees it empty, and knows to set it on the `api` service or upgrade the Compose file.

Pairs with #6628, which adds the value to the api service in those Compose files.

Closes #6629

https://claude.ai/code/session_015akbm8MYys7pVjkhdP9R9a
