### PR TITLE
[fix] Stop telling agents that allow_reads is the new-agent default

### DIFF
--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -258,8 +258,9 @@ the run:
   built-ins on every harness. `default_mode` applies to Claude only. Pi harnesses read prompt
   overrides (`system` / `append_system`) from `extras`.
 - `runner` — `{ "kind": "sidecar", "permissions": { "default": "allow"|"ask"|"deny"|
-  "allow_reads" }, "extras": {...} }`. `allow_reads` (the default) runs read-hinted tools and
-  asks for everything else.
+  "allow_reads" }, "extras": {...} }`. `allow_reads` runs read-hinted tools and asks for
+  everything else, and is what applies when the field is absent. The standard template writes
+  `allow`, so that is what a new agent starts on.
 - `sandbox` — `{ "kind": "local" | "daytona", "permissions": {...}, "extras": {...} }`.
   `permissions` (optional) is the security boundary: `{ "network": { "mode": "on"|"off"|
   "allowlist", "allowlist": ["<CIDR>"] }, "filesystem": "on"|"readonly"|"off", "enforcement":

--- a/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
+++ b/sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py
@@ -110,7 +110,7 @@ _CONFIG_SCHEMA_FIELDS = """\
   "mcps": [],
   "skills": [],
   "harness": { "kind": "pi_core" },
-  "runner": { "kind": "sidecar", "permissions": { "default": "allow_reads" } },
+  "runner": { "kind": "sidecar", "permissions": { "default": "allow" } },
   "sandbox": { "kind": "local" }
 }
 ```
@@ -258,9 +258,9 @@ the run:
   built-ins on every harness. `default_mode` applies to Claude only. Pi harnesses read prompt
   overrides (`system` / `append_system`) from `extras`.
 - `runner` — `{ "kind": "sidecar", "permissions": { "default": "allow"|"ask"|"deny"|
-  "allow_reads" }, "extras": {...} }`. `allow_reads` runs read-hinted tools and asks for
-  everything else, and is what applies when the field is absent. The standard template writes
-  `allow`, so that is what a new agent starts on.
+  "allow_reads" }, "extras": {...} }`. The standard creation template sets
+  `runner.permissions.default` to `allow`. Omitting the field applies `allow_reads`, which runs
+  read-hinted tools and asks for everything else.
 - `sandbox` — `{ "kind": "local" | "daytona", "permissions": {...}, "extras": {...} }`.
   `permissions` (optional) is the security boundary: `{ "network": { "mode": "on"|"off"|
   "allowlist", "allowlist": ["<CIDR>"] }, "filesystem": "on"|"readonly"|"off", "enforcement":

--- a/sdks/python/agenta/sdk/utils/types.py
+++ b/sdks/python/agenta/sdk/utils/types.py
@@ -1382,8 +1382,8 @@ class _PermissionsSchema(BaseModel):
         description=(
             "allow runs every tool without asking. ask requires approval for every tool. "
             "deny refuses every tool. allow_reads runs read-hinted tools and asks for "
-            "everything else, and is what applies when this field is absent. The standard "
-            "template writes allow, so that is what a new agent starts on."
+            "everything else. Omitting this field applies allow_reads; the standard "
+            "creation template sets it to allow."
         ),
     )
 

--- a/sdks/python/agenta/sdk/utils/types.py
+++ b/sdks/python/agenta/sdk/utils/types.py
@@ -1382,7 +1382,8 @@ class _PermissionsSchema(BaseModel):
         description=(
             "allow runs every tool without asking. ask requires approval for every tool. "
             "deny refuses every tool. allow_reads runs read-hinted tools and asks for "
-            "everything else; this is the default."
+            "everything else, and is what applies when this field is absent. The standard "
+            "template writes allow, so that is what a new agent starts on."
         ),
     )
 


### PR DESCRIPTION
## Context

Follow-up to [#6672](https://github.com/Agenta-AI/agenta/pull/6672) and [#6681](https://github.com/Agenta-AI/agenta/pull/6681), which fixed the same wrong claim in the Permissions selector and in the docs. Two SDK strings still tell a reader that `allow_reads` is the default, without saying which default they mean.

Both are read by an agent, not by a person. One is the config reference the platform prompt ships, which an agent reads before its first `commit_revision`. The other is the field description on `_PermissionsSchema`, which reaches the config schema. An agent editing its own config could conclude that a new agent starts on `allow_reads` and reason from there.

The claim is half true, which is why it survived. `allow_reads` really is what the runner applies when `runner.permissions.default` is absent. It is not what a new agent gets: the standard template has written `allow` since [#6641](https://github.com/Agenta-AI/agenta/pull/6641).

## Changes

Two strings, each now saying which default it means.

Before, in the config reference:

```
`allow_reads` (the default) runs read-hinted tools and asks for everything else.
```

After:

```
The standard creation template sets `runner.permissions.default` to `allow`. Omitting
the field applies `allow_reads`, which runs read-hinted tools and asks for everything else.
```

Before, in the field description:

```
allow_reads runs read-hinted tools and asks for everything else; this is the default.
```

After:

```
allow_reads runs read-hinted tools and asks for everything else. Omitting this field
applies allow_reads; the standard creation template sets it to allow.
```

Both name `runner.permissions.default` rather than "the field", and both say "the standard creation template" rather than "a new agent". The broader phrasing was not quite true: a bare `AgentTemplateSchema()` still yields `allow_reads`, and the tests pin that for all three harnesses.

The schema default itself is unchanged. `_DEFAULT_PERMISSION_MODE` is still `allow_reads` and no behaviour moves, which is what #6641 intended.

The example JSON in the same reference now shows `"permissions": {"default": "allow"}`. It does not contradict anything on its own, because the surrounding text calls it "one common setup" and tells the agent to keep `runner` as it is. But a model that copies the whole object got `allow_reads` while the sentence three lines below said the template writes `allow`, so aligning it removes a copying risk for one token.

## Tests

- `sdks/python/oss/tests/pytest/unit/agents`: 1365 passed, 4 skipped. Includes the drift test that asserts the config reference still names every template field.
- `ruff@0.15.12 check` clean at the repo root, which is what CI runs. `ruff@0.15.12 format --check` clean on both files.
- Reviewed by Codex at xhigh: approve, with the non-blocking wording and example edits above applied. It verified against the code that `allow_reads` is still the absent-field fallback in both the schema and the runner's own plan, that every standard creation path writes `allow`, and that no test asserts either sentence verbatim.

Two internal leftovers are not touched, because they are a Python comment and a test string rather than anything a model or user reads: `op_catalog.py` around line 1146 and `sandbox-agent-run-plan.test.ts` around line 444. Codex also notes that "allow runs every tool without asking" overstates the case, since an explicit per-tool permission takes precedence over the global policy. That is pre-existing and true of all four descriptions, so correcting it is a separate change rather than part of a default-claim fix.

One pre-existing failure is excluded and is not caused by this change: `test_streaming.py::test_cli_stream_terminal_only_on_empty_request` fails with a `JSONDecodeError` on a pristine checkout of `release/v0.115.3` at `f84fa7b144` as well. Verified by reverting the diff, running that test alone, and re-applying.

## A note for whoever deploys this

The config reference is bundled skill content, which is part of the runner's workspace configuration, and a workspace change currently triggers a sandbox rebuild on reconciliation. So a warm session that picks up the new bundle can rebuild once. Nothing about warm reuse changes; it is a one-time effect of the content moving.

## What to QA

Nothing user-visible. If you want to check it at the source, ask an agent in the playground to read its config reference and say what policy a new agent starts on. It should say `Allow all`, and should still describe `allow_reads` correctly as the fallback for an absent field.