### PR TITLE
fix(hosting): make the Helm chart deploy cleanly on a managed Kubernetes (GKE Autopilot)

### DIFF
--- a/hosting/kubernetes/README.md
+++ b/hosting/kubernetes/README.md
@@ -1,0 +1,206 @@
+# Agenta on Kubernetes
+
+The Helm chart in `helm/` deploys a full Agenta stack. The step-by-step guide is
+[Deploy to Kubernetes](../../docs/docs/self-host/deploy/03-deploy-to-kubernetes.mdx).
+This file is the operator reference for the values you need on a managed cluster.
+
+## What is in this directory
+
+| Path | What it is |
+| --- | --- |
+| `helm/` | The chart. `values.yaml` holds the defaults, `values.schema.json` documents and validates every key. |
+| `oss/values.oss.example.yaml` | A commented starting point for the OSS edition. |
+| `ee/values.ee.example.yaml` | The same for the Enterprise edition. |
+| `run.sh` | A wrapper around `helm upgrade --install`. Run `./hosting/kubernetes/run.sh --help`. |
+
+Copy an example to `.values.oss.yaml` or `.values.ee.yaml` next to it, fill it in,
+and `run.sh` picks it up.
+
+## What the chart deploys
+
+The api, the web app, the mobile web app, the services API, the agent runner, the
+stream worker, the queue worker, the cron loop, SuperTokens, and a migration Job.
+It can also bundle PostgreSQL, two Redis instances, and SeaweedFS, or you can
+point it at your own.
+
+The chart does not create a database, a DNS record, a TLS certificate, or a
+static IP. Bring those yourself.
+
+## Required values
+
+The chart refuses to install until these are set. Generate each key with
+`openssl rand -hex 32`.
+
+```yaml
+agenta:
+  authKey: "..."
+  cryptKey: "..."
+  servicesInternalKey: "..."
+  runnerToken: "..."
+postgres:
+  password: "..."
+ingress:
+  enabled: true
+  host: agenta.example.com
+```
+
+The public URLs are derived from `ingress.host`. Set `agenta.webUrl`,
+`agenta.apiUrl` and `agenta.servicesUrl` only if you route them somewhere else.
+
+Instead of the four keys and the password you can pre-create one Secret and set
+`secrets.existingSecret`. It must hold `AGENTA_AUTH_KEY`, `AGENTA_CRYPT_KEY`,
+`AGENTA_SERVICES_INTERNAL_KEY`, `AGENTA_RUNNER_TOKEN` and `POSTGRES_PASSWORD`.
+With the bundled PostgreSQL you must point the subchart at the same Secret:
+
+```yaml
+secrets:
+  existingSecret: agenta
+global:
+  postgresql:
+    auth:
+      existingSecret: agenta
+```
+
+## An external PostgreSQL
+
+```yaml
+postgresql:
+  enabled: false
+  external:
+    host: 10.20.30.40
+    port: 5432
+    username: agenta
+    sslmode: require
+postgres:
+  password: "..."   # or a key in secrets.existingSecret
+alembic:
+  hookPhase: pre
+```
+
+Create the three databases first. The bundled PostgreSQL creates them through an
+initdb script; an external one does not. On the OSS edition they are
+`agenta_oss_core`, `agenta_oss_tracing` and `agenta_oss_supertokens`. On the EE
+edition, `agenta_ee_*`. Override the names under `postgresql.databases`.
+
+Nothing constrains the keys under `postgresql`, so `helm install` accepts a
+misspelled one and falls back to the default. Render the chart and read the
+`POSTGRES_URI_CORE` value back before you install.
+
+`alembic.hookPhase: pre` runs the migration Job before the app pods start.
+Keep the default `post` with the bundled PostgreSQL, whose StatefulSet does not
+exist yet at pre-install time and would deadlock the Job.
+
+## A managed ingress (GKE)
+
+```yaml
+ingress:
+  enabled: true
+  className: gce
+  host: agenta.example.com
+  annotations:
+    kubernetes.io/ingress.global-static-ip-name: agenta-ip
+    networking.gke.io/managed-certificates: agenta-cert
+  paths:
+    api:       { path: /api,      pathType: ImplementationSpecific }
+    services:  { path: /services, pathType: ImplementationSpecific }
+    webMobile: { path: /m,        pathType: ImplementationSpecific }
+    web:       { path: /,         pathType: ImplementationSpecific }
+```
+
+Do not strip `/api`. The API is mounted at `/api` and its redirects keep the
+prefix. Do strip `/services`. Keep the mobile path at `/m`, because the mobile
+image is built with that basePath.
+
+The GCE ingress controller reads two annotations off each Service, so set them
+per component:
+
+```yaml
+api:
+  service:
+    annotations:
+      cloud.google.com/neg: '{"ingress": true}'
+      cloud.google.com/backend-config: '{"default": "agenta-api"}'
+web:
+  service:
+    annotations:
+      cloud.google.com/neg: '{"ingress": true}'
+```
+
+`webMobile.service.annotations` and `services.service.annotations` work the same
+way. The BackendConfig objects themselves are yours to create; put them in
+`extraObjects` if you want the release to own them.
+
+To route one more path on the same host, or a second hostname, use
+`ingress.extraPaths` and `ingress.extraHosts`. The Service must already exist in
+the namespace.
+
+```yaml
+ingress:
+  extraPaths:
+    - path: /llm
+      pathType: ImplementationSpecific
+      serviceName: litellm
+      servicePort: 4000
+  extraHosts:
+    - host: docs.example.com
+      paths:
+        - path: /
+          serviceName: docs
+          servicePort: 80
+```
+
+For TLS that you manage yourself, `ingress.tls` is a list in the shape the
+Ingress spec uses. Any non-empty list also switches the derived URLs to https.
+
+## GKE Autopilot
+
+Autopilot rejects the `SYS_ADMIN` capability and a hostPath mount of
+`/dev/fuse`. The runner asks for both when the object store is on, so that a
+local sandbox can mount the store prefix on the node. Turn it off and run
+sandboxes on Daytona instead:
+
+```yaml
+agentRunner:
+  fuse:
+    enabled: false
+  providers:
+    enabled: [daytona]
+    default: daytona
+    daytona:
+      apiKeySecretRef:
+        name: agenta-daytona
+        key: api-key
+```
+
+## The object store
+
+`store.enabled` is false by default and the whole `store` block does nothing
+until you set it. Turning it on also deploys a bundled SeaweedFS StatefulSet,
+because `store.seaweedfs.enabled` defaults to true. With your own S3 or GCS
+bucket, turn that off:
+
+```yaml
+store:
+  enabled: true
+  seaweedfs:
+    enabled: false
+  endpointUrl: https://s3.us-east-1.amazonaws.com
+  region: us-east-1
+  bucket: agenta
+  accessKey: "..."
+  secretKey: "..."
+```
+
+## Checking a values file before you install
+
+```bash
+helm lint hosting/kubernetes/helm -f my-values.yaml
+helm template agenta hosting/kubernetes/helm -f my-values.yaml
+```
+
+`values.schema.json` rejects an unknown or misspelled key, and the chart's own
+validations fail the render with a message that names the key to fix.
+
+The tests in `helm/tests/` render the chart and assert on the result. Run one
+with `uv run hosting/kubernetes/helm/tests/<name>.py`; each needs `helm` on the
+PATH.

--- a/hosting/kubernetes/README.md
+++ b/hosting/kubernetes/README.md
@@ -221,6 +221,14 @@ The Ingress renders only when the bundled SeaweedFS is deployed, and `host` is
 required once you enable it. Compose does the same thing with
 `AGENTA_STORE_TRAEFIK_ENABLE` and `AGENTA_STORE_DOMAIN`.
 
+## The runner bind address
+
+The runner binds `127.0.0.1` on its own. In a pod the kubelet connects over the
+pod IP, so a runner bound to loopback refuses every health probe and never
+becomes ready. The chart sets `AGENTA_RUNNER_HOST=0.0.0.0` for you. Change it
+with `agentRunner.host`, or through the `agentRunner.env` map, which suppresses
+the chart's entry rather than adding a second one.
+
 ## Checking a values file before you install
 
 ```bash

--- a/hosting/kubernetes/README.md
+++ b/hosting/kubernetes/README.md
@@ -98,6 +98,10 @@ ingress:
   className: gce
   host: agenta.example.com
   annotations:
+    # GKE does not act on spec.ingressClassName. The controller reads this legacy
+    # annotation, and without it the Ingress gets no events and never gets an IP.
+    # The chart always renders ingressClassName, so set both.
+    kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: agenta-ip
     networking.gke.io/managed-certificates: agenta-cert
   paths:
@@ -112,7 +116,9 @@ prefix. Do strip `/services`. Keep the mobile path at `/m`, because the mobile
 image is built with that basePath.
 
 The GCE ingress controller reads two annotations off each Service, so set them
-per component:
+per component. Set the NEG annotation yourself even on Autopilot, which adds it
+only when it creates the Service: a `helm upgrade --force` recreates Services
+without it.
 
 ```yaml
 api:

--- a/hosting/kubernetes/README.md
+++ b/hosting/kubernetes/README.md
@@ -95,12 +95,9 @@ exist yet at pre-install time and would deadlock the Job.
 ```yaml
 ingress:
   enabled: true
-  className: gce
+  className: ""            # see the note below: GKE ignores this field
   host: agenta.example.com
   annotations:
-    # GKE does not act on spec.ingressClassName. The controller reads this legacy
-    # annotation, and without it the Ingress gets no events and never gets an IP.
-    # The chart always renders ingressClassName, so set both.
     kubernetes.io/ingress.class: gce
     kubernetes.io/ingress.global-static-ip-name: agenta-ip
     networking.gke.io/managed-certificates: agenta-cert
@@ -110,6 +107,14 @@ ingress:
     webMobile: { path: /m,        pathType: ImplementationSpecific }
     web:       { path: /,         pathType: ImplementationSpecific }
 ```
+
+The GKE ingress controller ignores `spec.ingressClassName`. An Ingress carrying
+`className: gce` gets no controller events and never gets an IP, even with an
+IngressClass object present. The controller reacts only to the legacy
+`kubernetes.io/ingress.class` annotation. Set `ingress.className: ""` so the
+chart leaves the field out, and route with the annotation. An unset
+`ingress.className` still defaults to `traefik`, which is right for the bundled
+stack.
 
 Do not strip `/api`. The API is mounted at `/api` and its redirects keep the
 prefix. Do strip `/services`. Keep the mobile path at `/m`, because the mobile

--- a/hosting/kubernetes/README.md
+++ b/hosting/kubernetes/README.md
@@ -221,6 +221,35 @@ The Ingress renders only when the bundled SeaweedFS is deployed, and `host` is
 required once you enable it. Compose does the same thing with
 `AGENTA_STORE_TRAEFIK_ENABLE` and `AGENTA_STORE_DOMAIN`.
 
+## Extra environment variables
+
+`<component>.env` takes plain strings only, so it cannot reference a Secret key.
+Two more keys take raw Kubernetes entries and render verbatim after the chart's
+own variables, which means a later entry wins:
+
+```yaml
+api:
+  extraEnv:
+    - name: AGENTA_STARTER_CREDITS_BRIDGE_MASTER_KEY
+      valueFrom:
+        secretKeyRef:
+          name: agenta
+          key: AGENTA_STARTER_CREDITS_BRIDGE_MASTER_KEY
+  envFrom:
+    - secretRef:
+        name: agenta-extra
+        optional: true
+```
+
+Both work on every workload: `api`, `services`, `web`, `webMobile`, `cron`,
+`workerStreams`, `workerQueues`, `agentRunner`, `alembic` and `supertokens`.
+
+Be careful on the runner. Its environment is narrow on purpose, because a local
+harness process shares that container and can read `/proc`. Add one key at a time
+with `extraEnv`, and avoid `envFrom` there: it pulls a whole Secret and defeats
+the guard in `helm/tests/test_runner_secret_absence.py`, which can only see
+named entries.
+
 ## The runner bind address
 
 The runner binds `127.0.0.1` on its own. In a pod the kubelet connects over the

--- a/hosting/kubernetes/README.md
+++ b/hosting/kubernetes/README.md
@@ -191,6 +191,36 @@ store:
   secretKey: "..."
 ```
 
+### Reaching the bundled store from outside the cluster
+
+Pods reach the bundled gateway through its in-cluster Service, and that is the
+default. A Daytona sandbox runs outside the cluster and cannot resolve that name,
+so give the gateway a hostname and point every pod at it. Set both keys:
+
+```yaml
+store:
+  enabled: true
+  endpointUrl: https://store.example.com    # what pods and sandboxes are told to use
+  seaweedfs:
+    enabled: true
+    ingress:
+      enabled: true                         # default false
+      className: gce
+      host: store.example.com
+      annotations:
+        kubernetes.io/ingress.global-static-ip-name: agenta-store-ip
+      tls:
+        - hosts:
+            - store.example.com
+          secretName: agenta-store-tls
+```
+
+`store.endpointUrl` wins over the internal Service URL whenever it is set, with
+or without the bundled SeaweedFS. Leave it unset to keep the store internal.
+The Ingress renders only when the bundled SeaweedFS is deployed, and `host` is
+required once you enable it. Compose does the same thing with
+`AGENTA_STORE_TRAEFIK_ENABLE` and `AGENTA_STORE_DOMAIN`.
+
 ## Checking a values file before you install
 
 ```bash

--- a/hosting/kubernetes/README.md
+++ b/hosting/kubernetes/README.md
@@ -8,7 +8,7 @@ This file is the operator reference for the values you need on a managed cluster
 
 | Path | What it is |
 | --- | --- |
-| `helm/` | The chart. `values.yaml` holds the defaults, `values.schema.json` documents and validates every key. |
+| `helm/` | The chart. `values.yaml` holds the defaults, and `values.schema.json` documents and validates declared fields. |
 | `oss/values.oss.example.yaml` | A commented starting point for the OSS edition. |
 | `ee/values.ee.example.yaml` | The same for the Enterprise edition. |
 | `run.sh` | A wrapper around `helm upgrade --install`. Run `./hosting/kubernetes/run.sh --help`. |
@@ -229,14 +229,17 @@ store:
 `store.endpointUrl` wins over the internal Service URL whenever it is set, with
 or without the bundled SeaweedFS. Leave it unset to keep the store internal.
 The Ingress renders only when the bundled SeaweedFS is deployed, and `host` is
-required once you enable it. Compose does the same thing with
-`AGENTA_STORE_TRAEFIK_ENABLE` and `AGENTA_STORE_DOMAIN`.
+required once you enable it. The advertised `store.endpointUrl` must use HTTPS;
+configure TLS with `ingress.tls` or controller-specific annotations. Compose
+does the same thing with `AGENTA_STORE_TRAEFIK_ENABLE` and
+`AGENTA_STORE_DOMAIN`.
 
 ## Extra environment variables
 
 `<component>.env` takes plain strings only, so it cannot reference a Secret key.
-Two more keys take raw Kubernetes entries and render verbatim after the chart's
-own variables, which means a later entry wins:
+Two more keys take raw Kubernetes entries. `extraEnv` renders explicit `env`
+entries after the chart's own variables, so matching names there win. `envFrom`
+supplies only names absent from explicit `env` entries, regardless of order:
 
 ```yaml
 api:
@@ -276,8 +279,10 @@ helm lint hosting/kubernetes/helm -f my-values.yaml
 helm template agenta hosting/kubernetes/helm -f my-values.yaml
 ```
 
-`values.schema.json` rejects an unknown or misspelled key, and the chart's own
-validations fail the render with a message that names the key to fix.
+`values.schema.json` validates declared fields, and the chart's own validations
+fail the render with a message that names the key to fix. Some open sections,
+including the root and `postgresql`, accept unknown keys for subchart wiring and
+other pass-through settings.
 
 The tests in `helm/tests/` render the chart and assert on the result. Run one
 with `uv run hosting/kubernetes/helm/tests/<name>.py`; each needs `helm` on the

--- a/hosting/kubernetes/ee/values.ee.example.yaml
+++ b/hosting/kubernetes/ee/values.ee.example.yaml
@@ -432,10 +432,10 @@ posthog:
 # ================================================================== #
 # === api / web / services / workers / cron — deployment knobs ===
 # ================================================================== #
-# Every workload below also takes `extraEnv` (a raw list of Kubernetes env entries,
-# so valueFrom works) and `envFrom` (raw list of secretRef/configMapRef). Both render
-# after the chart's own variables, so a later entry wins. Use extraEnv to reach a
-# Secret key the chart does not model:
+# Every workload below also takes `extraEnv` (explicit Kubernetes env entries, so
+# valueFrom works) and `envFrom` (raw secretRef/configMapRef entries). Matching names
+# in extraEnv override chart entries. envFrom supplies only names absent from explicit
+# env entries. Use extraEnv to reach a Secret key the chart does not model:
 #   api:
 #     extraEnv:
 #       - name: AGENTA_STARTER_CREDITS_BRIDGE_MASTER_KEY
@@ -483,8 +483,8 @@ posthog:
 #       memory: 512Mi
 #     limits:
 #       memory: 1Gi
-# The chart has two worker deployments. `streams` and `queues` are selector
-# lists; an empty list means every loop of that kind.
+# The chart has two worker deployments. `streams` and `queues` are comma-separated
+# selector strings; an empty string means every loop of that kind.
 # workerStreams:
 #   enabled: true
 #   replicas: 1
@@ -542,7 +542,7 @@ posthog:
 # ================================================================== #
 # store:
 #   enabled: false
-#   endpointUrl:       # wins over the internal Service URL even with SeaweedFS bundled.
+#   endpointUrl: https://store.example.com  # wins over the internal Service URL even with SeaweedFS bundled.
 #                      # Set it to the ingress host below so a Daytona sandbox, which runs
 #                      # outside the cluster, can reach the store.
 #   stsEndpointUrl:

--- a/hosting/kubernetes/ee/values.ee.example.yaml
+++ b/hosting/kubernetes/ee/values.ee.example.yaml
@@ -532,7 +532,9 @@ posthog:
 # ================================================================== #
 # store:
 #   enabled: false
-#   endpointUrl:
+#   endpointUrl:       # wins over the internal Service URL even with SeaweedFS bundled.
+#                      # Set it to the ingress host below so a Daytona sandbox, which runs
+#                      # outside the cluster, can reach the store.
 #   stsEndpointUrl:
 #   accessKey:
 #   secretKey:

--- a/hosting/kubernetes/ee/values.ee.example.yaml
+++ b/hosting/kubernetes/ee/values.ee.example.yaml
@@ -432,6 +432,15 @@ posthog:
 # ================================================================== #
 # === api / web / services / workers / cron — deployment knobs ===
 # ================================================================== #
+# Every workload below also takes `extraEnv` (a raw list of Kubernetes env entries,
+# so valueFrom works) and `envFrom` (raw list of secretRef/configMapRef). Both render
+# after the chart's own variables, so a later entry wins. Use extraEnv to reach a
+# Secret key the chart does not model:
+#   api:
+#     extraEnv:
+#       - name: AGENTA_STARTER_CREDITS_BRIDGE_MASTER_KEY
+#         valueFrom:
+#           secretKeyRef: {name: agenta, key: AGENTA_STARTER_CREDITS_BRIDGE_MASTER_KEY}
 # api:
 #   enabled: true
 #   replicas: 1

--- a/hosting/kubernetes/ee/values.ee.example.yaml
+++ b/hosting/kubernetes/ee/values.ee.example.yaml
@@ -474,37 +474,32 @@ posthog:
 #       memory: 512Mi
 #     limits:
 #       memory: 1Gi
-# workerEvaluations:
+# The chart has two worker deployments. `streams` and `queues` are selector
+# lists; an empty list means every loop of that kind.
+# workerStreams:
 #   enabled: true
 #   replicas: 1
-# workerTracing:
+#   # streams: "tracing"
+# workerQueues:
 #   enabled: true
 #   replicas: 1
-# workerWebhooks:
-#   enabled: true
-#   replicas: 1
-# workerEvents:
-#   enabled: true
-#   replicas: 1
-# workerRecords:
-#   enabled: true
-#   replicas: 1
-# workerTriggers:
-#   enabled: true
-#   replicas: 1
-# workerInteractions:
-#   enabled: true
-#   replicas: 1
+#   # queues: "evaluations"
 # cron:
 #   enabled: true
 #   replicas: 1
 
 # ================================================================== #
 # === ingress ===
-# Path routing: / → web, /m → web-mobile, /api → api (prefix-stripped),
-# /services → services (prefix-stripped). The /m route is fixed because the mobile
-# image is built with basePath /m.  When running behind Traefik, attach the StripPrefix
+# Path routing: / → web, /m → web-mobile, /api → api, /services → services.
+#
+# Do NOT strip /api.  The API is mounted at /api (SCRIPT_NAME plus the FastAPI
+# root_path), so it needs the prefix and its redirects keep it.  This matches
+# docker-compose.
+#
+# DO strip /services.  When running behind Traefik, attach the StripPrefix
 # Middleware defined under extraObjects below.
+#
+# The /m route is fixed because the mobile image is built with basePath /m.
 # ================================================================== #
 # ingress:
 #   enabled: true
@@ -526,8 +521,17 @@ posthog:
 # ================================================================== #
 # === store — object store (AGENTA_STORE_*) ===
 # Docs: https://docs.agenta.ai/self-host/configuration#store-durable-object-store
+#
+# store.enabled is FALSE by default, so the whole block below does nothing until
+# you set it.  The store holds session artifacts and file mounts.
+#
+# With store.enabled: true the chart also deploys a bundled SeaweedFS
+# StatefulSet, because store.seaweedfs.enabled defaults to true.  If you point
+# the store at your own S3 or GCS bucket, set store.seaweedfs.enabled: false as
+# well, or you pay for a StatefulSet nothing reads.
 # ================================================================== #
 # store:
+#   enabled: false
 #   endpointUrl:
 #   stsEndpointUrl:
 #   accessKey:
@@ -539,7 +543,7 @@ posthog:
 #   jwtIssuer:
 #   jwtPrivateKey:
 #   seaweedfs:
-#     enabled: false
+#     enabled: false   # defaults to TRUE when store.enabled is true; set false for an external store
 #     port: 8333
 #     image:
 #       repository: chrislusf/seaweedfs
@@ -548,8 +552,8 @@ posthog:
 # ================================================================== #
 # === extraObjects — arbitrary Kubernetes resources ===
 # Includes the Traefik v3 StripPrefix Middleware referenced from the
-# ingress.annotations above.  Required so /api and /services backends
-# receive requests without the prefix.
+# ingress.annotations above.  Required so the services backend receives
+# requests without its prefix.  The API keeps /api, so it is not listed.
 # ================================================================== #
 # extraObjects:
 #   - apiVersion: traefik.io/v1alpha1
@@ -559,6 +563,6 @@ posthog:
 #       namespace: "{{ .Release.Namespace }}"
 #     spec:
 #       stripPrefix:
+#         # /api is deliberately absent: the API expects its own prefix.
 #         prefixes:
-#           - /api
 #           - /services

--- a/hosting/kubernetes/ee/values.ee.example.yaml
+++ b/hosting/kubernetes/ee/values.ee.example.yaml
@@ -512,7 +512,8 @@ posthog:
 # ================================================================== #
 # ingress:
 #   enabled: true
-#   className: traefik
+#   className: traefik   # "" leaves spec.ingressClassName out entirely, for a controller that
+#                        # ignores the field and routes by annotation instead (GKE).
 #   host: agenta.example.com
 #   annotations:
 #     traefik.ingress.kubernetes.io/router.middlewares: agenta-strip-prefixes@kubernetescrd

--- a/hosting/kubernetes/ee/values.ee.example.yaml
+++ b/hosting/kubernetes/ee/values.ee.example.yaml
@@ -547,6 +547,14 @@ posthog:
 #   seaweedfs:
 #     enabled: false   # defaults to TRUE when store.enabled is true; set false for an external store
 #     port: 8333
+#     ingress:         # optional public route to the bundled S3 gateway; off by default
+#       enabled: false
+#       className: nginx
+#       host: store.example.com
+#       annotations: {}
+#       tls:
+#         - hosts: [store.example.com]
+#           secretName: agenta-store-tls
 #     image:
 #       repository: chrislusf/seaweedfs
 #       tag: "4.37"  # pin a 4.37-era image — IAM regressed in other releases

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -348,7 +348,9 @@ http://{{ include "agenta.agentRunner.serviceName" . }}:{{ include "agenta.agent
 {{- /* Services sends the shared runner protocol credential the runner verifies (interface.md
        section 2). REQUIRED and always rendered — the runner rejects an un-tokened request with 401
        and refuses to boot without the secret, so a Services pod without it could never call it.
-       Mirrors runner-deployment.yaml: an explicit auth.tokenSecretRef wins, else the platform Secret. */}}
+       Mirrors runner-deployment.yaml: an explicit auth.tokenSecretRef wins, else the platform Secret.
+       The platform Secret is `agenta.secretName`, so a `secrets.existingSecret` install reads the
+       operator's own Secret instead of a chart-managed one the chart never creates. */}}
 - name: AGENTA_RUNNER_TOKEN
   valueFrom:
     secretKeyRef:
@@ -356,7 +358,7 @@ http://{{ include "agenta.agentRunner.serviceName" . }}:{{ include "agenta.agent
       name: {{ $auth.tokenSecretRef.name | quote }}
       key: {{ $auth.tokenSecretRef.key | quote }}
       {{- else }}
-      name: {{ include "agenta.fullname" . | quote }}
+      name: {{ include "agenta.secretName" . | quote }}
       key: AGENTA_RUNNER_TOKEN
       {{- end }}
 {{- end }}

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -426,7 +426,16 @@ http://{{ include "agenta.agentRunner.serviceName" . }}:{{ include "agenta.agent
 {{/* ================================================================
    Ingress defaults.
    ================================================================ */}}
-{{- define "agenta.ingress.className" -}}{{ default "traefik" (default dict .Values.ingress).className }}{{- end }}
+{{- /* Default "traefik", but an explicit empty string means "render no ingressClassName".
+       hasKey, not `default`, because `default` would turn "" back into "traefik".
+       Some controllers ignore the field: GKE reacts only to the legacy
+       kubernetes.io/ingress.class annotation, and an Ingress carrying a className it does
+       not own gets no controller events at all. Setting className: "" lets the operator
+       route by annotation alone. */ -}}
+{{- define "agenta.ingress.className" -}}
+{{- $ingress := default dict .Values.ingress -}}
+{{- if hasKey $ingress "className" }}{{ $ingress.className }}{{ else }}traefik{{ end }}
+{{- end }}
 {{- define "agenta.ingress.host" -}}{{ default "agenta.local" (default dict .Values.ingress).host }}{{- end }}
 {{- define "agenta.ingress.paths.api.path" -}}
 {{- $paths := default dict (default dict .Values.ingress).paths -}}

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -936,11 +936,19 @@ imagePullSecrets:
       key: AGENTA_CRYPT_KEY
 {{- if eq (include "agenta.store.enabled" .) "true" }}
 {{- $store := default dict .Values.store }}
+{{- /* An explicit store.endpointUrl always wins, even with SeaweedFS bundled. A Daytona
+       sandbox runs outside the cluster and cannot resolve the in-cluster Service name, so
+       it needs a public URL. Expose the bundled store through store.seaweedfs.ingress and
+       set store.endpointUrl to that hostname. Compose does the same with
+       AGENTA_STORE_TRAEFIK_ENABLE plus AGENTA_STORE_DOMAIN. The internal Service URL stays
+       the fallback for a cluster-only deployment. */}}
 - name: AGENTA_STORE_ENDPOINT_URL
-  {{- if eq (include "agenta.seaweedfs.enabled" .) "true" }}
+  {{- if $store.endpointUrl }}
+  value: {{ $store.endpointUrl | quote }}
+  {{- else if eq (include "agenta.seaweedfs.enabled" .) "true" }}
   value: {{ printf "http://%s-seaweedfs:%v" (include "agenta.fullname" .) (include "agenta.seaweedfs.port" .) | quote }}
   {{- else }}
-  value: {{ default "" $store.endpointUrl | quote }}
+  value: ""
   {{- end }}
 {{- if $store.stsEndpointUrl }}
 - name: AGENTA_STORE_STS_ENDPOINT_URL

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -162,6 +162,9 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- define "agenta.webMobile.port" -}}{{ default 3000 (default dict .Values.webMobile).port }}{{- end }}
 {{- define "agenta.services.port" -}}{{ default 80 (default dict .Values.services).port }}{{- end }}
 {{- define "agenta.agentRunner.port" -}}{{ default 8765 (default dict .Values.agentRunner).port }}{{- end }}
+{{- /* Bind address for the runner (AGENTA_RUNNER_HOST). The runner defaults to 127.0.0.1,
+       which no probe and no other pod can reach. Always 0.0.0.0 here unless overridden. */ -}}
+{{- define "agenta.agentRunner.host" -}}{{ default "0.0.0.0" (default dict .Values.agentRunner).host }}{{- end }}
 {{- define "agenta.supertokens.port" -}}{{ default 3567 (default dict (include "agenta.values" . | fromYaml).supertokens).port }}{{- end }}
 {{- define "agenta.redisVolatile.port" -}}{{ default 6379 (default dict .Values.redisVolatile).port }}{{- end }}
 {{- define "agenta.redisDurable.port" -}}{{ default 6381 (default dict .Values.redisDurable).port }}{{- end }}

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -470,6 +470,28 @@ http://{{ include "agenta.agentRunner.serviceName" . }}:{{ include "agenta.agent
 {{- end }}
 
 {{/* ================================================================
+   One extra ingress path item, shared by ingress.extraPaths and by
+   ingress.extraHosts[].paths. The caller passes the item itself, not
+   the root context, so this helper must not use `.Values`.
+
+   servicePort accepts a number (rendered as port.number) or a string
+   (rendered as port.name), which is what the Ingress spec allows.
+   ================================================================ */}}
+{{- define "agenta.ingress.extraPath" -}}
+- path: {{ .path }}
+  pathType: {{ default "Prefix" .pathType }}
+  backend:
+    service:
+      name: {{ .serviceName | quote }}
+      port:
+        {{- if kindIs "string" .servicePort }}
+        name: {{ .servicePort | quote }}
+        {{- else }}
+        number: {{ .servicePort | int }}
+        {{- end }}
+{{- end }}
+
+{{/* ================================================================
    Postgresql section defaults (Bitnami subchart wiring).
    ================================================================ */}}
 {{- define "agenta.postgresql.authUsername" -}}

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -433,8 +433,19 @@ http://{{ include "agenta.agentRunner.serviceName" . }}:{{ include "agenta.agent
 {{- $svc := default dict $paths.services -}}
 {{- default "Prefix" $svc.pathType -}}
 {{- end }}
-{{- define "agenta.ingress.paths.webMobile.path" -}}/m{{- end }}
-{{- define "agenta.ingress.paths.webMobile.pathType" -}}Prefix{{- end }}
+{{- /* The mobile image is built with basePath /m, so the path must stay /m unless the image
+       is rebuilt. pathType is still worth overriding: a managed ingress (GKE) may need
+       ImplementationSpecific. */ -}}
+{{- define "agenta.ingress.paths.webMobile.path" -}}
+{{- $paths := default dict (default dict .Values.ingress).paths -}}
+{{- $m := default dict $paths.webMobile -}}
+{{- default "/m" $m.path -}}
+{{- end }}
+{{- define "agenta.ingress.paths.webMobile.pathType" -}}
+{{- $paths := default dict (default dict .Values.ingress).paths -}}
+{{- $m := default dict $paths.webMobile -}}
+{{- default "Prefix" $m.pathType -}}
+{{- end }}
 {{- define "agenta.ingress.paths.web.path" -}}
 {{- $paths := default dict (default dict .Values.ingress).paths -}}
 {{- $w := default dict $paths.web -}}

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -411,6 +411,11 @@ http://{{ include "agenta.agentRunner.serviceName" . }}:{{ include "agenta.agent
 {{/* ================================================================
    Alembic job defaults.
    ================================================================ */}}
+{{- /* Which Helm hook phase the migration Job runs in. "post" (the default) keeps the
+       behavior the chart always had, which the bundled PostgreSQL StatefulSet needs. "pre"
+       runs the migrations before the app pods start, which is what an external database
+       wants. See alembic-job.yaml. */ -}}
+{{- define "agenta.alembic.hookPhase" -}}{{ default "post" (default dict .Values.alembic).hookPhase }}{{- end }}
 {{- define "agenta.alembic.activeDeadlineSeconds" -}}{{ default 600 (default dict .Values.alembic).activeDeadlineSeconds }}{{- end }}
 {{- define "agenta.alembic.backoffLimit" -}}{{ default 3 (default dict .Values.alembic).backoffLimit }}{{- end }}
 {{- define "agenta.alembic.ttlSecondsAfterFinished" -}}{{ default 300 (default dict .Values.alembic).ttlSecondsAfterFinished }}{{- end }}

--- a/hosting/kubernetes/helm/templates/_helpers.tpl
+++ b/hosting/kubernetes/helm/templates/_helpers.tpl
@@ -112,6 +112,13 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
 {{- define "agenta.seaweedfs.pullPolicy" -}}{{ default "IfNotPresent" (default dict (default dict (default dict .Values.store).seaweedfs).image).pullPolicy }}{{- end }}
 {{- define "agenta.seaweedfs.port" -}}{{ default 8333 (default dict (default dict .Values.store).seaweedfs).port }}{{- end }}
+{{- /* FUSE for the runner's local sandboxes. Default true, which is the behavior the chart
+       always had. Set agentRunner.fuse.enabled=false on a cluster that forbids SYS_ADMIN or
+       a hostPath mount of /dev/fuse, such as GKE Autopilot; use the Daytona provider there. */ -}}
+{{- define "agenta.agentRunner.fuse.enabled" -}}
+{{- $v := (default dict (default dict .Values.agentRunner).fuse).enabled -}}
+{{- if kindIs "invalid" $v }}true{{- else }}{{- $v -}}{{- end }}
+{{- end }}
 {{- define "agenta.workerStreams.enabled" -}}
 {{- $v := (default dict .Values.workerStreams).enabled -}}
 {{- if kindIs "invalid" $v }}true{{- else }}{{- $v -}}{{- end }}

--- a/hosting/kubernetes/helm/templates/_validations.tpl
+++ b/hosting/kubernetes/helm/templates/_validations.tpl
@@ -77,7 +77,12 @@ The chart derives these from ingress.host when ingress.enabled=true. Either:
        ingress:
          enabled: true
          host: agenta.example.com
-         tls: true   # optional
+         # tls is optional and is a list, in the shape the Ingress spec uses.
+         # Any non-empty list also switches the derived URLs to https.
+         tls:
+           - hosts:
+               - agenta.example.com
+             secretName: agenta-tls
 
   2. Or set the three URLs explicitly:
 

--- a/hosting/kubernetes/helm/templates/_validations.tpl
+++ b/hosting/kubernetes/helm/templates/_validations.tpl
@@ -236,6 +236,28 @@ redisDurable.persistence.enabled in your values file (was: %v).
 {{- end }}
 
 {{/* ================================================================
+   Validate the Alembic hook phase. A typo would silently fall back to
+   "post", so an operator who asked for "pre" would keep the behavior
+   they tried to change and never learn why.
+   ================================================================ */}}
+{{- define "agenta.validateAlembicHookPhase" -}}
+{{- $phase := include "agenta.alembic.hookPhase" . -}}
+{{- if not (has $phase (list "post" "pre")) -}}
+{{- fail (printf `
+
+CONFIGURATION ERROR: alembic.hookPhase=%q is not a valid phase.
+
+Allowed values:
+
+  post   (default) run the migrations after the release is applied. Required with
+         the bundled PostgreSQL, which does not exist yet at pre-install time.
+  pre              run the migrations before the app pods start. Use this with an
+         external database (postgresql.enabled=false).
+` $phase) -}}
+{{- end -}}
+{{- end }}
+
+{{/* ================================================================
    Validate license value is in the allowed set. Catches typos like
    `agenta.license: enterprise` that would otherwise fall through to
    the OSS code paths and silently disable EE features.

--- a/hosting/kubernetes/helm/templates/_validations.tpl
+++ b/hosting/kubernetes/helm/templates/_validations.tpl
@@ -98,6 +98,42 @@ absolute-URL builder in the app.
 {{- end }}
 
 {{/* ================================================================
+   A public object-store route hands credentials and signed requests to
+   clients outside the cluster. Require the URL advertised to those
+   clients to use HTTPS. TLS may be configured through spec.tls or
+   controller-specific annotations, so validate the advertised URL
+   rather than prescribing one Ingress controller's configuration.
+   ================================================================ */}}
+{{- define "agenta.validateSeaweedfsIngress" -}}
+{{- $values := include "agenta.values" . | fromYaml -}}
+{{- $store := default dict $values.store -}}
+{{- $seaweedfs := default dict $store.seaweedfs -}}
+{{- $ingress := default dict $seaweedfs.ingress -}}
+{{- if and (eq (include "agenta.store.enabled" .) "true") (eq (include "agenta.seaweedfs.enabled" .) "true") $ingress.enabled -}}
+{{- $endpoint := default "" $store.endpointUrl -}}
+{{- if not (hasPrefix "https://" $endpoint) -}}
+{{- fail `
+
+CONFIGURATION ERROR: a public SeaweedFS ingress requires an HTTPS store.endpointUrl.
+
+Set store.endpointUrl to the public HTTPS URL and configure TLS through
+store.seaweedfs.ingress.tls or your Ingress controller's annotations. For example:
+
+  store:
+    endpointUrl: "https://store.example.com"
+    seaweedfs:
+      ingress:
+        enabled: true
+        host: store.example.com
+        tls:
+          - hosts: [store.example.com]
+            secretName: agenta-store-tls
+` -}}
+{{- end -}}
+{{- end -}}
+{{- end }}
+
+{{/* ================================================================
    Validate that the canonical app secrets are provided when the chart
    is creating the Secret itself (i.e. secrets.existingSecret is unset).
    Without this guard the chart renders, the pods start, and the app

--- a/hosting/kubernetes/helm/templates/alembic-job.yaml
+++ b/hosting/kubernetes/helm/templates/alembic-job.yaml
@@ -81,10 +81,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
-                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
-                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
-                   above. */}}
+            {{- /* extraEnv is a raw list of explicit Kubernetes env entries, so valueFrom works
+                   and names here override earlier chart entries. envFrom pulls whole Secrets or
+                   ConfigMaps, but Kubernetes uses those values only for names absent from env. */}}
             {{- with $alembic.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/hosting/kubernetes/helm/templates/alembic-job.yaml
+++ b/hosting/kubernetes/helm/templates/alembic-job.yaml
@@ -9,16 +9,27 @@ metadata:
     {{- include "agenta.labels" . | nindent 4 }}
     app.kubernetes.io/component: alembic
   annotations:
-    # post-install/post-upgrade (not pre-) is intentional: pre-install hooks
-    # run before any release resources are created, so the PostgreSQL
-    # StatefulSet would not exist yet and the migration job would deadlock
-    # waiting for the database.  The tradeoff is that application pods may
-    # briefly start against an unmigrated schema; their init-containers
-    # wait for PostgreSQL readiness but not for Alembic completion.  In
-    # practice this is acceptable because the migration job finishes within
-    # seconds and Kubernetes will restart any pods that fail their startup
-    # probes during that window.
+    # alembic.hookPhase picks the phase; the default "post" is the behavior the
+    # chart always had.
+    #
+    # post-install/post-upgrade is the right default with the BUNDLED PostgreSQL:
+    # pre-install hooks run before any release resource is created, so the
+    # PostgreSQL StatefulSet would not exist yet and the migration job would
+    # deadlock waiting for the database.  The tradeoff is that application pods
+    # may briefly start against an unmigrated schema; their init-containers wait
+    # for PostgreSQL readiness but not for Alembic completion.  In practice this
+    # is acceptable because the migration job finishes within seconds and
+    # Kubernetes will restart any pods that fail their startup probes during
+    # that window.
+    #
+    # With an EXTERNAL database (postgresql.enabled=false) the deadlock cannot
+    # happen, and that brief unmigrated window is worth closing.  Set
+    # alembic.hookPhase: pre to run the migrations before the app pods start.
+    {{- if eq (include "agenta.alembic.hookPhase" .) "pre" }}
+    helm.sh/hook: pre-install,pre-upgrade
+    {{- else }}
     helm.sh/hook: post-install,post-upgrade
+    {{- end }}
     helm.sh/hook-weight: "0"
     helm.sh/hook-delete-policy: before-hook-creation
 spec:

--- a/hosting/kubernetes/helm/templates/alembic-job.yaml
+++ b/hosting/kubernetes/helm/templates/alembic-job.yaml
@@ -81,6 +81,17 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
+                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
+                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
+                   above. */}}
+            {{- with $alembic.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $alembic.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           {{- with $alembic.resources }}
           resources:
             {{- toYaml . | nindent 12 }}

--- a/hosting/kubernetes/helm/templates/api-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/api-deployment.yaml
@@ -81,6 +81,17 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
+                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
+                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
+                   above. */}}
+            {{- with $api.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $api.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           startupProbe:
             httpGet:
               path: /health

--- a/hosting/kubernetes/helm/templates/api-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/api-deployment.yaml
@@ -81,10 +81,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
-                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
-                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
-                   above. */}}
+            {{- /* extraEnv is a raw list of explicit Kubernetes env entries, so valueFrom works
+                   and names here override earlier chart entries. envFrom pulls whole Secrets or
+                   ConfigMaps, but Kubernetes uses those values only for names absent from env. */}}
             {{- with $api.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/hosting/kubernetes/helm/templates/api-service.yaml
+++ b/hosting/kubernetes/helm/templates/api-service.yaml
@@ -6,6 +6,12 @@ metadata:
   labels:
     {{- include "agenta.labels" . | nindent 4 }}
     app.kubernetes.io/component: api
+  {{- /* Annotation hook for the ingress controller. GKE reads
+         cloud.google.com/backend-config and cloud.google.com/neg here. */}}
+  {{- with (default dict (default dict .Values.api).service).annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/hosting/kubernetes/helm/templates/cron-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/cron-deployment.yaml
@@ -41,10 +41,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
-                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
-                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
-                   above. */}}
+            {{- /* extraEnv is a raw list of explicit Kubernetes env entries, so valueFrom works
+                   and names here override earlier chart entries. envFrom pulls whole Secrets or
+                   ConfigMaps, but Kubernetes uses those values only for names absent from env. */}}
             {{- with $cron.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/hosting/kubernetes/helm/templates/cron-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/cron-deployment.yaml
@@ -41,6 +41,17 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
+                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
+                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
+                   above. */}}
+            {{- with $cron.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $cron.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             exec:
               command: ["pgrep", "supercronic"]

--- a/hosting/kubernetes/helm/templates/ingress.yaml
+++ b/hosting/kubernetes/helm/templates/ingress.yaml
@@ -21,7 +21,11 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  ingressClassName: {{ include "agenta.ingress.className" . }}
+  {{- /* Omitted when ingress.className is an empty string, for a controller that ignores the
+         field and routes by annotation instead (GKE). */}}
+  {{- with (include "agenta.ingress.className" .) }}
+  ingressClassName: {{ . }}
+  {{- end }}
   {{- with $ingress.tls }}
   tls:
     {{- toYaml . | nindent 4 }}

--- a/hosting/kubernetes/helm/templates/ingress.yaml
+++ b/hosting/kubernetes/helm/templates/ingress.yaml
@@ -4,7 +4,12 @@
 {{- $servicesEnabled := eq (include "agenta.services.enabled" .) "true" -}}
 {{- $webEnabled := eq (include "agenta.web.enabled" .) "true" -}}
 {{- $webMobileEnabled := eq (include "agenta.webMobile.enabled" .) "true" -}}
-{{- if and (eq (include "agenta.ingress.enabled" .) "true") (or $apiEnabled $servicesEnabled $webEnabled $webMobileEnabled) }}
+{{- $extraPaths := default (list) $ingress.extraPaths -}}
+{{- $extraHosts := default (list) $ingress.extraHosts -}}
+{{- /* The main host rule needs at least one path. Skip it, but still render the Ingress,
+       when the operator disabled every chart component and routes only extra hosts. */ -}}
+{{- $mainHostHasPaths := or $apiEnabled $servicesEnabled $webEnabled $webMobileEnabled (gt (len $extraPaths) 0) -}}
+{{- if and (eq (include "agenta.ingress.enabled" .) "true") (or $mainHostHasPaths (gt (len $extraHosts) 0)) }}
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
@@ -22,6 +27,7 @@ spec:
     {{- toYaml . | nindent 4 }}
   {{- end }}
   rules:
+    {{- if $mainHostHasPaths }}
     - host: {{ include "agenta.ingress.host" . }}
       http:
         paths:
@@ -61,4 +67,21 @@ spec:
                 port:
                   name: http
           {{- end }}
+          {{- /* Extra routes on the same host, for a Service the chart does not own
+                 (for example /llm in front of a gateway). Appended after the built-in
+                 paths. */}}
+          {{- range $extraPaths }}
+          {{- include "agenta.ingress.extraPath" . | nindent 10 }}
+          {{- end }}
+    {{- end }}
+    {{- /* Extra hosts, each with its own path list. Use this for a second hostname
+           that must reach a Service in this namespace. */}}
+    {{- range $extraHosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+          {{- range .paths }}
+          {{- include "agenta.ingress.extraPath" . | nindent 10 }}
+          {{- end }}
+    {{- end }}
 {{- end }}

--- a/hosting/kubernetes/helm/templates/runner-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/runner-deployment.yaml
@@ -209,12 +209,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if and (eq (include "agenta.store.enabled" .) "true") (eq (include "agenta.agentRunner.fuse.enabled" .) "true") (not $runner.securityContext) }}
+          {{- if and (eq (include "agenta.store.enabled" .) "true") (eq (include "agenta.agentRunner.fuse.enabled" .) "true") }}
           volumeMounts:
             - name: fuse
               mountPath: /dev/fuse
           {{- end }}
-      {{- if and (eq (include "agenta.store.enabled" .) "true") (eq (include "agenta.agentRunner.fuse.enabled" .) "true") (not $runner.securityContext) }}
+      {{- if and (eq (include "agenta.store.enabled" .) "true") (eq (include "agenta.agentRunner.fuse.enabled" .) "true") }}
       volumes:
         - name: fuse
           hostPath:

--- a/hosting/kubernetes/helm/templates/runner-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/runner-deployment.yaml
@@ -34,12 +34,14 @@ spec:
           image: {{ include "agenta.agentRunnerImage" . }}
           imagePullPolicy: {{ include "agenta.agentRunner.pullPolicy" . }}
           {{- /* FUSE for the durable session cwd: geesefs mounts the store prefix on-host for
-                 local sandboxes, which needs SYS_ADMIN + /dev/fuse. Only granted when mounts is
-                 on; an explicit runner.securityContext (if set) overrides this default. */ -}}
+                 local sandboxes, which needs SYS_ADMIN + /dev/fuse. Only granted when the store
+                 is on AND agentRunner.fuse.enabled is true; an explicit runner.securityContext
+                 (if set) overrides this default. Set agentRunner.fuse.enabled=false on a cluster
+                 that rejects SYS_ADMIN or a hostPath, such as GKE Autopilot. */ -}}
           {{- if $runner.securityContext }}
           securityContext:
             {{- toYaml $runner.securityContext | nindent 12 }}
-          {{- else if eq (include "agenta.store.enabled" .) "true" }}
+          {{- else if and (eq (include "agenta.store.enabled" .) "true") (eq (include "agenta.agentRunner.fuse.enabled" .) "true") }}
           securityContext:
             capabilities:
               add: ["SYS_ADMIN"]
@@ -185,12 +187,12 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
-          {{- if and (eq (include "agenta.store.enabled" .) "true") (not $runner.securityContext) }}
+          {{- if and (eq (include "agenta.store.enabled" .) "true") (eq (include "agenta.agentRunner.fuse.enabled" .) "true") (not $runner.securityContext) }}
           volumeMounts:
             - name: fuse
               mountPath: /dev/fuse
           {{- end }}
-      {{- if and (eq (include "agenta.store.enabled" .) "true") (not $runner.securityContext) }}
+      {{- if and (eq (include "agenta.store.enabled" .) "true") (eq (include "agenta.agentRunner.fuse.enabled" .) "true") (not $runner.securityContext) }}
       volumes:
         - name: fuse
           hostPath:

--- a/hosting/kubernetes/helm/templates/runner-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/runner-deployment.yaml
@@ -171,6 +171,18 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- /* extraEnv and envFrom widen the runner's environment, which is narrow ON
+                   PURPOSE: a local harness process shares this container and can read /proc.
+                   envFrom in particular pulls a whole Secret and defeats
+                   tests/test_runner_secret_absence.py, which can only see named entries. Add one
+                   key at a time with extraEnv and keep platform credentials out. */}}
+            {{- with $runner.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $runner.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           startupProbe:
             httpGet:
               path: /health

--- a/hosting/kubernetes/helm/templates/runner-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/runner-deployment.yaml
@@ -63,6 +63,16 @@ spec:
             - name: AGENTA_API_INTERNAL_URL
               value: {{ $agentaVals.agenta.apiInternalUrl | quote }}
             {{- end }}
+            {{- /* The runner binds 127.0.0.1 by default, which is right for a laptop and wrong
+                   in a pod: kubelet reaches the container over the pod IP, so every probe on
+                   :<port>/health got connection refused and the pod never became ready.
+                   Bind all interfaces. Override with agentRunner.host, or through the
+                   agentRunner.env map below, which suppresses this entry the same way
+                   AGENTA_RUNNER_REPLICA_ID and PI_CODING_AGENT_DIR do. */}}
+            {{- if not (hasKey (default dict $runner.env) "AGENTA_RUNNER_HOST") }}
+            - name: AGENTA_RUNNER_HOST
+              value: {{ include "agenta.agentRunner.host" . | quote }}
+            {{- end }}
             - name: AGENTA_RUNNER_PORT
               value: {{ include "agenta.agentRunner.port" . | quote }}
             - name: AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS

--- a/hosting/kubernetes/helm/templates/runner-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/runner-deployment.yaml
@@ -140,7 +140,11 @@ spec:
                    `optional`. An explicit `auth.tokenSecretRef` overrides the platform Secret for
                    operators who keep the runner credential in their own vault. Note this mounts a
                    SINGLE key, not the whole Secret: the runner's env must stay narrow, because a
-                   local harness shares its container and can read /proc (tests/test_runner_secret_absence.py). */}}
+                   local harness shares its container and can read /proc (tests/test_runner_secret_absence.py).
+                   The fallback goes through `agenta.secretName`, not `agenta.fullname`, so a
+                   `secrets.existingSecret` install reads the operator's own Secret. The chart does
+                   not create its own Secret in that case, so a hardcoded name would never resolve
+                   and the runner would crash-loop (tests/test_existing_secret.py). */}}
             - name: AGENTA_RUNNER_TOKEN
               valueFrom:
                 secretKeyRef:
@@ -148,7 +152,7 @@ spec:
                   name: {{ $auth.tokenSecretRef.name | quote }}
                   key: {{ $auth.tokenSecretRef.key | quote }}
                   {{- else }}
-                  name: {{ include "agenta.fullname" . | quote }}
+                  name: {{ include "agenta.secretName" . | quote }}
                   key: AGENTA_RUNNER_TOKEN
                   {{- end }}
             {{- range $key, $val := $runner.env }}

--- a/hosting/kubernetes/helm/templates/seaweedfs-ingress.yaml
+++ b/hosting/kubernetes/helm/templates/seaweedfs-ingress.yaml
@@ -1,0 +1,43 @@
+{{- /* Optional public route to the bundled SeaweedFS S3 gateway.
+
+       A Daytona sandbox runs outside the cluster, so it cannot reach the store through the
+       in-cluster Service name. Expose the gateway on a hostname here, then point
+       store.endpointUrl at that hostname so every pod hands out the same URL.
+
+       Off by default: the store is internal unless the operator asks for this. Only renders
+       when the bundled SeaweedFS is deployed, because it is the only backend the chart owns. */ -}}
+{{- $store := default dict .Values.store -}}
+{{- $seaweedfs := default dict $store.seaweedfs -}}
+{{- $ingress := default dict $seaweedfs.ingress -}}
+{{- if and (eq (include "agenta.seaweedfs.enabled" .) "true") $ingress.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ include "agenta.fullname" . }}-seaweedfs
+  labels:
+    {{- include "agenta.labels" . | nindent 4 }}
+    app.kubernetes.io/component: seaweedfs
+  {{- with $ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- with $ingress.className }}
+  ingressClassName: {{ . }}
+  {{- end }}
+  {{- with $ingress.tls }}
+  tls:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  rules:
+    - host: {{ required "store.seaweedfs.ingress.host is required when store.seaweedfs.ingress.enabled=true" $ingress.host | quote }}
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ include "agenta.fullname" . }}-seaweedfs
+                port:
+                  name: s3
+{{- end }}

--- a/hosting/kubernetes/helm/templates/secrets.yaml
+++ b/hosting/kubernetes/helm/templates/secrets.yaml
@@ -1,6 +1,7 @@
 {{- include "agenta.validateLicense" . -}}
 {{- include "agenta.validateRequiredSecrets" . -}}
 {{- include "agenta.validatePublicUrls" . -}}
+{{- include "agenta.validateSeaweedfsIngress" . -}}
 {{- include "agenta.validateRedisDurablePersistenceToggle" . -}}
 {{- include "agenta.validateAlembicHookPhase" . -}}
 {{- $values := include "agenta.values" . | fromYaml -}}

--- a/hosting/kubernetes/helm/templates/secrets.yaml
+++ b/hosting/kubernetes/helm/templates/secrets.yaml
@@ -2,6 +2,7 @@
 {{- include "agenta.validateRequiredSecrets" . -}}
 {{- include "agenta.validatePublicUrls" . -}}
 {{- include "agenta.validateRedisDurablePersistenceToggle" . -}}
+{{- include "agenta.validateAlembicHookPhase" . -}}
 {{- $values := include "agenta.values" . | fromYaml -}}
 {{- $secrets := default dict $values.secrets -}}
 {{- $agenta := default dict $values.agenta -}}

--- a/hosting/kubernetes/helm/templates/services-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/services-deployment.yaml
@@ -81,6 +81,17 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
+                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
+                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
+                   above. */}}
+            {{- with $services.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $services.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           startupProbe:
             httpGet:
               path: /health

--- a/hosting/kubernetes/helm/templates/services-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/services-deployment.yaml
@@ -81,10 +81,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
-                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
-                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
-                   above. */}}
+            {{- /* extraEnv is a raw list of explicit Kubernetes env entries, so valueFrom works
+                   and names here override earlier chart entries. envFrom pulls whole Secrets or
+                   ConfigMaps, but Kubernetes uses those values only for names absent from env. */}}
             {{- with $services.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/hosting/kubernetes/helm/templates/services-service.yaml
+++ b/hosting/kubernetes/helm/templates/services-service.yaml
@@ -6,6 +6,12 @@ metadata:
   labels:
     {{- include "agenta.labels" . | nindent 4 }}
     app.kubernetes.io/component: services
+  {{- /* Annotation hook for the ingress controller. GKE reads
+         cloud.google.com/backend-config and cloud.google.com/neg here. */}}
+  {{- with (default dict (default dict .Values.services).service).annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/hosting/kubernetes/helm/templates/supertokens-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/supertokens-deployment.yaml
@@ -60,6 +60,17 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
+                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
+                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
+                   above. */}}
+            {{- with $supertokens.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $supertokens.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           startupProbe:
             httpGet:
               path: /hello

--- a/hosting/kubernetes/helm/templates/supertokens-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/supertokens-deployment.yaml
@@ -60,10 +60,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
-                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
-                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
-                   above. */}}
+            {{- /* extraEnv is a raw list of explicit Kubernetes env entries, so valueFrom works
+                   and names here override earlier chart entries. envFrom pulls whole Secrets or
+                   ConfigMaps, but Kubernetes uses those values only for names absent from env. */}}
             {{- with $supertokens.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/hosting/kubernetes/helm/templates/web-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/web-deployment.yaml
@@ -46,12 +46,15 @@ spec:
               value: "0.0.0.0"
             - name: AGENTA_LICENSE
               value: {{ include "agenta.edition" . | quote }}
+            {{- /* Use the *Effective helpers, like every other workload: they fall back to
+                   ingress.host when the operator does not set agenta.webUrl/apiUrl/servicesUrl.
+                   Reading the raw values here shipped empty URLs to the browser bundle. */}}
             - name: AGENTA_WEB_URL
-              value: {{ $agenta.webUrl | default "" | quote }}
+              value: {{ include "agenta.webUrlEffective" . | quote }}
             - name: AGENTA_SERVICES_URL
-              value: {{ $agenta.servicesUrl | default "" | quote }}
+              value: {{ include "agenta.servicesUrlEffective" . | quote }}
             - name: AGENTA_API_URL
-              value: {{ $agenta.apiUrl | default "" | quote }}
+              value: {{ include "agenta.apiUrlEffective" . | quote }}
             - name: AGENTA_MOBILE_GATE
               value: {{ eq (include "agenta.webMobile.enabled" .) "true" | quote }}
             - name: AGENTA_AUTH_KEY

--- a/hosting/kubernetes/helm/templates/web-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/web-deployment.yaml
@@ -80,6 +80,17 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
+                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
+                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
+                   above. */}}
+            {{- with $web.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $web.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           startupProbe:
             httpGet:
               path: /

--- a/hosting/kubernetes/helm/templates/web-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/web-deployment.yaml
@@ -80,10 +80,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
-                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
-                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
-                   above. */}}
+            {{- /* extraEnv is a raw list of explicit Kubernetes env entries, so valueFrom works
+                   and names here override earlier chart entries. envFrom pulls whole Secrets or
+                   ConfigMaps, but Kubernetes uses those values only for names absent from env. */}}
             {{- with $web.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/hosting/kubernetes/helm/templates/web-mobile-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/web-mobile-deployment.yaml
@@ -46,12 +46,15 @@ spec:
               value: "0.0.0.0"
             - name: AGENTA_LICENSE
               value: {{ include "agenta.edition" . | quote }}
+            {{- /* Use the *Effective helpers, like every other workload: they fall back to
+                   ingress.host when the operator does not set agenta.webUrl/apiUrl/servicesUrl.
+                   Reading the raw values here shipped empty URLs to the browser bundle. */}}
             - name: AGENTA_WEB_URL
-              value: {{ $agenta.webUrl | default "" | quote }}
+              value: {{ include "agenta.webUrlEffective" . | quote }}
             - name: AGENTA_SERVICES_URL
-              value: {{ $agenta.servicesUrl | default "" | quote }}
+              value: {{ include "agenta.servicesUrlEffective" . | quote }}
             - name: AGENTA_API_URL
-              value: {{ $agenta.apiUrl | default "" | quote }}
+              value: {{ include "agenta.apiUrlEffective" . | quote }}
             - name: AGENTA_MOBILE_GATE
               value: {{ eq (include "agenta.webMobile.enabled" .) "true" | quote }}
             - name: AGENTA_MOBILE_REVERSE_GATE

--- a/hosting/kubernetes/helm/templates/web-mobile-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/web-mobile-deployment.yaml
@@ -82,6 +82,17 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
+                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
+                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
+                   above. */}}
+            {{- with $webMobile.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $webMobile.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           startupProbe:
             httpGet:
               path: /m/__env.js

--- a/hosting/kubernetes/helm/templates/web-mobile-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/web-mobile-deployment.yaml
@@ -82,10 +82,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
-                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
-                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
-                   above. */}}
+            {{- /* extraEnv is a raw list of explicit Kubernetes env entries, so valueFrom works
+                   and names here override earlier chart entries. envFrom pulls whole Secrets or
+                   ConfigMaps, but Kubernetes uses those values only for names absent from env. */}}
             {{- with $webMobile.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/hosting/kubernetes/helm/templates/web-mobile-service.yaml
+++ b/hosting/kubernetes/helm/templates/web-mobile-service.yaml
@@ -6,6 +6,12 @@ metadata:
   labels:
     {{- include "agenta.labels" . | nindent 4 }}
     app.kubernetes.io/component: web-mobile
+  {{- /* Annotation hook for the ingress controller. GKE reads
+         cloud.google.com/backend-config and cloud.google.com/neg here. */}}
+  {{- with (default dict (default dict .Values.webMobile).service).annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/hosting/kubernetes/helm/templates/web-service.yaml
+++ b/hosting/kubernetes/helm/templates/web-service.yaml
@@ -6,6 +6,12 @@ metadata:
   labels:
     {{- include "agenta.labels" . | nindent 4 }}
     app.kubernetes.io/component: web
+  {{- /* Annotation hook for the ingress controller. GKE reads
+         cloud.google.com/backend-config and cloud.google.com/neg here. */}}
+  {{- with (default dict (default dict .Values.web).service).annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: ClusterIP
   ports:

--- a/hosting/kubernetes/helm/templates/worker-queues-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/worker-queues-deployment.yaml
@@ -50,10 +50,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
-                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
-                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
-                   above. */}}
+            {{- /* extraEnv is a raw list of explicit Kubernetes env entries, so valueFrom works
+                   and names here override earlier chart entries. envFrom pulls whole Secrets or
+                   ConfigMaps, but Kubernetes uses those values only for names absent from env. */}}
             {{- with $workerQueues.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/hosting/kubernetes/helm/templates/worker-queues-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/worker-queues-deployment.yaml
@@ -50,6 +50,17 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
+                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
+                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
+                   above. */}}
+            {{- with $workerQueues.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $workerQueues.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             exec:
               command: ["pgrep", "-f", "entrypoints.worker_queues"]

--- a/hosting/kubernetes/helm/templates/worker-streams-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/worker-streams-deployment.yaml
@@ -50,10 +50,9 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
-            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
-                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
-                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
-                   above. */}}
+            {{- /* extraEnv is a raw list of explicit Kubernetes env entries, so valueFrom works
+                   and names here override earlier chart entries. envFrom pulls whole Secrets or
+                   ConfigMaps, but Kubernetes uses those values only for names absent from env. */}}
             {{- with $workerStreams.extraEnv }}
             {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/hosting/kubernetes/helm/templates/worker-streams-deployment.yaml
+++ b/hosting/kubernetes/helm/templates/worker-streams-deployment.yaml
@@ -50,6 +50,17 @@ spec:
             - name: {{ $key }}
               value: {{ $val | quote }}
             {{- end }}
+            {{- /* extraEnv is a raw list of Kubernetes env entries, so valueFrom works and the
+                   operator can reach a Secret key the chart knows nothing about. envFrom pulls
+                   whole Secrets or ConfigMaps. Both render last, so they win over the entries
+                   above. */}}
+            {{- with $workerStreams.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          {{- with $workerStreams.envFrom }}
+          envFrom:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           livenessProbe:
             exec:
               command: ["pgrep", "-f", "entrypoints.worker_streams"]

--- a/hosting/kubernetes/helm/tests/test_existing_secret.py
+++ b/hosting/kubernetes/helm/tests/test_existing_secret.py
@@ -1,0 +1,173 @@
+# /// script
+# requires-python = ">=3.11"
+# dependencies = ["PyYAML>=6"]
+# ///
+"""Rendered-chart guard for `secrets.existingSecret`.
+
+When the operator brings their own Secret the chart does not create one, so every
+`secretKeyRef` in the rendered manifests must point at that Secret. A reference to the
+chart-managed name (`agenta.fullname`) resolves to nothing and the pod crash-loops with
+`CreateContainerConfigError`. The runner token used to be hardcoded to `agenta.fullname`
+in the runner Deployment and in the `agenta.agentRunner.servicesEnv` helper; this test is
+the guard that keeps it, or any new reference, from regressing.
+
+Run: uv run hosting/kubernetes/helm/tests/test_existing_secret.py
+Requires the `helm` binary on PATH.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import sys
+from pathlib import Path
+
+import yaml
+
+CHART_DIR = Path(__file__).resolve().parents[1]
+
+RELEASE = "existing-secret-test"
+EXISTING_SECRET = "my-agenta-secret"
+
+# The chart-managed Secret name is `agenta.fullname`, which is "<release>-<chart>" unless the
+# release name already contains the chart name. Keep this in sync with agenta.fullname.
+CHART_MANAGED_SECRET = f"{RELEASE}-agenta"
+
+BASE_ARGS = [
+    "--set",
+    "agenta.webUrl=https://agenta.example.com",
+    "--set",
+    "agenta.apiUrl=https://agenta.example.com/api",
+    "--set",
+    "agenta.servicesUrl=https://agenta.example.com/services",
+    "--set",
+    "agentRunner.enabled=true",
+    "--set",
+    f"secrets.existingSecret={EXISTING_SECRET}",
+    # The bundled PostgreSQL subchart must be pointed at the same Secret; the chart's own
+    # agenta.validatePgauthSecret fails the render otherwise.
+    "--set",
+    f"global.postgresql.auth.existingSecret={EXISTING_SECRET}",
+]
+
+
+def render(extra_args: list[str] | None = None) -> list[dict]:
+    result = subprocess.run(
+        [
+            "helm",
+            "template",
+            RELEASE,
+            str(CHART_DIR),
+            *BASE_ARGS,
+            *(extra_args or []),
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [doc for doc in yaml.safe_load_all(result.stdout) if doc]
+
+
+def pod_specs(docs: list[dict]) -> list[tuple[str, dict]]:
+    """(workload name, pod spec) for every workload the chart renders."""
+    specs: list[tuple[str, dict]] = []
+    for doc in docs:
+        if doc.get("kind") not in ("Deployment", "StatefulSet", "Job", "Pod"):
+            continue
+        name = doc.get("metadata", {}).get("name", "<unnamed>")
+        if doc["kind"] == "Pod":
+            specs.append((name, doc["spec"]))
+        else:
+            specs.append((name, doc["spec"]["template"]["spec"]))
+    return specs
+
+
+def secret_references(docs: list[dict]) -> list[tuple[str, str, str]]:
+    """(workload, where, secret name) for every Secret reference in every pod spec."""
+    refs: list[tuple[str, str, str]] = []
+    for workload, spec in pod_specs(docs):
+        containers = list(spec.get("initContainers", [])) + list(spec.get("containers", []))
+        for container in containers:
+            where = f"container {container.get('name')}"
+            for entry in container.get("env", []):
+                ref = entry.get("valueFrom", {}).get("secretKeyRef")
+                if ref and ref.get("name"):
+                    refs.append((workload, f"{where} env {entry['name']}", ref["name"]))
+            for entry in container.get("envFrom", []):
+                ref = entry.get("secretRef")
+                if ref and ref.get("name"):
+                    refs.append((workload, f"{where} envFrom", ref["name"]))
+        for volume in spec.get("volumes", []):
+            secret = volume.get("secret")
+            if secret and secret.get("secretName"):
+                refs.append(
+                    (workload, f"volume {volume.get('name')}", secret["secretName"])
+                )
+    return refs
+
+
+def main() -> int:
+    failures: list[str] = []
+    docs = render()
+
+    # 1. The chart must not create its own Secret when the operator supplies one.
+    for doc in docs:
+        if doc.get("kind") == "Secret" and doc["metadata"]["name"] == CHART_MANAGED_SECRET:
+            failures.append(
+                f"chart rendered its own Secret {CHART_MANAGED_SECRET} despite secrets.existingSecret"
+            )
+
+    # 2. No workload may reference the chart-managed Secret name.
+    refs = secret_references(docs)
+    for workload, where, name in refs:
+        if name == CHART_MANAGED_SECRET:
+            failures.append(
+                f"{workload}: {where} references the chart-managed Secret {name!r}, "
+                f"expected {EXISTING_SECRET!r}"
+            )
+
+    # 3. The runner token specifically must come from the operator's Secret, on the runner
+    #    Deployment and on every workload the servicesEnv helper feeds (api, services).
+    token_refs = {
+        workload: name
+        for workload, where, name in refs
+        if where.endswith("env AGENTA_RUNNER_TOKEN")
+    }
+    if not token_refs:
+        failures.append("no workload references AGENTA_RUNNER_TOKEN")
+    for workload, name in sorted(token_refs.items()):
+        if name != EXISTING_SECRET:
+            failures.append(
+                f"{workload}: AGENTA_RUNNER_TOKEN reads Secret {name!r}, expected {EXISTING_SECRET!r}"
+            )
+    for suffix in ("-runner", "-api", "-services"):
+        if not any(workload.endswith(suffix) for workload in token_refs):
+            failures.append(f"no {suffix.lstrip('-')} workload reads AGENTA_RUNNER_TOKEN")
+
+    # 4. agentRunner.auth.tokenSecretRef still wins over both Secret names.
+    own_ref_docs = render(
+        [
+            "--set",
+            "agentRunner.auth.tokenSecretRef.name=runner-only-secret",
+            "--set",
+            "agentRunner.auth.tokenSecretRef.key=token",
+        ]
+    )
+    for workload, where, name in secret_references(own_ref_docs):
+        if where.endswith("env AGENTA_RUNNER_TOKEN") and name != "runner-only-secret":
+            failures.append(
+                f"{workload}: agentRunner.auth.tokenSecretRef ignored, reads {name!r}"
+            )
+
+    if failures:
+        print("FAIL: secrets.existingSecret is not honored:", file=sys.stderr)
+        for line in failures:
+            print(f"  - {line}", file=sys.stderr)
+        return 1
+
+    print("OK: every Secret reference honors secrets.existingSecret.")
+    print(f"  runner token sources: {sorted(token_refs.items())}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/hosting/kubernetes/helm/tests/test_existing_secret.py
+++ b/hosting/kubernetes/helm/tests/test_existing_secret.py
@@ -85,7 +85,9 @@ def secret_references(docs: list[dict]) -> list[tuple[str, str, str]]:
     """(workload, where, secret name) for every Secret reference in every pod spec."""
     refs: list[tuple[str, str, str]] = []
     for workload, spec in pod_specs(docs):
-        containers = list(spec.get("initContainers", [])) + list(spec.get("containers", []))
+        containers = list(spec.get("initContainers", [])) + list(
+            spec.get("containers", [])
+        )
         for container in containers:
             where = f"container {container.get('name')}"
             for entry in container.get("env", []):
@@ -111,7 +113,10 @@ def main() -> int:
 
     # 1. The chart must not create its own Secret when the operator supplies one.
     for doc in docs:
-        if doc.get("kind") == "Secret" and doc["metadata"]["name"] == CHART_MANAGED_SECRET:
+        if (
+            doc.get("kind") == "Secret"
+            and doc["metadata"]["name"] == CHART_MANAGED_SECRET
+        ):
             failures.append(
                 f"chart rendered its own Secret {CHART_MANAGED_SECRET} despite secrets.existingSecret"
             )
@@ -141,7 +146,9 @@ def main() -> int:
             )
     for suffix in ("-runner", "-api", "-services"):
         if not any(workload.endswith(suffix) for workload in token_refs):
-            failures.append(f"no {suffix.lstrip('-')} workload reads AGENTA_RUNNER_TOKEN")
+            failures.append(
+                f"no {suffix.lstrip('-')} workload reads AGENTA_RUNNER_TOKEN"
+            )
 
     # 4. agentRunner.auth.tokenSecretRef still wins over both Secret names.
     own_ref_docs = render(

--- a/hosting/kubernetes/helm/tests/test_existing_secret.py
+++ b/hosting/kubernetes/helm/tests/test_existing_secret.py
@@ -169,5 +169,10 @@ def main() -> int:
     return 0
 
 
+def test_existing_secret_is_honored() -> None:
+    """pytest entry point. The module also runs standalone; both call main()."""
+    assert main() == 0, "secrets.existingSecret is honored"
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/hosting/kubernetes/helm/tests/test_ingress_validation.py
+++ b/hosting/kubernetes/helm/tests/test_ingress_validation.py
@@ -1,0 +1,86 @@
+# /// script
+# requires-python = ">=3.11"
+# ///
+"""Regression checks for Ingress values that Kubernetes cannot safely accept."""
+
+from __future__ import annotations
+
+import subprocess
+from pathlib import Path
+
+CHART_DIR = Path(__file__).resolve().parents[1]
+
+BASE_ARGS = [
+    "--set",
+    "agenta.webUrl=https://agenta.example.com",
+    "--set",
+    "agenta.apiUrl=https://agenta.example.com/api",
+    "--set",
+    "agenta.servicesUrl=https://agenta.example.com/services",
+    "--set",
+    "agenta.authKey=test-auth-key",
+    "--set",
+    "agenta.cryptKey=test-crypt-key",
+    "--set",
+    "agenta.servicesInternalKey=test-services-internal-key",
+    "--set",
+    "agenta.runnerToken=test-runner-token",
+    "--set",
+    "postgres.password=test-postgres-password",
+]
+
+
+def render(*args: str) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["helm", "template", "ingress-test", str(CHART_DIR), *BASE_ARGS, *args],
+        capture_output=True,
+        text=True,
+    )
+
+
+def test_ingress_values_are_safe() -> None:
+    disabled = render("--set", "store.seaweedfs.ingress.enabled=false")
+    assert disabled.returncode == 0, disabled.stderr
+
+    missing_host = render("--set", "store.seaweedfs.ingress.enabled=true")
+    assert missing_host.returncode != 0
+    assert "host is required" in missing_host.stderr
+
+    empty_paths = render(
+        "--set-json",
+        'ingress.extraHosts=[{"host":"extra.example.com","paths":[]}]',
+    )
+    assert empty_paths.returncode != 0
+    assert "must have at least 1 items" in empty_paths.stderr.lower()
+
+    insecure = render(
+        "--set",
+        "store.enabled=true",
+        "--set",
+        "store.seaweedfs.ingress.enabled=true",
+        "--set",
+        "store.seaweedfs.ingress.host=store.example.com",
+        "--set",
+        "store.endpointUrl=http://store.example.com",
+    )
+    assert insecure.returncode != 0
+    assert "requires an HTTPS store.endpointUrl" in insecure.stderr
+
+    secure = render(
+        "--set",
+        "store.enabled=true",
+        "--set",
+        "store.seaweedfs.ingress.enabled=true",
+        "--set",
+        "store.seaweedfs.ingress.host=store.example.com",
+        "--set",
+        "store.endpointUrl=https://store.example.com",
+        "--set-json",
+        'store.seaweedfs.ingress.tls=[{"hosts":["store.example.com"],"secretName":"store-tls"}]',
+    )
+    assert secure.returncode == 0, secure.stderr
+
+
+if __name__ == "__main__":
+    test_ingress_values_are_safe()
+    print("OK: invalid ingress values fail before Kubernetes sees them.")

--- a/hosting/kubernetes/helm/tests/test_runner_secret_absence.py
+++ b/hosting/kubernetes/helm/tests/test_runner_secret_absence.py
@@ -231,7 +231,8 @@ def main() -> int:
     for args, expected in (
         (DEFAULT_TOKEN_ARGS + ["--set", "agentRunner.host=127.0.0.1"], "127.0.0.1"),
         (
-            DEFAULT_TOKEN_ARGS + ["--set", "agentRunner.env.AGENTA_RUNNER_HOST=10.0.0.5"],
+            DEFAULT_TOKEN_ARGS
+            + ["--set", "agentRunner.env.AGENTA_RUNNER_HOST=10.0.0.5"],
             "10.0.0.5",
         ),
     ):
@@ -257,7 +258,9 @@ def main() -> int:
     if mounts.get("fuse") != "/dev/fuse":
         failures.append("custom runner securityContext suppresses the /dev/fuse mount")
     if volumes.get("fuse", {}).get("hostPath", {}).get("path") != "/dev/fuse":
-        failures.append("custom runner securityContext suppresses the /dev/fuse hostPath")
+        failures.append(
+            "custom runner securityContext suppresses the /dev/fuse hostPath"
+        )
 
     if failures:
         print("FAIL: runner environment is not narrow:", file=sys.stderr)

--- a/hosting/kubernetes/helm/tests/test_runner_secret_absence.py
+++ b/hosting/kubernetes/helm/tests/test_runner_secret_absence.py
@@ -195,5 +195,10 @@ def main() -> int:
     return 0
 
 
+def test_runner_env_stays_narrow() -> None:
+    """pytest entry point. The module also runs standalone; both call main()."""
+    assert main() == 0, "the runner environment stays narrow"
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/hosting/kubernetes/helm/tests/test_runner_secret_absence.py
+++ b/hosting/kubernetes/helm/tests/test_runner_secret_absence.py
@@ -86,6 +86,10 @@ FORBIDDEN_PREFIXES = (
 REQUIRED = {
     "AGENTA_RUNNER_PORT",
     "AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS",
+    # The runner binds 127.0.0.1 unless told otherwise. In a pod that makes every health
+    # probe fail with connection refused and the pod never becomes ready, which is what
+    # happened on a live GKE cluster. See runner_bind_address() below for the value check.
+    "AGENTA_RUNNER_HOST",
 }
 
 
@@ -117,6 +121,28 @@ def runner_container_env_names(docs: list[dict]) -> list[str]:
         containers = doc["spec"]["template"]["spec"]["containers"]
         runner = next(c for c in containers if c["name"] == "runner")
         return [entry["name"] for entry in runner.get("env", [])]
+    raise AssertionError("no runner Deployment found in the rendered chart")
+
+
+def runner_bind_address(docs: list[dict]) -> str:
+    """The AGENTA_RUNNER_HOST value on the runner container, and how many times it is set."""
+    for doc in docs:
+        if doc.get("kind") != "Deployment":
+            continue
+        if (
+            doc.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component")
+            != "runner"
+        ):
+            continue
+        containers = doc["spec"]["template"]["spec"]["containers"]
+        runner = next(c for c in containers if c["name"] == "runner")
+        values = [
+            entry.get("value")
+            for entry in runner.get("env", [])
+            if entry["name"] == "AGENTA_RUNNER_HOST"
+        ]
+        assert len(values) == 1, f"AGENTA_RUNNER_HOST set {len(values)} times"
+        return values[0]
     raise AssertionError("no runner Deployment found in the rendered chart")
 
 
@@ -181,6 +207,24 @@ def main() -> int:
     # Operator supplies their own secret ref: same narrow env, token sourced from their Secret.
     names_with_token = runner_container_env_names(render(TOKEN_ARGS))
     failures += check(names_with_token)
+
+    # The runner must bind every interface, or the kubelet cannot reach its health endpoint
+    # over the pod IP and the pod never becomes ready.
+    bind = runner_bind_address(docs)
+    if bind != "0.0.0.0":
+        failures.append(f"runner binds {bind!r}, expected '0.0.0.0'")
+
+    # Both override paths still win, and neither produces a duplicate entry.
+    for args, expected in (
+        (DEFAULT_TOKEN_ARGS + ["--set", "agentRunner.host=127.0.0.1"], "127.0.0.1"),
+        (
+            DEFAULT_TOKEN_ARGS + ["--set", "agentRunner.env.AGENTA_RUNNER_HOST=10.0.0.5"],
+            "10.0.0.5",
+        ),
+    ):
+        got = runner_bind_address(render(args))
+        if got != expected:
+            failures.append(f"runner bind override gave {got!r}, expected {expected!r}")
 
     if failures:
         print("FAIL: runner environment is not narrow:", file=sys.stderr)

--- a/hosting/kubernetes/helm/tests/test_runner_secret_absence.py
+++ b/hosting/kubernetes/helm/tests/test_runner_secret_absence.py
@@ -146,6 +146,19 @@ def runner_bind_address(docs: list[dict]) -> str:
     raise AssertionError("no runner Deployment found in the rendered chart")
 
 
+def runner_pod_spec(docs: list[dict]) -> dict:
+    """The runner Deployment's pod spec."""
+    for doc in docs:
+        if doc.get("kind") != "Deployment":
+            continue
+        if (
+            doc.get("metadata", {}).get("labels", {}).get("app.kubernetes.io/component")
+            == "runner"
+        ):
+            return doc["spec"]["template"]["spec"]
+    raise AssertionError("no runner Deployment found in the rendered chart")
+
+
 def deployment_env_names(docs: list[dict], component: str) -> set[str]:
     """Environment variable names on a component's primary container."""
     for doc in docs:
@@ -225,6 +238,26 @@ def main() -> int:
         got = runner_bind_address(render(args))
         if got != expected:
             failures.append(f"runner bind override gave {got!r}, expected {expected!r}")
+
+    # A custom securityContext controls capabilities, but it must not suppress the /dev/fuse
+    # device when FUSE is enabled. Operators use this path to supply their own SYS_ADMIN shape.
+    fuse_docs = render(
+        DEFAULT_TOKEN_ARGS
+        + [
+            "--set",
+            "store.enabled=true",
+            "--set",
+            "agentRunner.securityContext.allowPrivilegeEscalation=true",
+        ]
+    )
+    spec = runner_pod_spec(fuse_docs)
+    runner = next(c for c in spec["containers"] if c["name"] == "runner")
+    mounts = {m["name"]: m["mountPath"] for m in runner.get("volumeMounts", [])}
+    volumes = {v["name"]: v for v in spec.get("volumes", [])}
+    if mounts.get("fuse") != "/dev/fuse":
+        failures.append("custom runner securityContext suppresses the /dev/fuse mount")
+    if volumes.get("fuse", {}).get("hostPath", {}).get("path") != "/dev/fuse":
+        failures.append("custom runner securityContext suppresses the /dev/fuse hostPath")
 
     if failures:
         print("FAIL: runner environment is not narrow:", file=sys.stderr)

--- a/hosting/kubernetes/helm/tests/test_web_mobile.py
+++ b/hosting/kubernetes/helm/tests/test_web_mobile.py
@@ -28,6 +28,8 @@ BASE_ARGS = [
     "--set",
     "agenta.cryptKey=test-crypt-key",
     "--set",
+    "agenta.servicesInternalKey=test-services-internal-key",
+    "--set",
     "agenta.runnerToken=test-runner-token",
     "--set",
     "postgres.password=test-postgres-password",

--- a/hosting/kubernetes/helm/tests/test_web_mobile.py
+++ b/hosting/kubernetes/helm/tests/test_web_mobile.py
@@ -161,5 +161,10 @@ def main() -> int:
     return 0
 
 
+def test_web_mobile_is_deployed_and_routed() -> None:
+    """pytest entry point. The module also runs standalone; both call main()."""
+    assert main() == 0, "web-mobile is deployed and routed"
+
+
 if __name__ == "__main__":
     raise SystemExit(main())

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -284,6 +284,19 @@
           "properties": {
             "enabled":     { "type": "boolean", "description": "Deploy the bundled SeaweedFS StatefulSet." },
             "port":        { "type": ["integer", "string"], "description": "SeaweedFS S3 gateway port (default 8333)." },
+            "ingress": {
+              "type": "object",
+              "additionalProperties": false,
+              "description": "Optional public route to the bundled S3 gateway, for clients outside the cluster such as a Daytona sandbox. Set store.endpointUrl to the same hostname so every pod hands out that URL.",
+              "required": ["host"],
+              "properties": {
+                "enabled":     { "type": "boolean", "description": "Default false." },
+                "className":   { "type": "string", "description": "IngressClass name. Unset leaves the field out and the cluster default applies." },
+                "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
+                "host":        { "type": "string", "description": "Hostname for the gateway, for example store.example.com. Required when enabled." },
+                "tls":         { "type": "array", "items": { "type": "object", "additionalProperties": true }, "description": "Passed through verbatim, in the shape the Ingress spec uses." }
+              }
+            },
             "image": {
               "type": "object",
               "additionalProperties": true,

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -439,6 +439,24 @@
             "webMobile": { "$ref": "#/$defs/ingressPath", "description": "Mobile web route. The mobile image is built with basePath /m, so keep path at /m unless you rebuild it; pathType is free to change (a managed ingress may need ImplementationSpecific)." },
             "web":       { "$ref": "#/$defs/ingressPath" }
           }
+        },
+        "extraPaths": {
+          "type": "array",
+          "description": "Extra routes on ingress.host, appended after the built-in api/services/webMobile/web paths. Use them to reach a Service the chart does not own, for example /llm in front of a gateway.",
+          "items": { "$ref": "#/$defs/ingressExtraPath" }
+        },
+        "extraHosts": {
+          "type": "array",
+          "description": "Extra ingress rules, one per hostname, each with its own path list.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["host", "paths"],
+            "properties": {
+              "host":  { "type": "string" },
+              "paths": { "type": "array", "items": { "$ref": "#/$defs/ingressExtraPath" } }
+            }
+          }
         }
       }
     },
@@ -473,6 +491,18 @@
       "properties": {
         "path":     { "type": "string" },
         "pathType": { "type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"] }
+      }
+    },
+    "ingressExtraPath": {
+      "type": "object",
+      "additionalProperties": false,
+      "required": ["path", "serviceName", "servicePort"],
+      "description": "One extra ingress route pointing at a Service the chart does not own. The Service must already exist in the release namespace.",
+      "properties": {
+        "path":        { "type": "string" },
+        "pathType":    { "type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"], "description": "Default Prefix." },
+        "serviceName": { "type": "string" },
+        "servicePort": { "type": ["integer", "string"], "description": "A number renders as port.number, a string as port.name." }
       }
     },
     "component": {

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -486,7 +486,15 @@
         "resources":   { "type": "object", "additionalProperties": true },
         "env":         { "type": "object", "additionalProperties": { "type": ["string", "number", "boolean"] } },
         "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
-        "labels":      { "type": "object", "additionalProperties": { "type": "string" } }
+        "labels":      { "type": "object", "additionalProperties": { "type": "string" } },
+        "service": {
+          "type": "object",
+          "additionalProperties": true,
+          "description": "Knobs for the component's Service object.",
+          "properties": {
+            "annotations": { "type": "object", "additionalProperties": { "type": "string" }, "description": "Annotations on the Service. GKE reads cloud.google.com/backend-config and cloud.google.com/neg here." }
+          }
+        }
       }
     },
     "bundledRedis": {

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -307,6 +307,14 @@
         "externalUrl": { "type": "string", "description": "AGENTA_RUNNER_INTERNAL_URL override pointing at an external runner." },
         "piAgentDir":  { "type": "string", "description": "PI_CODING_AGENT_DIR for local Pi runs (default /pi-agent); unset means no Agenta extension for the run (the runner logs a warning)." },
         "logLevel":    { "type": "string", "description": "AGENTA_RUNNER_LOG_LEVEL read by the runner service." },
+        "fuse": {
+          "type": "object",
+          "additionalProperties": false,
+          "description": "FUSE support for the runner's local sandboxes (geesefs mounts the store prefix on the node).",
+          "properties": {
+            "enabled": { "type": "boolean", "description": "Default true. When true and store.enabled is true, the runner container gets the SYS_ADMIN capability and a hostPath mount of /dev/fuse. Set false on a cluster that rejects either, such as GKE Autopilot, and run sandboxes on the Daytona provider instead." }
+          }
+        },
         "liveFrames":  { "type": "boolean", "description": "AGENTA_RUNNER_LIVE_FRAMES; temporary live-frame publication. Defaults to true." },
         "providers": {
           "type": "object",

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -425,9 +425,10 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "api":      { "$ref": "#/$defs/ingressPath" },
-            "services": { "$ref": "#/$defs/ingressPath" },
-            "web":      { "$ref": "#/$defs/ingressPath" }
+            "api":       { "$ref": "#/$defs/ingressPath" },
+            "services":  { "$ref": "#/$defs/ingressPath" },
+            "webMobile": { "$ref": "#/$defs/ingressPath", "description": "Mobile web route. The mobile image is built with basePath /m, so keep path at /m unless you rebuild it; pathType is free to change (a managed ingress may need ImplementationSpecific)." },
+            "web":       { "$ref": "#/$defs/ingressPath" }
           }
         }
       }

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -320,6 +320,9 @@
         "externalUrl": { "type": "string", "description": "AGENTA_RUNNER_INTERNAL_URL override pointing at an external runner." },
         "piAgentDir":  { "type": "string", "description": "PI_CODING_AGENT_DIR for local Pi runs (default /pi-agent); unset means no Agenta extension for the run (the runner logs a warning)." },
         "logLevel":    { "type": "string", "description": "AGENTA_RUNNER_LOG_LEVEL read by the runner service." },
+        "host":        { "type": "string", "description": "AGENTA_RUNNER_HOST, the runner's bind address. Default 0.0.0.0. The runner itself defaults to 127.0.0.1, which the kubelet cannot reach, so the probes would fail forever." },
+        "port":        { "type": ["integer", "string"], "description": "AGENTA_RUNNER_PORT and the container port. Default 8765." },
+        "replicas":    { "type": "integer", "minimum": 0 },
         "fuse": {
           "type": "object",
           "additionalProperties": false,

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -291,7 +291,8 @@
               "type": "object",
               "additionalProperties": false,
               "description": "Optional public route to the bundled S3 gateway, for clients outside the cluster such as a Daytona sandbox. Set store.endpointUrl to the same hostname so every pod hands out that URL.",
-              "required": ["host"],
+              "if": { "properties": { "enabled": { "const": true } }, "required": ["enabled"] },
+              "then": { "required": ["host"] },
               "properties": {
                 "enabled":     { "type": "boolean", "description": "Default false." },
                 "className":   { "type": "string", "description": "IngressClass name. Unset leaves the field out and the cluster default applies." },
@@ -478,7 +479,7 @@
             "required": ["host", "paths"],
             "properties": {
               "host":  { "type": "string" },
-              "paths": { "type": "array", "items": { "$ref": "#/$defs/ingressExtraPath" } }
+              "paths": { "type": "array", "minItems": 1, "items": { "$ref": "#/$defs/ingressExtraPath" } }
             }
           }
         }

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -450,7 +450,7 @@
       "additionalProperties": true,
       "properties": {
         "enabled":     { "type": "boolean" },
-        "className":   { "type": "string", "description": "IngressClass name. Default 'traefik'." },
+        "className":   { "type": "string", "description": "IngressClass name. Unset means 'traefik'. An empty string leaves spec.ingressClassName out entirely, for a controller that ignores the field and routes by annotation instead (GKE reacts only to kubernetes.io/ingress.class)." },
         "host":        { "type": "string" },
         "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
         "tls":         { "type": "array", "items": { "type": "object", "additionalProperties": true } },

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -155,6 +155,9 @@
       "properties": {
         "enabled":          { "type": "boolean" },
         "apiKey":           { "type": "string", "description": "SUPERTOKENS_API_KEY via Secret." },
+        "env":              { "type": "object", "additionalProperties": { "type": ["string", "number", "boolean"] } },
+        "extraEnv":         { "$ref": "#/$defs/rawEnvList" },
+        "envFrom":          { "$ref": "#/$defs/envFromList" },
         "uriCore":          { "type": "string", "description": "SUPERTOKENS_URI_CORE (override; ignored when bundled)." },
         "application":      { "type": "string", "description": "SUPERTOKENS_APPLICATION." },
         "tenant":           { "type": "string", "description": "SUPERTOKENS_TENANT." },
@@ -320,6 +323,8 @@
         "externalUrl": { "type": "string", "description": "AGENTA_RUNNER_INTERNAL_URL override pointing at an external runner." },
         "piAgentDir":  { "type": "string", "description": "PI_CODING_AGENT_DIR for local Pi runs (default /pi-agent); unset means no Agenta extension for the run (the runner logs a warning)." },
         "logLevel":    { "type": "string", "description": "AGENTA_RUNNER_LOG_LEVEL read by the runner service." },
+        "extraEnv":    { "$ref": "#/$defs/rawEnvList", "description": "Raw env entries for the runner. Keep it to one key at a time: a local harness shares this container and can read /proc, which is why the runner's environment is narrow." },
+        "envFrom":     { "$ref": "#/$defs/envFromList", "description": "Whole Secrets or ConfigMaps on the runner. Discouraged: it defeats the narrow-environment guard in tests/test_runner_secret_absence.py." },
         "host":        { "type": "string", "description": "AGENTA_RUNNER_HOST, the runner's bind address. Default 0.0.0.0. The runner itself defaults to 127.0.0.1, which the kubelet cannot reach, so the probes would fail forever." },
         "port":        { "type": ["integer", "string"], "description": "AGENTA_RUNNER_PORT and the container port. Default 8765." },
         "replicas":    { "type": "integer", "minimum": 0 },
@@ -422,6 +427,9 @@
         "autoMigrations":          { "type": ["boolean", "string"], "description": "ALEMBIC_AUTO_MIGRATIONS." },
         "cfgPathCore":             { "type": "string", "description": "ALEMBIC_CFG_PATH_CORE." },
         "cfgPathTracing":          { "type": "string", "description": "ALEMBIC_CFG_PATH_TRACING." },
+        "env":                     { "type": "object", "additionalProperties": { "type": ["string", "number", "boolean"] } },
+        "extraEnv":                { "$ref": "#/$defs/rawEnvList" },
+        "envFrom":                 { "$ref": "#/$defs/envFromList" },
         "hookPhase":               { "type": "string", "enum": ["post", "pre"], "description": "Helm hook phase for the migration Job. 'post' (default) renders post-install,post-upgrade and is required with the bundled PostgreSQL, which does not exist yet at pre-install time. 'pre' renders pre-install,pre-upgrade so the migrations finish before the app pods start; use it with an external database." },
         "activeDeadlineSeconds":   { "type": "integer" },
         "backoffLimit":            { "type": "integer" },
@@ -509,6 +517,16 @@
         "pathType": { "type": "string", "enum": ["Exact", "Prefix", "ImplementationSpecific"] }
       }
     },
+    "rawEnvList": {
+      "type": "array",
+      "description": "Raw Kubernetes env entries, rendered verbatim after the chart's own variables, so valueFrom works and a later entry wins. Use it to reach a Secret key the chart does not model.",
+      "items": { "type": "object", "additionalProperties": true, "required": ["name"], "properties": { "name": { "type": "string" } } }
+    },
+    "envFromList": {
+      "type": "array",
+      "description": "Raw Kubernetes envFrom entries (secretRef or configMapRef), rendered verbatim on the container.",
+      "items": { "type": "object", "additionalProperties": true }
+    },
     "ingressExtraPath": {
       "type": "object",
       "additionalProperties": false,
@@ -540,6 +558,8 @@
           }
         },
         "resources":   { "type": "object", "additionalProperties": true },
+        "extraEnv":    { "$ref": "#/$defs/rawEnvList" },
+        "envFrom":     { "$ref": "#/$defs/envFromList" },
         "env":         { "type": "object", "additionalProperties": { "type": ["string", "number", "boolean"] } },
         "annotations": { "type": "object", "additionalProperties": { "type": "string" } },
         "labels":      { "type": "object", "additionalProperties": { "type": "string" } },

--- a/hosting/kubernetes/helm/values.schema.json
+++ b/hosting/kubernetes/helm/values.schema.json
@@ -406,6 +406,7 @@
         "autoMigrations":          { "type": ["boolean", "string"], "description": "ALEMBIC_AUTO_MIGRATIONS." },
         "cfgPathCore":             { "type": "string", "description": "ALEMBIC_CFG_PATH_CORE." },
         "cfgPathTracing":          { "type": "string", "description": "ALEMBIC_CFG_PATH_TRACING." },
+        "hookPhase":               { "type": "string", "enum": ["post", "pre"], "description": "Helm hook phase for the migration Job. 'post' (default) renders post-install,post-upgrade and is required with the bundled PostgreSQL, which does not exist yet at pre-install time. 'pre' renders pre-install,pre-upgrade so the migrations finish before the app pods start; use it with an external database." },
         "activeDeadlineSeconds":   { "type": "integer" },
         "backoffLimit":            { "type": "integer" },
         "ttlSecondsAfterFinished": { "type": "integer" },

--- a/hosting/kubernetes/helm/values.yaml
+++ b/hosting/kubernetes/helm/values.yaml
@@ -124,6 +124,9 @@ redisDurable:
 #   seaweedfs:
 #     enabled: false
 #     port: 8333
+#     ingress:         # optional public route to the bundled S3 gateway; off by default.
+#       enabled: false # Set store.endpointUrl to this host so clients outside the cluster
+#       host: store.example.com   # (a Daytona sandbox) can reach the store.
 #     image:
 #       repository: chrislusf/seaweedfs
 #       tag: "4.37"  # pin a 4.37-era image — IAM regressed in other releases

--- a/hosting/kubernetes/helm/values.yaml
+++ b/hosting/kubernetes/helm/values.yaml
@@ -111,7 +111,7 @@ redisDurable:
 # Docs: https://docs.agenta.ai/self-host/configuration#store-durable-object-store
 # ================================================================== #
 # store:
-#   endpointUrl:
+#   endpointUrl: https://store.example.com
 #   stsEndpointUrl:
 #   accessKey:
 #   secretKey:
@@ -125,8 +125,11 @@ redisDurable:
 #     enabled: false
 #     port: 8333
 #     ingress:         # optional public route to the bundled S3 gateway; off by default.
-#       enabled: false # Set store.endpointUrl to this host so clients outside the cluster
+#       enabled: false # Set store.endpointUrl to this HTTPS host so clients outside the cluster
 #       host: store.example.com   # (a Daytona sandbox) can reach the store.
+#       tls:
+#         - hosts: [store.example.com]
+#           secretName: agenta-store-tls
 #     image:
 #       repository: chrislusf/seaweedfs
 #       tag: "4.37"  # pin a 4.37-era image — IAM regressed in other releases

--- a/hosting/kubernetes/helm/values.yaml
+++ b/hosting/kubernetes/helm/values.yaml
@@ -162,6 +162,15 @@ redisDurable:
 #     tokenSecretRef:          # AGENTA_RUNNER_TOKEN; Services sends it, the runner verifies it
 #       name: agenta-runner
 #       key: token
+#   fuse:
+#     enabled: true            # default true. With store.enabled=true the runner container gets
+#                              # the SYS_ADMIN capability and a hostPath mount of /dev/fuse, which
+#                              # geesefs needs for a local sandbox.
+#                              # GKE Autopilot rejects both, so set this to false there and run
+#                              # sandboxes on the Daytona provider:
+#                              #   agentRunner.fuse.enabled: false
+#                              #   agentRunner.providers.enabled: [daytona]
+#                              #   agentRunner.providers.default: daytona
 
 # ================================================================== #
 # workers — topology A (workers-sprawl); see docs/designs/workers-sprawl/specs.md

--- a/hosting/kubernetes/helm/values.yaml
+++ b/hosting/kubernetes/helm/values.yaml
@@ -141,6 +141,9 @@ redisDurable:
 # ================================================================== #
 # agentRunner:
 #   enabled: true
+#   host: "0.0.0.0"            # AGENTA_RUNNER_HOST, the bind address. Leave it alone: the runner
+#                              # itself defaults to 127.0.0.1, which the kubelet cannot reach, so
+#                              # the health probes fail forever and the pod never becomes ready.
 #   liveFrames: true           # AGENTA_RUNNER_LIVE_FRAMES; set false to disable live-frame relay
 #   providers:
 #     enabled: [local]        # AGENTA_RUNNER_ENABLED_SANDBOX_PROVIDERS (rendered comma-joined)

--- a/hosting/kubernetes/oss/values.oss.example.yaml
+++ b/hosting/kubernetes/oss/values.oss.example.yaml
@@ -509,7 +509,8 @@ posthog:
 # ================================================================== #
 # ingress:
 #   enabled: true
-#   className: traefik
+#   className: traefik   # "" leaves spec.ingressClassName out entirely, for a controller that
+#                        # ignores the field and routes by annotation instead (GKE).
 #   host: agenta.example.com
 #   annotations:
 #     traefik.ingress.kubernetes.io/router.middlewares: agenta-strip-prefixes@kubernetescrd

--- a/hosting/kubernetes/oss/values.oss.example.yaml
+++ b/hosting/kubernetes/oss/values.oss.example.yaml
@@ -429,10 +429,10 @@ posthog:
 # ================================================================== #
 # === api / web / services / workers / cron — deployment knobs ===
 # ================================================================== #
-# Every workload below also takes `extraEnv` (a raw list of Kubernetes env entries,
-# so valueFrom works) and `envFrom` (raw list of secretRef/configMapRef). Both render
-# after the chart's own variables, so a later entry wins. Use extraEnv to reach a
-# Secret key the chart does not model:
+# Every workload below also takes `extraEnv` (explicit Kubernetes env entries, so
+# valueFrom works) and `envFrom` (raw secretRef/configMapRef entries). Matching names
+# in extraEnv override chart entries. envFrom supplies only names absent from explicit
+# env entries. Use extraEnv to reach a Secret key the chart does not model:
 #   api:
 #     extraEnv:
 #       - name: AGENTA_STARTER_CREDITS_BRIDGE_MASTER_KEY
@@ -480,8 +480,8 @@ posthog:
 #       memory: 512Mi
 #     limits:
 #       memory: 1Gi
-# The chart has two worker deployments. `streams` and `queues` are selector
-# lists; an empty list means every loop of that kind.
+# The chart has two worker deployments. `streams` and `queues` are comma-separated
+# selector strings; an empty string means every loop of that kind.
 # workerStreams:
 #   enabled: true
 #   replicas: 1
@@ -539,7 +539,7 @@ posthog:
 # ================================================================== #
 # store:
 #   enabled: false
-#   endpointUrl:       # wins over the internal Service URL even with SeaweedFS bundled.
+#   endpointUrl: https://store.example.com  # wins over the internal Service URL even with SeaweedFS bundled.
 #                      # Set it to the ingress host below so a Daytona sandbox, which runs
 #                      # outside the cluster, can reach the store.
 #   stsEndpointUrl:

--- a/hosting/kubernetes/oss/values.oss.example.yaml
+++ b/hosting/kubernetes/oss/values.oss.example.yaml
@@ -429,6 +429,15 @@ posthog:
 # ================================================================== #
 # === api / web / services / workers / cron — deployment knobs ===
 # ================================================================== #
+# Every workload below also takes `extraEnv` (a raw list of Kubernetes env entries,
+# so valueFrom works) and `envFrom` (raw list of secretRef/configMapRef). Both render
+# after the chart's own variables, so a later entry wins. Use extraEnv to reach a
+# Secret key the chart does not model:
+#   api:
+#     extraEnv:
+#       - name: AGENTA_STARTER_CREDITS_BRIDGE_MASTER_KEY
+#         valueFrom:
+#           secretKeyRef: {name: agenta, key: AGENTA_STARTER_CREDITS_BRIDGE_MASTER_KEY}
 # api:
 #   enabled: true
 #   replicas: 1

--- a/hosting/kubernetes/oss/values.oss.example.yaml
+++ b/hosting/kubernetes/oss/values.oss.example.yaml
@@ -544,6 +544,14 @@ posthog:
 #   seaweedfs:
 #     enabled: false   # defaults to TRUE when store.enabled is true; set false for an external store
 #     port: 8333
+#     ingress:         # optional public route to the bundled S3 gateway; off by default
+#       enabled: false
+#       className: nginx
+#       host: store.example.com
+#       annotations: {}
+#       tls:
+#         - hosts: [store.example.com]
+#           secretName: agenta-store-tls
 #     image:
 #       repository: chrislusf/seaweedfs
 #       tag: "4.37"  # pin a 4.37-era image — IAM regressed in other releases

--- a/hosting/kubernetes/oss/values.oss.example.yaml
+++ b/hosting/kubernetes/oss/values.oss.example.yaml
@@ -471,37 +471,32 @@ posthog:
 #       memory: 512Mi
 #     limits:
 #       memory: 1Gi
-# workerEvaluations:
+# The chart has two worker deployments. `streams` and `queues` are selector
+# lists; an empty list means every loop of that kind.
+# workerStreams:
 #   enabled: true
 #   replicas: 1
-# workerTracing:
+#   # streams: "tracing"
+# workerQueues:
 #   enabled: true
 #   replicas: 1
-# workerWebhooks:
-#   enabled: true
-#   replicas: 1
-# workerEvents:
-#   enabled: true
-#   replicas: 1
-# workerRecords:
-#   enabled: true
-#   replicas: 1
-# workerTriggers:
-#   enabled: true
-#   replicas: 1
-# workerInteractions:
-#   enabled: true
-#   replicas: 1
+#   # queues: "evaluations"
 # cron:
 #   enabled: true
 #   replicas: 1
 
 # ================================================================== #
 # === ingress ===
-# Path routing: / → web, /m → web-mobile, /api → api (prefix-stripped),
-# /services → services (prefix-stripped). The /m route is fixed because the mobile
-# image is built with basePath /m.  When running behind Traefik, attach the StripPrefix
+# Path routing: / → web, /m → web-mobile, /api → api, /services → services.
+#
+# Do NOT strip /api.  The API is mounted at /api (SCRIPT_NAME plus the FastAPI
+# root_path), so it needs the prefix and its redirects keep it.  This matches
+# docker-compose.
+#
+# DO strip /services.  When running behind Traefik, attach the StripPrefix
 # Middleware defined under extraObjects below.
+#
+# The /m route is fixed because the mobile image is built with basePath /m.
 # ================================================================== #
 # ingress:
 #   enabled: true
@@ -523,8 +518,17 @@ posthog:
 # ================================================================== #
 # === store — object store (AGENTA_STORE_*) ===
 # Docs: https://docs.agenta.ai/self-host/configuration#store-durable-object-store
+#
+# store.enabled is FALSE by default, so the whole block below does nothing until
+# you set it.  The store holds session artifacts and file mounts.
+#
+# With store.enabled: true the chart also deploys a bundled SeaweedFS
+# StatefulSet, because store.seaweedfs.enabled defaults to true.  If you point
+# the store at your own S3 or GCS bucket, set store.seaweedfs.enabled: false as
+# well, or you pay for a StatefulSet nothing reads.
 # ================================================================== #
 # store:
+#   enabled: false
 #   endpointUrl:
 #   stsEndpointUrl:
 #   accessKey:
@@ -536,7 +540,7 @@ posthog:
 #   jwtIssuer:
 #   jwtPrivateKey:
 #   seaweedfs:
-#     enabled: false
+#     enabled: false   # defaults to TRUE when store.enabled is true; set false for an external store
 #     port: 8333
 #     image:
 #       repository: chrislusf/seaweedfs
@@ -545,8 +549,8 @@ posthog:
 # ================================================================== #
 # === extraObjects — arbitrary Kubernetes resources ===
 # Includes the Traefik v3 StripPrefix Middleware referenced from the
-# ingress.annotations above.  Required so /api and /services backends
-# receive requests without the prefix.
+# ingress.annotations above.  Required so the services backend receives
+# requests without its prefix.  The API keeps /api, so it is not listed.
 # ================================================================== #
 # extraObjects:
 #   - apiVersion: traefik.io/v1alpha1
@@ -556,6 +560,6 @@ posthog:
 #       namespace: "{{ .Release.Namespace }}"
 #     spec:
 #       stripPrefix:
+#         # /api is deliberately absent: the API expects its own prefix.
 #         prefixes:
-#           - /api
 #           - /services

--- a/hosting/kubernetes/oss/values.oss.example.yaml
+++ b/hosting/kubernetes/oss/values.oss.example.yaml
@@ -529,7 +529,9 @@ posthog:
 # ================================================================== #
 # store:
 #   enabled: false
-#   endpointUrl:
+#   endpointUrl:       # wins over the internal Service URL even with SeaweedFS bundled.
+#                      # Set it to the ingress host below so a Daytona sandbox, which runs
+#                      # outside the cluster, can reach the store.
 #   stsEndpointUrl:
 #   accessKey:
 #   secretKey:


### PR DESCRIPTION
## Why

We deployed the chart on GKE Autopilot with an external Cloud SQL and found a set of defects and missing knobs. Each one either broke the install outright or forced a manual step after every `helm upgrade`. All of them were found on a live cluster; none is theoretical.

## What changed

**Correctness fixes**

- `secrets.existingSecret` was ignored for `AGENTA_RUNNER_TOKEN` in the runner Deployment and in the helper that feeds api and services; those three pods failed on a missing Secret. New test covers it.
- The web and mobile Deployments read the raw URL values, so an install that relied on ingress derivation gave them empty strings while every other workload got the derived URL. They now use the same effective helpers.
- The runner never set `AGENTA_RUNNER_HOST`, bound `127.0.0.1`, and failed its startup probe forever. It now binds `0.0.0.0` by default (`agentRunner.host`).
- `AGENTA_STORE_ENDPOINT_URL` ignored `store.endpointUrl` when SeaweedFS was bundled. Daytona sandboxes need the public URL; the value now wins over the internal Service URL.
- `ingress.paths.webMobile` was rendered but rejected by the schema. The schema and the helpers agree now.
- `spec.ingressClassName` is rendered only when `ingress.className` is non-empty. The GKE controller ignores that field and reads only the legacy `kubernetes.io/ingress.class` annotation.
- The `ingress.tls` validation message described a shape the schema rejects.

**New operator knobs**

- `<component>.service.annotations` on the four Services (GKE `BackendConfig` and NEG annotations).
- `agentRunner.fuse.enabled` to turn off the `SYS_ADMIN` capability and the `/dev/fuse` hostPath, which Autopilot rejects.
- `alembic.hookPhase: pre` to run migrations before the pods start when the database is external.
- `ingress.extraPaths` and `ingress.extraHosts`.
- `store.seaweedfs.ingress` for a public store hostname.
- `<component>.extraEnv` and `<component>.envFrom` on every workload.

**Docs and tests**

- New `hosting/kubernetes/README.md` with the external-Postgres and managed-ingress deltas.
- The example values files no longer list seven worker components the chart does not have, and their `/api` stripping comment matches the chart.
- The web-mobile chart test was red on the release branch (missing internal services key), and pytest collected the chart tests while running none of them. Both fixed.

Chart version, appVersion and default ports are unchanged. A default render is byte for byte identical to the base except for the web URL fix.

## How to verify

```
cd hosting/kubernetes/helm
helm lint . -f ../ee/values.ee.example.yaml --set agenta.authKey=a --set agenta.cryptKey=b --set agenta.servicesInternalKey=c --set agenta.runnerToken=d
python3 -m pytest -q tests
```

Live: the `oss` and `staging` stages on the GKE cluster in `agenta-stage` deploy from this branch.

https://claude.ai/code/session_01GZqpvjwLHgVnMrpKH8hzq8