### PR TITLE
[fix] Refuse a chat link whose target names a host, not a path

### DIFF
--- a/web/mobile/src/features/chat/AssistantMarkdown.tsx
+++ b/web/mobile/src/features/chat/AssistantMarkdown.tsx
@@ -1,5 +1,10 @@
 import {useTypewriter} from "@agenta/chat/hooks"
-import {isExternalHref, withExplicitRelativeLinks} from "@agenta/entity-ui/drive"
+import {
+    BlockedChatLink,
+    isExternalHref,
+    isProtocolRelativeHref,
+    withExplicitRelativeLinks,
+} from "@agenta/entity-ui/drive"
 import {defaultRehypePlugins, Streamdown, type Components} from "streamdown"
 
 import {DriveLink} from "./DriveLink"
@@ -10,8 +15,15 @@ const rehypePlugins = withExplicitRelativeLinks(defaultRehypePlugins)
 export const markdownComponents: Components = {
     // Streamdown's own anchor already sets target=_blank + rel=noreferrer; make the
     // opener-severing explicit so the guarantee survives an upstream refresh.
+    //
+    // The host check runs FIRST, on the raw href: a target that names a host is refused and
+    // rendered the way harden renders the targets it refuses (#6666), never as an anchor.
     a: ({node: _node, className, children, ...props}) =>
-        isExternalHref(props.href) ? (
+        isProtocolRelativeHref(props.href) ? (
+            <BlockedChatLink href={props.href} className={className}>
+                {children}
+            </BlockedChatLink>
+        ) : isExternalHref(props.href) ? (
             <a
                 {...props}
                 className={`text-primary font-medium underline ${className ?? ""}`}

--- a/web/mobile/tests/unit/assistantMarkdownLinks.test.tsx
+++ b/web/mobile/tests/unit/assistantMarkdownLinks.test.tsx
@@ -47,8 +47,7 @@ describe("mobile assistant markdown links", () => {
     })
 
     it("refuses a target that names a host instead of a path (#6666)", () => {
-        // The shapes that reach the anchor: what harden hands back for a dot segment that climbs
-        // to a host, and the encoded and backslash spellings of the same thing.
+        // Every spelling of a host that can reach the anchor.
         const targets = [
             "//evil.com/x",
             "..//evil.com/x",
@@ -71,9 +70,11 @@ describe("mobile assistant markdown links", () => {
     })
 
     it("keeps the file link the platform prompt prescribes working", () => {
+        // `resolved` accumulates across the whole file, so read only what this render added.
+        const before = resolved.length
         const html = renderLink("/agent-files/report.md")
         expect(html).not.toContain("[blocked]")
-        expect(resolved).toContain("/agent-files/report.md")
+        expect(resolved.slice(before)).toEqual(["/agent-files/report.md"])
     })
 
     it("keeps a web link whose own path has a double slash", () => {

--- a/web/mobile/tests/unit/assistantMarkdownLinks.test.tsx
+++ b/web/mobile/tests/unit/assistantMarkdownLinks.test.tsx
@@ -45,4 +45,40 @@ describe("mobile assistant markdown links", () => {
         expect(html).toContain('target="_blank"')
         expect(html).toContain('rel="noopener noreferrer"')
     })
+
+    it("refuses a target that names a host instead of a path (#6666)", () => {
+        // The shapes that reach the anchor: what harden hands back for a dot segment that climbs
+        // to a host, and the encoded and backslash spellings of the same thing.
+        const targets = [
+            "//evil.com/x",
+            "..//evil.com/x",
+            "a/..//evil.com/x",
+            "//EVIL.com/x",
+            "%2F%2Fevil.com",
+            "%2f%2fevil.com",
+            "\\\\evil.com",
+            "/\\evil.com",
+            "  //evil.com/x",
+        ]
+        for (const target of targets) {
+            const before = resolved.length
+            const html = renderLink(target)
+            expect(html, target).not.toContain("<a")
+            expect(html, target).toContain("[blocked]")
+            // It never reaches the drive resolver either, so no file read is attempted for it.
+            expect(resolved.length, target).toBe(before)
+        }
+    })
+
+    it("keeps the file link the platform prompt prescribes working", () => {
+        const html = renderLink("/agent-files/report.md")
+        expect(html).not.toContain("[blocked]")
+        expect(resolved).toContain("/agent-files/report.md")
+    })
+
+    it("keeps a web link whose own path has a double slash", () => {
+        const html = renderLink("https://example.com//deep/report.md")
+        expect(html).toContain('href="https://example.com//deep/report.md"')
+        expect(html).not.toContain("[blocked]")
+    })
 })

--- a/web/mobile/tests/unit/assistantMarkdownPipeline.test.tsx
+++ b/web/mobile/tests/unit/assistantMarkdownPipeline.test.tsx
@@ -1,0 +1,102 @@
+// @vitest-environment jsdom
+/**
+ * `/m` end to end through the real markdown pipeline (#6666).
+ *
+ * The sibling suite calls the anchor renderer directly, which cannot catch a missing rehype
+ * plugin, a parser transformation, or a renderer that stopped using the component map. This one
+ * renders `AssistantMarkdown` itself, so the only things stubbed are the typewriter clock and the
+ * drive resolution, and every link goes through Streamdown, harden and the real anchor.
+ */
+import {type ReactNode} from "react"
+
+import {renderToStaticMarkup} from "react-dom/server"
+import {describe, expect, it, vi} from "vitest"
+
+const resolved: string[] = []
+
+vi.mock("@agenta/chat/hooks", () => ({
+    // Reveal the whole text at once; the reveal animation is not what this suite is about.
+    useTypewriter: (target: string) => ({text: target, settled: true}),
+}))
+
+vi.mock("@agenta/entity-ui/drive", async (original) => ({
+    ...(await original<object>()),
+    chatFileResolver: {
+        renderCode: (text: string, fallback: ReactNode) => {
+            resolved.push(text)
+            return fallback
+        },
+    },
+}))
+
+const {AssistantMarkdown} = await import("@/features/chat/AssistantMarkdown")
+
+const render = (markdown: string, streaming = false): string =>
+    renderToStaticMarkup(<AssistantMarkdown streaming={streaming} text={markdown} />)
+
+const link = (target: string) => `Created [report.md](${target}) for you.`
+
+describe("mobile assistant markdown, through the real pipeline", () => {
+    it("never renders a target that names a host as a link", () => {
+        for (const target of [
+            "..//evil.com/x",
+            "//evil.com/x",
+            "a/..//evil.com/x",
+            ".././/evil.com/x",
+            "..//EVIL.com/x",
+            "..//evil.com/x?a=1",
+            "%2F%2Fevil.com",
+            "\\\\evil.com",
+            "/\\evil.com",
+        ]) {
+            const html = render(link(target))
+            expect(html, target).not.toContain("<a")
+            expect(html, target).not.toContain("href=")
+        }
+    })
+
+    it("blocks the target harden hands over as a host, in streaming mode too", () => {
+        // Incomplete-markdown repair runs while a reply streams, so the shape has to be refused
+        // on that path as well as the settled one.
+        for (const streaming of [false, true]) {
+            const html = render(link("..//evil.com/x"), streaming)
+            expect(html, String(streaming)).toContain("[blocked]")
+            expect(html, String(streaming)).not.toContain("<a")
+        }
+    })
+
+    it("refuses the same target written as raw HTML", () => {
+        // `rehype-raw` admits the anchor, so it reaches the same component map.
+        const html = render('<a href="..//evil.com/x">report.md</a>')
+        expect(html).not.toContain("<a")
+        expect(html).not.toContain("href=")
+        expect(html).toContain("[blocked]")
+    })
+
+    it("still opens an ordinary web link in a new tab", () => {
+        const html = render(link("https://example.com/report.md"))
+        expect(html).toContain('href="https://example.com/report.md"')
+        expect(html).toContain('target="_blank"')
+        expect(html).toContain('rel="noopener noreferrer"')
+    })
+
+    it("still opens a bare web link written as an autolink", () => {
+        const html = render("See <https://example.com/report.md> for the numbers.")
+        expect(html).toContain('href="https://example.com/report.md"')
+        expect(html).toContain('target="_blank"')
+    })
+
+    it("still sends the file link the platform prompt prescribes to the drive resolver", () => {
+        resolved.length = 0
+        const html = render(link("agent-files/report.md"))
+        expect(html).not.toContain("[blocked]")
+        // Harden respells it to the leading-slash form the drive resolver handles.
+        expect(resolved).toContain("/agent-files/report.md")
+    })
+
+    it("decodes a percent-encoded file name on the way to the resolver", () => {
+        resolved.length = 0
+        render(link("<agent-files/my report.md>"))
+        expect(resolved).toContain("/agent-files/my report.md")
+    })
+})

--- a/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
@@ -1,8 +1,10 @@
 import {memo, type ReactNode} from "react"
 
 import {
+    BlockedChatLink,
     decodeDriveHref,
     isExternalHref,
+    isProtocolRelativeHref,
     useDriveSessionId,
     withExplicitRelativeLinks,
 } from "@agenta/entity-ui/drive"
@@ -177,9 +179,19 @@ const DriveLink = ({href, ...rest}: AnchorProps) => {
     return fallback
 }
 
-/** Split so an ordinary URL costs nothing: only a relative href subscribes to the drive resolver. */
-const Anchor = ({href, title, className, children}: AnchorProps) =>
-    isExternalHref(href) ? (
+/** Split so an ordinary URL costs nothing: only a relative href subscribes to the drive resolver.
+ *
+ * The host check runs FIRST, on the raw href, before anything here can normalise or decode it. A
+ * target that names a host is refused outright and rendered the way harden renders the targets it
+ * refuses (#6666); nothing downstream ever sees it. */
+const Anchor = ({href, title, className, children}: AnchorProps) => {
+    if (isProtocolRelativeHref(href))
+        return (
+            <BlockedChatLink href={href} className={className}>
+                {children}
+            </BlockedChatLink>
+        )
+    return isExternalHref(href) ? (
         <ExternalLink href={href} title={title} className={className}>
             {children}
         </ExternalLink>
@@ -188,6 +200,7 @@ const Anchor = ({href, title, className, children}: AnchorProps) =>
             {children}
         </DriveLink>
     )
+}
 
 /** Stable maps/configs: fresh object literals per render churn Streamdown's prop identity, and
  * this renderer re-renders on every throttled streaming token — so hoist them to module scope.

--- a/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
@@ -231,13 +231,15 @@ const MD_CONTROLS = {code: {copy: true, download: false}, mermaid: false, table:
 /** Light/dark pair — Shiki dual themes track the app theme instead of the old always-dark Prism. */
 const SHIKI_THEMES: [ThemeInput, ThemeInput] = ["one-light", "one-dark-pro"]
 
-/** Shared markdown renderer for the slice — used by message bubbles and the composer live
- * preview, so both render identically. `className` appends to `MD_CLASS` so callers can tweak
- * size/color (e.g. the muted reasoning block) without forking the renderer.
+/** Shared markdown renderer for the slice — used by the streaming message bubble and the
+ * inspector's context lens, so both render identically. The composer has its own Lexical
+ * renderer and does NOT come through here. `className` appends to `MD_CLASS` so callers can
+ * tweak size/color (e.g. the muted reasoning block) without forking the renderer.
  *
  * Sanitization: Streamdown's default rehype pipeline (`rehype-raw → rehype-sanitize (GitHub
  * schema) → rehype-harden`) replaces the old DOMPurify FORBID_TAGS config — document-affecting
- * tags, handlers, and javascript: URLs are stripped by default.
+ * tags, handlers, and javascript: URLs are stripped by default. `Anchor` adds the one gate
+ * harden does not apply, on a target that resolves to a host (#6666).
  *
  * Memoized on `content`/`className`: within the one message that re-renders per streamed token
  * (the streaming one), its already-settled parts — a reasoning block, text before a tool call —

--- a/web/oss/src/components/AgentChatSlice/assets/markdownLinkGate.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdownLinkGate.test.tsx
@@ -98,19 +98,22 @@ describe("chat markdown link gate", () => {
         }
     })
 
-    it("is the anchor that refuses the shape harden hands over as a host (#6666)", () => {
-        // `..//evil.com/x` starts with `../`, so harden parses it and returns its pathname,
-        // `//evil.com/x`. The browser fills in the page scheme and leaves the app, so the anchor
-        // has to be the one to say no. These are the targets that reach it in that shape.
-        for (const target of ["..//evil.com/x", "a/..//evil.com/x", ".././/evil.com/x"]) {
-            const html = renderToStaticMarkup(<Markdown content={link(target)} />)
-            expect(html, target).toContain("[blocked]")
+    it("is the anchor, not harden, that refuses a resolved host (#6666)", () => {
+        // Which layer catches what, stated separately from the rendered result. `gate` reports the
+        // href the anchor slot receives, so it shows harden's own verdict first.
+        for (const target of ["..//evil.com/x", ".././/evil.com/x"]) {
+            // Harden parses it (it starts with `../`) and returns its pathname, a live host.
+            expect(gate(link(target)), target).toBe("//evil.com/x")
+            // The anchor is therefore the only thing standing between that href and a click.
+            expect(renderToStaticMarkup(<Markdown content={link(target)} />), target).toContain(
+                "[blocked]",
+            )
         }
-        // Written with no dot segment, harden drops the host itself and hands over a bare path.
-        // Nothing to block, and still not a link.
-        const bare = renderToStaticMarkup(<Markdown content={link("//evil.com/x")} />)
-        expect(bare).not.toContain("<a ")
-        expect(bare).not.toContain("evil.com")
+        // Harden already refuses this one: the pre-harden respelling declines a dot segment that
+        // climbs to a host, and the bare form left over does not parse.
+        expect(gate(link("a/..//evil.com/x"))).toBe("[blocked]")
+        // And written with no dot segment, harden drops the host itself and hands over a path.
+        expect(gate(link("//evil.com/x"))).toBe("/x")
     })
 
     it("refuses it the same way harden refuses a bad scheme, so both read alike", () => {
@@ -135,7 +138,9 @@ describe("chat markdown link gate", () => {
         const doubled = renderToStaticMarkup(<Markdown content={link("https://example.com//a")} />)
         expect(doubled).toContain('href="https://example.com//a"')
 
-        // The file link the platform prompt prescribes still reaches the drive resolver.
+        // The file link the platform prompt prescribes still reaches the anchor as the
+        // leading-slash form the drive resolver handles, not as a blocked span.
+        expect(gate(link("agent-files/report.md"))).toBe("/agent-files/report.md")
         const file = renderToStaticMarkup(<Markdown content={link("agent-files/report.md")} />)
         expect(file).not.toContain("[blocked]")
         expect(file).toContain("report.md")

--- a/web/oss/src/components/AgentChatSlice/assets/markdownLinkGate.test.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdownLinkGate.test.tsx
@@ -75,6 +75,72 @@ describe("chat markdown link gate", () => {
         expect(html).toContain('target="_blank"')
     })
 
+    it("never renders a target that names a host as a link (#6666)", () => {
+        const targets = [
+            "..//evil.com/x",
+            "//evil.com/x",
+            "a/..//evil.com/x",
+            ".././/evil.com/x",
+            "..//EVIL.com/x",
+            "..//evil.com/x?a=1",
+            "%2F%2Fevil.com",
+            "%2f%2fevil.com",
+            "\\\\evil.com",
+            "/\\evil.com",
+        ]
+        for (const target of targets) {
+            const html = renderToStaticMarkup(<Markdown content={link(target)} />)
+            // No anchor at all, so there is nothing to click and no href to resolve. A refused
+            // target still appears inside a `title`, the same place harden puts one it refused.
+            expect(html, target).not.toContain("<a ")
+            expect(html, target).not.toContain("href=")
+            expect(html, target).toContain("report.md")
+        }
+    })
+
+    it("is the anchor that refuses the shape harden hands over as a host (#6666)", () => {
+        // `..//evil.com/x` starts with `../`, so harden parses it and returns its pathname,
+        // `//evil.com/x`. The browser fills in the page scheme and leaves the app, so the anchor
+        // has to be the one to say no. These are the targets that reach it in that shape.
+        for (const target of ["..//evil.com/x", "a/..//evil.com/x", ".././/evil.com/x"]) {
+            const html = renderToStaticMarkup(<Markdown content={link(target)} />)
+            expect(html, target).toContain("[blocked]")
+        }
+        // Written with no dot segment, harden drops the host itself and hands over a bare path.
+        // Nothing to block, and still not a link.
+        const bare = renderToStaticMarkup(<Markdown content={link("//evil.com/x")} />)
+        expect(bare).not.toContain("<a ")
+        expect(bare).not.toContain("evil.com")
+    })
+
+    it("refuses it the same way harden refuses a bad scheme, so both read alike", () => {
+        const blockedHere = renderToStaticMarkup(<Markdown content={link("..//evil.com/x")} />)
+        const blockedByHarden = renderToStaticMarkup(
+            <Markdown content={link("javascript:alert(1)")} />,
+        )
+        for (const html of [blockedHere, blockedByHarden]) {
+            expect(html).toContain("<span")
+            expect(html).toContain('title="Blocked URL:')
+            expect(html).toContain("[blocked]")
+        }
+    })
+
+    it("keeps the links a reply is allowed to have", () => {
+        const web = renderToStaticMarkup(<Markdown content={link("https://example.com")} />)
+        expect(web).toContain('href="https://example.com/"')
+        expect(web).toContain('target="_blank"')
+        expect(web).not.toContain("[blocked]")
+
+        // A web link whose own path has a double slash is a link, not a host escape.
+        const doubled = renderToStaticMarkup(<Markdown content={link("https://example.com//a")} />)
+        expect(doubled).toContain('href="https://example.com//a"')
+
+        // The file link the platform prompt prescribes still reaches the drive resolver.
+        const file = renderToStaticMarkup(<Markdown content={link("agent-files/report.md")} />)
+        expect(file).not.toContain("[blocked]")
+        expect(file).toContain("report.md")
+    })
+
     it("blocked every relative shape before the fix", () => {
         // Streamdown's stock list: the before column of the table.
         const stock = Object.values(defaultRehypePlugins)

--- a/web/packages/agenta-entity-ui/src/drive/BlockedChatLink.tsx
+++ b/web/packages/agenta-entity-ui/src/drive/BlockedChatLink.tsx
@@ -1,0 +1,29 @@
+/**
+ * What the chat renders in place of a link it refuses (#6666).
+ *
+ * `rehype-harden` already drops most bad targets and leaves this exact markup behind: a span
+ * carrying the original target in its `title` and a trailing " [blocked]". One shape gets past
+ * harden and has to be refused at the anchor instead, so it is rendered the same way. A reader
+ * seeing two refused links in one reply should not be able to tell which layer caught which.
+ */
+import {type ReactNode} from "react"
+
+/** Harden's own class for a blocked link. Kept literal so the two look identical. */
+const BLOCKED_LINK_CLASS = "text-gray-500"
+
+export const BlockedChatLink = ({
+    href,
+    className,
+    children,
+}: {
+    href?: string
+    className?: string
+    children?: ReactNode
+}) => (
+    <span
+        title={`Blocked URL: ${href ?? ""}`}
+        className={className ? `${BLOCKED_LINK_CLASS} ${className}` : BLOCKED_LINK_CLASS}
+    >
+        {children} [blocked]
+    </span>
+)

--- a/web/packages/agenta-entity-ui/src/drive/chatFileLinkGate.ts
+++ b/web/packages/agenta-entity-ui/src/drive/chatFileLinkGate.ts
@@ -5,8 +5,10 @@
  * href is all this module does. `rehype-sanitize`, upstream of it, is what strips a dangerous
  * scheme, and harden still gates every href this module rewrites.
  *
- * It also owns the one shape harden lets through that it should not: a target that resolves to a
- * host instead of a path. See {@link isProtocolRelativeHref}, which the chat anchor calls first.
+ * The module now holds two things, both about which link targets the chat will render. The
+ * respelling above gets a bare relative path THROUGH harden. {@link isProtocolRelativeHref} is the
+ * opposite: the one shape harden lets through that it should not, a target that resolves to a host
+ * instead of a path. Both hosts' anchors call it first.
  */
 
 /** True for a `scheme:` URL, a protocol-relative `//host` or a `#fragment`; false for a path. */
@@ -40,23 +42,33 @@ const PROBE_HOST = "link-gate.invalid"
  * link text the markdown author chose. Model output is markdown an agent can be steered into
  * writing, so the anchor refuses the shape instead of trusting the target.
  *
- * The test is deliberately wider than a literal `//` prefix, because several spellings reach the
- * same place. A browser reads a backslash as a slash in an http(s) URL, so `/\host` is `//host`.
- * Percent-encoding hides the slashes from a prefix test but not from the browser, so the check
- * decodes until the value stops changing. Tabs, newlines and surrounding controls are dropped by
- * the URL parser, so {@link asBrowserReadsIt} drops them here first. And a target harden did not
- * resolve can still resolve to another host, so the last step resolves it and compares.
+ * Two normalizations are what a browser really does, and the check has to match them or it can be
+ * spelled around. It removes every ASCII tab, newline and carriage return from the whole href and
+ * ignores the surrounding C0 controls and spaces, so `/<tab>/host` is `//host` to it
+ * ({@link asBrowserReadsIt}). And it reads a backslash as a slash in an http(s) URL, so `/\host`,
+ * `\/host` and `\\host` are all `//host`.
+ *
+ * The percent-decoding rounds are NOT that. A browser leaves `%2F` encoded, so `%2F%2Fhost` is a
+ * same-origin path to it. They are here because a target that decodes to a host is never a link
+ * this chat wants to render, and because {@link decodeDriveHref} downstream does decode one layer.
+ * Four rounds is a bounded belt-and-braces limit, not a model of anything; a deeper encoding is
+ * still just an encoded path. The cost is refusing a filename that literally contains `%2F%2F`,
+ * which is why {@link fileCandidate} uses the literal prefix test instead of this one.
+ *
+ * The last step resolves what is left against a probe origin, which catches a target harden did not
+ * resolve. `link-gate.invalid` is a reserved TLD, so nothing can name it on purpose, and every
+ * host-naming spelling already opens with `//` after the normalizations above.
  *
  * A `scheme:` URL is not this function's business and returns false: `rehype-sanitize` drops a
  * dangerous scheme and `rehype-harden` gates the rest, and an `https://` link is a link a reply is
- * allowed to contain. The cost of the rule is a legitimate `//host` spelling of a web link in a
+ * allowed to contain. That also keeps `https://example.com//deep/path` working, whose own pathname
+ * starts with `//`. The cost of the rule is a legitimate `//host` spelling of a web link in a
  * reply, which renders blocked. That trade is the decision recorded on #6666.
  */
 export const isProtocolRelativeHref = (href?: string | null): boolean => {
     if (typeof href !== "string" || !href) return false
     let value = href
-    // Four rounds covers `%252f`-style double encoding with room to spare. The loop stops as soon
-    // as decoding is a no-op, so an ordinary path costs one pass.
+    // The loop stops as soon as decoding is a no-op, so an ordinary path costs one pass.
     for (let round = 0; round < 4; round += 1) {
         value = asBrowserReadsIt(value)
         if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return false

--- a/web/packages/agenta-entity-ui/src/drive/chatFileLinkGate.ts
+++ b/web/packages/agenta-entity-ui/src/drive/chatFileLinkGate.ts
@@ -4,11 +4,76 @@
  * form the platform prompt prescribes rendered as inert "[blocked]" text (#6659). Respelling the
  * href is all this module does. `rehype-sanitize`, upstream of it, is what strips a dangerous
  * scheme, and harden still gates every href this module rewrites.
+ *
+ * It also owns the one shape harden lets through that it should not: a target that resolves to a
+ * host instead of a path. See {@link isProtocolRelativeHref}, which the chat anchor calls first.
  */
 
 /** True for a `scheme:` URL, a protocol-relative `//host` or a `#fragment`; false for a path. */
 export const isExternalHref = (href?: string): boolean =>
     !href || /^([a-z][a-z0-9+.-]*:|\/\/|#)/i.test(href)
+
+/** Drop the leading and trailing C0 controls and spaces a browser drops before it parses an href. */
+const trimHref = (value: string): string => {
+    let start = 0
+    let end = value.length
+    while (start < end && value[start] <= " ") start += 1
+    while (end > start && value[end - 1] <= " ") end -= 1
+    return value.slice(start, end)
+}
+
+/** Resolving against this tells a same-document path apart from one that names another host. */
+const PROBE_ORIGIN = "http://link-gate.invalid"
+const PROBE_HOST = "link-gate.invalid"
+
+/**
+ * True when a browser would read this href as naming a HOST rather than a path in this app (#6666).
+ *
+ * The escape harden leaves open: it parses a target that starts with `../`, then emits
+ * `parsedUrl.pathname`, and the pathname of `..//evil.com/x` is `//evil.com/x`. That is a
+ * protocol-relative URL, so the browser fills in the page's scheme and navigates off-site under a
+ * link text the markdown author chose. Model output is markdown an agent can be steered into
+ * writing, so the anchor refuses the shape instead of trusting the target.
+ *
+ * The test is deliberately wider than a literal `//` prefix, because several spellings reach the
+ * same place. A browser reads a backslash as a slash in an http(s) URL, so `/\host` is `//host`.
+ * Percent-encoding hides the slashes from a prefix test but not from the browser, so the check
+ * decodes until the value stops changing. A leading control character or space is dropped by the
+ * browser before it parses, so it is dropped here first. And a target harden did not resolve can
+ * still resolve to another host, so the last step resolves it and compares.
+ *
+ * A `scheme:` URL is not this function's business and returns false: `rehype-sanitize` drops a
+ * dangerous scheme and `rehype-harden` gates the rest, and an `https://` link is a link a reply is
+ * allowed to contain. The cost of the rule is a legitimate `//host` spelling of a web link in a
+ * reply, which renders blocked. That trade is the decision recorded on #6666.
+ */
+export const isProtocolRelativeHref = (href?: string | null): boolean => {
+    if (typeof href !== "string" || !href) return false
+    let value = href
+    // Four rounds covers `%252f`-style double encoding with room to spare. The loop stops as soon
+    // as decoding is a no-op, so an ordinary path costs one pass.
+    for (let round = 0; round < 4; round += 1) {
+        value = trimHref(value)
+        if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return false
+        if (value.replace(/\\/g, "/").startsWith("//")) return true
+        let decoded: string
+        try {
+            decoded = decodeURIComponent(value)
+        } catch {
+            break
+        }
+        if (decoded === value) break
+        value = decoded
+    }
+    try {
+        const url = new URL(value.replace(/\\/g, "/"), PROBE_ORIGIN)
+        // A different host means the target named one. A pathname that still starts with `//` is
+        // the shape harden hands back, which the NEXT resolution (the browser's) reads as a host.
+        return url.host !== PROBE_HOST || url.pathname.startsWith("//")
+    } catch {
+        return false
+    }
+}
 
 /** The explicit-relative spelling of a bare relative href, else null. */
 export const explicitRelativeHref = (href: string): string | null => {

--- a/web/packages/agenta-entity-ui/src/drive/chatFileLinkGate.ts
+++ b/web/packages/agenta-entity-ui/src/drive/chatFileLinkGate.ts
@@ -13,13 +13,18 @@
 export const isExternalHref = (href?: string): boolean =>
     !href || /^([a-z][a-z0-9+.-]*:|\/\/|#)/i.test(href)
 
-/** Drop the leading and trailing C0 controls and spaces a browser drops before it parses an href. */
-const trimHref = (value: string): string => {
+/**
+ * What the URL parser sees. It removes every ASCII tab, newline and carriage return from the whole
+ * input, then ignores leading and trailing C0 controls and spaces. So `/<tab>/host` is `//host` to a
+ * browser, and this has to be the shape the checks below run on.
+ */
+const asBrowserReadsIt = (value: string): string => {
+    const stripped = value.replace(/[\t\n\r]/g, "")
     let start = 0
-    let end = value.length
-    while (start < end && value[start] <= " ") start += 1
-    while (end > start && value[end - 1] <= " ") end -= 1
-    return value.slice(start, end)
+    let end = stripped.length
+    while (start < end && stripped[start] <= " ") start += 1
+    while (end > start && stripped[end - 1] <= " ") end -= 1
+    return stripped.slice(start, end)
 }
 
 /** Resolving against this tells a same-document path apart from one that names another host. */
@@ -38,9 +43,9 @@ const PROBE_HOST = "link-gate.invalid"
  * The test is deliberately wider than a literal `//` prefix, because several spellings reach the
  * same place. A browser reads a backslash as a slash in an http(s) URL, so `/\host` is `//host`.
  * Percent-encoding hides the slashes from a prefix test but not from the browser, so the check
- * decodes until the value stops changing. A leading control character or space is dropped by the
- * browser before it parses, so it is dropped here first. And a target harden did not resolve can
- * still resolve to another host, so the last step resolves it and compares.
+ * decodes until the value stops changing. Tabs, newlines and surrounding controls are dropped by
+ * the URL parser, so {@link asBrowserReadsIt} drops them here first. And a target harden did not
+ * resolve can still resolve to another host, so the last step resolves it and compares.
  *
  * A `scheme:` URL is not this function's business and returns false: `rehype-sanitize` drops a
  * dangerous scheme and `rehype-harden` gates the rest, and an `https://` link is a link a reply is
@@ -53,7 +58,7 @@ export const isProtocolRelativeHref = (href?: string | null): boolean => {
     // Four rounds covers `%252f`-style double encoding with room to spare. The loop stops as soon
     // as decoding is a no-op, so an ordinary path costs one pass.
     for (let round = 0; round < 4; round += 1) {
-        value = trimHref(value)
+        value = asBrowserReadsIt(value)
         if (/^[a-z][a-z0-9+.-]*:/i.test(value)) return false
         if (value.replace(/\\/g, "/").startsWith("//")) return true
         let decoded: string

--- a/web/packages/agenta-entity-ui/src/drive/chatFileRefs.tsx
+++ b/web/packages/agenta-entity-ui/src/drive/chatFileRefs.tsx
@@ -28,6 +28,7 @@ import {
 import {atom, useAtomValue} from "jotai"
 import {atomFamily} from "jotai-family"
 
+import {isProtocolRelativeHref} from "./chatFileLinkGate"
 import {DriveFileInlineRef} from "./DriveFileCard"
 import {useDriveArtifactId, useDriveSessionId} from "./driveSessionContext"
 
@@ -37,6 +38,9 @@ import {useDriveArtifactId, useDriveSessionId} from "./driveSessionContext"
  * guaranteed-404 on-demand read once scrolled into view; the shape test drops those. */
 export const fileCandidate = (text: string): string | null => {
     const trimmed = text.trim()
+    // A span or a link target that names a HOST is not a file, whichever host called in (#6666).
+    // The anchors refuse it before this point; an inline-code mention arrives here directly.
+    if (isProtocolRelativeHref(trimmed)) return null
     // Keep the leading slash on an absolute sandbox path. The Quick Look host uses the complete
     // tool-path tail to match the mount-relative file, while removing it turns `/tmp/...` into an
     // unrelated drive-relative path and loses the information needed for that match (#5983).

--- a/web/packages/agenta-entity-ui/src/drive/chatFileRefs.tsx
+++ b/web/packages/agenta-entity-ui/src/drive/chatFileRefs.tsx
@@ -28,7 +28,6 @@ import {
 import {atom, useAtomValue} from "jotai"
 import {atomFamily} from "jotai-family"
 
-import {isProtocolRelativeHref} from "./chatFileLinkGate"
 import {DriveFileInlineRef} from "./DriveFileCard"
 import {useDriveArtifactId, useDriveSessionId} from "./driveSessionContext"
 
@@ -38,9 +37,11 @@ import {useDriveArtifactId, useDriveSessionId} from "./driveSessionContext"
  * guaranteed-404 on-demand read once scrolled into view; the shape test drops those. */
 export const fileCandidate = (text: string): string | null => {
     const trimmed = text.trim()
-    // A span or a link target that names a HOST is not a file, whichever host called in (#6666).
-    // The anchors refuse it before this point; an inline-code mention arrives here directly.
-    if (isProtocolRelativeHref(trimmed)) return null
+    // A mention that opens with two slashes names a HOST, not a file (#6666). This is the literal
+    // spelling only, deliberately narrower than the anchor's {@link isProtocolRelativeHref}: that
+    // one decodes, and a raw filename may legitimately contain `%2F` or a backslash. Nothing here
+    // navigates, so the wide test buys no safety and would reject real names.
+    if (trimmed.replace(/\\/g, "/").startsWith("//")) return null
     // Keep the leading slash on an absolute sandbox path. The Quick Look host uses the complete
     // tool-path tail to match the mount-relative file, while removing it turns `/tmp/...` into an
     // unrelated drive-relative path and loses the information needed for that match (#5983).

--- a/web/packages/agenta-entity-ui/src/drive/index.ts
+++ b/web/packages/agenta-entity-ui/src/drive/index.ts
@@ -3,6 +3,7 @@
  * their rows, plus the toast-reporting download hooks, over the headless layer in
  * `@agenta/entities/drive`. antd-free so the mobile app renders it.
  */
+export * from "./BlockedChatLink"
 export * from "./ContextRail"
 export * from "./DriveBreadcrumb"
 export * from "./DriveExplorer"

--- a/web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts
@@ -5,9 +5,11 @@ import {
     decodeDriveHref,
     explicitRelativeHref,
     isExternalHref,
+    isProtocolRelativeHref,
     rehypeExplicitRelativeLinks,
     withExplicitRelativeLinks,
 } from "../../src/drive/chatFileLinkGate"
+import {fileCandidate} from "../../src/drive/chatFileRefs"
 
 describe("explicitRelativeHref", () => {
     it("respells the working-directory-relative path the platform prompt prescribes", () => {
@@ -54,6 +56,84 @@ describe("isExternalHref", () => {
     it("is false for a path, which may name a drive file", () => {
         expect(isExternalHref("/agent-files/report.md")).toBe(false)
         expect(isExternalHref("agent-files/report.md")).toBe(false)
+    })
+})
+
+describe("isProtocolRelativeHref", () => {
+    it("refuses the target harden hands back for a dot segment that climbs to a host (#6666)", () => {
+        // What the anchor actually receives: harden resolved `..//evil.com/x` to its pathname.
+        expect(isProtocolRelativeHref("//evil.com/x")).toBe(true)
+        // And the target as written, in case a pipeline change stops resolving it first.
+        expect(isProtocolRelativeHref("..//evil.com/x")).toBe(true)
+        expect(isProtocolRelativeHref("a/..//evil.com/x")).toBe(true)
+        expect(isProtocolRelativeHref(".././/evil.com/x")).toBe(true)
+    })
+
+    it("refuses the encoded spellings of the same target", () => {
+        expect(isProtocolRelativeHref("%2F%2Fevil.com")).toBe(true)
+        expect(isProtocolRelativeHref("%2f%2fevil.com")).toBe(true)
+        expect(isProtocolRelativeHref("%252F%252Fevil.com")).toBe(true)
+        expect(isProtocolRelativeHref("/%2F%2Fevil.com")).toBe(true)
+    })
+
+    it("refuses the backslash spellings a browser reads as slashes", () => {
+        expect(isProtocolRelativeHref("\\\\evil.com")).toBe(true)
+        expect(isProtocolRelativeHref("/\\evil.com")).toBe(true)
+        expect(isProtocolRelativeHref("\\/evil.com")).toBe(true)
+        expect(isProtocolRelativeHref("/%5Cevil.com")).toBe(true)
+        expect(isProtocolRelativeHref("%5C%5Cevil.com")).toBe(true)
+    })
+
+    it("refuses a target hidden behind the whitespace a browser strips", () => {
+        expect(isProtocolRelativeHref("  //evil.com/x")).toBe(true)
+        expect(isProtocolRelativeHref("\n//evil.com/x")).toBe(true)
+        expect(isProtocolRelativeHref("\t\\\\evil.com")).toBe(true)
+        expect(isProtocolRelativeHref("\u0000//evil.com/x")).toBe(true)
+    })
+
+    it("does not care how the host is cased", () => {
+        expect(isProtocolRelativeHref("//EVIL.com/x")).toBe(true)
+        expect(isProtocolRelativeHref("%2F%2FEVIL.com")).toBe(true)
+    })
+
+    it("lets an ordinary web link through, double slashes in its path included", () => {
+        expect(isProtocolRelativeHref("https://example.com")).toBe(false)
+        expect(isProtocolRelativeHref("https://example.com//deep/path")).toBe(false)
+        expect(isProtocolRelativeHref("HTTPS://example.com")).toBe(false)
+        expect(isProtocolRelativeHref("mailto:qa@agenta.ai")).toBe(false)
+    })
+
+    it("lets every file path through", () => {
+        expect(isProtocolRelativeHref("agent-files/report.md")).toBe(false)
+        expect(isProtocolRelativeHref("/agent-files/report.md")).toBe(false)
+        expect(isProtocolRelativeHref("./agent-files/report.md")).toBe(false)
+        expect(isProtocolRelativeHref("../report.md")).toBe(false)
+        expect(isProtocolRelativeHref("/tmp/agenta/mounts/p/m/agent-files/report.md")).toBe(false)
+        expect(isProtocolRelativeHref("/agent-files/my%20report.md")).toBe(false)
+        expect(isProtocolRelativeHref("/a//b/report.md")).toBe(false)
+        expect(isProtocolRelativeHref("#section")).toBe(false)
+    })
+
+    it("survives a malformed escape and a missing href instead of throwing", () => {
+        expect(isProtocolRelativeHref("/agent-files/100%.md")).toBe(false)
+        expect(isProtocolRelativeHref("%")).toBe(false)
+        expect(isProtocolRelativeHref("")).toBe(false)
+        expect(isProtocolRelativeHref(undefined)).toBe(false)
+        expect(isProtocolRelativeHref(null)).toBe(false)
+    })
+})
+
+describe("fileCandidate", () => {
+    it("refuses a mention that names a host, so the resolver never treats it as a file (#6666)", () => {
+        expect(fileCandidate("//evil.com/x")).toBeNull()
+        expect(fileCandidate("\\\\evil.com")).toBeNull()
+        expect(fileCandidate("%2F%2Fevil.com")).toBeNull()
+    })
+
+    it("still accepts an ordinary file mention", () => {
+        expect(fileCandidate("agent-files/report.md")).toBe("agent-files/report.md")
+        expect(fileCandidate("./report.md")).toBe("report.md")
+        expect(fileCandidate("/tmp/agenta/report.md")).toBe("/tmp/agenta/report.md")
     })
 })
 

--- a/web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts
@@ -91,6 +91,23 @@ describe("isProtocolRelativeHref", () => {
         expect(isProtocolRelativeHref("\u0000//evil.com/x")).toBe(true)
     })
 
+    it("refuses a target split by the tab and newline the URL parser removes", () => {
+        // The URL parser deletes these from ANYWHERE in the input, not just the ends, so a
+        // browser reads each of these as `//evil.com`.
+        expect(isProtocolRelativeHref("/\t/evil.com")).toBe(true)
+        expect(isProtocolRelativeHref("/\n/evil.com")).toBe(true)
+        expect(isProtocolRelativeHref("/\r/evil.com")).toBe(true)
+        expect(isProtocolRelativeHref("/\t\\evil.com")).toBe(true)
+        expect(isProtocolRelativeHref("%2F\t%2Fevil.com")).toBe(true)
+        expect(isProtocolRelativeHref("//evil.com/x  ")).toBe(true)
+    })
+
+    it("does not treat an ordinary space inside a path as a slash", () => {
+        // A space is percent-encoded by the parser, not removed, so this stays a path.
+        expect(isProtocolRelativeHref("/ /evil.com")).toBe(false)
+        expect(isProtocolRelativeHref("/agent-files/my report.md")).toBe(false)
+    })
+
     it("does not care how the host is cased", () => {
         expect(isProtocolRelativeHref("//EVIL.com/x")).toBe(true)
         expect(isProtocolRelativeHref("%2F%2FEVIL.com")).toBe(true)

--- a/web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts
@@ -92,8 +92,7 @@ describe("isProtocolRelativeHref", () => {
     })
 
     it("refuses a target split by the tab and newline the URL parser removes", () => {
-        // The URL parser deletes these from ANYWHERE in the input, not just the ends, so a
-        // browser reads each of these as `//evil.com`.
+        // The parser deletes these from anywhere, so a browser reads each as `//evil.com`.
         expect(isProtocolRelativeHref("/\t/evil.com")).toBe(true)
         expect(isProtocolRelativeHref("/\n/evil.com")).toBe(true)
         expect(isProtocolRelativeHref("/\r/evil.com")).toBe(true)

--- a/web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts
@@ -134,17 +134,44 @@ describe("isProtocolRelativeHref", () => {
     it("survives a malformed escape and a missing href instead of throwing", () => {
         expect(isProtocolRelativeHref("/agent-files/100%.md")).toBe(false)
         expect(isProtocolRelativeHref("%")).toBe(false)
+        expect(isProtocolRelativeHref("%FF%2F%2Fevil.com")).toBe(false)
         expect(isProtocolRelativeHref("")).toBe(false)
         expect(isProtocolRelativeHref(undefined)).toBe(false)
         expect(isProtocolRelativeHref(null)).toBe(false)
+        expect(isProtocolRelativeHref(42 as unknown as string)).toBe(false)
+        expect(isProtocolRelativeHref({} as unknown as string)).toBe(false)
+    })
+
+    it("does not treat a unicode look-alike slash as a slash", () => {
+        // The URL parser percent-encodes these as ordinary path text. Blocking them would refuse
+        // real filenames for no gain.
+        expect(isProtocolRelativeHref("⁄⁄evil.com")).toBe(false)
+        expect(isProtocolRelativeHref("／／evil.com")).toBe(false)
+        expect(isProtocolRelativeHref("⧸⧸evil.com")).toBe(false)
+    })
+
+    it("refuses a target that names the probe host itself", () => {
+        // The probe origin is a reserved TLD nobody can register, but the answer must not depend
+        // on that: a host-naming spelling is caught by the prefix test, before any resolution.
+        expect(isProtocolRelativeHref("//link-gate.invalid/x")).toBe(true)
+        expect(isProtocolRelativeHref("/\\link-gate.invalid/x")).toBe(true)
+        expect(isProtocolRelativeHref("/\tlink-gate.invalid/x")).toBe(false)
     })
 })
 
 describe("fileCandidate", () => {
-    it("refuses a mention that names a host, so the resolver never treats it as a file (#6666)", () => {
+    it("refuses a mention that opens with two slashes, which names a host (#6666)", () => {
         expect(fileCandidate("//evil.com/x")).toBeNull()
         expect(fileCandidate("\\\\evil.com")).toBeNull()
-        expect(fileCandidate("%2F%2Fevil.com")).toBeNull()
+        expect(fileCandidate("/\\evil.com")).toBeNull()
+    })
+
+    it("keeps a literal filename that only LOOKS like an encoded host", () => {
+        // Deliberately narrower than the anchor's check. Nothing here navigates, so a name that
+        // decodes to `//host` is still just a name and must resolve or fail on its own merits.
+        expect(fileCandidate("%2F%2Freport.md")).toBe("%2F%2Freport.md")
+        expect(fileCandidate("a/..//report.md")).toBe("a/..//report.md")
+        expect(fileCandidate("dir\\report.md")).toBe("dir\\report.md")
     })
 
     it("still accepts an ordinary file mention", () => {


### PR DESCRIPTION
## Context

Fixes [#6666](https://github.com/Agenta-AI/agenta/issues/6666). An agent reply that contains

```
[report.md](..//evil.com/x)
```

renders as an ordinary blue link and opens `https://evil.com/x` in a new tab. The link text is chosen by whoever wrote the markdown, so it can read like a filename while the target is a website.

`rehype-harden` parses a target that starts with `../`, and for a path-relative input it returns `parsedUrl.pathname`. The pathname of `..//evil.com/x` is `//evil.com/x`. That is protocol-relative, so the browser supplies the page's scheme and leaves the app. Harden hands the anchor a target it believes is a path, and the anchor believed it too.

This is not [#6665](https://github.com/Agenta-AI/agenta/pull/6665). That PR respells bare relative targets and already refuses to respell one that climbs to a host. This shape never needed respelling, so it reached the renderer unchanged before that PR and after it.

Replies are model output, and model output can be steered by a web page or a repository file the agent reads during a turn. The text that produces this link does not have to come from the person using the app.

## Changes

The chat anchor on both hosts now refuses any target that names a host, and renders it the way harden renders the targets it refuses.

`isProtocolRelativeHref` in `@agenta/entity-ui` is the single test, and both anchors call it first, on the raw href, before anything normalises or decodes it. Two of its steps match what a browser really does, and the check has to match them or it can be spelled around:

- The URL parser removes every ASCII tab, newline and carriage return from the whole href and ignores the surrounding C0 controls and spaces. So `/<tab>/host` is `//host` to a browser.
- It reads a backslash as a slash in an http(s) URL. So `/\host`, `\/host` and `\\host` are all `//host`.

The percent-decoding rounds are not that. A browser leaves `%2F` encoded, so `%2F%2Fhost` is a same-origin path to it. They are there because a target that decodes to a host is never a link this chat wants to render, and because `decodeDriveHref` downstream does decode one layer. The last step resolves what is left against a probe origin, which catches a target harden did not resolve.

A `scheme:` URL returns false and is left alone. `rehype-sanitize` drops a dangerous scheme, harden gates the rest, and an `https://` link is one a reply is allowed to contain. That also keeps `https://example.com//deep/path` working, whose own pathname starts with `//`.

`fileCandidate` gets a deliberately narrower guard: the literal two-slash prefix, no decoding. Nothing on that path navigates, and a raw filename may legitimately contain `%2F` or a backslash, so the wide test would reject real names for no safety.

### Link shapes

| Markdown target | Before | After |
| --- | --- | --- |
| `..//evil.com/x` | `<a href="//evil.com/x" target="_blank">` opens evil.com | blocked, inert text |
| `.././/evil.com/x` | opens evil.com | blocked, inert text |
| `..//EVIL.com/x` | opens evil.com | blocked, inert text |
| `..//evil.com/x?a=1` | opens evil.com | blocked, inert text |
| `/<tab>/evil.com` | opens evil.com | blocked, inert text |
| `//evil.com/x` | harden drops the host, renders `/x` inert | unchanged |
| `a/..//evil.com/x` | blocked by harden | unchanged |
| `%2F%2Fevil.com` | inert text | blocked, inert text |
| `\\evil.com`, `/\evil.com` | inert text | blocked, inert text |
| `https://example.com` | new tab | unchanged |
| `https://example.com//deep/path` | new tab | unchanged |
| `agent-files/report.md` | opens the file | unchanged |
| `/tmp/agenta/mounts/p/m/report.md` | opens the file | unchanged |
| `%2F%2Freport.md` as an inline mention | resolved as a file | unchanged |

The cost is that a reply can no longer write a web link in the `//host` spelling. That spelling is real but uncommon, and the trade is the decision recorded on the issue.

The refused link renders as `<span title="Blocked URL: ..." class="text-gray-500">report.md [blocked]</span>`, which is harden's own markup. A reader who sees two refused links in one reply cannot tell which layer caught which.

## Tests

- `web/packages/agenta-entity-ui/tests/unit/chatFileLinkGate.test.ts` pins the predicate directly: the dot-segment shapes, percent-encoded and double-encoded ones, the four backslash spellings, interior tab and newline, leading whitespace and a NUL, mixed case, unicode look-alike slashes, the probe host, non-string values, and the negatives (a scheme URL, a web link with a doubled path, every file path shape, a malformed escape, invalid UTF-8, an empty and a missing href). It also pins the narrowed `fileCandidate` contract in both directions.
- `web/oss/src/components/AgentChatSlice/assets/markdownLinkGate.test.tsx` drives the production `Markdown` component, so the assertions run through the real Streamdown pipeline and the real anchor. Ten targets produce no anchor and no `href`. One case names the enforcing layer for each shape rather than asserting `[blocked]` and assuming, and another pins that the blocked markup matches what harden emits for `javascript:alert(1)`.
- `web/mobile/tests/unit/assistantMarkdownPipeline.test.tsx` renders `AssistantMarkdown` itself, stubbing only the typewriter clock and drive resolution, so a missing rehype plugin or a renderer that stopped using the component map would fail it. Covers raw HTML anchors, autolinks and streaming mode.
- `web/mobile/tests/unit/assistantMarkdownLinks.test.tsx` keeps the direct component-map assertions, including that a refused target never reaches the drive resolver.
- Full suites green: `@agenta/oss` 510 passed, `@agenta/entity-ui` 701 passed, `mobile` 188 passed. Type checks clean for `@agenta/oss`, `@agenta/ee`, `@agenta/entity-ui` and `mobile`. `pnpm lint-fix` and `pnpm run format` clean.

Browser check on the rendered output. This repo has no Railway preview job on a PR, and the Vercel check is the documentation site, so there was no deployed build of this branch to drive. Instead both hosts' production renderers were run over a reply containing `[report.md](..//evil.com/x)` and an ordinary `https://` link, and the resulting markup was opened in Chromium. Before the change the first link is a real anchor and the browser resolves it to the host `evil.com`. After it, that anchor is gone and only the `https://` one remains, with the refused link showing `report.md [blocked]` and `title="Blocked URL: //evil.com/x"`. Screenshots for `/w` and `/m`: `~/agenta-qa-evidence/2026-09-08-protocol-relative-links/`. This exercises the real Streamdown pipeline and the real anchor, but not the live app, so a run against a deployed stack is still worth doing.

Reviewed by Codex at xhigh, which probed the predicate against Chromium across 5,796 prefix combinations and found no external-host miss, and confirmed the anchor ordering on both hosts. Its two blocking findings, the file-candidate false positives and the mobile suite testing the wrong layer, are the last commit.

## Known remaining route, not fixed here

Codex found that Streamdown's image download button still opens a protocol-relative target. Given `<img src="..//evil.com/x.png">`, its handler calls `window.open("//evil.com/x.png", "_blank")` after the fetch fails. That is a different sink from the anchor, and explicit external images are already permitted today, so closing it is a separate product question rather than part of the decision recorded on #6666. Filed as [#6680](https://github.com/Agenta-AI/agenta/issues/6680) rather than widening this PR.

The desktop composer's Lexical link handling is also outside this check. It renders what the person typed, not model output.

## What to QA

- In the `/w` playground, ask the agent to reply with the literal line `[report.md](..//evil.com/x)`. The reply shows grey `report.md [blocked]` text. Hovering it shows the target in a tooltip. There is nothing to click.
- Same prompt on `/m`. Same result.
- Regression: ask for a reply containing an ordinary `https://` link. It still opens in a new tab.
- Regression: ask the agent to write a file under `agent-files/` and link it. The link is still a file chip and still opens the file. Same for a file in the session working directory.