### PR TITLE
[fix] Harden hosted subscription release paths

### DIFF
--- a/.agents/skills/agent-release-gate/SKILL.md
+++ b/.agents/skills/agent-release-gate/SKILL.md
@@ -80,6 +80,9 @@ journey expires the stored login itself and needs the stack for that (`--db-cont
 hide the expiry), and their `dead` journey needs a reachable runner replica (`--runner`). Run
 `dead` LAST:
 proving the failure a user meets means killing the login, and only a person can sign in again.
+For a release that changes subscription login storage or publication, `--release-base` forces the
+`refresh` journey even when `--only` names another journey. A successful chat alone does not prove
+that the rotated login reached the durable vault.
 The `relogin_needed` journey always SKIPs and its reason carries the steps. Full runbook and
 ordering: `resources/coverage.md`.
 

--- a/.agents/skills/agent-release-gate/resources/path_triggers.py
+++ b/.agents/skills/agent-release-gate/resources/path_triggers.py
@@ -74,6 +74,7 @@ SESSION_CONTEXT = ("matrix_n1_session_context.py",)
 # green release while the coverage the rule exists for never ran. Journeys named here are FORCED
 # into the selection, even against an explicit --only.
 CONCURRENCY_JOURNEYS = ("burst", "crosstalk")
+HOSTED_SUBSCRIPTION_JOURNEYS = ("refresh",)
 
 # Glob -> cells. Matching is fnmatch over the whole repo-relative path, so `*` crosses directory
 # separators: `a/b/*` and `a/b/**` behave the same, and both mean "anything under a/b". Write
@@ -136,7 +137,7 @@ PATH_TRIGGERS: dict[str, tuple[str, ...]] = {
     "web/packages/agenta-entity-ui/src/secret/**": CUSTOM_SECRETS,
     "web/packages/agenta-entity-ui/src/clientTools/SecretRequest*": CUSTOM_SECRETS,
     "web/packages/agenta-chat/src/clientTools/secretInteractions.ts": CUSTOM_SECRETS,
-    "api/oss/src/core/secrets/**": CUSTOM_SECRETS,
+    "api/oss/src/core/secrets/**": CUSTOM_SECRETS + HOSTED_SUBSCRIPTION,
     "api/oss/src/apis/fastapi/vault/router.py": CUSTOM_SECRETS,
     "api/oss/src/apis/fastapi/workflows/router.py": CUSTOM_SECRETS,
     "api/oss/src/core/workflows/static_catalog.py": CUSTOM_SECRETS,
@@ -186,6 +187,14 @@ PATH_TRIGGERS: dict[str, tuple[str, ...]] = {
 # separate table so a rule can demand a cell, a journey, or both, without changing the shape of
 # either one.
 PATH_TRIGGER_JOURNEYS: dict[str, tuple[str, ...]] = {
+    # Selecting H1/H2 is insufficient when --only names another journey. A credential-path change
+    # must prove that a provider refresh reaches the vault, because a normal chat can keep working
+    # from the runner's private auth.json while the durable vault remains stale.
+    "services/runner/src/engines/sandbox_agent/subscription-*": HOSTED_SUBSCRIPTION_JOURNEYS,
+    "services/runner/src/subscription-*": HOSTED_SUBSCRIPTION_JOURNEYS,
+    "api/oss/src/core/secrets/subscription_*": HOSTED_SUBSCRIPTION_JOURNEYS,
+    "api/oss/src/core/secrets/services.py": HOSTED_SUBSCRIPTION_JOURNEYS,
+    "api/oss/src/dbs/postgres/secrets/**": HOSTED_SUBSCRIPTION_JOURNEYS,
     # The concurrency journeys (`burst`, `crosstalk`) are journeys, not cells: listed under
     # PATH_TRIGGERS they would be registered as cell names and never run. A change to the
     # sandbox engine or the Daytona provider makes them mandatory on every applicable cell.
@@ -226,6 +235,17 @@ def mandatory_cells(paths: list[str]) -> dict[str, list[str]]:
                 for cell in cells:
                     activated.setdefault(cell, set()).add(path)
     return {cell: sorted(why) for cell, why in sorted(activated.items())}
+
+
+def mandatory_journeys(paths: list[str]) -> dict[str, list[str]]:
+    """Journey -> the changed paths that make it mandatory."""
+    activated: dict[str, set[str]] = {}
+    for glob, journeys in PATH_TRIGGER_JOURNEYS.items():
+        for path in paths:
+            if fnmatch.fnmatch(path, glob):
+                for journey in journeys:
+                    activated.setdefault(journey, set()).add(path)
+    return {journey: sorted(why) for journey, why in sorted(activated.items())}
 
 
 def main() -> int:

--- a/.agents/skills/agent-release-gate/resources/qa_product.py
+++ b/.agents/skills/agent-release-gate/resources/qa_product.py
@@ -32,7 +32,7 @@ import uuid
 
 import httpx
 
-from path_triggers import changed_paths, mandatory_cells
+from path_triggers import changed_paths, mandatory_cells, mandatory_journeys
 
 HERE = pathlib.Path(__file__).resolve().parent
 # Results land in the CURRENT working directory, never inside the skill, so repeated runs do not
@@ -2949,12 +2949,14 @@ def main() -> int:
     # fact, and so a rule naming a cell nobody has written yet fails immediately instead of
     # spending the whole matrix first.
     triggered: dict = {}
+    triggered_journeys: dict = {}
     if args.release_base or args.changed_path:
         paths = list(args.changed_path or [])
         if args.release_base:
             repo = pathlib.Path(args.repo) if args.repo else None
             paths += changed_paths(args.release_base, repo=repo)
         triggered = mandatory_cells(paths)
+        triggered_journeys = mandatory_journeys(paths)
     missing_cells = [
         cell for cell in triggered if cell not in CELLS and not (HERE / cell).exists()
     ]
@@ -2964,6 +2966,15 @@ def main() -> int:
     for cell in triggered:
         if cell in CELLS and cell not in cells:
             cells.append(cell)
+    missing_journeys = [name for name in triggered_journeys if name not in JOURNEYS]
+    if missing_journeys:
+        raise SystemExit(
+            "The release diff makes these journeys mandatory, but they do not exist: "
+            + ", ".join(missing_journeys)
+        )
+    for journey in triggered_journeys:
+        if journey not in journeys:
+            journeys.append(journey)
     if triggered:
         print("Path-scoped rules make these cells MANDATORY for this release:")
         for cell, why in triggered.items():
@@ -2977,6 +2988,13 @@ def main() -> int:
                 )
             )
             print(f"  {cell} ({where})")
+            for path in why:
+                print(f"      because this release changed {path}")
+        print()
+    if triggered_journeys:
+        print("Path-scoped rules make these journeys MANDATORY for this release:")
+        for journey, why in triggered_journeys.items():
+            print(f"  {journey} (added to this run)")
             for path in why:
                 print(f"      because this release changed {path}")
         print()
@@ -3109,6 +3127,14 @@ def main() -> int:
                 "\nThis release is NOT green until every cell above marked "
                 "`run it separately` has a recorded result.\n"
             )
+    if triggered_journeys:
+        (outdir / "mandatory-journeys.json").write_text(
+            json.dumps(triggered_journeys, indent=2)
+        )
+        table += "\n\nMandatory journeys for this release, by path rule:\n\n"
+        table += "| journey | because this release changed |\n|---|---|\n"
+        for journey, why in triggered_journeys.items():
+            table += f"| {journey} | {', '.join(why)} |\n"
     (outdir / "summary.md").write_text(table + "\n")
     print("\n" + table)
     print(f"\nresults: {outdir}")

--- a/.agents/skills/agent-release-gate/resources/test_qa_product_concurrency.py
+++ b/.agents/skills/agent-release-gate/resources/test_qa_product_concurrency.py
@@ -392,6 +392,19 @@ def test_a_runner_path_change_makes_the_journeys_mandatory():
     assert triggers.mandatory_journeys(["web/oss/src/app/page.tsx"]) == {}
 
 
+def test_a_subscription_change_makes_refresh_mandatory():
+    """A chat-only release run cannot bypass the vault write-back assertion."""
+    sys.path.insert(0, str(HERE))
+    triggers = importlib.import_module("path_triggers")
+    for path in (
+        "services/runner/src/engines/sandbox_agent/subscription-login/publisher.ts",
+        "api/oss/src/core/secrets/services.py",
+        "api/oss/src/dbs/postgres/secrets/dao.py",
+    ):
+        journeys = triggers.mandatory_journeys([path])
+        assert "refresh" in journeys, (path, journeys)
+
+
 def _session_control_result(status="PASS"):
     import session_control
 

--- a/api/oss/src/core/secrets/services.py
+++ b/api/oss/src/core/secrets/services.py
@@ -547,8 +547,9 @@ class VaultService:
         if not header.name:
             header.name = SUBSCRIPTION_PROVIDER_DISPLAY_NAMES[provider_kind]
 
-        if not create_secret_dto.slug:
-            create_secret_dto.slug = provider_kind.value
+        # This is the storage identity, not the editable display identity. Keeping it canonical
+        # lets the database's (project_id, slug) unique index serialize concurrent creates.
+        create_secret_dto.slug = provider_kind.value
 
         create_secret_dto.secret.data.provider_slug = subscription_provider_slug(
             header.name

--- a/api/oss/src/dbs/postgres/secrets/dao.py
+++ b/api/oss/src/dbs/postgres/secrets/dao.py
@@ -1,27 +1,28 @@
 from typing import Callable, Optional
 from uuid import UUID
 
-from oss.src.dbs.postgres.secrets.dbes import SecretsDBE
-from oss.src.core.secrets.interfaces import SecretsDAOInterface
-from oss.src.core.secrets.managed import SecretManagementDTO
-
-from oss.src.dbs.postgres.shared.engine import (
-    TransactionsEngine,
-    get_transactions_engine,
-)
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 
 from oss.src.core.secrets.dtos import (
     CreateSecretDTO,
     SecretResponseDTO,
     UpdateSecretDTO,
 )
+from oss.src.core.secrets.enums import SecretKind
+from oss.src.core.secrets.interfaces import SecretsDAOInterface
+from oss.src.core.secrets.managed import SecretManagementDTO
+from oss.src.core.secrets.types import SubscriptionProviderConflict
+from oss.src.dbs.postgres.secrets.dbes import SecretsDBE
 from oss.src.dbs.postgres.secrets.mappings import (
-    map_secrets_dto_to_dbe,
     map_secrets_dbe_to_dto,
+    map_secrets_dto_to_dbe,
     map_secrets_dto_to_dbe_update,
 )
-
-from sqlalchemy import select
+from oss.src.dbs.postgres.shared.engine import (
+    TransactionsEngine,
+    get_transactions_engine,
+)
 
 
 class SecretsDAO(SecretsDAOInterface):
@@ -60,9 +61,20 @@ class SecretsDAO(SecretsDAOInterface):
             secret_dto=create_secret_dto,
             management=management,
         )
-        async with self.engine.session() as session:
-            session.add(secrets_dbe)
-            await session.commit()
+        try:
+            async with self.engine.session() as session:
+                session.add(secrets_dbe)
+                await session.commit()
+        except IntegrityError as e:
+            if (
+                create_secret_dto.secret.kind == SecretKind.SUBSCRIPTION_PROVIDER
+                and "uq_secrets_project_id_slug" in str(e.orig)
+            ):
+                provider = create_secret_dto.secret.data.provider
+                raise SubscriptionProviderConflict(
+                    provider=getattr(provider, "value", provider)
+                ) from e
+            raise
 
         secrets_dto = map_secrets_dbe_to_dto(secrets_dbe=secrets_dbe)
         return secrets_dto

--- a/api/oss/tests/pytest/unit/secrets/test_subscription_login_service.py
+++ b/api/oss/tests/pytest/unit/secrets/test_subscription_login_service.py
@@ -257,6 +257,22 @@ class TestCreateRules:
         with pytest.raises(SubscriptionProviderConflict):
             await _make_secret(vault)
 
+    async def test_a_caller_cannot_replace_the_provider_storage_slug(self, vault):
+        secret = await vault.create_secret(
+            project_id=PROJECT_ID,
+            create_secret_dto=CreateSecretDTO.model_validate(
+                {
+                    "slug": "my-personal-plan",
+                    "header": {"name": "Personal ChatGPT"},
+                    "secret": {"kind": "subscription_provider", "data": {}},
+                }
+            ),
+        )
+
+        assert secret.slug == "chatgpt"
+        assert secret.header.name == "Personal ChatGPT"
+        assert secret.data.provider_slug == "personal-chatgpt"
+
 
 class TestAttemptLifecycle:
     async def test_start_stores_the_attempt_and_hides_the_code_from_the_row_reader(

--- a/api/oss/tests/pytest/unit/secrets/test_subscription_secret_dao_conflict.py
+++ b/api/oss/tests/pytest/unit/secrets/test_subscription_secret_dao_conflict.py
@@ -1,0 +1,67 @@
+"""The database tie-breaker for concurrent subscription-connection creation."""
+
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.exc import IntegrityError
+
+from oss.src.core.secrets.dtos import CreateSecretDTO
+from oss.src.core.secrets.types import SubscriptionProviderConflict
+from oss.src.dbs.postgres.secrets.dao import SecretsDAO
+
+
+class _ConflictingSession:
+    def add(self, _dbe):
+        pass
+
+    async def commit(self):
+        raise IntegrityError(
+            "INSERT INTO secrets ...",
+            {},
+            Exception(
+                "duplicate key value violates unique constraint "
+                '"uq_secrets_project_id_slug"'
+            ),
+        )
+
+    async def rollback(self):
+        pass
+
+
+class _ConflictingEngine:
+    @asynccontextmanager
+    async def session(self):
+        session = _ConflictingSession()
+        try:
+            yield session
+        except Exception:
+            await session.rollback()
+            raise
+
+
+@pytest.mark.anyio
+async def test_concurrent_subscription_create_returns_domain_conflict(anyio_backend):
+    assert anyio_backend == "asyncio"
+    dao = SecretsDAO(engine=_ConflictingEngine())
+    create = CreateSecretDTO.model_validate(
+        {
+            "slug": "chatgpt",
+            "header": {"name": "ChatGPT"},
+            "secret": {"kind": "subscription_provider", "data": {}},
+        }
+    )
+
+    with pytest.raises(SubscriptionProviderConflict) as exc_info:
+        await dao.create(
+            project_id=uuid4(),
+            organization_id=None,
+            create_secret_dto=create,
+        )
+
+    assert exc_info.value.provider == "chatgpt"
+
+
+@pytest.fixture
+def anyio_backend():
+    return "asyncio"

--- a/services/runner/src/engines/sandbox_agent/environment.ts
+++ b/services/runner/src/engines/sandbox_agent/environment.ts
@@ -34,6 +34,10 @@ import { existsSync, mkdirSync, rmSync } from "node:fs";
 import { join } from "node:path";
 
 import { apiBase } from "../../apiBase.ts";
+import {
+  observeSubscription,
+  thrownFields,
+} from "../../subscription-events.ts";
 import { abortableSandboxProvider } from "../../environment/abortable-sandbox-provider.ts";
 import { throwIfAcquireAborted } from "../../environment/acquire-abort.ts";
 
@@ -1524,18 +1528,29 @@ async function acquireEnvironmentOnce(
       environment.subscriptionPublish
     ) {
       const publisher = environment.subscriptionPublisher;
-      const recovery = await recoverSubscriptionAuthFailure({
-        err,
-        subscription: subscriptionForError,
-        state: environment.subscriptionPublish,
-        home: subscriptionHomeForError,
-        isDaytona: plan.isDaytona,
-        sandbox: environment.sandbox as never,
-        api: { apiBase: apiBase(), authorization: runCred, log: logger },
-        ...(publisher ? { publish: publisher.reconcile } : {}),
-        log: logger,
-      });
-      if (recovery?.action === "fail") classified = recovery.classified;
+      try {
+        const recovery = await recoverSubscriptionAuthFailure({
+          err,
+          subscription: subscriptionForError,
+          state: environment.subscriptionPublish,
+          home: subscriptionHomeForError,
+          isDaytona: plan.isDaytona,
+          sandbox: environment.sandbox as never,
+          api: { apiBase: apiBase(), authorization: runCred, log: logger },
+          ...(publisher ? { publish: publisher.reconcile } : {}),
+          log: logger,
+        });
+        if (recovery?.action === "fail") classified = recovery.classified;
+      } catch (recoveryError) {
+        // Recovery is best effort. The original acquire failure still has to reach the caller,
+        // and every resource registered so far still has to be destroyed below.
+        observeSubscription(logger, "subscription.recovery", {
+          connection: subscriptionForError.id,
+          trigger: "acquire",
+          verdict: "threw",
+          ...thrownFields(recoveryError),
+        });
+      }
     }
     const error = classified.message;
     // Mirror today's shared teardown: no otel exists yet during acquire, so there is no partial

--- a/services/runner/src/engines/sandbox_agent/subscription-login/publisher.ts
+++ b/services/runner/src/engines/sandbox_agent/subscription-login/publisher.ts
@@ -17,6 +17,10 @@
 import { createHash } from "node:crypto";
 
 import {
+  startPlatformCredentialLease,
+  type PlatformCredentialLease,
+} from "../../../sessions/auth.ts";
+import {
   observeSubscription,
   thrownFields,
 } from "../../../subscription-events.ts";
@@ -119,17 +123,14 @@ export function adoptSubscriptionLogin(
 
 export interface SubscriptionApiDeps {
   apiBase: string;
-  authorization: string;
+  /** Read at request time because a session can outlive the platform credential it started with. */
+  authorization: string | (() => string);
   fetchImpl?: typeof fetch;
   log?: Log;
 }
 
 /** Which moment asked for a pass. A log field, so a publication can be traced to its cause. */
-export type PublishTrigger =
-  | "start"
-  | "interval"
-  | "recovery"
-  | "shutdown";
+export type PublishTrigger = "start" | "interval" | "recovery" | "shutdown";
 
 /**
  * A running publisher. `stop` drains and is idempotent; neither method ever rejects.
@@ -164,6 +165,8 @@ export function startSubscriptionPublisher(input: {
   log?: Log;
   intervalMs?: number;
   fileDeps?: LocalSubscriptionFileDeps;
+  /** Test seam. Production creates and owns a refreshing platform-credential lease. */
+  credentialLease?: PlatformCredentialLease;
 }): SubscriptionPublisher | undefined {
   const subscription = input.plan.credentials.subscription;
   const home = input.plan.credentials.subscriptionHome;
@@ -183,9 +186,12 @@ export function startSubscriptionPublisher(input: {
     return undefined;
   }
   const isDaytona = input.plan.isDaytona;
+  const credentialLease =
+    input.credentialLease ??
+    startPlatformCredentialLease(input.apiBase, input.authorization);
   const api: SubscriptionApiDeps = {
     apiBase: input.apiBase,
-    authorization: input.authorization,
+    authorization: credentialLease.credential,
     ...(input.fetchImpl ? { fetchImpl: input.fetchImpl } : {}),
     log,
   };
@@ -272,7 +278,11 @@ export function startSubscriptionPublisher(input: {
     // The final sample goes through the queue, so it runs AFTER the in-flight pass and a refresh
     // written during that pass is still seen.
     queue = queue.then(() => pass("shutdown")).catch(() => {});
-    await queue;
+    try {
+      await queue;
+    } finally {
+      credentialLease.release();
+    }
   };
 
   // The start pass repairs a publication a previous session lost: the agent dir can already hold a
@@ -285,11 +295,17 @@ export function startSubscriptionPublisher(input: {
   };
 }
 
+function authorizationValue(
+  authorization: SubscriptionApiDeps["authorization"],
+): string {
+  return typeof authorization === "function" ? authorization() : authorization;
+}
+
 /**
  * Send one login to the API. `answered` is true when the API judged it, which is what lets the
- * runner stop retrying: a 4xx other than 408 and 429 is the API's decision and repeating the same
- * body cannot change it, while a timeout, a network failure, and a 5xx leave the credential
- * unacknowledged for the next pass.
+ * runner stop retrying: a 4xx other than 401, 403, 408 and 429 is the API's decision and repeating
+ * the same body cannot change it. Authentication failures can change after the platform credential
+ * lease refreshes, so they leave the login unacknowledged with timeouts, network failures and 5xx.
  *
  * `version` is the row version the API reports, and ONLY when the answer says this credential is
  * what the row now holds: `updated: true` (it was stored) or `reason: "same_login"` (the row
@@ -326,7 +342,7 @@ async function pushLogin(
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: deps.authorization,
+        authorization: authorizationValue(deps.authorization),
       },
       // `version` is the newest row version this session knows about. The API orders by generation
       // and expiry and does not read it as a precondition; it stays on the wire because the route
@@ -340,7 +356,11 @@ async function pushLogin(
     });
     if (!res.ok) {
       const retryable =
-        res.status >= 500 || res.status === 408 || res.status === 429;
+        res.status >= 500 ||
+        res.status === 401 ||
+        res.status === 403 ||
+        res.status === 408 ||
+        res.status === 429;
       // The body can carry the API's own account and version detail; only the status is recorded.
       observeSubscription(log, "subscription.publish", {
         ...event,
@@ -424,7 +444,7 @@ export async function reportSubscriptionLoginFailure(
       method: "POST",
       headers: {
         "content-type": "application/json",
-        authorization: deps.authorization,
+        authorization: authorizationValue(deps.authorization),
       },
       // What was DELIVERED to this run, which is what asks "was the login I ran on superseded?".
       body: JSON.stringify({
@@ -456,7 +476,8 @@ export async function reportSubscriptionLoginFailure(
       report.login = body.login as SubscriptionLogin;
     }
     if (typeof body.version === "number") report.version = body.version;
-    if (typeof body.generation === "number") report.generation = body.generation;
+    if (typeof body.generation === "number")
+      report.generation = body.generation;
     observeSubscription(log, "subscription.recovery", {
       ...event,
       decision: stale ? "stale" : "dead",

--- a/services/runner/tests/unit/subscription-login-publish.test.ts
+++ b/services/runner/tests/unit/subscription-login-publish.test.ts
@@ -79,6 +79,7 @@ interface FakeApi {
   fetchImpl: typeof fetch;
   pushed: SubscriptionLogin[];
   bodies: Array<Record<string, unknown>>;
+  authorizations: string[];
 }
 
 function fakeApi(
@@ -89,10 +90,12 @@ function fakeApi(
 ): FakeApi {
   const pushed: SubscriptionLogin[] = [];
   const bodies: Array<Record<string, unknown>> = [];
+  const authorizations: string[] = [];
   const fetchImpl = (async (_url: string, init: RequestInit) => {
     const body = JSON.parse(String(init.body)) as Record<string, unknown>;
     bodies.push(body);
     pushed.push(body.login as SubscriptionLogin);
+    authorizations.push(new Headers(init.headers).get("authorization") ?? "");
     const answer = respond(bodies.length);
     return {
       ok: answer.status >= 200 && answer.status < 300,
@@ -100,7 +103,7 @@ function fakeApi(
       json: async () => answer.body ?? {},
     };
   }) as unknown as typeof fetch;
-  return { fetchImpl, pushed, bodies };
+  return { fetchImpl, pushed, bodies, authorizations };
 }
 
 function start(input: {
@@ -111,6 +114,7 @@ function start(input: {
   log?: (line: string) => void;
   /** Pass one in to read it back after the pass; the publisher mutates it in place. */
   state?: SubscriptionPublishState;
+  credentialLease?: { credential: () => string; release: () => void };
 }): SubscriptionPublisher {
   const publisher = startSubscriptionPublisher({
     plan: {
@@ -123,6 +127,7 @@ function start(input: {
     authorization: "ApiKey test",
     fetchImpl: input.api.fetchImpl,
     log: input.log ?? (() => {}),
+    ...(input.credentialLease ? { credentialLease: input.credentialLease } : {}),
     ...(input.intervalMs !== undefined ? { intervalMs: input.intervalMs } : {}),
   });
   assert.ok(publisher, "the publisher must start for a wired subscription run");
@@ -308,6 +313,43 @@ describe("the reconciliation pass", () => {
     assert.deepEqual(api.pushed, [REFRESHED, REFRESHED, REFRESHED]);
   });
 
+  for (const status of [401, 403]) {
+    it(`retries ${status} with the refreshed platform credential`, async () => {
+      const home = tempHome();
+      writeLogin(home, REFRESHED);
+      let authorization = "ApiKey expired";
+      let released = false;
+      const api = fakeApi((call) =>
+        call === 1
+          ? { status }
+          : { status: 200, body: { version: 4, updated: true } },
+      );
+      const publisher = start({
+        home,
+        api,
+        intervalMs: 60_000,
+        credentialLease: {
+          credential: () => authorization,
+          release: () => { released = true; },
+        },
+      });
+
+      const deadline = Date.now() + 2_000;
+      while (api.pushed.length === 0 && Date.now() < deadline) {
+        await new Promise((resolve) => setTimeout(resolve, 10));
+      }
+      assert.equal(api.pushed.length, 1, "the start pass reached the API");
+      authorization = "ApiKey refreshed";
+      await publisher.reconcile("interval");
+      await publisher.reconcile("interval");
+      await publisher.stop();
+
+      assert.deepEqual(api.pushed, [REFRESHED, REFRESHED]);
+      assert.deepEqual(api.authorizations, ["ApiKey expired", "ApiKey refreshed"]);
+      assert.equal(released, true, "the publisher releases its credential lease");
+    });
+  }
+
   it("stops retrying a login the API judged and refused", async () => {
     const home = tempHome();
     writeLogin(home, REFRESHED);
@@ -435,7 +477,7 @@ describe("shutdown", () => {
         json: async () => ({ version: 4, updated: true }),
       };
     }) as unknown as typeof fetch;
-    const api: FakeApi = { fetchImpl, pushed, bodies: [] };
+    const api: FakeApi = { fetchImpl, pushed, bodies: [], authorizations: [] };
 
     const lines: string[] = [];
     const publisher = start({ home, api, intervalMs: 60_000, log: (l) => lines.push(l) });

--- a/services/runner/tests/unit/subscription-recovery-throws.test.ts
+++ b/services/runner/tests/unit/subscription-recovery-throws.test.ts
@@ -104,6 +104,28 @@ function runRequest(): AgentRunRequest {
 }
 
 describe("a subscription recovery that throws", () => {
+  it("still destroys an environment when acquire-time recovery throws", async () => {
+    const { calls, deps, logs } = fakeHarness({
+      probeError: new Error("Authentication failed for openai-codex"),
+    });
+
+    const result = await runSandboxAgent(runRequest(), undefined, undefined, deps);
+
+    assert.equal(result.ok, false);
+    assert.equal(calls.sandboxDestroyed, 1, "acquire failure releases the sandbox");
+    assert.equal(calls.sandboxDisposed, 1, "acquire failure disposes the sandbox client");
+    assert.equal(calls.workspaceCleanup, 1, "acquire failure releases the workspace");
+    assert.equal(
+      logs.some((line) =>
+        line.includes("event=subscription.recovery") &&
+        line.includes("trigger=acquire") &&
+        line.includes("verdict=threw")
+      ),
+      true,
+      logs.join("\n"),
+    );
+  });
+
   it("ends the turn with its own error instead of rejecting", async () => {
     const { deps, logs } = fakeHarness({
       // Pi's own words for a login it cannot use, which is what asks for a recovery.

--- a/services/runner/tests/utils/sandbox-agent-harness.ts
+++ b/services/runner/tests/utils/sandbox-agent-harness.ts
@@ -34,6 +34,7 @@ export interface FakeOptions {
   streamUsage?: Record<string, number>;
   output?: string;
   promptError?: Error;
+  probeError?: Error;
   permissionDecision?: PermissionDecision | "pendingApproval";
   emitPermission?: boolean;
   permissionToolCallId?: string;
@@ -272,8 +273,9 @@ export function fakeHarness(options: FakeOptions = {}) {
         },
       };
     }) as any,
-    probeCapabilities: async () =>
-      ({
+    probeCapabilities: async () => {
+      if (options.probeError) throw options.probeError;
+      return ({
         source: "probed",
         capabilities: {
           mcpTools: true,
@@ -282,7 +284,8 @@ export function fakeHarness(options: FakeOptions = {}) {
           streamingDeltas: true,
           ...(options.capabilities ?? {}),
         },
-      }) as any,
+      }) as any;
+    },
     applyModel: async (_session, model, _log, options) => {
       calls.applyModelArgs.push({ model, options });
       return model ?? "resolved-model";


### PR DESCRIPTION
## Problem

Hosted ChatGPT sessions can lose a rotated login after the initial Agenta run credential expires. A `401` or `403` currently marks the rotated login as acknowledged even though the vault never stored it. Acquire-time recovery can also skip environment cleanup when recovery throws, and concurrent ChatGPT connection creation can escape the application precheck and fail as an unhandled database conflict.

This is a follow-up to #6674.

## Result

- Keep a live platform-credential lease for the subscription publisher and retry `401` and `403` responses without acknowledging the login.
- Contain acquire-time recovery failures so sandbox, workspace, and publisher cleanup still runs.
- Force the canonical `chatgpt` storage slug and translate the database uniqueness tie-breaker into the existing subscription `409` conflict.
- Make the hosted `refresh` journey mandatory when release changes touch subscription storage or publication, even when the release command uses `--only`.

## How to review

1. Start in `publisher.ts`: verify each API request reads the lease's current credential, authentication failures remain unacknowledged, and `stop()` releases the lease.
2. Review the acquire catch in `environment.ts`: a recovery exception is logged and execution reaches `environment.destroy()`.
3. Review `services.py` and the secrets DAO: the provider owns the storage slug and the unique-index race becomes `SubscriptionProviderConflict`.
4. Review `path_triggers.py` and `qa_product.py`: subscription paths select H1/H2 and force the `refresh` journey.

## Validation

- `pnpm exec vitest run --project unit tests/unit/subscription-login-publish.test.ts tests/unit/subscription-recovery-throws.test.ts` (25 passed)
- `pnpm run typecheck` (passed)
- `pytest -q oss/tests/pytest/unit/secrets` (167 passed)
- `pytest -q .agents/skills/agent-release-gate/resources/test_qa_product_concurrency.py -k subscription_change` (1 passed)
- Full runner unit suite: 3,116 passed; five existing failures. Four require `build:extension` in a fresh checkout and pass after building it. The remaining `AGENTA_API_URL` expectation failure reproduces unchanged on `origin/release/v0.117.0`.
