### PR TITLE
[AGE-4302] fix(frontend): Stop offering a custom provider under a harness that cannot reach it

### DIFF
--- a/web/packages/agenta-entities/src/secret/core/agentModelCandidates.ts
+++ b/web/packages/agenta-entities/src/secret/core/agentModelCandidates.ts
@@ -38,12 +38,118 @@ export interface BuildAgentModelCandidatesArgs {
 export const selectableAgentHarnesses = (harnessIds: string[]): string[] =>
     harnessIds.filter((id) => id !== "pi_agenta")
 
+/**
+ * The OpenAI-compatible deployment surface, and the family a route through it falls back to.
+ *
+ * A `custom` record is an endpoint address, not a protocol declaration. Agenta's form calls it the
+ * OpenAI-compatible endpoint and the SDK resolver defaults a custom route it cannot otherwise place
+ * to `openai`. The very same record is an Anthropic gateway when the model names that family, so
+ * the fallback is a default and never a fact.
+ */
+const CUSTOM_KIND = "custom"
+const CUSTOM_FALLBACK_FAMILY = "openai"
+
+/**
+ * A model key with its storage namespace removed.
+ *
+ * The API stores a custom connection's models as `<provider-slug>/<kind>/<model-slug>`, so the
+ * first token names the CONNECTION and says nothing about the model. A connection called "openai"
+ * holding `anthropic/claude-fable-5` would otherwise read as an openai model, and one called
+ * "anthropic" holding `openai/gpt-4o-mini` as an anthropic one. Both are realistic names.
+ *
+ * Matched on the shape rather than on an identity, because the stored namespace is the header name
+ * and the record's stable slug is a different, suffixed string. The second segment is the kind, so
+ * that is what says a prefix is the namespace and not part of the model id.
+ */
+const withoutConnectionNamespace = (id: string, connection: ProviderConnection): string => {
+    // The saved model slugs are the authority, the same way `selected_model_id` reads a key in the
+    // SDK. A header name is free text and may itself contain "/", so counting segments is not
+    // enough. Longest match wins, so a shorter slug never truncates a longer one.
+    const matched = (connection.models ?? []).filter(
+        (slug) => slug && (id === slug || id.endsWith(`/${slug}`)),
+    )
+    if (matched.length) return matched.reduce((a, b) => (b.length > a.length ? b : a))
+
+    // A legacy record keeps only the keys. Fall back to the storage shape, whose second segment is
+    // the kind: `<provider-slug>/<kind>/<model-slug>`.
+    const parts = id.split("/")
+    const kind = (connection.kind ?? "").toLowerCase()
+    if (parts.length < 3 || !kind || parts[1].toLowerCase() !== kind) return id
+    return parts.slice(2).join("/")
+}
+
+/**
+ * The provider family a harness accepts through the `custom` surface, or null when it accepts none.
+ *
+ * Mirrors `HARNESS_CUSTOM_DEPLOYMENT_PROVIDERS` in the SDK, which the catalog does not publish, and
+ * derives it from what the catalog does publish: a harness that reaches `openai` speaks the
+ * OpenAI-compatible dialect, and one that reaches a single other family speaks that. On the shipped
+ * catalog this is pi_core and codex to `openai`, claude to `anthropic`, which is the SDK map.
+ */
+const customRouteFamily = (
+    capabilities: HarnessCapabilityMap | null | undefined,
+    harness: string,
+): string | null => {
+    const providers = capabilities?.[harness]?.providers ?? []
+    if (providers.some((provider) => provider.toLowerCase() === CUSTOM_FALLBACK_FAMILY)) {
+        return CUSTOM_FALLBACK_FAMILY
+    }
+    return soleAgentHarnessProviderFamily(capabilities, harness)
+}
+
+/**
+ * Whether one model on a custom connection is a route this harness is offered by default.
+ *
+ * Asymmetric, because the two kinds of route are not the same claim. An OpenAI-compatible route
+ * takes every model: that IS what the surface means, and a gateway serving Mistral or DeepSeek over
+ * the OpenAI wire format is ordinary. Any other route is a claim about the endpoint's protocol, and
+ * the model naming that vendor is the only evidence a vault record carries.
+ *
+ * A default, not a verdict. A model's upstream vendor does not establish the endpoint's protocol: a
+ * LiteLLM gateway serves OpenAI-named models over the Anthropic Messages endpoint for exactly this
+ * harness. So a saved harness policy is taken at its word and skips this check entirely; only a
+ * connection with no policy is decided here.
+ *
+ * Per model, not per connection: on a mixed gateway with no policy, one Anthropic id must not hand
+ * Claude Code the OpenAI ids beside it (issue #6692).
+ */
+const customRouteAdmitsModel = (
+    capabilities: HarnessCapabilityMap | null | undefined,
+    harness: string,
+    family: string | null,
+): boolean => {
+    const route = customRouteFamily(capabilities, harness)
+    if (!route) return false
+    if (route === CUSTOM_FALLBACK_FAMILY) return true
+    return family === route
+}
+
+/**
+ * The provider to persist for a custom pick, so the SDK resolves the route the picker offered.
+ *
+ * Null where the resolver's own default already answers, which keeps every existing OpenAI-compatible
+ * pick byte-identical. A Claude Code route needs `anthropic` written, or the resolver defaults the
+ * pair to `openai` and the harness refuses it.
+ */
+const customRouteProvider = (
+    capabilities: HarnessCapabilityMap | null | undefined,
+    harness: string,
+): string | null => {
+    const route = customRouteFamily(capabilities, harness)
+    return route && route !== CUSTOM_FALLBACK_FAMILY ? route : null
+}
+
+/**
+ * The harnesses a connection may be used from: the user's saved policy, if any, intersected with
+ * what the harness can technically drive. Which of a custom connection's MODELS each harness is
+ * then offered is `connectionCandidates` below.
+ */
 export const effectiveHarnesses = (
     connection: ProviderConnection,
     capabilities: HarnessCapabilityMap | null | undefined,
     harnessIds: string[],
 ): string[] => {
-    const allowed = connection.harnesses ?? harnessIds
+    const allowed = Array.isArray(connection.harnesses) ? connection.harnesses : harnessIds
     return harnessIds.filter(
         (harness) =>
             allowed.includes(harness) &&
@@ -153,6 +259,8 @@ const connectionCandidates = ({
 
         const slug = connectionSlugFor(connection)
         const standard = connection.secretKind === SecretKind.ProviderKey
+        const customKind = (connection.kind ?? "").toLowerCase() === CUSTOM_KIND
+        const savedPolicy = Array.isArray(connection.harnesses)
         const savedModels = Boolean(connection.models)
         const managed = connection.managementPolicy === SecretManagementPolicy.ManagerOnly
 
@@ -180,9 +288,22 @@ const connectionCandidates = ({
             }
 
             for (const id of ids) {
+                // A custom connection's endpoint dialect is unknown, so with no saved policy each
+                // model is admitted on the family its own id names (#6692). A policy is the user's
+                // own statement about the endpoint and skips the check: the vendor a model comes
+                // from says nothing about the protocol a translating gateway speaks.
+                if (customKind && !savedPolicy) {
+                    const family = agentFamilyFromModelId(
+                        withoutConnectionNamespace(id, connection),
+                        capabilities,
+                    )
+                    if (!customRouteAdmitsModel(capabilities, harness, family)) continue
+                }
                 candidates.push({
                     modelId: id,
-                    provider: agentVaultProviderFamily(id, connection.kind, capabilities, harness),
+                    provider: customKind
+                        ? customRouteProvider(capabilities, harness)
+                        : agentVaultProviderFamily(id, connection.kind, capabilities, harness),
                     mode: "agenta",
                     slug,
                     harness,

--- a/web/packages/agenta-entities/src/secret/core/connections.ts
+++ b/web/packages/agenta-entities/src/secret/core/connections.ts
@@ -543,6 +543,11 @@ export const buildModelOptions = ({
  * A standard API key is reachable when the harness lists the family; the credential-set kinds are
  * reachable when the harness consumes that deployment surface. The saved harness list is user
  * policy layered on top — this is the technical limit underneath it.
+ *
+ * Deliberately coarse for a deployment surface, because the surface does not name a family: an
+ * endpoint the harness can speak to at all passes here. Which family a connection under that
+ * surface is ASSUMED to speak, and therefore which harnesses it is offered under by default, is
+ * `effectiveHarnesses` in ./agentModelCandidates.
  */
 export const harnessSupportsProviderKind = (
     capabilities: HarnessCapabilityMap | null | undefined,

--- a/web/packages/agenta-entities/tests/unit/provider-connections.test.ts
+++ b/web/packages/agenta-entities/tests/unit/provider-connections.test.ts
@@ -466,6 +466,21 @@ describe("harnessSupportsProviderKind", () => {
         expect(harnessSupportsProviderKind(capabilities, "claude", "bedrock")).toBe(true)
         expect(harnessSupportsProviderKind(capabilities, "pi_core", "bedrock")).toBe(false)
     })
+
+    // Deliberately coarse: the surface says the harness can speak to the endpoint at all, not which
+    // family the endpoint serves. Which harnesses a custom connection is OFFERED under by default is
+    // `effectiveHarnesses`, tested in @agenta/entity-ui's connectionPicker suite (#6692).
+    it("does not judge the family behind a deployment surface", () => {
+        const shipped: HarnessCapabilityMap = {
+            claude: {
+                providers: ["anthropic"],
+                deployments: ["direct", "custom", "bedrock", "vertex_ai"],
+            },
+        }
+
+        expect(harnessSupportsProviderKind(shipped, "claude", "custom")).toBe(true)
+        expect(harnessSupportsProviderKind(shipped, "claude", "vertex_ai")).toBe(true)
+    })
 })
 
 describe("doneState", () => {

--- a/web/packages/agenta-entity-ui/tests/unit/connectionPicker.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/connectionPicker.test.ts
@@ -121,6 +121,259 @@ describe("effectiveHarnesses", () => {
     })
 })
 
+/**
+ * #6692: an OpenAI-compatible (`custom`) connection appeared under BOTH Pi and Claude Code, and
+ * picking the Claude Code entry committed a revision the server refuses.
+ *
+ * `custom` is an endpoint address, not a protocol declaration, and Claude Code publishes it among
+ * its deployments for its own Anthropic gateway. So consuming the surface was never enough. Each
+ * MODEL is admitted on the family its own id names, after its connection's storage namespace is
+ * stripped, and falls back to `openai` when it names none. An admitted route carries the provider
+ * the SDK needs to resolve it.
+ *
+ * A saved harness policy skips the family check. It is the one place a user can state what the
+ * record cannot, and the only route left for a gateway whose ids name nothing.
+ */
+describe("an OpenAI-compatible connection under a harness that cannot reach openai", () => {
+    // Matched to GET /workflows/catalog/harnesses/ as served on oss.preview: Pi reaches nine
+    // families over direct and custom, Claude Code reaches anthropic alone over four surfaces.
+    const SHIPPED: HarnessCapabilitiesMap = {
+        pi_core: {
+            ...CAPABILITIES.pi_core,
+            providers: [
+                "openai",
+                "anthropic",
+                "gemini",
+                "mistral",
+                "groq",
+                "minimax",
+                "together_ai",
+                "openrouter",
+                "openai-codex",
+            ],
+            deployments: ["direct", "custom"],
+        },
+        claude: {...CAPABILITIES.claude, deployments: ["direct", "custom", "bedrock", "vertex_ai"]},
+    }
+
+    /** The (harness, model, provider) tuples the picker would offer, in order. */
+    const routes = (connection: ProviderConnection, capabilities = SHIPPED, ids = HARNESS_IDS) =>
+        buildAgentModelCandidates({
+            connections: [connection],
+            capabilities: capabilities as never,
+            harnessIds: ids,
+            subscriptionPairs: [],
+        }).map((candidate) => [candidate.harness, candidate.modelId, candidate.provider])
+
+    it("offers the reported connection under Pi only", () => {
+        // The live oss.preview record, with the namespacing the API applies.
+        const qaCustom = custom(
+            "1",
+            "custom",
+            ["qa-custom/custom/openai/gpt-4o-mini", "qa-custom/custom/deepseek/deepseek-v4-flash"],
+            {name: "qa-custom", slug: "qa-custom"},
+        )
+
+        expect(routes(qaCustom)).toEqual([
+            ["pi_core", "qa-custom/custom/openai/gpt-4o-mini", null],
+            ["pi_core", "qa-custom/custom/deepseek/deepseek-v4-flash", null],
+        ])
+    })
+
+    it("gives an Anthropic route only the models that name anthropic", () => {
+        // A mixed gateway. Claude Code gets the anthropic model and nothing else. Pi keeps all
+        // three: OpenAI-compatible is a wire format, not a vendor. Order follows the saved list.
+        const mixed = custom(
+            "2",
+            "custom",
+            [
+                "gw/custom/openai/gpt-4o-mini",
+                "gw/custom/anthropic/claude-fable-5",
+                "gw/custom/some-opaque-id",
+            ],
+            {name: "gw", slug: "gw"},
+        )
+
+        expect(routes(mixed)).toEqual([
+            ["pi_core", "gw/custom/openai/gpt-4o-mini", null],
+            ["pi_core", "gw/custom/anthropic/claude-fable-5", null],
+            ["pi_core", "gw/custom/some-opaque-id", null],
+            ["claude", "gw/custom/anthropic/claude-fable-5", "anthropic"],
+        ])
+    })
+
+    it("keeps another vendor's models on the OpenAI-compatible route", () => {
+        // An OpenAI-compatible endpoint commonly serves many vendors, and the runner drives them
+        // with openai-completions. Dropping these would remove a route that runs today.
+        const gateway = custom(
+            "9",
+            "custom",
+            ["gw/custom/mistral/mistral-small-latest", "gw/custom/gemini/gemini-3-flash"],
+            {name: "gw", slug: "gw"},
+        )
+
+        expect(routes(gateway)).toEqual([
+            ["pi_core", "gw/custom/mistral/mistral-small-latest", null],
+            ["pi_core", "gw/custom/gemini/gemini-3-flash", null],
+        ])
+    })
+
+    it("strips the stored namespace even when it is not the record's stable slug", () => {
+        // The API namespaces a key with the header NAME; the record's own slug is a different,
+        // suffixed string. Matching on the identity would leave the name in the model id.
+        const named = custom("10", "custom", ["anthropic/custom/openai/gpt-4o-mini"], {
+            name: "anthropic",
+            slug: "anthropic-01a082ad18dd",
+        })
+
+        expect(routes(named)).toEqual([["pi_core", "anthropic/custom/openai/gpt-4o-mini", null]])
+    })
+
+    it("reads the model past its own connection's namespace", () => {
+        // The first token is the CONNECTION name and means nothing about the model. A connection
+        // named "openai" holding an anthropic model must still reach Claude Code.
+        const named = custom("3", "custom", ["openai/custom/anthropic/claude-fable-5"], {
+            name: "openai",
+            slug: "openai",
+        })
+
+        expect(routes(named)).toEqual([
+            ["pi_core", "openai/custom/anthropic/claude-fable-5", null],
+            ["claude", "openai/custom/anthropic/claude-fable-5", "anthropic"],
+        ])
+    })
+
+    it("does not let a connection's name lend a model its family", () => {
+        const named = custom("4", "custom", ["anthropic/custom/openai/gpt-4o-mini"], {
+            name: "anthropic",
+            slug: "anthropic",
+        })
+
+        expect(routes(named)).toEqual([["pi_core", "anthropic/custom/openai/gpt-4o-mini", null]])
+    })
+
+    it("finds the model in a key whose namespace contains a slash", () => {
+        // A connection name is free text. Counting segments would leave "team/custom/anthropic" in
+        // the model id and hide the Claude route, so the saved model slugs decide instead.
+        const named = custom("11", "custom", ["openai/team/custom/anthropic/claude-fable-5"], {
+            name: "openai/team",
+            slug: "openai-team-01a082ad",
+            models: ["anthropic/claude-fable-5"],
+        })
+
+        expect(routes(named)).toEqual([
+            ["pi_core", "openai/team/custom/anthropic/claude-fable-5", null],
+            ["claude", "openai/team/custom/anthropic/claude-fable-5", "anthropic"],
+        ])
+    })
+
+    it("does not lend a slashed connection name its family either", () => {
+        const named = custom("12", "custom", ["anthropic/team/custom/openai/gpt-4o-mini"], {
+            name: "anthropic/team",
+            slug: "anthropic-team-01a082ad",
+            models: ["openai/gpt-4o-mini"],
+        })
+
+        expect(routes(named)).toEqual([
+            ["pi_core", "anthropic/team/custom/openai/gpt-4o-mini", null],
+        ])
+    })
+
+    it("keeps another vendor's real id on the OpenAI-compatible route", () => {
+        // OpenRouter spells Mistral as "mistralai/...", which the catalog's family vocabulary does
+        // not carry. It reads as no family, and the OpenAI-compatible route takes it regardless.
+        const gw = custom("5b", "custom", ["gw/custom/mistralai/mistral-small-2603"], {
+            name: "gw",
+            slug: "gw",
+        })
+
+        expect(routes(gw)).toEqual([["pi_core", "gw/custom/mistralai/mistral-small-2603", null]])
+    })
+
+    it("picks the longest saved slug, whichever order the list is in", () => {
+        // Two slugs where one ends with the other. Matching the shorter one would strip "anthropic/"
+        // off the longer key along with the namespace, and the family would be read as none.
+        const overlapping = (models: string[]) =>
+            custom("14", "custom", ["gw/custom/sonnet", "gw/custom/anthropic/sonnet"], {
+                name: "gw",
+                slug: "gw",
+                models,
+            })
+
+        for (const order of [
+            ["sonnet", "anthropic/sonnet"],
+            ["anthropic/sonnet", "sonnet"],
+        ]) {
+            expect(routes(overlapping(order))).toEqual([
+                ["pi_core", "gw/custom/sonnet", null],
+                ["pi_core", "gw/custom/anthropic/sonnet", null],
+                ["claude", "gw/custom/anthropic/sonnet", "anthropic"],
+            ])
+        }
+    })
+
+    it("takes a saved harness policy at its word, and writes the provider it needs", () => {
+        // The user's tick is a statement about the ENDPOINT, which the record cannot carry, so it
+        // skips the family check. A LiteLLM gateway serves OpenAI-named models over the Anthropic
+        // Messages endpoint for Claude Code, so the model's vendor is not evidence against it.
+        // The written `anthropic` is what makes the SDK resolve the pair Claude Code accepts.
+        const gateway = custom(
+            "5",
+            "custom",
+            ["bare-gw/custom/sonnet", "bare-gw/custom/openai/gpt-4o-mini"],
+            {name: "bare-gw", slug: "bare-gw", harnesses: ["claude"]},
+        )
+
+        expect(routes(gateway)).toEqual([
+            ["claude", "bare-gw/custom/sonnet", "anthropic"],
+            ["claude", "bare-gw/custom/openai/gpt-4o-mini", "anthropic"],
+        ])
+    })
+
+    it("reads an empty saved policy as no harness, not as an absent policy", () => {
+        const none = custom("6", "custom", ["off/custom/openai/gpt-4o-mini"], {
+            name: "off",
+            slug: "off",
+            harnesses: [],
+        })
+
+        expect(routes(none)).toEqual([])
+    })
+
+    it("never lets a saved policy beat the hard technical limit", () => {
+        // Codex reaches openai but consumes `direct` only, so it cannot speak to a custom endpoint
+        // at all. That is a capability, and a tick does not change it.
+        const withCodex: HarnessCapabilitiesMap = {
+            ...SHIPPED,
+            codex: {
+                providers: ["openai"],
+                deployments: ["direct"],
+                connection_modes: ["agenta", "self_managed"],
+                model_selection: "provider/id",
+                models: {openai: ["gpt-5.5"]},
+            },
+        }
+        const ticked = custom("7", "custom", ["qa/custom/openai/gpt-4o-mini"], {
+            name: "qa",
+            slug: "qa",
+            harnesses: ["codex"],
+        })
+
+        expect(routes(ticked, withCodex, [...HARNESS_IDS, "codex"])).toEqual([])
+    })
+
+    it("leaves a deployment surface that names no family to the deployment list", () => {
+        // Not a blanket rule for credential sets. Bedrock is not the OpenAI-compatible surface, so
+        // the deployment list decides alone: Pi does not consume it, Claude Code does.
+        const bedrock = custom("8", "bedrock", ["claude-3-sonnet-20240229-v1:0"], {
+            name: "aws",
+            slug: "aws",
+        })
+
+        expect(effectiveHarnesses(bedrock, SHIPPED, HARNESS_IDS)).toEqual(["claude"])
+    })
+})
+
 describe("connectionModelIds", () => {
     it("uses the saved list when the connection has one", () => {
         const connection = standard("1", "openai", {models: ["gpt-5.4"]})


### PR DESCRIPTION
## Context

A project with an OpenAI-compatible provider in the vault saw each of its models twice in the model picker, once under Pi and once under Claude Code, with labels that differ only in casing. Picking the Claude Code one committed a new revision right away. The Model row then read `Unavailable · Claude Code · gpt-4o-mini`, and a send from that revision failed with a generic "Message wasn't sent" and nothing else.

Claude Code publishes `custom` among its deployment surfaces, for its own Anthropic gateway, while reaching the `anthropic` provider family only. The candidate builder asked only whether the harness consumes the surface, got yes, and offered every model on the connection under both harnesses.

## Changes

`custom` is an endpoint address, not a protocol declaration. A connection with no saved harness policy now admits each model per route, and the two kinds of route are not the same claim.

An **OpenAI-compatible route** takes every model on the connection. That surface is a wire format, and a gateway serving Mistral or DeepSeek over it is ordinary. Any **other route**, Claude Code's Anthropic gateway being the only one today, is a claim about the endpoint's protocol, so it takes only the models that name that vendor.

Against the live `oss.preview` catalog and the reported vault record:

```
before  pi_core :: qa-custom/custom/openai/gpt-4o-mini
        pi_core :: qa-custom/custom/deepseek/deepseek-v4-flash
        claude  :: qa-custom/custom/openai/gpt-4o-mini
        claude  :: qa-custom/custom/deepseek/deepseek-v4-flash

after   pi_core :: qa-custom/custom/openai/gpt-4o-mini
        pi_core :: qa-custom/custom/deepseek/deepseek-v4-flash
```

On a mixed gateway, same catalog, showing the asymmetry:

```
after   pi_core :: gw/custom/openai/gpt-4o-mini
        pi_core :: gw/custom/anthropic/claude-fable-5
        pi_core :: gw/custom/mistral/mistral-small-latest
        claude  :: gw/custom/anthropic/claude-fable-5   provider=anthropic
```

Three details make that rule correct rather than merely narrower.

**It is a default, not a verdict.** A saved `connection.harnesses` policy skips the family check entirely. A model's upstream vendor does not establish the endpoint's protocol: a LiteLLM gateway serves OpenAI-named models over the Anthropic Messages endpoint for exactly this harness. The tick is the user's own statement about the endpoint, and the vault record carries nothing that could contradict it.

**A model id is read past its storage namespace.** The API stores a custom model as `<provider-slug>/<kind>/<model-slug>`, so the first token names the connection and says nothing about the model. A connection called `openai` holding an Anthropic model still reaches Claude Code, and one called `anthropic` holding an OpenAI model does not. The saved model slugs find that boundary, because the stored prefix is a free-text header name that may itself contain a slash.

**An admitted route carries the provider the SDK needs.** A Claude Code route writes `anthropic`, or the resolver defaults the custom route to `openai` and the harness refuses the pair. An OpenAI-compatible pick still writes no provider and is byte-identical to before, so no existing selection changes.

`harnessSupportsProviderKind` is unchanged and still wins over everything, so Codex is never offered a custom endpoint it consumes no surface for. Keeping that predicate coarse also keeps Claude Code tickable on the provider connection card, which is what a gateway user needs.

## Tests

Eleven cases in `@agenta/entity-ui`'s picker suite, asserting ordered `(harness, model, provider)` tuples through `buildAgentModelCandidates`, on a fixture carrying the full nine families the live catalog publishes for Pi.

- The reported connection yields two Pi routes and no Claude Code routes.
- A mixed gateway gives Claude Code only its Anthropic model, with `anthropic` written, and leaves all three on Pi.
- Another vendor's models keep their Pi route, including OpenRouter's real `mistralai/...` spelling, which the family vocabulary does not carry.
- A connection named `openai` holding an Anthropic model still reaches Claude Code, and one named `anthropic` holding an OpenAI model does not, including when the stored namespace differs from the stable slug and when it contains a slash.
- A saved policy is honored for every model on the connection and writes the provider its route needs. An empty policy means no harness. No policy beats the technical limit.
- A Bedrock connection is left to the deployment list alone.

I also ran the builder against the live catalog and the live `qa-custom` record, which is where the listings above come from.

`@agenta/entities` (1601), `@agenta/entity-ui` (714), `@agenta/chat` (894), `@agenta/oss` (510) and `@agenta/mobile` (188) pass. `tsc --noEmit` passes for oss, ee and mobile. `pnpm lint-fix` is clean.

## Live QA

On the PR's Railway preview I created an OpenAI-compatible connection against OpenRouter holding `openai/gpt-4o-mini`, `mistralai/mistral-small-2603` and `anthropic/claude-sonnet-5`.

A newly created connection is saved with `harnesses: ["pi_core"]`, not null, so it shows one Pi section and the reported duplication cannot arise. The reported record has `harnesses: null`, which is what a connection created before that default looks like, and that is the shape the family rule decides. Setting the policy to `["pi_core","claude"]` puts every model under Claude Code as well, which is the deliberate override working.

## Known limits, and what is not here

All of these are tracked in #6710.

Ticking Claude Code on an OpenAI-compatible connection offers models Claude Code may not run. That is the user's own declaration, and the SDK accepts the resulting pair, so the frontend has no ground to refuse it. A picker cannot verify a protocol.

`customRouteFamily` derives the SDK's `HARNESS_CUSTOM_DEPLOYMENT_PROVIDERS` from the flat catalog lists, which reproduces it exactly for every harness shipping today. A future harness reaching two families, neither of them `openai`, would need the catalog to publish that pairing.

A legacy record that kept no saved model slugs falls back to a fixed-segment namespace strip, which a connection name containing a slash still defeats.

`selectedModelRowKey` falls back across harnesses, so a saved Claude selection whose row disappears can light up the Pi row instead. It misrepresents the selection without rewriting it.

The composer still explains a refused revision only as a generic "Message wasn't sent", while the `Unavailable` pill sits inside a config section a user has no reason to open. A first draft added a composer strip; review showed its rule inferred incompatibility from picker candidacy, which misfires on an API-authored config, on a model outside a connection's active list, and when subscription discovery fails. The sound version is a shared compatibility selector returning a status and a reason, driving both the pill and the composer.

Reported as "the composer loses its Send button". That did not reproduce. The button is icon-only with `aria-label="Send"`, so a text match on `^Send$` finds nothing on any revision. On the failing revision it is present and enables as soon as you type.

## What to QA

- Open an agent in a project whose OpenAI-compatible connection predates the saved harness default, so it has no policy. Open the model picker. Its OpenAI and unknown-vendor models appear under Pi only.
- Add an anthropic-named model to that connection. It appears under Claude Code as well, and the models beside it stay on Pi alone.
- Open the same picker on /m through the config pane. Mobile shares this builder, so it shows the same sections.
- Tick Claude Code on the connection in Settings, AI providers. Every model appears under Claude Code. Untick it and the rule decides again.
- Regression: a Bedrock or Vertex connection still offers Claude Code, and picking one runs.
- Regression: a plain OpenAI key still offers Pi, and an Anthropic key still offers both Pi and Claude Code.
- Regression: the agent left on the failing revision (`QA-v0.115.3 ossbanner`, version 4) still shows `Unavailable`, and the composer still accepts input.

Fixes #6692