### PR TITLE
[test] Wait for the Use API drawer to settle before clicking inside it

### DIFF
--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -107,11 +107,7 @@ const deployFirstVariantToDevelopment = async (
     })
 }
 
-/**
- * Reports whether an element keeps the same bounding box across two animation
- * frames. Runs in the page so both samples come from real frames, which a
- * Playwright-side poll interval cannot guarantee.
- */
+// Reports whether the element keeps the same bounding box across two frames.
 const hasStableBoxAcrossFrames = (element: Element): Promise<boolean> =>
     new Promise((resolve) => {
         const first = element.getBoundingClientRect()
@@ -128,14 +124,7 @@ const hasStableBoxAcrossFrames = (element: Element): Promise<boolean> =>
         })
     })
 
-/**
- * Waits until the drawer finishes its slide-in animation.
- * The Sheet panel translates in over about 333ms, so every control inside it
- * moves while it opens. Playwright's actionability check needs a stable
- * bounding box, and it cannot settle inside that window: a click that starts
- * during the slide fails with "element is not stable". Wait for the panel's
- * own box to stop moving before any caller clicks inside it.
- */
+// Waits out the drawer slide-in; a click during it fails "element is not stable".
 const waitForDrawerAnimationToSettle = async (drawer: any) => {
     await expect
         .poll(() => pollLocatorState(() => drawer.evaluate(hasStableBoxAcrossFrames)), {

--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -108,6 +108,43 @@ const deployFirstVariantToDevelopment = async (
 }
 
 /**
+ * Reports whether an element keeps the same bounding box across two animation
+ * frames. Runs in the page so both samples come from real frames, which a
+ * Playwright-side poll interval cannot guarantee.
+ */
+const hasStableBoxAcrossFrames = (element: Element): Promise<boolean> =>
+    new Promise((resolve) => {
+        const first = element.getBoundingClientRect()
+        requestAnimationFrame(() => {
+            requestAnimationFrame(() => {
+                const second = element.getBoundingClientRect()
+                resolve(
+                    first.x === second.x &&
+                        first.y === second.y &&
+                        first.width === second.width &&
+                        first.height === second.height,
+                )
+            })
+        })
+    })
+
+/**
+ * Waits until the drawer finishes its slide-in animation.
+ * The Sheet panel translates in over about 333ms, so every control inside it
+ * moves while it opens. Playwright's actionability check needs a stable
+ * bounding box, and it cannot settle inside that window: a click that starts
+ * during the slide fails with "element is not stable". Wait for the panel's
+ * own box to stop moving before any caller clicks inside it.
+ */
+const waitForDrawerAnimationToSettle = async (drawer: any) => {
+    await expect
+        .poll(() => pollLocatorState(() => drawer.evaluate(hasStableBoxAcrossFrames)), {
+            timeout: 10000,
+        })
+        .toBe(true)
+}
+
+/**
  * Opens the "How to use API" drawer from the Variants tab.
  * Uses the data-tour attribute so we target exactly this button even if other
  * "Use API" buttons exist elsewhere in the page.
@@ -142,6 +179,7 @@ const openVariantUseApiDrawer = async (page: any) => {
         hasText: "How to use API",
     })
     await expect(drawer).toBeVisible({timeout: 20000})
+    await waitForDrawerAnimationToSettle(drawer)
     return drawer
 }
 
@@ -163,6 +201,7 @@ const openDeploymentUseApiDrawer = async (page: any) => {
         hasText: "How to use API",
     })
     await expect(drawer).toBeVisible({timeout: 20000})
+    await waitForDrawerAnimationToSettle(drawer)
     return drawer
 }
 


### PR DESCRIPTION
## Context

The acceptance test "Registry: use API snippets > should show variant TypeScript snippet for Fetch Prompt/Config and Invoke LLM" fails on both stage suites. Example failing job: https://github.com/Agenta-AI/agenta_cloud/actions/runs/34269469817

The failure is always the same, on the TypeScript tab click inside the "How to use API" drawer:

```
locator.click: Test timeout of 60000ms exceeded.
waiting for element to be visible, enabled and stable
element is not stable
```

A browser QA pass measured the cause. The drawer is a Radix Sheet that slides in over about 333 ms. During that slide the TypeScript tab moves through 18 different x positions, from 1552 to 832. The test clicks as soon as the drawer is visible, which is the start of the slide, so Playwright's actionability check never sees a stable bounding box and the click times out. By hand the tab works every time, and the test passed 3 of 3 with a page reload inserted before the click. Both facts point at the animation window, not at the tab or the snippet content.

## Changes

The two helpers that open the drawer now wait for the panel to stop moving before they return it. Callers therefore click a settled element.

The wait polls the panel's own bounding box, sampled inside the page across two animation frames. Two consecutive identical boxes mean the slide has finished. The sampling runs in the page because a Playwright-side poll interval cannot promise that two samples land on different frames.

Before, in `openVariantUseApiDrawer` and `openDeploymentUseApiDrawer`:

```ts
await expect(drawer).toBeVisible({timeout: 20000})
return drawer
```

After:

```ts
await expect(drawer).toBeVisible({timeout: 20000})
await waitForDrawerAnimationToSettle(drawer)
return drawer
```

The assertions are unchanged. There are no fixed sleeps, no added retries, and no raised test timeouts. The new poll wraps its page call in the existing `pollLocatorState` helper, so a strict-mode selector bug still surfaces as itself instead of a bare poll timeout.

## Tests

Run against a local EE dev stack, one test at a time, workers 1, retries 0.

- The failing test passed 3 of 3 runs, in about 19 s each.
- The sibling test "should show deployment TypeScript snippet for Fetch Prompt/Config and Invoke LLM" passed once. It shares the changed helper.
- `pnpm lint-fix` and `pnpm run format` are clean in `web`.
