### PR TITLE
[fix] Stop the Use API drawer render loop with two variants [#6708]

### DIFF
--- a/web/oss/src/components/DeploymentsDashboard/assets/VariantUseApiContent.loop.test.tsx
+++ b/web/oss/src/components/DeploymentsDashboard/assets/VariantUseApiContent.loop.test.tsx
@@ -1,17 +1,18 @@
 /**
  * Regression test for the "How to use API" drawer render loop (issue #6708).
  *
- * The drawer opened from the variants registry took a revision id as a prop and then
- * reconciled it against a variant with three effects that wrote each other's inputs.
- * With MORE THAN ONE variant the reconciliation never reached a fixed point: the
- * snippet alternated between the two variants forever, and the first click on a
- * language tab turned the loop synchronous and froze the tab.
+ * The drawer opened from the variants registry takes a revision id as a prop and used to
+ * reconcile it against a separately stored variant id with three effects that each wrote
+ * what another read. With MORE THAN ONE variant those effects oscillated instead of
+ * settling: the snippet alternated between the two variants forever, and the first click on
+ * a language tab turned the loop synchronous and froze the tab.
  *
- * The test keeps the real workflow atoms and the real react-query wiring, and mocks
- * only the HTTP layer and the heavy leaf components. It asserts that the snippet
- * settles on ONE variant and that the component stops committing.
+ * The test keeps the real workflow atoms and the real react-query wiring, and mocks only the
+ * HTTP layer and the heavy leaf components. It asserts that the snippet settles on ONE
+ * variant, that the drawer never renders the variant the user did not open, and that
+ * rendering stops once the queries have resolved.
  */
-import {act} from "react"
+import {act, useState} from "react"
 
 import {queryClient} from "@agenta/shared/api"
 import {projectIdAtom, sessionAtom} from "@agenta/shared/state"
@@ -72,22 +73,47 @@ const REVISIONS = [
     revisionFixture(REV_SECOND_V1, VARIANT_SECOND, "e2e", 1),
 ]
 
-/** Per-URL latency, so the test can order the two list queries the way the browser does. */
+/**
+ * Per-request-shape controls. `/workflows/revisions/query` serves three different requests
+ * and the drawer's behaviour depends on which of them lands first, so each shape gets its
+ * own handler: a latency for the ordering cases, and a gate the late-prop case releases by
+ * hand.
+ */
 const latency = {byVariant: 0, byWorkflow: 0}
+let byVariantGate: Promise<void> | null = null
+let releaseByVariantGate: (() => void) | null = null
+
+const openByVariantGate = () => {
+    byVariantGate = new Promise<void>((resolve) => {
+        releaseByVariantGate = resolve
+    })
+}
 
 const post = vi.fn(async (url: string, body: any) => {
     if (url.endsWith("/workflows/variants/query")) {
         return {data: {count: VARIANTS.length, workflow_variants: VARIANTS}}
     }
     if (url.endsWith("/workflows/revisions/query")) {
+        // One revision by id: the detail fetch behind workflowMolecule.selectors.data.
+        if (body?.workflow_revision_refs) {
+            const ids = body.workflow_revision_refs.map((ref: any) => ref.id)
+            const revisions = REVISIONS.filter((revision) => ids.includes(revision.id))
+            return {data: {count: revisions.length, workflow_revisions: revisions}}
+        }
+        // Every revision of one variant.
         if (body?.workflow_variant_refs) {
             const variantId = body.workflow_variant_refs[0]?.id
+            if (byVariantGate) await byVariantGate
             await new Promise((r) => setTimeout(r, latency.byVariant))
             const revisions = REVISIONS.filter((r) => r.workflow_variant_id === variantId)
             return {data: {count: revisions.length, workflow_revisions: revisions}}
         }
-        await new Promise((r) => setTimeout(r, latency.byWorkflow))
-        return {data: {count: REVISIONS.length, workflow_revisions: REVISIONS}}
+        // Every revision of the whole app.
+        if (body?.workflow_refs) {
+            await new Promise((r) => setTimeout(r, latency.byWorkflow))
+            return {data: {count: REVISIONS.length, workflow_revisions: REVISIONS}}
+        }
+        throw new Error(`unexpected /workflows/revisions/query body: ${JSON.stringify(body)}`)
     }
     return {data: {}}
 })
@@ -106,28 +132,28 @@ vi.mock("@agenta/shared/api", async (original) => ({
     },
 }))
 
-/** Reads the variant slug the drawer put in the snippet, for one recorded commit. */
+/** Reads the variant slug the drawer put in the snippet, for one recorded render. */
 const slugOf = (snippet: string) => {
     const match = snippet.match(/variant_slug="([^"]*)"/)
     return match?.[1] ?? null
 }
 
-// Leaf components the loop does not need. LanguageCodeBlock stands in for the Lexical
-// code editor and records the snippet the drawer hands it on every commit.
+// Leaf components the loop does not need. LanguageCodeBlock stands in for the Lexical code
+// block editor and records the snippet the drawer hands it on every render.
 const snippets: string[] = []
 /**
- * A synchronous render loop never yields, so a plain timeout would hang the whole run
- * instead of failing this test. Cap the commits and throw the trajectory instead.
+ * A synchronous render loop never yields, so a plain test timeout would hang the whole run
+ * instead of failing this test. Cap the renders and throw the trajectory instead.
  */
-const MAX_COMMITS = 60
+const MAX_RENDERS = 60
 vi.mock(
     "@/oss/components/pages/overview/deployments/DeploymentDrawer/assets/LanguageCodeBlock",
     () => ({
         default: ({fetchConfigCodeSnippet}: any) => {
             snippets.push(String(fetchConfigCodeSnippet?.python ?? ""))
-            if (snippets.length > MAX_COMMITS) {
+            if (snippets.length > MAX_RENDERS) {
                 throw new Error(
-                    `render loop: ${snippets.length} commits, variant slug trajectory ` +
+                    `render loop: ${snippets.length} renders, variant slug trajectory ` +
                         JSON.stringify(snippets.slice(0, 24).map(slugOf)),
                 )
             }
@@ -153,6 +179,10 @@ let root: ReturnType<typeof createRoot> | null = null
 
 beforeEach(() => {
     snippets.length = 0
+    latency.byVariant = 0
+    latency.byWorkflow = 0
+    byVariantGate = null
+    releaseByVariantGate = null
     queryClient.clear()
     Object.defineProperty(window, "matchMedia", {
         writable: true,
@@ -173,7 +203,15 @@ afterEach(() => {
     container = null
 })
 
-const mount = async (initialRevisionId: string) => {
+/** Lets the test change the prop after mount, the way the host swaps the opened row. */
+let setPropRevisionId: ((value: string | undefined) => void) | null = null
+const Host = ({initial}: {initial: string | undefined}) => {
+    const [revisionId, setRevisionId] = useState(initial)
+    setPropRevisionId = setRevisionId
+    return <VariantUseApiContent initialRevisionId={revisionId} />
+}
+
+const renderDrawer = async (initialRevisionId: string | undefined) => {
     const store = createStore()
     store.set(queryClientAtom, queryClient)
     store.set(projectIdAtom, "project-1")
@@ -187,14 +225,16 @@ const mount = async (initialRevisionId: string) => {
         root!.render(
             <QueryClientProvider client={queryClient}>
                 <Provider store={store}>
-                    <VariantUseApiContent initialRevisionId={initialRevisionId} />
+                    <Host initial={initialRevisionId} />
                 </Provider>
             </QueryClientProvider>,
         )
     })
+}
 
-    // Let every query settle.
-    for (let i = 0; i < 30; i++) {
+/** Runs timers and microtasks until every query has settled. */
+const settle = async (rounds = 30) => {
+    for (let i = 0; i < rounds; i++) {
         await act(async () => {
             await new Promise((r) => setTimeout(r, 10))
         })
@@ -202,33 +242,71 @@ const mount = async (initialRevisionId: string) => {
 }
 
 it("settles on the opened revision's variant when the app has two variants", async () => {
-    // The by-variant list resolves before the by-workflow list, as it does in the browser:
+    // The by-variant list resolves before the workflow-wide list, as it does in the browser:
     // the drawer used to pick a variant from the variants list first and only then learn
     // which variant the opened revision belongs to.
-    latency.byVariant = 0
     latency.byWorkflow = 30
 
-    await mount(REV_SECOND_V1)
+    await renderDrawer(REV_SECOND_V1)
+    await settle()
 
     const trajectory = snippets.map(slugOf)
 
     // Before the fix this ran forever, alternating between the two variants.
-    expect(trajectory.length).toBeLessThanOrEqual(6)
+    expect(trajectory.length).toBeLessThan(MAX_RENDERS)
     expect(trajectory[trajectory.length - 1]).toBe(`${APP_SLUG}.e2e`)
     // The drawer must never build a snippet for the variant the user did not open.
     expect(trajectory).not.toContain(`${APP_SLUG}.default`)
+
+    // Rendering has stopped: another idle period adds no renders.
+    const settledCount = snippets.length
+    await settle(10)
+    expect(snippets.length).toBe(settledCount)
 }, 20000)
 
 it("falls back to the first variant's latest revision when opened without one", async () => {
-    latency.byVariant = 0
-    latency.byWorkflow = 0
-
-    await mount("")
+    await renderDrawer(undefined)
+    await settle()
 
     const trajectory = snippets.map(slugOf)
 
-    expect(trajectory.length).toBeLessThanOrEqual(6)
+    expect(trajectory.length).toBeLessThan(MAX_RENDERS)
     expect(trajectory[trajectory.length - 1]).toBe(`${APP_SLUG}.default`)
     // v2 is the latest revision of the default variant.
+    expect(snippets[snippets.length - 1]).toContain("variant_version=2")
+}, 20000)
+
+it("keeps a revision the prop supplies in the same pass as the fallback list", async () => {
+    // Both writers see an empty selection in one pass: the prop arrives while the fallback
+    // variant's revision list lands. The fallback must not overwrite the requested revision.
+    openByVariantGate()
+
+    await renderDrawer(undefined)
+    await settle(5)
+
+    await act(async () => {
+        setPropRevisionId?.(REV_SECOND_V1)
+        releaseByVariantGate?.()
+        await new Promise((r) => setTimeout(r, 10))
+    })
+    byVariantGate = null
+    await settle()
+
+    const trajectory = snippets.map(slugOf)
+
+    expect(trajectory.length).toBeLessThan(MAX_RENDERS)
+    expect(trajectory[trajectory.length - 1]).toBe(`${APP_SLUG}.e2e`)
+}, 20000)
+
+it("recovers when the opened revision does not exist", async () => {
+    // A stale id behind a shared link resolves to nothing. The drawer must fall back to a
+    // real revision rather than wait for a revision that will never arrive.
+    await renderDrawer("rev-deleted")
+    await settle()
+
+    const trajectory = snippets.map(slugOf)
+
+    expect(trajectory.length).toBeLessThan(MAX_RENDERS)
+    expect(trajectory[trajectory.length - 1]).toBe(`${APP_SLUG}.default`)
     expect(snippets[snippets.length - 1]).toContain("variant_version=2")
 }, 20000)

--- a/web/oss/src/components/DeploymentsDashboard/assets/VariantUseApiContent.loop.test.tsx
+++ b/web/oss/src/components/DeploymentsDashboard/assets/VariantUseApiContent.loop.test.tsx
@@ -1,0 +1,234 @@
+/**
+ * Regression test for the "How to use API" drawer render loop (issue #6708).
+ *
+ * The drawer opened from the variants registry took a revision id as a prop and then
+ * reconciled it against a variant with three effects that wrote each other's inputs.
+ * With MORE THAN ONE variant the reconciliation never reached a fixed point: the
+ * snippet alternated between the two variants forever, and the first click on a
+ * language tab turned the loop synchronous and froze the tab.
+ *
+ * The test keeps the real workflow atoms and the real react-query wiring, and mocks
+ * only the HTTP layer and the heavy leaf components. It asserts that the snippet
+ * settles on ONE variant and that the component stops committing.
+ */
+import {act} from "react"
+
+import {queryClient} from "@agenta/shared/api"
+import {projectIdAtom, sessionAtom} from "@agenta/shared/state"
+import {QueryClientProvider} from "@tanstack/react-query"
+import {createStore, Provider} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+import {createRoot} from "react-dom/client"
+import {afterEach, beforeEach, expect, it, vi} from "vitest"
+
+// React 19 needs this flag before any act() call.
+;(globalThis as any).IS_REACT_ACT_ENVIRONMENT = true
+;(globalThis as any).ResizeObserver =
+    (globalThis as any).ResizeObserver ??
+    class {
+        observe() {}
+        unobserve() {}
+        disconnect() {}
+    }
+
+const APP_ID = "app-1"
+const APP_SLUG = "myapp"
+
+const VARIANT_DEFAULT = "var-default"
+const VARIANT_SECOND = "var-second"
+
+const REV_DEFAULT_V1 = "rev-default-1"
+const REV_DEFAULT_V2 = "rev-default-2"
+const REV_SECOND_V1 = "rev-second-1"
+
+const flags = () => ({is_llm: true, is_application: true})
+
+const variantFixture = (id: string, name: string) => ({
+    id,
+    slug: `${APP_SLUG}.${name}`,
+    name,
+    flags: flags(),
+    workflow_id: APP_ID,
+})
+
+const revisionFixture = (id: string, variantId: string, variantName: string, version: number) => ({
+    id,
+    slug: `${APP_SLUG}.${variantName}.v${version}`,
+    version,
+    name: variantName,
+    flags: flags(),
+    workflow_id: APP_ID,
+    workflow_variant_id: variantId,
+    workflow_slug: APP_SLUG,
+    workflow_variant_slug: `${APP_SLUG}.${variantName}`,
+    created_at: new Date(1700000000000 + version * 1000).toISOString(),
+    data: {uri: "http://localhost/services/completion"},
+})
+
+const VARIANTS = [variantFixture(VARIANT_DEFAULT, "default"), variantFixture(VARIANT_SECOND, "e2e")]
+const REVISIONS = [
+    revisionFixture(REV_DEFAULT_V1, VARIANT_DEFAULT, "default", 1),
+    revisionFixture(REV_DEFAULT_V2, VARIANT_DEFAULT, "default", 2),
+    revisionFixture(REV_SECOND_V1, VARIANT_SECOND, "e2e", 1),
+]
+
+/** Per-URL latency, so the test can order the two list queries the way the browser does. */
+const latency = {byVariant: 0, byWorkflow: 0}
+
+const post = vi.fn(async (url: string, body: any) => {
+    if (url.endsWith("/workflows/variants/query")) {
+        return {data: {count: VARIANTS.length, workflow_variants: VARIANTS}}
+    }
+    if (url.endsWith("/workflows/revisions/query")) {
+        if (body?.workflow_variant_refs) {
+            const variantId = body.workflow_variant_refs[0]?.id
+            await new Promise((r) => setTimeout(r, latency.byVariant))
+            const revisions = REVISIONS.filter((r) => r.workflow_variant_id === variantId)
+            return {data: {count: revisions.length, workflow_revisions: revisions}}
+        }
+        await new Promise((r) => setTimeout(r, latency.byWorkflow))
+        return {data: {count: REVISIONS.length, workflow_revisions: REVISIONS}}
+    }
+    return {data: {}}
+})
+
+const get = vi.fn(async (url: string) => {
+    const match = REVISIONS.find((revision) => url.includes(revision.id))
+    if (match) return {data: {count: 1, workflow_revision: match}}
+    return {data: {}}
+})
+
+vi.mock("@agenta/shared/api", async (original) => ({
+    ...(await original<object>()),
+    axios: {
+        post: (...args: any[]) => post(args[0], args[1]),
+        get: (...args: any[]) => get(args[0]),
+    },
+}))
+
+/** Reads the variant slug the drawer put in the snippet, for one recorded commit. */
+const slugOf = (snippet: string) => {
+    const match = snippet.match(/variant_slug="([^"]*)"/)
+    return match?.[1] ?? null
+}
+
+// Leaf components the loop does not need. LanguageCodeBlock stands in for the Lexical
+// code editor and records the snippet the drawer hands it on every commit.
+const snippets: string[] = []
+/**
+ * A synchronous render loop never yields, so a plain timeout would hang the whole run
+ * instead of failing this test. Cap the commits and throw the trajectory instead.
+ */
+const MAX_COMMITS = 60
+vi.mock(
+    "@/oss/components/pages/overview/deployments/DeploymentDrawer/assets/LanguageCodeBlock",
+    () => ({
+        default: ({fetchConfigCodeSnippet}: any) => {
+            snippets.push(String(fetchConfigCodeSnippet?.python ?? ""))
+            if (snippets.length > MAX_COMMITS) {
+                throw new Error(
+                    `render loop: ${snippets.length} commits, variant slug trajectory ` +
+                        JSON.stringify(snippets.slice(0, 24).map(slugOf)),
+                )
+            }
+            return null
+        },
+    }),
+)
+vi.mock("@/oss/components/Playground/Components/Menus/SelectVariant", () => ({
+    default: () => null,
+}))
+vi.mock("@agenta/entity-ui/variant", () => ({VariantDetailsWithStatus: () => null}))
+vi.mock("next/dynamic", () => ({default: () => () => null}))
+vi.mock("@/oss/hooks/useAppId", () => ({useAppId: () => APP_ID}))
+vi.mock("@/oss/state/app", async () => {
+    const {atom: jotaiAtom} = await import("jotai")
+    return {currentAppAtom: jotaiAtom({id: APP_ID, slug: APP_SLUG})}
+})
+
+const {default: VariantUseApiContent} = await import("./VariantUseApiContent")
+
+let container: HTMLDivElement | null = null
+let root: ReturnType<typeof createRoot> | null = null
+
+beforeEach(() => {
+    snippets.length = 0
+    queryClient.clear()
+    Object.defineProperty(window, "matchMedia", {
+        writable: true,
+        value: () => ({
+            matches: false,
+            addListener: () => undefined,
+            removeListener: () => undefined,
+            addEventListener: () => undefined,
+            removeEventListener: () => undefined,
+        }),
+    })
+})
+
+afterEach(() => {
+    act(() => root?.unmount())
+    container?.remove()
+    root = null
+    container = null
+})
+
+const mount = async (initialRevisionId: string) => {
+    const store = createStore()
+    store.set(queryClientAtom, queryClient)
+    store.set(projectIdAtom, "project-1")
+    store.set(sessionAtom, true as any)
+
+    container = document.createElement("div")
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+        root!.render(
+            <QueryClientProvider client={queryClient}>
+                <Provider store={store}>
+                    <VariantUseApiContent initialRevisionId={initialRevisionId} />
+                </Provider>
+            </QueryClientProvider>,
+        )
+    })
+
+    // Let every query settle.
+    for (let i = 0; i < 30; i++) {
+        await act(async () => {
+            await new Promise((r) => setTimeout(r, 10))
+        })
+    }
+}
+
+it("settles on the opened revision's variant when the app has two variants", async () => {
+    // The by-variant list resolves before the by-workflow list, as it does in the browser:
+    // the drawer used to pick a variant from the variants list first and only then learn
+    // which variant the opened revision belongs to.
+    latency.byVariant = 0
+    latency.byWorkflow = 30
+
+    await mount(REV_SECOND_V1)
+
+    const trajectory = snippets.map(slugOf)
+
+    // Before the fix this ran forever, alternating between the two variants.
+    expect(trajectory.length).toBeLessThanOrEqual(6)
+    expect(trajectory[trajectory.length - 1]).toBe(`${APP_SLUG}.e2e`)
+    // The drawer must never build a snippet for the variant the user did not open.
+    expect(trajectory).not.toContain(`${APP_SLUG}.default`)
+}, 20000)
+
+it("falls back to the first variant's latest revision when opened without one", async () => {
+    latency.byVariant = 0
+    latency.byWorkflow = 0
+
+    await mount("")
+
+    const trajectory = snippets.map(slugOf)
+
+    expect(trajectory.length).toBeLessThanOrEqual(6)
+    expect(trajectory[trajectory.length - 1]).toBe(`${APP_SLUG}.default`)
+    // v2 is the latest revision of the default variant.
+    expect(snippets[snippets.length - 1]).toContain("variant_version=2")
+}, 20000)

--- a/web/oss/src/components/DeploymentsDashboard/assets/VariantUseApiContent.tsx
+++ b/web/oss/src/components/DeploymentsDashboard/assets/VariantUseApiContent.tsx
@@ -4,7 +4,6 @@ import {
     workflowMolecule,
     workflowVariantsListDataAtomFamily,
     workflowRevisionsListDataAtomFamily,
-    workflowRevisionsByWorkflowListDataAtomFamily,
 } from "@agenta/entities/workflow"
 import {VariantDetailsWithStatus} from "@agenta/entity-ui/variant"
 import {PythonOutlined} from "@ant-design/icons"
@@ -36,13 +35,24 @@ interface VariantUseApiContentProps {
 const VariantUseApiContent = ({initialRevisionId}: VariantUseApiContentProps) => {
     const appId = useAppId()
     const variants = useAtomValue(workflowVariantsListDataAtomFamily(appId || ""))
-    const revisionList = useAtomValue(workflowRevisionsByWorkflowListDataAtomFamily(appId || ""))
     const currentApp = useAtomValue(currentAppAtom)
 
-    const [selectedVariantId, setSelectedVariantId] = useState<string | undefined>()
-    const [selectedRevisionId, setSelectedRevisionId] = useState<string | undefined>()
+    // The revision is the ONLY selection state here; the variant is DERIVED from it and is
+    // never stored. Two states that must agree cannot be reconciled by effects that each
+    // write what another reads: with more than one variant that reconciliation had no fixed
+    // point and the drawer re-rendered forever (issue #6708).
+    const [selectedRevisionId, setSelectedRevisionId] = useState<string | undefined>(
+        initialRevisionId,
+    )
     const [selectedLang, setSelectedLang] = useState("python")
     const [apiKeyValue, setApiKeyValue] = useState("")
+
+    // The drawer is destroyed when it closes, so this only fires when the host swaps the
+    // opened row while the drawer stays mounted. It is keyed on the prop, not on derived
+    // state, so it writes once per prop value.
+    useEffect(() => {
+        if (initialRevisionId) setSelectedRevisionId(initialRevisionId)
+    }, [initialRevisionId])
 
     // Get invocation URL and input ports from workflow molecule
     const uri = useAtomValue(
@@ -51,7 +61,6 @@ const VariantUseApiContent = ({initialRevisionId}: VariantUseApiContentProps) =>
             [selectedRevisionId],
         ),
     )
-    const isLoading = false
 
     const inputPorts = useAtomValue(
         useMemo(
@@ -70,22 +79,21 @@ const VariantUseApiContent = ({initialRevisionId}: VariantUseApiContentProps) =>
         ),
     )
 
-    const initialRevision = useMemo(
-        () => revisionList.find((rev) => rev.id === initialRevisionId),
-        [initialRevisionId, revisionList],
+    // The selected revision carries its own parent variant, so read it straight from the
+    // revision entity instead of looking it up in a list that arrives later.
+    const selectedRevision = useAtomValue(
+        useMemo(
+            () => workflowMolecule.selectors.data(selectedRevisionId || ""),
+            [selectedRevisionId],
+        ),
     )
 
-    useEffect(() => {
-        if (initialRevision?.workflow_variant_id) {
-            setSelectedVariantId(initialRevision.workflow_variant_id)
-            setSelectedRevisionId(initialRevision.id)
-            return
-        }
+    const derivedVariantId =
+        selectedRevision?.workflow_variant_id ?? selectedRevision?.variant_id ?? undefined
 
-        if (!selectedVariantId && variants.length) {
-            setSelectedVariantId(variants[0]?.id)
-        }
-    }, [initialRevision, selectedVariantId, variants])
+    // With no revision selected yet the drawer defaults to the first variant, and the effect
+    // below then adopts that variant's latest revision.
+    const selectedVariantId = derivedVariantId ?? (selectedRevisionId ? undefined : variants[0]?.id)
 
     const variantRevisionsAtom = useMemo(
         () => workflowRevisionsListDataAtomFamily(selectedVariantId || ""),
@@ -99,50 +107,25 @@ const VariantUseApiContent = ({initialRevisionId}: VariantUseApiContentProps) =>
         return variantRevisions[0]
     }, [variantRevisions])
 
+    // The only other writer of the selection. It runs while nothing is selected and writes a
+    // truthy id, so it can run at most once and cannot cycle with anything.
     useEffect(() => {
-        if (!selectedVariantId) return
-
-        const hasSelectedRevision =
-            selectedRevisionId &&
-            (variantRevisions || []).some((rev) => rev.id === selectedRevisionId)
-
-        if (hasSelectedRevision) return
-
-        const nextRevisionId =
-            initialRevision && initialRevision.workflow_variant_id === selectedVariantId
-                ? initialRevision.id
-                : latestRevision?.id
-
-        if (nextRevisionId) {
-            setSelectedRevisionId(nextRevisionId)
-        }
-    }, [
-        initialRevision,
-        latestRevision?.id,
-        selectedRevisionId,
-        selectedVariantId,
-        variantRevisions,
-    ])
+        if (selectedRevisionId) return
+        if (latestRevision?.id) setSelectedRevisionId(latestRevision.id)
+    }, [latestRevision?.id, selectedRevisionId])
 
     const selectedVariant = useMemo(
         () => variants.find((variant) => variant.id === selectedVariantId),
         [selectedVariantId, variants],
     )
 
-    const selectedRevision = useMemo(
-        () => (variantRevisions || []).find((revision) => revision.id === selectedRevisionId),
-        [selectedRevisionId, variantRevisions],
-    )
+    // Show the spinner while the opened revision resolves, rather than a snippet built from
+    // whichever variant happens to be first.
+    const isLoading = Boolean(selectedRevisionId) && !selectedRevision
 
-    useEffect(() => {
-        if (!selectedRevisionId) return
-        const revision = revisionList.find((item) => item.id === selectedRevisionId)
-        if (revision?.workflow_variant_id && revision.workflow_variant_id !== selectedVariantId) {
-            setSelectedVariantId(revision.workflow_variant_id)
-        }
-    }, [revisionList, selectedRevisionId, selectedVariantId])
-
-    const variantSlug = selectedVariant?.slug || "my-variant-slug"
+    // The variants list can arrive after the revision does; the revision carries the same slug.
+    const variantSlug =
+        selectedVariant?.slug || selectedRevision?.workflow_variant_slug || "my-variant-slug"
     const variantVersion = selectedRevision?.version ?? latestRevision?.version ?? 1
     const appSlug = currentApp?.slug || "my-app-slug"
     const apiKey = apiKeyValue || "YOUR_API_KEY"
@@ -244,14 +227,7 @@ const VariantUseApiContent = ({initialRevisionId}: VariantUseApiContentProps) =>
                         <SelectVariant
                             value={selectedRevisionId}
                             onChange={(value) => {
-                                const nextRevisionId = value as string
-                                setSelectedRevisionId(nextRevisionId)
-                                const revision = revisionList.find(
-                                    (item) => item.id === nextRevisionId,
-                                )
-                                if (revision?.workflow_variant_id) {
-                                    setSelectedVariantId(revision.workflow_variant_id)
-                                }
+                                setSelectedRevisionId(value as string)
                             }}
                             showCreateNew={false}
                             showLatestTag={false}

--- a/web/oss/src/components/DeploymentsDashboard/assets/VariantUseApiContent.tsx
+++ b/web/oss/src/components/DeploymentsDashboard/assets/VariantUseApiContent.tsx
@@ -3,7 +3,7 @@ import {useCallback, useEffect, useMemo, useState} from "react"
 import {
     workflowMolecule,
     workflowVariantsListDataAtomFamily,
-    workflowRevisionsListDataAtomFamily,
+    workflowRevisionRefsByVariantAtomFamily,
 } from "@agenta/entities/workflow"
 import {VariantDetailsWithStatus} from "@agenta/entity-ui/variant"
 import {PythonOutlined} from "@ant-design/icons"
@@ -37,10 +37,10 @@ const VariantUseApiContent = ({initialRevisionId}: VariantUseApiContentProps) =>
     const variants = useAtomValue(workflowVariantsListDataAtomFamily(appId || ""))
     const currentApp = useAtomValue(currentAppAtom)
 
-    // The revision is the ONLY selection state here; the variant is DERIVED from it and is
-    // never stored. Two states that must agree cannot be reconciled by effects that each
-    // write what another reads: with more than one variant that reconciliation had no fixed
-    // point and the drawer re-rendered forever (issue #6708).
+    // The revision is the authoritative selection; the parent variant is derived from it and
+    // is never stored. Two states that must agree used to be reconciled by three effects that
+    // each wrote what another read, and with more than one variant they oscillated instead of
+    // settling on a coherent pair (issue #6708).
     const [selectedRevisionId, setSelectedRevisionId] = useState<string | undefined>(
         initialRevisionId,
     )
@@ -87,45 +87,70 @@ const VariantUseApiContent = ({initialRevisionId}: VariantUseApiContentProps) =>
             [selectedRevisionId],
         ),
     )
+    const selectedRevisionQuery = useAtomValue(
+        useMemo(
+            () => workflowMolecule.selectors.query(selectedRevisionId || ""),
+            [selectedRevisionId],
+        ),
+    )
+
+    // Tell "still fetching" apart from "this revision does not exist". Without the split a
+    // stale id (a deleted revision behind a shared link) would spin for ever.
+    const isResolvingRevision =
+        Boolean(selectedRevisionId) &&
+        !selectedRevision &&
+        Boolean(selectedRevisionQuery?.isPending)
+    const isUnresolvableRevision =
+        Boolean(selectedRevisionId) && !selectedRevision && !selectedRevisionQuery?.isPending
 
     const derivedVariantId =
         selectedRevision?.workflow_variant_id ?? selectedRevision?.variant_id ?? undefined
 
-    // With no revision selected yet the drawer defaults to the first variant, and the effect
-    // below then adopts that variant's latest revision.
-    const selectedVariantId = derivedVariantId ?? (selectedRevisionId ? undefined : variants[0]?.id)
+    // Before a revision is chosen, and when the chosen one cannot be resolved, the drawer
+    // falls back to the first variant and the effect below adopts its latest revision.
+    const needsFallbackVariant = !selectedRevisionId || isUnresolvableRevision
+    const selectedVariantId =
+        derivedVariantId ?? (needsFallbackVariant ? variants[0]?.id : undefined)
 
-    const variantRevisionsAtom = useMemo(
-        () => workflowRevisionsListDataAtomFamily(selectedVariantId || ""),
-        [selectedVariantId],
+    // Only the newest revision's id and version are needed, so read the thin refs rather than
+    // resolving every revision entity of the variant.
+    const variantRevisionRefs = useAtomValue(
+        useMemo(
+            () => workflowRevisionRefsByVariantAtomFamily(selectedVariantId || ""),
+            [selectedVariantId],
+        ),
     )
-
-    const variantRevisions = useAtomValue(variantRevisionsAtom)
     const latestRevision = useMemo(() => {
-        if (!Array.isArray(variantRevisions) || variantRevisions.length === 0) return null
+        if (!Array.isArray(variantRevisionRefs) || variantRevisionRefs.length === 0) return null
         // Already sorted by version desc from the atom family
-        return variantRevisions[0]
-    }, [variantRevisions])
+        return variantRevisionRefs[0]
+    }, [variantRevisionRefs])
 
-    // The only other writer of the selection. It runs while nothing is selected and writes a
-    // truthy id, so it can run at most once and cannot cycle with anything.
+    // The only other writer of the selection. It writes only while there is nothing usable
+    // selected, and the functional update keeps a revision the prop supplied in the same pass.
     useEffect(() => {
-        if (selectedRevisionId) return
-        if (latestRevision?.id) setSelectedRevisionId(latestRevision.id)
-    }, [latestRevision?.id, selectedRevisionId])
+        if (!latestRevision?.id) return
+        if (selectedRevisionId && !isUnresolvableRevision) return
+        setSelectedRevisionId((current) =>
+            current && !isUnresolvableRevision ? current : latestRevision.id,
+        )
+    }, [isUnresolvableRevision, latestRevision?.id, selectedRevisionId])
 
     const selectedVariant = useMemo(
         () => variants.find((variant) => variant.id === selectedVariantId),
         [selectedVariantId, variants],
     )
 
-    // Show the spinner while the opened revision resolves, rather than a snippet built from
-    // whichever variant happens to be first.
-    const isLoading = Boolean(selectedRevisionId) && !selectedRevision
+    // Show the spinner while the opened revision is still being fetched, rather than a snippet
+    // built from whichever variant happens to be first.
+    const isLoading = isResolvingRevision
 
     // The variants list can arrive after the revision does; the revision carries the same slug.
     const variantSlug =
-        selectedVariant?.slug || selectedRevision?.workflow_variant_slug || "my-variant-slug"
+        selectedVariant?.slug ||
+        selectedRevision?.workflow_variant_slug ||
+        selectedRevision?.variant_slug ||
+        "my-variant-slug"
     const variantVersion = selectedRevision?.version ?? latestRevision?.version ?? 1
     const appSlug = currentApp?.slug || "my-app-slug"
     const apiKey = apiKeyValue || "YOUR_API_KEY"


### PR DESCRIPTION
Closes #6708

## Context

Open an app that has more than one variant, go to the Variants registry, select a row and click **Use API**. The "How to use API" drawer enters an infinite React render loop the moment it opens. The snippet flips between the two variants many times a second. Click any language tab and the loop turns synchronous: React throws #185 continuously and the tab is frozen until it is reloaded. The drawer opened from the Deployments tab is not affected. Issue: https://github.com/Agenta-AI/agenta/issues/6708

`VariantUseApiContent` kept two pieces of state that must agree, `selectedVariantId` and `selectedRevisionId`, and reconciled them with three effects that each wrote what another read. The three effects run in one pass, so each one sees a snapshot where the others have not applied yet, and each re-asserts its own view. With one variant all three agree and it settles. With two variants the branch `initialRevision.workflow_variant_id !== selectedVariantId` becomes reachable and they oscillate.

Here is the cycle, logged from the reproduction:

```
AGEFFECT A-fallback var-default                     # no revision known yet, pick variants[0]
AGEFFECT A-init     var-second rev-second-1         # the opened revision resolves, adopt its variant
AGEFFECT B variant=var-default -> rev=rev-default-2 # same pass, stale variant, adopt ITS latest revision
AGEFFECT C rev=rev-default-2 -> variant=var-default # that revision belongs to the other variant
AGEFFECT A-init     var-second rev-second-1         # and back
```

This is not a v0.115.3 regression. The three effects have been in the file since March 2026 and last changed in May 2026. What is new is the acceptance test's drawer wait, which made the freeze reachable in CI instead of failing earlier on a stability check.

## Changes

The revision is now the authoritative selection. The parent variant is derived from it and never stored.

Before, the variant came from a workflow-wide revision list that arrives late, and three effects pushed the two states at each other:

```
useState selectedVariantId + useState selectedRevisionId
effect A: initialRevision -> write BOTH
effect B: selectedVariantId + variantRevisions -> write revision
effect C: revisionList + selectedRevisionId -> write variant
```

After, the drawer reads the selected revision entity, which already carries `workflow_variant_id`, so nothing has to arrive before the drawer knows which variant it is showing:

```
useState selectedRevisionId          (initialised from the prop)
const selectedVariantId = selectedRevision?.workflow_variant_id ?? <fallback>
effect: if there is no usable selection, adopt the latest revision
```

Two writers remain and neither can fight the other. One is keyed on the `initialRevisionId` prop. The other runs only while there is no usable selection, and it writes through a functional update so it cannot overwrite a revision the prop supplied in the same pass.

The drawer also tells "still fetching" apart from "this revision does not exist". A stale id, for example a deleted revision behind a shared link, now falls back to the first variant's latest revision instead of spinning for ever.

Two smaller consequences. The drawer no longer mounts the workflow-wide revisions query, and it reads the thin revision refs for the variant rather than resolving every revision entity, so it opens with fewer queries than before. While the opened revision is still being fetched the drawer shows its spinner.

## Tests

- New unit test `VariantUseApiContent.loop.test.tsx` mounts the drawer content against the real workflow atoms and real react-query, with two variants and the arrival order that opens the race. On the old component it records 62 renders alternating `myapp.default` and `myapp.e2e` and React reports "Maximum update depth exceeded". On the new component the trajectory is two renders, it never builds a snippet for the variant the user did not open, and rendering stops once the queries resolve. Four cases: the loop, the drawer opened without a revision, a revision the prop supplies in the same pass as the fallback list, and a revision that does not exist. The last two fail on the first pass of this fix and pass now.
- `pnpm exec tsc --noEmit` in `web/oss`: 0 errors. `pnpm run lint-fix` in `web/oss`: clean. Full `web/oss` unit suite: 62 files, 531 tests, all pass.
- Acceptance pair run three times against a local EE stack serving this branch, `--workers=1 --retries=0`. "Registry: use API snippets > should show variant TypeScript snippet" passed all three times, in 5.2 s, 3.4 s and 3.2 s. It used to hang for the full 60 s timeout. The one failure in each run is "Should run single view variant for chat", which times out waiting for an LLM response because that stack has no provider key. It is unrelated and fails identically on every run. Both use-API tests passed again on the final code.
- Live browser check on the same stack, eleven attempts on this branch: 0 DOM mutations in the drawer over 3 s, the variant slug identical across all 12 samples, the TypeScript tab selected in about 0.2 s, and zero React #185 errors.
- I could not reproduce the old loop in the browser on that stack. Ten attempts on the release code, including runs that delay the workflow-wide revisions request, all stayed stable. The registry page warms the revision cache before the drawer opens, which closes the race. The issue reports 3 of 5 on staging, so this is consistent. The deterministic reproduction is the unit test.

PR #6709 quarantines the acceptance test for this bug. It is still open and not merged, so there is no `fixme` on `release/v0.115.3` to revert. Close #6709 rather than merging it.

A Codex review at xhigh found the two selection defects listed above, which are now fixed and covered. It also reported a separate pre-existing oscillation in `TraceDrawerContent.tsx` in the observability package, where a local `selected` span and the global `activeSpanId` copy into each other. That is not this component and not these atoms, so it is out of scope here and worth its own issue.

## What to QA

- Open an app with two or more variants, go to Variants, select a row, click **Use API**. The snippet names the variant of the row you selected and does not change on its own.
- Click the TypeScript tab and then the cURL tab. Both respond at once and the page stays interactive.
- Change the variant with the picker inside the drawer. The snippet follows the picker, and the version tag next to it matches.
- Regression: open **Use API** from the Deployments tab. It behaves as before.
- Regression: open the drawer on an app with a single variant. The snippet names that variant.
