### PR TITLE
[fix] Send a Classic-mode-on user out of /m

### DIFF
--- a/web/mobile/src/features/app/ContextSync.tsx
+++ b/web/mobile/src/features/app/ContextSync.tsx
@@ -1,7 +1,7 @@
 import {useEffect} from "react"
 
 import {useProfile} from "@agenta/entities/profile"
-import {useClassicModeCookieSync} from "@agenta/shared/hooks"
+import {useClassicModeCookieSync, useDesktopModeRedirect} from "@agenta/shared/hooks"
 import {activeUserIdAtom, setProjectIdAtom, setSessionAtom, setUserAtom} from "@agenta/shared/state"
 import {useSetAtom} from "jotai"
 import {useRouter} from "next/router"
@@ -38,6 +38,11 @@ export const ContextSync = () => {
 
     // Publish Classic mode as a cookie here too, or a switch flipped on /m would not stick.
     useClassicModeCookieSync()
+
+    // The other half: Classic mode ON belongs on the desktop app, and the device gate can land a
+    // user here before any cookie exists for the proxy to read. Held until the profile settles —
+    // a pending query is not a signed-out user, and the preference is scoped by user id.
+    useDesktopModeRedirect(!profilePending)
 
     // The auth half of the same context, and the other half of the desktop's `SessionListener`.
     // `sessionAtom` defaults to FALSE and every entity query gates on it, so a host that never

--- a/web/packages/agenta-shared/src/hooks/index.ts
+++ b/web/packages/agenta-shared/src/hooks/index.ts
@@ -14,5 +14,6 @@ export {
     desktopEscapeHref,
     useClassicModeCookieSync,
     useClassicModeRedirect,
+    useDesktopModeRedirect,
     writeClassicModeCookie,
 } from "./useClassicModeGate"

--- a/web/packages/agenta-shared/src/hooks/useClassicModeGate.ts
+++ b/web/packages/agenta-shared/src/hooks/useClassicModeGate.ts
@@ -13,6 +13,7 @@ import {activeUserIdAtom} from "../state/featureFlags"
 import {
     CLASSIC_MODE_COOKIE,
     GATE_COOKIE_MAX_AGE,
+    MOBILE_OPTIN_COOKIE,
     MOBILE_OPTOUT_COOKIE,
     desktopRouteFor,
     isDesktopOnlyLink,
@@ -120,4 +121,31 @@ export const desktopEscapeHref = (): string => {
     const {pathname, search} = window.location
     const stripped = pathname === "/m" ? "/" : pathname.replace(/^\/m(?=\/)/, "")
     return desktopRouteFor(stripped, search) ?? "/w"
+}
+
+/**
+ * `/m`-only: send a Classic-mode-ON user back to the desktop app. Mirror of
+ * {@link useClassicModeRedirect}, and needed for the same reason — the proxy reads only cookies,
+ * and the device gate can land a user here before one exists. Bounces a phone too, because
+ * Classic mode outranks the device heuristic on both sides of the gate.
+ */
+export const useDesktopModeRedirect = (enabled = true) => {
+    const userId = useAtomValue(activeUserIdAtom)
+    const advancedNavHidden = useSettledAdvancedNavHidden()
+
+    useEffect(() => {
+        if (!enabled || typeof window === "undefined") return
+        if (!classicGateEnabled()) return
+        // `null` is "not known yet", and `true` is Classic mode OFF — both stay put.
+        if (!userId || advancedNavHidden !== false) return
+
+        const {pathname} = window.location
+        // Sign-in and the OAuth landing finish where they are: the mobile flow's state lives in
+        // this origin's sessionStorage, and bouncing the callback drops the one-time code.
+        if (/^\/m\/auth(\/|$)/.test(pathname)) return
+        // "Open mobile version" is an explicit request for this app; it outranks the preference.
+        if (readCookie(MOBILE_OPTIN_COOKIE)) return
+
+        window.location.replace(desktopEscapeHref())
+    }, [enabled, userId, advancedNavHidden])
 }

--- a/web/packages/agenta-shared/src/utils/mobileGate/index.ts
+++ b/web/packages/agenta-shared/src/utils/mobileGate/index.ts
@@ -352,7 +352,10 @@ export function decideDesktopGate(input: GateInput): GateDecision {
 /** Reverse gate: runs in the MOBILE app. Sees only /m traffic behind Traefik. */
 export function decideMobileGate(input: GateInput): GateDecision {
     try {
-        if (!input.gateEnabled) return {kind: "pass"}
+        // Independent gates, as on the desktop half: `/m` still honours Classic mode on a
+        // deployment that turned the DEVICE gate off.
+        const classicGateEnabled = input.classicGateEnabled !== false
+        if (!input.gateEnabled && !classicGateEnabled) return {kind: "pass"}
         if (!isDocumentNavigation(input)) return {kind: "pass"}
 
         // Escape hatch: "Open mobile version" links carry ?view=mobile.
@@ -369,13 +372,25 @@ export function decideMobileGate(input: GateInput): GateDecision {
         // one-time code and strands the flow.
         if (AUTH_CALLBACK_RE.test(input.pathname)) return {kind: "pass"}
         if (input.cookie(MOBILE_OPTIN_COOKIE)) return {kind: "pass"}
-        // Classic mode off means /m is where this user belongs, so the device heuristic must not
-        // bounce them out of it. Without this the two gates ping-pong forever on a desktop UA:
-        // the desktop gate sends them here for the preference, this one sends them back for the
-        // device, and the cookie that started it never changes.
-        if (input.classicGateEnabled !== false && input.cookie(CLASSIC_MODE_COOKIE) === "0") {
-            return {kind: "pass"}
+        if (classicGateEnabled) {
+            const classic = input.cookie(CLASSIC_MODE_COOKIE)
+            // Classic mode off means /m is where this user belongs, so the device heuristic must
+            // not bounce them out of it. Without this the two gates ping-pong forever on a
+            // desktop UA: the desktop gate sends them here for the preference, this one sends
+            // them back for the device, and the cookie that started it never changes.
+            if (classic === "0") return {kind: "pass"}
+            // Mirror image: the desktop gate already ranks Classic mode above the device
+            // heuristic (`wantsClassic`), so without the same precedence here a phone whose user
+            // asked for the full app is passed through below and parked on /m.
+            if (classic === "1") {
+                return {
+                    kind: "redirect",
+                    location: mapMobileToDesktop(input.pathname, input.search),
+                }
+            }
         }
+
+        if (!input.gateEnabled) return {kind: "pass"}
         // Checked after ?view=mobile so the opt-in cookie is still set if the bounce is re-enabled.
         if (input.reverseGateEnabled === false) return {kind: "pass"}
         if (isMobileDevice(input.header)) return {kind: "pass"}

--- a/web/packages/agenta-shared/tests/unit/mobileGate.test.ts
+++ b/web/packages/agenta-shared/tests/unit/mobileGate.test.ts
@@ -579,6 +579,66 @@ describe("decideMobileGate", () => {
         })
     })
 
+    it("bounces a Classic-mode-ON user out of /m, phone included", () => {
+        // The switch says "full desktop app", so it outranks the device heuristic here exactly
+        // as `wantsClassic` does on the desktop half.
+        const i = input({
+            gateEnabled: true,
+            pathname: "/w/ws1/p/pr1/sessions/abc",
+            headers: docHeaders(MOBILE_UA),
+        })
+        i.cookie = (name) => (name === CLASSIC_MODE_COOKIE ? "1" : undefined)
+        expect(decideMobileGate(i)).toEqual({
+            kind: "redirect",
+            location: "/w/ws1/p/pr1/observability?session=abc",
+        })
+
+        // And the desktop half must keep them there, or the two gates loop.
+        expect(decideDesktopGate({...i, pathname: "/w/ws1/p/pr1/observability"})).toEqual({
+            kind: "pass",
+        })
+    })
+
+    it("bounces a Classic-mode-ON user out of /m with the device gate off", () => {
+        const i = input({
+            gateEnabled: false,
+            pathname: "/w/ws1/p/pr1/sessions",
+            headers: docHeaders(MOBILE_UA),
+        })
+        i.cookie = (name) => (name === CLASSIC_MODE_COOKIE ? "1" : undefined)
+        expect(decideMobileGate(i)).toEqual({kind: "redirect", location: "/w/ws1/p/pr1/sessions"})
+    })
+
+    it("keeps a Classic-mode-ON user on /m when they opted in or the classic gate is off", () => {
+        for (const overrides of [{}, {classicGateEnabled: false}]) {
+            const i = input({
+                gateEnabled: true,
+                pathname: "/w/ws1/p/pr1/sessions",
+                headers: docHeaders(MOBILE_UA),
+                ...overrides,
+            })
+            const optedIn = "classicGateEnabled" in overrides ? undefined : "1"
+            i.cookie = (name) =>
+                name === CLASSIC_MODE_COOKIE
+                    ? "1"
+                    : name === MOBILE_OPTIN_COOKIE
+                      ? optedIn
+                      : undefined
+            expect(decideMobileGate(i)).toEqual({kind: "pass"})
+        }
+    })
+
+    it("never bounces a Classic-mode-ON user off an OAuth landing", () => {
+        const i = input({
+            gateEnabled: true,
+            pathname: "/auth/callback/google",
+            search: "?code=abc",
+            headers: docHeaders(MOBILE_UA),
+        })
+        i.cookie = (name) => (name === CLASSIC_MODE_COOKIE ? "1" : undefined)
+        expect(decideMobileGate(i)).toEqual({kind: "pass"})
+    })
+
     it("still bounces a desktop UA out of /m when the classic gate is disabled", () => {
         const i = input({
             gateEnabled: true,


### PR DESCRIPTION
## Context

With Classic mode switched on, a user could still end up stuck on `/m`. The desktop gate already ranks the preference above the device heuristic (`wantsClassic`), so it never sends a Classic-mode user to `/m`. The reverse gate in the mobile app never learned the other half: it only handled Classic mode *off* (`agenta-classic-mode=0`, meaning "stay on `/m`"), so with the cookie set to `1` the request fell through to `isMobileDevice(...) → pass`. On a phone, or on any first landing that happened before the cookie existed, the switch said desktop while the address bar said `/m`, and nothing ever moved the user to `/w`.

## Changes

`decideMobileGate` now reads both values of the cookie instead of one:

Before:

```ts
if (classicGateEnabled && cookie(CLASSIC_MODE_COOKIE) === "0") return {kind: "pass"}
// "1" fell through to the device check below, which passed a phone through
```

After:

```ts
if (classic === "0") return {kind: "pass"}
if (classic === "1") return {kind: "redirect", location: mapMobileToDesktop(pathname, search)}
```

The redirect fires whatever the device, for the same reason the desktop half does not care about the device: the switch is the user saying which app they want. `?view=mobile`, the opt-in cookie, and the OAuth callback still win over it, so no one loses an explicit choice or a one-time code.

The top guard was also split so the classic gate survives `AGENTA_MOBILE_GATE=false`, matching the shape `decideDesktopGate` already has. The two flags are meant to be independent.

Last, `/m` gained the client half it was missing. The proxy reads only cookies, so the device gate can land a user on `/m` before one exists. `useDesktopModeRedirect` is the mirror of the desktop's existing `useClassicModeRedirect`, mounted in `ContextSync` once the profile settles. It skips `/m/auth*` and respects the opt-in cookie.

## Tests

- `pnpm --filter @agenta/shared test` (528 passing, 95 in `mobileGate.test.ts`). Four new cases: the phone bounce, the bounce with the device gate off, the two ways to stay (opt-in cookie, classic gate disabled), and the OAuth landing.
- One of them asserts the desktop half passes the same request, so a reviewer can see the two gates cannot loop.
- `pnpm --filter @agenta/shared types:check`, `pnpm --filter @agenta/mobile types:check`, `pnpm --filter @agenta/mobile test` all clean.
- No changes to `web/oss` or `web/ee`. Their middlewares are thin adapters over the shared decision and were already correct.

## What to QA

Needs one origin serving both apps, so use the local compose stack rather than `pnpm dev-oss` on its own. The whole thing turns on a cookie shared between `/` and `/m`.

- Settings › Preferences on the desktop, turn Classic mode off. You land on `/m/...`.
- Settings › Preferences on `/m`, turn Classic mode on. You land on `/w/...` and stay there.
- The bug itself: with Classic mode on, put `localhost/m/w/<ws>/p/<proj>/sessions` in the address bar. It now forwards to `/w/<ws>/p/<proj>/sessions`.
- Same URL in a phone-sized window or on a real device. It must still forward, since the preference outranks the device check.
- Regression: with Classic mode off, `/m` must stay put on a desktop browser. That pass exists to stop the two gates ping-ponging.
- Regression: sign in through Google or another SSO provider from `/m`. The callback still completes on `/m` and is never bounced.
