### PR TITLE
[AGE-4279] fix(frontend): open a chat at its latest message

### DIFF
--- a/web/mobile/src/features/chat/useTranscriptAutoScroll.ts
+++ b/web/mobile/src/features/chat/useTranscriptAutoScroll.ts
@@ -1,4 +1,4 @@
-import {useCallback, useLayoutEffect, useRef, useState} from "react"
+import {useCallback, useEffect, useLayoutEffect, useRef, useState} from "react"
 
 import {shouldRevealJump} from "@agenta/chat/assets"
 
@@ -17,6 +17,8 @@ export const useTranscriptAutoScroll = (content: unknown) => {
     const [showJump, setShowJump] = useState(false)
 
     const measure = useCallback((el: HTMLDivElement) => {
+        // A pane hidden behind the config split measures 0 everywhere; that is not the reader moving.
+        if (el.clientHeight === 0) return
         nearBottomRef.current = el.scrollHeight - el.scrollTop - el.clientHeight <= NEAR_BOTTOM_PX
         const next = !nearBottomRef.current && shouldRevealJump(el)
         setShowJump((prev) => (prev === next ? prev : next))
@@ -46,6 +48,22 @@ export const useTranscriptAutoScroll = (content: unknown) => {
         // scroll event, so re-measure on content instead of waiting for a gesture that never comes.
         measure(el)
     }, [content, measure])
+
+    // The pin above measures at layout time, but a transcript keeps growing after that — a fence
+    // finishes highlighting, an image loads, a tool card lays itself out. Without this the opening
+    // pin lands on a fraction of the final height and a long chat reads as starting at the top.
+    // Follow the growth while the reader is at the bottom; the moment they scroll up this no-ops.
+    useEffect(() => {
+        const el = ref.current
+        if (!el) return
+        const observer = new ResizeObserver(() => {
+            if (!nearBottomRef.current || el.clientHeight === 0) return
+            el.scrollTop = el.scrollHeight
+        })
+        observer.observe(el)
+        for (const child of Array.from(el.children)) observer.observe(child)
+        return () => observer.disconnect()
+    }, [content])
 
     return {ref, onScroll, jumpToLatest, showJump}
 }


### PR DESCRIPTION
Closes #6623.

Opening an existing chat on `/m` showed the **first** message of the conversation, not the latest, so any long chat had to be scrolled from the top every time it was opened.

## Why it happened

`useTranscriptAutoScroll` pins the transcript in a `useLayoutEffect` keyed on turn-array identity. That measures the height at layout time, but a transcript keeps growing afterwards: a code fence finishes highlighting, an image loads, a tool card lays itself out. `web/mobile` had no `ResizeObserver` anywhere, so nothing followed that growth — the pin stayed at what had been the bottom of a much shorter document, which on a long chat is the very top.

It only reproduces on a **cold** open, where the session has no cached messages and every turn arrives in one commit. With a warm `localStorage` cache the turns land in a later commit and re-fire the pin after layout, which hides it entirely. That is why it reads as "on mobile or desktop" in the report: a second device is a cold open by definition.

The EE transcript is unaffected — its SC-3 `ResizeObserver` in `useTranscriptScroll` already re-pins on post-layout growth. This change makes `/m` do the same thing.

## Before / after

Cold open (cleared `localStorage`) of a 10-turn chat, sampled every 4s:

| viewport | before | after |
| --- | --- | --- |
| 390x844 | `top=0` of max 6480 | `top=6375` = bottom |
| 1440x900 | `top=0` of max 3997 | `top=3892` = bottom |

At 390x844 the pre-fix transcript happened to correct itself after ~20s, when a background poll changed the turns array and re-fired the pin. At 1440x900 nothing rescued it — it stayed on the first message for the whole sample. Since `/m` now serves large viewports, that is the more reliable case, not a secondary one.

## Not regressed

A reader parked mid-transcript is not pulled to the bottom: the observer no-ops while `nearBottomRef` is false. Verified at both viewports (parked at 900 and at 1500, held across samples). The zero-height guard keeps a pane hidden behind the config split from being read as the reader moving.

Verified in a real browser against the local EE stack, not only in tests.