### PR TITLE
[hotfix] fix(sdk): tolerate saved gateway tool entries the strict parser refuses

### DIFF
--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -50,10 +50,21 @@ log = get_module_logger(__name__)
 def _is_legacy_gateway_entry(entry: Any) -> bool:
     """Whether an entry is the pre-rework one-action gateway shape.
 
+    The tag alone does not say so. A current-format ``gateway`` entry is still authored
+    today, and a malformed one is a mistake its author must see, so the entry has to carry a
+    positive mark of its age before it may be dropped:
+
+    * ``provider_action``, the field name the pre-2026-08-27 writer used, or
+    * neither ``action`` nor ``connection``, which no current-format entry can be missing.
+
     ``composio`` is the same shape under its older name: ``coerce_tool_config`` renames it
     before it parses, so a refusal for either spelling names the same legacy entry.
     """
-    return isinstance(entry, dict) and entry.get("type") in {"gateway", "composio"}
+    if not isinstance(entry, dict) or entry.get("type") not in {"gateway", "composio"}:
+        return False
+    if entry.get("provider_action"):
+        return True
+    return not entry.get("action") and not entry.get("connection")
 
 
 # ---------------------------------------------------------------------------

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -35,10 +35,25 @@ from .mcp import (
 from .pi_builtins import PI_BUILTIN_TOOL_NAMES
 from .skills import SkillTemplate, parse_skill_templates, skills_to_wire
 from .permission_rules import wire_author_permission_rules
-from .tools import ToolCallback, ToolConfig, ToolSpec, coerce_tool_configs
+from .tools import (
+    ToolCallback,
+    ToolConfig,
+    ToolConfigurationError,
+    ToolSpec,
+    coerce_tool_configs,
+)
 from .tools.models import PermissionMode, ResolvedGatewayPolicy, coerce_tool_spec
 
 log = get_module_logger(__name__)
+
+
+def _is_legacy_gateway_entry(entry: Any) -> bool:
+    """Whether an entry is the pre-rework one-action gateway shape.
+
+    ``composio`` is the same shape under its older name: ``coerce_tool_config`` renames it
+    before it parses, so a refusal for either spelling names the same legacy entry.
+    """
+    return isinstance(entry, dict) and entry.get("type") in {"gateway", "composio"}
 
 
 # ---------------------------------------------------------------------------
@@ -719,13 +734,31 @@ class AgentTemplate(BaseModel):
     @field_validator("tools", mode="before")
     @classmethod
     def _coerce_tools(cls, value: Any) -> List[ToolConfig]:
-        # A saved revision is never re-validated against these models when it is written,
-        # so one unparsable entry must not fail the whole run. Drop it with a warning, as
-        # the resolver already does for a gateway action the catalog no longer carries.
-        result = coerce_tool_configs(_as_list(value), on_error="collect")
+        # Tolerance is deliberately narrow. A legacy ``gateway`` entry predates the rework
+        # and no migration ever rewrote one, so an unrepairable one is dropped rather than
+        # allowed to fail every run of an agent nobody can edit back into shape.
+        #
+        # Every OTHER refusal still fails the run, loudly and unchanged: a typo in a tool
+        # name, a malformed connection entry, and two conflicting policies for the same
+        # integration are all real misconfigurations the author must see. Dropping those
+        # would take a tool the author believes is configured and make it vanish in silence.
+        entries = _as_list(value)
+        result = coerce_tool_configs(entries, on_error="collect")
         for diagnostic in result.diagnostics:
+            entry = (
+                entries[diagnostic.index]
+                if 0 <= diagnostic.index < len(entries)
+                else None
+            )
+            if not _is_legacy_gateway_entry(entry):
+                raise ToolConfigurationError(
+                    diagnostic.message,
+                    index=diagnostic.index,
+                    value=entry,
+                )
             log.warning(
-                "agent: dropped an unparsable tool entry: %s", diagnostic.message
+                "agent: dropped an unrepairable legacy gateway tool entry: %s",
+                diagnostic.message,
             )
         return result.tool_configs
 

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -23,6 +23,7 @@ from pydantic import (
 )
 
 from agenta.sdk.engines.running.errors import ERRORS_BASE_URL, ErrorStatus
+from agenta.sdk.utils.logging import get_module_logger
 
 from .connections import EnvironmentCredentialBinding, ModelRef, ResolvedConnection
 from .mcp import (
@@ -36,6 +37,8 @@ from .skills import SkillTemplate, parse_skill_templates, skills_to_wire
 from .permission_rules import wire_author_permission_rules
 from .tools import ToolCallback, ToolConfig, ToolSpec, coerce_tool_configs
 from .tools.models import PermissionMode, ResolvedGatewayPolicy, coerce_tool_spec
+
+log = get_module_logger(__name__)
 
 
 # ---------------------------------------------------------------------------
@@ -716,7 +719,15 @@ class AgentTemplate(BaseModel):
     @field_validator("tools", mode="before")
     @classmethod
     def _coerce_tools(cls, value: Any) -> List[ToolConfig]:
-        return coerce_tool_configs(_as_list(value)).tool_configs
+        # A saved revision is never re-validated against these models when it is written,
+        # so one unparsable entry must not fail the whole run. Drop it with a warning, as
+        # the resolver already does for a gateway action the catalog no longer carries.
+        result = coerce_tool_configs(_as_list(value), on_error="collect")
+        for diagnostic in result.diagnostics:
+            log.warning(
+                "agent: dropped an unparsable tool entry: %s", diagnostic.message
+            )
+        return result.tool_configs
 
     @field_validator("mcp_servers", mode="before")
     @classmethod

--- a/sdks/python/agenta/sdk/agents/tools/compat.py
+++ b/sdks/python/agenta/sdk/agents/tools/compat.py
@@ -60,6 +60,26 @@ def _copy_tool_metadata(
     return result
 
 
+def _action_key_from_provider_action(
+    provider_action: Any, integration: Any
+) -> Optional[str]:
+    """The catalog tool key a legacy ``provider_action`` names, or ``None``.
+
+    ``provider_action`` holds the PROVIDER action id, which carries the integration as a
+    prefix (``GITHUB_GET_AN_ISSUE``). The ``action`` field holds the catalog key, which does
+    not (``GET_AN_ISSUE``), and the backend resolves a legacy reference by that key alone.
+    Copying the id across verbatim would name a tool no catalog carries, so strip the prefix
+    exactly as the catalog does when it derives the key.
+    """
+    if not isinstance(provider_action, str) or not provider_action:
+        return None
+    if isinstance(integration, str) and integration:
+        prefix = f"{integration.upper()}_"
+        if provider_action.upper().startswith(prefix):
+            return provider_action[len(prefix) :]
+    return provider_action
+
+
 def coerce_tool_config(value: Any) -> ToolConfig:
     """Convert one supported legacy shape into canonical tool configuration."""
     if isinstance(
@@ -94,12 +114,12 @@ def coerce_tool_config(value: Any) -> ToolConfig:
     # canonical ``action`` would refuse the entry for the field it no longer needs.
     if data.get("type") == "gateway":
         provider_action = data.pop("provider_action", None)
-        if (
-            not data.get("action")
-            and isinstance(provider_action, str)
-            and provider_action
-        ):
-            data["action"] = provider_action
+        if not data.get("action"):
+            action = _action_key_from_provider_action(
+                provider_action, data.get("integration")
+            )
+            if action:
+                data["action"] = action
 
     if data.get("type") in {
         "builtin",

--- a/sdks/python/agenta/sdk/agents/tools/compat.py
+++ b/sdks/python/agenta/sdk/agents/tools/compat.py
@@ -70,12 +70,18 @@ def _action_key_from_provider_action(
     not (``GET_AN_ISSUE``), and the backend resolves a legacy reference by that key alone.
     Copying the id across verbatim would name a tool no catalog carries, so strip the prefix
     exactly as the catalog does when it derives the key.
+
+    "Exactly" includes the case rule. The catalog upper-cases the INTEGRATION to build the
+    prefix and then matches the raw provider id against it, so a lower-case prefix on the id
+    is not a prefix at all and stays part of the key. Matching case-insensitively here would
+    strip a prefix the catalog keeps, and turn a key that was already correct into one no
+    catalog holds.
     """
     if not isinstance(provider_action, str) or not provider_action:
         return None
     if isinstance(integration, str) and integration:
         prefix = f"{integration.upper()}_"
-        if provider_action.upper().startswith(prefix):
+        if provider_action.startswith(prefix):
             return provider_action[len(prefix) :]
     return provider_action
 

--- a/sdks/python/agenta/sdk/agents/tools/compat.py
+++ b/sdks/python/agenta/sdk/agents/tools/compat.py
@@ -88,6 +88,19 @@ def coerce_tool_config(value: Any) -> ToolConfig:
         data["type"] = "gateway"
         data.setdefault("provider", "composio")
 
+    # Pre-2026-08-27 ``gateway`` entries spelled the action ``provider_action``, the field
+    # name the discovery response uses. No migration ever rewrote them, so translate on
+    # read. The key is dropped either way: the arm forbids extras, so leaving it beside a
+    # canonical ``action`` would refuse the entry for the field it no longer needs.
+    if data.get("type") == "gateway":
+        provider_action = data.pop("provider_action", None)
+        if (
+            not data.get("action")
+            and isinstance(provider_action, str)
+            and provider_action
+        ):
+            data["action"] = provider_action
+
     if data.get("type") in {
         "builtin",
         "gateway",

--- a/sdks/python/agenta/sdk/agents/tools/models.py
+++ b/sdks/python/agenta/sdk/agents/tools/models.py
@@ -213,7 +213,9 @@ class GatewayPermissions(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    default: GatewayPermission
+    # ``inherit`` is the safe absent value: the compiler defers every tool to the
+    # agent-wide runner mode, which is what an entry saved without a policy means.
+    default: GatewayPermission = "inherit"
     tools: Dict[Annotated[str, Field(min_length=1)], GatewayPermission] = Field(
         default_factory=dict
     )
@@ -225,7 +227,7 @@ class GatewayConnectionPolicy(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    permissions: GatewayPermissions
+    permissions: GatewayPermissions = Field(default_factory=GatewayPermissions)
 
 
 class GatewayConnectionToolConfig(BaseModel):
@@ -247,7 +249,10 @@ class GatewayConnectionToolConfig(BaseModel):
 
     type: Literal["gateway_connection"] = "gateway_connection"
     connection: GatewayConnectionRef
-    policy: GatewayConnectionPolicy
+    # Defaulted, not required. The commit path does not validate an entry against this
+    # model, so an entry written without ``policy`` must mean "inherit the runner policy"
+    # rather than fail the run at parse time.
+    policy: GatewayConnectionPolicy = Field(default_factory=GatewayConnectionPolicy)
 
 
 class CompiledTool(BaseModel):

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_gateway_connection_config.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_gateway_connection_config.py
@@ -99,17 +99,21 @@ def test_tools_defaults_to_an_empty_map():
 # --- C20 to C23: validation --------------------------------------------------------
 
 
-def test_a_missing_default_is_rejected():
-    # C20. Without a default there is no answer for a catalog tool the entry never names.
-    with pytest.raises(ToolConfigurationError):
-        parse_tool_config(_entry(policy={"permissions": {"tools": {}}}))
+def test_a_missing_default_means_inherit():
+    # C20, relaxed. A catalog tool the entry never names still needs an answer, and
+    # `inherit` is one: it defers to the agent-wide runner mode. Refusing the entry instead
+    # failed every invoke of an agent whose saved entry was written without the field. The
+    # tolerance cases live in test_saved_entry_tolerance.py.
+    config = parse_tool_config(_entry(policy={"permissions": {"tools": {}}}))
+    assert config.policy.permissions.default == "inherit"
 
 
-def test_a_missing_policy_is_rejected():
-    with pytest.raises(ToolConfigurationError):
-        parse_tool_config(
-            {key: value for key, value in _ENTRY.items() if key != "policy"}
-        )
+def test_a_missing_policy_means_inherit():
+    config = parse_tool_config(
+        {key: value for key, value in _ENTRY.items() if key != "policy"}
+    )
+    assert config.policy.permissions.default == "inherit"
+    assert config.policy.permissions.tools == {}
 
 
 @pytest.mark.parametrize(

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py
@@ -1,0 +1,184 @@
+"""Tolerance for saved tool entries the strict parser used to refuse.
+
+A revision's tool entries are never validated against these models when they are written:
+the agent's own ``commit_revision`` writes free JSON, and the commit gate validates only the
+revision DTO, whose ``parameters`` is an open dict. Two shapes reached production and failed
+every invoke with a 500 at config-parse time:
+
+* a ``gateway_connection`` entry with no ``policy`` node,
+* a pre-2026-08-27 ``gateway`` entry that spells the action ``provider_action``.
+
+An unrunnable entry must cost its own tool, never the whole run.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+import pytest
+
+from agenta.sdk.agents.dtos import AgentTemplate
+from agenta.sdk.agents.tools import (
+    GatewayConnectionToolConfig,
+    GatewayToolConfig,
+    coerce_tool_config,
+    coerce_tool_configs,
+    parse_tool_config,
+)
+from agenta.sdk.agents.tools.gateway_policy import (
+    CatalogToolInfo,
+    compile_gateway_permissions,
+)
+
+# Shape A, exactly as production saved it: the three routing fields, no policy.
+_NO_POLICY_ENTRY = {
+    "type": "gateway_connection",
+    "connection": {
+        "provider": "composio",
+        "integration": "github",
+        "slug": "github-work",
+    },
+}
+
+# Shape B: the legacy action field name, which no migration ever rewrote.
+_PROVIDER_ACTION_ENTRY = {
+    "type": "gateway",
+    "provider": "composio",
+    "integration": "github",
+    "provider_action": "GITHUB_GET_AN_ISSUE",
+    "connection": "github-work",
+}
+
+_CLIENT_ENTRY = {
+    "type": "client",
+    "name": "ask_user",
+    "description": "Ask the caller.",
+    "input_schema": {"type": "object"},
+}
+
+
+# --- Shape A: a connection entry with no policy -------------------------------------
+
+
+def test_a_connection_entry_without_a_policy_parses():
+    config = parse_tool_config(_NO_POLICY_ENTRY)
+    assert isinstance(config, GatewayConnectionToolConfig)
+    assert config.connection.slug == "github-work"
+
+
+def test_an_absent_policy_means_inherit():
+    # Absent is not "allow" and not "deny": every tool defers to the agent-wide mode, which
+    # is what the runner would have applied had the entry never been configured at all.
+    config = parse_tool_config(_NO_POLICY_ENTRY)
+    assert config.policy.permissions.default == "inherit"
+    assert config.policy.permissions.tools == {}
+
+
+def test_an_absent_policy_compiles_to_the_agent_wide_mode():
+    config = parse_tool_config(_NO_POLICY_ENTRY)
+    compiled = compile_gateway_permissions(
+        config.policy.permissions,
+        [
+            CatalogToolInfo(key="GITHUB_GET_AN_ISSUE", read_only=True),
+            CatalogToolInfo(key="GITHUB_CREATE_AN_ISSUE", read_only=False),
+        ],
+        "allow_reads",
+    )
+    assert compiled.tools["GITHUB_GET_AN_ISSUE"].permission == "allow"
+    assert compiled.tools["GITHUB_CREATE_AN_ISSUE"].permission == "ask"
+    assert compiled.stale_keys == []
+
+
+def test_an_explicit_policy_still_wins():
+    # The default must not overwrite an authored policy, in either direction.
+    config = parse_tool_config(
+        {
+            **_NO_POLICY_ENTRY,
+            "policy": {
+                "permissions": {
+                    "default": "deny",
+                    "tools": {"GITHUB_GET_AN_ISSUE": "allow"},
+                }
+            },
+        }
+    )
+    assert config.policy.permissions.default == "deny"
+    assert config.policy.permissions.tools == {"GITHUB_GET_AN_ISSUE": "allow"}
+
+
+# --- Shape B: the legacy provider_action spelling -----------------------------------
+
+
+def test_provider_action_is_read_as_the_action():
+    # The translation lives in the compat layer, which is what every reader of a SAVED
+    # revision goes through. `parse_tool_config` stays strict on the canonical spelling.
+    config = coerce_tool_config(_PROVIDER_ACTION_ENTRY)
+    assert isinstance(config, GatewayToolConfig)
+    assert config.action == "GITHUB_GET_AN_ISSUE"
+    assert config.connection == "github-work"
+
+
+def test_an_explicit_action_wins_over_provider_action():
+    config = coerce_tool_config(
+        {**_PROVIDER_ACTION_ENTRY, "action": "GITHUB_CREATE_AN_ISSUE"}
+    )
+    assert config.action == "GITHUB_CREATE_AN_ISSUE"
+
+
+# --- An entry that cannot be repaired -----------------------------------------------
+
+
+def test_an_unrepairable_gateway_entry_is_collected_not_raised():
+    # No action under either spelling and no connection: there is nothing to run. It is
+    # reported per entry so the caller can drop it.
+    result = coerce_tool_configs(
+        [{"type": "gateway", "provider": "composio", "integration": "github"}],
+        on_error="collect",
+    )
+    assert result.tool_configs == []
+    assert [d.index for d in result.diagnostics] == [0]
+
+
+class _RecordingLog:
+    def __init__(self) -> None:
+        self.warnings: List[Tuple[str, Any]] = []
+
+    def warning(self, message: str, *args: Any) -> None:
+        self.warnings.append((message, args))
+
+
+def test_an_unrepairable_entry_is_dropped_with_a_warning_and_the_rest_survive(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The whole point of the fix: one dead entry costs its own tool, not the agent's run.
+    recorder = _RecordingLog()
+    monkeypatch.setattr("agenta.sdk.agents.dtos.log", recorder)
+
+    template = AgentTemplate(
+        tools=[
+            {"type": "gateway", "provider": "composio", "integration": "github"},
+            _NO_POLICY_ENTRY,
+            _PROVIDER_ACTION_ENTRY,
+            _CLIENT_ENTRY,
+        ]
+    )
+
+    kinds = [type(tool).__name__ for tool in template.tools]
+    assert kinds == [
+        "GatewayConnectionToolConfig",
+        "GatewayToolConfig",
+        "ClientToolConfig",
+    ]
+    assert len(recorder.warnings) == 1
+
+
+def test_a_template_with_only_valid_tools_logs_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    recorder = _RecordingLog()
+    monkeypatch.setattr("agenta.sdk.agents.dtos.log", recorder)
+
+    template = AgentTemplate(tools=[_NO_POLICY_ENTRY, _CLIENT_ENTRY])
+
+    assert len(template.tools) == 2
+    assert recorder.warnings == []

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py
@@ -18,9 +18,11 @@ from typing import Any, List, Tuple
 import pytest
 
 from agenta.sdk.agents.dtos import AgentTemplate
+from agenta.sdk.agents.platform.gateway import _to_gateway_reference
 from agenta.sdk.agents.tools import (
     GatewayConnectionToolConfig,
     GatewayToolConfig,
+    ToolConfigurationError,
     coerce_tool_config,
     coerce_tool_configs,
     parse_tool_config,
@@ -114,8 +116,36 @@ def test_provider_action_is_read_as_the_action():
     # revision goes through. `parse_tool_config` stays strict on the canonical spelling.
     config = coerce_tool_config(_PROVIDER_ACTION_ENTRY)
     assert isinstance(config, GatewayToolConfig)
-    assert config.action == "GITHUB_GET_AN_ISSUE"
     assert config.connection == "github-work"
+
+
+def test_the_integration_prefix_is_stripped_from_a_provider_action():
+    # The backend resolves a legacy reference by the CATALOG KEY, which carries no
+    # integration prefix. A verbatim copy of the provider action id would name a tool the
+    # catalog does not hold, and the run would drop the tool as stale.
+    config = coerce_tool_config(_PROVIDER_ACTION_ENTRY)
+    assert config.action == "GET_AN_ISSUE"
+
+
+def test_a_provider_action_without_the_prefix_is_kept_whole():
+    config = coerce_tool_config(
+        {**_PROVIDER_ACTION_ENTRY, "provider_action": "GET_AN_ISSUE"}
+    )
+    assert config.action == "GET_AN_ISSUE"
+
+
+def test_a_translated_entry_resolves_to_the_catalog_key_on_the_wire():
+    # The reference the resolver sends to the backend is where the key has to be right: the
+    # backend matches it against the catalog key, so a provider id here resolves to nothing
+    # and the tool is dropped as stale at run time instead of running.
+    reference = _to_gateway_reference(coerce_tool_config(_PROVIDER_ACTION_ENTRY))
+    assert reference == {
+        "type": "gateway",
+        "provider": "composio",
+        "integration": "github",
+        "action": "GET_AN_ISSUE",
+        "connection": "github-work",
+    }
 
 
 def test_an_explicit_action_wins_over_provider_action():
@@ -170,6 +200,42 @@ def test_an_unrepairable_entry_is_dropped_with_a_warning_and_the_rest_survive(
         "ClientToolConfig",
     ]
     assert len(recorder.warnings) == 1
+
+
+def test_a_misspelled_tool_field_still_fails_the_run():
+    # Tolerance must not swallow a typo. The author believes this tool is configured, so a
+    # silent drop would take it away with nothing to see anywhere.
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(tools=[{"type": "client", "nmae": "ask_user"}])
+
+
+def test_two_conflicting_policies_for_one_integration_still_fail_the_run():
+    # One integration takes one entry. Dropping the second would silently pick a policy,
+    # and the pair here disagree: the run would allow what the author also denied.
+    permissive = {
+        **_NO_POLICY_ENTRY,
+        "policy": {"permissions": {"default": "allow", "tools": {}}},
+    }
+    restrictive = {
+        **_NO_POLICY_ENTRY,
+        "policy": {"permissions": {"default": "deny", "tools": {}}},
+    }
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(tools=[permissive, restrictive])
+
+
+def test_a_malformed_connection_entry_still_fails_the_run():
+    # Only the LEGACY gateway shape is tolerated. A connection entry missing a routing
+    # field is a current-format mistake, and it stays a loud one.
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(
+            tools=[
+                {
+                    "type": "gateway_connection",
+                    "connection": {"provider": "composio", "integration": "github"},
+                }
+            ]
+        )
 
 
 def test_a_template_with_only_valid_tools_logs_nothing(

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py
@@ -267,6 +267,31 @@ def test_a_malformed_connection_entry_still_fails_the_run():
         )
 
 
+def test_a_malformed_current_format_gateway_entry_still_fails_the_run():
+    # A `gateway` entry carrying no legacy mark is authored today, not inherited. This one
+    # names an action and no connection, so it is a mistake its author must see rather than
+    # a shape from before the rework.
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(
+            tools=[
+                {
+                    "type": "gateway",
+                    "provider": "composio",
+                    "integration": "github",
+                    "action": "GET_AN_ISSUE",
+                }
+            ]
+        )
+
+
+def test_an_empty_action_beside_a_legacy_one_is_repaired():
+    # An empty `action` is not an authored value, so the legacy field fills it. A NON-empty
+    # one is authored and is never overwritten, which
+    # `test_an_explicit_action_wins_over_provider_action` pins.
+    config = coerce_tool_config({**_PROVIDER_ACTION_ENTRY, "action": ""})
+    assert config.action == "GET_AN_ISSUE"
+
+
 def test_a_null_entry_still_fails_the_run():
     with pytest.raises(ToolConfigurationError):
         AgentTemplate(tools=[None])

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py
@@ -134,10 +134,39 @@ def test_a_provider_action_without_the_prefix_is_kept_whole():
     assert config.action == "GET_AN_ISSUE"
 
 
-def test_a_translated_entry_resolves_to_the_catalog_key_on_the_wire():
+def test_an_integration_whose_case_differs_still_strips_the_prefix():
+    # The catalog builds the prefix from the UPPER-CASED integration, so the integration's
+    # own case never decides the key.
+    config = coerce_tool_config({**_PROVIDER_ACTION_ENTRY, "integration": "GitHub"})
+    assert config.action == "GET_AN_ISSUE"
+
+
+def test_a_lower_case_prefix_on_the_provider_id_is_not_stripped():
+    # The catalog matches the RAW provider id against that upper-cased prefix, so a
+    # lower-case prefix is not a prefix and stays part of the key. Stripping it here would
+    # turn a key the catalog holds into one it does not.
+    config = coerce_tool_config(
+        {**_PROVIDER_ACTION_ENTRY, "provider_action": "github_GET_AN_ISSUE"}
+    )
+    assert config.action == "github_GET_AN_ISSUE"
+
+
+def test_an_integration_with_an_underscore_strips_its_whole_prefix():
+    config = coerce_tool_config(
+        {
+            **_PROVIDER_ACTION_ENTRY,
+            "integration": "google_drive",
+            "provider_action": "GOOGLE_DRIVE_LIST_FILES",
+        }
+    )
+    assert config.action == "LIST_FILES"
+
+
+def test_a_translated_entry_carries_the_catalog_key_in_its_gateway_reference():
     # The reference the resolver sends to the backend is where the key has to be right: the
     # backend matches it against the catalog key, so a provider id here resolves to nothing
-    # and the tool is dropped as stale at run time instead of running.
+    # and the tool is dropped as stale at run time instead of running. This pins the
+    # serialized reference, not the HTTP resolution behind it.
     reference = _to_gateway_reference(coerce_tool_config(_PROVIDER_ACTION_ENTRY))
     assert reference == {
         "type": "gateway",
@@ -236,6 +265,31 @@ def test_a_malformed_connection_entry_still_fails_the_run():
                 }
             ]
         )
+
+
+def test_a_null_entry_still_fails_the_run():
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(tools=[None])
+
+
+def test_a_non_dict_entry_that_is_not_a_name_still_fails_the_run():
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(tools=[["gateway"]])
+
+
+def test_the_composio_alias_is_tolerated_like_the_gateway_tag(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # `composio` is the same legacy shape under its older tag, renamed before it parses.
+    recorder = _RecordingLog()
+    monkeypatch.setattr("agenta.sdk.agents.dtos.log", recorder)
+
+    template = AgentTemplate(
+        tools=[{"type": "composio", "integration": "github"}, _CLIENT_ENTRY]
+    )
+
+    assert [type(tool).__name__ for tool in template.tools] == ["ClientToolConfig"]
+    assert len(recorder.warnings) == 1
 
 
 def test_a_template_with_only_valid_tools_logs_nothing(


### PR DESCRIPTION
## The incident

Production invokes of agent chats return HTTP 500 from the agent service, and the UI shows
"Message wasn't sent". US has been failing since 06:40 UTC today. EU failed 16 times between
August 30 and September 2.

The 500 happens at config-parse time, before any model call. The SDK's strict tool parser
refuses the saved tool configuration, so the whole agent config fails to build and every
invoke of that agent dies. The agent is unusable until its configuration is edited by hand.

## The two saved shapes

**A. A `gateway_connection` entry with no `policy` node.** Seen on an agent created today at
05:13 UTC on v0.115.2.

```
[{'type': 'missing', 'loc': ('gateway_connection', 'policy'), 'msg': 'Field required'}]
```

**B. A pre-2026-08-27 legacy `gateway` entry that spells the action `provider_action`.** Seen
on an agent created 2026-08-24, never migrated.

```
missing ('gateway','action'), missing ('gateway','connection'),
extra_forbidden ('gateway','provider_action')
```

## Why a saved entry can be invalid

Nothing validates a tool entry when it is written.

The web UI always writes a complete entry: `buildGatewayConnectionEntry` and
`applyToSavedEntry` in `web/packages/agenta-entity-ui/src/DrillInView/SchemaControls/toolUtils.ts`
both set `policy.permissions` with a `default` and a `tools` map, and they are the only
writers on that surface.

The other writer is the agent itself. The model authors the entry as free JSON through
`commit_revision` (`api/oss/src/core/tools/platform_handlers.py`), the delta is applied in
`api/oss/src/core/workflows/service.py`, and the only gate there is `_validate_persisted_shape`,
which constructs `WorkflowRevisionData`. That DTO's `parameters` is an open dict, so no tool
entry is ever checked against the SDK models on write. The prompt in
`sdks/python/agenta/sdk/agents/adapters/agenta_builtins.py` tells the model to include a
policy, but nothing enforces it. A model that omits the node commits without complaint, and
the agent then fails on every run.

Shape B has a second cause: there is no migration and no read-side normalization for
`provider_action` anywhere in the API or the SDK. The web migration helper cannot see such an
entry either, because `parseGatewayTool` needs a canonical `action` and `connection`.

## The fix

Tolerance on the read side, where the damage is.

- **An absent `policy` means inherit.** `GatewayConnectionToolConfig.policy`,
  `GatewayConnectionPolicy.permissions`, and `GatewayPermissions.default` now have defaults,
  and the default permission is `inherit`. That is the safe value, not a convenient one:
  `compile_gateway_permissions` resolves every `inherit` against the agent-wide runner mode,
  so an entry with no policy behaves exactly as the runner default would. It cannot allow
  more than the runner allows. Under `allow_reads` a read compiles to `allow` and a write to
  `ask`.
- **`provider_action` is translated to the catalog key on read**, in the compat layer that
  every reader of a saved revision goes through. The provider action id carries the
  integration as a prefix (`GITHUB_GET_AN_ISSUE`) and the catalog key does not
  (`GET_AN_ISSUE`), and the backend resolves a legacy reference by that key alone. Copying
  the id across verbatim would name a tool no catalog holds, so the prefix is stripped
  exactly as the catalog strips it. The legacy field is dropped either way, because the arm
  forbids extra fields.
- **A legacy `gateway` entry that cannot be repaired is dropped with a warning** instead of
  failing the run. That shape predates the rework and no migration ever rewrote one, so it
  must not fail every run of an agent nobody can edit back into shape.

The tolerance stops there, and everything else still fails loudly. A typo in a tool name, a
malformed connection entry, and two conflicting policies for one integration are real
misconfigurations, and dropping them would take a tool the author believes is configured and
make it vanish in silence. An unknown permission value and a top-level `permission` on a
connection entry are still refused too.

## Tests

New: `sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py` covers
shape A parsing and compiling to the runner mode, shape B translating to the catalog key and
reaching the wire with it, an explicit policy still winning, an unrepairable legacy entry
dropped with one warning while the other tools survive, and a typo, a malformed connection
entry, and conflicting policies each still failing the run.

Two existing cases in `test_gateway_connection_config.py` asserted the strictness this change
removes, so they now assert the inherit behavior instead.

`uv run --no-sync pytest oss/tests/pytest/unit/agents -q` reports 1382 passed. The one
failure, `test_streaming.py::test_cli_stream_terminal_only_on_empty_request`, fails
identically on untouched source and is unrelated.

## Review

Reviewed by Codex at xhigh reasoning effort against the first commit. It returned NEEDS WORK
with two blocking findings, both fixed in the second commit: the provider action id was
copied verbatim and would have resolved to a dead tool, and the blanket drop swallowed typos
and conflicting connection policies that used to fail loudly.

Its remaining observation is a follow-up, not a blocker. The drop warning goes to the server
log, and the run's own warnings channel would be the better home. That channel is not
delivered to the caller on this branch either, so using it would be a larger change than a
hot fix should carry.

## Follow-up

Fix the writer as well. Tool entries should be validated against the SDK models when a
revision is committed, in `api/oss/src/core/workflows/service.py` beside
`_validate_persisted_shape`, so an agent that writes a malformed entry is refused at commit
time with a message it can act on. This PR repairs what is already saved. It does not stop
the next bad write.