### PR TITLE
fix(frontend): hold the idle deferral in the desktop permissions test

### DIFF
--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/permissions.test.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/permissions.test.tsx
@@ -155,10 +155,7 @@ it.each([{environments: []}, {environments: ["local"]}, {environments: ["local",
         Object.assign(globalThis, {IS_REACT_ACT_ENVIRONMENT: true})
         Element.prototype.scrollIntoView = vi.fn()
         Element.prototype.hasPointerCapture = () => false
-        // Hold the deferred bootstrap work before idle for the whole test. jsdom has no
-        // requestIdleCallback, so idleReadyAtom falls back to a timer once it mounts, and
-        // a slow case lets the idle-gated queries fetch. This test covers the pre-idle
-        // render only.
+        // Keep idle-gated queries deferred; jsdom's fallback timer would fetch mid-test.
         vi.stubGlobal(
             "requestIdleCallback",
             vi.fn(() => 1),

--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/permissions.test.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/permissions.test.tsx
@@ -153,6 +153,15 @@ it.each([{environments: []}, {environments: ["local"]}, {environments: ["local",
         Object.assign(globalThis, {IS_REACT_ACT_ENVIRONMENT: true})
         Element.prototype.scrollIntoView = vi.fn()
         Element.prototype.hasPointerCapture = () => false
+        // idleReadyAtom gates the deferred bootstrap queries (trigger subscriptions and
+        // schedules). jsdom has no requestIdleCallback, so the atom falls back to a 1.5s
+        // timer and those queries start to fetch mid-test on a slow machine. Their explicit
+        // `enabled` overrides the disabled query default below. Stub an idle callback that
+        // never runs, so the deferral holds for the whole test.
+        Object.assign(globalThis, {
+            requestIdleCallback: vi.fn(() => 1),
+            cancelIdleCallback: vi.fn(),
+        })
         const store = createStore()
         const router: NextRouter = {
             basePath: "",

--- a/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/permissions.test.tsx
+++ b/web/oss/src/components/Playground/Components/PlaygroundVariantConfig/permissions.test.tsx
@@ -10,7 +10,7 @@ import {queryClientAtom} from "jotai-tanstack-query"
 import {RouterContext} from "next/dist/shared/lib/router-context.shared-runtime"
 import type {NextRouter} from "next/router"
 import {createRoot} from "react-dom/client"
-import {expect, it, vi} from "vitest"
+import {afterEach, expect, it, vi} from "vitest"
 
 import {OSSdrillInUIProvider} from "@/oss/components/DrillInView/OSSdrillInUIProvider"
 import {appStateSnapshotAtom} from "@/oss/state/appState"
@@ -145,6 +145,8 @@ vi.mock("@/oss/hooks/useURL", () => ({
 
 import PlaygroundVariantConfig from "."
 
+afterEach(() => vi.unstubAllGlobals())
+
 it.each([{environments: []}, {environments: ["local"]}, {environments: ["local", "daytona"]}])(
     "desktop host renders shared permissions with environments $environments",
     async ({environments}) => {
@@ -153,15 +155,15 @@ it.each([{environments: []}, {environments: ["local"]}, {environments: ["local",
         Object.assign(globalThis, {IS_REACT_ACT_ENVIRONMENT: true})
         Element.prototype.scrollIntoView = vi.fn()
         Element.prototype.hasPointerCapture = () => false
-        // idleReadyAtom gates the deferred bootstrap queries (trigger subscriptions and
-        // schedules). jsdom has no requestIdleCallback, so the atom falls back to a 1.5s
-        // timer and those queries start to fetch mid-test on a slow machine. Their explicit
-        // `enabled` overrides the disabled query default below. Stub an idle callback that
-        // never runs, so the deferral holds for the whole test.
-        Object.assign(globalThis, {
-            requestIdleCallback: vi.fn(() => 1),
-            cancelIdleCallback: vi.fn(),
-        })
+        // Hold the deferred bootstrap work before idle for the whole test. jsdom has no
+        // requestIdleCallback, so idleReadyAtom falls back to a timer once it mounts, and
+        // a slow case lets the idle-gated queries fetch. This test covers the pre-idle
+        // render only.
+        vi.stubGlobal(
+            "requestIdleCallback",
+            vi.fn(() => 1),
+        )
+        vi.stubGlobal("cancelIdleCallback", vi.fn())
         const store = createStore()
         const router: NextRouter = {
             basePath: "",


### PR DESCRIPTION
## Context

`run-web-unit-tests` is red on `release/v0.115.3`. The failure is in the permissions test that PR #6641 added:

```
FAIL src/components/Playground/Components/PlaygroundVariantConfig/permissions.test.tsx
 > desktop host renders shared permissions with environments []
AssertionError: expected "fetch" to not be called at all, but actually been called 2 times
```

The two calls are `queryTriggerSubscriptions` and `queryTriggerSchedules`, both through axios.

The test disables React Query with a client-wide `enabled: false` default. That default does not reach these two queries, because `triggerSubscriptionsQueryAtom` and `triggerSchedulesQueryAtom` set `enabled` themselves. Their gate is `idleReadyAtom`. jsdom has no `requestIdleCallback`, so that atom takes its fallback branch: it starts a 1.5 second timer when the backing atom mounts, which here is during the render under test, not at import time. A case that stays mounted for longer than 1.5 seconds lets the timer fire, and the two queries then go to the network.

The case is therefore a race against wall-clock time. Locally each case takes about 0.4 seconds and passes. The CI runner is slower and fails the first case.

## Changes

Stub a `requestIdleCallback` that never runs its callback, next to the other jsdom stubs in the test. The stubs go through `vi.stubGlobal` and a file-local `afterEach` restores them. The test now holds the deferred bootstrap work before idle on any machine, and it covers the pre-idle render only.

I did not change the component or the atoms. Codex found two product defects behind this test while reviewing the change. Both are out of scope for this release branch. They are tracked in #6655.

## Tests

Run in a clean worktree off `origin/release/v0.115.3`.

To reproduce the CI failure locally, I copied the test file and added a 2.5 second wait before the assertion, which forces the idle timer to fire:

| Run | Result |
| --- | --- |
| copy without the stub, 2.5 s wait | 3 failed, 3 total |
| copy with the stub, 2.5 s wait | 3 passed, 3 total |

Both copies were deleted after the check.

The real suites, re-run after the `vi.stubGlobal` cleanup:

| Suite | Result |
| --- | --- |
| `permissions.test.tsx` | 3 passed, 3 total |
| `web/oss` `pnpm run test:unit` | 502 passed, 1 skipped, 59 files |

`pnpm lint-fix` in `web` is clean, 25 of 25 tasks. Prettier reports no change for the touched file.