### PR TITLE
docs(docs): preserve quoted values when loading test env files

### DIFF
--- a/docs/docs/contributing/guides/testing.mdx
+++ b/docs/docs/contributing/guides/testing.mdx
@@ -37,13 +37,15 @@ Then source the env file you deployed with before running tests:
 load-env hosting/docker-compose/oss/.env.oss.dev
 ```
 
-If you use a different shell, the equivalent one-liner is:
+To load the file without a shell helper, pass `--env-file` to the Python test runner. For example, from `api/`, after installing dependencies:
 
 ```bash
-export $(grep -v '^#' hosting/docker-compose/oss/.env.oss.dev | xargs)
+uv run --no-sync python run-tests.py --env-file ../hosting/docker-compose/oss/.env.oss.dev
 ```
 
-Each Python test runner also accepts `--env-file <path>` directly if you prefer not to export the variables.
+The SDK and services runners accept the same option. Paths are relative to the directory you run the command from: use `../../hosting/docker-compose/oss/.env.oss.dev` from `sdks/python/`, or `../hosting/docker-compose/oss/.env.oss.dev` from `services/`. Choose the file that matches your running stack.
+
+This preserves quoted values containing spaces. Avoid loading `.env` files through `export $(... | xargs)`, which splits those values into separate shell arguments.
 
 ## API Tests
 

--- a/docs/docs/contributing/guides/testing.mdx
+++ b/docs/docs/contributing/guides/testing.mdx
@@ -37,9 +37,10 @@ Then source the env file you deployed with before running tests:
 load-env hosting/docker-compose/oss/.env.oss.dev
 ```
 
-To load the file without a shell helper, pass `--env-file` to the Python test runner. For example, from `api/`, after installing dependencies:
+To load the file without a shell helper, pass `--env-file` to the Python test runner. First unset any exported `AGENTA_API_URL` and `AGENTA_AUTH_KEY`: the runners read these variables before loading the file, so existing values take precedence. For example, from `api/`, after installing dependencies:
 
 ```bash
+unset AGENTA_API_URL AGENTA_AUTH_KEY
 uv run --no-sync python run-tests.py --env-file ../hosting/docker-compose/oss/.env.oss.dev
 ```
 


### PR DESCRIPTION
## Summary

The testing guide's `export $(... | xargs)` fallback splits quoted environment values. For example, `AGENTA_AUTH_KEY="synthetic key with spaces"` becomes just `synthetic`. The guide now uses the Python runners' existing `--env-file` option, with the correct relative paths for API, services, and SDK contributors.

## Testing

### Verified locally
- Reproduced value truncation with the old shell command using a synthetic fixture.
- Invoked the actual API, services, and SDK runner CLIs with the fixture. All three preserved the full value before dispatching pytest; the pytest subprocess was mocked, so this is an environment-loading check, not an application test run.
- `npm run build` in `docs/`: passed with Node 22.21.1 and dependencies installed using pinned pnpm 10.30.0. Existing redirect/deprecation warnings remain.
- `git diff --check`: passed.

### Added or updated tests
No permanent tests added for this documentation-only correction.

### QA follow-up
No live application stack or production credentials were used.

## Demo
N/A: documentation-only command correction, no UI behavior change.

## Checklist
- [x] Demo is marked N/A for this documentation-only change.
- [x] Relevant environment-loading checks pass locally.
- [x] Documentation formatting follows the existing page; whitespace check passes.
- [ ] CLA status to be checked after submission.

## Contributor Resources
[Contributing guide](https://agenta.ai/docs/contributing/overview)

