### PR TITLE
[test] Carry the v0.115.3 test suites onto the v0.115.4 structure

### DIFF
--- a/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
+++ b/web/oss/src/components/AgentChatSlice/assets/markdown.tsx
@@ -1,6 +1,6 @@
 import {memo} from "react"
 
-import ChatMarkdown from "@agenta/chat/markdown"
+import ChatMarkdown, {MD_REHYPE_PLUGINS} from "@agenta/chat/markdown"
 import {useDriveSessionId} from "@agenta/entity-ui/drive"
 import {useAtomValue} from "jotai"
 
@@ -101,6 +101,9 @@ export const MD_CLASS =
     // The `display:block` fix for Shiki line spans lives in ChatMarkdown's structural class.
     // Trim the outer edges so the bubble padding isn't doubled by leading/trailing margins.
     "[&>:first-child]:!mt-0 [&>:last-child]:!mb-0 [&>:last-child>*]:!mb-0"
+
+/** Re-exported for the link-gate test, which drives the plugin list this surface renders with. */
+export {MD_REHYPE_PLUGINS}
 
 /** Resolve file mentions against THIS conversation's session, from the ambient drive context. */
 const useChatFileLink = () => {

--- a/web/oss/vitest.config.ts
+++ b/web/oss/vitest.config.ts
@@ -20,6 +20,14 @@ export default defineConfig({
                 find: /^@\/agenta-oss-common\/(.*)$/,
                 replacement: path.resolve(__dirname, "./src/$1"),
             },
+            // The app and the `@agenta/*` packages resolve different Next versions, so each
+            // gets its own router context and a tree spanning both cannot satisfy the
+            // packages' `useRouter` — the app's `RouterContext.Provider` is invisible to it.
+            // One copy for the whole run, the same one the tests import the context from.
+            {
+                find: /^next\/router$/,
+                replacement: path.resolve(__dirname, "./node_modules/next/router.js"),
+            },
         ],
     },
     test: {

--- a/web/packages/agenta-chat/src/components/ChatMarkdown.tsx
+++ b/web/packages/agenta-chat/src/components/ChatMarkdown.tsx
@@ -133,7 +133,7 @@ export const chatMarkdownComponents: Components = {
 }
 
 /** Streamdown's own list, plus one plugin BEFORE its harden gate; the prop replaces the defaults. */
-const MD_REHYPE_PLUGINS = withExplicitRelativeLinks(defaultRehypePlugins)
+export const MD_REHYPE_PLUGINS = withExplicitRelativeLinks(defaultRehypePlugins)
 
 /** KaTeX math ($…$ / $$…$$) + Shiki-highlighted fences; both tree-shaken plugin packages. */
 const MD_PLUGINS = {math, code}

--- a/web/packages/agenta-chat/tests/unit/hooks/useChatSlashCommands.test.tsx
+++ b/web/packages/agenta-chat/tests/unit/hooks/useChatSlashCommands.test.tsx
@@ -1,3 +1,4 @@
+// @vitest-environment jsdom
 import {act} from "react"
 
 import {draftConfigChangeSignalAtom} from "@agenta/shared/state"
@@ -31,16 +32,9 @@ vi.mock("@agenta/entities/workflow", async (original) => {
         agentModelCandidatesAtomFamily: () => candidates,
     }
 })
-vi.mock("@/oss/components/pages/agent-home/PlaygroundOnboarding/OnboardingContext", () => ({
-    useOptionalOnboardingContext: () => null,
-}))
-vi.mock("../state/scope", () => ({useChatScopeKey: () => "test"}))
-vi.mock("../state/sessions", () => {
-    const add = atom(null, () => undefined)
-    return {addSessionAtomFamily: () => add}
-})
-
-import {useChatSlashCommands} from "./useChatSlashCommands"
+// The host's own concerns (onboarding, scope, `/new`) reach the hook as props now, so nothing
+// app-shaped needs stubbing here.
+import {useChatSlashCommands} from "../../../src/hooks/useChatSlashCommands"
 
 it("pulses Permissions, not Advanced, and preserves explicit restrictions", async () => {
     Object.assign(globalThis, {IS_REACT_ACT_ENVIRONMENT: true})

--- a/web/packages/agenta-chat/tests/unit/hooks/useServerSessionInputs.test.ts
+++ b/web/packages/agenta-chat/tests/unit/hooks/useServerSessionInputs.test.ts
@@ -35,9 +35,12 @@ const {
     updateInput: vi.fn(),
 }))
 
-vi.mock("@agenta/entities/session", async () => {
+// Spread the original: the composer reaches for real exports of this module too (the file
+// palette reads the session's mounts), and a wholesale replacement hides them.
+vi.mock("@agenta/entities/session", async (importOriginal) => {
     const {atom} = await import("jotai")
     return {
+        ...(await importOriginal<object>()),
         fetchSessionCapabilitiesAtom: atom(null, (_get, _set, sessionId: string) =>
             fetchCapabilities(sessionId),
         ),


### PR DESCRIPTION
`run-web-unit-tests` is red on `release/v0.115.4`: https://github.com/Agenta-AI/agenta/commit/a17ae79a75

Four suites pass on `release/v0.115.3` and on `release/v0.115.4` separately, and fail only once the two are merged, because a v0.115.3 test now meets the surface v0.115.4 rebuilt under it. This carries them onto that structure.

## What was red, and why

| Package | Suite | Failing | Cause |
| --- | --- | --- | --- |
| `@agenta/chat` | `tests/unit/hooks/useServerSessionInputs.test.ts` | 4 | The test replaces `@agenta/entities/session` wholesale. The composer's file palette, which v0.115.4 added, reads a real export of it (`sessionMountsQueryFamily`). |
| `@agenta/oss` | `markdownLinkGate.test.tsx` | 4 | `MD_REHYPE_PLUGINS` is module-private inside `ChatMarkdown`, so the test's `gate` helper imports `undefined` and silently drives Streamdown's stock pipeline instead of ours. |
| `@agenta/oss` | `useChatSlashCommands.test.tsx` | 0 run | It sits beside a hook that moved into `@agenta/chat`, cannot resolve `./useChatSlashCommands`, and fails to collect. Its one test has not run since the merge. |
| `@agenta/oss` | `permissions.test.tsx` | 3 | Two Next versions resolve in this workspace, so the app's `RouterContext.Provider` is a different module from the one a package component's `useRouter` reads. |

Eleven failing tests, plus one that never runs.

## The link-gate row is not a product bug

Worth stating plainly, because "keeps the working-directory-relative path (#6659)" failing looks like agent file links are broken. They are not.

`ChatMarkdown` builds the plugin list and passes it to `Streamdown`, so a bare relative path in a reply still gets the pre-harden respelling and still resolves. Only the test's view of that list broke. The cost is that the four assertions which prove #6659 works currently prove nothing about the real pipeline, which is why they are worth repairing rather than deleting.

## What this changes

Five files. Everything is test-side except one line.

- **The one non-test line.** `MD_REHYPE_PLUGINS` in `web/packages/agenta-chat/src/components/ChatMarkdown.tsx` gains the `export` keyword. The constant, its value and its use are untouched; the desktop surface re-exports it so the link-gate test keeps its import path.
- The admission suite spreads the original module rather than replacing it.
- The slash-command test moves into `@agenta/chat`, beside the hook, and drops the host stubs the hook now takes as props. Nothing is deleted.
- `web/oss/vitest.config.ts` pins one `next/router` for the run, so every copy of Next shares the router context the tests provide.

Source is otherwise untouched.

## After

| Package | Result |
| --- | --- |
| `@agenta/chat` | 1019 passed, 89 files |
| `@agenta/oss` | 517 passed, 1 skipped, 59 files |
| `@agenta/entity-ui` | 729 passed, 53 files |
| `@agenta/mobile` | 185 passed, 26 files |
| `@agenta/sessions-ui` | 25 passed, 4 files |

Typecheck clean on chat, sessions-ui, entity-ui, home-ui, oss, ee and mobile. Lint clean per package; mobile keeps five pre-existing warnings and no errors, in files this branch does not touch. Prettier clean.
