### PR TITLE
[test] Replace every newline in the CRLF framing test (CodeQL)

### DIFF
--- a/web/packages/agenta-chat/tests/unit/hooks/readRunAdmission.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/readRunAdmission.test.ts
@@ -46,7 +46,7 @@ describe("readRunAdmission", () => {
     it("reads CRLF and CR-only framing", async () => {
         for (const eol of ["\r\n", "\r"]) {
             const w = watcher()
-            const frame = accepted("turn-3").replace("\n", eol)
+            const frame = accepted("turn-3").replaceAll("\n", eol)
             await readRunAdmission(streamOf([frame, `data: {}${eol}`]), w)
             expect(w.onAccepted).toHaveBeenCalledWith("turn-3")
         }


### PR DESCRIPTION
CodeQL flags `.replace("\n", eol)` on the release PR #6616 as incomplete sanitization (alert 319, js/incomplete-sanitization) in `web/packages/agenta-chat/tests/unit/hooks/readRunAdmission.test.ts`. The frame has one newline, so the behavior is unchanged; `replaceAll` states the intent and clears the alert.

Test-only. Same class as #6670. Unblocks the CodeQL check on #6616.