### PR TITLE
[test] Re-enable the Use API acceptance test after the drawer loop fix

### DIFF
--- a/web/oss/tests/playwright/acceptance/use-api/index.ts
+++ b/web/oss/tests/playwright/acceptance/use-api/index.ts
@@ -207,8 +207,7 @@ const switchToTypescriptTab = async (drawer: any) => {
 
 const useApiTests = () => {
     // WEB-ACC-USEAPI-001
-    // Quarantined on the drawer freeze: https://github.com/Agenta-AI/agenta/issues/6708
-    test.fixme(
+    test(
         "should show variant TypeScript snippet for Fetch Prompt/Config and Invoke LLM",
         {tag: lightFastTags},
         async ({page, apiHelpers, uiHelpers}) => {


### PR DESCRIPTION
Reverts the quarantine from #6709. The freeze it hid was fixed by #6711 (root cause in #6708). The acceptance test passed three times in a row on the fixed branch (5.2 s, 3.4 s, 3.2 s).

Test-only change: the `test.fixme` in `web/oss/tests/playwright/acceptance/use-api/index.ts` becomes `test` again.