### PR TITLE
[fix] Stop the /w to /m redirect loop and defaults posing as choices

### DIFF
--- a/web/mobile/src/features/app/ContextSync.tsx
+++ b/web/mobile/src/features/app/ContextSync.tsx
@@ -1,7 +1,7 @@
 import {useEffect} from "react"
 
 import {useProfile} from "@agenta/entities/profile"
-import {useClassicModeCookieSync, useDesktopModeRedirect} from "@agenta/shared/hooks"
+import {useClassicModeCookieSync} from "@agenta/shared/hooks"
 import {activeUserIdAtom, setProjectIdAtom, setSessionAtom, setUserAtom} from "@agenta/shared/state"
 import {useSetAtom} from "jotai"
 import {useRouter} from "next/router"
@@ -39,11 +39,6 @@ export const ContextSync = () => {
 
     // Publish Classic mode as a cookie here too, or a switch flipped on /m would not stick.
     useClassicModeCookieSync()
-
-    // The other half: Classic mode ON belongs on the desktop app, and the device gate can land a
-    // user here before any cookie exists for the proxy to read. Held until the profile settles —
-    // a pending query is not a signed-out user, and the preference is scoped by user id.
-    useDesktopModeRedirect(!profilePending)
 
     // The auth half of the same context, and the other half of the desktop's `SessionListener`.
     // `sessionAtom` defaults to FALSE and every entity query gates on it, so a host that never

--- a/web/packages/agenta-shared/src/hooks/index.ts
+++ b/web/packages/agenta-shared/src/hooks/index.ts
@@ -14,6 +14,5 @@ export {
     desktopEscapeHref,
     useClassicModeCookieSync,
     useClassicModeRedirect,
-    useDesktopModeRedirect,
     writeClassicModeCookie,
 } from "./useClassicModeGate"

--- a/web/packages/agenta-shared/src/hooks/useClassicModeGate.ts
+++ b/web/packages/agenta-shared/src/hooks/useClassicModeGate.ts
@@ -14,7 +14,6 @@ import {userAtom} from "../state/user"
 import {
     CLASSIC_MODE_COOKIE,
     GATE_COOKIE_MAX_AGE,
-    MOBILE_OPTIN_COOKIE,
     MOBILE_OPTOUT_COOKIE,
     desktopRouteFor,
     isDesktopOnlyLink,
@@ -106,6 +105,12 @@ export const useClassicModeCookieSync = () => {
  * `location.replace`, not the router: `/m` is a different Next app behind the same origin, so
  * this is a document navigation whichever way it is spelled — and replace keeps the desktop URL
  * out of history, where Back would bounce off it.
+ *
+ * DELIBERATELY ONE-WAY. `/m` has no mirror of this hook, and must not grow one: the two hosts
+ * write `activeUserIdAtom` from different sources (`Session.getUserId()` here, the profile's
+ * `uid` on `/m`), so they can scope the preference to different keys and disagree about it. With
+ * a redirect on both sides that disagreement is an infinite `/w` ↔ `/m` loop rather than a stop.
+ * Leaving `/m` is the proxy's job — it reads one cookie, and the desktop gate yields to it.
  */
 export const useClassicModeRedirect = (enabled = true) => {
     const userId = useAtomValue(activeUserIdAtom)
@@ -142,31 +147,4 @@ export const desktopEscapeHref = (): string => {
     const {pathname, search} = window.location
     const stripped = pathname === "/m" ? "/" : pathname.replace(/^\/m(?=\/)/, "")
     return desktopRouteFor(stripped, search) ?? "/w"
-}
-
-/**
- * `/m`-only: send a Classic-mode-ON user back to the desktop app. Mirror of
- * {@link useClassicModeRedirect}, and needed for the same reason — the proxy reads only cookies,
- * and the device gate can land a user here before one exists. Bounces a phone too, because
- * Classic mode outranks the device heuristic on both sides of the gate.
- */
-export const useDesktopModeRedirect = (enabled = true) => {
-    const userId = useAtomValue(activeUserIdAtom)
-    const advancedNavHidden = useSettledAdvancedNavHidden()
-
-    useEffect(() => {
-        if (!enabled || typeof window === "undefined") return
-        if (!classicGateEnabled()) return
-        // `null` is "not known yet", and `true` is Classic mode OFF — both stay put.
-        if (!userId || advancedNavHidden !== false) return
-
-        const {pathname} = window.location
-        // Sign-in and the OAuth landing finish where they are: the mobile flow's state lives in
-        // this origin's sessionStorage, and bouncing the callback drops the one-time code.
-        if (/^\/m\/auth(\/|$)/.test(pathname)) return
-        // "Open mobile version" is an explicit request for this app; it outranks the preference.
-        if (readCookie(MOBILE_OPTIN_COOKIE)) return
-
-        window.location.replace(desktopEscapeHref())
-    }, [enabled, userId, advancedNavHidden])
 }

--- a/web/packages/agenta-shared/src/hooks/useClassicModeGate.ts
+++ b/web/packages/agenta-shared/src/hooks/useClassicModeGate.ts
@@ -9,7 +9,7 @@ import {useAtomValue} from "jotai"
 
 import {getEnv} from "../api/env"
 import {advancedNavHiddenAtom, readSettledAdvancedNavHidden} from "../state/classicMode"
-import {activeUserIdAtom} from "../state/featureFlags"
+import {ACTIVE_USER_ID_KEY, activeUserIdAtom} from "../state/featureFlags"
 import {userAtom} from "../state/user"
 import {
     CLASSIC_MODE_COOKIE,
@@ -85,6 +85,11 @@ export const useClassicModeCookieSync = () => {
     useEffect(() => {
         if (typeof document === "undefined") return
         if (!userId) {
+            // Storage, not the atom: `activeUserIdAtom` has no `getOnInit`, so it reads null on
+            // every first render and only then hydrates. Clearing on that would drop the cookie
+            // at the start of EVERY page load, and a redirect landing in that window arrives at
+            // a gate with no preference to read. Only a real sign-out empties the key.
+            if (localStorage.getItem(ACTIVE_USER_ID_KEY)) return
             clearCookie(CLASSIC_MODE_COOKIE)
             return
         }
@@ -106,11 +111,11 @@ export const useClassicModeCookieSync = () => {
  * this is a document navigation whichever way it is spelled — and replace keeps the desktop URL
  * out of history, where Back would bounce off it.
  *
- * DELIBERATELY ONE-WAY. `/m` has no mirror of this hook, and must not grow one: the two hosts
- * write `activeUserIdAtom` from different sources (`Session.getUserId()` here, the profile's
- * `uid` on `/m`), so they can scope the preference to different keys and disagree about it. With
- * a redirect on both sides that disagreement is an infinite `/w` ↔ `/m` loop rather than a stop.
- * Leaving `/m` is the proxy's job — it reads one cookie, and the desktop gate yields to it.
+ * DELIBERATELY ONE-WAY. `/m` must not grow a mirror of this hook. The two apps are separate JS
+ * contexts sharing only storage, so each would redirect on a value the other cannot see, with
+ * nothing to arbitrate and nothing to break the cycle: any disagreement becomes an endless
+ * `/w` ↔ `/m` bounce instead of a stop. Leaving `/m` is the proxy's job — one cookie, and the
+ * desktop gate yields to it through `wantsClassic`.
  */
 export const useClassicModeRedirect = (enabled = true) => {
     const userId = useAtomValue(activeUserIdAtom)
@@ -133,7 +138,13 @@ export const useClassicModeRedirect = (enabled = true) => {
         if (readCookie(MOBILE_OPTOUT_COOKIE)) return
 
         const target = mobileRouteFor(pathname, search)
-        if (target) window.location.replace(target)
+        if (!target) return
+        // Publish before navigating, exactly as the Classic mode switch does. Relying on the
+        // sync effect above having already run makes this correct only by hook order; if the
+        // cookie is missing when `/m` is asked for, its proxy sees no preference, falls through
+        // to the device check, and bounces a desktop UA straight back here. That is a loop.
+        writeClassicModeCookie(false)
+        window.location.replace(target)
     }, [enabled, userId, advancedNavHidden])
 }
 

--- a/web/packages/agenta-shared/src/hooks/useClassicModeGate.ts
+++ b/web/packages/agenta-shared/src/hooks/useClassicModeGate.ts
@@ -8,8 +8,12 @@ import {useEffect} from "react"
 import {useAtomValue} from "jotai"
 
 import {getEnv} from "../api/env"
-import {advancedNavHiddenAtom, readSettledAdvancedNavHidden} from "../state/classicMode"
-import {ACTIVE_USER_ID_KEY, activeUserIdAtom} from "../state/featureFlags"
+import {
+    advancedNavHiddenAtom,
+    readSettledAdvancedNavHidden,
+    readSettledClassicModeCookie,
+} from "../state/classicMode"
+import {activeUserIdAtom} from "../state/featureFlags"
 import {userAtom} from "../state/user"
 import {
     CLASSIC_MODE_COOKIE,
@@ -76,28 +80,28 @@ const useSettledAdvancedNavHidden = (): boolean | null => {
  *
  * Written only once a user is known — the preference is scoped by user id, and a cookie written
  * under nobody would decide which app the NEXT person on this browser gets. Cleared on sign-out
- * for the same reason.
+ * for the same reason, and cleared again when the answer is a bare default rather than a choice.
+ * `readSettledClassicModeCookie` draws that line and explains why the gates need it drawn.
  */
 export const useClassicModeCookieSync = () => {
-    const userId = useAtomValue(activeUserIdAtom)
-    const advancedNavHidden = useSettledAdvancedNavHidden()
+    useAtomValue(activeUserIdAtom)
+    useAtomValue(advancedNavHiddenAtom)
+    const user = useAtomValue(userAtom)
+    // A primitive, so the effect still runs only when the answer actually changes.
+    const value = readSettledClassicModeCookie(user)
 
     useEffect(() => {
         if (typeof document === "undefined") return
-        if (!userId) {
-            // Storage, not the atom: `activeUserIdAtom` has no `getOnInit`, so it reads null on
-            // every first render and only then hydrates. Clearing on that would drop the cookie
-            // at the start of EVERY page load, and a redirect landing in that window arrives at
-            // a gate with no preference to read. Only a real sign-out empties the key.
-            if (localStorage.getItem(ACTIVE_USER_ID_KEY)) return
+        // `undefined` is "nothing new to say" — leave whatever is there. `null` is a real
+        // answer: this browser has no preference to publish, so the gates fall back to the
+        // device heuristic.
+        if (value === undefined) return
+        if (value === null) {
             clearCookie(CLASSIC_MODE_COOKIE)
             return
         }
-        // Publishing an unsettled value would park the WRONG answer where the middleware reads
-        // it, and the next load acts on the cookie before any of this runs.
-        if (advancedNavHidden === null) return
-        writeCookie(CLASSIC_MODE_COOKIE, advancedNavHidden ? "0" : "1")
-    }, [userId, advancedNavHidden])
+        writeCookie(CLASSIC_MODE_COOKIE, value)
+    }, [value])
 }
 
 /**

--- a/web/packages/agenta-shared/src/state/classicMode.ts
+++ b/web/packages/agenta-shared/src/state/classicMode.ts
@@ -160,6 +160,44 @@ export const readSettledAdvancedNavHidden = (user: User | null): boolean | null 
     return user ? isSimplifiedCohort(user) : null
 }
 
+/**
+ * What the gate cookie should say, or `undefined` to leave it alone. `null` means "publish
+ * nothing" — clear it.
+ *
+ * Distinct from {@link readSettledAdvancedNavHidden}, and deliberately so. That one answers
+ * "which surface does this user get", where the signup-era default is as good an answer as a
+ * choice. The gates ask something narrower: both treat `"1"` as the user asking for the desktop
+ * app in as many words, and rank it ABOVE the device heuristic. Only an explicit choice earns
+ * that. An account that predates the switch has classic mode on because nobody ever turned it
+ * off, and publishing `"1"` for them tells the gate a phone should get the desktop app — which
+ * is how every pre-existing account lost `/m`.
+ *
+ * So classic-mode-ON publishes only from the override. The default answers UNKNOWN, and the
+ * device gate decides, exactly as it did before this preference existed.
+ *
+ * Simplified (`"0"`) has no such problem and publishes from any source: it is the cohort the
+ * default was built to route, and `/m` is where they belong however we learned it.
+ */
+export const readSettledClassicModeCookie = (user: User | null): "0" | "1" | null | undefined => {
+    if (typeof window === "undefined") return undefined
+
+    // Storage, not `activeUserIdAtom`: that atom has no `getOnInit` and reads null on the first
+    // render of every page load. Treating that as a sign-out clears the cookie mid-session.
+    const userId = localStorage.getItem(ACTIVE_USER_ID_KEY)
+    if (!userId) return null
+
+    const override = readStoredBoolean(onboardingScopedKey(userId, "nav-simplified-override"))
+    if (override !== null) return override ? "0" : "1"
+
+    if (readStoredBoolean(onboardingScopedKey(userId, "nav-simplified")) === true) return "0"
+
+    // The cohort answer lives on the profile. Until it lands we know nothing new, and a stale
+    // cookie beats no cookie: clearing here would drop a correct answer on every reload.
+    if (!user) return undefined
+
+    return isSimplifiedCohort(user) ? "0" : null
+}
+
 /** The one atom both apps' Preferences pages bind their "Classic mode" switch to. */
 export const classicModeEnabledAtom = atom(
     (get) => !get(advancedNavHiddenAtom),

--- a/web/packages/agenta-shared/src/state/featureFlags.ts
+++ b/web/packages/agenta-shared/src/state/featureFlags.ts
@@ -16,9 +16,16 @@ import {stringStorage} from "./stringStorage"
  * The signed-in user's id, as the browser last saw it — the scope for every per-user
  * preference below.
  *
- * Storage-backed rather than derived from the profile query so a preference resolves on the
- * first paint, before any request settles. Apps push into it once they know who is signed in
- * (OSS from onboarding, mobile from its profile query).
+ * Storage-backed rather than derived from the profile query, so a preference survives a reload
+ * without waiting on a request. Apps push into it once they know who is signed in (OSS from
+ * onboarding, mobile from its profile query).
+ *
+ * It does NOT resolve on the first paint. Deliberately no `getOnInit`: this atom scopes values
+ * that render (the Classic mode switch, the sidebar's nav areas), and reading storage during
+ * the first render would diverge from prerendered HTML and break hydration on `/m`. So it reads
+ * `null` on every first render and settles a tick later. Anything that ACTS on a preference —
+ * writing a cookie, navigating — must therefore read storage directly rather than treat that
+ * first `null` as "signed out"; see `readSettledClassicModeCookie` in `./classicMode`.
  */
 export const ACTIVE_USER_ID_KEY = "agenta:onboarding:active-user-id"
 

--- a/web/packages/agenta-shared/tests/unit/classicMode.test.ts
+++ b/web/packages/agenta-shared/tests/unit/classicMode.test.ts
@@ -26,8 +26,9 @@ import {
     navSimplifiedDefaultAtom,
     navSimplifiedOverrideAtom,
     readSettledAdvancedNavHidden,
+    readSettledClassicModeCookie,
 } from "../../src/state/classicMode"
-import {activeUserIdAtom} from "../../src/state/featureFlags"
+import {ACTIVE_USER_ID_KEY, activeUserIdAtom} from "../../src/state/featureFlags"
 import {userAtom} from "../../src/state/user"
 
 /**
@@ -257,5 +258,80 @@ describe("readSettledAdvancedNavHidden", () => {
     it("withholds an answer when no user is known", () => {
         localStorage.clear()
         expect(readSettledAdvancedNavHidden(profile(CUTOFF_AFTER))).toBeNull()
+    })
+})
+
+describe("the gate cookie", () => {
+    // A user, as the cookie reader sees one: it reads storage itself, so only the active-user
+    // key and the scoped preference keys matter.
+    const browser = (userId: string | null, stored: Record<string, string> = {}) => {
+        if (userId === null) localStorage.removeItem(ACTIVE_USER_ID_KEY)
+        else localStorage.setItem(ACTIVE_USER_ID_KEY, userId)
+        for (const [key, value] of Object.entries(stored)) {
+            localStorage.setItem(`agenta:onboarding:${userId}:${key}`, value)
+        }
+    }
+    const profile = (createdAt?: string) => ({
+        id: "u",
+        uid: "u",
+        username: "u",
+        email: "u@example.com",
+        ...(createdAt ? {created_at: createdAt} : {}),
+    })
+    const OLD = "2026-07-01 00:00:00.000000+00:00"
+    const NEW = "2026-08-02 00:00:00.000000+00:00"
+
+    it("publishes classic mode on only from an explicit choice", () => {
+        browser("u", {"nav-simplified-override": "false"})
+        expect(readSettledClassicModeCookie(profile(OLD))).toBe("1")
+    })
+
+    it("says nothing for an account that merely defaulted to classic mode", () => {
+        // The regression this exists for: an account older than the switch has classic mode on
+        // because nobody turned it off. Publishing "1" tells both gates the user asked for the
+        // desktop app, which outranks the device check and takes /m away from every phone.
+        browser("u")
+        expect(readSettledClassicModeCookie(profile(OLD))).toBeNull()
+    })
+
+    it("publishes simplified from a choice, the signup seed, or the cohort", () => {
+        browser("a", {"nav-simplified-override": "true"})
+        expect(readSettledClassicModeCookie(profile(OLD))).toBe("0")
+
+        localStorage.clear()
+        browser("b", {"nav-simplified": "true"})
+        expect(readSettledClassicModeCookie(profile(OLD))).toBe("0")
+
+        localStorage.clear()
+        browser("c")
+        expect(readSettledClassicModeCookie(profile(NEW))).toBe("0")
+    })
+
+    it("lets an explicit choice outrank the cohort in both directions", () => {
+        browser("a", {"nav-simplified-override": "false"})
+        expect(readSettledClassicModeCookie(profile(NEW))).toBe("1")
+
+        localStorage.clear()
+        browser("b", {"nav-simplified-override": "true"})
+        expect(readSettledClassicModeCookie(profile(OLD))).toBe("0")
+    })
+
+    it("leaves the cookie alone until the profile lands", () => {
+        // Only the cohort branch needs the profile. Clearing while it is in flight would drop a
+        // correct answer on every reload, and the gate would fall back to the device heuristic.
+        browser("u")
+        expect(readSettledClassicModeCookie(null)).toBeUndefined()
+    })
+
+    it("answers from storage before the profile, when storage is enough", () => {
+        browser("u", {"nav-simplified-override": "true"})
+        expect(readSettledClassicModeCookie(null)).toBe("0")
+    })
+
+    it("clears on sign-out, and only on sign-out", () => {
+        // The active-user key is what a sign-out empties. `activeUserIdAtom` reading null on a
+        // first render is NOT that, which is why this reads storage rather than the atom.
+        browser(null)
+        expect(readSettledClassicModeCookie(profile(OLD))).toBeNull()
     })
 })


### PR DESCRIPTION
## Context

The app bounces between `/w` and `/m` without stopping. Three separate ways in, one shared shape: a client-side redirect on the desktop and a server-side gate on `/m` each decide where the user belongs, and when they disagree neither one yields.

**1. The mirror redirect (from #6645, mine).** That PR added `useDesktopModeRedirect`, a client redirect on `/m` mirroring the desktop's `useClassicModeRedirect`. One fires when the settled preference reads Classic mode off, the other when it reads on. That is only safe while both hosts compute the same value, and nothing guarantees it. The two apps are separate JS contexts sharing only storage, so each redirects on a value the other cannot see, with nothing to arbitrate and nothing to break the cycle.

**2. The cookie cleared on every page load.** `activeUserIdAtom` is an `atomWithStorage` with no `getOnInit`, so it reads `null` on the first render and only then hydrates. `useClassicModeCookieSync` read that `null` as a sign-out and cleared the classic-mode cookie, at the start of every single page load.

**3. The redirect that navigated before publishing.** `useClassicModeRedirect` relied on the sync effect above having already written the cookie. That holds only because of hook order inside `ClassicModeGate`.

2 and 3 land in the same place. If the cookie is missing when `/m` is requested, its proxy sees no preference, falls through to the device check, and bounces a desktop UA straight back to `/w`, where the client redirect sends it to `/m` again. `/m`'s React never mounts on a redirected document request, so it never gets the chance to write the cookie that would stop it. Both predate #6645.

## Changes

**Drop the mirror.** The client redirect is one-way again, desktop to `/m` only, as before #6645. Leaving `/m` goes back to being the proxy's job, which cannot loop on its own: it reads one cookie, and the desktop gate yields to that same cookie through `wantsClassic`. The test added in #6645 asserts exactly that.

**Clear the cookie only on a real sign-out.** The sync effect now checks storage directly instead of trusting the pre-hydration `null`:

```ts
if (!userId) {
    if (localStorage.getItem(ACTIVE_USER_ID_KEY)) return  // not hydrated yet, not a sign-out
    clearCookie(CLASSIC_MODE_COOKIE)
    return
}
```

**Publish before navigating.** `useClassicModeRedirect` now writes the cookie itself immediately before `location.replace`, the way the Classic mode switch on `/m` already does. Correctness no longer depends on which effect React runs first.

The gate fix from #6645 is untouched, so the original bug stays fixed: a Classic-mode-on user who lands on `/m` is still moved to `/w` by the proxy. The only thing given up is the instant hop on a first landing with no cookie yet, which now waits for the next navigation. That is the behaviour that shipped before, and it is worth far more than the loop.

**4. The cookie could not tell a choice from a default.** `readSettledAdvancedNavHidden` falls back to the signup cohort, so an account older than the switch published `agenta-classic-mode=1` for the simple reason that nobody had ever turned classic mode off. Both gates read `"1"` as the user asking for the desktop app in as many words and rank it above the device heuristic. Every pre-existing account was therefore handed the desktop app on a phone, and since #6645 could not reach `/m` at all except through `?view=mobile`.

**Publish classic-mode-on only when the user chose it.** `readSettledClassicModeCookie` splits the gate's question from the app's:

```
override set        -> "0" / "1"   an explicit choice, either direction
signup seed         -> "0"         simplified
cohort simplified   -> "0"         the cohort the default was built to route
cohort default (on) -> null        UNKNOWN: the device gate decides, as before
profile not in yet  -> undefined   leave the cookie alone
```

Simplified still publishes from any source. Only the bare classic-on default stops claiming to be a choice.

## Tests

- `pnpm --filter @agenta/shared test`: 528 passing, including all 95 in `mobileGate.test.ts`. No test changed, because none of this is gate logic.
- Seven new tests in `classicMode.test.ts` cover the cookie decision, including the regression above. The reader is a pure function and the suite already stubs `localStorage`, so the branch that caused this is now covered without adding a DOM environment.
- The remaining untested part is the `useEffect` plumbing in the three hooks, which needs a jsdom project (`jsdom` is in the store but not a dependency of this package). Worth doing, deliberately not in a hotfix.
- Correction to #6645: its description blamed `uid` differing from `Session.getUserId()`. That is wrong. `UserDB.uid` IS the SuperTokens id (`api/oss/src/apis/fastapi/auth/router.py:70`), so the two hosts do agree on the scope key. The reason `/m` must not mirror the redirect is structural, not identity, and the code comment now says so.

## What to QA

The loop is the whole point. Use the local compose stack, since this needs one origin serving both apps.

- Sign in with Classic mode off. You land on `/m` and stay. No flicker in the address bar.
- Clear cookies but stay signed in, then load `/w/...` with Classic mode off. You get one hop to `/m` and it stops. This is fix 2 and 3; before, this was the loop.
- Turn Classic mode on from `/m` Settings, Preferences. You land on `/w` once and stay.
- With Classic mode on, open `localhost/m/w/<ws>/p/<proj>/sessions` directly. It forwards to `/w/...` once. This is the #6645 fix and must still work.
- Sign out. The classic-mode cookie disappears and the next sign-in routes by preference again, not by a stale one.
- Reload any page a few times on both apps and watch the cookie in devtools. It must stay put, not blink out on each load.
- On an account created before August 2026 that has never touched the switch, open the app on a phone. You get `/m`, from the device gate, and the classic-mode cookie is absent rather than `"1"`. Flip Classic mode on explicitly and you get `/w` and a `"1"` cookie.
