### PR TITLE
[docs] Say which permission policy a new agent really starts on

### DIFF
--- a/docs/docs/guides/02-control-what-an-agent-can-do.mdx
+++ b/docs/docs/guides/02-control-what-an-agent-can-do.mdx
@@ -27,8 +27,8 @@ Permissions decide which tool calls an agent can make on its own and which need 
 
 | `Policy` | What it does |
 |---|---|
-| `Allow reads` | Reads run, writes ask. This is the default. |
-| `Allow all` | Every tool runs without asking. |
+| `Allow reads` | Reads run, writes ask. |
+| `Allow all` | Every tool runs without asking. A new agent starts here. |
 | `Ask` | A human approves every tool call. |
 | `Deny all` | Every tool call is refused. |
 

--- a/docs/docs/guides/04-add-an-mcp-server.mdx
+++ b/docs/docs/guides/04-add-an-mcp-server.mdx
@@ -48,7 +48,7 @@ The MCP form does not store the key directly. It references a project secret tha
 The server's actions appear as tools labelled with the server name. When the agent calls one, it appears in the conversation and on any approval card.
 
 :::note
-The agent's `Policy` in the **Advanced** dialog governs MCP tools. They have no per-tool `Permission`, and `Always allow` is not offered on their approval cards. Under the default `Allow reads` policy, every MCP call asks for approval. To run MCP tools without approval, including on a schedule, set `Policy` to `Allow all`. See [Control what an agent can do](/guides/control-what-an-agent-can-do).
+The agent's `Policy` in the **Advanced** dialog governs MCP tools. They have no per-tool `Permission`, and `Always allow` is not offered on their approval cards. A new agent starts on `Allow all`, where MCP tools run without approval, including on a schedule. Under `Allow reads`, every MCP call asks for approval instead. See [Control what an agent can do](/guides/control-what-an-agent-can-do).
 :::
 
 ## Next

--- a/docs/docs/guides/06-create-an-automation.mdx
+++ b/docs/docs/guides/06-create-an-automation.mdx
@@ -35,8 +35,8 @@ Open `Advanced`, then the `Permissions` section, and set `Policy`:
 
 | Option | What it does |
 |---|---|
-| `Allow reads` | Reads run, writes ask. This is the default |
-| `Allow all` | Every tool runs without asking |
+| `Allow reads` | Reads run, writes ask |
+| `Allow all` | Every tool runs without asking. A new agent starts here |
 | `Ask` | A human approves every tool call |
 | `Deny all` | Every tool call is refused |
 

--- a/docs/docs/learn/_01-build-your-first-agent.mdx
+++ b/docs/docs/learn/_01-build-your-first-agent.mdx
@@ -200,7 +200,7 @@ Your agent can now read from GitHub and write files. Permissions decide which of
 
 1. In the `Configuration` column, click `Advanced`.
 2. Open the `Permissions` section.
-3. Set `Policy` to `Allow reads`. It is the default, so it may already be selected.
+3. Set `Policy` to `Allow reads`. A new agent starts on `Allow all`, so this is a change.
 4. Click `Save`.
 
 <Stream controls autoplay muted loop src="043728b716bd954b6084a6fb8d247b1b" height="400px" />
@@ -210,8 +210,8 @@ The four policies are:
 
 | Policy | What it does |
 |---|---|
-| `Allow reads` | Reads run, writes ask. This is the default. |
-| `Allow all` | Every tool runs without asking. |
+| `Allow reads` | Reads run, writes ask. |
+| `Allow all` | Every tool runs without asking. A new agent starts here. |
 | `Ask` | A human approves every tool call. |
 | `Deny all` | Every tool call is refused. |
 


### PR DESCRIPTION
## Context

Follow-up to [#6672](https://github.com/Agenta-AI/agenta/pull/6672), which fixed the same wrong claim in the Permissions selector itself. Four docs pages still tell readers that `Allow reads` is the default. [#6641](https://github.com/Agenta-AI/agenta/pull/6641) moved the standard template to `Allow all`, so a reader following these pages gets a different agent than the page describes.

The tutorial is the one that actually misleads. Step 3 says to set `Policy` to `Allow reads` and adds "It is the default, so it may already be selected", so a reader who trusts that skips the step and finishes the tutorial on `Allow all`. Every following sentence about the agent stopping before it writes is then wrong for them.

## Changes

Five lines across four pages. Each now names `Allow all` as where a new agent starts, instead of crediting `Allow reads`.

Before:

```
3. Set `Policy` to `Allow reads`. It is the default, so it may already be selected.

| `Allow reads` | Reads run, writes ask. This is the default. |
| `Allow all`   | Every tool runs without asking. |
```

After:

```
3. Set `Policy` to `Allow reads`. A new agent starts on `Allow all`, so this is a change.

| `Allow reads` | Reads run, writes ask. |
| `Allow all`   | Every tool runs without asking. A new agent starts here. |
```

The MCP page carried the claim in prose rather than a table, and its advice ran backwards from the new default. It said MCP calls ask for approval under the default and told the reader to switch to `Allow all` to avoid that. A new agent is already there, so the note now says so first and describes `Allow reads` as the stricter choice.

`docs/docs/reference/agents/01-agent-configuration.mdx` is left alone on purpose. Its `allow_reads` default is correct: that table documents what the runner applies when the field is omitted from the config, which #6641 deliberately did not change.

## Tests

Docs only, no code. The styling workflow does not run on `docs/**` (it triggers on `api/**`, `sdks/python/**` and `web/**`), and prettier in this repo runs inside `web` only, so there is no formatter to apply here. The edits are single table cells and one sentence, in the surrounding style.

## What to QA

- Read the permissions step of the first-agent tutorial. It tells you to change the policy rather than implying it is already set.
- The three policy tables name `Allow all` as where a new agent starts, and no table says `Allow reads` is the default.
- The MCP note matches what a new agent actually does: MCP tools run without approval until you move to `Allow reads`.
