### PR TITLE
[test] Drop the partial escape CodeQL flagged in the link-gate test

### DIFF
--- a/web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts
@@ -94,9 +94,7 @@ describe("rehypeExplicitRelativeLinks", () => {
 
 describe("decodeDriveHref", () => {
     it("undoes the percent-encoding harden's URL round-trip adds", () => {
-        expect(decodeDriveHref("/agent-files/my report.md".replace(" ", "%20"))).toBe(
-            "/agent-files/my report.md",
-        )
+        expect(decodeDriveHref("/agent-files/my%20report.md")).toBe("/agent-files/my report.md")
     })
 
     it("returns a malformed escape unchanged rather than throwing", () => {


### PR DESCRIPTION
CodeQL raised one high alert on the release branch after #6665 merged: `js/incomplete-sanitization` on `chatFileLinkGate.test.ts:97`, where `.replace(" ", "%20")` encodes only the first space.

The case never needed to encode anything. It now passes the percent-encoded href as a literal, which asserts the same thing and reads better. No source change, and the entity-ui suite still passes at 686.
