### PR TITLE
fix(frontend): drop a refused message's row only once the composer confirms it took the text

### DIFF
--- a/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
+++ b/web/oss/src/components/AgentChatSlice/AgentConversation.tsx
@@ -442,8 +442,8 @@ const AgentConversation = ({
         reject: attachments.setRejections,
     })
     lateRefusalRef.current = {restore: restoreAttachments, reject: attachments.setRejections}
-    const restoreLateRefusedSend = useCallback((message: QueuedMessage) => {
-        const taken = restoreRefusedSendInto(
+    const restoreLateRefusedSend = useCallback(async (message: QueuedMessage) => {
+        const taken = await restoreRefusedSendInto(
             richInputRef.current,
             {
                 text: message.text,

--- a/web/oss/src/components/AgentChatSlice/assets/refusedMessageRecovery.test.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/refusedMessageRecovery.test.ts
@@ -8,7 +8,7 @@ import {
 } from "./refusedMessageRecovery"
 
 describe("restoreRefusedDraft", () => {
-    it("restores a refused message only into an empty composer", () => {
+    it("restores a refused message only into an empty composer", async () => {
         // The stub STORES what it is given, because success is now confirmed by reading it back
         // rather than by the call returning.
         let markdown = ""
@@ -17,19 +17,19 @@ describe("restoreRefusedDraft", () => {
         })
         const editor = {getMarkdown: () => markdown, setMarkdown} as never
 
-        expect(restoreRefusedDraft(editor, "try again")).toBe(true)
+        expect(await restoreRefusedDraft(editor, "try again")).toBe(true)
         expect(setMarkdown).toHaveBeenCalledWith("try again")
     })
 
-    it("does not overwrite a newer draft", () => {
+    it("does not overwrite a newer draft", async () => {
         const setMarkdown = vi.fn()
         const editor = {getMarkdown: () => "new draft", setMarkdown} as never
 
-        expect(restoreRefusedDraft(editor, "old refused message")).toBe(false)
+        expect(await restoreRefusedDraft(editor, "old refused message")).toBe(false)
         expect(setMarkdown).not.toHaveBeenCalled()
     })
 
-    it("allows attachment recovery only while the composer is still empty", () => {
+    it("allows attachment recovery only while the composer is still empty", async () => {
         expect(canRestoreRefusedSend({getMarkdown: () => "", setMarkdown: vi.fn()} as never)).toBe(
             true,
         )
@@ -38,20 +38,24 @@ describe("restoreRefusedDraft", () => {
         ).toBe(false)
     })
 
-    it("leaves a refused send with staged attachments untouched behind a newer draft", () => {
+    it("leaves a refused send with staged attachments untouched behind a newer draft", async () => {
         const setMarkdown = vi.fn()
         const restoreAttachments = vi.fn()
         const stagedFiles = [{uid: "file-1", name: "brief.pdf"}]
         const editor = {getMarkdown: () => "newer draft", setMarkdown} as never
 
         expect(
-            restoreRefusedSend(editor, {text: "refused message", stagedFiles}, restoreAttachments),
+            await restoreRefusedSend(
+                editor,
+                {text: "refused message", stagedFiles},
+                restoreAttachments,
+            ),
         ).toBe(false)
         expect(setMarkdown).not.toHaveBeenCalled()
         expect(restoreAttachments).not.toHaveBeenCalled()
     })
 
-    it("captures a refusal before deferred placement and restores it once", () => {
+    it("captures a refusal before deferred placement and restores it once", async () => {
         let markdown = "newer draft"
         const setMarkdown = vi.fn((next: string) => {
             markdown = next
@@ -68,7 +72,7 @@ describe("restoreRefusedDraft", () => {
         }
         const slot: {current: typeof refused | undefined} = {current: undefined}
         const editor = {getMarkdown: () => markdown, setMarkdown} as never
-        const frames: (() => boolean)[] = []
+        const frames: (() => Promise<boolean>)[] = []
 
         expect(slot.current).toBeUndefined()
         if (!slot.current) slot.current = takeLastSent()
@@ -76,7 +80,7 @@ describe("restoreRefusedDraft", () => {
 
         lastSent = newer
         markdown = ""
-        expect(frames.shift()?.()).toBe(true)
+        await expect(frames.shift()?.()).resolves.toBe(true)
 
         expect(setMarkdown).toHaveBeenCalledTimes(1)
         expect(setMarkdown).toHaveBeenCalledWith("refused message")
@@ -84,7 +88,7 @@ describe("restoreRefusedDraft", () => {
         expect(restoreAttachments).toHaveBeenCalledWith(stagedFiles)
         expect(lastSent).toBe(newer)
 
-        expect(restoreHeldRefusedSend(slot, editor, restoreAttachments)).toBe(false)
+        expect(await restoreHeldRefusedSend(slot, editor, restoreAttachments)).toBe(false)
         expect(setMarkdown).toHaveBeenCalledTimes(1)
         expect(restoreAttachments).toHaveBeenCalledTimes(1)
     })
@@ -95,7 +99,7 @@ describe("restoreRefusedSend for a late refusal", () => {
     // rejected send the user has had time to type something else. These pin the two properties
     // the late path depends on: it never overwrites that, and it says so by returning false, which
     // is what keeps the echo row as the recovery surface in exactly that case.
-    it("refuses a composer the user has typed into, and reports it", () => {
+    it("refuses a composer the user has typed into, and reports it", async () => {
         const editor = {
             getMarkdown: () => "something I typed since",
             setMarkdown: vi.fn(),
@@ -103,13 +107,17 @@ describe("restoreRefusedSend for a late refusal", () => {
         const restoreAttachments = vi.fn()
 
         expect(
-            restoreRefusedSend(editor, {text: "refused", stagedFiles: []}, restoreAttachments),
+            await restoreRefusedSend(
+                editor,
+                {text: "refused", stagedFiles: []},
+                restoreAttachments,
+            ),
         ).toBe(false)
         expect(editor.setMarkdown).not.toHaveBeenCalled()
         expect(restoreAttachments).not.toHaveBeenCalled()
     })
 
-    it("puts the staged files back with the text, not the text alone", () => {
+    it("puts the staged files back with the text, not the text alone", async () => {
         let markdown = ""
         const editor = {
             getMarkdown: () => markdown,
@@ -120,16 +128,16 @@ describe("restoreRefusedSend for a late refusal", () => {
         const restoreAttachments = vi.fn()
         const stagedFiles = [{uid: "f1"}]
 
-        expect(restoreRefusedSend(editor, {text: "refused", stagedFiles}, restoreAttachments)).toBe(
-            true,
-        )
+        expect(
+            await restoreRefusedSend(editor, {text: "refused", stagedFiles}, restoreAttachments),
+        ).toBe(true)
         expect(markdown).toBe("refused")
         expect(restoreAttachments).toHaveBeenCalledWith(stagedFiles)
     })
 })
 
 describe("restoreRefusedDraft with a stale editor handle", () => {
-    it("reports failure when setMarkdown silently does nothing", () => {
+    it("reports failure when setMarkdown silently does nothing", async () => {
         // The handle's setMarkdown returns void and is a no-op once its internal ref is gone.
         // Reporting success there tells the caller the message is safe in the composer when it is
         // nowhere, and the caller uses that to drop the only row showing it.
@@ -138,8 +146,10 @@ describe("restoreRefusedDraft with a stale editor handle", () => {
             setMarkdown: () => undefined,
         } as unknown as RichChatInputHandle
 
-        expect(restoreRefusedDraft(stale, "refused")).toBe(false)
-        expect(restoreRefusedSend(stale, {text: "refused", stagedFiles: []}, vi.fn())).toBe(false)
+        expect(await restoreRefusedDraft(stale, "refused")).toBe(false)
+        expect(await restoreRefusedSend(stale, {text: "refused", stagedFiles: []}, vi.fn())).toBe(
+            false,
+        )
     })
 })
 
@@ -159,12 +169,12 @@ describe("restoreRefusedSend for a send carrying attachments", () => {
         } as never
     }
 
-    it("restores an attachments-only send into the composer and reports success", () => {
+    it("restores an attachments-only send into the composer and reports success", async () => {
         const restoreAttachments = vi.fn()
         const stagedFiles = [{uid: "file-1", name: "brief.pdf"}]
 
         expect(
-            restoreRefusedSend(
+            await restoreRefusedSend(
                 emptyEditor(),
                 {text: "", stagedFiles, fileParts: [{type: "file"}]},
                 restoreAttachments,
@@ -173,13 +183,13 @@ describe("restoreRefusedSend for a send carrying attachments", () => {
         expect(restoreAttachments).toHaveBeenCalledWith(stagedFiles)
     })
 
-    it("refuses when the send carried attachments the tray cannot take back", () => {
+    it("refuses when the send carried attachments the tray cannot take back", async () => {
         // A merged queue edit or a seed handed over from another surface arrives with file parts
         // and no staged entry behind them. Restoring the words alone would delete the files.
         const restoreAttachments = vi.fn()
 
         expect(
-            restoreRefusedSend(
+            await restoreRefusedSend(
                 emptyEditor(),
                 {text: "with a file", stagedFiles: [], fileParts: [{type: "file"}]},
                 restoreAttachments,
@@ -188,12 +198,12 @@ describe("restoreRefusedSend for a send carrying attachments", () => {
         expect(restoreAttachments).not.toHaveBeenCalled()
     })
 
-    it("refuses an attachments-only send whose staged entries are gone", () => {
+    it("refuses an attachments-only send whose staged entries are gone", async () => {
         // Reporting success here puts nothing anywhere and drops the row with it.
         const restoreAttachments = vi.fn()
 
         expect(
-            restoreRefusedSend(
+            await restoreRefusedSend(
                 emptyEditor(),
                 {text: "", stagedFiles: [], fileParts: [{type: "file"}]},
                 restoreAttachments,
@@ -202,17 +212,17 @@ describe("restoreRefusedSend for a send carrying attachments", () => {
         expect(restoreAttachments).not.toHaveBeenCalled()
     })
 
-    it("refuses a send with nothing in it at all", () => {
-        expect(restoreRefusedSend(emptyEditor(), {text: ""}, vi.fn())).toBe(false)
+    it("refuses a send with nothing in it at all", async () => {
+        expect(await restoreRefusedSend(emptyEditor(), {text: ""}, vi.fn())).toBe(false)
     })
 
-    it("still treats the staged entries as the whole send when no file parts are given", () => {
+    it("still treats the staged entries as the whole send when no file parts are given", async () => {
         const restoreAttachments = vi.fn()
         const stagedFiles = [{uid: "file-1", name: "brief.pdf"}]
 
-        expect(restoreRefusedSend(emptyEditor(), {text: "", stagedFiles}, restoreAttachments)).toBe(
-            true,
-        )
+        expect(
+            await restoreRefusedSend(emptyEditor(), {text: "", stagedFiles}, restoreAttachments),
+        ).toBe(true)
         expect(restoreAttachments).toHaveBeenCalledWith(stagedFiles)
     })
 })
@@ -228,7 +238,7 @@ describe("restoreHeldRefusedSend has no row to fall back on", () => {
         } as never
     }
 
-    it("places what it can when the send carried files the tray cannot take back", () => {
+    it("places what it can when the send carried files the tray cannot take back", async () => {
         // The early rejection already dropped the echo row, so refusing here would leave the
         // message in no visible place at all. The words go back; the files are already lost.
         const restoreAttachments = vi.fn()
@@ -237,15 +247,81 @@ describe("restoreHeldRefusedSend has no row to fall back on", () => {
         }
         const editor = emptyEditor()
 
-        expect(restoreHeldRefusedSend(slot, editor, restoreAttachments)).toBe(true)
+        expect(await restoreHeldRefusedSend(slot, editor, restoreAttachments)).toBe(true)
         expect(slot.current).toBeUndefined()
     })
 
-    it("still keeps the send held behind a newer draft", () => {
+    it("still keeps the send held behind a newer draft", async () => {
         const slot = {current: {text: "refused", stagedFiles: []} as never}
         const editor = {getMarkdown: () => "newer draft", setMarkdown: vi.fn()} as never
 
-        expect(restoreHeldRefusedSend(slot, editor, vi.fn())).toBe(false)
+        expect(await restoreHeldRefusedSend(slot, editor, vi.fn())).toBe(false)
         expect(slot.current).toBeDefined()
+    })
+})
+
+/**
+ * The live defect, at the helper. The desktop composer is Lexical, and `setMarkdown` schedules the
+ * write rather than applying it, so reading the editor back in the calling tick answers "no" for a
+ * placement that is on its way. The caller keeps the flagged row on that answer, and the text turns
+ * up in the composer a moment later, so the same message is in both places and can be sent twice.
+ * Reproduced on staging at `66ed5a6c57` on /w with a refusal arriving as a 200 whose stream errors.
+ */
+describe("restoreRefusedSend against a composer that commits late", () => {
+    /** Applies `setMarkdown` after `commitAfter` microtask turns, the way Lexical batches. */
+    const lateEditor = (commitAfter: number) => {
+        let markdown = ""
+        return {
+            getMarkdown: () => markdown,
+            setMarkdown: vi.fn((next: string) => {
+                let turns = commitAfter
+                const apply = () => {
+                    if (turns > 0) {
+                        turns -= 1
+                        void Promise.resolve().then(apply)
+                        return
+                    }
+                    markdown = next
+                }
+                void Promise.resolve().then(apply)
+            }),
+        } as never
+    }
+
+    it("reports the restore once the composer commits a tick later", async () => {
+        const restoreAttachments = vi.fn()
+
+        await expect(
+            restoreRefusedSend(lateEditor(1), {text: "refused message"}, restoreAttachments),
+        ).resolves.toBe(true)
+    })
+
+    it("reports it for a composer that takes several turns to commit", async () => {
+        await expect(
+            restoreRefusedSend(lateEditor(6), {text: "refused message"}, vi.fn()),
+        ).resolves.toBe(true)
+    })
+
+    it("still reports failure for a composer that never takes the text", async () => {
+        const editor = {getMarkdown: () => "", setMarkdown: vi.fn()} as never
+
+        await expect(restoreRefusedSend(editor, {text: "refused"}, vi.fn())).resolves.toBe(false)
+    })
+
+    it("restores the attachments only after the words are confirmed", async () => {
+        // Putting the files back before the composer has taken the words would leave the tray and
+        // the row holding the same attachment.
+        const restoreAttachments = vi.fn()
+        const stagedFiles = [{uid: "file-1", name: "brief.pdf"}]
+
+        const pending = restoreRefusedSend(
+            lateEditor(3),
+            {text: "with a file", stagedFiles},
+            restoreAttachments,
+        )
+        expect(restoreAttachments).not.toHaveBeenCalled()
+
+        await expect(pending).resolves.toBe(true)
+        expect(restoreAttachments).toHaveBeenCalledWith(stagedFiles)
     })
 })

--- a/web/oss/src/components/AgentChatSlice/assets/refusedMessageRecovery.ts
+++ b/web/oss/src/components/AgentChatSlice/assets/refusedMessageRecovery.ts
@@ -3,12 +3,34 @@ import type {RichChatInputHandle} from "@agenta/ui/rich-chat-input"
 export const canRestoreRefusedSend = (editor: RichChatInputHandle | null): boolean =>
     Boolean(editor && editor.getMarkdown() === "")
 
-export const restoreRefusedDraft = (editor: RichChatInputHandle | null, text: string): boolean => {
+/**
+ * Turns of the microtask queue the composer gets to commit the text before we call it a failure.
+ *
+ * The editor is Lexical, and `setMarkdown` schedules an update rather than applying one: the state
+ * `getMarkdown` reads is the COMMITTED state, which has not changed yet in the calling tick. A
+ * microtask loop is what that costs, and it is proof against a test that fakes timers.
+ */
+const PLACEMENT_CONFIRM_TICKS = 12
+
+/**
+ * Write the text and wait for the composer to actually hold it.
+ *
+ * Reading it back in the same tick answers "no" for a placement that is on its way, which is how a
+ * refused message ended up in the transcript AND the composer at the same time: the caller kept the
+ * flagged row on that answer while the text arrived a moment later, and the user could send it
+ * twice (staging, `66ed5a6c57`). Reporting success without reading it back at all is the opposite
+ * failure and loses the message, so the read-back stays; it just gets the ticks it needs.
+ */
+export const restoreRefusedDraft = async (
+    editor: RichChatInputHandle | null,
+    text: string,
+): Promise<boolean> => {
     if (!editor || !text || !canRestoreRefusedSend(editor)) return false
     editor.setMarkdown(text)
-    // `setMarkdown` returns void and does nothing at all when the handle's internal ref is gone,
-    // so the only way to know it took the text is to read it back. Reporting success falsely tells
-    // the caller the message is safe in the composer when it is nowhere.
+    for (let tick = 0; tick < PLACEMENT_CONFIRM_TICKS; tick += 1) {
+        if (editor.getMarkdown() === text) return true
+        await Promise.resolve()
+    }
     return editor.getMarkdown() === text
 }
 
@@ -43,12 +65,12 @@ interface RefusedSendSlot<TAttachment> {
  * this caller does not: its echo row is already gone, so placing the words is better than placing
  * nothing, and refusing would leave the message in no visible place at all.
  */
-export const restoreRefusedSend = <TAttachment>(
+export const restoreRefusedSend = async <TAttachment>(
     editor: RichChatInputHandle | null,
     sent: RefusedSend<TAttachment>,
     restoreAttachments: (files: TAttachment[]) => void,
     {partial = false}: {partial?: boolean} = {},
-): boolean => {
+): Promise<boolean> => {
     if (!canRestoreRefusedSend(editor)) return false
     const staged = sent.stagedFiles ?? []
     // Absent `fileParts` means the caller does not track them separately, so the staged entries are
@@ -56,7 +78,7 @@ export const restoreRefusedSend = <TAttachment>(
     const carried = sent.fileParts?.length ?? staged.length
     if (!partial && carried > staged.length) return false
     if (!sent.text && staged.length === 0) return false
-    if (sent.text && !restoreRefusedDraft(editor, sent.text)) return false
+    if (sent.text && !(await restoreRefusedDraft(editor, sent.text))) return false
     if (staged.length) restoreAttachments(staged)
     return true
 }
@@ -66,15 +88,17 @@ export const restoreRefusedSend = <TAttachment>(
  * composer is the ONLY place this message can be. Hence `partial` — there is no row to leave it
  * on, and a refusal here would leave it nowhere.
  */
-export const restoreHeldRefusedSend = <TAttachment>(
+export const restoreHeldRefusedSend = async <TAttachment>(
     slot: RefusedSendSlot<TAttachment>,
     editor: RichChatInputHandle | null,
     restoreAttachments: (files: TAttachment[]) => void,
-): boolean => {
+): Promise<boolean> => {
     const sent = slot.current
     if (!sent) return false
+    // Cleared before the await, so a second caller arriving while the composer commits does not
+    // place the same message twice. It goes back if the composer turns out not to have taken it.
     slot.current = undefined
-    if (restoreRefusedSend(editor, sent, restoreAttachments, {partial: true})) return true
+    if (await restoreRefusedSend(editor, sent, restoreAttachments, {partial: true})) return true
     slot.current = sent
     return false
 }

--- a/web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts
@@ -84,11 +84,14 @@ interface UseAgentChatQueueArgs {
     /** Mark this tab as the next run's owner before a released send reaches the transport. */
     markRunOwned: () => void
     /**
-     * Hand a refused send back to the composer. Returns whether the composer took it: if it did,
+     * Hand a refused send back to the composer. Reports whether the composer took it: if it did,
      * the message lives there and its echo row goes; if it could not (no mounted editor), the row
      * stays as the one place the text survives.
+     *
+     * May answer later than the call. A rich text editor commits a write on a following tick, so a
+     * host that reads its own composer back cannot always answer in this one.
      */
-    restoreRefusedSend?: (message: QueuedMessage) => boolean
+    restoreRefusedSend?: (message: QueuedMessage) => boolean | Promise<boolean>
     /** Send one released message into the conversation (wraps `useChat`'s `sendMessage`). Must be
      * referentially stable so the release effect doesn't churn on every streamed token. */
     sendQueued: (item: QueuedMessage) => void
@@ -346,14 +349,22 @@ export const useAgentChatQueue = ({
                             // wording for it. The row is the fallback only when no composer can
                             // take the text.
                             onFailed: () => {
-                                if (restoreRefusedSendRef.current?.(message)) {
-                                    echoes.drop(message.id)
-                                } else {
-                                    // Re-create the row if the count rule already retired it,
-                                    // or a refusal arriving after that leaves the message with
-                                    // nowhere at all to be seen.
-                                    echoes.markFailed(message.id, message)
-                                }
+                                // The row goes up FIRST and comes down only once the composer
+                                // confirms it took the text. It is the safe side to fail to: the
+                                // message must never be in neither place, and a host cannot always
+                                // answer in this tick, because its editor commits a write on a
+                                // following one. Deciding on a same-tick answer left a refused
+                                // message in the transcript AND the composer, where it could be
+                                // sent twice (staging, `66ed5a6c57`).
+                                //
+                                // Passing the message re-creates the row when the count rule has
+                                // already retired it, so a late refusal always has somewhere to be.
+                                echoes.markFailed(message.id, message)
+                                const restoring = restoreRefusedSendRef.current?.(message)
+                                if (!restoring) return
+                                void Promise.resolve(restoring).then((taken) => {
+                                    if (taken) echoes.drop(message.id)
+                                })
                             },
                             // The turn ended and its records were re-read. An echo still on
                             // screen is one whose row was never persisted, so it stops waiting

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -149,7 +149,7 @@ export interface UseAgentConversationArgs {
     /** Timestamp of the liveness snapshot behind `sharedReaderRunning`. */
     sharedReaderLivenessUpdatedAt?: number
     /** Hand a late-refused send back to the composer; return whether it took the text. */
-    restoreRefusedSend?: (message: {text: string}) => boolean
+    restoreRefusedSend?: (message: {text: string}) => boolean | Promise<boolean>
     /** Override the client-tool predicate. Defaults to the package registry's, so a host does not
      * have to opt IN to elicitation and connect widgets — /m shipped without one for months and
      * silently folded every client tool into the plain "used N tools" group, leaving the run

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentChatQueue.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentChatQueue.test.ts
@@ -1470,6 +1470,83 @@ describe("useAgentChatQueue late refusal recovery", () => {
     })
 })
 
+describe("useAgentChatQueue late refusal recovery, asynchronous composer", () => {
+    // The live defect on staging at 66ed5a6c57: on /w, a refusal arriving as a 200 whose stream
+    // errors left the message in BOTH places, a flagged row AND the text in the composer, so it
+    // could be sent twice. The restorer places the text into Lexical, which commits on a later
+    // tick, so a restorer that can only answer on the next tick was read as a refusal to take it.
+    it("drops the row once a composer that answers LATE confirms it took the text", async () => {
+        const {server, watchers} = durableServer()
+        let settle: ((took: boolean) => void) | undefined
+        const restoreRefusedSend = vi.fn(
+            () =>
+                new Promise<boolean>((resolve) => {
+                    settle = resolve
+                }),
+        )
+        const {result} = setup({...settledEmpty, server, restoreRefusedSend})
+
+        await act(async () => {
+            await result.current.submit({text: "refused late"})
+        })
+        await act(async () => watchers[0].onFailed?.())
+
+        // The row is up while the composer has not answered: the message must never be in
+        // NEITHER place, so the row is the safe side to fail to.
+        expect(echoText(result)).toEqual(["refused late"])
+        expect(result.current.pendingSendRows[0].metadata).toMatchObject({pendingSendFailed: true})
+
+        await act(async () => {
+            settle!(true)
+            await Promise.resolve()
+        })
+
+        // ...and it comes down once the composer confirms, so the message ends in exactly one.
+        expect(result.current.pendingSendRows).toHaveLength(0)
+    })
+
+    it("keeps the row when a composer that answers LATE says it could not take the text", async () => {
+        const {server, watchers} = durableServer()
+        let settle: ((took: boolean) => void) | undefined
+        const restoreRefusedSend = vi.fn(
+            () =>
+                new Promise<boolean>((resolve) => {
+                    settle = resolve
+                }),
+        )
+        const {result} = setup({...settledEmpty, server, restoreRefusedSend})
+
+        await act(async () => {
+            await result.current.submit({text: "nowhere to go"})
+        })
+        await act(async () => watchers[0].onFailed?.())
+        await act(async () => {
+            settle!(false)
+            await Promise.resolve()
+        })
+
+        expect(echoText(result)).toEqual(["nowhere to go"])
+        expect(result.current.pendingSendRows[0].metadata).toMatchObject({pendingSendFailed: true})
+    })
+
+    it("still drops the row for a composer that answers immediately", async () => {
+        // Both hosts' restorers may report synchronously; that path must not regress.
+        const {server, watchers} = durableServer()
+        const restoreRefusedSend = vi.fn(() => true)
+        const {result} = setup({...settledEmpty, server, restoreRefusedSend})
+
+        await act(async () => {
+            await result.current.submit({text: "taken at once"})
+        })
+        await act(async () => {
+            watchers[0].onFailed?.()
+            await Promise.resolve()
+        })
+
+        expect(result.current.pendingSendRows).toHaveLength(0)
+    })
+})
+
 describe("useAgentChatQueue settlement never touches the composer", () => {
     it("does not restore a delivered message when its echo has already retired", async () => {
         // The normal accepted path: row adopted, echo retired, stream ends. Restoring here wrote

--- a/web/packages/agenta-chat/tests/unit/hooks/useAgentChatQueue.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useAgentChatQueue.test.ts
@@ -3,7 +3,11 @@ import {act, renderHook} from "@testing-library/react"
 import type {FileUIPart, UIMessage} from "ai"
 import {describe, expect, it, vi} from "vitest"
 
-import {useAgentChatQueue, type ServerQueueAdapter} from "../../../src/hooks/useAgentChatQueue"
+import {
+    useAgentChatQueue,
+    type QueuedMessage,
+    type ServerQueueAdapter,
+} from "../../../src/hooks/useAgentChatQueue"
 
 // The pure release predicates (`canReleaseQueuedMessage`, `isHitlPending`) are unit-tested in
 // the playground package; these tests cover the HOOK's stateful behavior on top of them:
@@ -65,7 +69,12 @@ interface HarnessProps {
     continuationExecutionId?: string | null
     sessionId?: string
     server?: ServerQueueAdapter
-    restoreRefusedSend?: (message: QueuedMessage) => boolean
+    /**
+     * Taken from the hook rather than restated, so the harness cannot drift from the seam it is
+     * meant to exercise. It drifted once: the seam started accepting a host that answers later
+     * than the call, and this stayed synchronous.
+     */
+    restoreRefusedSend?: Parameters<typeof useAgentChatQueue>[0]["restoreRefusedSend"]
 }
 
 const setup = (initial: HarnessProps) => {


### PR DESCRIPTION
## Context

On the desktop, a refused message could end up in two places at once: a flagged row in the transcript saying it was not sent, and the same text back in the composer. The user could send it twice.

Found on staging at `66ed5a6c57` by the closing QA for #6658, reproduced twice, with two controls passing: a non-ok HTTP refusal on `/w` was fine, and the same erroring-stream refusal on `/m` was fine.

```json
{"rows": 1, "flagged": true, "echoRow": true, "inComposer": true,
 "composerText": "REFUSED16fem reply with the word ok",
 "notice": "Message wasn't sent — try again.",
 "red": ["FAIL invariant: the message is in BOTH places, so it can be sent twice",
         "FAIL: a transcript row remained"]}
```

The composer is Lexical, and `setMarkdown` schedules the write rather than applying it. The read-back that confirms the placement runs against the committed state, which has not changed yet in the calling tick, so it answered "no" for a placement that was on its way. The caller kept the flagged row on that answer, and the text arrived a moment later.

Only the erroring-stream path reaches it. A non-ok status rejects the send promise, and that recovery runs a frame later from an effect, by which time the editor has committed.

## Changes

**The read-back stays and gets the ticks it needs.** Removing it is the opposite failure: `setMarkdown` does nothing at all when the handle's inner ref is gone, and reporting success then loses the message. `restoreRefusedDraft` now waits for the composer to actually hold the text, over a bounded microtask loop, and the restore helpers report asynchronously.

Microtasks rather than timers on purpose: it is what the editor needs, and it cannot hang a test that fakes timers.

**The queue fails to the safe side.** The row goes up first and comes down only once the composer confirms it took the text, so the message is never in neither place and it ends in exactly one. The seam accepts a synchronous answer too, so a host that can answer at once is unaffected.

**Attachments go back only after the words are confirmed**, so the tray and the row cannot hold the same file.

## Before and after, on a local EE stack

Same cell, same stack, the only difference being this commit.

| Cell | Release head | This branch |
| --- | --- | --- |
| Desktop, prefixed erroring stream | rows 1, flagged, text also in composer | rows 0, text in composer, notice shown |
| Desktop, non-ok status (control) | passes | passes |
| Mobile, prefixed erroring stream (control) | passes | passes |
| File-only, prefixed erroring stream | passes | passes |

The desktop cell was run twice on this branch and once more after re-applying, all clean.

## A second defect, pre-existing, not fixed here

The same run showed the draft-overwrite guard failing: with a draft typed into the composer after the send cleared and before the refusal landed, the restore overwrites it. The cell proves the draft was there first (`draftSeenBeforeRefusal: true`).

I checked whether this commit caused it by putting the release head back on the same stack and re-running. It fails there too, and worse:

| | Release head | This branch |
| --- | --- | --- |
| Message in both places | yes | no |
| Later draft destroyed | yes | yes |

So it predates this change and this change does not worsen it. Filed as
https://github.com/Agenta-AI/agenta/issues/6706 rather than fixed here, because the cause is not
yet understood: the guard reads the editor back and sees an empty composer although the draft is on
screen, and finding out why is more surgery than a release branch should carry.

## Tests

- Three cases at the queue seam for the exact ordering: the row is present at the refusal, it goes when a composer that answers late confirms, and it stays when that composer says no. A fourth pins the synchronous answer so that path cannot regress.
- Four at the helper, driving an editor that commits after one and after six microtask turns, plus one that never takes the text, plus one that the attachments follow the confirmed words.
- Both sets fail against the unfixed code with the live symptom, checked by reverting the loop and the ordering.
- Suites: 984 in `@agenta/chat`, 379 in the OSS chat slice, 191 in mobile. All three typecheck. `pnpm lint-fix` and prettier are clean.

## Review

Codex at xhigh on `644ea7ef82`: **SHIP with follow-ups**, no new merge blocker. It confirmed the
microtask confirmation is sufficient for the pinned Lexical 0.46, which commits this update through
a microtask with no timer or frame deferral on this path, and that twelve turns cover it. It found
the ordering correct, with `markFailed` and `drop` using functional updates so their order holds,
and no resurrection or premature-drop path. It agreed the draft-overwrite defect can stay separate.

Two follow-ups it raised:

- The harness's restore type was still synchronous. CodeRabbit raised the same thing. Fixed at
  `771b4c2c55` by deriving the field from the hook's own parameter type, so it cannot drift again.
  The harness also referenced `QueuedMessage` without importing it. Neither showed up locally,
  because the package tsconfig includes `src` only and nothing typechecks the tests directory.
- The helper tests drive a stub that commits after N microtask turns, which assumes the scheduling
  under test. A test against real Lexical would be stronger. Codex ran DOM-mounted Lexical probes
  of its own and they passed, and the live browser cell is real-Lexical evidence, so this is left
  as a follow-up rather than built on a release branch.

## How this got through

My browser cell for #6658 could not see this path. With `SHAPE=b` and no `DRAFT` it served a non-ok status instead of the erroring stream, so the desktop case was never exercised, and the row it reported green was the control. Codex raised the read-back as a P1 against that PR and I recorded it as a follow-up on the strength of that cell. The cell was corrected before the merge; this is the defect it was hiding.


