### PR TITLE
[fix] Restore the read-only Skills empty text in the agent config card

### DIFF
--- a/web/packages/agenta-entity-ui/src/agent/AgentConfigSummaryCard.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentConfigSummaryCard.tsx
@@ -110,7 +110,7 @@ export const AgentConfigSummaryCard = ({appId, onEdit}: AgentConfigSummaryCardPr
             title: "Skills",
             ...(summary.skills
                 ? stated(`${summary.skills} ${summary.skills === 1 ? "skill" : "skills"}`)
-                : emptyAction(onEdit ? "Add skills" : "None added")),
+                : emptyAction(onEdit ? "Add skills" : "None available")),
             // Expands to the skill names — the count alone says how many, never which.
             expands: summary.skillNames.length > 0,
         },


### PR DESCRIPTION
## Context
`agentConfigSummaryCard.test.tsx` fails on `release/v0.116.0`, so every PR against the release branch inherits a red `run-web-unit-tests`. The read-only agent config card shows "None added" for an agent with no skills. #6641 made that text "None available" and pinned it in the test. The `release/v0.116.0` merge into `feat/skill-registry` (#6604) then resolved the line to "None added".

## Changes
The read-only Skills row goes back to "None available". That matches #6641, its test, and the other read-only rows ("None enabled", "None connected"). The editable card still offers "Add skills".

## Tests
- `vitest run tests/unit/agentConfigSummaryCard.test.tsx` in `@agenta/entity-ui`: 13 of 13 pass (1 failed before).
- This branch will still show the API unit failures (`KeyError: 'search_skills'`). #6744 fixes those. Once both land, the web and API unit jobs on `release/v0.116.0` should be green.
- The five acceptance failures predate #6604 (same five on PR heads from September 8 and 9) and are not addressed here.
