### PR TITLE
[fix] Stop the Permissions dropdown claiming the wrong default

### DIFF
--- a/docs/design/docs-agent-platform/product-facts.md
+++ b/docs/design/docs-agent-platform/product-facts.md
@@ -352,7 +352,7 @@ it must ask."*
 
 | Field | Exact label | Options / behaviour |
 |---|---|---|
-| Policy | `Policy` | Exactly four options, each with a sub-line: **`Allow reads`** — *Reads run, writes ask; default*; **`Allow all`** — *Every tool runs without asking*; **`Ask`** — *A human approves every tool call*; **`Deny all`** — *Every tool call is refused* |
+| Policy | `Policy` | Exactly four options, each with a sub-line: **`Allow reads`** — *Reads run, writes ask*; **`Allow all`** — *Every tool runs without asking; default*; **`Ask`** — *A human approves every tool call*; **`Deny all`** — *Every tool call is refused* |
 | Harness label | `Pi harness` (a small pill above the next field) | Names the harness whose built-ins the next field lists |
 | Built-in tools | `Built-in tools` | Multi-select tags: `Read`, `Bash`, `Edit`, `Write` |
 | Auto-approve | `Auto-approve` | When empty: `Nothing auto-approved — every gated tool asks each time.` Otherwise lists the granted tool patterns. Tooltip: *"Tools that run without asking. Added from an approval card's "Always allow". Everything else still prompts, and commit stays gated."* |

--- a/docs/design/docs-agent-platform/product-facts.md
+++ b/docs/design/docs-agent-platform/product-facts.md
@@ -352,7 +352,7 @@ it must ask."*
 
 | Field | Exact label | Options / behaviour |
 |---|---|---|
-| Policy | `Policy` | Exactly four options, each with a sub-line: **`Allow reads`** — *Reads run, writes ask*; **`Allow all`** — *Every tool runs without asking; default*; **`Ask`** — *A human approves every tool call*; **`Deny all`** — *Every tool call is refused* |
+| Policy | `Policy` | Exactly four options, each with a sub-line: **`Allow reads`** — *Reads run, writes ask*; **`Allow all`** — *Every tool runs without asking*; **`Ask`** — *A human approves every tool call*; **`Deny all`** — *Every tool call is refused*. No sub-line names a default |
 | Harness label | `Pi harness` (a small pill above the next field) | Names the harness whose built-ins the next field lists |
 | Built-in tools | `Built-in tools` | Multi-select tags: `Read`, `Bash`, `Edit`, `Write` |
 | Auto-approve | `Auto-approve` | When empty: `Nothing auto-approved — every gated tool asks each time.` Otherwise lists the granted tool patterns. Tooltip: *"Tools that run without asking. Added from an approval card's "Always allow". Everything else still prompts, and commit stays gated."* |

--- a/web/packages/agenta-shared/src/utils/permissionPolicy.ts
+++ b/web/packages/agenta-shared/src/utils/permissionPolicy.ts
@@ -11,23 +11,22 @@ export interface PermissionPolicyOption {
  * The four policies, in the order the selector shows them. `help` is the sub-line under each label
  * on both hosts, so this list is the only place the wording lives.
  *
- * Exactly ONE option says "default", and it is the policy a NEW agent is created with — `allow`
- * since #6641. That is a different question from {@link DEFAULT_PERMISSION_POLICY}, which is the
- * fallback the runner applies to a template that names no policy at all. A reader of the dropdown
- * is choosing a policy for an agent, so the word describes what they would have got by doing
- * nothing (#6662).
+ * No option claims to be the default, because "the default" is two different policies here (#6662).
+ * The standard template creates an agent on `allow`, while an agent whose config names no policy
+ * runs on {@link DEFAULT_PERMISSION_POLICY}, and both surfaces show that fallback as the applied
+ * value. A sub-line has no room to say which one it means, so it says neither.
  */
 export const PERMISSION_POLICY_OPTIONS: PermissionPolicyOption[] = [
     {value: "allow_reads", label: "Allow reads", help: "Reads run, writes ask"},
-    {value: "allow", label: "Allow all", help: "Every tool runs without asking; default"},
+    {value: "allow", label: "Allow all", help: "Every tool runs without asking"},
     {value: "ask", label: "Ask", help: "A human approves every tool call"},
     {value: "deny", label: "Deny all", help: "Every tool call is refused"},
 ]
 
 /**
- * What the runner applies when the template names no policy. NOT what a new agent is created with
- * (that is `allow`, written into the template by the SDK since #6641) — this is only the fallback
- * for a template with no `runner.permissions.default` at all, which #6641 deliberately left alone.
+ * What the runner applies, and what both selectors display, when the config names no policy. NOT
+ * what a new agent is created with: the standard template writes `allow` (`AgentTemplateSchema` in
+ * the SDK), and #6641 deliberately left this fallback alone.
  */
 export const DEFAULT_PERMISSION_POLICY: PermissionPolicy = "allow_reads"
 

--- a/web/packages/agenta-shared/src/utils/permissionPolicy.ts
+++ b/web/packages/agenta-shared/src/utils/permissionPolicy.ts
@@ -7,14 +7,28 @@ export interface PermissionPolicyOption {
     help: string
 }
 
+/**
+ * The four policies, in the order the selector shows them. `help` is the sub-line under each label
+ * on both hosts, so this list is the only place the wording lives.
+ *
+ * Exactly ONE option says "default", and it is the policy a NEW agent is created with — `allow`
+ * since #6641. That is a different question from {@link DEFAULT_PERMISSION_POLICY}, which is the
+ * fallback the runner applies to a template that names no policy at all. A reader of the dropdown
+ * is choosing a policy for an agent, so the word describes what they would have got by doing
+ * nothing (#6662).
+ */
 export const PERMISSION_POLICY_OPTIONS: PermissionPolicyOption[] = [
-    {value: "allow_reads", label: "Allow reads", help: "Reads run, writes ask; default"},
-    {value: "allow", label: "Allow all", help: "Every tool runs without asking"},
+    {value: "allow_reads", label: "Allow reads", help: "Reads run, writes ask"},
+    {value: "allow", label: "Allow all", help: "Every tool runs without asking; default"},
     {value: "ask", label: "Ask", help: "A human approves every tool call"},
     {value: "deny", label: "Deny all", help: "Every tool call is refused"},
 ]
 
-/** What the runner applies when the template names no policy. */
+/**
+ * What the runner applies when the template names no policy. NOT what a new agent is created with
+ * (that is `allow`, written into the template by the SDK since #6641) — this is only the fallback
+ * for a template with no `runner.permissions.default` at all, which #6641 deliberately left alone.
+ */
 export const DEFAULT_PERMISSION_POLICY: PermissionPolicy = "allow_reads"
 
 const PERMISSION_POLICY_VALUES = new Set<string>(

--- a/web/packages/agenta-shared/tests/unit/permissionPolicy.test.ts
+++ b/web/packages/agenta-shared/tests/unit/permissionPolicy.test.ts
@@ -1,0 +1,50 @@
+/**
+ * The Permissions selector's sub-lines. One option says "default", and it has to be the policy a
+ * new agent really gets — `allow` since #6641, while the dropdown still credited `allow_reads`
+ * (#6662). The copy lives in one list, so pin the claim here rather than in each host's render.
+ */
+import {describe, expect, it} from "vitest"
+
+import {
+    DEFAULT_PERMISSION_POLICY,
+    PERMISSION_POLICY_OPTIONS,
+    permissionPolicyOptionsForEnum,
+} from "../../src/utils/permissionPolicy"
+
+/** What the SDK writes into a new agent template (`sdks/python/agenta/sdk/utils/types.py`). */
+const NEW_AGENT_POLICY = "allow"
+
+const claimsDefault = (help: string) => /\bdefault\b/i.test(help)
+
+describe("permission policy option copy", () => {
+    it("marks exactly one option as the default", () => {
+        const marked = PERMISSION_POLICY_OPTIONS.filter((option) => claimsDefault(option.help))
+        expect(marked.map((option) => option.value)).toEqual([NEW_AGENT_POLICY])
+    })
+
+    it("does not call Allow reads the default any more (#6662)", () => {
+        const allowReads = PERMISSION_POLICY_OPTIONS.find(
+            (option) => option.value === "allow_reads",
+        )
+        expect(allowReads?.help).toBe("Reads run, writes ask")
+    })
+
+    it("keeps the runner's missing-policy fallback separate from the new-agent default", () => {
+        // #6641 changed what a new template names and deliberately left the fallback alone, so
+        // these two are allowed to differ. The test exists to make a change to either deliberate.
+        expect(DEFAULT_PERMISSION_POLICY).toBe("allow_reads")
+        expect(DEFAULT_PERMISSION_POLICY).not.toBe(NEW_AGENT_POLICY)
+    })
+
+    it("keeps the default marker on a schema that narrows the options", () => {
+        const narrowed = permissionPolicyOptionsForEnum(["allow", "ask"])
+        expect(narrowed.filter((option) => claimsDefault(option.help))).toHaveLength(1)
+    })
+
+    it("gives every option a label and a sub-line", () => {
+        for (const option of PERMISSION_POLICY_OPTIONS) {
+            expect(option.label).toBeTruthy()
+            expect(option.help).toBeTruthy()
+        }
+    })
+})

--- a/web/packages/agenta-shared/tests/unit/permissionPolicy.test.ts
+++ b/web/packages/agenta-shared/tests/unit/permissionPolicy.test.ts
@@ -1,44 +1,21 @@
 /**
- * The Permissions selector's sub-lines. One option says "default", and it has to be the policy a
- * new agent really gets — `allow` since #6641, while the dropdown still credited `allow_reads`
- * (#6662). The copy lives in one list, so pin the claim here rather than in each host's render.
+ * The Permissions selector's sub-lines. One of them called `Allow reads` the default while the
+ * standard template creates an agent on `Allow all`, and an agent with no stored policy runs on
+ * `Allow reads` (#6662). No sub-line can say which of those it means, so none of them claims a
+ * default. The copy lives in one list, so pin that here rather than in each host's render.
  */
 import {describe, expect, it} from "vitest"
 
 import {
     DEFAULT_PERMISSION_POLICY,
     PERMISSION_POLICY_OPTIONS,
-    permissionPolicyOptionsForEnum,
 } from "../../src/utils/permissionPolicy"
 
-/** What the SDK writes into a new agent template (`sdks/python/agenta/sdk/utils/types.py`). */
-const NEW_AGENT_POLICY = "allow"
-
-const claimsDefault = (help: string) => /\bdefault\b/i.test(help)
-
 describe("permission policy option copy", () => {
-    it("marks exactly one option as the default", () => {
-        const marked = PERMISSION_POLICY_OPTIONS.filter((option) => claimsDefault(option.help))
-        expect(marked.map((option) => option.value)).toEqual([NEW_AGENT_POLICY])
-    })
-
-    it("does not call Allow reads the default any more (#6662)", () => {
-        const allowReads = PERMISSION_POLICY_OPTIONS.find(
-            (option) => option.value === "allow_reads",
-        )
-        expect(allowReads?.help).toBe("Reads run, writes ask")
-    })
-
-    it("keeps the runner's missing-policy fallback separate from the new-agent default", () => {
-        // #6641 changed what a new template names and deliberately left the fallback alone, so
-        // these two are allowed to differ. The test exists to make a change to either deliberate.
-        expect(DEFAULT_PERMISSION_POLICY).toBe("allow_reads")
-        expect(DEFAULT_PERMISSION_POLICY).not.toBe(NEW_AGENT_POLICY)
-    })
-
-    it("keeps the default marker on a schema that narrows the options", () => {
-        const narrowed = permissionPolicyOptionsForEnum(["allow", "ask"])
-        expect(narrowed.filter((option) => claimsDefault(option.help))).toHaveLength(1)
+    it("does not call any option the default (#6662)", () => {
+        for (const option of PERMISSION_POLICY_OPTIONS) {
+            expect(option.help, option.value).not.toMatch(/\bdefaults?\b/i)
+        }
     })
 
     it("gives every option a label and a sub-line", () => {
@@ -46,5 +23,10 @@ describe("permission policy option copy", () => {
             expect(option.label).toBeTruthy()
             expect(option.help).toBeTruthy()
         }
+    })
+
+    it("still falls back to Allow reads for a config that names no policy", () => {
+        // Unchanged by #6641 and unchanged here. Both selectors show this as the applied value.
+        expect(DEFAULT_PERMISSION_POLICY).toBe("allow_reads")
     })
 })

--- a/web/packages/agenta-shared/tests/unit/permissionPolicy.test.ts
+++ b/web/packages/agenta-shared/tests/unit/permissionPolicy.test.ts
@@ -1,9 +1,4 @@
-/**
- * The Permissions selector's sub-lines. One of them called `Allow reads` the default while the
- * standard template creates an agent on `Allow all`, and an agent with no stored policy runs on
- * `Allow reads` (#6662). No sub-line can say which of those it means, so none of them claims a
- * default. The copy lives in one list, so pin that here rather than in each host's render.
- */
+/** No option claims to be the default, because "the default" is two policies here (#6662). */
 import {describe, expect, it} from "vitest"
 
 import {
@@ -14,7 +9,7 @@ import {
 describe("permission policy option copy", () => {
     it("does not call any option the default (#6662)", () => {
         for (const option of PERMISSION_POLICY_OPTIONS) {
-            expect(option.help, option.value).not.toMatch(/\bdefaults?\b/i)
+            expect(`${option.label} ${option.help}`, option.value).not.toMatch(/\bdefaults?\b/i)
         }
     })
 

--- a/web/storybook/stories/entity-ui/PermissionPolicySelect.stories.tsx
+++ b/web/storybook/stories/entity-ui/PermissionPolicySelect.stories.tsx
@@ -34,8 +34,8 @@ export default meta
 type Story = StoryObj<typeof meta>
 
 const OPTIONS = [
-    {value: "allow_reads", title: "Allow reads", help: "Reads run, writes ask; default"},
-    {value: "allow", title: "Allow all", help: "Every tool runs without asking"},
+    {value: "allow_reads", title: "Allow reads", help: "Reads run, writes ask"},
+    {value: "allow", title: "Allow all", help: "Every tool runs without asking; default"},
     {value: "ask", title: "Ask", help: "A human approves every tool call"},
     {value: "deny", title: "Deny all", help: "Every tool call is refused"},
 ]

--- a/web/storybook/stories/entity-ui/PermissionPolicySelect.stories.tsx
+++ b/web/storybook/stories/entity-ui/PermissionPolicySelect.stories.tsx
@@ -35,7 +35,7 @@ type Story = StoryObj<typeof meta>
 
 const OPTIONS = [
     {value: "allow_reads", title: "Allow reads", help: "Reads run, writes ask"},
-    {value: "allow", title: "Allow all", help: "Every tool runs without asking; default"},
+    {value: "allow", title: "Allow all", help: "Every tool runs without asking"},
     {value: "ask", title: "Ask", help: "A human approves every tool call"},
     {value: "deny", title: "Deny all", help: "Every tool call is refused"},
 ]
@@ -93,7 +93,7 @@ const Live = ({disabled}: {disabled?: boolean}) => {
     )
 }
 
-/** Default policy — "Allow reads". */
+/** The selector on "Allow reads", the policy an agent runs on when its config names none. */
 export const Default: Story = {
     args: {value: "allow_reads", onChange: () => undefined, options: OPTIONS},
     render: () => <Live />,


### PR DESCRIPTION
## Context

Fixes [#6662](https://github.com/Agenta-AI/agenta/issues/6662). Open the Permissions selector on a fresh agent and the trigger reads `Allow all`, while the dropdown says `Allow reads` is the default. That is the one line a user reads while deciding how much freedom to give an agent, so being wrong about it matters more here than in most copy.

[#6641](https://github.com/Agenta-AI/agenta/pull/6641) moved the standard template to `runner.permissions.default: "allow"`. The sub-line under `Allow reads` was written before that and still claimed the title.

## Changes

The marker is removed rather than moved, because "the default" is two different policies:

- The standard template creates an agent on `allow`. That is what #6641 changed.
- An agent whose config names no policy at all runs on `allow_reads`, which #6641 deliberately left alone. Both selectors display that fallback as the applied value, in the composer palette and in the config drawer.

Before:

```
Allow reads   Reads run, writes ask; default
Allow all     Every tool runs without asking
```

After:

```
Allow reads   Reads run, writes ask
Allow all     Every tool runs without asking
```

A one-line sub-line has no room to say which default it means, so it says neither. The issue allowed either fix, and this is the one that cannot be wrong again the next time a creation default moves.

`/w` and `/m` both read `PERMISSION_POLICY_OPTIONS` from `@agenta/shared`, and so does the composer's `/permissions` palette, so the wording changes in one place and all three follow. No runtime behaviour changes and `DEFAULT_PERMISSION_POLICY` is untouched. The storybook fixture for the selector and the product-facts sheet that transcribes this dropdown carry the same lines, so they move too.

## Tests

- `web/packages/agenta-shared/tests/unit/permissionPolicy.test.ts` asserts no option's sub-line claims a default, that every option still has a label and a sub-line, and that the missing-policy fallback is still `allow_reads`.
- Full suites green on this branch: `@agenta/shared` 466 passed, `@agenta/entity-ui` 686 passed, `@agenta/oss` 506 passed, `mobile` 178 passed. `tsc --noEmit` clean for the changed package. `pnpm lint-fix` and `pnpm run format` clean.

Reviewed by Codex at xhigh, which asked for the marker to be removed rather than moved. That is the change above.

No browser check. This is four words in one array that both hosts already render from, and no rendering path changed.

## Not in this PR

Codex found four user-facing docs pages and two SDK strings that still call `Allow reads` the default. They are wrong for the same reason, and they predate this PR:

- `docs/docs/learn/_01-build-your-first-agent.mdx` lines 203 and 213
- `docs/docs/guides/02-control-what-an-agent-can-do.mdx` line 30
- `docs/docs/guides/06-create-an-automation.mdx` line 38
- `docs/docs/guides/04-add-an-mcp-server.mdx` line 51
- `sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py` line 261, in the config reference the platform prompt ships to agents
- `sdks/python/agenta/sdk/utils/types.py` line 1385, the schema description

`docs/docs/reference/agents/01-agent-configuration.mdx` line 233 is correct as written, because it documents the omitted-field fallback. The SDK strings need a redeploy and sit in another PR's territory, so they are flagged rather than folded into a copy change.

## What to QA

- Create a blank agent on `/w` and open Permissions. The trigger says `Allow all`. No option in the dropdown claims to be the default.
- Same check on `/m`.
- Type `/permissions` in the desktop composer. The palette shows the same four sub-lines.
- Regression: pick `Ask`, save, reopen the agent. The saved policy is still `Ask`. Nothing here touches what gets stored.