### PR TITLE
[6683] fix(frontend): make the Rename menu entry open the inline editor

### DIFF
--- a/web/mobile/src/features/agents/AgentOverviewScreen.tsx
+++ b/web/mobile/src/features/agents/AgentOverviewScreen.tsx
@@ -154,6 +154,7 @@ export const AgentOverviewScreen = ({
                             onOpenRow={sessionMenu.open}
                             menuFor={sessionMenu.menuFor}
                             onMenuSelect={sessionMenu.onMenuSelect}
+                            onRenameRow={sessionMenu.onRenameRow}
                         />
                     </div>
                 </ScreenScaffold>

--- a/web/mobile/src/features/chat/SessionHistoryMenu.tsx
+++ b/web/mobile/src/features/chat/SessionHistoryMenu.tsx
@@ -71,6 +71,7 @@ export const SessionHistoryMenu = ({
                         onOpenRow={openRow}
                         menuFor={menu.menuFor}
                         onMenuSelect={menu.onMenuSelect}
+                        onRenameRow={menu.onRenameRow}
                     />
                 </div>
             </PopoverContent>

--- a/web/mobile/src/features/chat/SessionTabs.tsx
+++ b/web/mobile/src/features/chat/SessionTabs.tsx
@@ -73,6 +73,7 @@ export const SessionTabs = ({
                 activeFallbackTitle={query.data?.name}
                 menuFor={menu.menuFor}
                 onMenuSelect={menu.onMenuSelect}
+                onRenameRow={menu.onRenameRow}
                 onSelect={(vm) => {
                     if (vm.id !== sessionId) void router.push(`${base}/sessions/${vm.id}`)
                 }}

--- a/web/mobile/src/features/chat/SessionsPane.tsx
+++ b/web/mobile/src/features/chat/SessionsPane.tsx
@@ -61,6 +61,7 @@ export const SessionsPane = ({
                     onOpenRow={open}
                     menuFor={menu.menuFor}
                     onMenuSelect={menu.onMenuSelect}
+                    onRenameRow={menu.onRenameRow}
                 />
             </div>
         </div>

--- a/web/mobile/src/features/home/HomeScreen.tsx
+++ b/web/mobile/src/features/home/HomeScreen.tsx
@@ -118,6 +118,7 @@ export const HomeScreen = ({workspaceId, projectId}: {workspaceId: string; proje
             onOpenSession={sessionMenu.open}
             sessionMenuFor={sessionMenu.menuFor}
             onSessionMenuSelect={sessionMenu.onMenuSelect}
+            onSessionRename={sessionMenu.onRenameRow}
             alwaysShowPin
             agentsPanel={
                 <AgentsPanel

--- a/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
@@ -24,6 +24,7 @@ import {
     reorderSessionsAtomFamily,
     sessionFirstUserTextAtomFamily,
 } from "../state/sessions"
+import {renameSessionRequestAtom} from "../state/uiRequests"
 
 import SessionTabLabel, {type SessionTabLabelHandle} from "./SessionTabLabel"
 
@@ -308,6 +309,10 @@ const SessionTagBar = ({
     const tabIds = useMemo(() => sessions.map((session) => session.id), [sessions])
     const {isPinned} = useSessionPins()
     const {menuItems, onMenuClick} = useSessionActions()
+    // Rename edits the chip in place, and the chip owns that state — so the menu asks for it the
+    // way Alt+R does, through the one-shot request atom `useInlineRenameRequest` consumes. One
+    // path for both, so the menu entry cannot drift from the shortcut.
+    const requestRename = useSetAtom(renameSessionRequestAtom)
     const menuFor = useCallback(
         (session: AgentChatSession) => {
             const target = {
@@ -326,7 +331,9 @@ const SessionTagBar = ({
                 .slice(index + 1)
                 .filter((s) => !isPinned(s.id))
                 .map((s) => s.id)
-            const shared = onMenuClick(target)
+            const shared = onMenuClick(target, {
+                onRename: () => requestRename({scope, sessionId: session.id, nonce: Date.now()}),
+            })
             return {
                 items: [
                     ...menuItems(target).map((entry) => {
@@ -363,10 +370,13 @@ const SessionTagBar = ({
                     if (key === "close-others") return onCloseMany?.(others)
                     if (key === "close-right") return onCloseMany?.(toRight)
                     shared({key})
+                    // Rename opens the chip's own input. Say so, or the menu's closing focus
+                    // restore blurs it and the blur commits — the editor would flash and vanish.
+                    return key === "rename"
                 },
             }
         },
-        [isPinned, menuItems, onClose, onCloseMany, onMenuClick, scope, sessions],
+        [isPinned, menuItems, onClose, onCloseMany, onMenuClick, requestRename, scope, sessions],
     )
     // Session ids present when the bar first mounted. Seeded once; NOT topped up, so an id that
     // appears later reads as "added after mount" and scrolls smoothly (see SessionTag).

--- a/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
+++ b/web/oss/src/components/AgentChatSlice/components/SessionTagBar.tsx
@@ -6,6 +6,7 @@ import {
     SessionTab,
     SessionTabDragItem,
     SessionTabStrip,
+    type MenuSelect,
 } from "@agenta/sessions-ui"
 import {ShortcutKeys} from "@agenta/ui/shortcuts"
 import {Button, SimpleTooltip} from "@agenta/ui/ui"
@@ -116,7 +117,7 @@ interface SessionTagProps {
     onClose: (id: string) => void
     onRename: (id: string, title: string) => void
     /** Right-click actions, from the shared `useSessionActions` set. */
-    menu: {items: SessionMenuItem[]; onClick: (info: {key: string}) => void}
+    menu: {items: SessionMenuItem[]; onClick: MenuSelect}
 }
 
 /** One session chip: status dot + truncated label (double-click or pencil to rename) + hover
@@ -205,7 +206,7 @@ const SessionTag = memo(function SessionTag({
             }}
             className="flex shrink-0 items-center overflow-hidden"
         >
-            <SessionRowContextMenu entries={menu.items} onSelect={(key) => menu.onClick({key})}>
+            <SessionRowContextMenu entries={menu.items} onSelect={(key) => menu.onClick(key)}>
                 <SessionTab
                     active={active}
                     pinned={pinned}
@@ -365,14 +366,15 @@ const SessionTagBar = ({
                         disabled: toRight.length === 0,
                     },
                 ],
-                onClick: ({key}: {key: string}) => {
+                onClick: (key: string) => {
                     if (key === "close") return onClose(session.id)
                     if (key === "close-others") return onCloseMany?.(others)
                     if (key === "close-right") return onCloseMany?.(toRight)
+                    // Deferred, not run here: the request mounts the chip's input, and an input
+                    // that mounts inside the menu's focus trap is blurred straight back out —
+                    // and a blur commits. See `useDeferredMenuSelect`.
+                    if (key === "rename") return () => shared({key})
                     shared({key})
-                    // Rename opens the chip's own input. Say so, or the menu's closing focus
-                    // restore blurs it and the blur commits — the editor would flash and vanish.
-                    return key === "rename"
                 },
             }
         },

--- a/web/oss/src/components/pages/agent-home/StripHome.tsx
+++ b/web/oss/src/components/pages/agent-home/StripHome.tsx
@@ -115,6 +115,11 @@ const StripHome: React.FC = () => {
             })({key}),
         [sessionActions, handleOpenSession],
     )
+    // Rename happens IN the row, so this only supplies the commit — the card owns the edit.
+    const onSessionRename = useCallback(
+        (vm: SessionRowVm, name: string) => sessionActions.commitRename(actionTargetFor(vm), name),
+        [sessionActions],
+    )
 
     // A card here IS the create action — no composer step, no second confirmation.
     const {createFromTemplate, pendingKey} = useCreateAgentFromTemplate("create")
@@ -184,6 +189,7 @@ const StripHome: React.FC = () => {
                     onOpenSession={handleOpenSession}
                     sessionMenuFor={sessionMenuFor}
                     onSessionMenuSelect={onSessionMenuSelect}
+                    onSessionRename={onSessionRename}
                     agentsPanel={<YourAgentsTable variant="list" />}
                     triggersPanel={<NextTriggersSection />}
                     usagePanel={

--- a/web/oss/src/components/pages/sessions/SessionsPage.tsx
+++ b/web/oss/src/components/pages/sessions/SessionsPage.tsx
@@ -157,6 +157,7 @@ const SessionsPage = ({scopedAgentId, title = "Sessions"}: Props) => {
                     onOpenRow={handleOpen}
                     menuFor={menuFor}
                     onMenuSelect={onMenuSelect}
+                    onRenameRow={onRenameRow}
                     className="min-h-0 flex-1 overflow-y-auto px-6 pb-4"
                 />
             </FilterRailLayout>

--- a/web/oss/src/components/pages/sessions/components/SessionListCard.tsx
+++ b/web/oss/src/components/pages/sessions/components/SessionListCard.tsx
@@ -6,7 +6,7 @@ import {useSessionCardVerbs} from "./useSessionCardVerbs"
 
 type Props = Omit<
     React.ComponentProps<typeof SharedSessionListCard>,
-    "viewAllHref" | "onOpenRow" | "menuFor" | "onMenuSelect"
+    "viewAllHref" | "onOpenRow" | "menuFor" | "onMenuSelect" | "onRenameRow"
 > & {
     /** Defaults to the project sessions page; an agent-scoped page carries its own route. */
     viewAllHref?: string

--- a/web/oss/src/components/pages/sessions/components/useSessionCardVerbs.ts
+++ b/web/oss/src/components/pages/sessions/components/useSessionCardVerbs.ts
@@ -46,5 +46,11 @@ export const useSessionCardVerbs = () => {
         [actions, onOpenRow],
     )
 
-    return {onOpenRow, menuFor, onMenuSelect}
+    // Rename happens IN the row, so this only supplies the commit — the list owns the edit.
+    const onRenameRow = useCallback(
+        (vm: SessionRowVm, name: string) => actions.commitRename(actionTargetFor(vm), name),
+        [actions],
+    )
+
+    return {onOpenRow, menuFor, onMenuSelect, onRenameRow}
 }

--- a/web/packages/agenta-entity-ui/src/agent/AgentOverviewBody.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentOverviewBody.tsx
@@ -28,6 +28,7 @@ export interface AgentOverviewBodyProps {
     onOpenRow: SessionListCardProps["onOpenRow"]
     menuFor?: SessionListCardProps["menuFor"]
     onMenuSelect?: SessionListCardProps["onMenuSelect"]
+    onRenameRow?: SessionListCardProps["onRenameRow"]
     /** Touch hosts keep the pin visible instead of revealing it on hover. */
     alwaysShowPin?: boolean
     /** Display names for the triggers section's bound-agent labels. */
@@ -51,6 +52,7 @@ export const AgentOverviewBody = ({
     onOpenRow,
     menuFor,
     onMenuSelect,
+    onRenameRow,
     alwaysShowPin,
     agentNames,
 }: AgentOverviewBodyProps) => (
@@ -72,6 +74,7 @@ export const AgentOverviewBody = ({
                         onOpenRow={onOpenRow}
                         menuFor={menuFor}
                         onMenuSelect={onMenuSelect}
+                        onRenameRow={onRenameRow}
                     />
                     {/* Co-equal with Sessions, not a filter of it: an automation run is one the
                         user configured but did not start. */}
@@ -88,6 +91,7 @@ export const AgentOverviewBody = ({
                         onOpenRow={onOpenRow}
                         menuFor={menuFor}
                         onMenuSelect={onMenuSelect}
+                        onRenameRow={onRenameRow}
                     />
                 </div>
             </>

--- a/web/packages/agenta-home-ui/src/HomeOverview.tsx
+++ b/web/packages/agenta-home-ui/src/HomeOverview.tsx
@@ -18,6 +18,8 @@ export interface HomeOverviewProps {
     onOpenSession: (vm: SessionRowVm) => void
     sessionMenuFor?: (vm: SessionRowVm) => SessionMenuEntry[]
     onSessionMenuSelect?: (vm: SessionRowVm, key: string) => void
+    /** Persists a rename; supply it and a row renames in place from its menu. */
+    onSessionRename?: (vm: SessionRowVm, name: string) => Promise<boolean>
     /** Touch has no hover, so the pin must stay visible there. */
     alwaysShowPin?: boolean
     /** The rail, top to bottom: agents, next triggers, usage. Apps pass what they can render. */
@@ -60,6 +62,7 @@ export const HomeOverview = ({
     onOpenSession,
     sessionMenuFor,
     onSessionMenuSelect,
+    onSessionRename,
     alwaysShowPin,
     agentsPanel,
     triggersPanel,
@@ -113,6 +116,7 @@ export const HomeOverview = ({
                     onOpenRow={onOpenSession}
                     menuFor={sessionMenuFor}
                     onMenuSelect={onSessionMenuSelect}
+                    onRenameRow={onSessionRename}
                     alwaysShowPin={alwaysShowPin}
                 />
                 {/*
@@ -136,6 +140,7 @@ export const HomeOverview = ({
                     onOpenRow={onOpenSession}
                     menuFor={sessionMenuFor}
                     onMenuSelect={onSessionMenuSelect}
+                    onRenameRow={onSessionRename}
                     alwaysShowPin={alwaysShowPin}
                 />
             </div>

--- a/web/packages/agenta-sessions-ui/src/SessionCardList.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionCardList.tsx
@@ -77,12 +77,9 @@ const Row = ({
 
     const onSelect = useCallback(
         (key: string) => {
-            if (key === "rename" && onRename) {
-                rename.start()
-                // The editor takes the caret; the menu must not take it back. See
-                // `SessionRowContextMenu`.
-                return true
-            }
+            // Deferred, not run here: the editor must not mount inside the menu's focus trap.
+            // See `SessionRowContextMenu`.
+            if (key === "rename" && onRename) return () => rename.start()
             onMenuSelect?.(vm, key)
         },
         [onMenuSelect, onRename, rename, vm],

--- a/web/packages/agenta-sessions-ui/src/SessionCardList.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionCardList.tsx
@@ -5,7 +5,7 @@
  * come from `useSessionCardList` (waiting → pinned → recent) and `useSessionPins`; the host
  * supplies only its verbs: how a row opens, and its context-menu entries.
  */
-import {useMemo, type ReactNode} from "react"
+import {useCallback, useMemo, type ReactNode} from "react"
 
 import {pendingGateLabel, type SessionRowVm} from "@agenta/sessions/row"
 import {
@@ -19,11 +19,13 @@ import {ArrowRightIcon, ChatCircleIcon, ClockIcon} from "@phosphor-icons/react"
 import {AnimatePresence, MotionConfig, motion} from "motion/react"
 
 import {ROW_VARIANTS, SESSION_SPRING} from "./assets/motion"
+import InlineRenameInput from "./InlineRenameInput"
 import {type SessionMenuEntry} from "./menu"
 import {SessionAgentName} from "./SessionAgentName"
 import {SessionAutomationKind} from "./SessionAutomationKind"
 import {SessionPinButton} from "./SessionPinButton"
 import {SessionRowContextMenu} from "./SessionRowContextMenu"
+import {useInlineRename} from "./useInlineRename"
 
 export interface SessionCardListProps extends UseSessionCardListArgs {
     emptyText: string
@@ -32,6 +34,12 @@ export interface SessionCardListProps extends UseSessionCardListArgs {
     /** The host's context-menu verbs for a row; omit for no menu (e.g. touch surfaces). */
     menuFor?: (vm: SessionRowVm) => SessionMenuEntry[]
     onMenuSelect?: (vm: SessionRowVm, key: string) => void
+    /**
+     * Persists a rename. Given this, a row renames IN PLACE from its context menu — the same edit
+     * `SessionsListView` offers. Without it the "rename" key falls through to `onMenuSelect`,
+     * where a host that cannot rename leaves the entry dead.
+     */
+    onRenameRow?: (vm: SessionRowVm, name: string) => Promise<boolean>
     /** Hide the per-row agent name (an agent-scoped list restates its heading otherwise). */
     showAgent?: boolean
     /** Touch surfaces have no hover — keep the pin always visible there. */
@@ -48,6 +56,7 @@ const Row = ({
     onTogglePin,
     menuFor,
     onMenuSelect,
+    onRenameRow,
 }: {
     vm: SessionRowVm
     origin?: string
@@ -57,8 +66,28 @@ const Row = ({
     onTogglePin: (id: string) => void
     menuFor?: (vm: SessionRowVm) => SessionMenuEntry[]
     onMenuSelect?: (vm: SessionRowVm, key: string) => void
+    onRenameRow?: (vm: SessionRowVm, name: string) => Promise<boolean>
 }) => {
     const entries = menuFor?.(vm)
+    const onRename = useMemo(
+        () => (onRenameRow ? (name: string) => onRenameRow(vm, name) : undefined),
+        [onRenameRow, vm],
+    )
+    const rename = useInlineRename({current: vm.title, onCommit: onRename ?? (async () => false)})
+
+    const onSelect = useCallback(
+        (key: string) => {
+            if (key === "rename" && onRename) {
+                rename.start()
+                // The editor takes the caret; the menu must not take it back. See
+                // `SessionRowContextMenu`.
+                return true
+            }
+            onMenuSelect?.(vm, key)
+        },
+        [onMenuSelect, onRename, rename, vm],
+    )
+
     const row = (
         // A plain container, not a button: descendants of a button role are presentational, and
         // the pin nested inside one was keyboard-unreachable. The TITLE button is the open action.
@@ -79,30 +108,44 @@ const Row = ({
                 </span>
             </SimpleTooltip>
 
-            <button
-                type="button"
-                onClick={(event) => {
-                    event.stopPropagation()
-                    onOpenRow(vm)
-                }}
-                className="flex min-w-0 flex-1 cursor-pointer flex-col gap-1 border-0 bg-transparent p-0 text-left"
-            >
-                <span className="flex w-full min-w-0 items-center gap-2">
-                    <span className="min-w-0 flex-1 truncate text-sm text-colorText">
-                        {vm.title}
-                    </span>
-                    {/* An automation row IS its schedule/subscription — the kind is what tells it
-                        apart from a conversation you started (#5927). Matches SessionRow. */}
-                    {vm.automation ? <SessionAutomationKind kind={vm.automation.kind} /> : null}
+            {/* The editor REPLACES the open button rather than sitting inside it: an input is not
+                allowed inside a button, and a click in it would otherwise open the session. */}
+            {rename.renaming ? (
+                <span
+                    className="flex min-w-0 flex-1 items-center"
+                    onClick={(event) => event.stopPropagation()}
+                >
+                    <InlineRenameInput
+                        rename={rename}
+                        className="h-6 w-full min-w-0 rounded border border-solid border-colorBorder bg-colorBgContainer px-1 text-sm leading-6 text-colorText outline-none [font-family:inherit] focus:border-colorPrimary"
+                    />
                 </span>
-                {/* What actually happened, so deciding whether to reopen a session doesn't mean
-                    opening it. Absent when the title is already the message. */}
-                {vm.subtitle ? (
-                    <span className="w-full truncate text-[13px] text-colorTextTertiary">
-                        {vm.subtitle}
+            ) : (
+                <button
+                    type="button"
+                    onClick={(event) => {
+                        event.stopPropagation()
+                        onOpenRow(vm)
+                    }}
+                    className="flex min-w-0 flex-1 cursor-pointer flex-col gap-1 border-0 bg-transparent p-0 text-left"
+                >
+                    <span className="flex w-full min-w-0 items-center gap-2">
+                        <span className="min-w-0 flex-1 truncate text-sm text-colorText">
+                            {vm.title}
+                        </span>
+                        {/* An automation row IS its schedule/subscription — the kind is what tells it
+                        apart from a conversation you started (#5927). Matches SessionRow. */}
+                        {vm.automation ? <SessionAutomationKind kind={vm.automation.kind} /> : null}
                     </span>
-                ) : null}
-            </button>
+                    {/* What actually happened, so deciding whether to reopen a session doesn't mean
+                    opening it. Absent when the title is already the message. */}
+                    {vm.subtitle ? (
+                        <span className="w-full truncate text-[13px] text-colorTextTertiary">
+                            {vm.subtitle}
+                        </span>
+                    ) : null}
+                </button>
+            )}
 
             {/* h-5 = the title's line box, so the trailing controls centre on the TITLE rather
                 than on a row whose height the subtitle decides. */}
@@ -144,7 +187,7 @@ const Row = ({
             exit="exit"
             className="overflow-hidden"
         >
-            <SessionRowContextMenu entries={entries} onSelect={(key) => onMenuSelect?.(vm, key)}>
+            <SessionRowContextMenu entries={entries} onSelect={onSelect}>
                 {row}
             </SessionRowContextMenu>
         </motion.div>
@@ -156,6 +199,7 @@ export const SessionCardList = ({
     onOpenRow,
     menuFor,
     onMenuSelect,
+    onRenameRow,
     showAgent,
     alwaysShowPin = false,
     ...listArgs
@@ -205,6 +249,7 @@ export const SessionCardList = ({
                         onTogglePin={togglePin}
                         menuFor={menuFor}
                         onMenuSelect={onMenuSelect}
+                        onRenameRow={onRenameRow}
                     />
                 )),
             ]),
@@ -217,6 +262,7 @@ export const SessionCardList = ({
             togglePin,
             menuFor,
             onMenuSelect,
+            onRenameRow,
         ],
     )
 

--- a/web/packages/agenta-sessions-ui/src/SessionListCard.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionListCard.tsx
@@ -28,6 +28,8 @@ export interface SessionListCardProps {
     onOpenRow: SessionCardListProps["onOpenRow"]
     menuFor?: SessionCardListProps["menuFor"]
     onMenuSelect?: SessionCardListProps["onMenuSelect"]
+    /** Supply it and a row renames in place from its menu; omit it and the entry is inert. */
+    onRenameRow?: SessionCardListProps["onRenameRow"]
 }
 
 const WAITING_BADGE_CLASS =
@@ -70,6 +72,7 @@ export const SessionListCard = ({
     onOpenRow,
     menuFor,
     onMenuSelect,
+    onRenameRow,
 }: SessionListCardProps) => {
     // Only the header badge reads the list here; the shared card list runs the same hook (one
     // query — the args match, so the fetch is shared through the query cache).
@@ -126,6 +129,7 @@ export const SessionListCard = ({
                 onOpenRow={onOpenRow}
                 menuFor={menuFor}
                 onMenuSelect={onMenuSelect}
+                onRenameRow={onRenameRow}
             />
         </PanelSection>
     )

--- a/web/packages/agenta-sessions-ui/src/SessionListPanel.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionListPanel.tsx
@@ -29,6 +29,8 @@ export interface SessionListPanelProps {
     /** Host verb: the row context menu. Omit on touch surfaces that have no menu. */
     menuFor?: (vm: SessionRowVm) => SessionMenuEntry[]
     onMenuSelect?: (vm: SessionRowVm, key: string) => void
+    /** Supply it and a row renames in place from its menu; omit it and the entry is inert. */
+    onRenameRow?: (vm: SessionRowVm, name: string) => Promise<boolean>
     /** Keep the pin affordance visible without hover — touch has none. */
     alwaysShowPin?: boolean
 }
@@ -50,6 +52,7 @@ export const SessionListPanel = ({
     onOpenRow,
     menuFor,
     onMenuSelect,
+    onRenameRow,
     alwaysShowPin,
 }: SessionListPanelProps) => {
     // Only the header badge reads the list here; the shared card list runs the same hook (one
@@ -110,6 +113,7 @@ export const SessionListPanel = ({
                 onOpenRow={onOpenRow}
                 menuFor={menuFor}
                 onMenuSelect={onMenuSelect}
+                onRenameRow={onRenameRow}
                 alwaysShowPin={alwaysShowPin}
             />
         </PanelSection>

--- a/web/packages/agenta-sessions-ui/src/SessionRow.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionRow.tsx
@@ -19,6 +19,7 @@ import {SessionAgentName} from "./SessionAgentName"
 import {SessionAutomationKind} from "./SessionAutomationKind"
 import {SessionPinButton} from "./SessionPinButton"
 import {SessionStatusIcon} from "./SessionStatusIcon"
+import {useDeferredMenuSelect, type MenuSelect} from "./useDeferredMenuSelect"
 import type {InlineRename} from "./useInlineRename"
 
 export interface SessionRowProps {
@@ -34,7 +35,8 @@ export interface SessionRowProps {
     renderAgent?: (agentId: string | null) => ReactNode
     /** The app's verbs for this row, in the neutral shape. No items → no kebab. */
     menuItems?: SessionMenuEntry[]
-    onMenuSelect?: (key: string) => void
+    /** Runs the verb; a returned function is deferred until the menu closes. */
+    onMenuSelect?: MenuSelect
     /**
      * The row's rename-in-place state, owned by the caller so the kebab and the right-click menu
      * that wraps the row drive the same edit. Absent, the title is never editable.
@@ -59,6 +61,9 @@ const SessionRowImpl = ({
     const handleOpen = () => {
         if (openable) onOpen?.()
     }
+    // The kebab honours the same close handoff the right-click menu does, so "Rename" opens the
+    // editor from either one.
+    const {handleSelect, handleCloseAutoFocus} = useDeferredMenuSelect(onMenuSelect)
 
     return (
         // A plain container, not an ARIA button: descendants of a button role are
@@ -179,6 +184,7 @@ const SessionRowImpl = ({
                         <DropdownMenuContent
                             align="end"
                             onClick={(event) => event.stopPropagation()}
+                            onCloseAutoFocus={handleCloseAutoFocus}
                         >
                             {menuItems.map((entry, index) =>
                                 isMenuDivider(entry) ? (
@@ -190,7 +196,7 @@ const SessionRowImpl = ({
                                         variant={entry.danger ? "destructive" : "default"}
                                         onSelect={(event) => {
                                             event.stopPropagation()
-                                            onMenuSelect?.(entry.key)
+                                            handleSelect(entry.key)
                                         }}
                                     >
                                         {entry.icon ? (

--- a/web/packages/agenta-sessions-ui/src/SessionRowContextMenu.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionRowContextMenu.tsx
@@ -1,4 +1,4 @@
-import {useCallback, useRef, type ReactElement} from "react"
+import type {ReactElement} from "react"
 
 import {
     ContextMenu,
@@ -9,20 +9,14 @@ import {
 } from "@agenta/ui/ui"
 
 import {isMenuDivider, type SessionMenuEntry} from "./menu"
+import {useDeferredMenuSelect, type MenuSelect} from "./useDeferredMenuSelect"
 
 export interface SessionRowContextMenuProps {
     /** The row's verbs. Empty or absent renders the row bare — no menu, no wrapper. */
     entries?: SessionMenuEntry[]
-    /**
-     * Runs the verb. Return `true` when the verb PUT THE CARET SOMEWHERE ITSELF — the inline
-     * rename editor is the only one that does.
-     *
-     * Radix returns focus to the trigger as the menu closes, which lands AFTER the editor's
-     * `autoFocus`. The editor then blurs, and a blur commits and closes it — so "Rename" opened
-     * an input the user never saw. A `true` here suppresses that one focus restore. Every other
-     * verb keeps it, because returning the caret to the row is the correct behaviour for them.
-     */
-    onSelect?: (key: string) => boolean | void
+    /** Runs the verb. Return a function to defer it until the menu closes — see
+     * `useDeferredMenuSelect`, which the row kebab shares. */
+    onSelect?: MenuSelect
     /** The row itself; it becomes the trigger, so it must forward a ref (`asChild`). */
     children: ReactElement
 }
@@ -38,21 +32,7 @@ export const SessionRowContextMenu = ({
     onSelect,
     children,
 }: SessionRowContextMenuProps) => {
-    // Set during `onSelect`, read one tick later by `onCloseAutoFocus`. A ref, not state: the
-    // close happens in the same commit as the select, so a re-render would be too late.
-    const keepFocusRef = useRef(false)
-
-    const handleSelect = useCallback(
-        (key: string) => {
-            keepFocusRef.current = onSelect?.(key) === true
-        },
-        [onSelect],
-    )
-
-    const handleCloseAutoFocus = useCallback((event: Event) => {
-        if (keepFocusRef.current) event.preventDefault()
-        keepFocusRef.current = false
-    }, [])
+    const {handleSelect, handleCloseAutoFocus} = useDeferredMenuSelect(onSelect)
 
     if (!entries || entries.length === 0) return children
 

--- a/web/packages/agenta-sessions-ui/src/SessionRowContextMenu.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionRowContextMenu.tsx
@@ -1,4 +1,4 @@
-import type {ReactElement} from "react"
+import {useCallback, useRef, type ReactElement} from "react"
 
 import {
     ContextMenu,
@@ -13,7 +13,16 @@ import {isMenuDivider, type SessionMenuEntry} from "./menu"
 export interface SessionRowContextMenuProps {
     /** The row's verbs. Empty or absent renders the row bare — no menu, no wrapper. */
     entries?: SessionMenuEntry[]
-    onSelect?: (key: string) => void
+    /**
+     * Runs the verb. Return `true` when the verb PUT THE CARET SOMEWHERE ITSELF — the inline
+     * rename editor is the only one that does.
+     *
+     * Radix returns focus to the trigger as the menu closes, which lands AFTER the editor's
+     * `autoFocus`. The editor then blurs, and a blur commits and closes it — so "Rename" opened
+     * an input the user never saw. A `true` here suppresses that one focus restore. Every other
+     * verb keeps it, because returning the caret to the row is the correct behaviour for them.
+     */
+    onSelect?: (key: string) => boolean | void
     /** The row itself; it becomes the trigger, so it must forward a ref (`asChild`). */
     children: ReactElement
 }
@@ -29,12 +38,28 @@ export const SessionRowContextMenu = ({
     onSelect,
     children,
 }: SessionRowContextMenuProps) => {
+    // Set during `onSelect`, read one tick later by `onCloseAutoFocus`. A ref, not state: the
+    // close happens in the same commit as the select, so a re-render would be too late.
+    const keepFocusRef = useRef(false)
+
+    const handleSelect = useCallback(
+        (key: string) => {
+            keepFocusRef.current = onSelect?.(key) === true
+        },
+        [onSelect],
+    )
+
+    const handleCloseAutoFocus = useCallback((event: Event) => {
+        if (keepFocusRef.current) event.preventDefault()
+        keepFocusRef.current = false
+    }, [])
+
     if (!entries || entries.length === 0) return children
 
     return (
         <ContextMenu>
             <ContextMenuTrigger asChild>{children}</ContextMenuTrigger>
-            <ContextMenuContent>
+            <ContextMenuContent onCloseAutoFocus={handleCloseAutoFocus}>
                 {entries.map((entry, index) =>
                     isMenuDivider(entry) ? (
                         <ContextMenuSeparator key={`divider-${index}`} />
@@ -43,7 +68,7 @@ export const SessionRowContextMenu = ({
                             key={entry.key}
                             disabled={entry.disabled}
                             variant={entry.danger ? "destructive" : undefined}
-                            onSelect={() => onSelect?.(entry.key)}
+                            onSelect={() => handleSelect(entry.key)}
                         >
                             {entry.icon ? (
                                 <span className="flex shrink-0 items-center">{entry.icon}</span>

--- a/web/packages/agenta-sessions-ui/src/SessionTabRail.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionTabRail.tsx
@@ -23,11 +23,13 @@ import {Skeleton, SimpleTooltip} from "@agenta/ui/ui"
 import clsx from "clsx"
 import {useAtomValue, useSetAtom} from "jotai"
 
+import InlineRenameInput from "./InlineRenameInput"
 import {type SessionMenuEntry} from "./menu"
 import {SessionRowContextMenu} from "./SessionRowContextMenu"
 import {SessionTab} from "./SessionTab"
 import {SessionTabDragItem} from "./SessionTabDragItem"
 import {SessionTabStrip} from "./SessionTabStrip"
+import {useInlineRename} from "./useInlineRename"
 
 export interface SessionTabRailProps extends UseSessionCardListArgs {
     /** The session on screen — its chip is the active one. */
@@ -48,6 +50,12 @@ export interface SessionTabRailProps extends UseSessionCardListArgs {
      */
     menuFor?: (vm: SessionRowVm) => SessionMenuEntry[]
     onMenuSelect?: (vm: SessionRowVm, key: string) => void
+    /**
+     * Persists a rename. Given this, a chip renames IN PLACE from its menu, the way a row does on
+     * every list. Without it the "rename" key falls through to `onMenuSelect` and the entry is
+     * inert, which is what it was here.
+     */
+    onRenameRow?: (vm: SessionRowVm, name: string) => Promise<boolean>
     /**
      * Drag to hand-arrange the tabs, persisted per agent. On by default — a tab strip is a place
      * users expect to arrange. Off leaves the rail in list order.
@@ -71,6 +79,7 @@ const RailTab = ({
     onSelect,
     menuFor,
     onMenuSelect,
+    onRenameRow,
     draggable,
 }: {
     vm: SessionRowVm
@@ -78,6 +87,7 @@ const RailTab = ({
     onSelect: (vm: SessionRowVm) => void
     menuFor?: (vm: SessionRowVm) => SessionMenuEntry[]
     onMenuSelect?: (vm: SessionRowVm, key: string) => void
+    onRenameRow?: (vm: SessionRowVm, name: string) => Promise<boolean>
     /** A drag slot only inside a reorder group — a lone `Reorder.Item` has no context to drag in. */
     draggable: boolean
 }) => {
@@ -103,12 +113,35 @@ const RailTab = ({
         }
     }, [active])
     const handleSelect = useCallback(() => onSelect(vm), [onSelect, vm])
+    const onRename = useMemo(
+        () => (onRenameRow ? (name: string) => onRenameRow(vm, name) : undefined),
+        [onRenameRow, vm],
+    )
+    const rename = useInlineRename({current: vm.title, onCommit: onRename ?? (async () => false)})
+    const handleMenuSelect = useCallback(
+        (key: string) => {
+            // Deferred, not run here: an input that mounts inside the menu's focus trap is
+            // blurred straight back out, and a blur commits. See `useDeferredMenuSelect`.
+            if (key === "rename" && onRename) return () => rename.start()
+            onMenuSelect?.(vm, key)
+        },
+        [onMenuSelect, onRename, rename, vm],
+    )
 
     const chip = (
-        <SessionRowContextMenu entries={menuFor?.(vm)} onSelect={(key) => onMenuSelect?.(vm, key)}>
+        <SessionRowContextMenu entries={menuFor?.(vm)} onSelect={handleMenuSelect}>
             <SessionTab
                 active={active}
-                label={vm.title}
+                label={
+                    rename.renaming ? (
+                        <InlineRenameInput
+                            rename={rename}
+                            className="h-5 w-full min-w-0 rounded border border-solid border-colorBorder bg-colorBgContainer px-1 text-xs leading-5 text-colorText outline-none [font-family:inherit] focus:border-colorPrimary"
+                        />
+                    ) : (
+                        vm.title
+                    )
+                }
                 onSelect={handleSelect}
                 statusDot={
                     <SimpleTooltip title={vm.status.label}>
@@ -177,6 +210,7 @@ export const SessionTabRail = ({
     activeFallbackTitle,
     menuFor,
     onMenuSelect,
+    onRenameRow,
     reorderable = true,
     className,
     ...listArgs
@@ -228,6 +262,7 @@ export const SessionTabRail = ({
                           vm={vm}
                           active={vm.id === activeSessionId}
                           onSelect={onSelect}
+                          onRenameRow={onRenameRow}
                           draggable={reorderable}
                           menuFor={(row) => [
                               ...(menuFor?.(row) ?? []),

--- a/web/packages/agenta-sessions-ui/src/SessionsListView.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionsListView.tsx
@@ -76,10 +76,10 @@ const SessionsListRow = ({
 
     const onSelect = useCallback(
         (key: string) => {
-            if (key === "rename" && onRename) {
-                rename.start()
-                return
-            }
+            // Deferred, not run here: the editor must not mount inside the menu's focus trap.
+            // See `SessionRowContextMenu`. The row's kebab calls this too, where nothing defers
+            // it — the returned function is simply dropped and the menu's own close focuses it.
+            if (key === "rename" && onRename) return () => rename.start()
             onMenuSelect?.(vm, key)
         },
         [onMenuSelect, onRename, rename, vm],

--- a/web/packages/agenta-sessions-ui/src/index.ts
+++ b/web/packages/agenta-sessions-ui/src/index.ts
@@ -62,4 +62,5 @@ export {
 export {default as SessionRowActions, type SessionRowTarget} from "./SessionRowActions"
 export {default as InlineRenameInput} from "./InlineRenameInput"
 export {useInlineRename, type InlineRename} from "./useInlineRename"
+export {useDeferredMenuSelect, type MenuSelect} from "./useDeferredMenuSelect"
 export {useSessionRowChrome, type SessionRowChrome} from "./useSessionRowChrome"

--- a/web/packages/agenta-sessions-ui/src/useDeferredMenuSelect.ts
+++ b/web/packages/agenta-sessions-ui/src/useDeferredMenuSelect.ts
@@ -1,0 +1,40 @@
+import {useCallback, useRef} from "react"
+
+/** A menu verb. Return a function to have it run once the menu has closed. */
+export type MenuSelect = (key: string) => (() => void) | void
+
+/**
+ * The close handoff every session menu shares.
+ *
+ * A menu item's `onSelect` runs while the menu is still open and still holding a focus trap, and
+ * Radix then restores focus to the trigger as the menu closes. Work that PUTS THE CARET somewhere
+ * — the inline rename editor is the only such verb — is blurred twice over if it runs there, and
+ * a blur commits and closes the editor. So a verb may hand its work back as a function: it runs
+ * from the close, after the trap is released, and the focus restore that would have undone it is
+ * suppressed for that one close. Every other verb keeps the restore, because putting the caret
+ * back on the row is the right behaviour for them.
+ *
+ * Shared so the right-click menu, the row kebab and the rail kebab cannot drift on it.
+ */
+export const useDeferredMenuSelect = (onSelect?: MenuSelect) => {
+    // Held between the select and the close. A ref, not state: nothing renders from it, and the
+    // close handler must read what the select just wrote without waiting for a commit.
+    const deferredRef = useRef<(() => void) | null>(null)
+
+    const handleSelect = useCallback(
+        (key: string) => {
+            deferredRef.current = onSelect?.(key) ?? null
+        },
+        [onSelect],
+    )
+
+    const handleCloseAutoFocus = useCallback((event: Event) => {
+        const deferred = deferredRef.current
+        deferredRef.current = null
+        if (!deferred) return
+        event.preventDefault()
+        deferred()
+    }, [])
+
+    return {handleSelect, handleCloseAutoFocus}
+}

--- a/web/packages/agenta-sessions-ui/src/useSessionActions.tsx
+++ b/web/packages/agenta-sessions-ui/src/useSessionActions.tsx
@@ -250,10 +250,20 @@ export const useSessionActions = ({localCache, sharePathFor}: UseSessionActionsO
         [pinnedSet, sharePathFor],
     )
 
+    /**
+     * Routes a menu key to its verb.
+     *
+     * "rename" is the one key this hook cannot finish on its own: the edit happens IN the row, and
+     * only the surface knows which row that is. So it travels back out as `onRename`, the same way
+     * "open" does. A surface that renders the "rename" entry MUST supply it, or hand the key to a
+     * component that starts the edit itself (`SessionsListView`, `SessionRowActions`) — otherwise
+     * the entry is dead. It was dead on the chat tab strip and the card lists until now.
+     */
     const onMenuClick = useCallback(
-        (target: SessionActionTarget, options?: {onOpen?: () => void}) =>
+        (target: SessionActionTarget, options?: {onOpen?: () => void; onRename?: () => void}) =>
             ({key}: {key: string}) => {
                 if (key === "open") options?.onOpen?.()
+                if (key === "rename") options?.onRename?.()
                 if (key === "pin") togglePin(target.sessionId)
                 if (key === "copy-link") void copyShareLink(target)
                 if (key === "archive") void setArchived(target)

--- a/web/packages/agenta-sessions-ui/tests/unit/SessionCardListRename.test.tsx
+++ b/web/packages/agenta-sessions-ui/tests/unit/SessionCardListRename.test.tsx
@@ -1,0 +1,179 @@
+/**
+ * Renaming a card-list row from its context menu.
+ *
+ * The card list is what the mobile chat panes, both agent overviews and both homes render, and
+ * its "Rename" entry did nothing at all. This drives the real row: pick the entry, let the menu
+ * close, and the row must swap its title for an input that saves what you type.
+ */
+import {act, createElement, type ReactNode} from "react"
+import {createRoot, type Root} from "react-dom/client"
+
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+const menuStub = vi.hoisted(() => ({
+    onCloseAutoFocus: undefined as ((event: Event) => void) | undefined,
+}))
+
+vi.mock("@agenta/shared/utils", () => ({timeAgo: () => "now"}))
+vi.mock("@agenta/sessions/row", () => ({pendingGateLabel: () => "Waiting"}))
+vi.mock("@agenta/sessions/state", () => ({
+    useSessionCardList: () => ({
+        isPending: false,
+        groups: [
+            {
+                key: "recent",
+                label: null,
+                rows: [
+                    {
+                        id: "session-1",
+                        title: "Old name",
+                        subtitle: null,
+                        status: {label: "Idle", dotClassName: "", pulse: false, chipLabel: null},
+                        pending: undefined,
+                        agentId: "agent-1",
+                        activityAt: null,
+                        automation: null,
+                        isPinned: false,
+                        stream: {session_id: "session-1"},
+                    },
+                ],
+            },
+        ],
+    }),
+    useSessionPins: () => ({toggle: vi.fn()}),
+}))
+vi.mock("motion/react", async () => {
+    const {createElement} = await import("react")
+    return {
+        AnimatePresence: ({children}: {children: ReactNode}) => children,
+        MotionConfig: ({children}: {children: ReactNode}) => children,
+        motion: new Proxy(
+            {},
+            {
+                get: () => (props: Record<string, unknown> & {children?: ReactNode}) =>
+                    createElement("div", null, props.children),
+            },
+        ),
+    }
+})
+vi.mock("@agenta/ui/ui", async () => {
+    const {createElement} = await import("react")
+    return {
+        SimpleTooltip: ({children}: {children: ReactNode}) => children,
+        SkeletonBlock: () => null,
+        ContextMenu: ({children}: {children: ReactNode}) => children,
+        ContextMenuTrigger: ({children}: {children: ReactNode}) => children,
+        ContextMenuContent: ({
+            children,
+            onCloseAutoFocus,
+        }: {
+            children: ReactNode
+            onCloseAutoFocus?: (event: Event) => void
+        }) => {
+            menuStub.onCloseAutoFocus = onCloseAutoFocus
+            return createElement("div", null, children)
+        },
+        ContextMenuItem: ({children, onSelect}: {children: ReactNode; onSelect?: () => void}) =>
+            createElement("button", {onClick: onSelect}, children),
+        ContextMenuSeparator: () => createElement("hr"),
+    }
+})
+vi.mock("../../src/SessionAgentName", () => ({SessionAgentName: () => null}))
+vi.mock("../../src/SessionAutomationKind", () => ({SessionAutomationKind: () => null}))
+vi.mock("../../src/SessionPinButton", () => ({SessionPinButton: () => null}))
+
+import {SessionCardList} from "../../src/SessionCardList"
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+})
+
+afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    menuStub.onCloseAutoFocus = undefined
+    vi.clearAllMocks()
+})
+
+const render = (onRenameRow?: (vm: {id: string}, name: string) => Promise<boolean>) =>
+    act(() =>
+        root.render(
+            createElement(SessionCardList, {
+                emptyText: "none",
+                onOpenRow: vi.fn(),
+                menuFor: () => [{key: "rename", label: "Rename"}],
+                onMenuSelect: vi.fn(),
+                onRenameRow,
+            } as never),
+        ),
+    )
+
+/** Picks "Rename", then runs the close the menu would run. */
+const chooseRename = () => {
+    const item = Array.from(container.querySelectorAll("button")).find(
+        (element) => element.textContent === "Rename",
+    )
+    act(() => item?.dispatchEvent(new MouseEvent("click", {bubbles: true})))
+    act(() => menuStub.onCloseAutoFocus?.(new Event("closeAutoFocus", {cancelable: true})))
+}
+
+describe("SessionCardList rename", () => {
+    it("shows the title and no editor at rest", () => {
+        render(async () => true)
+
+        expect(container.textContent).toContain("Old name")
+        expect(container.querySelectorAll("input")).toHaveLength(0)
+    })
+
+    it("swaps the title for an editor seeded with the current name", () => {
+        render(async () => true)
+
+        chooseRename()
+
+        const input = container.querySelector("input")
+        expect(input).not.toBeNull()
+        expect(input?.value).toBe("Old name")
+    })
+
+    it("saves what you type when you press Enter", async () => {
+        const onRenameRow = vi.fn(async () => true)
+        render(onRenameRow)
+        chooseRename()
+
+        // Re-queried at every step: the row re-renders on each keystroke and hands back a new
+        // input node, so a reference held from before the change is detached and hears nothing.
+        const liveInput = () => container.querySelector("input")
+        const nativeValue = Object.getOwnPropertyDescriptor(
+            HTMLInputElement.prototype,
+            "value",
+        )?.set
+        act(() => {
+            const input = liveInput()
+            nativeValue?.call(input, "New name")
+            input?.dispatchEvent(new InputEvent("input", {bubbles: true}))
+        })
+        await act(async () => {
+            liveInput()?.dispatchEvent(new KeyboardEvent("keydown", {key: "Enter", bubbles: true}))
+        })
+
+        expect(onRenameRow).toHaveBeenCalledWith(
+            expect.objectContaining({id: "session-1"}),
+            "New name",
+        )
+        expect(container.querySelectorAll("input")).toHaveLength(0)
+    })
+
+    it("leaves the row alone where the host cannot persist a rename", () => {
+        render(undefined)
+
+        chooseRename()
+
+        expect(container.querySelectorAll("input")).toHaveLength(0)
+    })
+})

--- a/web/packages/agenta-sessions-ui/tests/unit/sessionRenameMenu.test.tsx
+++ b/web/packages/agenta-sessions-ui/tests/unit/sessionRenameMenu.test.tsx
@@ -140,14 +140,14 @@ describe("onMenuClick", () => {
     })
 })
 
-describe("SessionRowContextMenu focus contract", () => {
+describe("the menu's close handoff", () => {
     const entries = [
         {key: "rename", label: "Rename"},
         {key: "archive", label: "Archive"},
     ]
 
-    /** Renders the wrapper, clicks one entry, then runs the close handler Radix would run. */
-    const selectThenClose = (key: string, onSelect: (selected: string) => boolean | void) => {
+    /** Clicks one entry, then runs the close handler Radix runs as the menu unmounts. */
+    const selectThenClose = (label: string, onSelect: (key: string) => (() => void) | void) => {
         act(() =>
             root.render(
                 createElement(
@@ -158,7 +158,7 @@ describe("SessionRowContextMenu focus contract", () => {
             ),
         )
         const button = Array.from(container.querySelectorAll("button")).find(
-            (element) => element.textContent === (key === "rename" ? "Rename" : "Archive"),
+            (element) => element.textContent === label,
         )
         act(() => button?.dispatchEvent(new MouseEvent("click", {bubbles: true})))
 
@@ -167,17 +167,44 @@ describe("SessionRowContextMenu focus contract", () => {
         return event.defaultPrevented
     }
 
-    // Without this the tab chip's input mounts, Radix pulls focus back to the row, the blur
-    // commits, and the editor is gone before the user sees it.
-    it("keeps the caret where a verb that opened an editor put it", () => {
-        expect(selectThenClose("rename", (selected) => selected === "rename")).toBe(true)
+    // The editor must not mount while the menu still holds its focus trap: the trap blurs it
+    // straight back out, and a blur commits and closes it.
+    it("runs deferred work after the menu closes, not during the select", () => {
+        const ran: string[] = []
+        const restored = selectThenClose("Rename", () => {
+            ran.push("select")
+            return () => ran.push("close")
+        })
+
+        expect(ran).toEqual(["select", "close"])
+        expect(restored).toBe(true)
     })
 
-    it("restores focus to the row for every other verb", () => {
-        expect(selectThenClose("archive", (selected) => selected === "rename")).toBe(false)
+    it("restores focus to the row for a verb that defers nothing", () => {
+        expect(selectThenClose("Archive", () => undefined)).toBe(false)
     })
 
-    it("restores focus where the surface cannot rename in place", () => {
-        expect(selectThenClose("rename", () => undefined)).toBe(false)
+    it("drops the deferred work when a later select supersedes it", () => {
+        const deferred = vi.fn()
+        act(() =>
+            root.render(
+                createElement(
+                    SessionRowContextMenu,
+                    {entries, onSelect: (key: string) => (key === "rename" ? deferred : undefined)},
+                    createElement("div", null, "row"),
+                ),
+            ),
+        )
+        const click = (label: string) =>
+            act(() =>
+                Array.from(container.querySelectorAll("button"))
+                    .find((element) => element.textContent === label)
+                    ?.dispatchEvent(new MouseEvent("click", {bubbles: true})),
+            )
+        click("Rename")
+        click("Archive")
+        act(() => menuStub.onCloseAutoFocus?.(new Event("closeAutoFocus", {cancelable: true})))
+
+        expect(deferred).not.toHaveBeenCalled()
     })
 })

--- a/web/packages/agenta-sessions-ui/tests/unit/sessionRenameMenu.test.tsx
+++ b/web/packages/agenta-sessions-ui/tests/unit/sessionRenameMenu.test.tsx
@@ -1,0 +1,183 @@
+/**
+ * The "Rename" menu entry, end to end through the shared layer.
+ *
+ * The entry shipped on every session surface but `onMenuClick` had no branch for its key, so on
+ * the chat tab strip and the card lists it did nothing at all. These lock both halves of the fix:
+ * the key reaches the surface, and the surface keeps the caret it just claimed.
+ */
+import {act, createElement, type ReactNode} from "react"
+import {createRoot, type Root} from "react-dom/client"
+
+import {atom} from "jotai"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+vi.mock("@agenta/entities/session", () => ({
+    archiveSessionRemote: vi.fn(async () => true),
+    deleteSessionRemote: vi.fn(async () => true),
+    setSessionHeader: vi.fn(async () => true),
+    unarchiveSessionRemote: vi.fn(async () => true),
+}))
+vi.mock("@agenta/sessions/link", () => ({shareUrl: (path: string) => path}))
+vi.mock("@agenta/sessions/state", () => ({
+    pinnedSessionIdsAtom: atom<string[]>([]),
+    toggleSessionPinAtom: atom(null, () => undefined),
+}))
+vi.mock("@agenta/shared/state", () => ({projectIdAtom: atom("project-1")}))
+vi.mock("@agenta/ui/app-message", () => ({
+    message: {error: vi.fn(), success: vi.fn()},
+    modal: {confirm: vi.fn()},
+}))
+vi.mock("@agenta/ui/utils", () => ({copyToClipboard: vi.fn(async () => true)}))
+vi.mock("@tanstack/react-query", () => ({
+    useQueryClient: () => ({
+        invalidateQueries: vi.fn(),
+        setQueriesData: vi.fn(),
+    }),
+}))
+
+/** Radix portals nothing jsdom can lay out, so the primitives are stubbed and the content
+ * element's `onCloseAutoFocus` is captured — that handler IS the focus contract under test. */
+const menuStub = vi.hoisted(() => ({
+    onCloseAutoFocus: undefined as ((event: Event) => void) | undefined,
+}))
+vi.mock("@agenta/ui/ui", async () => {
+    const {createElement} = await import("react")
+    return {
+        ContextMenu: ({children}: {children: ReactNode}) => children,
+        ContextMenuTrigger: ({children}: {children: ReactNode}) => children,
+        ContextMenuContent: ({
+            children,
+            onCloseAutoFocus,
+        }: {
+            children: ReactNode
+            onCloseAutoFocus?: (event: Event) => void
+        }) => {
+            menuStub.onCloseAutoFocus = onCloseAutoFocus
+            return createElement("div", null, children)
+        },
+        ContextMenuItem: ({
+            children,
+            onSelect,
+            disabled,
+        }: {
+            children: ReactNode
+            onSelect?: () => void
+            disabled?: boolean
+        }) => createElement("button", {disabled, onClick: onSelect}, children),
+        ContextMenuSeparator: () => createElement("hr"),
+    }
+})
+
+import {SessionRowContextMenu} from "../../src/SessionRowContextMenu"
+import {useSessionActions} from "../../src/useSessionActions"
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+})
+
+afterEach(() => {
+    act(() => root.unmount())
+    container.remove()
+    vi.clearAllMocks()
+})
+
+const target = {sessionId: "session-1", appId: "agent-1", name: "Old name", archived: false}
+
+/** Renders the hook once and hands back its return value. */
+const readActions = () => {
+    let actions: ReturnType<typeof useSessionActions> | null = null
+    const Probe = () => {
+        actions = useSessionActions({sharePathFor: () => "/s/session-1"})
+        return null
+    }
+    act(() => root.render(createElement(Probe)))
+    if (!actions) throw new Error("hook did not run")
+    return actions as ReturnType<typeof useSessionActions>
+}
+
+describe("onMenuClick", () => {
+    it("routes the rename key to the surface that owns the editor", () => {
+        const onRename = vi.fn()
+        const onOpen = vi.fn()
+        const actions = readActions()
+
+        act(() => actions.onMenuClick(target, {onOpen, onRename})({key: "rename"}))
+
+        expect(onRename).toHaveBeenCalledTimes(1)
+        expect(onOpen).not.toHaveBeenCalled()
+    })
+
+    it("leaves every other key alone", () => {
+        const onRename = vi.fn()
+        const onOpen = vi.fn()
+        const actions = readActions()
+
+        act(() => actions.onMenuClick(target, {onOpen, onRename})({key: "open"}))
+
+        expect(onOpen).toHaveBeenCalledTimes(1)
+        expect(onRename).not.toHaveBeenCalled()
+    })
+
+    it("does not throw where the surface renames by intercepting the key itself", () => {
+        const actions = readActions()
+
+        expect(() => act(() => actions.onMenuClick(target)({key: "rename"}))).not.toThrow()
+    })
+
+    it("offers rename on a live session and drops it on an archived one", () => {
+        const actions = readActions()
+        const keys = (entries: ReturnType<typeof actions.menuItems>) =>
+            entries.map((entry) => ("key" in entry ? entry.key : "divider"))
+
+        expect(keys(actions.menuItems(target))).toContain("rename")
+        expect(keys(actions.menuItems({...target, archived: true}))).not.toContain("rename")
+    })
+})
+
+describe("SessionRowContextMenu focus contract", () => {
+    const entries = [
+        {key: "rename", label: "Rename"},
+        {key: "archive", label: "Archive"},
+    ]
+
+    /** Renders the wrapper, clicks one entry, then runs the close handler Radix would run. */
+    const selectThenClose = (key: string, onSelect: (selected: string) => boolean | void) => {
+        act(() =>
+            root.render(
+                createElement(
+                    SessionRowContextMenu,
+                    {entries, onSelect},
+                    createElement("div", null, "row"),
+                ),
+            ),
+        )
+        const button = Array.from(container.querySelectorAll("button")).find(
+            (element) => element.textContent === (key === "rename" ? "Rename" : "Archive"),
+        )
+        act(() => button?.dispatchEvent(new MouseEvent("click", {bubbles: true})))
+
+        const event = new Event("closeAutoFocus", {cancelable: true})
+        act(() => menuStub.onCloseAutoFocus?.(event))
+        return event.defaultPrevented
+    }
+
+    // Without this the tab chip's input mounts, Radix pulls focus back to the row, the blur
+    // commits, and the editor is gone before the user sees it.
+    it("keeps the caret where a verb that opened an editor put it", () => {
+        expect(selectThenClose("rename", (selected) => selected === "rename")).toBe(true)
+    })
+
+    it("restores focus to the row for every other verb", () => {
+        expect(selectThenClose("archive", (selected) => selected === "rename")).toBe(false)
+    })
+
+    it("restores focus where the surface cannot rename in place", () => {
+        expect(selectThenClose("rename", () => undefined)).toBe(false)
+    })
+})


### PR DESCRIPTION
## Context

Fixes [#6683](https://github.com/Agenta-AI/agenta/issues/6683). Right-clicking a session tab in
the playground and choosing **Rename** did nothing: the menu closed and the label stayed as it
was. `Alt+R` on the same tab opened the editor and saved correctly, so only the menu entry was
broken.

**Not a regression in this release.** The shared menu router lost its rename branch on
2026-08-26, when the rename modal was deleted in favour of renaming in place
(`39140e65ae`, first shipped in v0.114.1). `web/packages/agenta-sessions-ui` has no commits in
`v0.115.2..release/v0.115.3`.

Two surfaces kept working and hid how wide the breakage was. The nav rail and the standalone
sessions list intercept the `rename` key themselves before it reaches the shared router. Every
surface that does not intercept it showed an entry that did nothing:

| Surface | Before | After |
|---|---|---|
| Playground session tab strip | dead | opens the tab's inline editor |
| Mobile chat session tabs | dead | renames in the chip |
| Mobile chat sessions pane and history popover | dead | renames in the row |
| Agent overview and both homes | dead | renames in the row |
| Nav rail, sessions list page | worked | unchanged, and now keeps the caret |

## Changes

**`onMenuClick` routes the rename key back out as `onRename`**, the way `open` already travels.
Only the surface knows which row holds the editor, so the shared hook cannot finish the verb on
its own.

**The playground tab strip asks through the request atom `Alt+R` already uses.** The entry and
the shortcut drive one code path, so they cannot drift.

**`SessionCardList` and `SessionTabRail` gain the in-place edit `SessionsListView` already had**,
behind a new `onRenameRow` prop threaded through `SessionListCard`, `SessionListPanel`,
`AgentOverviewBody` and `HomeOverview`.

**The menu hands editor work back to run after it closes.** A menu item's select runs while the
menu still holds a focus trap, so an editor opened there is blurred straight back out, and a blur
commits. A verb may now return a function, which the menu runs from its own close, after the trap
is released; the focus restore that would have undone it is suppressed for that one close. The
right-click menu and the row kebab share one hook, `useDeferredMenuSelect`, so they cannot drift.

## Tests

Two new suites in the owning package, 11 cases: the key routing, the archived-row exclusion, the
close handoff, and the real card-list row driven end to end (pick Rename, close the menu, type,
press Enter). Removing the editor, dropping `rename.start()`, or running the deferred work during
the select each fail the suite.

| Suite | Result |
|---|---|
| `@agenta/sessions-ui` unit | 22 passed |
| `web/oss` | 510 passed, 1 skipped |
| `web/mobile` | 188 passed |

Typecheck passes for `oss`, `mobile`, `sessions-ui`, `entity-ui` and `home-ui`. `pnpm lint-fix`
and the Prettier check are clean.

## Live QA

On this PR's Railway preview at `d31e91ba9e`, with a fresh account and one real turn. Every
surface: the menu opened the editor, the editor held the caret, a new name saved, and the name
survived a reload, which means the server stored it.

| Surface | Editor opens | Caret in editor | Saved and persisted |
|---|---|---|---|
| `/w` playground tab strip | yes | yes | yes |
| `/w` sessions list | yes | yes | yes |
| `/m` sessions list | yes | yes | yes |
| `/m` chat session tab | yes | yes | yes |
| `/m` home Sessions card | yes | yes | yes |

The intermediate build carrying only the first commit reproduced the focus defect exactly: the
editor mounted and `document.activeElement` was `BODY`. On this head it is the input.

## Known, not in scope

Codex flagged three pre-existing defects this PR does not change. `commitRename` returns `true`
even when the host's local rename returned `false`, so a failed rename reports success.
`menuItems` emits Rename whether or not the surface can start one. A rename request survives in
its atom, so closing and reopening a tab can replay a stale one, which is the same family as
[#6657](https://github.com/Agenta-AI/agenta/issues/6657).