### PR TITLE
[hotfix] v0.115.3: tolerate saved gateway tool entries and refresh a stale starter-credits model

### DIFF
--- a/api/ee/src/core/starter_credits_bridge/client.py
+++ b/api/ee/src/core/starter_credits_bridge/client.py
@@ -77,6 +77,25 @@ class StarterCreditsProxyClient:
 
         return MintedKey(key=key, key_alias=key_alias)
 
+    async def update_key_models(self, *, key: str, models: list[str]) -> None:
+        """Rewrite an existing key's model allow-list, in place.
+
+        The proxy serves one model, and that model can be cut over. A key minted before
+        the cutover still allows only the old id, so it must be re-pointed at the funded
+        one. This never mints: the grant invariant is one key per organization, and a
+        second key would be a second grant.
+        """
+        await self._request(
+            "POST",
+            "/key/update",
+            json={
+                "key": key,
+                # An explicit list always, for the same reason the mint sends one: an
+                # omitted list would widen the key to every model the proxy serves.
+                "models": models,
+            },
+        )
+
     async def get_team_info(self, *, team_id: str) -> dict[str, Any]:
         payload = await self._request("GET", "/team/info", params={"team_id": team_id})
         return payload if isinstance(payload, dict) else {}

--- a/api/ee/src/core/starter_credits_bridge/service.py
+++ b/api/ee/src/core/starter_credits_bridge/service.py
@@ -16,6 +16,7 @@ from oss.src.utils.logging import get_module_logger
 from oss.src.dbs.redis.shared.engine import get_cache_engine
 from oss.src.core.secrets.dtos import (
     CreateSecretDTO,
+    UpdateSecretDTO,
     CustomModelSettingsDTO,
     CustomProviderDTO,
     CustomProviderSettingsDTO,
@@ -167,6 +168,14 @@ async def seed_starter_credits_bridge(
         project_id=project.id,
     )
     if row is not None:
+        await reconcile_starter_credits_model(
+            client=client,
+            config=config,
+            vault_service=vault_service,
+            project_id=project.id,
+            organization_id=organization_id,
+            row=row,
+        )
         return
 
     if not await _mint_policy_allows(organization_email, policy):
@@ -186,6 +195,254 @@ async def seed_starter_credits_bridge(
         if not seeded:
             # The consumed velocity slot funded no mint; hand it back best-effort.
             await _release_velocity_slots(organization_email, policy)
+
+
+# One reconcile at a time per project. Reads are concurrent (the picker and the runtime
+# resolver both list secrets), and without this a burst would send the same repair several
+# times. It is an in-flight set, not a memo: a repair that failed must be retried by the
+# next read, and a row already on the funded model costs a list scan either way.
+_reconciling_projects: set[str] = set()
+
+# How long a project waits after ONE repair attempt before a read makes another. A retry is
+# what recovers a transient proxy failure, but nothing else bounds how often a project can
+# be repaired, and two cases would otherwise write on every secrets list: a row that cannot
+# be repaired at all (a deleted proxy key, say), and two API replicas configured with
+# different model ids, each repairing the row back to its own. A healthy project never
+# reaches this: its row matches and the check above returns first.
+_RECONCILE_RETRY_COOLDOWN_SECONDS = 300.0
+
+_reconcile_cooldowns: dict[str, float] = {}
+
+
+async def reconcile_starter_credits_on_read(
+    *,
+    project_id: UUID,
+    secrets: list,
+) -> Optional[SecretResponseDTO]:
+    """Repair a stale starter-credits row as it is read, and return the repaired row.
+
+    Seeding runs once, at signup, so nothing else ever revisits a row that was written
+    before the funded model was cut over. This is the path that reaches those rows: the
+    picker and the runtime resolver both list a project's secrets, so the first read after
+    a cutover repairs the row and every read after it is a list scan that finds nothing to
+    do. Returns the current row when the caller's snapshot was stale, and None when there
+    was nothing to correct or nothing better to hand back.
+
+    Never raises. A read must not fail because a repair could not run — the caller would
+    lose its whole secrets list over a connection that is at worst as broken as it already
+    was.
+    """
+    config = env.starter_credits_bridge
+    if not config.armed:
+        return None
+
+    row = _find_starter_credits_row(secrets)
+    if row is None or _stored_model_slugs(row) == [config.model_id]:
+        # The whole cost of a healthy project: a scan of the list already in hand.
+        return None
+
+    key = str(project_id)
+    vault_service = _vault_service()
+    if _may_repair(key):
+        _reconciling_projects.add(key)
+        try:
+            await reconcile_starter_credits_model(
+                client=_proxy_client(config),
+                config=config,
+                vault_service=vault_service,
+                project_id=project_id,
+                # The read knows the project, not the organization. The project id already
+                # identifies the row, and resolving the organization would cost a query on
+                # a path that runs on every secrets list.
+                organization_id=None,
+                row=row,
+            )
+        except Exception:
+            log.warning(
+                "[starter_credits_bridge] could not reconcile on read; the read stands",
+                project_id=key,
+                exc_info=True,
+            )
+        finally:
+            # Armed on every attempt, not only a failed one: a repeated repair means
+            # something is wrong (a row that will not stay repaired), and that must not run
+            # per read.
+            _hold_off(key)
+            _reconciling_projects.discard(key)
+
+    # Read the row back whether or not THIS request repaired it. Skipping the repair does
+    # not mean the caller's snapshot is right: a concurrent request may have repaired the
+    # row already, and reads are served from a cached list, so a snapshot taken before that
+    # repair can still be published after it. Answering from the row itself is what keeps a
+    # reader that skipped the repair from serving the stale model anyway.
+    try:
+        fresh = await vault_service.get_secret_by_slug(
+            STARTER_CREDITS_SLUG,
+            project_id=project_id,
+        )
+        if fresh is None or _stored_model_slugs(fresh) != [config.model_id]:
+            # Still stale, so there is nothing better to hand back than what the caller has.
+            return None
+
+        # The caller's list was stale while the row was not, so the cached list it came from
+        # is stale too. Drop it, or every read pays for this re-read until the entry expires.
+        # Through the vault, which owns list-cache invalidation, and never the cache helper.
+        await vault_service.invalidate_secrets_cache(project_id)
+    except Exception:
+        # Inside the guard like everything else: the re-read and the cache drop both reach
+        # the database, and neither may take the caller's secrets list down with it.
+        log.warning(
+            "[starter_credits_bridge] could not read the row back; the read stands",
+            project_id=key,
+            exc_info=True,
+        )
+        return None
+
+    return fresh
+
+
+def _may_repair(project_id: str) -> bool:
+    """Whether this request should attempt the repair, rather than let another one do it."""
+    if project_id in _reconciling_projects:
+        return False
+
+    cooling_until = _reconcile_cooldowns.get(project_id)
+
+    return cooling_until is None or _monotonic() >= cooling_until
+
+
+def _hold_off(project_id: str) -> None:
+    """Stop reads repairing this project again for a while."""
+    _reconcile_cooldowns[project_id] = _monotonic() + _RECONCILE_RETRY_COOLDOWN_SECONDS
+
+
+def _find_starter_credits_row(secrets: list) -> Optional[SecretResponseDTO]:
+    """The seeded row inside an already-fetched list, or None. No query of its own."""
+    for secret in secrets or []:
+        if getattr(secret, "slug", None) != STARTER_CREDITS_SLUG:
+            continue
+        management = getattr(secret, "management", None)
+        # Only a row the bridge owns. A user is free to delete the seeded connection and
+        # save their own under the same slug, and that one is theirs to point anywhere.
+        if (
+            management is not None
+            and management.manager == SecretManager.STARTER_CREDITS_BRIDGE
+        ):
+            return secret
+    return None
+
+
+async def reconcile_starter_credits_model(
+    *,
+    client: StarterCreditsProxyClient,
+    config: StarterCreditsBridgeConfig,
+    vault_service: VaultService,
+    project_id: UUID,
+    organization_id: Optional[str],
+    row: SecretResponseDTO,
+) -> bool:
+    """Re-point an already-seeded row at the model the proxy funds today.
+
+    The row freezes the funded model at creation time, but the proxy serves exactly one
+    model and that model gets cut over. A row left on the old id resolves every run to a
+    model the proxy refuses, so a project seeded before a cutover fails on every turn with
+    HTTP 400 "Invalid model name passed in model=<old id>".
+
+    Rewrites the stored list and re-points the minted key's allow-list. It never mints: the
+    grant invariant is one key per organization. Returns whether the row was changed.
+    """
+    stored_models = _stored_model_slugs(row)
+    if stored_models == [config.model_id]:
+        return False
+
+    # The proxy first: a key still restricted to the old id would refuse the new one, so
+    # widening it before the row changes keeps the two consistent for as long as possible.
+    # A failure here is logged, not raised — the row must still move, and a key pointing at
+    # a model the proxy no longer serves is already unusable.
+    virtual_key = _stored_virtual_key(row)
+    if not virtual_key:
+        # A row with no credential cannot run whatever model it names, so re-pointing it
+        # would fix nothing. Bail rather than write: the read path retries a row it still
+        # sees as stale, and rewriting one that stays broken would retry on every read.
+        log.warning(
+            "[starter_credits_bridge] the seeded row carries no key; nothing to repair",
+            organization_id=organization_id,
+            project_id=str(project_id),
+        )
+        return False
+
+    try:
+        await client.update_key_models(
+            key=virtual_key,
+            models=[config.model_id],
+        )
+    except Exception:
+        # Do NOT write the row. A row on the new model whose key still allows only the old
+        # one is just as broken, and it would read as current forever, so nothing would try
+        # again. Leaving it stale is what keeps the next read retrying the whole repair.
+        log.warning(
+            "[starter_credits_bridge] could not re-point the key's models; "
+            "leaving the row stale so the next read retries",
+            organization_id=organization_id,
+            project_id=str(project_id),
+            exc_info=True,
+        )
+        return False
+
+    await vault_service.update_managed_secret(
+        secret_id=row.id,
+        project_id=project_id,
+        update_secret_dto=_model_update(row=row, config=config),
+        manager=SecretManager.STARTER_CREDITS_BRIDGE,
+    )
+
+    log.info(
+        "[starter_credits_bridge] reconciled a stale funded model",
+        organization_id=organization_id,
+        project_id=str(project_id),
+        secret_id=str(row.id),
+        stored_models=stored_models,
+        funded_model=config.model_id,
+    )
+    return True
+
+
+def _stored_model_slugs(row: SecretResponseDTO) -> list[str]:
+    """The model ids the row offers, in stored order."""
+    models = getattr(getattr(row, "data", None), "models", None) or []
+    slugs = [getattr(model, "slug", None) for model in models]
+    return [str(slug) for slug in slugs if slug]
+
+
+def _stored_virtual_key(row: SecretResponseDTO) -> Optional[str]:
+    """The minted key the row carries, or None when the read gave a value-less shape."""
+    key = getattr(getattr(getattr(row, "data", None), "provider", None), "key", None)
+    return key if isinstance(key, str) and key else None
+
+
+def _model_update(
+    *,
+    row: SecretResponseDTO,
+    config: StarterCreditsBridgeConfig,
+) -> UpdateSecretDTO:
+    """The narrowest update that re-points the row: its models, and nothing else.
+
+    Built from the STORED payload so the routing URL and every other saved field survive
+    verbatim. ``model_keys`` is dropped rather than carried, because it is derived from the
+    model list and a carried copy would keep publishing the old namespaced key.
+    """
+    data = row.data.model_dump(mode="json", exclude_none=True)
+    data["models"] = [{"slug": config.model_id}]
+    data.pop("model_keys", None)
+
+    return UpdateSecretDTO.model_validate(
+        {
+            "secret": {
+                "kind": SecretKind.CUSTOM_PROVIDER.value,
+                "data": data,
+            }
+        }
+    )
 
 
 async def _provision(

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_client.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_client.py
@@ -230,3 +230,56 @@ class TestTeamInfo:
         with pytest.raises(ProxyRequestError) as excinfo:
             await client.get_team_info(team_id="team-1")
         assert excinfo.value.status_code == 404
+
+
+class TestUpdateKeyModels:
+    async def test_posts_the_key_and_the_full_model_list(self):
+        seen = {}
+
+        def handler(request: httpx.Request) -> httpx.Response:
+            seen["method"] = request.method
+            seen["url"] = str(request.url)
+            seen["auth"] = request.headers.get("Authorization")
+            seen["body"] = _read_body(request)
+            return httpx.Response(200, json={"key": "sk-virtual-abc"})
+
+        await _client_with_handler(handler).update_key_models(
+            key="sk-virtual-abc",
+            models=["vertex_ai/new-model"],
+        )
+
+        assert seen["method"] == "POST"
+        assert seen["url"] == "https://proxy.internal.test/key/update"
+        assert seen["auth"] == "Bearer sk-master-test"
+        # An explicit list always. An omitted one would widen the key to every model the
+        # proxy serves.
+        assert seen["body"] == {
+            "key": "sk-virtual-abc",
+            "models": ["vertex_ai/new-model"],
+        }
+
+    async def test_a_proxy_refusal_raises(self):
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(404, text="key not found")
+
+        with pytest.raises(ProxyRequestError) as raised:
+            await _client_with_handler(handler).update_key_models(
+                key="sk-virtual-gone",
+                models=["vertex_ai/new-model"],
+            )
+
+        assert raised.value.status_code == 404
+
+    async def test_an_error_body_never_echoes_key_material(self):
+        # A proxy error may echo the failing request, which carries a virtual key.
+        def handler(request: httpx.Request) -> httpx.Response:
+            return httpx.Response(400, text="rejected models for key sk-virtual-abc")
+
+        with pytest.raises(ProxyRequestError) as raised:
+            await _client_with_handler(handler).update_key_models(
+                key="sk-virtual-abc",
+                models=["vertex_ai/new-model"],
+            )
+
+        assert "sk-virtual-abc" not in raised.value.detail
+        assert "sk-[redacted]" in raised.value.detail

--- a/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
+++ b/api/ee/tests/pytest/unit/test_starter_credits_bridge_seeding.py
@@ -5,14 +5,16 @@ blocking, alias conflicts), policy resolution, and velocity caps, with every
 external dependency stubbed."""
 
 import asyncio
+import copy
 from types import SimpleNamespace
 from uuid import uuid4
 
 import pytest
 
 from oss.src.utils.env import env, PostHogConfig, StarterCreditsBridgeConfig
-from oss.src.core.secrets.dtos import SecretResponseDTO
+from oss.src.core.secrets.dtos import CustomModelSettingsDTO, SecretResponseDTO
 from oss.src.core.secrets.enums import CustomProviderKind
+from oss.src.core.secrets.redaction import project_secret_response
 from oss.src.core.secrets.managed import (
     SecretManagementDTO,
     SecretManagementPolicy,
@@ -76,6 +78,8 @@ class FakeVaultService:
         self.create_dto = None
         self.management = None
         self.create_error = None
+        self.update_calls = []
+        self.invalidations = []
 
     async def get_secret_by_slug(self, secret_slug, project_id=None, **kwargs):
         assert secret_slug == service.STARTER_CREDITS_SLUG
@@ -91,12 +95,36 @@ class FakeVaultService:
         self.management = management
         self.row = SimpleNamespace(
             id=uuid4(),
+            slug=create_secret_dto.slug,
             header=create_secret_dto.header,
             data=create_secret_dto.secret.data,
             management=management,
             write_only=bool(create_secret_dto.write_only),
         )
         self.created_count += 1
+        return self.row
+
+    async def invalidate_secrets_cache(self, project_id):
+        await asyncio.sleep(0)
+        self.invalidations.append(str(project_id))
+
+    async def update_managed_secret(
+        self,
+        *,
+        secret_id,
+        update_secret_dto,
+        manager,
+        project_id=None,
+        organization_id=None,
+    ):
+        await asyncio.sleep(0)
+        assert self.row is not None
+        assert secret_id == self.row.id
+        assert manager is SecretManager.STARTER_CREDITS_BRIDGE
+        self.update_calls.append(update_secret_dto)
+        # The real service revalidates the merged payload and writes it back, so the row
+        # the next read returns is the update's own data.
+        self.row.data = update_secret_dto.secret.data
         return self.row
 
 
@@ -107,6 +135,7 @@ class FakeProxyClient:
 
     records: dict = {}
     generate_failures: list = []
+    update_failures: list = []
     instances: list = []
 
     def __init__(self, *, base_url, master_key):
@@ -114,6 +143,7 @@ class FakeProxyClient:
         self.master_key = master_key
         self.generate_calls = []
         self.block_calls = []
+        self.update_calls = []
         FakeProxyClient.instances.append(self)
 
     @classmethod
@@ -166,6 +196,17 @@ class FakeProxyClient:
     async def block_key(self, *, key):
         self.block_calls.append(key)
 
+    async def update_key_models(self, *, key, models):
+        await asyncio.sleep(0)
+        self.update_calls.append(dict(key=key, models=models))
+        if FakeProxyClient.update_failures:
+            raise FakeProxyClient.update_failures.pop(0)
+        for record in FakeProxyClient.records.values():
+            if record["key"] == key:
+                record["models"] = list(models)
+                return
+        raise ProxyRequestError(status_code=404, detail="no such key")
+
 
 def _all_generate_calls():
     return [
@@ -184,8 +225,11 @@ def _all_block_calls():
 @pytest.fixture
 def seeding_env(monkeypatch):
     """Arm the config and stub every dependency; returns the mutable stubs."""
+    service._reconciling_projects.clear()
+    service._reconcile_cooldowns.clear()
     FakeProxyClient.records = {}
     FakeProxyClient.generate_failures = []
+    FakeProxyClient.update_failures = []
     FakeProxyClient.instances = []
     service._verified_teams.clear()
 
@@ -1176,3 +1220,446 @@ def test_a_bridge_deployment_without_a_runtime_key_fails_at_startup(monkeypatch)
 
     with pytest.raises(RuntimeError, match="AGENTA_SERVICES_INTERNAL_KEY"):
         helpers.validate_platform_runtime_key()
+
+
+def _all_key_update_calls():
+    return [
+        call for instance in FakeProxyClient.instances for call in instance.update_calls
+    ]
+
+
+class TestReconcilingAStaleFundedModel:
+    """The row freezes the funded model at creation, but the proxy serves exactly one model
+    and that model gets cut over. A row left on the old id resolves every run to a model the
+    proxy refuses with HTTP 400 "Invalid model name passed in model=<old id>"."""
+
+    async def _seed_then_cut_the_model_over(self, seeding_env, *, funded: str):
+        await _seed()
+        assert seeding_env.vault.row is not None
+        seeding_env.monkeypatch.setattr(
+            env,
+            "starter_credits_bridge",
+            _armed_config(model_id=funded),
+        )
+
+    async def test_a_stale_row_is_repointed_at_the_funded_model(self, seeding_env):
+        await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+
+        await _seed()
+
+        row = seeding_env.vault.row
+        assert [model.slug for model in row.data.models] == ["vertex_ai/new-model"]
+        # The credential and the routing URL survive the rewrite untouched.
+        assert row.data.provider.key == FakeProxyClient.records[ORGANIZATION_ID]["key"]
+        assert row.data.provider.url == "https://credits-proxy.example.test"
+        assert row.data.provider_slug == service.STARTER_CREDITS_NAME
+        # A carried model_keys list would keep publishing the old model id.
+        assert row.data.model_keys is None
+
+    async def test_the_minted_key_is_repointed_and_never_re_minted(self, seeding_env):
+        await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+
+        await _seed()
+
+        (update,) = _all_key_update_calls()
+        assert update["models"] == ["vertex_ai/new-model"]
+        assert update["key"] == FakeProxyClient.records[ORGANIZATION_ID]["key"]
+        assert FakeProxyClient.records[ORGANIZATION_ID]["models"] == [
+            "vertex_ai/new-model"
+        ]
+        # One mint, from the original seed. The grant invariant is one key per organization.
+        assert len(_all_generate_calls()) == 1
+        assert _all_block_calls() == []
+
+    async def test_a_current_row_is_left_alone(self, seeding_env):
+        await _seed()
+        seeding_env.vault.update_calls.clear()
+
+        await _seed()
+
+        assert seeding_env.vault.update_calls == []
+        assert _all_key_update_calls() == []
+        assert len(_all_generate_calls()) == 1
+
+    async def test_a_failed_key_update_leaves_the_row_stale(self, seeding_env):
+        # A row on the new model whose key still allows only the old one is just as broken,
+        # and it would read as current forever, so nothing would try again. Leaving it stale
+        # is what keeps the next read retrying. Nothing is raised: the signup path this runs
+        # inside deletes the new user when setup raises.
+        await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        FakeProxyClient.update_failures = [
+            ProxyRequestError(status_code=503, detail="proxy down")
+        ]
+
+        await _seed()
+
+        row = seeding_env.vault.row
+        assert [model.slug for model in row.data.models] == ["vertex_ai/some-model"]
+        assert seeding_env.vault.update_calls == []
+        assert len(_all_key_update_calls()) == 1
+
+    async def test_reconciling_consumes_no_velocity_slot(self, seeding_env):
+        # The velocity caps meter GRANTS. A repair mints nothing, so it must not spend one.
+        await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+
+        await _seed()
+
+        assert seeding_env.released == []
+        assert len(_all_generate_calls()) == 1
+
+    async def test_the_repaired_row_resolves_to_the_funded_model(self, seeding_env):
+        # The end the repair exists for: what the runtime resolver runs after it.
+        from agenta.sdk.agents.connections import ModelRef
+        from agenta.sdk.agents.platform import connections
+
+        await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        await _seed()
+
+        row = seeding_env.vault.row
+        stored = SecretResponseDTO(
+            id=uuid4(),
+            slug=service.STARTER_CREDITS_SLUG,
+            kind="custom_provider",
+            data=row.data.model_dump(mode="json"),
+            header=row.header,
+            write_only=True,
+            management=seeding_env.vault.management,
+        )
+        # The shape the route actually returns to the runtime resolver: the management
+        # POLICY without the manager's name, which is what says the model list is Agenta's.
+        public = project_secret_response(stored, reveal_write_only=True)
+        (candidate,) = connections._catalog([public.model_dump(mode="json")])
+        assert candidate.managed is True
+
+        # A revision saved before the cutover still names the old id.
+        stale = ModelRef(
+            model=f"{service.STARTER_CREDITS_NAME}/custom/vertex_ai/some-model",
+            connection={"mode": "agenta", "slug": service.STARTER_CREDITS_SLUG},
+        )
+        assert candidate.selected_model_id(stale) == "vertex_ai/new-model"
+
+        fresh = ModelRef(
+            model=f"{service.STARTER_CREDITS_NAME}/custom/vertex_ai/new-model",
+            connection={"mode": "agenta", "slug": service.STARTER_CREDITS_SLUG},
+        )
+        assert candidate.selected_model_id(fresh) == "vertex_ai/new-model"
+
+
+class TestReconcilingOnRead:
+    """Seeding runs once, at signup, so nothing revisits a row written before a cutover.
+    The read path is what reaches those rows: the picker and the runtime resolver both list
+    a project's secrets."""
+
+    async def _seed_then_cut_the_model_over(self, seeding_env, *, funded: str):
+        await _seed()
+        seeding_env.monkeypatch.setattr(
+            env,
+            "starter_credits_bridge",
+            _armed_config(model_id=funded),
+        )
+        return seeding_env.vault.row
+
+    async def test_a_stale_row_read_comes_back_on_the_funded_model(self, seeding_env):
+        row = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        minted = FakeProxyClient.records[ORGANIZATION_ID]["key"]
+
+        repaired = await service.reconcile_starter_credits_on_read(
+            project_id=seeding_env.project.id,
+            secrets=[row],
+        )
+
+        assert repaired is not None
+        assert [model.slug for model in repaired.data.models] == ["vertex_ai/new-model"]
+        # One attempt per project per cooldown, so nothing can rewrite a row per read.
+        assert str(seeding_env.project.id) in service._reconcile_cooldowns
+        (update,) = _all_key_update_calls()
+        assert update == {"key": minted, "models": ["vertex_ai/new-model"]}
+        assert repaired.data.provider.key == minted
+        # A repair is not a grant.
+        assert len(_all_generate_calls()) == 1
+
+    async def test_a_current_row_read_costs_no_call(self, seeding_env):
+        await _seed()
+        row = seeding_env.vault.row
+        seeding_env.vault.update_calls.clear()
+
+        repaired = await service.reconcile_starter_credits_on_read(
+            project_id=seeding_env.project.id,
+            secrets=[row],
+        )
+
+        assert repaired is None
+        assert _all_key_update_calls() == []
+        assert seeding_env.vault.update_calls == []
+
+    async def test_a_failed_key_update_is_retried_by_a_later_read(self, seeding_env):
+        # The retry is the whole point of leaving the row stale, so pin that it happens
+        # once the proxy recovers.
+        row = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        FakeProxyClient.update_failures = [
+            ProxyRequestError(status_code=503, detail="proxy down")
+        ]
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        assert [model.slug for model in row.data.models] == ["vertex_ai/some-model"]
+
+        # The cooldown holds a project that did not repair, so a read inside it is free.
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        assert len(_all_key_update_calls()) == 1
+
+        service._reconcile_cooldowns.clear()
+        repaired = await service.reconcile_starter_credits_on_read(
+            project_id=seeding_env.project.id,
+            secrets=[row],
+        )
+
+        assert repaired is not None
+        assert [model.slug for model in repaired.data.models] == ["vertex_ai/new-model"]
+        assert len(_all_key_update_calls()) == 2
+
+    async def test_a_reader_that_skips_the_repair_still_answers_from_the_row(
+        self, seeding_env
+    ):
+        # Reads are served from a cached list, so a snapshot taken before another request
+        # repaired the row can still be published after it. A reader that skips the repair
+        # must not serve the stale model it is holding.
+        stale = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        snapshot = copy.deepcopy(stale)
+        # Another request has already repaired the row and is still in flight.
+        stale.data.models = [CustomModelSettingsDTO(slug="vertex_ai/new-model")]
+        service._reconciling_projects.add(str(seeding_env.project.id))
+
+        try:
+            fresh = await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[snapshot],
+            )
+        finally:
+            service._reconciling_projects.discard(str(seeding_env.project.id))
+
+        assert fresh is not None
+        assert [model.slug for model in fresh.data.models] == ["vertex_ai/new-model"]
+        # No second repair: the in-flight request owns it.
+        assert _all_key_update_calls() == []
+        assert seeding_env.vault.update_calls == []
+        # The cached list this snapshot came from is stale, so it is dropped.
+        assert seeding_env.vault.invalidations == [str(seeding_env.project.id)]
+
+    async def test_a_cooling_reader_still_answers_from_the_row(self, seeding_env):
+        # Same for a project inside its cooldown: suppressing another proxy call must not
+        # mean serving stale data.
+        stale = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        snapshot = copy.deepcopy(stale)
+        stale.data.models = [CustomModelSettingsDTO(slug="vertex_ai/new-model")]
+        service._hold_off(str(seeding_env.project.id))
+
+        fresh = await service.reconcile_starter_credits_on_read(
+            project_id=seeding_env.project.id,
+            secrets=[snapshot],
+        )
+
+        assert fresh is not None
+        assert [model.slug for model in fresh.data.models] == ["vertex_ai/new-model"]
+        assert _all_key_update_calls() == []
+
+    async def test_a_failed_read_back_never_reaches_the_caller(self, seeding_env):
+        # The re-read and the cache drop both reach the database. Neither may take the
+        # caller's secrets list down with it.
+        stale = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        service._hold_off(str(seeding_env.project.id))
+
+        async def explode(*args, **kwargs):
+            raise ConnectionError("the database is down")
+
+        seeding_env.monkeypatch.setattr(
+            seeding_env.vault, "get_secret_by_slug", explode
+        )
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[stale],
+            )
+            is None
+        )
+
+    async def test_a_row_that_is_still_stale_hands_nothing_back(self, seeding_env):
+        # Nothing better to give the caller than what it already holds, and the cached list
+        # must not be dropped on every read while a project cannot be repaired.
+        stale = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        service._hold_off(str(seeding_env.project.id))
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[stale],
+            )
+            is None
+        )
+        assert seeding_env.vault.invalidations == []
+
+    async def test_the_read_stands_when_the_repair_fails(self, seeding_env):
+        # A caller must never lose its whole secrets list over a connection that is at
+        # worst as broken as it already was.
+        row = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+
+        async def explode(**kwargs):
+            raise RuntimeError("vault is down")
+
+        seeding_env.monkeypatch.setattr(
+            seeding_env.vault, "update_managed_secret", explode
+        )
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        # The in-flight guard is released and the cooldown is armed, so a later read tries
+        # again without every read in between paying for it.
+        assert service._reconciling_projects == set()
+        assert str(seeding_env.project.id) in service._reconcile_cooldowns
+
+    async def test_a_row_the_bridge_does_not_own_is_left_alone(self, seeding_env):
+        # A user may delete the seeded connection and save their own under the same slug.
+        # That one is theirs to point anywhere.
+        row = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        row.management = None
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        assert _all_key_update_calls() == []
+
+    async def test_a_disarmed_bridge_reads_nothing(self, seeding_env):
+        row = await self._seed_then_cut_the_model_over(
+            seeding_env, funded="vertex_ai/new-model"
+        )
+        seeding_env.monkeypatch.setattr(
+            env,
+            "starter_credits_bridge",
+            _armed_config(model_id="vertex_ai/new-model", enabled=False),
+        )
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        assert _all_key_update_calls() == []
+
+
+class TestTheRepairSurvivesTheMapping:
+    """The repair is only worth anything if it PERSISTS. If the write did not change the
+    stored models, the read path would see the same stale row on every list and send the
+    same repair again, so this pins the round trip through the storage mapping."""
+
+    async def test_the_rewrite_round_trips_through_the_row(self, seeding_env):
+        from oss.src.dbs.postgres.secrets.mappings import (
+            map_secrets_dbe_to_dto,
+            map_secrets_dto_to_dbe,
+            map_secrets_dto_to_dbe_update,
+        )
+
+        await _seed()
+        created = seeding_env.vault.create_dto
+        dbe = map_secrets_dto_to_dbe(
+            project_id=seeding_env.project.id,
+            organization_id=None,
+            secret_dto=created,
+            management=seeding_env.vault.management,
+        )
+        stored = map_secrets_dbe_to_dto(secrets_dbe=dbe)
+        assert [model.slug for model in stored.data.models] == ["vertex_ai/some-model"]
+
+        config = _armed_config(model_id="vertex_ai/new-model")
+        map_secrets_dto_to_dbe_update(
+            secrets_dbe=dbe,
+            update_secret_dto=service._model_update(row=stored, config=config),
+        )
+        rewritten = map_secrets_dbe_to_dto(secrets_dbe=dbe)
+
+        assert [model.slug for model in rewritten.data.models] == [
+            "vertex_ai/new-model"
+        ]
+        # Everything else survives: the credential, the routing URL, the namespace, and
+        # the two server-controlled flags that ride inside the encrypted payload.
+        assert rewritten.data.provider.key == stored.data.provider.key
+        assert rewritten.data.provider.url == stored.data.provider.url
+        assert rewritten.data.provider_slug == service.STARTER_CREDITS_NAME
+        assert rewritten.data.harnesses == ["pi_core"]
+        assert rewritten.write_only is True
+        assert rewritten.management == seeding_env.vault.management
+        # The published namespaced key follows the new model, so the row stops offering
+        # the old one to the picker and to the runtime resolver.
+        assert rewritten.data.model_keys == [
+            f"{service.STARTER_CREDITS_NAME}/custom/vertex_ai/new-model"
+        ]
+
+    async def test_a_row_with_no_key_is_not_rewritten(self, seeding_env):
+        # A credential-less row cannot run any model, so a repair would fix nothing and the
+        # read path would send it again on every list.
+        await _seed()
+        row = seeding_env.vault.row
+        row.data.provider.key = None
+        seeding_env.monkeypatch.setattr(
+            env,
+            "starter_credits_bridge",
+            _armed_config(model_id="vertex_ai/new-model"),
+        )
+
+        assert (
+            await service.reconcile_starter_credits_on_read(
+                project_id=seeding_env.project.id,
+                secrets=[row],
+            )
+            is None
+        )
+        assert seeding_env.vault.update_calls == []
+        assert _all_key_update_calls() == []

--- a/api/oss/src/apis/fastapi/vault/router.py
+++ b/api/oss/src/apis/fastapi/vault/router.py
@@ -6,6 +6,7 @@ from fastapi import APIRouter, Request, status, HTTPException
 from fastapi.exceptions import RequestValidationError
 from fastapi.routing import APIRoute
 
+from oss.src.utils.common import is_ee
 from oss.src.utils.logging import get_module_logger
 from oss.src.utils.exceptions import intercept_exceptions
 
@@ -27,6 +28,16 @@ from oss.src.middlewares.auth import SECRET_RESOLVE_GRANT, request_has_grant
 
 
 log = get_module_logger(__name__)
+
+
+if is_ee():
+    from ee.src.core.starter_credits_bridge.service import (  # noqa: E402
+        reconcile_starter_credits_on_read,
+    )
+else:  # OSS seeds no managed connection, so there is nothing to reconcile.
+
+    async def reconcile_starter_credits_on_read(*, project_id, secrets):  # type: ignore[misc]
+        return None
 
 
 class SecretSafeRoute(APIRoute):
@@ -160,9 +171,33 @@ class VaultRouter:
                 status_code=403,
             )
 
-        secrets_dtos = await self.service.list_secrets(
-            project_id=UUID(request.state.project_id),
-        )
+        project_id = UUID(request.state.project_id)
+        secrets_dtos = await self.service.list_secrets(project_id=project_id)
+
+        # The one path that revisits an Agenta-managed connection after it was seeded. A
+        # seeded value can go stale (the funded model of a starter-credits connection gets
+        # cut over), and nothing else ever reads that row again: seeding runs at signup
+        # only. The call scans the list already in hand and does nothing when it is
+        # current, and it never raises, so the read stands either way.
+        try:
+            repaired = await reconcile_starter_credits_on_read(
+                project_id=project_id,
+                secrets=secrets_dtos,
+            )
+        except Exception:
+            # The repair guarantees this itself; the guard is here so the guarantee is
+            # structural. Losing a whole secrets list over a repair would be far worse
+            # than the stale connection the repair was for.
+            log.warning(
+                "[vault] managed-secret reconcile failed; the read stands",
+                exc_info=True,
+            )
+            repaired = None
+        if repaired is not None:
+            secrets_dtos = [
+                repaired if secret_dto.slug == repaired.slug else secret_dto
+                for secret_dto in secrets_dtos
+            ]
 
         return [self._for_caller(request, secret_dto) for secret_dto in secrets_dtos]
 

--- a/api/oss/src/core/secrets/services.py
+++ b/api/oss/src/core/secrets/services.py
@@ -29,6 +29,7 @@ from oss.src.core.secrets.dtos import (
 from oss.src.core.secrets.managed import (
     ManagedSecretReadOnlyError,
     SecretManagementDTO,
+    SecretManager,
 )
 
 
@@ -191,6 +192,40 @@ def _resolve_update(
     stored_secret_dto: SecretResponseDTO,
     requested_update: UpdateSecretDTO,
 ) -> UpdateSecretDTO:
+    """Resolve a CALLER update: a managed row is read-only, every other row merges."""
+    if stored_secret_dto.management is not None:
+        raise ManagedSecretReadOnlyError()
+
+    return _merge_update(stored_secret_dto, requested_update)
+
+
+def _resolve_managed_update(manager: SecretManager):
+    """Resolve an update issued by a managed row's OWN manager.
+
+    The read-only rule exists so a caller cannot edit a row the platform owns. It must not
+    stop the owning manager itself from repairing that row: a seeded value can go stale
+    (the funded model of a starter-credits connection, say), and only the manager knows
+    the current one. The merge below is the same one every other update runs.
+    """
+
+    def resolve(
+        stored_secret_dto: SecretResponseDTO,
+        requested_update: UpdateSecretDTO,
+    ) -> UpdateSecretDTO:
+        management = stored_secret_dto.management
+
+        if management is None or management.manager != manager:
+            raise ManagedSecretReadOnlyError()
+
+        return _merge_update(stored_secret_dto, requested_update)
+
+    return resolve
+
+
+def _merge_update(
+    stored_secret_dto: SecretResponseDTO,
+    requested_update: UpdateSecretDTO,
+) -> UpdateSecretDTO:
     """Fill this update's omitted credential from the row UNDER THE WRITE LOCK.
 
     Called by the DAO inside the locked transaction rather than by the service before it,
@@ -202,9 +237,6 @@ def _resolve_update(
     another kind's or another provider's credential — and that decision reads the same
     stored row, so it belongs under the same lock.
     """
-    if stored_secret_dto.management is not None:
-        raise ManagedSecretReadOnlyError()
-
     resolved_update = requested_update.model_copy(deep=True)
     if resolved_update.secret is None:
         return UpdateSecretDTO.model_validate(resolved_update.model_dump(mode="python"))
@@ -486,6 +518,44 @@ class VaultService:
         if project_id is not None:
             await invalidate_cache(project_id=str(project_id))
         return secret_dto
+
+    async def update_managed_secret(
+        self,
+        *,
+        secret_id: UUID,
+        update_secret_dto: UpdateSecretDTO,
+        manager: SecretManager,
+        project_id: UUID | None = None,
+        organization_id: UUID | None = None,
+    ):
+        """Rewrite a managed row on behalf of the manager that owns it.
+
+        Refuses any row another manager owns, and any unmanaged row: this path exists to
+        repair what the platform seeded, never to edit what a user saved.
+        """
+        with set_data_encryption_key(
+            data_encryption_key=self._data_encryption_key,
+        ):
+            secret_dto = await self.secrets_dao.update(
+                secret_id=secret_id,
+                update_secret_dto=update_secret_dto,
+                project_id=project_id,
+                organization_id=organization_id,
+                resolve_update=_resolve_managed_update(manager),
+            )
+
+        if project_id is not None:
+            await invalidate_cache(project_id=str(project_id))
+        return secret_dto
+
+    async def invalidate_secrets_cache(self, project_id: UUID) -> None:
+        """Drop this project's cached secrets list.
+
+        The vault owns list-cache invalidation so every writer goes through one path. A
+        reader that finds the cached list disagrees with the stored row needs the same door,
+        rather than reaching for the cache helper itself.
+        """
+        await invalidate_cache(project_id=str(project_id))
 
     async def delete_secret(
         self,

--- a/api/oss/tests/pytest/unit/secrets/test_managed_secrets.py
+++ b/api/oss/tests/pytest/unit/secrets/test_managed_secrets.py
@@ -73,6 +73,13 @@ class _DAO:
     ):
         if resolve_update:
             update_secret_dto = resolve_update(self.record, update_secret_dto)
+        # Apply it, the way the real DAO does. A fake that returns the row untouched lets a
+        # test claiming the update landed pass against an update that changed nothing.
+        if update_secret_dto.header is not None:
+            self.record.header = update_secret_dto.header
+        if update_secret_dto.secret is not None:
+            self.record.kind = update_secret_dto.secret.kind
+            self.record.data = update_secret_dto.secret.data
         return self.record
 
     async def delete(
@@ -154,3 +161,54 @@ def test_mapping_round_trip_uses_structured_management_without_flat_fallback():
     dbe.data = json.dumps(payload)
     legacy = map_secrets_dbe_to_dto(secrets_dbe=dbe)
     assert legacy.management is None
+
+
+@pytest.mark.asyncio
+async def test_the_owning_manager_may_rewrite_a_managed_secret():
+    # The read-only rule stops a CALLER editing a platform-owned row. The manager that owns
+    # the row has to be able to repair it: a seeded value can go stale, and only the manager
+    # knows the current one.
+    service = VaultService(_DAO())
+    created = await service.create_managed_secret(
+        project_id=PROJECT_ID,
+        create_secret_dto=_create(write_only=True),
+        management=_management(),
+    )
+
+    updated = await service.update_managed_secret(
+        secret_id=created.id,
+        project_id=PROJECT_ID,
+        update_secret_dto=UpdateSecretDTO(
+            header={"name": "Renamed"},
+            secret={
+                "kind": "provider_key",
+                "data": {"kind": "openai", "provider": {}},
+            },
+        ),
+        manager=SecretManager.STARTER_CREDITS_BRIDGE,
+    )
+
+    assert updated.header.name == "Renamed"
+    # The row keeps what it is and what it holds: still managed, still write-only, and the
+    # credential the update omitted was carried over rather than wiped.
+    assert updated.data.provider.key == "sk-managed"
+    assert updated.management == _management()
+    assert updated.write_only is True
+
+
+@pytest.mark.asyncio
+async def test_the_manager_path_refuses_a_row_no_manager_owns():
+    # The path exists to repair what the platform seeded, never to edit what a user saved.
+    service = VaultService(_DAO())
+    created = await service.create_secret(
+        project_id=PROJECT_ID,
+        create_secret_dto=_create(write_only=False),
+    )
+
+    with pytest.raises(ManagedSecretReadOnlyError):
+        await service.update_managed_secret(
+            secret_id=created.id,
+            project_id=PROJECT_ID,
+            update_secret_dto=UpdateSecretDTO(header={"name": "No"}),
+            manager=SecretManager.STARTER_CREDITS_BRIDGE,
+        )

--- a/api/oss/tests/pytest/unit/secrets/test_vault_router_reconcile.py
+++ b/api/oss/tests/pytest/unit/secrets/test_vault_router_reconcile.py
@@ -1,0 +1,101 @@
+"""The vault list route is the one path that revisits an Agenta-managed connection after
+it was seeded, so it is where a stale seeded value is repaired."""
+
+from types import SimpleNamespace
+from uuid import uuid4
+
+import pytest
+
+from oss.src.apis.fastapi.vault import router as vault_router
+from oss.src.core.secrets.dtos import SecretResponseDTO
+
+
+PROJECT_ID = uuid4()
+
+
+def _row(model: str) -> SecretResponseDTO:
+    return SecretResponseDTO(
+        id=uuid4(),
+        slug="starter-credits",
+        kind="custom_provider",
+        data={
+            "kind": "custom",
+            "provider_slug": "Agenta",
+            "provider": {"url": "https://credits.example.test", "key": "sk-virtual"},
+            "models": [{"slug": model}],
+        },
+        header={"name": "Agenta"},
+        write_only=True,
+        management={"manager": "starter-credits-bridge", "policy": "manager_only"},
+    )
+
+
+class _Service:
+    def __init__(self, rows):
+        self.rows = rows
+
+    async def list_secrets(self, project_id):
+        return list(self.rows)
+
+
+def _request():
+    return SimpleNamespace(
+        state=SimpleNamespace(user_id=str(uuid4()), project_id=str(PROJECT_ID))
+    )
+
+
+@pytest.fixture
+def route(monkeypatch):
+    async def allowed(**kwargs):
+        return True
+
+    monkeypatch.setattr(vault_router, "check_action_access", allowed)
+    monkeypatch.setattr(vault_router, "request_has_grant", lambda request, grant: False)
+    return vault_router.VaultRouter
+
+
+@pytest.mark.asyncio
+async def test_a_stale_row_is_read_back_repaired(route, monkeypatch):
+    stale = _row("vertex_ai/old-model")
+    repaired = _row("vertex_ai/new-model")
+    calls = []
+
+    async def reconcile(*, project_id, secrets):
+        calls.append((project_id, [secret.slug for secret in secrets]))
+        return repaired
+
+    monkeypatch.setattr(vault_router, "reconcile_starter_credits_on_read", reconcile)
+
+    response = await route(_Service([stale])).list_secrets(_request())
+
+    assert calls == [(PROJECT_ID, ["starter-credits"])]
+    (secret,) = response
+    assert [model.slug for model in secret.data.models] == ["vertex_ai/new-model"]
+
+
+@pytest.mark.asyncio
+async def test_a_current_row_is_returned_as_read(route, monkeypatch):
+    current = _row("vertex_ai/new-model")
+
+    async def reconcile(*, project_id, secrets):
+        return None
+
+    monkeypatch.setattr(vault_router, "reconcile_starter_credits_on_read", reconcile)
+
+    (secret,) = await route(_Service([current])).list_secrets(_request())
+
+    assert [model.slug for model in secret.data.models] == ["vertex_ai/new-model"]
+
+
+@pytest.mark.asyncio
+async def test_a_failed_reconcile_never_fails_the_read(route, monkeypatch):
+    current = _row("vertex_ai/old-model")
+
+    async def reconcile(*, project_id, secrets):
+        raise RuntimeError("proxy is down")
+
+    monkeypatch.setattr(vault_router, "reconcile_starter_credits_on_read", reconcile)
+
+    (secret,) = await route(_Service([current])).list_secrets(_request())
+
+    assert [model.slug for model in secret.data.models] == ["vertex_ai/old-model"]

--- a/sdks/python/agenta/sdk/agents/dtos.py
+++ b/sdks/python/agenta/sdk/agents/dtos.py
@@ -23,6 +23,7 @@ from pydantic import (
 )
 
 from agenta.sdk.engines.running.errors import ERRORS_BASE_URL, ErrorStatus
+from agenta.sdk.utils.logging import get_module_logger
 
 from .connections import EnvironmentCredentialBinding, ModelRef, ResolvedConnection
 from .mcp import (
@@ -34,8 +35,36 @@ from .mcp import (
 from .pi_builtins import PI_BUILTIN_TOOL_NAMES
 from .skills import SkillTemplate, parse_skill_templates, skills_to_wire
 from .permission_rules import wire_author_permission_rules
-from .tools import ToolCallback, ToolConfig, ToolSpec, coerce_tool_configs
+from .tools import (
+    ToolCallback,
+    ToolConfig,
+    ToolConfigurationError,
+    ToolSpec,
+    coerce_tool_configs,
+)
 from .tools.models import PermissionMode, ResolvedGatewayPolicy, coerce_tool_spec
+
+log = get_module_logger(__name__)
+
+
+def _is_legacy_gateway_entry(entry: Any) -> bool:
+    """Whether an entry is the pre-rework one-action gateway shape.
+
+    The tag alone does not say so. A current-format ``gateway`` entry is still authored
+    today, and a malformed one is a mistake its author must see, so the entry has to carry a
+    positive mark of its age before it may be dropped:
+
+    * ``provider_action``, the field name the pre-2026-08-27 writer used, or
+    * neither ``action`` nor ``connection``, which no current-format entry can be missing.
+
+    ``composio`` is the same shape under its older name: ``coerce_tool_config`` renames it
+    before it parses, so a refusal for either spelling names the same legacy entry.
+    """
+    if not isinstance(entry, dict) or entry.get("type") not in {"gateway", "composio"}:
+        return False
+    if entry.get("provider_action"):
+        return True
+    return not entry.get("action") and not entry.get("connection")
 
 
 # ---------------------------------------------------------------------------
@@ -716,7 +745,33 @@ class AgentTemplate(BaseModel):
     @field_validator("tools", mode="before")
     @classmethod
     def _coerce_tools(cls, value: Any) -> List[ToolConfig]:
-        return coerce_tool_configs(_as_list(value)).tool_configs
+        # Tolerance is deliberately narrow. A legacy ``gateway`` entry predates the rework
+        # and no migration ever rewrote one, so an unrepairable one is dropped rather than
+        # allowed to fail every run of an agent nobody can edit back into shape.
+        #
+        # Every OTHER refusal still fails the run, loudly and unchanged: a typo in a tool
+        # name, a malformed connection entry, and two conflicting policies for the same
+        # integration are all real misconfigurations the author must see. Dropping those
+        # would take a tool the author believes is configured and make it vanish in silence.
+        entries = _as_list(value)
+        result = coerce_tool_configs(entries, on_error="collect")
+        for diagnostic in result.diagnostics:
+            entry = (
+                entries[diagnostic.index]
+                if 0 <= diagnostic.index < len(entries)
+                else None
+            )
+            if not _is_legacy_gateway_entry(entry):
+                raise ToolConfigurationError(
+                    diagnostic.message,
+                    index=diagnostic.index,
+                    value=entry,
+                )
+            log.warning(
+                "agent: dropped an unrepairable legacy gateway tool entry: %s",
+                diagnostic.message,
+            )
+        return result.tool_configs
 
     @field_validator("mcp_servers", mode="before")
     @classmethod

--- a/sdks/python/agenta/sdk/agents/platform/connections.py
+++ b/sdks/python/agenta/sdk/agents/platform/connections.py
@@ -50,6 +50,11 @@ log = get_module_logger(__name__)
 # Canonical map lives in capabilities.py; this alias keeps the local name callers already use.
 _PROVIDER_ENV_VARS: Dict[str, str] = PROVIDER_ENV_VARS
 
+# The slug of the Agenta-funded starter-credits connection. It is the one connection whose
+# model list the user does not choose: Agenta seeds it, and Agenta re-points it when the
+# funded model is cut over. The same literal is `STARTER_CREDITS_SLUG` on the API side.
+STARTER_CREDITS_SLUG = "starter-credits"
+
 # The Claude harness selects a model by a bare alias (``haiku``/``sonnet``/``opus`` + ``[1m]``)
 # or by a dated id (``claude-opus-4-8``), never with a ``provider/`` prefix. Those bare ids are
 # unambiguously Anthropic, so the F-017 "needs a provider prefix" rule must not reject them: a
@@ -319,6 +324,9 @@ class _ConnectionCandidate:
     # True when value_status says a credential exists but this caller's
     # credential received the redacted, value-less shape.
     write_only_redacted: bool = False
+    # True when the vault says Agenta manages this row rather than the user. Only a managed
+    # row's model list is Agenta's to re-point, so only a managed row may be substituted.
+    managed: bool = False
 
     def matches_provider(self, provider: Optional[str]) -> bool:
         return bool(
@@ -371,8 +379,42 @@ class _ConnectionCandidate:
         if model.model in self.model_slugs:
             return model.model
         if model.model.startswith(prefix):
-            return model.model[len(prefix) :]
-        return model.model
+            stripped = model.model[len(prefix) :]
+            # The strip runs before the fallback, so an id spelled ``custom/<model>`` would
+            # otherwise reach the upstream stale, having matched nothing this connection has.
+            if stripped in self.model_slugs:
+                return stripped
+            return self._funded_starter_credits_model(model) or stripped
+        return self._funded_starter_credits_model(model) or model.model
+
+    def _funded_starter_credits_model(self, model: ModelRef) -> Optional[str]:
+        """The funded model, when a saved id names one this connection no longer offers.
+
+        The Agenta-funded starter-credits connection routes to a proxy that serves exactly one
+        model, and that model gets cut over. A revision saved before a cutover still names the
+        old id, so every turn fails upstream with an invalid-model error even though the
+        connection is healthy. The connection itself states what is funded now, so run that and
+        say so in the log.
+
+        Deliberately narrow. It applies to this one connection, only while Agenta manages it,
+        only when it offers exactly one model, and only after every match above missed. A user
+        may save their own connection under this slug, and their model list is theirs. Every
+        other connection keeps failing upstream, which is correct: silently running a model the
+        user did not pick would misreport what ran.
+        """
+        if self.slug != STARTER_CREDITS_SLUG or not self.managed:
+            return None
+        if len(self.model_slugs) != 1:
+            return None
+
+        funded = next(iter(self.model_slugs))
+        log.warning(
+            "starter credits: the saved model is not funded any more; using the funded one",
+            saved_model=model.model,
+            funded_model=funded,
+            slug=self.slug,
+        )
+        return funded
 
     def resolved_provider(self, model: ModelRef) -> str:
         if model.provider:
@@ -543,7 +585,20 @@ def _custom_provider_candidate(
         write_only_redacted=_write_only_redacted(
             secret, bool(api_key) or bool(credential_extras(extras))
         ),
+        managed=_managed(secret),
     )
+
+
+def _managed(secret: Dict[str, Any]) -> bool:
+    """Whether the vault says Agenta manages this row rather than the user.
+
+    The public secret carries the management POLICY (never the manager's name), and any
+    policy at all means the row is not the user's to edit. That is the property the funded
+    fallback needs: a user may save their own connection under any slug, including this
+    one's, and their model list is theirs.
+    """
+    management = secret.get("management")
+    return isinstance(management, dict) and bool(management.get("policy"))
 
 
 def _catalog(secrets: Iterable[Any]) -> List[_ConnectionCandidate]:

--- a/sdks/python/agenta/sdk/agents/tools/compat.py
+++ b/sdks/python/agenta/sdk/agents/tools/compat.py
@@ -60,6 +60,32 @@ def _copy_tool_metadata(
     return result
 
 
+def _action_key_from_provider_action(
+    provider_action: Any, integration: Any
+) -> Optional[str]:
+    """The catalog tool key a legacy ``provider_action`` names, or ``None``.
+
+    ``provider_action`` holds the PROVIDER action id, which carries the integration as a
+    prefix (``GITHUB_GET_AN_ISSUE``). The ``action`` field holds the catalog key, which does
+    not (``GET_AN_ISSUE``), and the backend resolves a legacy reference by that key alone.
+    Copying the id across verbatim would name a tool no catalog carries, so strip the prefix
+    exactly as the catalog does when it derives the key.
+
+    "Exactly" includes the case rule. The catalog upper-cases the INTEGRATION to build the
+    prefix and then matches the raw provider id against it, so a lower-case prefix on the id
+    is not a prefix at all and stays part of the key. Matching case-insensitively here would
+    strip a prefix the catalog keeps, and turn a key that was already correct into one no
+    catalog holds.
+    """
+    if not isinstance(provider_action, str) or not provider_action:
+        return None
+    if isinstance(integration, str) and integration:
+        prefix = f"{integration.upper()}_"
+        if provider_action.startswith(prefix):
+            return provider_action[len(prefix) :]
+    return provider_action
+
+
 def coerce_tool_config(value: Any) -> ToolConfig:
     """Convert one supported legacy shape into canonical tool configuration."""
     if isinstance(
@@ -87,6 +113,19 @@ def coerce_tool_config(value: Any) -> ToolConfig:
     if data.get("type") == "composio":
         data["type"] = "gateway"
         data.setdefault("provider", "composio")
+
+    # Pre-2026-08-27 ``gateway`` entries spelled the action ``provider_action``, the field
+    # name the discovery response uses. No migration ever rewrote them, so translate on
+    # read. The key is dropped either way: the arm forbids extras, so leaving it beside a
+    # canonical ``action`` would refuse the entry for the field it no longer needs.
+    if data.get("type") == "gateway":
+        provider_action = data.pop("provider_action", None)
+        if not data.get("action"):
+            action = _action_key_from_provider_action(
+                provider_action, data.get("integration")
+            )
+            if action:
+                data["action"] = action
 
     if data.get("type") in {
         "builtin",

--- a/sdks/python/agenta/sdk/agents/tools/models.py
+++ b/sdks/python/agenta/sdk/agents/tools/models.py
@@ -213,7 +213,9 @@ class GatewayPermissions(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    default: GatewayPermission
+    # ``inherit`` is the safe absent value: the compiler defers every tool to the
+    # agent-wide runner mode, which is what an entry saved without a policy means.
+    default: GatewayPermission = "inherit"
     tools: Dict[Annotated[str, Field(min_length=1)], GatewayPermission] = Field(
         default_factory=dict
     )
@@ -225,7 +227,7 @@ class GatewayConnectionPolicy(BaseModel):
 
     model_config = ConfigDict(extra="forbid")
 
-    permissions: GatewayPermissions
+    permissions: GatewayPermissions = Field(default_factory=GatewayPermissions)
 
 
 class GatewayConnectionToolConfig(BaseModel):
@@ -247,7 +249,10 @@ class GatewayConnectionToolConfig(BaseModel):
 
     type: Literal["gateway_connection"] = "gateway_connection"
     connection: GatewayConnectionRef
-    policy: GatewayConnectionPolicy
+    # Defaulted, not required. The commit path does not validate an entry against this
+    # model, so an entry written without ``policy`` must mean "inherit the runner policy"
+    # rather than fail the run at parse time.
+    policy: GatewayConnectionPolicy = Field(default_factory=GatewayConnectionPolicy)
 
 
 class CompiledTool(BaseModel):

--- a/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/platform/test_connections_http.py
@@ -840,6 +840,148 @@ async def test_bare_backend_model_id_is_left_untouched(fake_http, connection):
     assert resolved.model == _BACKEND_MODEL
 
 
+# ------------------------------------------ a starter-credits model that is no longer funded
+
+# What the proxy funds after a cutover; `_BACKEND_MODEL` above is what it funded before one.
+_FUNDED_MODEL = "vertex_ai/gemini-3.7-flash"
+
+
+def _funded_starter_credits(
+    *,
+    name: str = "Agenta",
+    slug: str = "starter-credits",
+    managed: bool = True,
+) -> dict:
+    """The seeded connection after Agenta re-pointed it at the model funded today.
+
+    The vault marks it managed, which is what says the model list is Agenta's and not the
+    user's. The public secret carries the policy only, never the manager's name.
+    """
+    secret = _custom_provider(
+        name,
+        "custom",
+        key="sk-gateway",
+        url=_GATEWAY_URL,
+        models=[_FUNDED_MODEL],
+        slug=slug,
+    )
+    if managed:
+        secret["management"] = {"policy": "manager_only"}
+    return secret
+
+
+async def test_a_stale_starter_credits_model_runs_the_funded_one(fake_http, connection):
+    # The starter-credits proxy serves exactly one model and that model gets cut over. A
+    # revision saved before a cutover still names the old id, and sending it upstream fails
+    # every turn with "Invalid model name passed in model=vertex_ai/gemini-3.6-flash". The
+    # connection states what is funded now, so run that instead of a certain failure.
+    fake_http(connections, payload=[_funded_starter_credits()])
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            model=f"Agenta/custom/{_BACKEND_MODEL}",
+            connection={"mode": "agenta", "slug": "starter-credits"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _FUNDED_MODEL
+
+
+async def test_a_stale_bare_starter_credits_model_runs_the_funded_one(
+    fake_http, connection
+):
+    # The same substitution for the un-namespaced spelling of the saved id.
+    fake_http(connections, payload=[_funded_starter_credits()])
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            provider="openai",
+            model=_BACKEND_MODEL,
+            connection={"mode": "agenta", "slug": "starter-credits"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _FUNDED_MODEL
+
+
+async def test_a_current_starter_credits_model_is_left_untouched(fake_http, connection):
+    # The substitution must be reachable only after every match misses.
+    fake_http(connections, payload=[_funded_starter_credits()])
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            model=f"Agenta/custom/{_FUNDED_MODEL}",
+            connection={"mode": "agenta", "slug": "starter-credits"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _FUNDED_MODEL
+
+
+async def test_a_stale_deployment_prefixed_model_runs_the_funded_one(
+    fake_http, connection
+):
+    # The namespace strip runs before the fallback, so this spelling would otherwise reach
+    # the upstream stale, having matched nothing the connection has.
+    fake_http(connections, payload=[_funded_starter_credits()])
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            provider="openai",
+            model=f"custom/{_BACKEND_MODEL}",
+            connection={"mode": "agenta", "slug": "starter-credits"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _FUNDED_MODEL
+
+
+async def test_a_connection_the_user_owns_under_the_slug_is_left_untouched(
+    fake_http, connection
+):
+    # A user may save their own connection under any slug, this one included. Their model
+    # list is theirs, so nothing may be substituted into it.
+    fake_http(connections, payload=[_funded_starter_credits(managed=False)])
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            provider="openai",
+            model=_BACKEND_MODEL,
+            connection={"mode": "agenta", "slug": "starter-credits"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _BACKEND_MODEL
+
+
+async def test_another_connections_unknown_model_is_left_untouched(
+    fake_http, connection
+):
+    # Only the Agenta-funded connection substitutes. On a connection the user configured,
+    # running a model they did not pick would misreport what ran, so the id goes upstream
+    # unchanged and fails there.
+    fake_http(
+        connections,
+        payload=[_funded_starter_credits(name="My gateway", slug="my-gateway")],
+    )
+
+    resolved = await VaultConnectionResolver(connection).resolve(
+        model=ModelRef(
+            provider="openai",
+            model=_BACKEND_MODEL,
+            connection={"mode": "agenta", "slug": "my-gateway"},
+        ),
+        context=_context(),
+    )
+
+    assert resolved.model == _BACKEND_MODEL
+
+
 async def test_provider_key_model_id_is_unaffected(fake_http, connection):
     # A plain provider key stores no namespaced model keys; its model id must survive verbatim.
     fake_http(

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_gateway_connection_config.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_gateway_connection_config.py
@@ -99,17 +99,21 @@ def test_tools_defaults_to_an_empty_map():
 # --- C20 to C23: validation --------------------------------------------------------
 
 
-def test_a_missing_default_is_rejected():
-    # C20. Without a default there is no answer for a catalog tool the entry never names.
-    with pytest.raises(ToolConfigurationError):
-        parse_tool_config(_entry(policy={"permissions": {"tools": {}}}))
+def test_a_missing_default_means_inherit():
+    # C20, relaxed. A catalog tool the entry never names still needs an answer, and
+    # `inherit` is one: it defers to the agent-wide runner mode. Refusing the entry instead
+    # failed every invoke of an agent whose saved entry was written without the field. The
+    # tolerance cases live in test_saved_entry_tolerance.py.
+    config = parse_tool_config(_entry(policy={"permissions": {"tools": {}}}))
+    assert config.policy.permissions.default == "inherit"
 
 
-def test_a_missing_policy_is_rejected():
-    with pytest.raises(ToolConfigurationError):
-        parse_tool_config(
-            {key: value for key, value in _ENTRY.items() if key != "policy"}
-        )
+def test_a_missing_policy_means_inherit():
+    config = parse_tool_config(
+        {key: value for key, value in _ENTRY.items() if key != "policy"}
+    )
+    assert config.policy.permissions.default == "inherit"
+    assert config.policy.permissions.tools == {}
 
 
 @pytest.mark.parametrize(

--- a/sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py
+++ b/sdks/python/oss/tests/pytest/unit/agents/tools/test_saved_entry_tolerance.py
@@ -1,0 +1,329 @@
+"""Tolerance for saved tool entries the strict parser used to refuse.
+
+A revision's tool entries are never validated against these models when they are written:
+the agent's own ``commit_revision`` writes free JSON, and the commit gate validates only the
+revision DTO, whose ``parameters`` is an open dict. Two shapes reached production and failed
+every invoke with a 500 at config-parse time:
+
+* a ``gateway_connection`` entry with no ``policy`` node,
+* a pre-2026-08-27 ``gateway`` entry that spells the action ``provider_action``.
+
+An unrunnable entry must cost its own tool, never the whole run.
+"""
+
+from __future__ import annotations
+
+from typing import Any, List, Tuple
+
+import pytest
+
+from agenta.sdk.agents.dtos import AgentTemplate
+from agenta.sdk.agents.platform.gateway import _to_gateway_reference
+from agenta.sdk.agents.tools import (
+    GatewayConnectionToolConfig,
+    GatewayToolConfig,
+    ToolConfigurationError,
+    coerce_tool_config,
+    coerce_tool_configs,
+    parse_tool_config,
+)
+from agenta.sdk.agents.tools.gateway_policy import (
+    CatalogToolInfo,
+    compile_gateway_permissions,
+)
+
+# Shape A, exactly as production saved it: the three routing fields, no policy.
+_NO_POLICY_ENTRY = {
+    "type": "gateway_connection",
+    "connection": {
+        "provider": "composio",
+        "integration": "github",
+        "slug": "github-work",
+    },
+}
+
+# Shape B: the legacy action field name, which no migration ever rewrote.
+_PROVIDER_ACTION_ENTRY = {
+    "type": "gateway",
+    "provider": "composio",
+    "integration": "github",
+    "provider_action": "GITHUB_GET_AN_ISSUE",
+    "connection": "github-work",
+}
+
+_CLIENT_ENTRY = {
+    "type": "client",
+    "name": "ask_user",
+    "description": "Ask the caller.",
+    "input_schema": {"type": "object"},
+}
+
+
+# --- Shape A: a connection entry with no policy -------------------------------------
+
+
+def test_a_connection_entry_without_a_policy_parses():
+    config = parse_tool_config(_NO_POLICY_ENTRY)
+    assert isinstance(config, GatewayConnectionToolConfig)
+    assert config.connection.slug == "github-work"
+
+
+def test_an_absent_policy_means_inherit():
+    # Absent is not "allow" and not "deny": every tool defers to the agent-wide mode, which
+    # is what the runner would have applied had the entry never been configured at all.
+    config = parse_tool_config(_NO_POLICY_ENTRY)
+    assert config.policy.permissions.default == "inherit"
+    assert config.policy.permissions.tools == {}
+
+
+def test_an_absent_policy_compiles_to_the_agent_wide_mode():
+    config = parse_tool_config(_NO_POLICY_ENTRY)
+    compiled = compile_gateway_permissions(
+        config.policy.permissions,
+        [
+            CatalogToolInfo(key="GITHUB_GET_AN_ISSUE", read_only=True),
+            CatalogToolInfo(key="GITHUB_CREATE_AN_ISSUE", read_only=False),
+        ],
+        "allow_reads",
+    )
+    assert compiled.tools["GITHUB_GET_AN_ISSUE"].permission == "allow"
+    assert compiled.tools["GITHUB_CREATE_AN_ISSUE"].permission == "ask"
+    assert compiled.stale_keys == []
+
+
+def test_an_explicit_policy_still_wins():
+    # The default must not overwrite an authored policy, in either direction.
+    config = parse_tool_config(
+        {
+            **_NO_POLICY_ENTRY,
+            "policy": {
+                "permissions": {
+                    "default": "deny",
+                    "tools": {"GITHUB_GET_AN_ISSUE": "allow"},
+                }
+            },
+        }
+    )
+    assert config.policy.permissions.default == "deny"
+    assert config.policy.permissions.tools == {"GITHUB_GET_AN_ISSUE": "allow"}
+
+
+# --- Shape B: the legacy provider_action spelling -----------------------------------
+
+
+def test_provider_action_is_read_as_the_action():
+    # The translation lives in the compat layer, which is what every reader of a SAVED
+    # revision goes through. `parse_tool_config` stays strict on the canonical spelling.
+    config = coerce_tool_config(_PROVIDER_ACTION_ENTRY)
+    assert isinstance(config, GatewayToolConfig)
+    assert config.connection == "github-work"
+
+
+def test_the_integration_prefix_is_stripped_from_a_provider_action():
+    # The backend resolves a legacy reference by the CATALOG KEY, which carries no
+    # integration prefix. A verbatim copy of the provider action id would name a tool the
+    # catalog does not hold, and the run would drop the tool as stale.
+    config = coerce_tool_config(_PROVIDER_ACTION_ENTRY)
+    assert config.action == "GET_AN_ISSUE"
+
+
+def test_a_provider_action_without_the_prefix_is_kept_whole():
+    config = coerce_tool_config(
+        {**_PROVIDER_ACTION_ENTRY, "provider_action": "GET_AN_ISSUE"}
+    )
+    assert config.action == "GET_AN_ISSUE"
+
+
+def test_an_integration_whose_case_differs_still_strips_the_prefix():
+    # The catalog builds the prefix from the UPPER-CASED integration, so the integration's
+    # own case never decides the key.
+    config = coerce_tool_config({**_PROVIDER_ACTION_ENTRY, "integration": "GitHub"})
+    assert config.action == "GET_AN_ISSUE"
+
+
+def test_a_lower_case_prefix_on_the_provider_id_is_not_stripped():
+    # The catalog matches the RAW provider id against that upper-cased prefix, so a
+    # lower-case prefix is not a prefix and stays part of the key. Stripping it here would
+    # turn a key the catalog holds into one it does not.
+    config = coerce_tool_config(
+        {**_PROVIDER_ACTION_ENTRY, "provider_action": "github_GET_AN_ISSUE"}
+    )
+    assert config.action == "github_GET_AN_ISSUE"
+
+
+def test_an_integration_with_an_underscore_strips_its_whole_prefix():
+    config = coerce_tool_config(
+        {
+            **_PROVIDER_ACTION_ENTRY,
+            "integration": "google_drive",
+            "provider_action": "GOOGLE_DRIVE_LIST_FILES",
+        }
+    )
+    assert config.action == "LIST_FILES"
+
+
+def test_a_translated_entry_carries_the_catalog_key_in_its_gateway_reference():
+    # The reference the resolver sends to the backend is where the key has to be right: the
+    # backend matches it against the catalog key, so a provider id here resolves to nothing
+    # and the tool is dropped as stale at run time instead of running. This pins the
+    # serialized reference, not the HTTP resolution behind it.
+    reference = _to_gateway_reference(coerce_tool_config(_PROVIDER_ACTION_ENTRY))
+    assert reference == {
+        "type": "gateway",
+        "provider": "composio",
+        "integration": "github",
+        "action": "GET_AN_ISSUE",
+        "connection": "github-work",
+    }
+
+
+def test_an_explicit_action_wins_over_provider_action():
+    config = coerce_tool_config(
+        {**_PROVIDER_ACTION_ENTRY, "action": "GITHUB_CREATE_AN_ISSUE"}
+    )
+    assert config.action == "GITHUB_CREATE_AN_ISSUE"
+
+
+# --- An entry that cannot be repaired -----------------------------------------------
+
+
+def test_an_unrepairable_gateway_entry_is_collected_not_raised():
+    # No action under either spelling and no connection: there is nothing to run. It is
+    # reported per entry so the caller can drop it.
+    result = coerce_tool_configs(
+        [{"type": "gateway", "provider": "composio", "integration": "github"}],
+        on_error="collect",
+    )
+    assert result.tool_configs == []
+    assert [d.index for d in result.diagnostics] == [0]
+
+
+class _RecordingLog:
+    def __init__(self) -> None:
+        self.warnings: List[Tuple[str, Any]] = []
+
+    def warning(self, message: str, *args: Any) -> None:
+        self.warnings.append((message, args))
+
+
+def test_an_unrepairable_entry_is_dropped_with_a_warning_and_the_rest_survive(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # The whole point of the fix: one dead entry costs its own tool, not the agent's run.
+    recorder = _RecordingLog()
+    monkeypatch.setattr("agenta.sdk.agents.dtos.log", recorder)
+
+    template = AgentTemplate(
+        tools=[
+            {"type": "gateway", "provider": "composio", "integration": "github"},
+            _NO_POLICY_ENTRY,
+            _PROVIDER_ACTION_ENTRY,
+            _CLIENT_ENTRY,
+        ]
+    )
+
+    kinds = [type(tool).__name__ for tool in template.tools]
+    assert kinds == [
+        "GatewayConnectionToolConfig",
+        "GatewayToolConfig",
+        "ClientToolConfig",
+    ]
+    assert len(recorder.warnings) == 1
+
+
+def test_a_misspelled_tool_field_still_fails_the_run():
+    # Tolerance must not swallow a typo. The author believes this tool is configured, so a
+    # silent drop would take it away with nothing to see anywhere.
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(tools=[{"type": "client", "nmae": "ask_user"}])
+
+
+def test_two_conflicting_policies_for_one_integration_still_fail_the_run():
+    # One integration takes one entry. Dropping the second would silently pick a policy,
+    # and the pair here disagree: the run would allow what the author also denied.
+    permissive = {
+        **_NO_POLICY_ENTRY,
+        "policy": {"permissions": {"default": "allow", "tools": {}}},
+    }
+    restrictive = {
+        **_NO_POLICY_ENTRY,
+        "policy": {"permissions": {"default": "deny", "tools": {}}},
+    }
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(tools=[permissive, restrictive])
+
+
+def test_a_malformed_connection_entry_still_fails_the_run():
+    # Only the LEGACY gateway shape is tolerated. A connection entry missing a routing
+    # field is a current-format mistake, and it stays a loud one.
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(
+            tools=[
+                {
+                    "type": "gateway_connection",
+                    "connection": {"provider": "composio", "integration": "github"},
+                }
+            ]
+        )
+
+
+def test_a_malformed_current_format_gateway_entry_still_fails_the_run():
+    # A `gateway` entry carrying no legacy mark is authored today, not inherited. This one
+    # names an action and no connection, so it is a mistake its author must see rather than
+    # a shape from before the rework.
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(
+            tools=[
+                {
+                    "type": "gateway",
+                    "provider": "composio",
+                    "integration": "github",
+                    "action": "GET_AN_ISSUE",
+                }
+            ]
+        )
+
+
+def test_an_empty_action_beside_a_legacy_one_is_repaired():
+    # An empty `action` is not an authored value, so the legacy field fills it. A NON-empty
+    # one is authored and is never overwritten, which
+    # `test_an_explicit_action_wins_over_provider_action` pins.
+    config = coerce_tool_config({**_PROVIDER_ACTION_ENTRY, "action": ""})
+    assert config.action == "GET_AN_ISSUE"
+
+
+def test_a_null_entry_still_fails_the_run():
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(tools=[None])
+
+
+def test_a_non_dict_entry_that_is_not_a_name_still_fails_the_run():
+    with pytest.raises(ToolConfigurationError):
+        AgentTemplate(tools=[["gateway"]])
+
+
+def test_the_composio_alias_is_tolerated_like_the_gateway_tag(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    # `composio` is the same legacy shape under its older tag, renamed before it parses.
+    recorder = _RecordingLog()
+    monkeypatch.setattr("agenta.sdk.agents.dtos.log", recorder)
+
+    template = AgentTemplate(
+        tools=[{"type": "composio", "integration": "github"}, _CLIENT_ENTRY]
+    )
+
+    assert [type(tool).__name__ for tool in template.tools] == ["ClientToolConfig"]
+    assert len(recorder.warnings) == 1
+
+
+def test_a_template_with_only_valid_tools_logs_nothing(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    recorder = _RecordingLog()
+    monkeypatch.setattr("agenta.sdk.agents.dtos.log", recorder)
+
+    template = AgentTemplate(tools=[_NO_POLICY_ENTRY, _CLIENT_ENTRY])
+
+    assert len(template.tools) == 2
+    assert recorder.warnings == []


### PR DESCRIPTION
Hot fix for production on top of v0.115.3. Two fixes already reviewed and merged into `release/v0.115.3` after the v0.115.3 deploy:

- #6722 fix(sdk): tolerate saved gateway tool entries the strict parser refuses. Every message on an agent with a `gateway_connection` entry saved without a `policy`, or with the pre-2026-08-27 `gateway` shape, failed with a 500 and "Message wasn't sent". A missing policy now means inherit; the legacy shape is repaired on read; only an unrepairable legacy entry is dropped, with a warning.
- #6723 fix(api,sdk): refresh a stale starter-credits model and fall back to the funded model. Projects created before the 2026-08-25 cutover still handed new agents `gemini-3.6-flash`, which the proxy refuses with a 400. The connection and its proxy key are repaired on first read, and a saved revision on the old model runs on the funded one.

Neither is a v0.115.3 regression; both predate the release. Deploy to production from this branch (fresh commit-hash image tags), then merge here and into `release/v0.115.4`.

Follow-ups: validate tool entries on write in the API commit path, #6725 (vault dependency injection).