### PR TITLE
feat(agents): align the build-an-agent skill with the platform prompt

### DIFF
--- a/.agents/skills/write-template-playbooks/SKILL.md
+++ b/.agents/skills/write-template-playbooks/SKILL.md
@@ -40,10 +40,10 @@ free-text asks that match no card.
   it as the field's `default` (prefilled, one-click acceptable); no default otherwise. [required]
 Only fields the agent genuinely cannot proceed without. One to four. Secrets never go here.
 
-## Researchable context (ask, defaulting to "figure it out")
-- <field>: the agent can discover this. Enum with a "Use your best judgment" or "Figure it
-  out from what's connected" option set as the `default`; the built-in Other… covers custom
-  values. Note the speed trade-off in the description.
+## Researchable context (do not ask; figure it out and state the assumption)
+- <field>: what the agent looks up, and what it assumes when the lookup is inconclusive. Never
+  a question and never an enum. The platform prompt forbids asking for a detail the agent can
+  look up or default, so this section names the lookup and the fallback assumption instead.
 
 ## Explore first (read before proposing)
 - Which read tools to discover_tools and wire.

--- a/.agents/skills/write-template-playbooks/references/worked-example.md
+++ b/.agents/skills/write-template-playbooks/references/worked-example.md
@@ -22,11 +22,9 @@ shipped" summaries from a repo.
 - Where release notes are published: the docs page, a Notion database, or a Linear
   document. Offer these as an enum with default "Figure it out from what's connected."
 
-## Researchable context (ask, defaulting to "figure it out")
-- How the team releases: merge to main, GitHub releases, or release branches. The agent can
-  discover this by reading the repo. Enum with default "Use your best judgment (I'll read
-  the repo)"; the built-in Other… covers anything else. Note in the description: handing
-  this over is faster than the agent researching it.
+## Researchable context (do not ask; figure it out and state the assumption)
+- How the team releases: read the repo for tags, release workflows, and long-lived release
+  branches. If that is inconclusive, assume merge to main and say so in your report.
 
 ## Explore first (read before proposing)
 1. discover_tools for the GitHub read tools (list merged PRs, get a PR).

--- a/api/oss/src/core/workflows/build_kit.py
+++ b/api/oss/src/core/workflows/build_kit.py
@@ -36,13 +36,12 @@ _READ_CONFIG_OPS: tuple[str, ...] = (
 
 _AUTO_ALLOWED_BUILD_KIT_OPS = frozenset({"rename_session", "rename_agent"})
 
-# Cut ops stay catalog opt-ins.
+# Cut ops stay catalog opt-ins. `annotate_trace` and `query_spans` left the kit on 2026-09-07:
+# no skill text told the model when to use them, and both are due for their own rework.
 DEFAULT_BUILD_KIT_OPS: tuple[str, ...] = (
     "discover_tools",
     *_READ_CONFIG_OPS,
     "commit_revision",
-    "annotate_trace",
-    "query_spans",
     "test_run",
     "rename_session",
     "rename_agent",

--- a/api/oss/src/core/workflows/static_catalog.py
+++ b/api/oss/src/core/workflows/static_catalog.py
@@ -223,9 +223,8 @@ def _request_input_revision() -> WorkflowRevision:
                     "description": (
                         "Pause the run and ask the user for typed input via an inline form. "
                         "Use this instead of guessing values the user must confirm — for "
-                        "example, when wiring a provider tool, ask WHICH actions to enable "
-                        "(enum from discover_tools results) or collect non-secret settings "
-                        "(subdomain, workspace) before request_connection; or collect schedule "
+                        "example, collect a non-secret setting before request_connection (an "
+                        "account subdomain, which workspace to use); or collect schedule "
                         "details (frequency, time of day, timezone) before create_schedule. "
                         "`requestedSchema` must be a FLAT JSON object schema: top-level "
                         "string/number/integer/boolean properties (enum, format, title and "

--- a/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
+++ b/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
@@ -43,8 +43,6 @@ from oss.src.core.workflows.static_catalog import StaticWorkflowCatalog
 EXPECTED_BUILD_KIT_OPS_WITHOUT_READ_CONFIG = (
     "discover_tools",
     "commit_revision",
-    "annotate_trace",
-    "query_spans",
     "test_run",
     "rename_session",
     "rename_agent",
@@ -62,8 +60,6 @@ EXPECTED_BUILD_KIT_OPS_WITH_READ_CONFIG = (
     "discover_tools",
     "read_config",
     "commit_revision",
-    "annotate_trace",
-    "query_spans",
     "test_run",
     "rename_session",
     "rename_agent",
@@ -104,6 +100,8 @@ EXPECTED_DEFAULT_BUILD_KIT_OPS = (
 )
 
 CUT_BUILD_KIT_OPS = (
+    "annotate_trace",
+    "query_spans",
     "pause_schedule",
     "resume_schedule",
     "pause_subscription",

--- a/api/oss/tests/pytest/unit/workflows/test_static_catalog.py
+++ b/api/oss/tests/pytest/unit/workflows/test_static_catalog.py
@@ -139,9 +139,11 @@ def test_default_static_skill_catalog_replaces_old_authoring_skills():
     playbook = catalog.retrieve_revision(slug=_PLAYBOOK_SLUG)
     skill = playbook.data.parameters["skill"]
     assert skill["name"] == "build-an-agent"
-    assert skill["body"].startswith("# Build an Agenta agent")
+    assert skill["body"].startswith("# Configure this Agenta agent")
     assert "test_run" in skill["body"]
-    assert "query_spans" in skill["body"]
+    # Left the build kit on 2026-09-07; the skill must not send the model to a tool it lacks.
+    assert "query_spans" not in skill["body"]
+    assert "annotate_trace" not in skill["body"]
 
 
 def test_build_kit_static_workflow_returns_agent_config_equivalent_to_overlay():
@@ -310,7 +312,7 @@ async def test_build_agent_skill_embed_resolves_through_static_catalog_without_d
 
     skill = resolved_revision.data.parameters["agent"]["skills"][0]
     assert skill["name"] == "build-an-agent"
-    assert skill["body"].startswith("# Build an Agenta agent")
+    assert skill["body"].startswith("# Configure this Agenta agent")
     assert resolution_info.embeds_resolved == 1
     # Resolving the static playbook skill must use the catalogue, not Postgres.
     workflows_dao.fetch_revision.assert_not_awaited()

--- a/docs/design/agent-platform-instructions/status.md
+++ b/docs/design/agent-platform-instructions/status.md
@@ -72,3 +72,21 @@ Branch `feat/release-1153-platform-prompt`, target `release/v0.115.3`.
   storing a preference in the instructions, which the prompt's Memory section requires. The
   SDK resolver collapses two identical copies of a reserved client tool, so a revision that
   embedded `request_secret` by hand before it joined the kit still runs.
+
+## 2026-09-07: the build-an-agent skill follows the platform prompt
+
+Branch `feat/release-1153-build-kit-skill`, stacked on `feat/release-1153-platform-prompt`.
+
+- The skill description no longer says "ALWAYS read this skill before your first reply". It
+  is read when the request is a change to the agent, and for a new agent's first request.
+- The decision table, the playbook-index detour, and the eight-step loop are gone. The
+  skill lists the template names inline, keeps a five-step change procedure aligned with
+  the prompt, and keeps the sections that came from evaluations: writing instructions for
+  multi-tool agents, prefer wired tools, when something fails, footguns.
+- `test_run` is no longer mandated after every commit, in the skill, in
+  `references/config-schema.md`, or in the 28 playbooks. Each playbook's Verify section is
+  now an "Offer a test" section. The read-before-propose use of `test_run` with an
+  uncommitted tools delta stays, because a newly committed integration is callable only in
+  the next session.
+- `annotate_trace` and `query_spans` left the build kit. They stay in the catalog as
+  opt-ins.

--- a/docs/design/agent-platform-instructions/status.md
+++ b/docs/design/agent-platform-instructions/status.md
@@ -90,3 +90,7 @@ Branch `feat/release-1153-build-kit-skill`, stacked on `feat/release-1153-platfo
   the next session.
 - `annotate_trace` and `query_spans` left the build kit. They stay in the catalog as
   opt-ins.
+- The `agenta-getting-started` skill is retired to a one-line stub. No default template
+  embeds it any more, but revisions saved earlier still reference its slug, and an embed the
+  catalog cannot resolve fails the run. The slug stays resolvable until a data migration
+  drops the embed from stored revisions; then the constant and the catalog entry go.

--- a/docs/design/agent-workflows/projects/agent-templates/exemplar.md
+++ b/docs/design/agent-workflows/projects/agent-templates/exemplar.md
@@ -29,11 +29,9 @@ shipped" summaries from a repo.
 - Where release notes are published: the docs page, a Notion database, or a Linear
   document. Offer these as an enum. First option: "Figure it out from what's connected."
 
-## Researchable context (ask, but the first option is "figure it out")
-- How the team releases: merge to main, GitHub releases, or release branches. The agent can
-  discover this by reading the repo. Enum first option: "Use your best judgment (I'll read
-  the repo)." Note in the description: handing this over is faster than the agent researching
-  it.
+## Researchable context (do not ask; figure it out and state the assumption)
+- How the team releases: read the repo for tags, release workflows, and long-lived release
+  branches. If that is inconclusive, assume merge to main and say so in your report.
 
 ## Explore first (read before proposing)
 1. discover_tools for the GitHub read tools (list merged PRs, get a PR).

--- a/docs/design/agent-workflows/projects/agent-templates/playbook-spec.md
+++ b/docs/design/agent-workflows/projects/agent-templates/playbook-spec.md
@@ -25,11 +25,10 @@ free-text asks that match no card.
 Only fields the agent genuinely cannot proceed without. Keep to one to four. Secrets never
 go here; they go to request_connection.
 
-## Researchable context (ask, defaulting to "figure it out")
-- <field>: the agent can discover this. Offer an enum including a "Use your best judgment"
-  or "Figure it out from what's connected" option and set it as the `default`; the built-in
-  Other… option covers custom values. Note the trade-off in the description: handing it over
-  is faster than the agent researching it.
+## Researchable context (do not ask; figure it out and state the assumption)
+- <field>: what the agent looks up, and what it assumes when the lookup is inconclusive.
+  Never a question and never an enum. The platform prompt forbids asking for a detail the
+  agent can look up or default, so this section names the lookup and the fallback assumption.
 
 ## Explore first (read before proposing)
 - Which read tools to discover_tools and wire.
@@ -89,9 +88,10 @@ elicitation form supports real defaults and two richer field shapes
   so a form whose proposals are right is accepted in one click. The default must match the
   declared type. An empty default (`""`/`[]`) means "no proposal" and is stripped.
   **Date/date-time fields ignore defaults** — do not set them there.
-- **Researchable context: set the "Figure it out" enum option as the `default`.** Enum options
-  are suggestions, not a hard constraint — every enum renders a built-in "Other…" free-text
-  escape hatch, so keep option lists short and likely.
+- **Researchable context never becomes a form field.** The agent looks the value up and states
+  the assumption it fell back on, so nothing in that section reaches `request_input`. Enum
+  options elsewhere are suggestions, not a hard constraint — every enum renders a built-in
+  "Other…" free-text escape hatch, so keep option lists short and likely.
 - **Multi-pick questions** use `{type: "array", items: {type: "string", enum: [...]}}` — the
   one admitted array shape; the answer is an array of strings.
 - **Context-ful options** use `oneOf: [{const, title, description}]` (single fields and array

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/engineering.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/engineering.py
@@ -67,14 +67,12 @@ Output shape:
     ### Fixes
     - <PR title> (#<number>)
 
-## Verify
-1. test_run with a blunt message ("Draft release notes from the last 5 merged PRs") and read
-   the verdict and the tools line, not a 200. An incomplete verdict means rewrite the
-   instructions blunter and re-test.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the real
-   trigger test: the Lightning "Test event" button for a subscription, the Play "Run" button
-   for a schedule.
-3. Read back the published note to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the published note) before
+you call it verified. For a trigger, point them at the Test event button of a subscription
+or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is scheduled or subscribed, what
@@ -135,12 +133,12 @@ Output shape (summary comment):
     - Risky: <file>:<line> - <why>
     - Missing tests: <file>
 
-## Verify
-1. test_run with a blunt message ("Review the latest open PR for risky changes and missing
-   tests") and read the verdict and the tools line, not a 200.
-2. Fire an artificial "PR opened" trigger test message first. If that passes, ask the user to
-   run the real trigger test: the Lightning "Test event" button.
-3. Read back the posted comments on the PR to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted review comments
+on the PR) before you call it verified. For a trigger, point them at the Test event button
+of a subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is subscribed, what you verified,
@@ -194,12 +192,12 @@ infer a priority label from keyword patterns (data loss or crash implies the hig
 apply the labels with the exact label tool, and finish by assigning the matched owner (from
 CODEOWNERS, if present) with the exact assign tool. Pin the repo id.
 
-## Verify
-1. test_run with a blunt message ("Triage the newest open issue") and read the verdict and the
-   tools line, not a 200.
-2. Fire an artificial "issue opened" trigger test message first. If that passes, ask the user to
-   run the real trigger test: the Lightning "Test event" button.
-3. Read back the issue's labels and assignee to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the issue's labels and
+assignee) before you call it verified. For a trigger, point them at the Test event button of
+a subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is subscribed, what you verified,
@@ -252,12 +250,12 @@ from the log (test failure, compile error, timeout, or infra), write a concise s
 finish by posting it as a comment on the PR or commit tagging the author with the exact comment
 tool (and, only if Slack is connected, also sending it to the channel). Pin the repo id.
 
-## Verify
-1. test_run with a blunt message ("Summarize why the last CI run failed") and read the verdict
-   and the tools line, not a 200.
-2. Fire an artificial "workflow run failed" trigger test message first. If that passes, ask the
-   user to run the real trigger test: the Lightning "Test event" button.
-3. Read back the posted comment to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted comment) before
+you call it verified. For a trigger, point them at the Test event button of a subscription
+or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected (note whether Slack is wired or
@@ -313,12 +311,12 @@ Output shape:
 
     Sources: <path>:<line>, <path>:<line>
 
-## Verify
-1. test_run with a blunt message ("What does <a real function or module> do?") and read the
-   verdict and the tools line, not a 200.
-2. Fire an artificial mention trigger test message first. If that passes, ask the user to run
-   the real trigger test: the Lightning "Test event" button.
-3. Read back the reply to confirm it landed in the right thread.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the reply in its thread)
+before you call it verified. For a trigger, point them at the Test event button of a
+subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is subscribed, what you verified,
@@ -374,12 +372,12 @@ Output shape:
     ### <ecosystem>
     - <package> <old version> -> <new version> (#<PR number>)
 
-## Verify
-1. test_run with a blunt message ("Summarize the open dependency-update PRs") and read the
-   verdict and the tools line, not a 200.
-2. Fire an artificial schedule-fired test message first. If that passes, ask the user to run
-   the real trigger test: the Play "Run" button.
-3. Read back the posted digest to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted digest) before
+you call it verified. For a trigger, point them at the Test event button of a subscription
+or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is scheduled, what you verified,

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/engineering.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/engineering.py
@@ -29,11 +29,9 @@ shipped" summaries from a repo.
 - Where release notes are published: the docs page, a Notion database, or a Linear
   document. Offer these as an enum with default "Figure it out from what's connected."
 
-## Researchable context (ask, defaulting to "figure it out")
-- How the team releases: merge to main, GitHub releases, or release branches. The agent can
-  discover this by reading the repo. Enum with default "Use your best judgment (I'll read
-  the repo)." Note in the description: handing this over is faster than the agent researching
-  it.
+## Researchable context (do not ask; figure it out and state the assumption)
+- How the team releases: read the repo for tags, release workflows, and long-lived release
+  branches. If that is inconclusive, assume merge to main and say so in your report.
 
 ## Explore first (read before proposing)
 1. discover_tools for the GitHub read tools (list merged PRs, get a PR).
@@ -93,13 +91,12 @@ repo.
   without it. Set the field default to the guess a prior read surfaced; leave no
   default otherwise.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Review posture: comment only (advisory) or request changes when tests are missing
-  (blocking). Enum with default "Use your best judgment (advisory comments, no blocking)."
-  Note the trade-off: blocking is stricter but can hold up a PR the agent misjudged.
-- What counts as risky: the agent can discover this from the diff (auth, secrets, migrations,
-  deletions). Enum with default "Figure it out from the diff"; the built-in Other… option
-  covers a short list the user types themselves.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Review posture: read the repo's CONTRIBUTING file and branch protection for whether reviews
+  block a merge. If that is inconclusive, assume advisory comments and no blocking, and say so.
+  Blocking is stricter but can hold up a PR the agent misjudged.
+- What counts as risky: read the diff and treat auth, secrets, migrations, and deletions as
+  risky. If the repo has another sensitive area, add it and state what you added.
 
 ## Explore first (read before proposing)
 1. discover_tools for the PR read tools (get PR diff, list changed files, list existing review
@@ -158,12 +155,11 @@ labeling.
   without it. Set the field default to the guess a prior read surfaced; leave no
   default otherwise.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Label taxonomy: which area and priority labels to use. Enum with default "Figure it out
-  from the repo's existing labels"; Other… covers a typed short list.
-- Owner assignment: how to pick who gets assigned. Enum with default "Use your best judgment
-  (read CODEOWNERS, or leave unassigned if there is none)." Note: handing over a mapping is
-  faster than the agent researching it.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Label taxonomy: list the repo's existing labels and use them. If the repo has no area or
+  priority labels, propose a minimal set of both, and state that you proposed it.
+- Owner assignment: read CODEOWNERS and assign the matched owner. If there is no CODEOWNERS
+  file, leave the issue unassigned and say so in your report.
 
 ## Explore first (read before proposing)
 1. discover_tools for the issue read tools (get issue, list labels) and the write tools (add
@@ -216,11 +212,11 @@ workflow runs or broken builds.
 - Repository: which GitHub repo's workflow runs to watch. The agent cannot proceed without
   it. Set the field default to the guess a prior read surfaced; leave no default otherwise.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Where to notify: a comment on the PR or commit tagging the author, or also a Slack channel if
-  Slack is connected. Enum with default "Use your best judgment (comment on the PR or commit;
-  add Slack only if it's already connected)." Slack and Discord are optional extensions here,
-  not requirements: GitHub alone is enough to run.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Where to notify: check which integrations are connected. Comment on the PR or commit and tag
+  the author, and add a Slack post only when Slack is already connected. Slack and Discord are
+  optional extensions here, not requirements: GitHub alone is enough to run. Say which
+  surfaces you wired.
 
 ## Explore first (read before proposing)
 1. discover_tools for the run read tools (get workflow run, list jobs, get job logs) and the
@@ -274,12 +270,12 @@ code Q&A bot. Card key code-qa. Also matches free-text asks for a repo-grounded 
   without it. Set the field default to the guess a prior read surfaced; leave no
   default otherwise.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Where questions come in: a Slack channel mention or a GitHub issue/PR comment mention. Enum
-  with default "Figure it out from what's connected." Note: handing this over is faster than
-  the agent researching it.
-- Answer depth: cite exact files and lines, or give a higher-level summary. Enum with default
-  "Use your best judgment (cite file paths and line numbers by default)."
+## Researchable context (do not ask; figure it out and state the assumption)
+- Where questions come in: check which integrations are connected, and wire that mention
+  surface. If both Slack and GitHub are connected, assume the GitHub comment mention, and say
+  so.
+- Answer depth: assume citations with exact file paths and line numbers, because a reader can
+  check them. State the assumption so the person can ask for shorter summaries instead.
 
 ## Explore first (read before proposing)
 1. discover_tools for the code search tool and the file read tool.
@@ -335,12 +331,13 @@ key dependency-digest. Also matches free-text asks about tracking Dependabot or 
   without it. Set the field default to the guess a prior read surfaced; leave no
   default otherwise.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Where to post the digest: a Slack channel if connected, or a comment on a pinned tracking
-  issue otherwise. Enum with default "Figure it out from what's connected." Slack is an
-  optional extension here, not a requirement.
-- Which PRs count as dependency updates: detect by author (dependabot[bot], renovate[bot]) or by
-  label. Enum with default "Use your best judgment (detect by author, then by label)."
+## Researchable context (do not ask; figure it out and state the assumption)
+- Where to post the digest: check what is connected. Post to Slack when Slack is connected,
+  and otherwise comment on a pinned tracking issue. Slack is an optional extension here, not a
+  requirement. Say which target you used.
+- Which PRs count as dependency updates: read the repo's open PRs for the dependabot[bot] and
+  renovate[bot] authors and for a "dependencies" label. If neither appears, assume detection
+  by author first and then by label, and state the assumption.
 
 ## Explore first (read before proposing)
 1. discover_tools for the PR list tool (filterable by author or label) and the get-PR tool.

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/knowledge.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/knowledge.py
@@ -62,12 +62,12 @@ Output shape:
     Sources:
     - <page title> (<link>)
 
-## Verify
-1. test_run with an artificial mention-shaped message ("@docs-bot how do I reset my API key?")
-   and read the verdict and the tools line, not a 200.
-2. Fire an artificial test message first; if it passes, ask the user to run the real trigger
-   test with the Lightning "Test event" button.
-3. Confirm the reply landed in the right channel/thread.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the reply in its channel or
+thread) before you call it verified. For a trigger, point them at the Test event button of a
+subscription or the Run button of a schedule.
 
 ## Closing report
 What the agent became, which sources it searches, which channel it answers in, what you
@@ -124,12 +124,12 @@ Output shape:
     Sources:
     - <page title> (<link>)
 
-## Verify
-1. test_run with an artificial mention/message ("Do you support refunds after 30 days?") and
-   read the verdict and the tools line, not a 200.
-2. Fire an artificial test message first; then ask the user to run the real trigger test with
-   the Lightning "Test event" button.
-3. Confirm the reply appears on the right platform and channel.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the reply on the right
+platform and channel) before you call it verified. For a trigger, point them at the Test
+event button of a subscription or the Run button of a schedule.
 
 ## Closing report
 What the agent became, which content it can see, which platform it answers on, what you
@@ -186,12 +186,12 @@ Output shape:
     Sources:
     - <page title> (<link>)
 
-## Verify
-1. test_run with an artificial mention-shaped message ("@onboarding-buddy where do I request a
-   laptop?") and read the verdict and the tools line, not a 200.
-2. Fire an artificial test message first; then ask the user to run the real trigger test with
-   the Lightning "Test event" button.
-3. Confirm the reply landed in the right channel/thread.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the reply in its channel or
+thread) before you call it verified. For a trigger, point them at the Test event button of a
+subscription or the Run button of a schedule.
 
 ## Closing report
 What the agent became, which wiki it searches, which channel it answers in, what you verified,
@@ -241,11 +241,11 @@ quotes the doc does not contain. Each draft links back to the source doc. If the
 enough substance for a platform, say so instead of padding with invented detail. Finish by
 posting the drafts to the review channel or draft page with the exact write tool.
 
-## Verify
-1. test_run with a blunt message ("Repurpose this doc into LinkedIn and X drafts") and read the
-   verdict and the tools line, not a 200.
-2. This template has no trigger to verify; it runs on demand by chatting with the agent.
-3. Read back the posted drafts to confirm they landed in the review channel or page.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted drafts in the
+review channel or page) before you call it verified.
 
 ## Closing report
 What the agent became, which doc it read, where drafts post, what you verified, and any
@@ -302,12 +302,12 @@ Output shape:
     ### Fixed
     - <item> (<link>)
 
-## Verify
-1. test_run with a blunt message ("Draft this week's newsletter from recent shipping activity")
-   and read the verdict and the tools line, not a 200.
-2. Fire an artificial scheduled-run test message first; if it passes, ask the user to run the
-   real trigger test with the Play "Run" button.
-3. Read back the Notion page to confirm the draft landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the Notion page with the
+draft) before you call it verified. For a trigger, point them at the Test event button of a
+subscription or the Run button of a schedule.
 
 ## Closing report
 What the agent became, which sources it reads, where it drafts, what is scheduled, what you

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/knowledge.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/knowledge.py
@@ -27,10 +27,10 @@ base" agent for teammates (not customers; see knowledge-chatbot for a customer-f
   workspace holds more than docs (product specs, meeting notes, and so on). Description:
   "Leave empty to search the whole connected workspace."
 
-## Researchable context (ask, defaulting to "figure it out")
-- Additional sources beyond Notion: also search Confluence, Google Drive, or Slack history if
-  connected. Multi-select ({type: "array", items: {type: "string", enum: [...]}}) with default
-  ["Figure it out from what's connected"]. Note: naming sources now saves a research pass.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Additional sources beyond Notion: check what is connected, and also search Confluence,
+  Google Drive, or Slack history when they are. Assume every connected source is in scope, and
+  list the sources you wired.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Notion search and page-read tools (and Confluence/Drive/Slack reads
@@ -90,9 +90,9 @@ teammate-only bot, see docs-qa instead).
   excluding anything internal-only. Description: "Leave empty to search the whole connected
   workspace" if there is no internal/external split.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Tone: match the brand voice found in existing customer-facing pages, or a plain, neutral
-  tone. Enum with default "Figure it out from the docs I find."
+## Researchable context (do not ask; figure it out and state the assumption)
+- Tone: read the existing customer-facing pages and match their brand voice. If you find no
+  such pages, assume a plain, neutral tone, and state the assumption.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Notion search/fetch tools and the reply tool for the chosen platform
@@ -152,10 +152,10 @@ this one).
   workspace holds more than onboarding content. Description: "Leave empty to search the whole
   connected workspace."
 
-## Researchable context (ask, defaulting to "figure it out")
-- Which topics to prioritize (benefits, tools setup, team structure): a multi-pick, so use
-  multi-select ({type: "array", items: {type: "string", enum: [...]}}) with default
-  ["Figure it out from what the wiki covers"].
+## Researchable context (do not ask; figure it out and state the assumption)
+- Which topics to prioritize: read the wiki and take the topics it already covers, such as
+  benefits, tools setup, and team structure. If the wiki is thin, assume those three, and say
+  which topics you covered.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Notion (or Confluence) search and page-read tools.
@@ -213,10 +213,9 @@ entry into social copy (this is a one-shot transform, not a standing Q&A bot).
 - Where to post drafts for review: a Slack channel or a Notion draft page. Offer as an enum
   with default "Figure it out from what's connected."
 
-## Researchable context (ask, defaulting to "figure it out")
-- Which platforms to draft for (LinkedIn, X, or both): a multi-pick, so use multi-select
-  ({type: "array", items: {type: "string", enum: ["LinkedIn", "X"]}}) with default
-  ["LinkedIn", "X"] (draft both).
+## Researchable context (do not ask; figure it out and state the assumption)
+- Which platforms to draft for: check which social accounts are connected and draft for those.
+  If none is connected, assume both LinkedIn and X, and state which you drafted for.
 
 ## Explore first (read before proposing)
 1. discover_tools for the source-read tool (Notion or Drive) and the draft-post tool (Slack
@@ -264,12 +263,11 @@ newsletter draft (for a Slack-only digest with no draft doc, see repo-slack-dige
 - Where to draft the newsletter: which Notion page or database to write the weekly draft into.
   No default; the agent cannot know this.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Which sources to pull from: GitHub merged PRs, Linear completed issues, or both. A
-  multi-pick, so use multi-select ({type: "array", items: {type: "string", enum: [...]}})
-  with default ["Figure it out from what's connected"].
-- Send day/time: enum with default "Monday 09:00 local"; the built-in Other… option covers a
-  custom time.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Which sources to pull from: check what is connected, and pull GitHub merged PRs, Linear
+  completed issues, or both. Assume every connected source is in scope, and list what you used.
+- Send day and time: assume Monday 09:00 local and state the assumption. Read the local
+  timezone from the workspace settings, and assume UTC when that is inconclusive.
 
 ## Explore first (read before proposing)
 1. discover_tools for the GitHub (merged PRs) and/or Linear (completed issues) read tools, and

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/monitoring.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/monitoring.py
@@ -31,10 +31,10 @@ incident-responder. Also matches free-text asks about incident response, alert t
   to page. No default; the agent cannot know who is on call or where the team looks for
   alerts without being told.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Paging threshold: which severities actually page vs. just get logged. Enum with default
-  "Use your best judgment (page on fatal/error, log the rest)." Note in the description:
-  handing this over is faster than the agent inferring it from issue history.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Paging threshold: read the issue history for which severities the team already acts on. If
+  that is inconclusive, assume paging on fatal and error, log the rest, and state the
+  assumption.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Sentry read tools (list issues, get an issue, list events).
@@ -95,10 +95,10 @@ file a ticket for this error."
 - Where new tickets go: a Linear team or a Jira project. No default; the agent cannot guess
   the filing destination.
 
-## Researchable context (ask, defaulting to "figure it out")
-- What counts as noise vs. a real error: known third-party or expected exceptions to ignore,
-  and the frequency that promotes an error to "file it." Enum with default "Use your best
-  judgment (ignore known-noisy exceptions, file anything crossing a frequency threshold)."
+## Researchable context (do not ask; figure it out and state the assumption)
+- What counts as noise against a real error: read the recent issues for third-party and
+  expected exceptions the team ignores. Assume you ignore those and file anything that crosses
+  a frequency threshold, and state the threshold you picked.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Sentry read tools (list issues, get an issue) and the ticket-create
@@ -154,10 +154,10 @@ uptime-reporter. Also matches free-text asks about a daily status digest or an S
 - Slack channel to post the daily summary to: no default; the agent cannot guess where the
   team wants it.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Whether to include an uptime percentage from Datadog or New Relic, if connected. Enum with
-  default "Use your best judgment (include it if connected, otherwise report error rate
-  only)." Note in the description: this is a CHECK integration, so treat it as optional.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Uptime percentage: check whether Datadog or New Relic is connected, and include the uptime
+  figure when one is. This is a CHECK integration, so treat it as optional. Without one,
+  report the error rate alone and say so.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Sentry read tools (list issues/events over a time window) and, if
@@ -216,10 +216,10 @@ incident standup.
 - Where to post the briefing: a Slack channel or DM, and, if PagerDuty is connected, which
   escalation policy to read on-call from. No default; the agent cannot guess either.
 
-## Researchable context (ask, defaulting to "figure it out")
-- How far back "open" reaches: all unresolved Sentry issues, or only ones touched in the last
-  24 hours. Enum with default "Use your best judgment (all unresolved issues, plus any open
-  PagerDuty incidents if connected)."
+## Researchable context (do not ask; figure it out and state the assumption)
+- How far back "open" reaches: read the unresolved issue count first. Assume all unresolved
+  Sentry issues, plus any open PagerDuty incidents when PagerDuty is connected, and state the
+  window you used.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Sentry read tools (list unresolved issues) and, if connected, the

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/monitoring.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/monitoring.py
@@ -69,14 +69,12 @@ Output shape:
     Suspected cause: <one line, or "unknown, investigating">
     Paged: <yes/no, escalation policy>
 
-## Verify
-1. test_run with an artificial alert-shaped message ("New Sentry issue: NullPointerException
-   in checkout-service, level=fatal, 40 events/min") and read the verdict and the tools line,
-   not a 200. An incomplete verdict means rewrite the instructions blunter and re-test.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the
-   real trigger test: the Lightning "Test event" button on the Sentry event subscription.
-3. Read back the posted Slack message (and the PagerDuty incident, if triggered) to confirm
-   the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted Slack message,
+and the PagerDuty incident if one was triggered) before you call it verified. For a trigger,
+point them at the Test event button of a subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is subscribed, what you
@@ -131,13 +129,12 @@ Ticket shape:
     Title: [<severity>] <exception type> in <service>
     Body: First seen <time>, <n> events/<window>. <stack trace excerpt>. Sentry: <link>
 
-## Verify
-1. test_run with an artificial message ("New Sentry issue: TimeoutError in payment-worker,
-   level=error, 12 events in 5m, first seen 3 min ago") and read the verdict and the tools
-   line, not a 200. Confirm it either files or correctly skips as noise.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the
-   real trigger test: the Lightning "Test event" button on the Sentry event subscription.
-3. Read back the created ticket to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the created ticket) before
+you call it verified. For a trigger, point them at the Test event button of a subscription
+or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is subscribed, what you
@@ -193,13 +190,12 @@ Output shape:
     Top issues:
     - <title> (<count> events)
 
-## Verify
-1. test_run with an artificial message ("Summarize the last 24 hours") and read the verdict
-   and the tools line, not a 200. An incomplete verdict means rewrite the instructions
-   blunter and re-test.
-2. Fire an artificial schedule-fire test message first. If that passes, ask the user to run
-   the real trigger test: the Play "Run" button on the schedule.
-3. Read back the posted Slack message to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted Slack message)
+before you call it verified. For a trigger, point them at the Test event button of a
+subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is scheduled, what you
@@ -257,13 +253,12 @@ Output shape:
     Still open: <n>
     - <title> (<days open>d)
 
-## Verify
-1. test_run with an artificial message ("Brief on-call with today's open incidents") and read
-   the verdict and the tools line, not a 200. An incomplete verdict means rewrite the
-   instructions blunter and re-test.
-2. Fire an artificial schedule-fire test message first. If that passes, ask the user to run
-   the real trigger test: the Play "Run" button on the schedule.
-3. Read back the posted Slack message to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted Slack message)
+before you call it verified. For a trigger, point them at the Test event button of a
+subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is scheduled, what you

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/ops.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/ops.py
@@ -23,13 +23,13 @@ Slack or Discord channel since yesterday.
 - Source channel: which Slack (or Discord) channel to summarize. No default; the agent
   cannot proceed without it.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Destination channel: post the digest back into the source channel, or to a separate
-  #standup channel. Enum with default "Same channel as the one being summarized."
-- Post time: local time to send the digest. Enum with default "09:00 local"; the built-in
-  Other… option covers an exact custom time.
-- Local timezone: needed to convert the daily post time into a UTC cron. Description:
-  "e.g. America/New_York. Leave empty to use UTC."
+## Researchable context (do not ask; figure it out and state the assumption)
+- Destination channel: list the workspace's channels and use a dedicated #standup channel
+  when one exists. If there is none, post back into the source channel, and say so.
+- Post time: assume 09:00 local and state the assumption, so the person can move it in one
+  reply.
+- Local timezone: read it from the workspace or the channel's own settings. If that is
+  inconclusive, assume UTC, and say which timezone the cron runs on.
 
 ## Explore first (read before proposing)
 1. discover_tools for the channel-read tool (read channel messages) and the send-message
@@ -88,12 +88,11 @@ sent to a channel.
   otherwise.
 - Destination channel: which Slack (or Discord) channel to post the digest to. No default.
 
-## Researchable context (ask, defaulting to "figure it out")
-- What to include: new issues, commits, and PRs, or a subset. A multi-pick, so use
-  multi-select ({type: "array", items: {type: "string", enum: ["issues", "commits", "PRs"]}})
-  with default ["issues", "commits", "PRs"] (all three).
-- Digest times: local times to post, twice a day. Enum with default "09:00 and 17:00 local";
-  the built-in Other… option covers exact custom times.
+## Researchable context (do not ask; figure it out and state the assumption)
+- What to include: read the repo's recent activity, and include issues, commits, and PRs. If
+  a kind has no activity at all, drop it from the digest and say which kinds you kept.
+- Digest times: assume 09:00 and 17:00 local, and state the assumption. Read the local
+  timezone from the workspace settings, and assume UTC when that is inconclusive.
 
 ## Explore first (read before proposing)
 1. discover_tools for the repo-read tools (list issues, list commits, list pull requests)
@@ -154,12 +153,12 @@ mirroring issues, tickets, or records between two systems.
 - Destination: which tool and identifier to write mirrored records to (for example, a Notion
   database URL, a Confluence space). No default.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Sync cadence: polling on a schedule, or event-driven if the source supports a webhook.
-  Enum with default "Use your best judgment (hourly schedule is simplest and most
-  reliable)."
-- Field mapping: which source fields map to which destination properties. Enum with
-  default "Use your best judgment based on the destination's existing schema."
+## Researchable context (do not ask; figure it out and state the assumption)
+- Sync cadence: run `discover_triggers` to check whether the source publishes a usable event.
+  If it does not, assume an hourly schedule, which is the simplest and most reliable, and say
+  so.
+- Field mapping: read the destination's existing schema and map the source fields onto it by
+  name and type. State the mapping you chose, and name any source field you dropped.
 
 ## Explore first (read before proposing)
 1. discover_tools for the source-read tool (list issues) and the destination-write tool
@@ -216,12 +215,11 @@ doc or channel.
 - Destination: which Notion page or database (or Slack channel) to publish the report to.
   No default.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Metrics scope: shipping activity only, or shipping plus product metrics from PostHog.
-  Enum with default "Use your best judgment: include PostHog only if it's connected,
-  otherwise shipping activity only."
-- Report time: enum with default "Monday 09:00 local"; the built-in Other… option covers a
-  custom time.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Metrics scope: check what is connected. Include PostHog product metrics only when PostHog
+  is connected, and otherwise report shipping activity alone. Say which scope you wired.
+- Report time: assume Monday 09:00 local and state the assumption. Read the local timezone
+  from the workspace settings, and assume UTC when that is inconclusive.
 
 ## Explore first (read before proposing)
 1. discover_tools for the GitHub read tools (list merged PRs, list commits), the Linear read

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/ops.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/ops.py
@@ -61,13 +61,12 @@ Output shape:
     - <person>: <what they did or asked>
     - <person>: <what they did or asked>
 
-## Verify
-1. test_run with a blunt message ("Summarize yesterday's activity in this channel") and read
-   the verdict and the tools line, not a 200. An incomplete verdict means rewrite the
-   instructions blunter and re-test.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the
-   real trigger test: the Play "Run" button on the schedule.
-3. Read back the posted digest to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted digest) before
+you call it verified. For a trigger, point them at the Test event button of a subscription
+or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, which channel it reads and posts to, the schedule
@@ -129,13 +128,12 @@ Output shape:
     ### Commits
     - <message> (<sha>)
 
-## Verify
-1. test_run with a blunt message ("Post a digest of today's repo activity") and read the
-   verdict and the tools line, not a 200.
-2. This template needs two schedules (morning and evening). Fire an artificial trigger test
-   message for each, then ask the user to run the real trigger test: the Play "Run" button on
-   each schedule.
-3. Read back the posted digest to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted digest) before
+you call it verified. For a trigger, point them at the Test event button of a subscription
+or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, the repo and channel it is wired to, both schedules
@@ -192,13 +190,12 @@ the last run with the exact list tool, for each one check the destination for an
 mirrored record by the source id, then create it if missing or update it if changed with the
 exact write tool. Pin the source id and destination id.
 
-## Verify
-1. test_run with a blunt message ("Sync the latest issues now") and read the verdict and the
-   tools line, not a 200.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the
-   real trigger test: the Play "Run" button for a schedule, or the Lightning "Test event"
-   button if wired to a source webhook.
-3. Read back the destination record to confirm the write landed and was not duplicated.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the destination record, and
+check it was not duplicated) before you call it verified. For a trigger, point them at the
+Test event button of a subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, the source and destination it syncs, the schedule or
@@ -258,13 +255,12 @@ Output shape:
     ### Product metrics (if connected)
     - <metric>: <value>
 
-## Verify
-1. test_run with a blunt message ("Compile this week's report now") and read the verdict and
-   the tools line, not a 200. Confirm it works both with and without the PostHog tool
-   present.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the
-   real trigger test: the Play "Run" button on the schedule.
-3. Read back the published report to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the published report)
+before you call it verified. For a trigger, point them at the Test event button of a
+subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected (and which PostHog-based section is

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/sales.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/sales.py
@@ -29,11 +29,11 @@ Card key lead-qualifier. Also matches free-text asks about scoring or triaging n
 - Qualification criteria: what makes a lead qualified (company size, industry, budget signal).
   Multiline. No default; this is the user's business judgment.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Lead source: which inbox, form, or CRM webhook produces new leads. Enum with default
-  "Figure it out from what's connected." Note: handing this over is faster than researching it.
-- Enrichment depth: a quick domain lookup or deeper company research per lead. Enum with
-  default "Use your best judgment (quick lookup, deepen only for borderline leads)."
+## Researchable context (do not ask; figure it out and state the assumption)
+- Lead source: check what is connected, and take the inbox, form, or CRM that already receives
+  leads. If more than one qualifies, assume the CRM, and say which source you wired.
+- Enrichment depth: assume a quick domain lookup per lead, and deepen only for a borderline
+  lead. State the assumption, because deeper research per lead costs run time.
 
 ## Explore first (read before proposing)
 1. discover_tools for the CRM read/write tools (get contact, create contact) and, if the lead
@@ -86,11 +86,12 @@ threads each day." Card key crm-updater. Also matches free-text asks about stale
 - CRM target and scope: which CRM (HubSpot, Salesforce, or Attio) and which list or pipeline of
   contacts to consider. No default; the agent cannot proceed without it.
 
-## Researchable context (ask, defaulting to "figure it out")
-- What counts as update-worthy: a new title, company change, or a mentioned next step, versus a
-  fixed field list. Enum with default "Use your best judgment from what the thread says."
-- Unknown senders: skip them, or flag as a possible new contact for review. Enum with default
-  "Figure it out (flag likely prospects, skip the rest)."
+## Researchable context (do not ask; figure it out and state the assumption)
+- What counts as update-worthy: read the CRM's own contact fields and update the ones a thread
+  can fill, such as a new title, a company change, or a mentioned next step. State which
+  fields you write.
+- Unknown senders: assume you flag a likely prospect for review and skip the rest, and state
+  the assumption. Creating a contact per unknown sender fills the CRM with noise.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Gmail read tool and the CRM get/update-contact tools.
@@ -141,11 +142,11 @@ outreach-drafter. Also matches free-text asks about cold email drafts or sequenc
 - Contact list or segment: which CRM view, list name, or filter to draft outreach for. No
   default; the agent cannot proceed without it.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Angle or value prop: the agent can infer this from each contact's company and role. Enum
-  with default "Figure it out per contact from their company and role."
-- Draft destination: Gmail drafts, or returned as text. Enum with default "Figure it out from
-  what's connected (Gmail drafts if connected, else text)."
+## Researchable context (do not ask; figure it out and state the assumption)
+- Angle or value prop: read each contact's company and role, and pick the angle from those.
+  State the angle you used in the first draft you show.
+- Draft destination: check what is connected. Write Gmail drafts when Gmail is connected, and
+  otherwise return the text in the reply. Say which destination you used.
 
 ## Explore first (read before proposing)
 1. discover_tools for the CRM list-contacts tool and, if connected, the Gmail create-draft tool.
@@ -200,9 +201,10 @@ Card key meeting-followup. Also matches free-text asks about post-call recaps or
   name. The trigger depends on it. Default to "recap email in Gmail" when no calendar is
   connected yet; otherwise leave no default.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Follow-up depth: a short thank-you-plus-next-steps note, or a fuller recap with agenda items.
-  Enum with default "Figure it out from the notes (short if sparse, fuller if detailed)."
+## Researchable context (do not ask; figure it out and state the assumption)
+- Follow-up depth: read the meeting notes and match their depth. Write a short thank-you with
+  next steps when the notes are sparse, and a fuller recap when they are detailed. Say which
+  shape you chose.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Gmail read and create-draft tools, plus Google Calendar and the CRM
@@ -253,9 +255,9 @@ key pipeline-digest. Also matches free-text asks about a deals summary or pipeli
 - Pipeline: which CRM pipeline to summarize, if the CRM has more than one. No default when more
   than one pipeline exists.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Stale threshold: how many days without activity marks a deal stale. Enum with default
-  "Use your best judgment (14 days)"; the built-in Other… option covers a custom number.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Stale threshold: read the CRM's own deal ages to see how long a live deal usually sits. If
+  that is inconclusive, assume 14 days without activity, and state the number you used.
 
 ## Explore first (read before proposing)
 1. discover_tools for the CRM list-deals tool and the Slack post-message tool.

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/sales.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/sales.py
@@ -63,12 +63,12 @@ Output shape (CRM note field):
     Qualified: <yes/no> - <one-line reason>
     Enrichment: <company size, industry, signal found>
 
-## Verify
-1. test_run with a blunt message ("Qualify this lead: <sample email/company>") and read the
-   verdict and the tools line, not a 200.
-2. Fire an artificial "new lead" trigger test message first. If that passes, ask the user to run
-   the real trigger test: the Lightning "Test event" button.
-3. Read back the CRM record to confirm the score and notes landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the CRM record with its
+score and notes) before you call it verified. For a trigger, point them at the Test event
+button of a subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is subscribed, what you verified,
@@ -118,12 +118,12 @@ contact at a time with the exact update tool, which is approval-gated: the platf
 gate on that tool is the review stop, not a separate step. If the gate is not approved, the run
 ends with the proposal posted and nothing written.
 
-## Verify
-1. test_run with a blunt message ("Propose CRM updates from yesterday's threads") and read the
-   verdict and the tools line, not a 200.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the real
-   trigger test: the Play "Run" button for the schedule.
-3. Read back one updated contact to confirm the applied change landed as proposed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (one updated contact) before
+you call it verified. For a trigger, point them at the Test event button of a subscription
+or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is scheduled, what you verified,
@@ -176,11 +176,11 @@ Output shape (per contact):
     Subject: <subject>
     Body: <2-4 short paragraphs, one personalized hook>
 
-## Verify
-1. test_run with a blunt message ("Draft outreach for these 3 contacts: <names>") and read the
-   verdict and the tools line, not a 200. Confirm no send tool appears in the tools line.
-2. This template has no trigger to verify; it runs on demand.
-3. Read back the Gmail Drafts folder (or the returned text) to confirm every contact got a draft.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the Gmail draft for every
+contact) before you call it verified. Confirm no send tool appears in `tools`.
 
 ## Closing report
 Tell the user how many drafts were created, where they landed, what is connected, and remind
@@ -228,13 +228,12 @@ agenda from the calendar event or notes thread, log a meeting note on the matchi
 with the exact note tool if the CRM is connected, then finish by creating a Gmail draft to the
 attendees with the exact create-draft tool. NEVER call a send tool.
 
-## Verify
-1. test_run with a blunt message describing a sample meeting and read the verdict and the tools
-   line, not a 200.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the real
-   trigger test: the Lightning "Test event" button for the calendar event, or the Play "Run"
-   button if it falls back to a schedule.
-3. Read back the Gmail draft and, if connected, the CRM note to confirm both landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the Gmail draft, and the
+CRM note if the CRM is connected) before you call it verified. For a trigger, point them at
+the Test event button of a subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is subscribed or scheduled, what
@@ -287,12 +286,12 @@ Output shape:
     New: <count> | Moved: <count> | Won: <count> | Lost: <count>
     Stale (14+ days): <deal name> - <days since activity>
 
-## Verify
-1. test_run with a blunt message ("Post today's pipeline digest now") and read the verdict and
-   the tools line, not a 200.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the real
-   trigger test: the Play "Run" button for the schedule.
-3. Read back the posted Slack message to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted Slack message)
+before you call it verified. For a trigger, point them at the Test event button of a
+subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is scheduled, what you verified,

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/support.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/support.py
@@ -26,10 +26,9 @@ ticket urgency, or routing threads to the right person.
 - Owners and their areas: who routes get sent to, and what each owns. No default; the agent
   cannot invent your team's routing.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Urgency scale: how many tiers (for example urgent/normal/low) and what counts as urgent.
-  Enum with default "Use your best judgment (I'll propose a 3-tier scale)." Note in the
-  description: handing this over is faster than the agent inferring it from past threads.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Urgency scale: read the ticket system's existing priority values and reuse them. If it has
+  none, assume three tiers, urgent, normal, and low, and state what counts as urgent.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Slack read tools (read channel, read thread, list channel members).
@@ -89,13 +88,12 @@ answering tickets from a knowledge base.
 - Ticket source: which Zendesk (or Intercom) instance to watch for new tickets. Set the field
   default to the guess a prior read surfaced; leave no default otherwise.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Knowledge source: where answers come from (Notion, Confluence, Google Drive, or the ticket
-  system's own help center). Enum with default "Figure it out from what's connected." These
-  are optional extensions, not required to run; without one the agent drafts from ticket
-  history alone and says so.
-- Draft posture: draft-only for review, or auto-send for high-confidence matches. Enum with
-  default "Use your best judgment (draft-only until you say otherwise)."
+## Researchable context (do not ask; figure it out and state the assumption)
+- Knowledge source: check what is connected, and use Notion, Confluence, Google Drive, or the
+  ticket system's own help center. These are optional extensions, not required to run. Without
+  one, draft from ticket history alone and say so.
+- Draft posture: assume draft-only for review, because an auto-sent wrong answer reaches the
+  customer. State the assumption so the person can turn auto-send on later.
 
 ## Explore first (read before proposing)
 1. discover_tools for the ticket read tools (get ticket, list tickets) and, if connected, the
@@ -156,10 +154,10 @@ Slack or Intercom messages into filed bugs, or being mentioned to file one.
 - Bug tracker and project: which Linear team, Jira project, or GitHub repo new tickets go to.
   Set the field default to the guess a prior read surfaced; leave no default otherwise.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Repro-steps extraction: whether to ask the reporter follow-up questions when steps are
-  missing, or file with what is given. Enum with default "Use your best judgment (ask once
-  if repro steps are missing, then file anyway)."
+## Researchable context (do not ask; figure it out and state the assumption)
+- Repro-steps extraction: read a sample of past bug reports for how complete they usually are.
+  Assume the agent asks the reporter once for missing steps and then files anyway, and state
+  the assumption.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Slack (or Intercom) read tools (read thread, read message) and the
@@ -221,10 +219,9 @@ trends or grouping complaints by topic.
 - Where clusters are logged: a Notion database or page. No default; the agent cannot invent
   where you track this.
 
-## Researchable context (ask, defaulting to "figure it out")
-- Clustering granularity: broad themes (3-5) or fine-grained topics. Enum with default "Use
-  your best judgment (I'll propose 3-5 themes from a sample day)." Note in the description:
-  handing this over is faster than the agent researching your past feedback volume.
+## Researchable context (do not ask; figure it out and state the assumption)
+- Clustering granularity: read a sample day of feedback to see how much arrives. Assume 3 to 5
+  broad themes, propose them from that sample, and state the assumption.
 
 ## Explore first (read before proposing)
 1. discover_tools for the Slack (or Intercom) read tools (read channel, read thread) and the

--- a/sdks/python/agenta/sdk/agents/adapters/agent_templates/support.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agent_templates/support.py
@@ -62,13 +62,12 @@ Output shape:
     Routed to: <owner>
     Why: <one line>
 
-## Verify
-1. test_run with a blunt test message shaped like a support thread ("Our export button is
-   throwing a 500, can someone look?") and read the verdict and the tools line, not a 200. An
-   incomplete verdict means rewrite the instructions blunter and re-test.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the real
-   trigger test: the Lightning "Test event" button for this event subscription.
-3. Read back the posted triage reply to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted triage reply)
+before you call it verified. For a trigger, point them at the Test event button of a
+subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what channel and owners it is watching for, what you
@@ -132,13 +131,12 @@ Output shape:
     Cited from: <source, or "ticket history only">
     Confidence: <high/low>
 
-## Verify
-1. test_run with a blunt test message shaped like a new ticket ("Customer asks how to export
-   their data to CSV") and read the verdict and the tools line, not a 200. An incomplete
-   verdict means rewrite the instructions blunter and re-test.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the real
-   trigger test: the Lightning "Test event" button for this event subscription.
-3. Read back the posted draft (or comment) to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the posted draft or
+comment) before you call it verified. For a trigger, point them at the Test event button of
+a subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what ticket system and knowledge source it uses (or that
@@ -196,14 +194,12 @@ Output shape:
     Reported by: <name/handle>
     Ticket: <link>
 
-## Verify
-1. test_run with a blunt test message shaped like a bug report ("The app crashes when I
-   upload a file over 10MB") and read the verdict and the tools line, not a 200. An incomplete
-   verdict means rewrite the instructions blunter and re-test.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the real
-   trigger test: the Lightning "Test event" button for this event subscription (or send a real
-   mention if mention-triggered).
-3. Read back the created ticket to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the created ticket) before
+you call it verified. For a trigger, point them at the Test event button of a subscription
+or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what channel and tracker it is wired to, what you
@@ -262,13 +258,12 @@ Output shape:
     - <count> mentions
     - Example: "<quoted message>"
 
-## Verify
-1. test_run with a blunt test message ("Cluster today's feedback from #feedback") and read
-   the verdict and the tools line, not a 200. An incomplete verdict means rewrite the
-   instructions blunter and re-test.
-2. Fire an artificial trigger test message first. If that passes, ask the user to run the real
-   trigger test: the Play "Run" button for this schedule.
-3. Read back the logged Notion entry to confirm the write landed.
+## Offer a test
+Tell the person the setup is committed and offer a test run. Run `test_run` only if they
+ask. When you do, send one blunt task message, read `verdict`, `tools`, and `approvals`
+rather than the HTTP status, and read back the real side effect (the logged Notion entry)
+before you call it verified. For a trigger, point them at the Test event button of a
+subscription or the Run button of a schedule.
 
 ## Closing report
 Tell the user what the agent became, what is connected, what is scheduled, what you verified,

--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -34,35 +34,26 @@ _ORDERED = ordered_operations_enabled()
 GETTING_STARTED_WITH_AGENTA_SLUG = "__ag__getting_started_with_agenta"
 BUILD_AN_AGENT_SLUG = "__ag__build_an_agent"
 
-# Canonical SKILL.md body for the platform "getting started" skill. Single source of the body
-# text: the server-side StaticWorkflowCatalog imports this constant rather than redeclaring it.
+# RETIRED on 2026-09-07. The four conventions this skill carried (greet once, state assumptions,
+# resolve relative paths against the skill folder, keep answers short) now live in the platform
+# prompt (`platform_instructions.py`), which every harness reads first. No default template
+# embeds the slug any more (`build_agent_v0_default()` is called without a skill slug), but
+# revisions saved before that still reference `__ag__getting_started_with_agenta`, and an
+# embed the catalog cannot resolve fails the run. So the slug stays resolvable and serves this
+# one-line stub. Delete the constant, the catalog entry, and this comment once a data migration
+# has dropped the embed from stored revisions.
 _GETTING_STARTED_BODY = (
     "# Getting started with Agenta agents\n"
     "\n"
-    "This skill orients an agent running on the Agenta platform.\n"
-    "\n"
-    "## When to use it\n"
-    "\n"
-    "Use it at the start of a task to recall how Agenta agents are expected to behave: be "
-    "concise, ask for missing inputs, and prefer the tools and skills the agent was given over "
-    "guessing.\n"
-    "\n"
-    "## Conventions\n"
-    "\n"
-    "- Greet the user once, then get to work.\n"
-    "- State assumptions briefly when a request is ambiguous.\n"
-    "- When a skill or tool references a relative path, resolve it against the skill directory "
-    "(the parent of SKILL.md) before running it.\n"
-    "- Keep answers short unless the user asks for depth.\n"
+    "This skill is retired. The platform instructions you already read cover how an Agenta "
+    "agent behaves. There is nothing more to do here.\n"
 )
 
-# The platform default skill as a concrete inline package. This is the canonical content; the
-# server-side catalogue serves the same SkillTemplate for the reserved slug above.
 GETTING_STARTED_WITH_AGENTA_SKILL = SkillTemplate(
     name="agenta-getting-started",
     description=(
-        "Getting started on the Agenta platform: how an Agenta agent should behave, ask for "
-        "missing inputs, and use its tools and skills. Use at the start of a task."
+        "Retired. The platform instructions cover how an Agenta agent behaves; this skill "
+        "adds nothing and you do not need to read it."
     ),
     body=_GETTING_STARTED_BODY,
 )

--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -34,9 +34,11 @@ _ORDERED = ordered_operations_enabled()
 GETTING_STARTED_WITH_AGENTA_SLUG = "__ag__getting_started_with_agenta"
 BUILD_AN_AGENT_SLUG = "__ag__build_an_agent"
 
-# RETIRED on 2026-09-07. The four conventions this skill carried (greet once, state assumptions,
-# resolve relative paths against the skill folder, keep answers short) now live in the platform
-# prompt (`platform_instructions.py`), which every harness reads first. No default template
+# RETIRED on 2026-09-07. Two of the four conventions this skill carried moved into the platform
+# prompt (`platform_instructions.py`), which every harness reads first: state assumptions, and
+# keep answers short. The other two were dropped on purpose. Greeting the user once is covered by
+# the prompt's "lead with the answer" rule, which leaves no room for an opening greeting. The
+# skill-relative path convention is not in the prompt because Pi supplies it itself. No default template
 # embeds the slug any more (`build_agent_v0_default()` is called without a skill slug), but
 # revisions saved before that still reference `__ag__getting_started_with_agenta`, and an
 # embed the catalog cannot resolve fails the run. So the slug stays resolvable and serves this
@@ -834,8 +836,10 @@ _BUILD_HEAD = """\
 
 Read this when the request is a change to you: new instructions, a skill, an integration, a
 trigger, or a first setup. Do not read it for a task. The platform instructions say how to tell
-the two apart. An agent that still has its default name and default instructions has not been
-set up yet, so its first real request is usually a change to you.
+the two apart. A fresh agent, with its default name and default instructions, still decides by
+intent: "Summarize my inbox" is a task on the first turn as much as on the hundredth. The
+request is a change to you only when the person describes a role, a recurring job, or an
+integration to connect.
 
 ## What you can change
 
@@ -955,7 +959,10 @@ and naming `LIST_REPOSITORY_ISSUES` as if it were callable sends the run looking
 does not exist.
 
 - Pin concrete ids, such as channel id and repo, instead of telling the agent to re-resolve them.
-- You no longer choose actions when wiring: the whole integration is enabled. Steer the RUN instead — tell it in `agents_md` to search for the narrowest tool (a `FIND_*` or `GET_A_*` over a `LIST_ALL_*`), and `deny` list-dump actions you never want run in the entry's `policy.permissions.tools`.
+- You no longer choose actions when wiring: an integration is added whole, with every action
+  allowed. Steer the RUN instead. Tell it in `agents_md` to search for the narrowest tool, a
+  `FIND_*` or `GET_A_*` over a `LIST_ALL_*`. Add a `deny` entry under
+  `policy.permissions.tools` only when the person asks you to restrict the integration.
 - Make the final numbered step the terminal side effect, such as the post or write.
 - Say "finish by doing step N" so the run does not stop after the early read steps.
 - Write the persona as an explicit imperative — who the agent is and what it does, stated as a
@@ -979,6 +986,10 @@ File tools, or raw HTTP only when your wired tools cannot do the job, and say so
 
 ## When something fails
 
+- The platform rule "do not repeat a refused action" bans resending the SAME call, so a refusal
+  that names a fix, a `next_step` or a stale `base_revision_id`, is corrected once and sent
+  again. A policy refusal, such as a denied approval, is reported to the person and never
+  retried.
 - A denied or failed `commit_revision` does not undo earlier connections or triggers; they still
   exist. Do not redo them.
 - A refused commit says what to do next in `next_step`. `retryable` only says whether the SAME
@@ -1056,8 +1067,9 @@ BUILD_AN_AGENT_SKILL = SkillTemplate(
     description=(
         "How to change this agent's own configuration: instructions, memory, skills, "
         "integrations, and triggers. Read it when the request is a change to you rather "
-        "than a task, and when an agent that still has its default name and instructions "
-        "gets its first real request. Do not read it for a task."
+        "than a task: a role, a recurring job, or an integration to connect. A default "
+        "name and default instructions do not make a request a change. Do not read it "
+        "for a task."
     ),
     body=_BUILD_AN_AGENT_BODY,
     files=[

--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -875,9 +875,9 @@ _BUILD_TEMPLATES = """\
 
 ## Templates
 
-There are playbooks for common agents, one file each under `references/agent-templates/`:
-{names}. If the ask clearly matches one of these, read that file and follow it. Otherwise
-skip them.
+There are playbooks for common agents, one file each under `references/agent-templates/`,
+named here with their file names: {names}. If the ask clearly matches one of these, read that
+file and follow it. Otherwise skip them.
 """
 
 _BUILD_LOOP_ORDERED = """\
@@ -1050,7 +1050,9 @@ _BUILD_AN_AGENT_BODY = (
     _BUILD_HEAD
     + (_BUILD_SHAPE_ORDERED if _ORDERED else _BUILD_SHAPE_LEGACY)
     + _BUILD_TEMPLATES.format(
-        names=", ".join(entry.name for entry in AGENT_TEMPLATE_ENTRIES)
+        names=", ".join(
+            f"{entry.name} (`{entry.key}.md`)" for entry in AGENT_TEMPLATE_ENTRIES
+        )
     )
     + (_BUILD_LOOP_ORDERED if _ORDERED else _BUILD_LOOP_LEGACY)
     + _BUILD_INSTRUCTIONS_WRITING

--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -15,7 +15,10 @@ from __future__ import annotations
 from ..flags import ordered_operations_enabled
 
 from ..skills import SkillFile, SkillTemplate
-from .agent_templates import build_agent_template_skill_files
+from .agent_templates import (
+    AGENT_TEMPLATE_ENTRIES,
+    build_agent_template_skill_files,
+)
 
 # Read once, at import, exactly like the op catalog builds its tool descriptions. The skill
 # TEACHES the commit surface the catalog ADVERTISES, and one deployment must show one shape:
@@ -85,7 +88,7 @@ below is addressed as `["parameters", "agent", ...]`. The portable definition �
 `llm`, `tools`, `mcps`, `skills` — is flat on it; the execution parts — `harness`, `runner`,
 `sandbox` — are nested sub-objects. The commit checks your target, NOT the value you write into
 it: a misplaced or misspelled field inside an entry commits fine and only bites when the agent
-next runs. Get the shape right from this reference, and verify with `test_run` after every commit.
+next runs. Get the shape right from this reference before you commit.
 """
 
 _CONFIG_SCHEMA_INTRO_LEGACY = """\
@@ -99,7 +102,7 @@ you need to check the shape.
 `instructions`, `llm`, `tools`, `mcps`, `skills` — is flat on it; the execution parts —
 `harness`, `runner`, `sandbox` — are nested sub-objects. The commit does NOT validate this shape:
 a misplaced or misspelled field commits fine and only bites when the agent next runs. Get the
-shape right from this reference, and verify with `test_run` after every commit.
+shape right from this reference before you commit.
 """
 
 _CONFIG_SCHEMA_FIELDS = """\
@@ -348,9 +351,9 @@ for almost every refusal, which means correct the call rather than repeat it.
   your run and are not part of your configuration. Remove them and commit again.
 
 The second group commits fine and bites later, at a different spot, because the commit checks
-your target and not the value you wrote into it. Your two detectors are `test_run` (read the
-`resolved` block and the executed tool list, not just the status) and a skill that fails to load
-on the next run.
+your target and not the value you wrote into it. Check each of these before you commit. They
+show up as a skill that fails to load on the next run, or in the `resolved` block of a
+`test_run` the person asked for.
 
 - `slug` or `content` as top-level fields on a skill entry. The skill's Markdown goes in `body`;
   a bundled file's text goes in that file's `content` inside `files`. Bites at RUN time: skill
@@ -361,7 +364,7 @@ on the next run.
   only. Bites at RUN time: the run's Model & Harness never resolves and the agent never runs.
 - A raw model id on the `claude` harness (Claude selects by alias) or an alias like `sonnet` on a
   `pi_core` harness (Pi selects by provider/id). Bites silently: the run falls back to
-  a default model with no error. Only `test_run`'s `resolved` block shows the fallback.
+  a default model with no error. Only the `resolved` block of a `test_run` shows the fallback.
 - Naming an `@ag.embed` entry with a selector. An embed has no key, so no operation can address
   it. Leave those entries where they are.
 
@@ -532,9 +535,9 @@ _CONFIG_SCHEMA_COMMIT_LEGACY = """\
 ## Mistakes that break your agent
 
 The commit accepts whatever you send — none of these return a validation error. Each one commits
-fine and then bites later, at a different spot. Your two detectors are `test_run` (read the
-`resolved` block and the executed tool list, not just the status) and a skill that fails to load
-on the next run.
+fine and then bites later, at a different spot. Check each of these before you commit. They
+show up as a skill that fails to load on the next run, or in the `resolved` block of a
+`test_run` the person asked for.
 
 - `slug` or `content` as top-level fields on a skill entry. The skill's Markdown goes in `body`;
   a bundled file's text goes in that file's `content` inside `files`. Bites at RUN time: skill
@@ -545,7 +548,7 @@ on the next run.
   only. Bites at RUN time: the run's Model & Harness never resolves and the agent never runs.
 - A raw model id on the `claude` harness (Claude selects by alias) or an alias like `sonnet` on a
   `pi_core` harness (Pi selects by provider/id). Bites silently: the run falls back
-  to a default model with no error. Only `test_run`'s `resolved` block shows the fallback.
+  to a default model with no error. Only the `resolved` block of a `test_run` shows the fallback.
 - Sending a short `tools`/`skills`/`mcps` list. Bites on the NEXT run: lists replace wholesale,
   so every entry you left out is gone.
 - Rebuilding the whole `parameters.agent` object instead of a narrow delta. Prefer a `delta.set`
@@ -822,181 +825,125 @@ Don't forget:
 """
 
 
-# SKILL.md, assembled from a common spine plus the three passages that describe HOW a commit is
-# made. Those three follow the deployment's commit surface (see `_ORDERED` above); everything
-# else — the decision table, discovery, triggers, verification, the footguns — is the same either
-# way, and lives in one copy so it cannot drift between the two arms.
+# SKILL.md, assembled from a common spine plus the passages that describe HOW a commit is made.
+# Those follow the deployment's commit surface (see `_ORDERED` above); everything else is the
+# same either way and lives in one copy so it cannot drift between the two arms.
+#
+# WHAT THIS SKILL IS FOR, AND WHAT IT IS NOT. The platform prompt (`platform_instructions.py`)
+# owns behavior: decide and proceed, the three ask gates, show a sample before building an
+# automation, run `test_run` only when the person asks. This skill owns the MECHANICS of a
+# configuration change and nothing else. A sentence here that restates or contradicts the
+# platform prompt is a bug: models pick between two wordings of one rule unpredictably.
+#
+# WHY THE TEMPLATE LIST IS INLINE. The skill used to send the model to a 28-row index file on
+# every ask. The names are short, so they ride here; the model reads a playbook file only when
+# the ask clearly matches one.
 _BUILD_HEAD = """\
-# Build an Agenta agent
+# Configure this Agenta agent
 
-You turn a plain-language request into a working, verified Agenta agent. You are configuring
-yourself: the committed template you edit is the agent that will keep running. Optimize for the
-fewest calls and the least time. A simple no-tool ask is two actions: write better
-`instructions.agents_md`, then call `commit_revision`.
+Read this when the request is a change to you: new instructions, a skill, an integration, a
+trigger, or a first setup. Do not read it for a task. The platform instructions say how to tell
+the two apart. An agent that still has its default name and default instructions has not been
+set up yet, so its first real request is usually a change to you.
 
-Before anything else, check `references/agent-templates/index.md` for a playbook matching the
-ask. When one matches, read it and follow it: a playbook layers this use case onto the loop
-below and never replaces its approval stops. When none matches, follow the generic loop below.
+## What you can change
 
-## When to use
+Four things under `parameters.agent`:
 
-Use this when the user asks you to build, set up, configure, or automate an agent.
-
-## The shape of your config
-
-You decide four things under `parameters.agent`:
-
-- `instructions.agents_md`: who you are and what you do.
-- `tools`: integration actions and platform ops you can call.
+- `instructions.agents_md`: who you are and what you do, with a `## Memory` section at the end.
 - `skills`: reusable know-how packaged as skill templates.
-- A trigger: either a schedule or an event subscription, only when the user asked for one.
+- `tools`: whole integrations, one `gateway_connection` entry each.
+- A trigger: a schedule or an event subscription, when the person asks for one or the job
+  clearly repeats.
+
+Everything else stays as it is unless the person asks to change it.
 """
 
 _BUILD_SHAPE_ORDERED = """\
-
-Everything else is fixed unless the user explicitly asks to change it. Configure yourself with
-`commit_revision` by changing `parameters.agent` fields; do not create a separate app.
-
-Editing files in your workspace does not change your configuration. That copy is rebuilt, and
-the edits are lost. Change your instructions and configuration only through `commit_revision`.
-
-Every commit is the same loop: `read_config` the part you are about to change, then
-`commit_revision` with the `base_revision_id` that read returned and a list of `delta.operations`.
-Each operation changes one field or one list entry, and leaves everything else alone.
-
-Read `references/config-schema.md` before your first `commit_revision`. It gives:
-
-- the exact shape of every field,
-- the tool-entry types,
-- the skill-entry shape,
-- the operations a commit is made of, with a worked example of each,
-- the mistakes that break your agent.
+Change your configuration only with `commit_revision`. Every change is the same two calls:
+`read_config` the part you are about to change, then `commit_revision` with the
+`base_revision_id` that read returned and a list of `delta.operations`. Each operation changes
+one field or one list entry and leaves everything else alone. Read
+`references/config-schema.md` before your first commit: it gives the exact shape of every
+field, the operations, worked examples, and the mistakes that break an agent.
 """
 
 _BUILD_SHAPE_LEGACY = """\
-
-Everything else is fixed unless the user explicitly asks to change it. Configure yourself with
-`commit_revision` by setting `parameters.agent` fields; do not create a separate app.
-
-Editing files in your workspace does not change your configuration. That copy is rebuilt, and
-the edits are lost. Change your instructions and configuration only through `commit_revision`.
-
-Read `references/config-schema.md` before your first `commit_revision`. It gives:
-
-- the exact shape of every field,
-- the tool-entry types,
-- the skill-entry shape,
-- the delta merge semantics,
-- the mistakes that break your agent.
+Change your configuration only with `commit_revision`, by setting `parameters.agent` fields.
+Read `references/config-schema.md` before your first commit: it gives the exact shape of every
+field, the delta merge semantics, worked examples, and the mistakes that break an agent.
 """
 
-_BUILD_TABLE_AND_LOOP = """\
+# The template names are rendered from the entries at import, so the list can never drift from
+# the playbook files that exist.
+_BUILD_TEMPLATES = """\
 
-Read `references/trigger-inputs.md` before you write a schedule or subscription's
-`inputs_fields`.
+## Templates
 
-## Decision table
-
-| The ask... | Needs | What to add |
-|---|---|---|
-| transform text the user pastes, such as summarize, rewrite, classify | nothing extra | `instructions.agents_md` only |
-| apply reusable know-how, such as a style guide or review rubric | a skill | one `skills` entry |
-| read or write in an outside tool, such as GitHub or Slack | a connected integration | `discover_tools`, then ONE `gateway_connection` entry on `tools` |
-| run on a clock | a schedule | `create_schedule` after committing |
-| react to an outside event | a subscription | `discover_triggers`, then `create_subscription` |
-
-Do not discover tools or triggers for an ask that does not need them.
-
-## The loop
-
-1. Clarify the ask. Get the missing timezone, channel, repo, account, output style, and success
-   criteria. Do not guess concrete destinations. When you need typed values the user must
-   confirm — which actions to enable, non-secret settings such as a subdomain or workspace,
-   schedule details — ask with `request_input` (renders an inline form) instead of prose.
-   Propose a `default` for every field you can — the form prefills, and the user accepts
-   everything in one click when your proposals are right. Enum options are suggestions (the
-   form has a built-in "Other…" escape hatch), so keep them short and likely. Use
-   `{type: "array", items: {type: "string", enum: [...]}}` for a multi-pick question, and
-   `oneOf: [{const, title, description}]` when options need a sentence of explanation.
-   For a form with several questions, set `"x-ag-stepper": true` on requestedSchema —
-   it presents one question at a time with a final review step.
-   Never request secrets through it; custom secrets go through `request_secret`, while integration credentials go through `request_connection`.
-2. Decide from the table. Most agents need only instructions. If the ask needs outside actions,
-   call `discover_tools` with one short fragment per capability, such as "list github issues" or
-   "post a slack message".
-3. Read discovery as a search result, not an oracle. It is a high-recall keyword match over the
-   live catalog, so check three things before wiring anything:
-   - Per-integration connection state is authoritative, not the headline match. The primary match
-     can be the wrong integration while reporting ready, and the tool you wanted can sit in
-     `alternatives` with `needs_auth`. Trust the per-integration connection block, not the top
-     `ready` line.
-   - Right integration is not enough — read the matched event's description. A fragment like "new
-     github issue" can match a `..._ARTIFACT_CREATED` event on the shared word "created" with a
-     ready connection. Confirm the matched action or event actually does what the user asked.
-   - When picking a SUBSCRIPTION EVENT, if nothing in the match or its alternatives plausibly
-     corresponds, stop and tell the user the integration does not support it yet; never wire the
-     closest keyword hit. For TOOLS you enable the whole integration, so you are choosing the
-     integration, not the action — the run picks the action through `search_tools`.
-4. If a needed connection is not ready, call `request_connection` for that integration and stop.
-   Give the user the connection request and wait for them. Re-run `discover_tools` after they
-   connect; do not silently create, fake, or skip connections.
+There are playbooks for common agents, one file each under `references/agent-templates/`:
+{names}. If the ask clearly matches one of these, read that file and follow it. Otherwise
+skip them.
 """
 
-_BUILD_STEP5_ORDERED = """\
-5. Configure yourself. `read_config` the parts you are about to change, then `commit_revision`
-   with that `base_revision_id`: `add_item` ONE `gateway_connection` entry per integration you
-   need — provider, integration, the REAL ready slug, and a permissions policy — onto `tools`,
-   and `set` `instructions.agents_md`. This is an approval stop. If the
-   commit is denied or fails, earlier connections or triggers are not undone.
+_BUILD_LOOP_ORDERED = """\
+
+## How a change goes
+
+1. `read_config` the part you are about to change. The answer carries `base_revision_id`.
+2. If the change needs an outside app, call `discover_tools` with one short fragment per
+   capability, such as "list github issues" or "post a slack message". Read the
+   per-integration connection state, not the headline match. If the integration is not
+   connected, call `request_connection` for it and stop until the person has connected it;
+   then run `discover_tools` again and take the real slug it reports as ready. Never invent a
+   slug: a guess commits fine and fails at run time.
+3. `commit_revision` with that `base_revision_id`. `add_item` ONE `gateway_connection` entry
+   per integration onto `tools`, with the real slug and the policy
+   `{ "default": "allow", "tools": {} }`. `set` `instructions.agents_md`. This is an approval
+   stop. If the commit is refused, read `next_step` and correct the call; earlier connections
+   and triggers are not undone.
+4. Add a trigger only when the person asked for one or the job clearly repeats. Read
+   `references/trigger-inputs.md` first. For a schedule, cron is UTC, five fields, one-minute
+   floor; convert the person's timezone yourself, then `create_schedule`. For an event,
+   `discover_triggers`, check that the returned event description really fits the ask (the
+   match is keyword search), then `create_subscription`. Both are approval stops. A trigger
+   pins the revision it was created on: after a later commit, re-point it.
+5. Say what changed in two or three sentences, offer a test, and stop. Run `test_run` only if
+   the person asks. When you do, read `verdict`, `tools`, and `approvals`, not the status
+   code, and read the real side effect back before you call it verified.
+
+Do not ask for details you can look up or default. When you need a value only the person has,
+such as a repo, a channel, or a timezone, ask once with `request_input`, with a proposed
+default in every field you can guess.
 """
 
-_BUILD_STEP5_LEGACY = """\
-5. Configure yourself. Put the chosen `capability.tool` entries and needed alternatives in
-   `tools`, write `instructions.agents_md`, and call `commit_revision`. This is an approval stop.
-   If the commit is denied or fails, earlier connections or triggers are not undone.
+_BUILD_LOOP_LEGACY = """\
+
+## How a change goes
+
+1. If the change needs an outside app, call `discover_tools` with one short fragment per
+   capability. Read the per-integration connection state, not the headline match. If the
+   integration is not connected, call `request_connection` and stop until the person has
+   connected it; then run `discover_tools` again and take the real slug. Never invent a slug.
+2. `commit_revision` with the chosen `gateway_connection` entries in `tools` and the new
+   `instructions.agents_md`. This is an approval stop. A refused commit does not undo earlier
+   connections or triggers.
+3. Add a trigger only when the person asked for one or the job clearly repeats. Read
+   `references/trigger-inputs.md` first. Cron is UTC, five fields; convert the person's
+   timezone. For an event, `discover_triggers`, check the event fits, then
+   `create_subscription`. A trigger pins the revision it was created on: after a later commit,
+   re-point it.
+4. Say what changed in two or three sentences, offer a test, and stop. Run `test_run` only if
+   the person asks.
+
+Do not ask for details you can look up or default. When you need a value only the person has,
+ask once with `request_input`, with a proposed default in every field you can guess.
 """
 
 # NOTE for a future audit: this block deliberately CONTAINS a banned provider action name
 # (`LIST_REPOSITORY_ISSUES`) as a named counter-example. A grep for banned action names in
 # the build-kit text will hit it and read as a regression; it is the fix. Check the role a
 # match plays before deleting it — removing this one deletes the warning, not the mistake.
-_BUILD_LOOP_TAIL = """\
-6. Verify with `test_run`. First warn the user that this is a real run: external write tools may
-   perform their action if approved. Then call `test_run` with `inputs.messages` as a blunt
-   instruction-framed test message and `expectations.terminal_tool` set to the final tool that
-   proves success. Read `verdict`, `verdict_reason`, `tools`, `approvals`, and `resolved`; a 200
-   response is not proof. The four verdicts:
-   - `pass` — the terminal tool ran and returned; done.
-   - `incomplete` — the run stopped short (did the early reads, then wandered or stopped before the
-     terminal action). Rewrite `instructions.agents_md` as a blunter numbered procedure, call
-     `commit_revision`, and run `test_run` again.
-   - `unconfirmed` — the terminal tool's completion could not be proven: it was dispatched but
-     never returned a result (the stalled-approval signature), or no `expectations.terminal_tool`
-     was set. A tool NAME appearing in the executed list is not proof it completed. If `approvals`
-     is non-empty this is an approval stop: report the waiting gate and wait for the user.
-   - `failed` — a tool errored or the run failed outright; read `verdict_reason` and fix.
-
-   For an EXTERNAL WRITE, even a returned result is only truly confirmed by reading the side effect
-   back (fetch the channel history, re-read the issue). Use `query_spans` to read back SCHEDULED
-   run spans after a schedule or subscription fires.
-7. Add a trigger only if asked. For schedules, cron is UTC, five fields, with a one-minute floor;
-   convert the user's timezone yourself, then stop for approval before `create_schedule`: say what
-   you are about to create and wait for the gate. After approval, call `create_schedule`, then
-   confirm with `list_schedules`. For events, call `discover_triggers` and check that the returned
-   integration and event description actually fit the ask — matching is keyword search, not
-   semantic. A no-match still lists the closest events as alternatives, and a bare integration
-   name ("slack") browses its closest events — both capped by `limit_alternatives` (default 3),
-   so raise it before concluding an event does not exist. If the integration you asked about
-   never appears at all, the provider has no trigger for it: say so instead of wiring the
-   closest keyword hit. Then ensure the integration is connected, and stop for approval before
-   `create_subscription`: say what you are about to create and wait for the gate. After
-   approval, call `create_subscription`, and confirm with `list_deliveries`. `test_subscription` waits for a real event, so warn the user before using it
-   in a chat turn. Use `remove_schedule` or `remove_subscription` only when cleaning up a wrong
-   trigger. Shape the run's inputs with `inputs_fields` (see `references/trigger-inputs.md`).
-   Triggers do NOT follow a new revision: after any later `commit_revision`, existing schedules and
-   subscriptions still point at the old revision, so re-point them to the new one.
-8. Report short: what you became, what is connected, what is scheduled, what you verified, and
-   what still needs the human.
+_BUILD_INSTRUCTIONS_WRITING = """\
 
 ## Writing instructions for multi-tool and scheduled agents
 
@@ -1034,7 +981,7 @@ _BUILD_TOOLS_AND_FAILURES_ORDERED = """\
 ## Prefer wired tools
 
 Prefer your wired tools (`read_config`, `discover_tools`, `request_input`, `request_connection`,
-`commit_revision`, `test_run`, `query_spans`, `create_schedule`, `list_schedules`,
+`request_secret`, `commit_revision`, `test_run`, `create_schedule`, `list_schedules`,
 `discover_triggers`, `create_subscription`, `test_subscription`, `list_deliveries`,
 `remove_schedule`, `remove_subscription`) over harness builtins. Touch Terminal, RemoteTrigger,
 File tools, or raw HTTP only when your wired tools cannot do the job, and say so when you do.
@@ -1050,22 +997,21 @@ File tools, or raw HTTP only when your wired tools cannot do the job, and say so
   new `base_revision_id`.
 - The commit checks your targets, not your values: a wrong shape inside an entry commits fine and
   surfaces at run time — a skill fails to load, the model silently falls back, a tool goes missing.
-  So verify with `test_run` after every commit: read `resolved` and the executed tool list, and
-  when something is off, check the shape against `references/config-schema.md` and commit the fix;
-  do not start over.
+  Check the shape against `references/config-schema.md` before you commit, and when a run
+  misbehaves after a commit, check it again and commit the fix; do not start over.
 - After any commit, existing schedules and subscriptions still point at the previous revision.
   Re-point them so they run the new config.
-- If `test_run`'s `resolved` harness or model differs from what you committed, the config silently
-  fell back (usually a harness/model/provider mismatch). Fix it against `references/config-schema.md`
-  and re-test.
+- If a `test_run` the person asked for shows a `resolved` harness or model that differs from what
+  you committed, the config silently fell back (usually a harness/model/provider mismatch). Fix it
+  against `references/config-schema.md`.
 """
 
 _BUILD_TOOLS_AND_FAILURES_LEGACY = """\
 
 ## Prefer wired tools
 
-Prefer your wired tools (`discover_tools`, `request_input`, `request_connection`, `commit_revision`,
-`test_run`, `query_spans`, `create_schedule`, `list_schedules`, `discover_triggers`,
+Prefer your wired tools (`discover_tools`, `request_input`, `request_connection`, `request_secret`,
+`commit_revision`, `test_run`, `create_schedule`, `list_schedules`, `discover_triggers`,
 `create_subscription`, `test_subscription`, `list_deliveries`, `remove_schedule`,
 `remove_subscription`) over harness builtins. Touch Terminal, RemoteTrigger, File tools, or raw
 HTTP only when your wired tools cannot do the job, and say so when you do.
@@ -1075,23 +1021,22 @@ HTTP only when your wired tools cannot do the job, and say so when you do.
 - A denied or failed `commit_revision` does not undo earlier connections or triggers; they still
   exist. Do not redo them.
 - The commit does not validate your config: a wrong shape commits fine and surfaces at run time —
-  a skill fails to load, the model silently falls back, a tool goes missing. So verify with
-  `test_run` after every commit: read `resolved` and the executed tool list, and when something
-  is off, check the shape against `references/config-schema.md` and re-commit the fix; do not
-  start over.
+  a skill fails to load, the model silently falls back, a tool goes missing. Check the shape
+  against `references/config-schema.md` before you commit, and when a run misbehaves after a
+  commit, check it again and re-commit the fix; do not start over.
 - After any commit, existing schedules and subscriptions still point at the previous revision.
   Re-point them so they run the new config.
-- If `test_run`'s `resolved` harness or model differs from what you committed, the config silently
-  fell back (usually a harness/model/provider mismatch). Fix it against `references/config-schema.md`
-  and re-test.
+- If a `test_run` the person asked for shows a `resolved` harness or model that differs from what
+  you committed, the config silently fell back (usually a harness/model/provider mismatch). Fix it
+  against `references/config-schema.md`.
 """
 
 _BUILD_FOOTGUNS = """\
 
 ## Footguns
 
-- Empty output is not enough to fail a run; read the `test_run` verdict, tools, approvals,
-  and verdict_reason before judging.
+- When you do run `test_run`, empty output is not enough to fail it; read the verdict, tools,
+  approvals, and verdict_reason before judging.
 - Never surface raw provider slugs such as `provider_action` to the user; speak in Agenta terms.
 - Re-run discovery after the user connects an integration so the committed tool gets the concrete
   connection id.
@@ -1102,9 +1047,11 @@ _BUILD_FOOTGUNS = """\
 _BUILD_AN_AGENT_BODY = (
     _BUILD_HEAD
     + (_BUILD_SHAPE_ORDERED if _ORDERED else _BUILD_SHAPE_LEGACY)
-    + _BUILD_TABLE_AND_LOOP
-    + (_BUILD_STEP5_ORDERED if _ORDERED else _BUILD_STEP5_LEGACY)
-    + _BUILD_LOOP_TAIL
+    + _BUILD_TEMPLATES.format(
+        names=", ".join(entry.name for entry in AGENT_TEMPLATE_ENTRIES)
+    )
+    + (_BUILD_LOOP_ORDERED if _ORDERED else _BUILD_LOOP_LEGACY)
+    + _BUILD_INSTRUCTIONS_WRITING
     + (
         _BUILD_TOOLS_AND_FAILURES_ORDERED
         if _ORDERED
@@ -1116,10 +1063,10 @@ _BUILD_AN_AGENT_BODY = (
 BUILD_AN_AGENT_SKILL = SkillTemplate(
     name="build-an-agent",
     description=(
-        "Build or configure an Agenta agent end to end. ALWAYS read this skill at the start "
-        "of the conversation, before your first reply, to load context on what you are and "
-        "how you configure yourself. Then follow it when the user asks to set up, automate, "
-        "connect tools for, schedule, or subscribe an agent."
+        "How to change this agent's own configuration: instructions, memory, skills, "
+        "integrations, and triggers. Read it when the request is a change to you rather "
+        "than a task, and when an agent that still has its default name and instructions "
+        "gets its first real request. Do not read it for a task."
     ),
     body=_BUILD_AN_AGENT_BODY,
     files=[


### PR DESCRIPTION
Stacked on #6632. Merge that one first; this diff shows only the skill and build-kit changes.

## What this changes

The build-an-agent skill was written before the platform prompt existed, and the two disagreed. The skill told the agent to read it before every first reply, to clarify the ask before acting, to walk an eight-step loop, and to run `test_run` after every commit. The prompt says decide and proceed, ask only at the three gates, show a sample before building, and test only when the person asks. The prompt wins, and the skill now describes only the mechanics of a configuration change.

- The description no longer says "ALWAYS read this skill at the start of the conversation". It says to read it when the request is a change to the agent, and for a new agent's first real request.
- The decision table, the playbook-index detour, and the eight-step loop are gone. The template names are listed inline (rendered from the entries, so they cannot drift), and a five-step change procedure replaces the loop.
- The sections that came from evaluations stay: writing instructions for multi-tool and scheduled agents, prefer wired tools, when something fails, footguns.
- `test_run` is no longer mandated after every commit, in the skill, in `references/config-schema.md`, or in the 28 playbooks. Each playbook's Verify section is now an "Offer a test" section. The read-before-propose use of `test_run` with an uncommitted tools delta stays in the playbooks, because a newly committed integration is callable only in the next session.
- `annotate_trace` and `query_spans` leave the build kit. They stay in the catalog as opt-ins.

## Size

The always-on skill body goes from about 3,400 tokens to about 2,300. The playbooks are 20 bytes smaller in total.

## Tests

- SDK agents unit suite: 1,247 passed, 4 skipped. The commit-teaching tests still hold: the body teaches `read_config`, `base_revision_id`, and `delta.operations`, and no playbook names a delta outside a `test_run` line.
- API: `test_build_kit_overlay.py` and the workflows unit tests, 51 passed on the two changed files, 627 on the directory.
- ruff 0.15.12 format and check clean on every changed Python file.

## Not in this PR

- `test_subscription` stays in the kit. It blocks a chat turn until an event arrives; I would cut it next but it was not on the list.
- `read_config`, `list_schedules`, and `list_deliveries` still show an approval card although they are read-only.
- The two search tools (`discover_tools` at configuration time, `search_tools` at run time) still coexist with different rules.

https://claude.ai/code/session_01VRLDWj1GQ6YFELyGr3gL9f