### PR TITLE
[fix] Read provider-key presence from value_status, not the write-only value

### DIFF
--- a/web/packages/agenta-entities/src/secret/state/persistence.ts
+++ b/web/packages/agenta-entities/src/secret/state/persistence.ts
@@ -7,8 +7,8 @@
  * every secret-value field is replaced with a truthy sentinel, metadata
  * (names, ids, kinds, models, timestamps) is kept verbatim.
  *
- * The sentinel keeps presence semantics (`!!secret.key`) intact so consumers
- * like the agent playground's model-key badges paint correctly from disk.
+ * The sentinel keeps a restored row from looking blanked; `hasStoredKey`, not `!!key`, is the
+ * presence rule (a write-only record has no value to sentinel).
  * Because restored rows carry sentinels instead of real values,
  * `refetchOnRestore: "always"` is mandatory — exactly one background refetch
  * fires on restore regardless of age, replacing sentinels with live data.

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/providerKeyPrompt.ts
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/providerKeyPrompt.ts
@@ -1,0 +1,35 @@
+import {hasStoredKey} from "@agenta/entities/secret"
+import type {LlmProvider} from "@agenta/shared/types"
+
+import type {ConnectionMode} from "../connectionUtils"
+
+/**
+ * Whether the Model section should prompt for the selected model's standard provider key.
+ *
+ * Presence comes from `hasStoredKey`, never the row's value: a write-only record returns no value
+ * and reports presence through `hasKey`, so `!row.key` called a connected project keyless (#6660).
+ *
+ * Answers `false` wherever it cannot judge: a `self_managed` connection signs itself in, a named
+ * `agenta` connection points at a vault record this rule never looks up, and an unresolved vault
+ * reads as keyless for every provider.
+ */
+export const shouldPromptForProviderKey = ({
+    connectionMode,
+    connectionSlug,
+    vaultLoaded,
+    standardProviderEntry,
+}: {
+    /** The config's `agent.llm.connection.mode`, normalized by `connectionFromConfig`. */
+    connectionMode: ConnectionMode | null | undefined
+    /** The named connection's slug, when the config points at one. */
+    connectionSlug: string | null | undefined
+    /** Whether the project vault query has resolved. */
+    vaultLoaded: boolean
+    /** The standard vault catalog row for the selected model's provider family, or `null`. */
+    standardProviderEntry: LlmProvider | null | undefined
+}): boolean => {
+    if (connectionMode === "self_managed") return false
+    if (connectionMode === "agenta" && !!connectionSlug) return false
+    if (!vaultLoaded || !standardProviderEntry) return false
+    return !hasStoredKey(standardProviderEntry)
+}

--- a/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
+++ b/web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/agentTemplate/useModelHarness.tsx
@@ -58,6 +58,7 @@ import {effectiveHarnessValue, enumLabel} from "./agentTemplateUtils"
 import {CatalogUnavailableNotice} from "./CatalogUnavailableNotice"
 import ModelPickerControl from "./ModelPickerControl"
 import {PermissionPolicySelect} from "./PermissionPolicySelect"
+import {shouldPromptForProviderKey} from "./providerKeyPrompt"
 import {RevertGroupButton} from "./RevertGroupButton"
 import {useBuildKit} from "./useBuildKit"
 
@@ -226,15 +227,13 @@ export function useModelHarness({
             ) ?? null
         )
     }, [standardSecrets, selectedProviderFamily])
-    // Self-managed agents never need a vault key — the harness signs itself in. Neither does a
-    // named custom-provider connection (agenta mode with a slug): it carries its own credentials,
-    // so a missing STANDARD vault key for the family is not this connection's problem.
-    const providerNeedsKey =
-        connection.mode !== "self_managed" &&
-        !(connection.mode === "agenta" && !!connection.slug) &&
-        vaultLoaded &&
-        !!providerVaultEntry &&
-        !providerVaultEntry.key
+    // Presence goes through `hasStoredKey`, never the row's value (see the module for the rule).
+    const providerNeedsKey = shouldPromptForProviderKey({
+        connectionMode: connection.mode,
+        connectionSlug: connection.slug,
+        vaultLoaded,
+        standardProviderEntry: providerVaultEntry,
+    })
 
     // The "Add custom provider" footer + drawer come from context, same source as the completion picker.
     const {llmProviderConfig, permissions, onWorkflowRevisionCommitted} = useDrillInUI()
@@ -701,8 +700,8 @@ export function useModelHarness({
     return {
         hasModelOrHarness,
         mcpSupported,
-        // The selected model's provider has a standard vault slot but no key yet — the config panel
-        // highlights the Model section and the chat gates on it until it's connected.
+        // Standard vault slot, no key yet: the config panel highlights the Model section. The chat
+        // composer gates on its own project-wide `gateActive`, not on this.
         needsProviderKey: providerNeedsKey,
         // A model is selected but its harness can't run it — a *model* problem, so the config panel
         // flags the Model section as invalid.

--- a/web/packages/agenta-entity-ui/tests/unit/providerKeyPrompt.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/providerKeyPrompt.test.ts
@@ -1,0 +1,83 @@
+/**
+ * `shouldPromptForProviderKey` drives the Model section's "Connect key" badge and tooltip.
+ * Fixtures are the row shapes the vault really serves; #6660 was the write-only one.
+ */
+import {describe, expect, it} from "vitest"
+
+import {shouldPromptForProviderKey} from "../../src/DrillInView/SchemaControls/agentTemplate/providerKeyPrompt"
+
+/** A catalog row for a provider the project has not connected, exactly as the atom serves it. */
+const unconnected = {name: "OPENAI_API_KEY", title: "OpenAI", key: ""}
+
+/** What `/secrets/` serves for a stored key on a write-only deployment: presence, no value. */
+const writeOnlyConnected = {
+    ...unconnected,
+    id: "01a08261-1955-75c0-a2c6-17b181c87e88",
+    writeOnly: true,
+    hasKey: true,
+    keyPreview: "sk-****AAA",
+}
+
+/** A readable record, which proves presence by carrying the value. */
+const readableConnected = {...unconnected, id: "readable", key: "sk-live-value"}
+
+/** Restored from IndexedDB: `redactVaultSecretRow` swapped the value for a truthy sentinel. */
+const readableRestoredFromDisk = {...readableConnected, key: "[redacted]"}
+
+/** Restored from IndexedDB: nothing to redact, so it returns exactly as the API served it. */
+const writeOnlyRestoredFromDisk = {...writeOnlyConnected}
+
+const prompt = (overrides: Partial<Parameters<typeof shouldPromptForProviderKey>[0]> = {}) =>
+    shouldPromptForProviderKey({
+        connectionMode: "agenta",
+        connectionSlug: null,
+        vaultLoaded: true,
+        standardProviderEntry: unconnected,
+        ...overrides,
+    })
+
+describe("shouldPromptForProviderKey", () => {
+    it("asks for a key while the project has none", () => {
+        expect(prompt()).toBe(true)
+    })
+
+    it("stops asking once a write-only key is stored (issue #6660)", () => {
+        // No value to read, only `hasKey`: reading the value left the badge over a working key.
+        expect(prompt({standardProviderEntry: writeOnlyConnected})).toBe(false)
+    })
+
+    it("stops asking for a readable key too", () => {
+        expect(prompt({standardProviderEntry: readableConnected})).toBe(false)
+    })
+
+    it("stops asking for either row shape restored from disk", () => {
+        expect(prompt({standardProviderEntry: readableRestoredFromDisk})).toBe(false)
+        expect(prompt({standardProviderEntry: writeOnlyRestoredFromDisk})).toBe(false)
+    })
+
+    it("keeps asking when the record says the key is gone but a value lingers", () => {
+        // The record's own answer wins; `hasKey || key` would hide the prompt on a keyless project.
+        expect(
+            prompt({standardProviderEntry: {...unconnected, hasKey: false, key: "sk-stale"}}),
+        ).toBe(true)
+    })
+
+    it("never asks while the vault is still loading", () => {
+        // The catalog serves empty keys until the query lands; asserting there flashes the badge.
+        expect(prompt({vaultLoaded: false})).toBe(false)
+    })
+
+    it("never asks for a provider family outside the vault catalog", () => {
+        expect(prompt({standardProviderEntry: null})).toBe(false)
+    })
+
+    it("never asks a self-managed connection, which signs itself in", () => {
+        expect(prompt({connectionMode: "self_managed"})).toBe(false)
+    })
+
+    it("never asks a named connection, which carries its own credentials", () => {
+        expect(prompt({connectionMode: "agenta", connectionSlug: "openai-6092496d30e7"})).toBe(
+            false,
+        )
+    })
+})


### PR DESCRIPTION
## Context

The playground's Model section kept asking for a provider key after one was added, while the agent ran on that same key. Reproduced on staging v0.115.3 with the steps from [#6660](https://github.com/Agenta-AI/agenta/issues/6660): fresh project, Settings, AI providers, Add provider, OpenAI, paste a working key, Test reports `133 models fetched`, Done. The provider row lists the key. Back in the playground the Model row still shows the amber `Connect key` badge and its "Connect the model's provider key to run this agent." tooltip, and it survives a reload. The turn that follows reaches OpenAI and comes back with a billing error, so the key is plainly in use.

The cause is a presence check reading the wrong field. Secrets are write-only on staging and on every dev stack, so `/secrets/` returns no value at all:

```
{"kind":"provider_key","data":{"kind":"openai","provider":{}},
 "write_only":true,"value_status":{"configured":true,"preview":"sk-****AAA"}}
```

Presence rides on `value_status.configured`, which the transform surfaces as `hasKey`, and `hasStoredKey` is the one rule that reads it. The Model section tested `!providerVaultEntry.key` instead, which is true for every write-only row, so a connected project read as keyless forever.

## Changes

```
Before:  vaultLoaded && !!providerVaultEntry && !providerVaultEntry.key
After:   vaultLoaded && !!standardProviderEntry && !hasStoredKey(standardProviderEntry)
```

The rule moves into `shouldPromptForProviderKey` (`providerKeyPrompt.ts`), which drives the badge, the section tooltip and the section auto-opening. Its exemptions are unchanged. A `self_managed` connection signs itself in through the harness, and a named `agenta` connection points at one vault record that this rule never looks up, so a missing standard key for the family says nothing about it. `vaultLoaded` still gates everything, so nothing prompts while the vault query is pending.

`providerNeedsKey` also drives the Provider credentials section's warning status, so that surface stops warning too.

One comment in the vault persister claimed `!!secret.key` was the presence rule. It is not, and it now points at `hasStoredKey`.

## Tests

- New `packages/agenta-entity-ui/tests/unit/providerKeyPrompt.test.ts` covers the row shapes the vault really serves: unconnected, write-only connected, readable connected, both of those restored from IndexedDB, and a record that says the key is gone while a stale value lingers. It fails against the old rule and passes against the new one.
- `pnpm --filter @agenta/entity-ui test`: 710 passed. `pnpm --filter @agenta/entities exec vitest run tests/unit`: 1600 passed.
- Types, `pnpm lint-fix` and `pnpm run format`: clean.
- Codex reviewed the rule at extra-high effort: "the presence fix is correct, and I would ship it." Its requested changes are in, including the name, the contract comments, and the stale-value test case.

## Browser verification

Before, on staging with a real OpenAI key, and after, on a PR preview with the same vault row shape, counting visible instances rather than matching text:

```
key present -> connectKeyBadges 0
key deleted -> connectKeyBadges 1
```

Screenshots are on the dev box under `~/agenta-qa-evidence/2026-09-08-issue-6660/`, before and after plus the no-key regression.

## Note on #6660

That issue described a second symptom, a stale banner above the composer, and it was closed as invalid: the banner text sits in the DOM in collapsed instances, so a whole-document text search reported it on every page whether or not anything was drawn. The closing comment keeps this half: "The `Connect key` badge bug that #6677 fixes in its first commit is real and was found independently on a fresh staging project. That fix stands on its own evidence." This PR is that fix, alone, off the current release head.

## What to QA

- Fresh project. Settings, AI providers, add an OpenAI key, Test, Done. Open an agent. The Model row shows the model with no `Connect key` badge, and no "Connect the model's provider key" tooltip on the section header.
- Reload the playground. The badge stays away.
- Regression: a project with no provider key at all. The badge is back and the Model section opens on it.
- Regression: an agent on a self-managed connection, and one pointed at a named connection. Neither asks for a key.
