### PR TITLE
[hotfix] fix(api,sdk): refresh a stale starter-credits model and fall back to the funded model

### DIFF
--- a/api/ee/src/core/starter_credits_bridge/client.py
+++ b/api/ee/src/core/starter_credits_bridge/client.py
@@ -77,6 +77,25 @@ class StarterCreditsProxyClient:
 
         return MintedKey(key=key, key_alias=key_alias)
 
+    async def update_key_models(self, *, key: str, models: list[str]) -> None:
+        """Rewrite an existing key's model allow-list, in place.
+
+        The proxy serves one model, and that model can be cut over. A key minted before
+        the cutover still allows only the old id, so it must be re-pointed at the funded
+        one. This never mints: the grant invariant is one key per organization, and a
+        second key would be a second grant.
+        """
+        await self._request(
+            "POST",
+            "/key/update",
+            json={
+                "key": key,
+                # An explicit list always, for the same reason the mint sends one: an
+                # omitted list would widen the key to every model the proxy serves.
+                "models": models,
+            },
+        )
+
     async def get_team_info(self, *, team_id: str) -> dict[str, Any]:
         payload = await self._request("GET", "/team/info", params={"team_id": team_id})
         return payload if isinstance(payload, dict) else {}

--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -203,6 +203,13 @@ async def seed_starter_credits_bridge(
 # next read, and a row already on the funded model costs a list scan either way.
 _reconciling_projects: set[str] = set()
 
+# How long a project that did NOT repair waits before a read tries again. The retry is what
+# recovers a transient proxy failure, but a row that cannot be repaired at all (a deleted
+# proxy key, say) would otherwise send one proxy call per secrets list forever.
+_RECONCILE_RETRY_COOLDOWN_SECONDS = 300.0
+
+_reconcile_cooldowns: dict[str, float] = {}
+
 
 async def reconcile_starter_credits_on_read(
     *,
@@ -232,6 +239,11 @@ async def reconcile_starter_credits_on_read(
     key = str(project_id)
     if key in _reconciling_projects:
         return None
+
+    cooling_until = _reconcile_cooldowns.get(key)
+    if cooling_until is not None and _monotonic() < cooling_until:
+        return None
+
     _reconciling_projects.add(key)
 
     try:
@@ -252,17 +264,26 @@ async def reconcile_starter_credits_on_read(
             project_id=key,
             exc_info=True,
         )
+        _hold_off(key)
         return None
     finally:
         _reconciling_projects.discard(key)
 
     if not repaired:
+        _hold_off(key)
         return None
+
+    _reconcile_cooldowns.pop(key, None)
 
     return await _vault_service().get_secret_by_slug(
         STARTER_CREDITS_SLUG,
         project_id=project_id,
     )
+
+
+def _hold_off(project_id: str) -> None:
+    """Stop reads retrying a project that did not repair, for a while."""
+    _reconcile_cooldowns[project_id] = _monotonic() + _RECONCILE_RETRY_COOLDOWN_SECONDS
 
 
 def _find_starter_credits_row(secrets: list) -> Optional[SecretResponseDTO]:
@@ -326,13 +347,17 @@ async def reconcile_starter_credits_model(
             models=[config.model_id],
         )
     except Exception:
+        # Do NOT write the row. A row on the new model whose key still allows only the old
+        # one is just as broken, and it would read as current forever, so nothing would try
+        # again. Leaving it stale is what keeps the next read retrying the whole repair.
         log.warning(
             "[starter_credits_bridge] could not re-point the key's models; "
-            "rewriting the row anyway",
+            "leaving the row stale so the next read retries",
             organization_id=organization_id,
             project_id=str(project_id),
             exc_info=True,
         )
+        return False
 
     await vault_service.update_managed_secret(
         secret_id=row.id,

--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -203,9 +203,12 @@ async def seed_starter_credits_bridge(
 # next read, and a row already on the funded model costs a list scan either way.
 _reconciling_projects: set[str] = set()
 
-# How long a project that did NOT repair waits before a read tries again. The retry is what
-# recovers a transient proxy failure, but a row that cannot be repaired at all (a deleted
-# proxy key, say) would otherwise send one proxy call per secrets list forever.
+# How long a project waits after ONE repair attempt before a read makes another. A retry is
+# what recovers a transient proxy failure, but nothing else bounds how often a project can
+# be repaired, and two cases would otherwise write on every secrets list: a row that cannot
+# be repaired at all (a deleted proxy key, say), and two API replicas configured with
+# different model ids, each repairing the row back to its own. A healthy project never
+# reaches this: its row matches and the check above returns first.
 _RECONCILE_RETRY_COOLDOWN_SECONDS = 300.0
 
 _reconcile_cooldowns: dict[str, float] = {}
@@ -264,16 +267,15 @@ async def reconcile_starter_credits_on_read(
             project_id=key,
             exc_info=True,
         )
-        _hold_off(key)
         return None
     finally:
+        # Armed on every attempt, not only a failed one: a repeated repair means something
+        # is wrong (a row that will not stay repaired), and that must not run per read.
+        _hold_off(key)
         _reconciling_projects.discard(key)
 
     if not repaired:
-        _hold_off(key)
         return None
-
-    _reconcile_cooldowns.pop(key, None)
 
     return await _vault_service().get_secret_by_slug(
         STARTER_CREDITS_SLUG,
@@ -282,7 +284,7 @@ async def reconcile_starter_credits_on_read(
 
 
 def _hold_off(project_id: str) -> None:
-    """Stop reads retrying a project that did not repair, for a while."""
+    """Stop reads repairing this project again for a while."""
     _reconcile_cooldowns[project_id] = _monotonic() + _RECONCILE_RETRY_COOLDOWN_SECONDS
 
 

--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -9,7 +9,7 @@ from uuid import UUID
 import httpx
 
 from oss.src.services import db_manager
-from oss.src.utils.caching import get_cache, invalidate_cache, set_cache
+from oss.src.utils.caching import get_cache, set_cache
 from oss.src.utils.env import env, StarterCreditsBridgeConfig
 from oss.src.utils.lazy import _load_posthog
 from oss.src.utils.logging import get_module_logger
@@ -242,13 +242,14 @@ async def reconcile_starter_credits_on_read(
         return None
 
     key = str(project_id)
+    vault_service = _vault_service()
     if _may_repair(key):
         _reconciling_projects.add(key)
         try:
             await reconcile_starter_credits_model(
                 client=_proxy_client(config),
                 config=config,
-                vault_service=_vault_service(),
+                vault_service=vault_service,
                 project_id=project_id,
                 # The read knows the project, not the organization. The project id already
                 # identifies the row, and resolving the organization would cost a query on
@@ -275,7 +276,7 @@ async def reconcile_starter_credits_on_read(
     # repair can still be published after it. Answering from the row itself is what keeps a
     # reader that skipped the repair from serving the stale model anyway.
     try:
-        fresh = await _vault_service().get_secret_by_slug(
+        fresh = await vault_service.get_secret_by_slug(
             STARTER_CREDITS_SLUG,
             project_id=project_id,
         )
@@ -285,7 +286,8 @@ async def reconcile_starter_credits_on_read(
 
         # The caller's list was stale while the row was not, so the cached list it came from
         # is stale too. Drop it, or every read pays for this re-read until the entry expires.
-        await invalidate_cache(project_id=key)
+        # Through the vault, which owns list-cache invalidation, and never the cache helper.
+        await vault_service.invalidate_secrets_cache(project_id)
     except Exception:
         # Inside the guard like everything else: the re-read and the cache drop both reach
         # the database, and neither may take the caller's secrets list down with it.

--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -16,6 +16,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.dbs.redis.shared.engine import get_cache_engine
 from oss.src.core.secrets.dtos import (
     CreateSecretDTO,
+    UpdateSecretDTO,
     CustomModelSettingsDTO,
     CustomProviderDTO,
     CustomProviderSettingsDTO,
@@ -167,6 +168,14 @@ async def seed_starter_credits_bridge(
         project_id=project.id,
     )
     if row is not None:
+        await reconcile_starter_credits_model(
+            client=client,
+            config=config,
+            vault_service=vault_service,
+            project_id=project.id,
+            organization_id=organization_id,
+            row=row,
+        )
         return
 
     if not await _mint_policy_allows(organization_email, policy):
@@ -186,6 +195,112 @@ async def seed_starter_credits_bridge(
         if not seeded:
             # The consumed velocity slot funded no mint; hand it back best-effort.
             await _release_velocity_slots(organization_email, policy)
+
+
+async def reconcile_starter_credits_model(
+    *,
+    client: StarterCreditsProxyClient,
+    config: StarterCreditsBridgeConfig,
+    vault_service: VaultService,
+    project_id: UUID,
+    organization_id: str,
+    row: SecretResponseDTO,
+) -> bool:
+    """Re-point an already-seeded row at the model the proxy funds today.
+
+    The row freezes the funded model at creation time, but the proxy serves exactly one
+    model and that model gets cut over. A row left on the old id resolves every run to a
+    model the proxy refuses, so a project seeded before a cutover fails on every turn with
+    HTTP 400 "Invalid model name passed in model=<old id>".
+
+    Rewrites the stored list and re-points the minted key's allow-list. It never mints: the
+    grant invariant is one key per organization. Returns whether the row was changed.
+    """
+    stored_models = _stored_model_slugs(row)
+    if stored_models == [config.model_id]:
+        return False
+
+    # The proxy first: a key still restricted to the old id would refuse the new one, so
+    # widening it before the row changes keeps the two consistent for as long as possible.
+    # A failure here is logged, not raised — the row must still move, and a key pointing at
+    # a model the proxy no longer serves is already unusable.
+    virtual_key = _stored_virtual_key(row)
+    if virtual_key:
+        try:
+            await client.update_key_models(
+                key=virtual_key,
+                models=[config.model_id],
+            )
+        except Exception:
+            log.warning(
+                "[starter_credits_bridge] could not re-point the key's models; "
+                "rewriting the row anyway",
+                organization_id=organization_id,
+                project_id=str(project_id),
+                exc_info=True,
+            )
+    else:
+        log.warning(
+            "[starter_credits_bridge] the seeded row carries no key; "
+            "rewriting its models only",
+            organization_id=organization_id,
+            project_id=str(project_id),
+        )
+
+    await vault_service.update_managed_secret(
+        secret_id=row.id,
+        project_id=project_id,
+        update_secret_dto=_model_update(row=row, config=config),
+        manager=SecretManager.STARTER_CREDITS_BRIDGE,
+    )
+
+    log.info(
+        "[starter_credits_bridge] reconciled a stale funded model",
+        organization_id=organization_id,
+        project_id=str(project_id),
+        secret_id=str(row.id),
+        stored_models=stored_models,
+        funded_model=config.model_id,
+    )
+    return True
+
+
+def _stored_model_slugs(row: SecretResponseDTO) -> list[str]:
+    """The model ids the row offers, in stored order."""
+    models = getattr(getattr(row, "data", None), "models", None) or []
+    slugs = [getattr(model, "slug", None) for model in models]
+    return [str(slug) for slug in slugs if slug]
+
+
+def _stored_virtual_key(row: SecretResponseDTO) -> Optional[str]:
+    """The minted key the row carries, or None when the read gave a value-less shape."""
+    key = getattr(getattr(getattr(row, "data", None), "provider", None), "key", None)
+    return key if isinstance(key, str) and key else None
+
+
+def _model_update(
+    *,
+    row: SecretResponseDTO,
+    config: StarterCreditsBridgeConfig,
+) -> UpdateSecretDTO:
+    """The narrowest update that re-points the row: its models, and nothing else.
+
+    Built from the STORED payload so the routing URL and every other saved field survive
+    verbatim. ``model_keys`` is dropped rather than carried, because it is derived from the
+    model list and a carried copy would keep publishing the old namespaced key.
+    """
+    data = row.data.model_dump(mode="json", exclude_none=True)
+    data["models"] = [{"slug": config.model_id}]
+    data.pop("model_keys", None)
+
+    return UpdateSecretDTO.model_validate(
+        {
+            "secret": {
+                "kind": SecretKind.CUSTOM_PROVIDER.value,
+                "data": data,
+            }
+        }
+    )
 
 
 async def _provision(

--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -273,17 +273,27 @@ async def reconcile_starter_credits_on_read(
     # row already, and reads are served from a cached list, so a snapshot taken before that
     # repair can still be published after it. Answering from the row itself is what keeps a
     # reader that skipped the repair from serving the stale model anyway.
-    fresh = await _vault_service().get_secret_by_slug(
-        STARTER_CREDITS_SLUG,
-        project_id=project_id,
-    )
-    if fresh is None or _stored_model_slugs(fresh) != [config.model_id]:
-        # Still stale, so there is nothing better to hand back than what the caller has.
-        return None
+    try:
+        fresh = await _vault_service().get_secret_by_slug(
+            STARTER_CREDITS_SLUG,
+            project_id=project_id,
+        )
+        if fresh is None or _stored_model_slugs(fresh) != [config.model_id]:
+            # Still stale, so there is nothing better to hand back than what the caller has.
+            return None
 
-    # The caller's list was stale while the row was not, so the cached list it came from is
-    # stale too. Drop it, or every read pays for this re-read until the entry expires.
-    await invalidate_cache(project_id=key)
+        # The caller's list was stale while the row was not, so the cached list it came from
+        # is stale too. Drop it, or every read pays for this re-read until the entry expires.
+        await invalidate_cache(project_id=key)
+    except Exception:
+        # Inside the guard like everything else: the re-read and the cache drop both reach
+        # the database, and neither may take the caller's secrets list down with it.
+        log.warning(
+            "[starter_credits_bridge] could not read the row back; the read stands",
+            project_id=key,
+            exc_info=True,
+        )
+        return None
 
     return fresh
 

--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -235,7 +235,7 @@ async def reconcile_starter_credits_on_read(
     _reconciling_projects.add(key)
 
     try:
-        await reconcile_starter_credits_model(
+        repaired = await reconcile_starter_credits_model(
             client=_proxy_client(config),
             config=config,
             vault_service=_vault_service(),
@@ -255,6 +255,9 @@ async def reconcile_starter_credits_on_read(
         return None
     finally:
         _reconciling_projects.discard(key)
+
+    if not repaired:
+        return None
 
     return await _vault_service().get_secret_by_slug(
         STARTER_CREDITS_SLUG,
@@ -306,26 +309,29 @@ async def reconcile_starter_credits_model(
     # A failure here is logged, not raised — the row must still move, and a key pointing at
     # a model the proxy no longer serves is already unusable.
     virtual_key = _stored_virtual_key(row)
-    if virtual_key:
-        try:
-            await client.update_key_models(
-                key=virtual_key,
-                models=[config.model_id],
-            )
-        except Exception:
-            log.warning(
-                "[starter_credits_bridge] could not re-point the key's models; "
-                "rewriting the row anyway",
-                organization_id=organization_id,
-                project_id=str(project_id),
-                exc_info=True,
-            )
-    else:
+    if not virtual_key:
+        # A row with no credential cannot run whatever model it names, so re-pointing it
+        # would fix nothing. Bail rather than write: the read path retries a row it still
+        # sees as stale, and rewriting one that stays broken would retry on every read.
         log.warning(
-            "[starter_credits_bridge] the seeded row carries no key; "
-            "rewriting its models only",
+            "[starter_credits_bridge] the seeded row carries no key; nothing to repair",
             organization_id=organization_id,
             project_id=str(project_id),
+        )
+        return False
+
+    try:
+        await client.update_key_models(
+            key=virtual_key,
+            models=[config.model_id],
+        )
+    except Exception:
+        log.warning(
+            "[starter_credits_bridge] could not re-point the key's models; "
+            "rewriting the row anyway",
+            organization_id=organization_id,
+            project_id=str(project_id),
+            exc_info=True,
         )
 
     await vault_service.update_managed_secret(

--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -225,7 +225,8 @@ async def reconcile_starter_credits_on_read(
     before the funded model was cut over. This is the path that reaches those rows: the
     picker and the runtime resolver both list a project's secrets, so the first read after
     a cutover repairs the row and every read after it is a list scan that finds nothing to
-    do. Returns None when there was nothing to repair.
+    do. Returns the current row when the caller's snapshot was stale, and None when there
+    was nothing to correct or nothing better to hand back.
 
     Never raises. A read must not fail because a repair could not run — the caller would
     lose its whole secrets list over a connection that is at worst as broken as it already

--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -197,13 +197,94 @@ async def seed_starter_credits_bridge(
             await _release_velocity_slots(organization_email, policy)
 
 
+# One reconcile at a time per project. Reads are concurrent (the picker and the runtime
+# resolver both list secrets), and without this a burst would send the same repair several
+# times. It is an in-flight set, not a memo: a repair that failed must be retried by the
+# next read, and a row already on the funded model costs a list scan either way.
+_reconciling_projects: set[str] = set()
+
+
+async def reconcile_starter_credits_on_read(
+    *,
+    project_id: UUID,
+    secrets: list,
+) -> Optional[SecretResponseDTO]:
+    """Repair a stale starter-credits row as it is read, and return the repaired row.
+
+    Seeding runs once, at signup, so nothing else ever revisits a row that was written
+    before the funded model was cut over. This is the path that reaches those rows: the
+    picker and the runtime resolver both list a project's secrets, so the first read after
+    a cutover repairs the row and every read after it is a list scan that finds nothing to
+    do. Returns None when there was nothing to repair.
+
+    Never raises. A read must not fail because a repair could not run — the caller would
+    lose its whole secrets list over a connection that is at worst as broken as it already
+    was.
+    """
+    config = env.starter_credits_bridge
+    if not config.armed:
+        return None
+
+    row = _find_starter_credits_row(secrets)
+    if row is None or _stored_model_slugs(row) == [config.model_id]:
+        return None
+
+    key = str(project_id)
+    if key in _reconciling_projects:
+        return None
+    _reconciling_projects.add(key)
+
+    try:
+        await reconcile_starter_credits_model(
+            client=_proxy_client(config),
+            config=config,
+            vault_service=_vault_service(),
+            project_id=project_id,
+            # The read knows the project, not the organization. The project id already
+            # identifies the row, and resolving the organization would cost a query on a
+            # path that runs on every secrets list.
+            organization_id=None,
+            row=row,
+        )
+    except Exception:
+        log.warning(
+            "[starter_credits_bridge] could not reconcile on read; the read stands",
+            project_id=key,
+            exc_info=True,
+        )
+        return None
+    finally:
+        _reconciling_projects.discard(key)
+
+    return await _vault_service().get_secret_by_slug(
+        STARTER_CREDITS_SLUG,
+        project_id=project_id,
+    )
+
+
+def _find_starter_credits_row(secrets: list) -> Optional[SecretResponseDTO]:
+    """The seeded row inside an already-fetched list, or None. No query of its own."""
+    for secret in secrets or []:
+        if getattr(secret, "slug", None) != STARTER_CREDITS_SLUG:
+            continue
+        management = getattr(secret, "management", None)
+        # Only a row the bridge owns. A user is free to delete the seeded connection and
+        # save their own under the same slug, and that one is theirs to point anywhere.
+        if (
+            management is not None
+            and management.manager == SecretManager.STARTER_CREDITS_BRIDGE
+        ):
+            return secret
+    return None
+
+
 async def reconcile_starter_credits_model(
     *,
     client: StarterCreditsProxyClient,
     config: StarterCreditsBridgeConfig,
     vault_service: VaultService,
     project_id: UUID,
-    organization_id: str,
+    organization_id: Optional[str],
     row: SecretResponseDTO,
 ) -> bool:
     """Re-point an already-seeded row at the model the proxy funds today.

--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -9,7 +9,7 @@ from uuid import UUID
 import httpx
 
 from oss.src.services import db_manager
-from oss.src.utils.caching import get_cache, set_cache
+from oss.src.utils.caching import get_cache, invalidate_cache, set_cache
 from oss.src.utils.env import env, StarterCreditsBridgeConfig
 from oss.src.utils.lazy import _load_posthog
 from oss.src.utils.logging import get_module_logger
@@ -237,50 +237,65 @@ async def reconcile_starter_credits_on_read(
 
     row = _find_starter_credits_row(secrets)
     if row is None or _stored_model_slugs(row) == [config.model_id]:
+        # The whole cost of a healthy project: a scan of the list already in hand.
         return None
 
     key = str(project_id)
-    if key in _reconciling_projects:
-        return None
+    if _may_repair(key):
+        _reconciling_projects.add(key)
+        try:
+            await reconcile_starter_credits_model(
+                client=_proxy_client(config),
+                config=config,
+                vault_service=_vault_service(),
+                project_id=project_id,
+                # The read knows the project, not the organization. The project id already
+                # identifies the row, and resolving the organization would cost a query on
+                # a path that runs on every secrets list.
+                organization_id=None,
+                row=row,
+            )
+        except Exception:
+            log.warning(
+                "[starter_credits_bridge] could not reconcile on read; the read stands",
+                project_id=key,
+                exc_info=True,
+            )
+        finally:
+            # Armed on every attempt, not only a failed one: a repeated repair means
+            # something is wrong (a row that will not stay repaired), and that must not run
+            # per read.
+            _hold_off(key)
+            _reconciling_projects.discard(key)
 
-    cooling_until = _reconcile_cooldowns.get(key)
-    if cooling_until is not None and _monotonic() < cooling_until:
-        return None
-
-    _reconciling_projects.add(key)
-
-    try:
-        repaired = await reconcile_starter_credits_model(
-            client=_proxy_client(config),
-            config=config,
-            vault_service=_vault_service(),
-            project_id=project_id,
-            # The read knows the project, not the organization. The project id already
-            # identifies the row, and resolving the organization would cost a query on a
-            # path that runs on every secrets list.
-            organization_id=None,
-            row=row,
-        )
-    except Exception:
-        log.warning(
-            "[starter_credits_bridge] could not reconcile on read; the read stands",
-            project_id=key,
-            exc_info=True,
-        )
-        return None
-    finally:
-        # Armed on every attempt, not only a failed one: a repeated repair means something
-        # is wrong (a row that will not stay repaired), and that must not run per read.
-        _hold_off(key)
-        _reconciling_projects.discard(key)
-
-    if not repaired:
-        return None
-
-    return await _vault_service().get_secret_by_slug(
+    # Read the row back whether or not THIS request repaired it. Skipping the repair does
+    # not mean the caller's snapshot is right: a concurrent request may have repaired the
+    # row already, and reads are served from a cached list, so a snapshot taken before that
+    # repair can still be published after it. Answering from the row itself is what keeps a
+    # reader that skipped the repair from serving the stale model anyway.
+    fresh = await _vault_service().get_secret_by_slug(
         STARTER_CREDITS_SLUG,
         project_id=project_id,
     )
+    if fresh is None or _stored_model_slugs(fresh) != [config.model_id]:
+        # Still stale, so there is nothing better to hand back than what the caller has.
+        return None
+
+    # The caller's list was stale while the row was not, so the cached list it came from is
+    # stale too. Drop it, or every read pays for this re-read until the entry expires.
+    await invalidate_cache(project_id=key)
+
+    return fresh
+
+
+def _may_repair(project_id: str) -> bool:
+    """Whether this request should attempt the repair, rather than let another one do it."""
+    if project_id in _reconciling_projects:
+        return False
+
+    cooling_until = _reconcile_cooldowns.get(project_id)
+
+    return cooling_until is None or _monotonic() >= cooling_until
 
 
 def _hold_off(project_id: str) -> None:

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_client.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_client.py
@@ -230,3 +230,56 @@ class TestTeamInfo:
         with pytest.raises(ProxyRequestError) as excinfo:
             await client.get_team_info(team_id="team-1")
         assert excinfo.value.status_code == 404
+
+
+class TestUpdateKeyModels:
+    async def test_posts_the_key_and_the_full_model_list(self):
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["method"] = request.method
+            seen["url"] = str(request.url)
+            seen["auth"] = request.headers.get("Authorization")
+            seen["body"] = _read_body(request)
+            return httpx.Response(200, json={"key": "sk-virtual-abc"})
+
+        await _client_with_handler(handler).update_key_models(
+            key="sk-virtual-abc",
+            models=["vertex_ai/new-model"],
+        )
+
+        assert seen["method"] == "POST"
+        assert seen["url"] == "https://proxy.internal.test/key/update"
+        assert seen["auth"] == "Bearer sk-master-test"
+        # An explicit list always. An omitted one would widen the key to every model the
+        # proxy serves.
+        assert seen["body"] == {
+            "key": "sk-virtual-abc",
+            "models": ["vertex_ai/new-model"],
+        }
+
+    async def test_a_proxy_refusal_raises(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="key not found")
+
+        with pytest.raises(ProxyRequestError) as raised:
+            await _client_with_handler(handler).update_key_models(
+                key="sk-virtual-gone",
+                models=["vertex_ai/new-model"],
+            )
+
+        assert raised.value.status_code == 404
+
+    async def test_an_error_body_never_echoes_key_material(self):
+        # A proxy error may echo the failing request, which carries a virtual key.
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, text="rejected models for key sk-virtual-abc")
+
+        with pytest.raises(ProxyRequestError) as raised:
+            await _client_with_handler(handler).update_key_models(
+                key="sk-virtual-abc",
+                models=["vertex_ai/new-model"],
+            )
+
+        assert "sk-virtual-abc" not in raised.value.detail
+        assert "sk-[redacted]" in raised.value.detail

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -218,6 +218,8 @@ def _all_block_calls():
 @pytest.fixture
 def seeding_env(monkeypatch):
     """Arm the config and stub every dependency; returns the mutable stubs."""
+    service._reconciling_projects.clear()
+    service._reconcile_cooldowns.clear()
     FakeProxyClient.records = {}
     FakeProxyClient.generate_failures = []
     FakeProxyClient.update_failures = []
@@ -1276,10 +1278,11 @@ class TestReconcilingAStaleFundedModel:
         assert _all_key_update_calls() == []
         assert len(_all_generate_calls()) == 1
 
-    async def test_a_failed_key_update_still_repoints_the_row(self, seeding_env):
-        # A key restricted to a model the proxy no longer serves is already unusable, so a
-        # transient proxy failure must not hold the row back. Nothing is raised here: the
-        # signup path this runs inside deletes the new user when setup raises.
+    async def test_a_failed_key_update_leaves_the_row_stale(self, seeding_env):
+        # A row on the new model whose key still allows only the old one is just as broken,
+        # and it would read as current forever, so nothing would try again. Leaving it stale
+        # is what keeps the next read retrying. Nothing is raised: the signup path this runs
+        # inside deletes the new user when setup raises.
         await self._seed_then_cut_the_model_over(
             seeding_env, funded="vertex_ai/new-model"
         )
@@ -1290,7 +1293,8 @@ class TestReconcilingAStaleFundedModel:
         await _seed()
 
         row = seeding_env.vault.row
-        assert [model.slug for model in row.data.models] == ["vertex_ai/new-model"]
+        assert [model.slug for model in row.data.models] == ["vertex_ai/some-model"]
+        assert seeding_env.vault.update_calls == []
         assert len(_all_key_update_calls()) == 1
 
     async def test_reconciling_consumes_no_velocity_slot(self, seeding_env):
@@ -1385,6 +1389,45 @@ class TestReconcilingOnRead:
         assert _all_key_update_calls() == []
         assert seeding_env.vault.update_calls == []
 
+    async def test_a_failed_key_update_is_retried_by_a_later_read(self, seeding_env):
+        # The retry is the whole point of leaving the row stale, so pin that it happens
+        # once the proxy recovers.
+        row = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        FakeProxyClient.update_failures = [
+            ProxyRequestError(status_code=503, detail="proxy down")
+        ]
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        assert [model.slug for model in row.data.models] == ["vertex_ai/some-model"]
+
+        # The cooldown holds a project that did not repair, so a read inside it is free.
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        assert len(_all_key_update_calls()) == 1
+
+        service._reconcile_cooldowns.clear()
+        repaired = await service.reconcile_starter_credits_on_read(
+            project_id=seeding_env.project.id,
+            secrets=[row],
+        )
+
+        assert repaired is not None
+        assert [model.slug for model in repaired.data.models] == ["vertex_ai/new-model"]
+        assert len(_all_key_update_calls()) == 2
+
     async def test_the_read_stands_when_the_repair_fails(self, seeding_env):
         # A caller must never lose its whole secrets list over a connection that is at
         # worst as broken as it already was.
@@ -1406,8 +1449,10 @@ class TestReconcilingOnRead:
             )
             is None
         )
-        # The in-flight guard is released, so the next read tries again.
+        # The in-flight guard is released and the cooldown is armed, so a later read tries
+        # again without every read in between paying for it.
         assert service._reconciling_projects == set()
+        assert str(seeding_env.project.id) in service._reconcile_cooldowns
 
     async def test_a_row_the_bridge_does_not_own_is_left_alone(self, seeding_env):
         # A user may delete the seeded connection and save their own under the same slug.

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -92,6 +92,7 @@ class FakeVaultService:
         self.management = management
         self.row = SimpleNamespace(
             id=uuid4(),
+            slug=create_secret_dto.slug,
             header=create_secret_dto.header,
             data=create_secret_dto.secret.data,
             management=management,
@@ -1335,3 +1336,111 @@ class TestReconcilingAStaleFundedModel:
             connection={"mode": "agenta", "slug": service.STARTER_CREDITS_SLUG},
         )
         assert candidate.selected_model_id(fresh) == "vertex_ai/new-model"
+
+
+class TestReconcilingOnRead:
+    """Seeding runs once, at signup, so nothing revisits a row written before a cutover.
+    The read path is what reaches those rows: the picker and the runtime resolver both list
+    a project's secrets."""
+
+    async def _seed_then_cut_the_model_over(self, seeding_env, *, funded: str):
+        await _seed()
+        seeding_env.monkeypatch.setattr(
+            env,
+            "starter_credits_bridge",
+            _armed_config(model_id=funded),
+        )
+        return seeding_env.vault.row
+
+    async def test_a_stale_row_read_comes_back_on_the_funded_model(self, seeding_env):
+        row = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        minted = FakeProxyClient.records[ORGANIZATION_ID]["key"]
+
+        repaired = await service.reconcile_starter_credits_on_read(
+            project_id=seeding_env.project.id,
+            secrets=[row],
+        )
+
+        assert repaired is not None
+        assert [model.slug for model in repaired.data.models] == ["vertex_ai/new-model"]
+        (update,) = _all_key_update_calls()
+        assert update == {"key": minted, "models": ["vertex_ai/new-model"]}
+        assert repaired.data.provider.key == minted
+        # A repair is not a grant.
+        assert len(_all_generate_calls()) == 1
+
+    async def test_a_current_row_read_costs_no_call(self, seeding_env):
+        await _seed()
+        row = seeding_env.vault.row
+        seeding_env.vault.update_calls.clear()
+
+        repaired = await service.reconcile_starter_credits_on_read(
+            project_id=seeding_env.project.id,
+            secrets=[row],
+        )
+
+        assert repaired is None
+        assert _all_key_update_calls() == []
+        assert seeding_env.vault.update_calls == []
+
+    async def test_the_read_stands_when_the_repair_fails(self, seeding_env):
+        # A caller must never lose its whole secrets list over a connection that is at
+        # worst as broken as it already was.
+        row = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+
+        async def explode(**kwargs):
+            raise RuntimeError("vault is down")
+
+        seeding_env.monkeypatch.setattr(
+            seeding_env.vault, "update_managed_secret", explode
+        )
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        # The in-flight guard is released, so the next read tries again.
+        assert service._reconciling_projects == set()
+
+    async def test_a_row_the_bridge_does_not_own_is_left_alone(self, seeding_env):
+        # A user may delete the seeded connection and save their own under the same slug.
+        # That one is theirs to point anywhere.
+        row = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        row.management = None
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        assert _all_key_update_calls() == []
+
+    async def test_a_disarmed_bridge_reads_nothing(self, seeding_env):
+        row = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        seeding_env.monkeypatch.setattr(
+            env,
+            "starter_credits_bridge",
+            _armed_config(model_id="vertex_ai/new-model", enabled=False),
+        )
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        assert _all_key_update_calls() == []

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -1369,6 +1369,8 @@ class TestReconcilingOnRead:
 
         assert repaired is not None
         assert [model.slug for model in repaired.data.models] == ["vertex_ai/new-model"]
+        # One attempt per project per cooldown, so nothing can rewrite a row per read.
+        assert str(seeding_env.project.id) in service._reconcile_cooldowns
         (update,) = _all_key_update_calls()
         assert update == {"key": minted, "models": ["vertex_ai/new-model"]}
         assert repaired.data.provider.key == minted

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -1444,3 +1444,73 @@ class TestReconcilingOnRead:
             is None
         )
         assert _all_key_update_calls() == []
+
+
+class TestTheRepairSurvivesTheMapping:
+    """The repair is only worth anything if it PERSISTS. If the write did not change the
+    stored models, the read path would see the same stale row on every list and send the
+    same repair again, so this pins the round trip through the storage mapping."""
+
+    async def test_the_rewrite_round_trips_through_the_row(self, seeding_env):
+        from oss.src.dbs.postgres.secrets.mappings import (
+            map_secrets_dbe_to_dto,
+            map_secrets_dto_to_dbe,
+            map_secrets_dto_to_dbe_update,
+        )
+
+        await _seed()
+        created = seeding_env.vault.create_dto
+        dbe = map_secrets_dto_to_dbe(
+            project_id=seeding_env.project.id,
+            organization_id=None,
+            secret_dto=created,
+            management=seeding_env.vault.management,
+        )
+        stored = map_secrets_dbe_to_dto(secrets_dbe=dbe)
+        assert [model.slug for model in stored.data.models] == ["vertex_ai/some-model"]
+
+        config = _armed_config(model_id="vertex_ai/new-model")
+        map_secrets_dto_to_dbe_update(
+            secrets_dbe=dbe,
+            update_secret_dto=service._model_update(row=stored, config=config),
+        )
+        rewritten = map_secrets_dbe_to_dto(secrets_dbe=dbe)
+
+        assert [model.slug for model in rewritten.data.models] == [
+            "vertex_ai/new-model"
+        ]
+        # Everything else survives: the credential, the routing URL, the namespace, and
+        # the two server-controlled flags that ride inside the encrypted payload.
+        assert rewritten.data.provider.key == stored.data.provider.key
+        assert rewritten.data.provider.url == stored.data.provider.url
+        assert rewritten.data.provider_slug == service.STARTER_CREDITS_NAME
+        assert rewritten.data.harnesses == ["pi_core"]
+        assert rewritten.write_only is True
+        assert rewritten.management == seeding_env.vault.management
+        # The published namespaced key follows the new model, so the row stops offering
+        # the old one to the picker and to the runtime resolver.
+        assert rewritten.data.model_keys == [
+            f"{service.STARTER_CREDITS_NAME}/custom/vertex_ai/new-model"
+        ]
+
+    async def test_a_row_with_no_key_is_not_rewritten(self, seeding_env):
+        # A credential-less row cannot run any model, so a repair would fix nothing and the
+        # read path would send it again on every list.
+        await _seed()
+        row = seeding_env.vault.row
+        row.data.provider.key = None
+        seeding_env.monkeypatch.setattr(
+            env,
+            "starter_credits_bridge",
+            _armed_config(model_id="vertex_ai/new-model"),
+        )
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        assert seeding_env.vault.update_calls == []
+        assert _all_key_update_calls() == []

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -5,14 +5,16 @@ blocking, alias conflicts), policy resolution, and velocity caps, with every
 external dependency stubbed."""
 
 import asyncio
+import copy
 from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 
 from oss.src.utils.env import env, PostHogConfig, StarterCreditsBridgeConfig
-from oss.src.core.secrets.dtos import SecretResponseDTO
+from oss.src.core.secrets.dtos import CustomModelSettingsDTO, SecretResponseDTO
 from oss.src.core.secrets.enums import CustomProviderKind
+from oss.src.core.secrets.redaction import project_secret_response
 from oss.src.core.secrets.managed import (
     SecretManagementDTO,
     SecretManagementPolicy,
@@ -265,6 +267,12 @@ def seeding_env(monkeypatch):
         "get_default_project_by_organization_id",
         fake_get_default_project,
     )
+    invalidations = []
+
+    async def fake_invalidate_cache(project_id=None, **kwargs):
+        invalidations.append(project_id)
+
+    monkeypatch.setattr(service, "invalidate_cache", fake_invalidate_cache)
     monkeypatch.setattr(service, "_vault_service", lambda: vault)
     monkeypatch.setattr(service, "_resolve_mint_policy", fake_resolve_policy)
     monkeypatch.setattr(service, "_team_ceiling_verified", fake_team_verified)
@@ -278,6 +286,7 @@ def seeding_env(monkeypatch):
         policy=policy,
         project=project,
         vault=vault,
+        invalidations=invalidations,
         alerts=alerts,
         released=released,
         monkeypatch=monkeypatch,
@@ -1325,8 +1334,14 @@ class TestReconcilingAStaleFundedModel:
             kind="custom_provider",
             data=row.data.model_dump(mode="json"),
             header=row.header,
+            write_only=True,
+            management=seeding_env.vault.management,
         )
-        (candidate,) = connections._catalog([stored.model_dump(mode="json")])
+        # The shape the route actually returns to the runtime resolver: the management
+        # POLICY without the manager's name, which is what says the model list is Agenta's.
+        public = project_secret_response(stored, reveal_write_only=True)
+        (candidate,) = connections._catalog([public.model_dump(mode="json")])
+        assert candidate.managed is True
 
         # A revision saved before the cutover still names the old id.
         stale = ModelRef(
@@ -1429,6 +1444,72 @@ class TestReconcilingOnRead:
         assert repaired is not None
         assert [model.slug for model in repaired.data.models] == ["vertex_ai/new-model"]
         assert len(_all_key_update_calls()) == 2
+
+    async def test_a_reader_that_skips_the_repair_still_answers_from_the_row(
+        self, seeding_env
+    ):
+        # Reads are served from a cached list, so a snapshot taken before another request
+        # repaired the row can still be published after it. A reader that skips the repair
+        # must not serve the stale model it is holding.
+        stale = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        snapshot = copy.deepcopy(stale)
+        # Another request has already repaired the row and is still in flight.
+        stale.data.models = [CustomModelSettingsDTO(slug="vertex_ai/new-model")]
+        service._reconciling_projects.add(str(seeding_env.project.id))
+
+        try:
+            fresh = await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[snapshot],
+            )
+        finally:
+            service._reconciling_projects.discard(str(seeding_env.project.id))
+
+        assert fresh is not None
+        assert [model.slug for model in fresh.data.models] == ["vertex_ai/new-model"]
+        # No second repair: the in-flight request owns it.
+        assert _all_key_update_calls() == []
+        assert seeding_env.vault.update_calls == []
+        # The cached list this snapshot came from is stale, so it is dropped.
+        assert seeding_env.invalidations == [str(seeding_env.project.id)]
+
+    async def test_a_cooling_reader_still_answers_from_the_row(self, seeding_env):
+        # Same for a project inside its cooldown: suppressing another proxy call must not
+        # mean serving stale data.
+        stale = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        snapshot = copy.deepcopy(stale)
+        stale.data.models = [CustomModelSettingsDTO(slug="vertex_ai/new-model")]
+        service._hold_off(str(seeding_env.project.id))
+
+        fresh = await service.reconcile_starter_credits_on_read(
+            project_id=seeding_env.project.id,
+            secrets=[snapshot],
+        )
+
+        assert fresh is not None
+        assert [model.slug for model in fresh.data.models] == ["vertex_ai/new-model"]
+        assert _all_key_update_calls() == []
+
+    async def test_a_row_that_is_still_stale_hands_nothing_back(self, seeding_env):
+        # Nothing better to give the caller than what it already holds, and the cached list
+        # must not be dropped on every read while a project cannot be repaired.
+        stale = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        service._hold_off(str(seeding_env.project.id))
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[stale],
+            )
+            is None
+        )
+        assert seeding_env.invalidations == []
 
     async def test_the_read_stands_when_the_repair_fails(self, seeding_env):
         # A caller must never lose its whole secrets list over a connection that is at

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -79,6 +79,7 @@ class FakeVaultService:
         self.management = None
         self.create_error = None
         self.update_calls = []
+        self.invalidations = []
 
     async def get_secret_by_slug(self, secret_slug, project_id=None, **kwargs):
         assert secret_slug == service.STARTER_CREDITS_SLUG
@@ -102,6 +103,10 @@ class FakeVaultService:
         )
         self.created_count += 1
         return self.row
+
+    async def invalidate_secrets_cache(self, project_id):
+        await asyncio.sleep(0)
+        self.invalidations.append(str(project_id))
 
     async def update_managed_secret(
         self,
@@ -267,12 +272,6 @@ def seeding_env(monkeypatch):
         "get_default_project_by_organization_id",
         fake_get_default_project,
     )
-    invalidations = []
-
-    async def fake_invalidate_cache(project_id=None, **kwargs):
-        invalidations.append(project_id)
-
-    monkeypatch.setattr(service, "invalidate_cache", fake_invalidate_cache)
     monkeypatch.setattr(service, "_vault_service", lambda: vault)
     monkeypatch.setattr(service, "_resolve_mint_policy", fake_resolve_policy)
     monkeypatch.setattr(service, "_team_ceiling_verified", fake_team_verified)
@@ -286,7 +285,6 @@ def seeding_env(monkeypatch):
         policy=policy,
         project=project,
         vault=vault,
-        invalidations=invalidations,
         alerts=alerts,
         released=released,
         monkeypatch=monkeypatch,
@@ -1473,7 +1471,7 @@ class TestReconcilingOnRead:
         assert _all_key_update_calls() == []
         assert seeding_env.vault.update_calls == []
         # The cached list this snapshot came from is stale, so it is dropped.
-        assert seeding_env.invalidations == [str(seeding_env.project.id)]
+        assert seeding_env.vault.invalidations == [str(seeding_env.project.id)]
 
     async def test_a_cooling_reader_still_answers_from_the_row(self, seeding_env):
         # Same for a project inside its cooldown: suppressing another proxy call must not
@@ -1532,7 +1530,7 @@ class TestReconcilingOnRead:
             )
             is None
         )
-        assert seeding_env.invalidations == []
+        assert seeding_env.vault.invalidations == []
 
     async def test_the_read_stands_when_the_repair_fails(self, seeding_env):
         # A caller must never lose its whole secrets list over a connection that is at

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -76,6 +76,7 @@ class FakeVaultService:
         self.create_dto = None
         self.management = None
         self.create_error = None
+        self.update_calls = []
 
     async def get_secret_by_slug(self, secret_slug, project_id=None, **kwargs):
         assert secret_slug == service.STARTER_CREDITS_SLUG
@@ -99,6 +100,25 @@ class FakeVaultService:
         self.created_count += 1
         return self.row
 
+    async def update_managed_secret(
+        self,
+        *,
+        secret_id,
+        update_secret_dto,
+        manager,
+        project_id=None,
+        organization_id=None,
+    ):
+        await asyncio.sleep(0)
+        assert self.row is not None
+        assert secret_id == self.row.id
+        assert manager is SecretManager.STARTER_CREDITS_BRIDGE
+        self.update_calls.append(update_secret_dto)
+        # The real service revalidates the merged payload and writes it back, so the row
+        # the next read returns is the update's own data.
+        self.row.data = update_secret_dto.secret.data
+        return self.row
+
 
 class FakeProxyClient:
     """Stands in for StarterCreditsProxyClient with a per-alias key registry, so
@@ -107,6 +127,7 @@ class FakeProxyClient:
 
     records: dict = {}
     generate_failures: list = []
+    update_failures: list = []
     instances: list = []
 
     def __init__(self, *, base_url, master_key):
@@ -114,6 +135,7 @@ class FakeProxyClient:
         self.master_key = master_key
         self.generate_calls = []
         self.block_calls = []
+        self.update_calls = []
         FakeProxyClient.instances.append(self)
 
     @classmethod
@@ -166,6 +188,17 @@ class FakeProxyClient:
     async def block_key(self, *, key):
         self.block_calls.append(key)
 
+    async def update_key_models(self, *, key, models):
+        await asyncio.sleep(0)
+        self.update_calls.append(dict(key=key, models=models))
+        if FakeProxyClient.update_failures:
+            raise FakeProxyClient.update_failures.pop(0)
+        for record in FakeProxyClient.records.values():
+            if record["key"] == key:
+                record["models"] = list(models)
+                return
+        raise ProxyRequestError(status_code=404, detail="no such key")
+
 
 def _all_generate_calls():
     return [
@@ -186,6 +219,7 @@ def seeding_env(monkeypatch):
     """Arm the config and stub every dependency; returns the mutable stubs."""
     FakeProxyClient.records = {}
     FakeProxyClient.generate_failures = []
+    FakeProxyClient.update_failures = []
     FakeProxyClient.instances = []
     service._verified_teams.clear()
 
@@ -1176,3 +1210,128 @@ def test_a_bridge_deployment_without_a_runtime_key_fails_at_startup(monkeypatch)
 
     with pytest.raises(RuntimeError, match="AGENTA_SERVICES_INTERNAL_KEY"):
         helpers.validate_platform_runtime_key()
+
+
+def _all_key_update_calls():
+    return [
+        call for instance in FakeProxyClient.instances for call in instance.update_calls
+    ]
+
+
+class TestReconcilingAStaleFundedModel:
+    """The row freezes the funded model at creation, but the proxy serves exactly one model
+    and that model gets cut over. A row left on the old id resolves every run to a model the
+    proxy refuses with HTTP 400 "Invalid model name passed in model=<old id>"."""
+
+    async def _seed_then_cut_the_model_over(self, seeding_env, *, funded: str):
+        await _seed()
+        assert seeding_env.vault.row is not None
+        seeding_env.monkeypatch.setattr(
+            env,
+            "starter_credits_bridge",
+            _armed_config(model_id=funded),
+        )
+
+    async def test_a_stale_row_is_repointed_at_the_funded_model(self, seeding_env):
+        await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+
+        await _seed()
+
+        row = seeding_env.vault.row
+        assert [model.slug for model in row.data.models] == ["vertex_ai/new-model"]
+        # The credential and the routing URL survive the rewrite untouched.
+        assert row.data.provider.key == FakeProxyClient.records[ORGANIZATION_ID]["key"]
+        assert row.data.provider.url == "https://credits-proxy.example.test"
+        assert row.data.provider_slug == service.STARTER_CREDITS_NAME
+        # A carried model_keys list would keep publishing the old model id.
+        assert row.data.model_keys is None
+
+    async def test_the_minted_key_is_repointed_and_never_re_minted(self, seeding_env):
+        await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+
+        await _seed()
+
+        (update,) = _all_key_update_calls()
+        assert update["models"] == ["vertex_ai/new-model"]
+        assert update["key"] == FakeProxyClient.records[ORGANIZATION_ID]["key"]
+        assert FakeProxyClient.records[ORGANIZATION_ID]["models"] == [
+            "vertex_ai/new-model"
+        ]
+        # One mint, from the original seed. The grant invariant is one key per organization.
+        assert len(_all_generate_calls()) == 1
+        assert _all_block_calls() == []
+
+    async def test_a_current_row_is_left_alone(self, seeding_env):
+        await _seed()
+        seeding_env.vault.update_calls.clear()
+
+        await _seed()
+
+        assert seeding_env.vault.update_calls == []
+        assert _all_key_update_calls() == []
+        assert len(_all_generate_calls()) == 1
+
+    async def test_a_failed_key_update_still_repoints_the_row(self, seeding_env):
+        # A key restricted to a model the proxy no longer serves is already unusable, so a
+        # transient proxy failure must not hold the row back. Nothing is raised here: the
+        # signup path this runs inside deletes the new user when setup raises.
+        await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        FakeProxyClient.update_failures = [
+            ProxyRequestError(status_code=503, detail="proxy down")
+        ]
+
+        await _seed()
+
+        row = seeding_env.vault.row
+        assert [model.slug for model in row.data.models] == ["vertex_ai/new-model"]
+        assert len(_all_key_update_calls()) == 1
+
+    async def test_reconciling_consumes_no_velocity_slot(self, seeding_env):
+        # The velocity caps meter GRANTS. A repair mints nothing, so it must not spend one.
+        await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+
+        await _seed()
+
+        assert seeding_env.released == []
+        assert len(_all_generate_calls()) == 1
+
+    async def test_the_repaired_row_resolves_to_the_funded_model(self, seeding_env):
+        # The end the repair exists for: what the runtime resolver runs after it.
+        from agenta.sdk.agents.connections import ModelRef
+        from agenta.sdk.agents.platform import connections
+
+        await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        await _seed()
+
+        row = seeding_env.vault.row
+        stored = SecretResponseDTO(
+            id=uuid4(),
+            slug=service.STARTER_CREDITS_SLUG,
+            kind="custom_provider",
+            data=row.data.model_dump(mode="json"),
+            header=row.header,
+        )
+        (candidate,) = connections._catalog([stored.model_dump(mode="json")])
+
+        # A revision saved before the cutover still names the old id.
+        stale = ModelRef(
+            model=f"{service.STARTER_CREDITS_NAME}/custom/vertex_ai/some-model",
+            connection={"mode": "agenta", "slug": service.STARTER_CREDITS_SLUG},
+        )
+        assert candidate.selected_model_id(stale) == "vertex_ai/new-model"
+
+        fresh = ModelRef(
+            model=f"{service.STARTER_CREDITS_NAME}/custom/vertex_ai/new-model",
+            connection={"mode": "agenta", "slug": service.STARTER_CREDITS_SLUG},
+        )
+        assert candidate.selected_model_id(fresh) == "vertex_ai/new-model"

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -1494,6 +1494,29 @@ class TestReconcilingOnRead:
         assert [model.slug for model in fresh.data.models] == ["vertex_ai/new-model"]
         assert _all_key_update_calls() == []
 
+    async def test_a_failed_read_back_never_reaches_the_caller(self, seeding_env):
+        # The re-read and the cache drop both reach the database. Neither may take the
+        # caller's secrets list down with it.
+        stale = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        service._hold_off(str(seeding_env.project.id))
+
+        async def explode(*args, **kwargs):
+            raise ConnectionError("the database is down")
+
+        seeding_env.monkeypatch.setattr(
+            seeding_env.vault, "get_secret_by_slug", explode
+        )
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[stale],
+            )
+            is None
+        )
+
     async def test_a_row_that_is_still_stale_hands_nothing_back(self, seeding_env):
         # Nothing better to give the caller than what it already holds, and the cached list
         # must not be dropped on every read while a project cannot be repaired.

--- a/api/oss/src/apis/fastapi/vault/router.py
+++ b/api/oss/src/apis/fastapi/vault/router.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request, status, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
 
+from oss.src.utils.common import is_ee
 from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions
 
@@ -27,6 +28,16 @@ from oss.src.middlewares.auth import SECRET_RESOLVE_GRANT, request_has_grant
 
 
 log = get_module_logger(__name__)
+
+
+if is_ee():
+    from ee.src.core.starter_credits_bridge.service import (  # noqa: E402
+        reconcile_starter_credits_on_read,
+    )
+else:  # OSS seeds no managed connection, so there is nothing to reconcile.
+
+    async def reconcile_starter_credits_on_read(*, project_id, secrets):  # type: ignore[misc]
+        return None
 
 
 class SecretSafeRoute(APIRoute):
@@ -160,9 +171,33 @@ class VaultRouter:
                 status_code=403,
             )
 
-        secrets_dtos = await self.service.list_secrets(
-            project_id=UUID(request.state.project_id),
-        )
+        project_id = UUID(request.state.project_id)
+        secrets_dtos = await self.service.list_secrets(project_id=project_id)
+
+        # The one path that revisits an Agenta-managed connection after it was seeded. A
+        # seeded value can go stale (the funded model of a starter-credits connection gets
+        # cut over), and nothing else ever reads that row again: seeding runs at signup
+        # only. The call scans the list already in hand and does nothing when it is
+        # current, and it never raises, so the read stands either way.
+        try:
+            repaired = await reconcile_starter_credits_on_read(
+                project_id=project_id,
+                secrets=secrets_dtos,
+            )
+        except Exception:
+            # The repair guarantees this itself; the guard is here so the guarantee is
+            # structural. Losing a whole secrets list over a repair would be far worse
+            # than the stale connection the repair was for.
+            log.warning(
+                "[vault] managed-secret reconcile failed; the read stands",
+                exc_info=True,
+            )
+            repaired = None
+        if repaired is not None:
+            secrets_dtos = [
+                repaired if secret_dto.slug == repaired.slug else secret_dto
+                for secret_dto in secrets_dtos
+            ]
 
         return [self._for_caller(request, secret_dto) for secret_dto in secrets_dtos]
 

--- a/api/oss/src/core/secrets/services.py
+++ b/api/oss/src/core/secrets/services.py
@@ -548,6 +548,15 @@ class VaultService:
             await invalidate_cache(project_id=str(project_id))
         return secret_dto
 
+    async def invalidate_secrets_cache(self, project_id: UUID) -> None:
+        """Drop this project's cached secrets list.
+
+        The vault owns list-cache invalidation so every writer goes through one path. A
+        reader that finds the cached list disagrees with the stored row needs the same door,
+        rather than reaching for the cache helper itself.
+        """
+        await invalidate_cache(project_id=str(project_id))
+
     async def delete_secret(
         self,
         secret_id: UUID,

--- a/api/oss/src/core/secrets/services.py
+++ b/api/oss/src/core/secrets/services.py
@@ -29,6 +29,7 @@ from oss.src.core.secrets.dtos import (
 from oss.src.core.secrets.managed import (
     ManagedSecretReadOnlyError,
     SecretManagementDTO,
+    SecretManager,
 )
 
 
@@ -191,6 +192,40 @@ def _resolve_update(
     stored_secret_dto: SecretResponseDTO,
     requested_update: UpdateSecretDTO,
 ) -> UpdateSecretDTO:
+    """Resolve a CALLER update: a managed row is read-only, every other row merges."""
+    if stored_secret_dto.management is not None:
+        raise ManagedSecretReadOnlyError()
+
+    return _merge_update(stored_secret_dto, requested_update)
+
+
+def _resolve_managed_update(manager: SecretManager):
+    """Resolve an update issued by a managed row's OWN manager.
+
+    The read-only rule exists so a caller cannot edit a row the platform owns. It must not
+    stop the owning manager itself from repairing that row: a seeded value can go stale
+    (the funded model of a starter-credits connection, say), and only the manager knows
+    the current one. The merge below is the same one every other update runs.
+    """
+
+    def resolve(
+        stored_secret_dto: SecretResponseDTO,
+        requested_update: UpdateSecretDTO,
+    ) -> UpdateSecretDTO:
+        management = stored_secret_dto.management
+
+        if management is None or management.manager != manager:
+            raise ManagedSecretReadOnlyError()
+
+        return _merge_update(stored_secret_dto, requested_update)
+
+    return resolve
+
+
+def _merge_update(
+    stored_secret_dto: SecretResponseDTO,
+    requested_update: UpdateSecretDTO,
+) -> UpdateSecretDTO:
     """Fill this update's omitted credential from the row UNDER THE WRITE LOCK.
 
     Called by the DAO inside the locked transaction rather than by the service before it,
@@ -202,9 +237,6 @@ def _resolve_update(
     another kind's or another provider's credential — and that decision reads the same
     stored row, so it belongs under the same lock.
     """
-    if stored_secret_dto.management is not None:
-        raise ManagedSecretReadOnlyError()
-
     resolved_update = requested_update.model_copy(deep=True)
     if resolved_update.secret is None:
         return UpdateSecretDTO.model_validate(resolved_update.model_dump(mode="python"))
@@ -481,6 +513,35 @@ class VaultService:
                 organization_id=organization_id,
                 user_id=user_id,
                 resolve_update=_resolve_update,
+            )
+
+        if project_id is not None:
+            await invalidate_cache(project_id=str(project_id))
+        return secret_dto
+
+    async def update_managed_secret(
+        self,
+        *,
+        secret_id: UUID,
+        update_secret_dto: UpdateSecretDTO,
+        manager: SecretManager,
+        project_id: UUID | None = None,
+        organization_id: UUID | None = None,
+    ):
+        """Rewrite a managed row on behalf of the manager that owns it.
+
+        Refuses any row another manager owns, and any unmanaged row: this path exists to
+        repair what the platform seeded, never to edit what a user saved.
+        """
+        with set_data_encryption_key(
+            data_encryption_key=self._data_encryption_key,
+        ):
+            secret_dto = await self.secrets_dao.update(
+                secret_id=secret_id,
+                update_secret_dto=update_secret_dto,
+                project_id=project_id,
+                organization_id=organization_id,
+                resolve_update=_resolve_managed_update(manager),
             )
 
         if project_id is not None:

--- a/api/oss/tests/pytest/unit/secrets/test_managed_secrets.py
+++ b/api/oss/tests/pytest/unit/secrets/test_managed_secrets.py
@@ -154,3 +154,43 @@ def test_mapping_round_trip_uses_structured_management_without_flat_fallback():
     dbe.data = json.dumps(payload)
     legacy = map_secrets_dbe_to_dto(secrets_dbe=dbe)
     assert legacy.management is None
+
+
+@pytest.mark.asyncio
+async def test_the_owning_manager_may_rewrite_a_managed_secret():
+    # The read-only rule stops a CALLER editing a platform-owned row. The manager that owns
+    # the row has to be able to repair it: a seeded value can go stale, and only the manager
+    # knows the current one.
+    service = VaultService(_DAO())
+    created = await service.create_managed_secret(
+        project_id=PROJECT_ID,
+        create_secret_dto=_create(write_only=True),
+        management=_management(),
+    )
+
+    updated = await service.update_managed_secret(
+        secret_id=created.id,
+        project_id=PROJECT_ID,
+        update_secret_dto=UpdateSecretDTO(header={"name": "Renamed"}),
+        manager=SecretManager.STARTER_CREDITS_BRIDGE,
+    )
+
+    assert updated is not None
+
+
+@pytest.mark.asyncio
+async def test_the_manager_path_refuses_a_row_no_manager_owns():
+    # The path exists to repair what the platform seeded, never to edit what a user saved.
+    service = VaultService(_DAO())
+    created = await service.create_secret(
+        project_id=PROJECT_ID,
+        create_secret_dto=_create(write_only=False),
+    )
+
+    with pytest.raises(ManagedSecretReadOnlyError):
+        await service.update_managed_secret(
+            secret_id=created.id,
+            project_id=PROJECT_ID,
+            update_secret_dto=UpdateSecretDTO(header={"name": "No"}),
+            manager=SecretManager.STARTER_CREDITS_BRIDGE,
+        )

--- a/api/oss/tests/pytest/unit/secrets/test_managed_secrets.py
+++ b/api/oss/tests/pytest/unit/secrets/test_managed_secrets.py
@@ -73,6 +73,13 @@ class _DAO:
     ):
         if resolve_update:
             update_secret_dto = resolve_update(self.record, update_secret_dto)
+        # Apply it, the way the real DAO does. A fake that returns the row untouched lets a
+        # test claiming the update landed pass against an update that changed nothing.
+        if update_secret_dto.header is not None:
+            self.record.header = update_secret_dto.header
+        if update_secret_dto.secret is not None:
+            self.record.kind = update_secret_dto.secret.kind
+            self.record.data = update_secret_dto.secret.data
         return self.record
 
     async def delete(
@@ -171,11 +178,22 @@ async def test_the_owning_manager_may_rewrite_a_managed_secret():
     updated = await service.update_managed_secret(
         secret_id=created.id,
         project_id=PROJECT_ID,
-        update_secret_dto=UpdateSecretDTO(header={"name": "Renamed"}),
+        update_secret_dto=UpdateSecretDTO(
+            header={"name": "Renamed"},
+            secret={
+                "kind": "provider_key",
+                "data": {"kind": "openai", "provider": {}},
+            },
+        ),
         manager=SecretManager.STARTER_CREDITS_BRIDGE,
     )
 
-    assert updated is not None
+    assert updated.header.name == "Renamed"
+    # The row keeps what it is and what it holds: still managed, still write-only, and the
+    # credential the update omitted was carried over rather than wiped.
+    assert updated.data.provider.key == "sk-managed"
+    assert updated.management == _management()
+    assert updated.write_only is True
 
 
 @pytest.mark.asyncio

--- a/api/oss/tests/pytest/unit/secrets/test_vault_router_reconcile.py
+++ b/api/oss/tests/pytest/unit/secrets/test_vault_router_reconcile.py
@@ -1,0 +1,101 @@
+"""The vault list route is the one path that revisits an Agenta-managed connection after
+it was seeded, so it is where a stale seeded value is repaired."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from oss.src.apis.fastapi.vault import router as vault_router
+from oss.src.core.secrets.dtos import SecretResponseDTO
+
+
+PROJECT_ID = uuid4()
+
+
+def _row(model: str) -> SecretResponseDTO:
+    return SecretResponseDTO(
+        id=uuid4(),
+        slug="starter-credits",
+        kind="custom_provider",
+        data={
+            "kind": "custom",
+            "provider_slug": "Agenta",
+            "provider": {"url": "https://credits.example.test", "key": "sk-virtual"},
+            "models": [{"slug": model}],
+        },
+        header={"name": "Agenta"},
+        write_only=True,
+        management={"manager": "starter-credits-bridge", "policy": "manager_only"},
+    )
+
+
+class _Service:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def list_secrets(self, project_id):
+        return list(self.rows)
+
+
+def _request():
+    return SimpleNamespace(
+        state=SimpleNamespace(user_id=str(uuid4()), project_id=str(PROJECT_ID))
+    )
+
+
+@pytest.fixture
+def route(monkeypatch):
+    async def allowed(**kwargs):
+        return True
+
+    monkeypatch.setattr(vault_router, "check_action_access", allowed)
+    monkeypatch.setattr(vault_router, "request_has_grant", lambda request, grant: False)
+    return vault_router.VaultRouter
+
+
+@pytest.mark.asyncio
+async def test_a_stale_row_is_read_back_repaired(route, monkeypatch):
+    stale = _row("vertex_ai/old-model")
+    repaired = _row("vertex_ai/new-model")
+    calls = []
+
+    async def reconcile(*, project_id, secrets):
+        calls.append((project_id, [secret.slug for secret in secrets]))
+        return repaired
+
+    monkeypatch.setattr(vault_router, "reconcile_starter_credits_on_read", reconcile)
+
+    response = await route(_Service([stale])).list_secrets(_request())
+
+    assert calls == [(PROJECT_ID, ["starter-credits"])]
+    (secret,) = response
+    assert [model.slug for model in secret.data.models] == ["vertex_ai/new-model"]
+
+
+@pytest.mark.asyncio
+async def test_a_current_row_is_returned_as_read(route, monkeypatch):
+    current = _row("vertex_ai/new-model")
+
+    async def reconcile(*, project_id, secrets):
+        return None
+
+    monkeypatch.setattr(vault_router, "reconcile_starter_credits_on_read", reconcile)
+
+    (secret,) = await route(_Service([current])).list_secrets(_request())
+
+    assert [model.slug for model in secret.data.models] == ["vertex_ai/new-model"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_reconcile_never_fails_the_read(route, monkeypatch):
+    current = _row("vertex_ai/old-model")
+
+    async def reconcile(*, project_id, secrets):
+        raise RuntimeError("proxy is down")
+
+    monkeypatch.setattr(vault_router, "reconcile_starter_credits_on_read", reconcile)
+
+    (secret,) = await route(_Service([current])).list_secrets(_request())
+
+    assert [model.slug for model in secret.data.models] == ["vertex_ai/old-model"]

--- a/sdks/python/agenta/sdk/agents/platform/connections.py
+++ b/sdks/python/agenta/sdk/agents/platform/connections.py
@@ -50,6 +50,11 @@ log = get_module_logger(__name__)
 # Canonical map lives in capabilities.py; this alias keeps the local name callers already use.
 _PROVIDER_ENV_VARS: Dict[str, str] = PROVIDER_ENV_VARS
 
+# The slug of the Agenta-funded starter-credits connection. It is the one connection whose
+# model list the user does not choose: Agenta seeds it, and Agenta re-points it when the
+# funded model is cut over. The same literal is `STARTER_CREDITS_SLUG` on the API side.
+STARTER_CREDITS_SLUG = "starter-credits"
+
 # The Claude harness selects a model by a bare alias (``haiku``/``sonnet``/``opus`` + ``[1m]``)
 # or by a dated id (``claude-opus-4-8``), never with a ``provider/`` prefix. Those bare ids are
 # unambiguously Anthropic, so the F-017 "needs a provider prefix" rule must not reject them: a
@@ -372,7 +377,38 @@ class _ConnectionCandidate:
             return model.model
         if model.model.startswith(prefix):
             return model.model[len(prefix) :]
+        funded = self._funded_starter_credits_model(model)
+        if funded is not None:
+            return funded
         return model.model
+
+    def _funded_starter_credits_model(self, model: ModelRef) -> Optional[str]:
+        """The funded model, when a saved id names one this connection no longer offers.
+
+        The Agenta-funded starter-credits connection routes to a proxy that serves exactly one
+        model, and that model gets cut over. A revision saved before a cutover still names the
+        old id, so every turn fails upstream with an invalid-model error even though the
+        connection is healthy. The connection itself states what is funded now, so run that and
+        say so in the log.
+
+        Deliberately narrow. It applies to this one connection, only when the connection offers
+        exactly one model, and only after every match above missed. Every other connection keeps
+        failing upstream, which is correct: silently running a model the user did not pick would
+        misreport what ran.
+        """
+        if self.slug != STARTER_CREDITS_SLUG:
+            return None
+        if len(self.model_slugs) != 1:
+            return None
+
+        funded = next(iter(self.model_slugs))
+        log.warning(
+            "starter credits: the saved model is not funded any more; using the funded one",
+            saved_model=model.model,
+            funded_model=funded,
+            slug=self.slug,
+        )
+        return funded
 
     def resolved_provider(self, model: ModelRef) -> str:
         if model.provider:

--- a/sdks/python/agenta/sdk/agents/platform/connections.py
+++ b/sdks/python/agenta/sdk/agents/platform/connections.py
@@ -324,6 +324,9 @@ class _ConnectionCandidate:
     # True when value_status says a credential exists but this caller's
     # credential received the redacted, value-less shape.
     write_only_redacted: bool = False
+    # True when the vault says Agenta manages this row rather than the user. Only a managed
+    # row's model list is Agenta's to re-point, so only a managed row may be substituted.
+    managed: bool = False
 
     def matches_provider(self, provider: Optional[str]) -> bool:
         return bool(
@@ -376,11 +379,13 @@ class _ConnectionCandidate:
         if model.model in self.model_slugs:
             return model.model
         if model.model.startswith(prefix):
-            return model.model[len(prefix) :]
-        funded = self._funded_starter_credits_model(model)
-        if funded is not None:
-            return funded
-        return model.model
+            stripped = model.model[len(prefix) :]
+            # The strip runs before the fallback, so an id spelled ``custom/<model>`` would
+            # otherwise reach the upstream stale, having matched nothing this connection has.
+            if stripped in self.model_slugs:
+                return stripped
+            return self._funded_starter_credits_model(model) or stripped
+        return self._funded_starter_credits_model(model) or model.model
 
     def _funded_starter_credits_model(self, model: ModelRef) -> Optional[str]:
         """The funded model, when a saved id names one this connection no longer offers.
@@ -391,12 +396,13 @@ class _ConnectionCandidate:
         connection is healthy. The connection itself states what is funded now, so run that and
         say so in the log.
 
-        Deliberately narrow. It applies to this one connection, only when the connection offers
-        exactly one model, and only after every match above missed. Every other connection keeps
-        failing upstream, which is correct: silently running a model the user did not pick would
-        misreport what ran.
+        Deliberately narrow. It applies to this one connection, only while Agenta manages it,
+        only when it offers exactly one model, and only after every match above missed. A user
+        may save their own connection under this slug, and their model list is theirs. Every
+        other connection keeps failing upstream, which is correct: silently running a model the
+        user did not pick would misreport what ran.
         """
-        if self.slug != STARTER_CREDITS_SLUG:
+        if self.slug != STARTER_CREDITS_SLUG or not self.managed:
             return None
         if len(self.model_slugs) != 1:
             return None
@@ -579,7 +585,20 @@ def _custom_provider_candidate(
         write_only_redacted=_write_only_redacted(
             secret, bool(api_key) or bool(credential_extras(extras))
         ),
+        managed=_managed(secret),
     )
+
+
+def _managed(secret: Dict[str, Any]) -> bool:
+    """Whether the vault says Agenta manages this row rather than the user.
+
+    The public secret carries the management POLICY (never the manager's name), and any
+    policy at all means the row is not the user's to edit. That is the property the funded
+    fallback needs: a user may save their own connection under any slug, including this
+    one's, and their model list is theirs.
+    """
+    management = secret.get("management")
+    return isinstance(management, dict) and bool(management.get("policy"))
 
 
 def _catalog(secrets: Iterable[Any]) -> List[_ConnectionCandidate]:

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
@@ -840,6 +840,100 @@ async def test_bare_backend_model_id_is_left_untouched(fake_http, connection):
     assert resolved.model == _BACKEND_MODEL
 
 
+# ------------------------------------------ a starter-credits model that is no longer funded
+
+# What the proxy funds after a cutover; `_BACKEND_MODEL` above is what it funded before one.
+_FUNDED_MODEL = "vertex_ai/gemini-3.7-flash"
+
+
+def _funded_starter_credits(
+    *, name: str = "Agenta", slug: str = "starter-credits"
+) -> dict:
+    """The seeded connection after Agenta re-pointed it at the model funded today."""
+    return _custom_provider(
+        name,
+        "custom",
+        key="sk-gateway",
+        url=_GATEWAY_URL,
+        models=[_FUNDED_MODEL],
+        slug=slug,
+    )
+
+
+async def test_a_stale_starter_credits_model_runs_the_funded_one(fake_http, connection):
+    # The starter-credits proxy serves exactly one model and that model gets cut over. A
+    # revision saved before a cutover still names the old id, and sending it upstream fails
+    # every turn with "Invalid model name passed in model=vertex_ai/gemini-3.6-flash". The
+    # connection states what is funded now, so run that instead of a certain failure.
+    fake_http(connections, payload=[_funded_starter_credits()])
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            model=f"Agenta/custom/{_BACKEND_MODEL}",
+            connection={"mode": "agenta", "slug": "starter-credits"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _FUNDED_MODEL
+
+
+async def test_a_stale_bare_starter_credits_model_runs_the_funded_one(
+    fake_http, connection
+):
+    # The same substitution for the un-namespaced spelling of the saved id.
+    fake_http(connections, payload=[_funded_starter_credits()])
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            provider="openai",
+            model=_BACKEND_MODEL,
+            connection={"mode": "agenta", "slug": "starter-credits"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _FUNDED_MODEL
+
+
+async def test_a_current_starter_credits_model_is_left_untouched(fake_http, connection):
+    # The substitution must be reachable only after every match misses.
+    fake_http(connections, payload=[_funded_starter_credits()])
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            model=f"Agenta/custom/{_FUNDED_MODEL}",
+            connection={"mode": "agenta", "slug": "starter-credits"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _FUNDED_MODEL
+
+
+async def test_another_connections_unknown_model_is_left_untouched(
+    fake_http, connection
+):
+    # Only the Agenta-funded connection substitutes. On a connection the user configured,
+    # running a model they did not pick would misreport what ran, so the id goes upstream
+    # unchanged and fails there.
+    fake_http(
+        connections,
+        payload=[_funded_starter_credits(name="My gateway", slug="my-gateway")],
+    )
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            provider="openai",
+            model=_BACKEND_MODEL,
+            connection={"mode": "agenta", "slug": "my-gateway"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _BACKEND_MODEL
+
+
 async def test_provider_key_model_id_is_unaffected(fake_http, connection):
     # A plain provider key stores no namespaced model keys; its model id must survive verbatim.
     fake_http(

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
@@ -847,10 +847,17 @@ _FUNDED_MODEL = "vertex_ai/gemini-3.7-flash"
 
 
 def _funded_starter_credits(
-    *, name: str = "Agenta", slug: str = "starter-credits"
+    *,
+    name: str = "Agenta",
+    slug: str = "starter-credits",
+    managed: bool = True,
 ) -> dict:
-    """The seeded connection after Agenta re-pointed it at the model funded today."""
-    return _custom_provider(
+    """The seeded connection after Agenta re-pointed it at the model funded today.
+
+    The vault marks it managed, which is what says the model list is Agenta's and not the
+    user's. The public secret carries the policy only, never the manager's name.
+    """
+    secret = _custom_provider(
         name,
         "custom",
         key="sk-gateway",
@@ -858,6 +865,9 @@ def _funded_starter_credits(
         models=[_FUNDED_MODEL],
         slug=slug,
     )
+    if managed:
+        secret["management"] = {"policy": "manager_only"}
+    return secret
 
 
 async def test_a_stale_starter_credits_model_runs_the_funded_one(fake_http, connection):
@@ -909,6 +919,44 @@ async def test_a_current_starter_credits_model_is_left_untouched(fake_http, conn
     )
 
     assert resolved.model == _FUNDED_MODEL
+
+
+async def test_a_stale_deployment_prefixed_model_runs_the_funded_one(
+    fake_http, connection
+):
+    # The namespace strip runs before the fallback, so this spelling would otherwise reach
+    # the upstream stale, having matched nothing the connection has.
+    fake_http(connections, payload=[_funded_starter_credits()])
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            provider="openai",
+            model=f"custom/{_BACKEND_MODEL}",
+            connection={"mode": "agenta", "slug": "starter-credits"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _FUNDED_MODEL
+
+
+async def test_a_connection_the_user_owns_under_the_slug_is_left_untouched(
+    fake_http, connection
+):
+    # A user may save their own connection under any slug, this one included. Their model
+    # list is theirs, so nothing may be substituted into it.
+    fake_http(connections, payload=[_funded_starter_credits(managed=False)])
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            provider="openai",
+            model=_BACKEND_MODEL,
+            connection={"mode": "agenta", "slug": "starter-credits"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _BACKEND_MODEL
 
 
 async def test_another_connections_unknown_model_is_left_untouched(


### PR DESCRIPTION
## Symptom

Every turn of a new agent fails in an affected project. The proxy rejects the request:

```
litellm.BadRequestError: Invalid model name passed in model=vertex_ai/gemini-3.6-flash
```

The agent defaults to `Agenta/custom/vertex_ai/gemini-3.6-flash`, which comes from the project's starter-credits connection.

## Cause

Every project gets a starter-credits connection at signup: a `custom_provider` vault row with slug `starter-credits` and name `Agenta`, plus one minted LiteLLM proxy key. Both freeze the funded model at creation time. `_create_row` writes `models=[config.model_id]` and `_mint_key` mints with `models=[config.model_id]`.

The proxy serves exactly one model, from `LITELLM_MODEL_ID`. That model was cut over from `vertex_ai/gemini-3.6-flash` to `vertex_ai/gemini-3.7-flash` around 2026-08-25. Rows created before the cutover still offer 3.6, so a new agent in such a project picks 3.6 and the proxy refuses it.

Blast radius today: one project on us, zero on eu.

## Layer 1: the bridge re-points a stale row

`reconcile_starter_credits_model` runs on the existing-row path of `seed_starter_credits_bridge`. When the stored model list differs from the configured `model_id`, it re-points the minted key's allow-list through the proxy admin client, then rewrites the row's models. It logs one info line per reconciled row.

- It never mints. The grant invariant stays one key per organization.
- The proxy call comes first, so the key accepts the new id before the row asks for it.
- A failed proxy call leaves the row stale, and nothing raises. A row on the new model whose key still allows only the old one is just as broken and would read as current forever, so nothing would try again. Staying stale is what keeps the next read retrying.
- It consumes no velocity slot. Those counters meter grants, and a repair grants nothing.

Two supporting changes. `StarterCreditsProxyClient.update_key_models` posts `/key/update` with the full model list, mirroring how the mint posts. `VaultService.update_managed_secret` lets a managed row's own manager rewrite it. The read-only rule exists to stop a caller editing a platform-owned row. It must not stop the owning manager repairing one, because only the manager knows the current value. The path refuses any row another manager owns and any unmanaged row.

A row with no credential is left alone. It cannot run whatever model it names, so a repair would fix nothing, and the read path below would send that repair on every list.

## Layer 1b: the repair reaches existing rows on read

Seeding runs once, at organization creation, so nothing ever revisited a row written before the cutover. `reconcile_starter_credits_on_read` is what reaches them. It hangs off the vault list route, which the connection picker and the runtime resolver both hit, so the first read of an affected project repairs the row and every read after it finds nothing to do.

No sweep. A sweep would call the proxy once per project, and eu has tens of thousands.

- A healthy read costs a scan of the list already in hand. No extra query, no proxy call.
- One repair at a time per project, and one attempt per project per cooldown. A repair that failed is retried by a later read, but a repeated repair means something is wrong and must not run per read. Two cases would otherwise write on every list: a row that will not stay repaired, and two API replicas configured with different model ids, each repairing the row back to its own. A healthy project never reaches the cooldown, because its row matches and the staleness check returns first.
- It repairs only a row the bridge owns. A user may delete the seeded connection and save their own under the same slug, and that one is theirs to point anywhere.
- It never raises, and the route guards the call again so the guarantee is structural. A caller must not lose its whole secrets list over a connection that is at worst as broken as it already was.
- A reader that skips the repair still answers from the row. Reads come from a cached list, so a snapshot taken before another request repaired the row can be published after it. The path re-reads the row whenever the caller's snapshot looks stale, and drops the cached list that produced it.
- OSS gets an inert stub through the `is_ee()` seam, since OSS seeds no managed connection.

## Layer 2: the resolver falls back to the funded model

`_ConnectionCandidate.selected_model_id` in the SDK resolver gains a last-resort substitution. When every match has missed, the connection is the starter-credits one, and it offers exactly one model, the resolver runs that model and logs a warning naming both ids.

It is narrow on purpose. It applies to that one connection, only while the vault's management policy says Agenta owns it, only after every match above misses, and only when the connection offers a single model. A user may save their own connection under any slug, this one included, and their model list is theirs. Every other connection keeps failing upstream, which is right. Silently running a model the user did not pick would misreport what ran.

The fallback also runs on the namespace-strip branch. An id spelled `custom/<model>` was stripped and returned before the fallback, so it reached the upstream stale.

## What users see

Existing revisions saved on 3.6 keep working, served by layer 2 against the funded model, until the user re-picks a model in the playground. New agents in a repaired project pick the funded model directly.

## Tests

Six new tests, all failing on `release/v0.115.3` and passing here.

- `TestReconcilingOnRead` covers a stale row read back on the funded model with the key re-pointed, a current row that costs no call, a read that stands when the repair fails, a row the bridge does not own, and a disarmed bridge. `test_a_stale_row_is_read_back_repaired` and its two siblings cover the route itself.
- `TestTheRepairSurvivesTheMapping` round-trips the rewrite through the storage mapping. The retry behavior rests on the write persisting: if it did not, every read would repeat it.
- `TestReconcilingAStaleFundedModel` covers the repaired row, the re-pointed key with no second mint, a current row left alone, a failed proxy update that still moves the row, the untouched velocity counters, and the resolver reading the repaired row.
- `test_the_owning_manager_may_rewrite_a_managed_secret` and `test_the_manager_path_refuses_a_row_no_manager_owns` cover the new vault path.
- Six resolver tests cover the stale namespaced id, the stale bare id, the stale deployment-prefixed id, a current id left untouched, a connection the user owns under the slug, and another connection's unknown model.
- The proxy key update is asserted at the transport: the endpoint, the body, a refusal, and that an error body never echoes key material.

```
api  ee/tests/pytest/unit oss/tests/pytest/unit   3685 passed, 176 skipped
sdk  oss/tests/pytest/unit/agents                 1373 passed, 4 skipped, 1 failed
```

The one SDK failure is `test_streaming.py::test_cli_stream_terminal_only_on_empty_request`. It fails identically on `release/v0.115.3` with these changes stashed, so it is pre-existing and unrelated.


## Review

CodeRabbit found that a failed key update still wrote the row, which left it reading as current with a key on the old model and nothing to retry it. Fixed in 0bbba8d.

It later asked for HTTPS on the proxy admin URL and for the vault dependency to be injected. Both are declined here, with the reasoning on the threads. The master key already rode that URL and header on three admin calls before this PR, and enforcing HTTPS would disarm the bridge in production, where the value is the proxy's internal address. The injection is a real guideline, and `_vault_service()` predates this PR, so it is filed as #6725 rather than reshaped in a hot fix. One thing from that thread did land: the design doc gives the vault ownership of list-cache invalidation, and the read path called the cache helper directly. Fixed in d2dac4c.

A Codex review at extended reasoning found three more, all fixed in cff85db. A reader that skipped the repair served its own stale cached snapshot. The resolver fallback was gated on the slug alone rather than on the vault's management policy. A deployment-prefixed selector was stripped before the fallback ran. Codex also pointed out that the fake secrets DAO never applied the update it resolved, so the managed-update test proved only that an object came back. That fake now applies the update.
