### PR TITLE
[chore] Correct three test comments that claimed more than the tests prove

### DIFF
--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_session_context_http.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_session_context_http.py
@@ -814,15 +814,16 @@ async def test_the_unbounded_read_carries_no_deadline_of_its_own(connection, rou
     assert context.session_name == "Sapphire Ledger"
 
 
-async def test_the_client_is_always_closed_on_the_abandonment_path(
+async def test_the_clients_close_is_entered_on_the_abandonment_path(
     connection, monkeypatch
 ):
     """Abandoning the unwind must not mean skipping it.
 
-    Cancelling the task raises into the `async with`, so the client's own close runs even
-    when the caller has already been handed None. If that close then hangs there is nothing
-    further to force: httpx exposes no way past `aclose`. The guarantee this pins is that
-    the close is entered every time, and that the caller does not wait for it.
+    Cancelling the task raises into the `async with`, so the client's own close is ENTERED
+    even when the caller has already been handed None. Entered is the whole claim. This does
+    not prove the close completes, and it cannot: if `aclose` hangs there is nothing further
+    to force, because httpx exposes no way past it. So the two things pinned here are that
+    the close runs at all, and that the caller does not wait for it to finish.
     """
     monkeypatch.setattr(session_context, "CLEANUP_GRACE", 0.05)
     closed = asyncio.Event()

--- a/services/oss/tests/pytest/unit/agent/test_session_context_resolution.py
+++ b/services/oss/tests/pytest/unit/agent/test_session_context_resolution.py
@@ -45,8 +45,13 @@ class _FakeResponse:
 
 
 @pytest.fixture
-def backend_facts(monkeypatch):
-    """Stub the three backend reads the resolver makes. Returns the mutable answers."""
+def backend_facts(monkeypatch, sdk_singleton):
+    """Stub the three backend reads the resolver makes. Returns the mutable answers.
+
+    Depends on ``sdk_singleton`` to make the order real rather than assumed. Two
+    function-scoped fixtures with no dependency between them have no guaranteed order, and
+    this one sets an environment variable the other reads.
+    """
     facts: Dict[str, Any] = {
         "names": {ARTIFACT_A: "Agent A", ARTIFACT_B: "Agent B"},
         "session_name": None,
@@ -105,11 +110,13 @@ def sdk_singleton():
     before the yield.
     """
     previous = getattr(agenta_sdk, "tracing", None)
-    # This fixture sets up BEFORE `backend_facts`, so no AGENTA_API_URL is in place yet and the
-    # exporter targets the loopback host below. An AGENTA_API_URL already in the environment
-    # would still win, so this is not exporter isolation. It does not need to be: nothing here
-    # reads a span, and the exporter flushes off the request path, so a failed export cannot
-    # change a result.
+    # The host below is a preference, not isolation. `init` prefers AGENTA_API_INTERNAL_URL,
+    # then AGENTA_API_URL, over anything passed here, and either may be ambient in the
+    # process. `backend_facts` depends on this fixture so at least it cannot be the one that
+    # sets the variable first, but that is ordering, not a guarantee about the target.
+    #
+    # Isolation is not needed. Nothing here reads a span, and the exporter flushes off the
+    # request path, so wherever it points, a failed export cannot change a result.
     agenta_sdk.init(host="http://127.0.0.1:1", api_key="test-key")
     assert agenta_sdk.tracing is not None, (
         "the route needs an initialized SDK singleton"

--- a/services/oss/tests/pytest/unit/agent/test_session_context_resolution.py
+++ b/services/oss/tests/pytest/unit/agent/test_session_context_resolution.py
@@ -88,20 +88,28 @@ def backend_facts(monkeypatch):
 
 @pytest.fixture
 def sdk_singleton():
-    """Own the SDK singleton for one test, and put back whatever was there.
+    """Give one test an initialized ``ag.tracing``, and put back the one it replaced.
 
     The route runs the INSTRUMENTED handler, which reads ``ag.tracing``. Inheriting it from
     whatever else ran first in the process is not safe: under the parallel runner the worker
     that gets this file may have run nothing that initializes it, and the failure is a 500 on
     ``NoneType.get_current_span`` in the very cell that proves the artifact check works.
 
-    Restoring on the way out matters as much as setting it. ``init`` mutates a process global,
-    and leaving an unroutable host installed would follow every later test in the worker.
+    Restoring on the way out matters as much as setting it, so a host meant for this file does
+    not follow every later test in the worker. Be clear about how far that goes: this puts back
+    the ``ag.tracing`` alias and nothing else. ``init`` also replaces the SDK singleton's api,
+    async_api and tracer, and installs a provider and exporter, and those stay. It is a
+    narrower guarantee than owning the singleton, and it is the part later tests read.
+
+    Pytest also unwinds this fixture after a failing test, but not after a failure raised
+    before the yield.
     """
     previous = getattr(agenta_sdk, "tracing", None)
-    # `host` does NOT isolate the exporter here: the AGENTA_API_URL set above wins, so the
-    # background exporter really does reach for that host. Nothing in this file reads a span,
-    # and the exporter flushes off the request path, so its failures do not affect a result.
+    # This fixture sets up BEFORE `backend_facts`, so no AGENTA_API_URL is in place yet and the
+    # exporter targets the loopback host below. An AGENTA_API_URL already in the environment
+    # would still win, so this is not exporter isolation. It does not need to be: nothing here
+    # reads a span, and the exporter flushes off the request path, so a failed export cannot
+    # change a result.
     agenta_sdk.init(host="http://127.0.0.1:1", api_key="test-key")
     assert agenta_sdk.tracing is not None, (
         "the route needs an initialized SDK singleton"


### PR DESCRIPTION
## Context

Three comments and one test name in [#6667](https://github.com/Agenta-AI/agenta/pull/6667) claim more than the code does. A Codex review caught them after that PR had been approved, so they landed with it. A CodeRabbit review of this PR then found that my first attempt at one of them was wrong on two further counts. Nothing here changes behaviour, and no assertion moves.

## Changes

**A comment described an ordering pytest does not guarantee, and the fixtures now enforce it.** `sdk_singleton` and `backend_facts` are both function-scoped with no dependency between them, so their relative order is unspecified. Argument order in the test signature does not decide it. One of them sets an environment variable the other reads, so `backend_facts` now depends on `sdk_singleton` and the order is a real dependency rather than a described one.

That ordering was the smaller half. `init` prefers `AGENTA_API_INTERNAL_URL`, then `AGENTA_API_URL`, over the `host` passed to it, and derives the host from whichever is set. Either can already be in the environment, so no amount of fixture ordering settles where the exporter points. The comment no longer names a target. It says the host is a preference that either variable overrides, and keeps the claim that does hold: isolation is not needed here, because nothing reads a span and the exporter flushes off the request path, so a failed export cannot change a result.

**The fixture docstring claimed to own the SDK singleton.** It restores the `ag.tracing` alias and nothing else. `init` also replaces the singleton's `api`, `async_api`, and `tracer`, and installs a provider and exporter, and those stay. The docstring now states that narrower guarantee, and notes that pytest unwinds the fixture after a failing test but not after a failure raised before the yield.

**A test was named for a close that always happens.** `test_the_client_is_always_closed_on_the_abandonment_path` proves the context manager's exit is entered and that the caller does not wait for it. It cannot prove the close completes, and nothing can: if `aclose` hangs there is no way past it. Renamed to `test_the_clients_close_is_entered_on_the_abandonment_path`, with the limit stated.

## Tests

No test logic changed. Services unit 167 passed; the SDK session-context suite 48 passed. `ruff format` and `check` clean at the CI-pinned 0.15.12.

## Notes

Timing on the merge, not a judgment call: these were flagged in a review round that finished after #6667 was approved, and the release manager chose not to spend another CI cycle on comment-only edits. This PR can ride the next batch or move to v0.115.4.

One thing worth carrying forward. Both wrong versions of the exporter comment came from running `pytest --setup-show`, seeing an order, and writing it down as though it were guaranteed. Observing an order is not the same as pytest promising one, which is why the fix here is a dependency rather than better wording.
