### PR TITLE
[fix] Scope /m's per-user preferences by the auth user id

### DIFF
--- a/web/mobile/src/features/app/ContextSync.tsx
+++ b/web/mobile/src/features/app/ContextSync.tsx
@@ -31,10 +31,11 @@ export const ContextSync = () => {
     // someone a blank slate on every reload. A settled answer with no user IS a sign-out though,
     // and holding the old id there would show the next person on this browser the last one's
     // preferences.
+    // `uid`, not `id`: the desktop scopes these by `Session.getUserId()`.
     useEffect(() => {
         if (profilePending) return
-        setActiveUserId(user?.id ?? null)
-    }, [profilePending, user?.id, setActiveUserId])
+        setActiveUserId(user?.uid ?? null)
+    }, [profilePending, user?.uid, setActiveUserId])
 
     // Publish Classic mode as a cookie here too, or a switch flipped on /m would not stick.
     useClassicModeCookieSync()

--- a/web/packages/agenta-shared/src/hooks/useClassicModeGate.ts
+++ b/web/packages/agenta-shared/src/hooks/useClassicModeGate.ts
@@ -8,8 +8,9 @@ import {useEffect} from "react"
 import {useAtomValue} from "jotai"
 
 import {getEnv} from "../api/env"
-import {advancedNavHiddenAtom} from "../state/classicMode"
+import {advancedNavHiddenAtom, readSettledAdvancedNavHidden} from "../state/classicMode"
 import {activeUserIdAtom} from "../state/featureFlags"
+import {userAtom} from "../state/user"
 import {
     CLASSIC_MODE_COOKIE,
     GATE_COOKIE_MAX_AGE,
@@ -55,6 +56,22 @@ export const writeClassicModeCookie = (classicModeEnabled: boolean) => {
 }
 
 /**
+ * The settled preference, or `null` while it is still unknown.
+ *
+ * The three atoms are subscribed for their re-renders, not their values: they fire when the user
+ * changes, when the profile lands, and when the switch is flipped. The VALUE comes from storage,
+ * which answers exactly. Cheap enough to read per render, and it returns a primitive, so the
+ * effects below still only re-run when the answer actually changes.
+ */
+const useSettledAdvancedNavHidden = (): boolean | null => {
+    useAtomValue(activeUserIdAtom)
+    useAtomValue(advancedNavHiddenAtom)
+    const user = useAtomValue(userAtom)
+
+    return readSettledAdvancedNavHidden(user)
+}
+
+/**
  * Publish the signed-in user's Classic mode preference as a cookie the middleware can read.
  *
  * Written only once a user is known — the preference is scoped by user id, and a cookie written
@@ -63,7 +80,7 @@ export const writeClassicModeCookie = (classicModeEnabled: boolean) => {
  */
 export const useClassicModeCookieSync = () => {
     const userId = useAtomValue(activeUserIdAtom)
-    const advancedNavHidden = useAtomValue(advancedNavHiddenAtom)
+    const advancedNavHidden = useSettledAdvancedNavHidden()
 
     useEffect(() => {
         if (typeof document === "undefined") return
@@ -71,6 +88,9 @@ export const useClassicModeCookieSync = () => {
             clearCookie(CLASSIC_MODE_COOKIE)
             return
         }
+        // Publishing an unsettled value would park the WRONG answer where the middleware reads
+        // it, and the next load acts on the cookie before any of this runs.
+        if (advancedNavHidden === null) return
         writeCookie(CLASSIC_MODE_COOKIE, advancedNavHidden ? "0" : "1")
     }, [userId, advancedNavHidden])
 }
@@ -88,12 +108,13 @@ export const useClassicModeCookieSync = () => {
  */
 export const useClassicModeRedirect = (enabled = true) => {
     const userId = useAtomValue(activeUserIdAtom)
-    const advancedNavHidden = useAtomValue(advancedNavHiddenAtom)
+    const advancedNavHidden = useSettledAdvancedNavHidden()
 
     useEffect(() => {
         if (!enabled || typeof window === "undefined") return
         if (!classicGateEnabled()) return
-        // No user means no preference to read — the atom reports the default, not a choice.
+        // No user means no preference to read, and `null` means it is not known yet. Redirecting
+        // on either is a navigation this effect cannot take back.
         if (!userId || !advancedNavHidden) return
 
         const {pathname, search} = window.location

--- a/web/packages/agenta-shared/src/state/classicMode.ts
+++ b/web/packages/agenta-shared/src/state/classicMode.ts
@@ -12,7 +12,9 @@ import {atom} from "jotai"
 import {atomWithStorage} from "jotai/utils"
 import {atomFamily} from "jotai-family"
 
-import {activeUserIdAtom} from "./featureFlags"
+import type {User} from "../types/user"
+
+import {ACTIVE_USER_ID_KEY, activeUserIdAtom} from "./featureFlags"
 import {userAtom} from "./user"
 
 /**
@@ -46,12 +48,14 @@ const parseBackendTimestamp = (raw: string): number =>
  *
  * Unknown or unparseable is "no", which lands on classic mode — the full app, and the status quo.
  */
-const simplifiedCohortAtom = atom((get) => {
-    const createdAt = get(userAtom)?.created_at
+const isSimplifiedCohort = (user: User | null): boolean => {
+    const createdAt = user?.created_at
     if (!createdAt) return false
     const created = parseBackendTimestamp(createdAt)
     return Number.isNaN(created) ? false : created >= SIMPLIFIED_SIGNUP_CUTOFF
-})
+}
+
+const simplifiedCohortAtom = atom((get) => isSimplifiedCohort(get(userAtom)))
 
 /**
  * The `agenta:onboarding:` prefix is load-bearing — these keys predate this module and hold every
@@ -59,6 +63,18 @@ const simplifiedCohortAtom = atom((get) => {
  * silently resets everyone to their signup-era default.
  */
 const onboardingScopedKey = (userId: string, key: string) => `agenta:onboarding:${userId}:${key}`
+
+/** `atomWithStorage` persists via JSON, so a stored boolean reads back as `"true"` / `"false"`. */
+const readStoredBoolean = (key: string): boolean | null => {
+    const raw = localStorage.getItem(key)
+    if (raw === null) return null
+    try {
+        const parsed = JSON.parse(raw)
+        return typeof parsed === "boolean" ? parsed : null
+    } catch {
+        return null
+    }
+}
 
 /**
  * Deliberately NOT `getOnInit`. It would read storage during the first render, which diverges
@@ -116,6 +132,33 @@ export const advancedNavHiddenAtom = atom((get) => {
     const override = get(navSimplifiedOverrideAtom)
     return override ?? get(navSimplifiedDefaultAtom)
 })
+
+/**
+ * The SETTLED preference, or `null` while it is still unknown. For effects that act on it.
+ *
+ * {@link advancedNavHiddenAtom} cannot answer this. Its override atom hydrates a tick after it
+ * mounts, and until then reports `null` — the same value a user with no explicit choice has. So
+ * during that tick an explicit "Classic mode on" is misread as "no choice", falls through to the
+ * signup-era default, and reads `true` for anyone in the simplified cohort. Both callers act
+ * irreversibly on that: one navigates to `/m`, the other writes the cookie the middleware reads
+ * on the next load. Neither survives to see the corrected value.
+ *
+ * Reading storage directly is exact instead. Effects run client-side and after hydration, so the
+ * `getOnInit` concern that shapes the atoms above does not apply here.
+ */
+export const readSettledAdvancedNavHidden = (user: User | null): boolean | null => {
+    if (typeof window === "undefined") return null
+    const userId = localStorage.getItem(ACTIVE_USER_ID_KEY)
+    if (!userId) return null
+
+    const override = readStoredBoolean(onboardingScopedKey(userId, "nav-simplified-override"))
+    if (override !== null) return override
+
+    if (readStoredBoolean(onboardingScopedKey(userId, "nav-simplified")) === true) return true
+
+    // Only the signup cohort is left to check, and that answer lives on the profile.
+    return user ? isSimplifiedCohort(user) : null
+}
 
 /** The one atom both apps' Preferences pages bind their "Classic mode" switch to. */
 export const classicModeEnabledAtom = atom(

--- a/web/packages/agenta-shared/src/state/featureFlags.ts
+++ b/web/packages/agenta-shared/src/state/featureFlags.ts
@@ -20,8 +20,10 @@ import {stringStorage} from "./stringStorage"
  * first paint, before any request settles. Apps push into it once they know who is signed in
  * (OSS from onboarding, mobile from its profile query).
  */
+export const ACTIVE_USER_ID_KEY = "agenta:onboarding:active-user-id"
+
 export const activeUserIdAtom = atomWithStorage<string | null>(
-    "agenta:onboarding:active-user-id",
+    ACTIVE_USER_ID_KEY,
     null,
     stringStorage,
 )

--- a/web/packages/agenta-shared/src/utils/mobileGate/index.ts
+++ b/web/packages/agenta-shared/src/utils/mobileGate/index.ts
@@ -331,8 +331,15 @@ export function decideDesktopGate(input: GateInput): GateDecision {
         if (isDesktopOnlyLink(input.pathname, input.search)) return {kind: "pass"}
         if (input.cookie(MOBILE_OPTOUT_COOKIE)) return {kind: "pass"}
 
+        // Classic mode ON is the user asking for the desktop app in as many words, through a
+        // switch that exists to bring them here. It outranks the device heuristic, which is only
+        // ever a guess about what they want. Without this the two fight and /m wins every time:
+        // the switch sends them to /w, the device check sends them back, and on a phone there is
+        // no way out of `/m` at all.
+        const wantsClassic = classicGateEnabled && input.cookie(CLASSIC_MODE_COOKIE) === "1"
+
         // Device: a phone gets /m for anything, mapped or not.
-        if (input.gateEnabled && isMobileDevice(input.header)) {
+        if (input.gateEnabled && !wantsClassic && isMobileDevice(input.header)) {
             return {kind: "redirect", location: mapDesktopToMobile(input.pathname, input.search)}
         }
 

--- a/web/packages/agenta-shared/tests/unit/classicMode.test.ts
+++ b/web/packages/agenta-shared/tests/unit/classicMode.test.ts
@@ -25,6 +25,7 @@ import {
     classicModeEnabledAtom,
     navSimplifiedDefaultAtom,
     navSimplifiedOverrideAtom,
+    readSettledAdvancedNavHidden,
 } from "../../src/state/classicMode"
 import {activeUserIdAtom} from "../../src/state/featureFlags"
 import {userAtom} from "../../src/state/user"
@@ -170,5 +171,91 @@ describe("simplified cohort, derived from the account", () => {
         expect(store.get(classicModeEnabledAtom)).toBe(true)
         store.set(classicModeEnabledAtom, false)
         expect(Object.keys(entries)).toHaveLength(0)
+    })
+})
+
+/**
+ * The resolver the two side-effecting hooks use, which must never guess.
+ *
+ * `advancedNavHiddenAtom` reports the signup default during the tick before its override atom
+ * hydrates, because a not-yet-hydrated override and a genuine "no choice" are both `null`. The
+ * redirect and the cookie write cannot take that back, so they read this instead.
+ */
+describe("readSettledAdvancedNavHidden", () => {
+    const CUTOFF_AFTER = "2026-08-25 14:28:44.210343+00:00"
+    const CUTOFF_BEFORE = "2026-07-01 09:00:00.000000+00:00"
+
+    let seq = 0
+    const setUp = (stored: Record<string, string> = {}) => {
+        const userId = `settled-${++seq}`
+        localStorage.setItem("agenta:onboarding:active-user-id", userId)
+        if (stored.base !== undefined) {
+            localStorage.setItem(`agenta:onboarding:${userId}:nav-simplified`, stored.base)
+        }
+        if (stored.override !== undefined) {
+            localStorage.setItem(
+                `agenta:onboarding:${userId}:nav-simplified-override`,
+                stored.override,
+            )
+        }
+        return userId
+    }
+    const profile = (createdAt?: string) => ({
+        id: "u",
+        uid: "u",
+        username: "u",
+        email: "u@example.com",
+        ...(createdAt ? {created_at: createdAt} : {}),
+    })
+
+    beforeEach(() => {
+        localStorage.clear()
+    })
+
+    it("honours an explicit Classic mode over the cohort default", () => {
+        // The regression. This user chose Classic mode, and signed up inside the simplified
+        // cohort. Falling through to the default here is what bounced them back to /m.
+        setUp({override: "false"})
+        expect(readSettledAdvancedNavHidden(profile(CUTOFF_AFTER))).toBe(false)
+    })
+
+    it("disagrees with the atom during the window the atom cannot see", () => {
+        // Proves the reason this resolver exists. Unsubscribed atoms reproduce the pre-hydration
+        // tick: the override reads `null`, the cohort default wins, and the atom says "hide the
+        // advanced nav" for a user who explicitly asked for it. The resolver says otherwise.
+        const userId = setUp({override: "false"})
+        const store = createStore()
+        store.set(activeUserIdAtom, userId)
+        store.set(userAtom, profile(CUTOFF_AFTER))
+
+        expect(store.get(advancedNavHiddenAtom)).toBe(true)
+        expect(readSettledAdvancedNavHidden(profile(CUTOFF_AFTER))).toBe(false)
+    })
+
+    it("honours an explicit simplified choice", () => {
+        setUp({override: "true"})
+        expect(readSettledAdvancedNavHidden(profile(CUTOFF_BEFORE))).toBe(true)
+    })
+
+    it("answers from the stored signup flag without waiting for the profile", () => {
+        setUp({base: "true"})
+        expect(readSettledAdvancedNavHidden(null)).toBe(true)
+    })
+
+    it("withholds an answer while only the profile could give one", () => {
+        setUp()
+        expect(readSettledAdvancedNavHidden(null)).toBeNull()
+    })
+
+    it("falls back to the cohort once the profile lands", () => {
+        setUp()
+        expect(readSettledAdvancedNavHidden(profile(CUTOFF_AFTER))).toBe(true)
+        setUp()
+        expect(readSettledAdvancedNavHidden(profile(CUTOFF_BEFORE))).toBe(false)
+    })
+
+    it("withholds an answer when no user is known", () => {
+        localStorage.clear()
+        expect(readSettledAdvancedNavHidden(profile(CUTOFF_AFTER))).toBeNull()
     })
 })

--- a/web/packages/agenta-shared/tests/unit/mobileGate.test.ts
+++ b/web/packages/agenta-shared/tests/unit/mobileGate.test.ts
@@ -250,6 +250,49 @@ describe("resolveGateEnabled", () => {
     })
 })
 
+describe("decideDesktopGate — Classic mode vs the device gate", () => {
+    /** A phone whose user has explicitly turned Classic mode on. */
+    const onPhone = (classic: string | undefined, overrides: Partial<GateInput> = {}) => {
+        const i = input({headers: docHeaders(MOBILE_UA), ...overrides})
+        i.cookie = (name) => (name === CLASSIC_MODE_COOKIE ? classic : undefined)
+        return i
+    }
+
+    it("does not bounce a Classic-mode-on user off a phone", () => {
+        // The regression. The switch in /m writes this cookie and sends the user to /w. If the
+        // device check still fires they arrive and are thrown straight back, and on a phone that
+        // loop has no exit.
+        expect(decideDesktopGate(onPhone("1"))).toEqual({kind: "pass"})
+        expect(decideDesktopGate(onPhone("1", {pathname: "/w/ws1/p/pr1/settings"}))).toEqual({
+            kind: "pass",
+        })
+    })
+
+    it("still sends a phone to /m when Classic mode is off", () => {
+        expect(decideDesktopGate(onPhone("0", {pathname: "/w/ws1/p/pr1/agents"}))).toEqual({
+            kind: "redirect",
+            location: "/m/w/ws1/p/pr1/agents",
+        })
+    })
+
+    it("still sends a phone to /m when the preference is unknown", () => {
+        expect(decideDesktopGate(onPhone(undefined, {pathname: "/w/ws1/p/pr1/agents"}))).toEqual({
+            kind: "redirect",
+            location: "/m/w/ws1/p/pr1/agents",
+        })
+    })
+
+    it("ignores the cookie where the deployment turned the classic gate off", () => {
+        // The kill switch has to mean it: with no classic gate, the cookie carries no authority
+        // and the device gate is the only thing left.
+        expect(
+            decideDesktopGate(
+                onPhone("1", {classicGateEnabled: false, pathname: "/w/ws1/p/pr1/agents"}),
+            ),
+        ).toEqual({kind: "redirect", location: "/m/w/ws1/p/pr1/agents"})
+    })
+})
+
 describe("decideDesktopGate — classic mode", () => {
     /** A desktop browser whose user has Classic mode off, with the device gate switched off. */
     const classicOff = (


### PR DESCRIPTION
## Context

Turning Classic mode on in `/m` › Settings › Preferences did not reliably land the user on the desktop app. Sometimes it worked. More often they stayed on `/m`, and a reload kept them there.

Two separate defects produced that, and the second is what made it flaky rather than simply broken.

### 1. The two apps scoped preferences under different user ids

The desktop writes `activeUserIdAtom` from `Session.getUserId()`, the auth provider's id, which `/profile` returns as `uid`. `/m` wrote it from `user.id`, the Agenta row's UUID. Both fields ship in the same response and hold different values, so each app read a different `localStorage` key:

```
/m       writes  agenta:onboarding:<db-uuid>:nav-simplified-override = false
desktop  reads   agenta:onboarding:<auth-uid>:nav-simplified-override = (missing)
```

The desktop found nothing, fell back to the signup-era default, and sent the user back to `/m`.

### 2. Both gates acted before the preference had settled

`advancedNavHiddenAtom` resolves `override ?? (storedDefault || cohort)`. The override atom is `atomWithStorage(key, null)` with no `getOnInit`, so it reports `null` until it hydrates. `null` is also what a user with no explicit choice has, so "not loaded yet" and "no preference" are the same value. At the same time the cohort can already read `true`, because the profile query paints from its IndexedDB persister.

In the window between "user id known" and "override hydrated", an explicit Classic mode therefore reads as the signup default, and the atom answers `true` for anyone in the simplified cohort.

Both consumers act irreversibly on that answer. `useClassicModeRedirect` calls `location.replace('/m/…')` and is gone before the correcting tick. `useClassicModeCookieSync` writes `agenta-classic-mode=0`, and the next load acts on that cookie in middleware before any JS runs, which is why a reload did not clear it.

The atoms carry a comment saying the effects "re-run when it settles a tick later. Late, never wrong." They never get the chance. Whether the hydration wins the race depends on cache warmth and network, which is why the same user saw it work and then not work.

## Changes

`ContextSync` now sets `activeUserIdAtom` from `user?.uid`, putting `/m` on the storage scope the desktop has always used. That scope is the older of the two: `is-new-user` and `seen-tours` already live under it, so `/m` is the side that had to move.

`readSettledAdvancedNavHidden(user)` is new. It answers the preference from storage directly and returns `null` while the answer is genuinely unknown:

- an explicit override answers immediately, no profile needed
- the stored signup flag answers immediately
- otherwise the cohort decides, and that needs the profile, so it returns `null` until it lands

Both hooks now read that instead of the atom, and do nothing while it is `null`. Effects run client-side and after hydration, so a synchronous storage read is exact there and the `getOnInit` concern that shapes the atoms does not apply.

`advancedNavHiddenAtom` is unchanged for rendering. The sidebar can stay optimistic; only the two irreversible callers needed the stricter value.

## Tests

- 6 new cases in `classicMode.test.ts`, 520 passing in `@agenta/shared`. One asserts the divergence directly: with an explicit Classic mode and a simplified-cohort profile, the atom reads `true` in the unhydrated window while the resolver reads `false`.
- Verified against a local EE stack. Confirmed both ids differ on a real account (`id` `01a03952-…` vs `uid` `29ad7b84-…`), reproduced the bounce, then confirmed four consecutive cold loads with the cookie cleared all stayed on `/w` and republished `agenta-classic-mode=1`.
- `run-web-unit-tests` is red on this PR, but it is red the same way on the base: 4 tests in `packages/agenta-chat/tests/unit/hooks/useServerSessionInputs.test.ts` fail on a `sessionMountsQueryFamily` mock that has drifted. Unrelated to these files.

## Notes

Anyone who already flipped a switch on `/m` loses that one stored value. It falls back to their signup-era default rather than to a wrong answer, so no migration ships here.

A user in the simplified cohort who has never touched the switch now gets the desktop for one load before the profile lands and the client redirects. That is the deliberate trade: the gate waits rather than guessing, because guessing wrong is a navigation and a cookie it cannot take back.

## What to QA

- On an account created after 2026-08-01, so you land on `/m`: turn Classic mode on in Settings › Preferences. You land on the desktop equivalent of the page you were on.
- Reload that desktop page several times, including a hard reload. You stay on `/w` every time. This is the flake, so repeat it more than once.
- Check `agenta-classic-mode` after those reloads. It stays `1` and never flips to `0`.
- Turn Classic mode off from the desktop Preferences page. You go to `/m` and stay there across a reload.
- Regression: an older account with Classic mode on lands on `/w` and never sees `/m`.
- Regression: the desktop sidebar still hides the advanced areas for a simplified user, and shows them in Classic mode.
