### PR TITLE
[fix] Land on the new project after creating one on mobile

### DIFF
--- a/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
+++ b/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
@@ -9,7 +9,7 @@ import {THEME_OPTIONS, themeIcon, useThemeMode} from "@agenta/ui/theme"
 import {useMutation, useQuery} from "@tanstack/react-query"
 import {useRouter} from "next/router"
 
-import {fetchProjects, writeLastContext} from "@/lib/context"
+import {fetchProjects, projectHomeUrl, writeLastContext} from "@/lib/context"
 
 import {useLogout} from "../auth/useLogout"
 import {groupByOrganization} from "../context/workspaceGroups"
@@ -56,7 +56,9 @@ export const DrawerProjectSwitcher = ({
 
     const goTo = (nextWorkspaceId: string, nextProjectId: string) => {
         writeLastContext({workspaceId: nextWorkspaceId, projectId: nextProjectId})
-        void router.push(`/w/${nextWorkspaceId}/p/${nextProjectId}/apps`)
+        // `projectHomeUrl` is the one spelling of the project home the resolver also forwards to;
+        // hand-rolling it here dropped the encoding it does.
+        void router.push(projectHomeUrl({workspaceId: nextWorkspaceId, projectId: nextProjectId}))
     }
 
     const projects = useMemo<SwitcherEntry[]>(
@@ -95,9 +97,15 @@ export const DrawerProjectSwitcher = ({
             const {createProject: create} = await import("@agenta/entities/project")
             return create({name: name.trim()}, workspaceId)
         },
-        onSuccess: async () => {
+        // Creating a project is a switch into it, exactly like picking one from the list — landing
+        // back on the old project left the new one with no way in but a second trip to the panel.
+        onSuccess: async (created) => {
             setCreateOpen(false)
+            // Refetch BEFORE navigating: the switcher label, the page title and every screen on
+            // the destination read this same query, and a list without the new project renders
+            // the route we just pushed as an unknown project.
             await query.refetch()
+            goTo(created.workspace_id ?? workspaceId, created.project_id)
         },
     })
 

--- a/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
+++ b/web/mobile/src/features/nav/DrawerProjectSwitcher.tsx
@@ -56,8 +56,7 @@ export const DrawerProjectSwitcher = ({
 
     const goTo = (nextWorkspaceId: string, nextProjectId: string) => {
         writeLastContext({workspaceId: nextWorkspaceId, projectId: nextProjectId})
-        // `projectHomeUrl` is the one spelling of the project home the resolver also forwards to;
-        // hand-rolling it here dropped the encoding it does.
+        // The resolver's own spelling of this route; the literal it replaces dropped the encoding.
         void router.push(projectHomeUrl({workspaceId: nextWorkspaceId, projectId: nextProjectId}))
     }
 
@@ -97,13 +96,10 @@ export const DrawerProjectSwitcher = ({
             const {createProject: create} = await import("@agenta/entities/project")
             return create({name: name.trim()}, workspaceId)
         },
-        // Creating a project is a switch into it, exactly like picking one from the list — landing
-        // back on the old project left the new one with no way in but a second trip to the panel.
+        // Creating a project is a switch into it, exactly like picking one from the list.
         onSuccess: async (created) => {
             setCreateOpen(false)
-            // Refetch BEFORE navigating: the switcher label, the page title and every screen on
-            // the destination read this same query, and a list without the new project renders
-            // the route we just pushed as an unknown project.
+            // Refetch first: the destination reads this same query for its title.
             await query.refetch()
             goTo(created.workspace_id ?? workspaceId, created.project_id)
         },


### PR DESCRIPTION
## Context

Creating a project from the `/m` drawer switcher left you where you started. The sheet closed, the project list refetched, and the new project appeared in the panel, but nothing routed to it. The only way in was to reopen the switcher and pick it by hand.

The create mutation's `onSuccess` only did `setCreateOpen(false)` and `query.refetch()`. Picking an existing project from that same panel calls `goTo`, which writes the continuity pair and pushes the project home. Creating one never did.

## Changes

`onSuccess` now refetches, then calls the same `goTo` the project list uses, with `created.workspace_id ?? workspaceId` as the destination workspace.

Order matters here. The switcher label, the page title and `useCurrentProject` all read the one `["mobile", "projects"]` query, so navigating before the refetch lands would render the route we just pushed as an unknown project.

Before:

```ts
onSuccess: async () => {
    setCreateOpen(false)
    await query.refetch()
},
```

After:

```ts
onSuccess: async (created) => {
    setCreateOpen(false)
    await query.refetch()
    goTo(created.workspace_id ?? workspaceId, created.project_id)
},
```

`goTo` also switches to `projectHomeUrl()`, the single spelling of the mobile project home that `ContextResolver` forwards to. The hand-rolled `` `/w/${id}/p/${id}/apps` `` it replaces duplicated that route and dropped its `encodeURIComponent`.

## Tests

- `pnpm --filter @agenta/mobile types:check` and `lint` are clean (the five lint warnings are pre-existing and in other files).
- Not verified in a browser yet. The QA steps below are what to run.

## What to QA

- On `/m`, open the drawer, open the project switcher, choose New project, name it, Create. You land on the new project's Apps screen and the switcher header shows its name.
- Regression: pick a different existing project from the same panel. It still navigates and still remembers that pair on the next `/m` visit.
- Regression: create a project while in an org with several workspaces. You land in the workspace the project was created under, not the one you came from.