### PR TITLE
fix(services): route under the public /services prefix without a stripping proxy

### DIFF
--- a/services/entrypoints/main.py
+++ b/services/entrypoints/main.py
@@ -48,6 +48,7 @@ from oss.src.chat import chat_v0_app
 from oss.src.completion import completion_v0_app
 from oss.src.agent import agent_v0_app
 from entrypoints.legacy import register_legacy_routes
+from entrypoints.prefix import ServicesPrefixStripMiddleware
 
 
 ag.init()
@@ -141,6 +142,11 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+
+# Added last => outermost: a managed ingress forwards the public `/services` prefix
+# verbatim, so normalize the path before anything else looks at it.
+app.add_middleware(ServicesPrefixStripMiddleware)
 
 
 @app.get("/health")

--- a/services/entrypoints/prefix.py
+++ b/services/entrypoints/prefix.py
@@ -1,0 +1,43 @@
+from os import getenv
+
+DEFAULT_PREFIX = "/services"
+
+
+class ServicesPrefixStripMiddleware:
+    """Strip the public path prefix so every hop shape routes.
+
+    The services app is published under `/services` on the shared host. Traefik and the
+    AWS ALB strip that prefix before the request reaches the container, so the routes live at
+    root. A managed ingress such as GKE cannot rewrite paths and forwards `/services/...`
+    verbatim, which used to answer 404. This middleware strips the prefix inbound, in a
+    loop so a double prefix still routes, and never issues a redirect. It mirrors the api's
+    `ApiPrefixStripMiddleware`.
+
+    The prefix comes from `AGENTA_SERVICES_PATH_PREFIX`, default `/services`. Set it to an
+    empty string to turn the strip off.
+    """
+
+    def __init__(self, app, prefix: str | None = None):
+        self.app = app
+        raw = DEFAULT_PREFIX if prefix is None else prefix
+        raw = getenv("AGENTA_SERVICES_PATH_PREFIX", raw) if prefix is None else raw
+        self.prefix = raw.rstrip("/")
+
+    async def __call__(self, scope, receive, send):
+        if self.prefix and scope["type"] in ("http", "websocket"):
+            scope = self._strip(scope)
+        await self.app(scope, receive, send)
+
+    def _strip(self, scope):
+        path = scope.get("path", "")
+        changed = False
+        while path == self.prefix or path.startswith(self.prefix + "/"):
+            path = path[len(self.prefix) :] or "/"
+            changed = True
+        if not changed:
+            return scope
+        scope = dict(scope)
+        scope["path"] = path
+        if isinstance(scope.get("raw_path"), (bytes, bytearray)):
+            scope["raw_path"] = path.encode("utf-8")
+        return scope

--- a/services/entrypoints/prefix.py
+++ b/services/entrypoints/prefix.py
@@ -30,14 +30,26 @@ class ServicesPrefixStripMiddleware:
 
     def _strip(self, scope):
         path = scope.get("path", "")
-        changed = False
+        stripped = 0
         while path == self.prefix or path.startswith(self.prefix + "/"):
             path = path[len(self.prefix) :] or "/"
-            changed = True
-        if not changed:
+            stripped += 1
+        if not stripped:
             return scope
         scope = dict(scope)
         scope["path"] = path
-        if isinstance(scope.get("raw_path"), (bytes, bytearray)):
-            scope["raw_path"] = path.encode("utf-8")
+        raw = scope.get("raw_path")
+        if isinstance(raw, (bytes, bytearray)):
+            # Keep the wire bytes: drop the consumed prefix from the front of the
+            # original encoded path instead of re-encoding the decoded one, so a
+            # percent-encoded segment such as caf%C3%A9 reaches the app unchanged.
+            raw_prefix = self.prefix.encode("utf-8")
+            raw_path = bytes(raw)
+            for _ in range(stripped):
+                if raw_path == raw_prefix or raw_path.startswith(raw_prefix + b"/"):
+                    raw_path = raw_path[len(raw_prefix) :] or b"/"
+                else:
+                    raw_path = path.encode("utf-8")
+                    break
+            scope["raw_path"] = raw_path
         return scope

--- a/services/oss/tests/pytest/unit/entrypoints/test_prefix_strip.py
+++ b/services/oss/tests/pytest/unit/entrypoints/test_prefix_strip.py
@@ -4,10 +4,17 @@ Traefik strips the prefix; a managed ingress (GKE) forwards it verbatim. Both sh
 reach the same route, and no redirect may be issued on the way.
 """
 
-from fastapi import FastAPI
+import pytest
+from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from entrypoints.prefix import ServicesPrefixStripMiddleware
+
+
+@pytest.fixture(autouse=True)
+def _no_prefix_env(monkeypatch):
+    """The default-prefix tests must not depend on the process environment."""
+    monkeypatch.delenv("AGENTA_SERVICES_PATH_PREFIX", raising=False)
 
 
 def _app(prefix=None) -> TestClient:
@@ -16,6 +23,10 @@ def _app(prefix=None) -> TestClient:
     @app.get("/health")
     async def health():
         return {"status": "ok"}
+
+    @app.get("/raw/{name}")
+    async def raw(request: Request, name: str):
+        return {"raw_path": request.scope["raw_path"].decode("latin-1")}
 
     app.add_middleware(ServicesPrefixStripMiddleware, prefix=prefix)
     return TestClient(app)
@@ -42,3 +53,16 @@ def test_bare_prefix_maps_to_root():
 
 def test_empty_prefix_turns_the_strip_off():
     assert _app(prefix="").get("/services/health").status_code == 404
+
+
+def test_env_prefix_is_honored(monkeypatch):
+    monkeypatch.setenv("AGENTA_SERVICES_PATH_PREFIX", "/svc")
+    client = _app()
+    assert client.get("/svc/health").status_code == 200
+    assert client.get("/services/health").status_code == 404
+
+
+def test_raw_path_keeps_the_wire_encoding():
+    r = _app().get("/services/raw/caf%C3%A9")
+    assert r.status_code == 200
+    assert r.json()["raw_path"] == "/raw/caf%C3%A9"

--- a/services/oss/tests/pytest/unit/entrypoints/test_prefix_strip.py
+++ b/services/oss/tests/pytest/unit/entrypoints/test_prefix_strip.py
@@ -1,0 +1,44 @@
+"""The services app must route with and without the public `/services` prefix.
+
+Traefik strips the prefix; a managed ingress (GKE) forwards it verbatim. Both shapes must
+reach the same route, and no redirect may be issued on the way.
+"""
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from entrypoints.prefix import ServicesPrefixStripMiddleware
+
+
+def _app(prefix=None) -> TestClient:
+    app = FastAPI()
+
+    @app.get("/health")
+    async def health():
+        return {"status": "ok"}
+
+    app.add_middleware(ServicesPrefixStripMiddleware, prefix=prefix)
+    return TestClient(app)
+
+
+def test_routes_at_root():
+    assert _app().get("/health").status_code == 200
+
+
+def test_routes_with_public_prefix():
+    r = _app().get("/services/health", follow_redirects=False)
+    assert r.status_code == 200
+    assert r.json() == {"status": "ok"}
+
+
+def test_double_prefix_still_routes():
+    assert _app().get("/services/services/health").status_code == 200
+
+
+def test_bare_prefix_maps_to_root():
+    # "/services" alone becomes "/", which this app does not serve: 404, not a crash.
+    assert _app().get("/services").status_code == 404
+
+
+def test_empty_prefix_turns_the_strip_off():
+    assert _app(prefix="").get("/services/health").status_code == 404


### PR DESCRIPTION
## Why

The services app is published under `/services` on the shared host. Traefik and the AWS ALB strip that prefix before the request reaches the container, so the routes live at root. A managed ingress such as GKE cannot rewrite paths and forwards `/services/...` verbatim. On the GKE staging stage every services route answered 404, including `/services/agent/v0/invoke`, the endpoint the playground and the release gate drive.

The api already solves this with `ApiPrefixStripMiddleware`. The services app had nothing equivalent.

## What changed

- New `services/entrypoints/prefix.py`: an ASGI middleware that strips the prefix inbound, in a loop so a double prefix still routes, and never issues a redirect. The prefix comes from `AGENTA_SERVICES_PATH_PREFIX`, default `/services`; an empty value turns the strip off.
- Registered last in `services/entrypoints/main.py`, so it runs before auth and routing.
- Unit tests for root, prefixed, double-prefixed, bare-prefix and disabled cases.

Behavior behind Traefik is unchanged: a request that arrives already stripped has no prefix to remove.

## How to verify

```
cd services && uv run python -m pytest -q oss/tests/pytest/unit/entrypoints/test_prefix_strip.py
```

Live: with this image the GKE staging stage answers `/services/agent/v0/invoke` and the release gate's chat journey runs.

https://claude.ai/code/session_01GZqpvjwLHgVnMrpKH8hzq8