### PR TITLE
[chore] Refresh featured blog posts

### DIFF
--- a/website/src/content/posts/best-grok-bot-alternatives.mdx
+++ b/website/src/content/posts/best-grok-bot-alternatives.mdx
@@ -8,7 +8,8 @@ readingTime: "19 min read"
 heroImage: "/blog/best-grok-bot-alternatives/hero.webp"
 ogImage: "/blog/best-grok-bot-alternatives/hero.webp"
 author: "mahmoud-mabrouk"
-featured: false
+featured: true
+featuredRank: 2
 tags: ["AI agents", "AI coworkers", "comparisons"]
 faq:
   - question: "What is the best Grok Bot alternative?"

--- a/website/src/content/posts/best-manus-alternatives.mdx
+++ b/website/src/content/posts/best-manus-alternatives.mdx
@@ -9,7 +9,8 @@ readingTime: "14 min read"
 heroImage: "/blog/best-manus-alternatives/hero.png"
 ogImage: "/blog/best-manus-alternatives/hero.png"
 author: "mahmoud-mabrouk"
-featured: false
+featured: true
+featuredRank: 3
 tags: ["AI agents", "AI coworkers", "comparisons"]
 faq:
   - question: "What is the best Manus alternative?"

--- a/website/src/content/posts/the-ai-engineer-s-guide-to-llm-observability-with-opentelemetry.mdx
+++ b/website/src/content/posts/the-ai-engineer-s-guide-to-llm-observability-with-opentelemetry.mdx
@@ -8,8 +8,7 @@ readingTime: "20 min read"
 heroImage: /blog/the-ai-engineer-s-guide-to-llm-observability-with-opentelemetry/hero.webp
 ogImage: /blog/the-ai-engineer-s-guide-to-llm-observability-with-opentelemetry/hero.webp
 author: mahmoud-mabrouk
-featured: true
-featuredRank: 2
+featured: false
 tags: ["Article"]
 ---
 

--- a/website/src/content/posts/the-definitive-guide-to-prompt-management-systems.mdx
+++ b/website/src/content/posts/the-definitive-guide-to-prompt-management-systems.mdx
@@ -8,8 +8,7 @@ readingTime: "10 min read"
 heroImage: /blog/the-definitive-guide-to-prompt-management-systems/hero.webp
 ogImage: /blog/the-definitive-guide-to-prompt-management-systems/hero.webp
 author: mahmoud-mabrouk
-featured: true
-featuredRank: 3
+featured: false
 tags: ["Article"]
 ---
 


### PR DESCRIPTION
## Context

The blog landing page still featured two 2025 guides alongside the Agenta 2.0 announcement. The featured row should represent the current Agenta 2.0 positioning and recent comparison content.

## Changes

The featured row now shows:

1. Introducing Agenta 2.0
2. 8 Best Grok Bot Alternatives in 2026
3. 7 Best Manus Alternatives in 2026

The OpenTelemetry observability and prompt management guides remain in the regular blog list.

## Tests

- `pnpm test`: 55 tests passed
- `pnpm build`: passed
- Verified the generated blog page contains exactly three featured posts in the requested rank order
- `git diff --check`: passed
- Licensed fonts were unavailable locally, so the build used the expected system font fallbacks

## What to QA

Open `/blog` and confirm the featured section shows the three posts above in order, with the Agenta 2.0 announcement as the primary card.