### PR TITLE
[test] Quarantine the variant Use API test on the drawer freeze [#6708]

### DIFF
--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -207,7 +207,13 @@ const switchToTypescriptTab = async (drawer: any) => {
 
 const useApiTests = () => {
     // WEB-ACC-USEAPI-001
-    test(
+    // Quarantined on a real product hang, not a flaky test: https://github.com/Agenta-AI/agenta/issues/6708
+    // For an app with more than one variant, the variant-mode "How to use API" drawer
+    // renders in an infinite update loop from the moment it opens. Clicking a language
+    // tab turns that loop synchronous and pins the renderer, so the click never returns
+    // and the test burns its full timeout. Re-enable this test with the fix for #6708.
+    // The deployment-mode test below covers the same drawer and still runs.
+    test.fixme(
         "should show variant TypeScript snippet for Fetch Prompt/Config and Invoke LLM",
         {tag: lightFastTags},
         async ({page, apiHelpers, uiHelpers}) => {

--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -207,12 +207,7 @@ const switchToTypescriptTab = async (drawer: any) => {
 
 const useApiTests = () => {
     // WEB-ACC-USEAPI-001
-    // Quarantined on a real product hang, not a flaky test: https://github.com/Agenta-AI/agenta/issues/6708
-    // For an app with more than one variant, the variant-mode "How to use API" drawer
-    // renders in an infinite update loop from the moment it opens. Clicking a language
-    // tab turns that loop synchronous and pins the renderer, so the click never returns
-    // and the test burns its full timeout. Re-enable this test with the fix for #6708.
-    // The deployment-mode test below covers the same drawer and still runs.
+    // Quarantined on the drawer freeze: https://github.com/Agenta-AI/agenta/issues/6708
     test.fixme(
         "should show variant TypeScript snippet for Fetch Prompt/Config and Invoke LLM",
         {tag: lightFastTags},


### PR DESCRIPTION
## Context

The acceptance test "Registry: use API snippets > should show variant TypeScript snippet ..." is still red on both stage suites after redeploy 2. Examples: [staging run 34285457143](https://github.com/Agenta-AI/agenta_cloud/actions/runs/34285457143) and [oss run 34286927964](https://github.com/Agenta-AI/agenta_cloud/actions/runs/34286927964).

It is not a flaky test. It is a real product hang, filed as [#6708](https://github.com/Agenta-AI/agenta/issues/6708).

For an app with more than one variant, the variant-mode "How to use API" drawer enters an infinite React render loop the moment it opens. The rendered snippet flips between the two variants many times a second. Clicking a language tab turns that loop synchronous, which pins the renderer. The page stops painting, and the tab is frozen until it is reloaded.

The measurements, all against a stack with two variants and three revisions:

```
DOM mutations in the 2.5 s after the drawer opened, before any click
  run that later froze:  591
  run that stayed OK:      0
```

The snippet text alternates in the DOM across those mutations:

```
AGDOM slug=variant_slug="...47az.e2e-variant-1788910375   muts=14
AGDOM slug=variant_slug="...47az.default",   variant_v    muts=24
AGDOM slug=variant_slug="...47az.e2e-variant-1788910375   muts=44
```

After the tab click the page throws React error #185 without pause and no timer, microtask, or screencast frame ever runs again:

```
Maximum update depth exceeded.
  at resetCanShowPlaceholder (@lexical/react/.../LexicalRichTextPlugin)
  at triggerListeners (lexical/Lexical.dev.mjs)
  at $commitPendingUpdatesImpl
```

Counted 514 of those on the staging run, 620 on the oss run, and 1019 in my own staging reproduction.

The wait for the drawer animation that landed in #6685 did not cause this. Before that wait the click failed Playwright's stability check and was never dispatched, so the test stopped short of the freeze and reported a different error. The wait let the click through, and the click found the hang.

## Changes

The variant test is now `test.fixme`, with a comment that names the issue and says why. Nothing else changes. The assertions, the helpers, and the drawer wait all stay as they are, so the test is ready to run again as soon as [#6708](https://github.com/Agenta-AI/agenta/issues/6708) is fixed.

The sibling test, "should show deployment TypeScript snippet ...", is untouched and still runs. It opens the same drawer in deployment mode and clicks the same tab, so the drawer keeps acceptance coverage.

This is a quarantine, not a fix. It stops a known product bug from reporting as a 60 second timeout on every suite run. It does not make the product bug any less real, and the release decision on [#6708](https://github.com/Agenta-AI/agenta/issues/6708) belongs to whoever owns the release.

## Tests

Run against staging, one test at a time, workers 1, retries 0.

- The quarantined test reports as skipped in 0 ms.
- The deployment test passes in 5.4 s.
- `pnpm lint-fix` and `pnpm run format` are clean in `web`.

Reproduction of the underlying hang, for whoever picks up [#6708](https://github.com/Agenta-AI/agenta/issues/6708):

```
AGENTA_LICENSE=ee AGENTA_WEB_URL=<url> AGENTA_API_URL=<url>/api \
  pnpm -C web/tests test:acceptance -- \
  --grep "(Playground: Run Variant|use API snippets)" --workers=1 --retries=0 --trace on
```

The playground tests add the second variant, which is the state the bug needs. It reproduced on 3 of 5 attempts, on staging and on a local EE dev stack.
