### PR TITLE
[fix] Give the skill registry ops a build-kit permission so skills load again

### DIFF
--- a/api/oss/src/core/workflows/build_kit.py
+++ b/api/oss/src/core/workflows/build_kit.py
@@ -36,6 +36,11 @@ _READ_CONFIG_OPS: tuple[str, ...] = (
 
 _BUILD_KIT_OP_PERMISSIONS = {
     "discover_tools": "allow",
+    # Registry discovery and the source-sync check are reads. The apply is a write, and its
+    # approval card is the user prompt, so it asks.
+    "search_skills": "allow",
+    "check_skill_updates": "allow",
+    "apply_skill_update": "ask",
     "read_config": "allow",
     "commit_revision": "allow",
     "test_run": "allow",

--- a/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
+++ b/api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py
@@ -120,6 +120,9 @@ CUT_BUILD_KIT_OPS = (
 
 EXPECTED_BUILD_KIT_PERMISSIONS = {
     "discover_tools": "allow",
+    "search_skills": "allow",
+    "check_skill_updates": "allow",
+    "apply_skill_update": "ask",
     "read_config": "allow",
     "commit_revision": "allow",
     "test_run": "allow",


### PR DESCRIPTION
## Context

On `release/v0.116.0` the Skills page, `POST /api/skills/query`, and the agent catalog answer 500 with `operation_id: query_registry_skills`. The API log shows `KeyError: 'search_skills'` from `build_agent_template_overlay`. The skill registry added `search_skills`, `check_skill_updates`, and `apply_skill_update` to `DEFAULT_BUILD_KIT_OPS`, and the later permissions change added `_BUILD_KIT_OP_PERMISSIONS` without them. Every overlay build looks up a permission for each op, so the first missing one raises. Found while doing QA for #6743 on a stack built from the release branch.

## Changes

The permission map gains the three ops. The two reads allow. The apply asks, because it is a write and its approval card is the user prompt, which is what the comment above the op list already says.

Before:

```
KeyError: 'search_skills'  -> 500 on skills query, skills page, agent catalog
```

After:

```
search_skills: allow, check_skill_updates: allow, apply_skill_update: ask
```

The overlay unit test's expected permission map gains the same three entries. It was red on the release branch for the same reason.

## Tests

- `api/oss/tests/pytest/unit/applications/test_build_kit_overlay.py` and `api/oss/tests/pytest/unit/workflows/test_static_catalog.py`: 51 passed. Before the change, 7 of 8 overlay tests failed with the same KeyError.
- `ruff format` and `ruff check` on both files: clean.

## What to QA

- Open the Skills page on a release build. It lists the registry instead of an error.
- Open an agent. The build kit loads and the agent runs.
- Regression: in the agent's Permissions section, the skill ops show allow for search and update check, and ask for apply.

https://claude.ai/code/session_01AY886ajXX65KAa1Vc9JCXU
