### PR TITLE
[test] Validate revision grouping on exe.dev

### DIFF
--- a/api/oss/src/apis/fastapi/applications/models.py
+++ b/api/oss/src/apis/fastapi/applications/models.py
@@ -1,6 +1,8 @@
 from typing import Any, Dict, Optional, List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from oss.src.core.git.dtos import RevisionGrouping, validate_revision_grouping
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -342,10 +344,29 @@ class ApplicationRevisionQueryRequest(BaseModel):
         description="When `true`, include archived revisions. Defaults to `false`.",
     )
     #
+    grouping: Optional[RevisionGrouping] = Field(
+        default=None,
+        description=(
+            "Divide matching revisions by artifact or variant and select one "
+            "revision from each group."
+        ),
+    )
+    #
     windowing: Optional[Windowing] = Field(
         default=None,
         description="Cursor pagination and time-range controls.",
     )
+
+    @model_validator(mode="after")
+    def _validate_grouping(self):
+        validate_revision_grouping(
+            grouping=self.grouping,
+            artifact_refs=self.application_refs,
+            variant_refs=self.application_variant_refs,
+            revision_refs=self.application_revision_refs,
+            windowing=self.windowing,
+        )
+        return self
 
 
 class ApplicationRevisionCommitRequest(BaseModel):

--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -1605,6 +1605,8 @@ class ApplicationsRouter:
             #
             include_archived=application_revision_query_request.include_archived,
             #
+            grouping=application_revision_query_request.grouping,
+            #
             windowing=application_revision_query_request.windowing,
         )
 

--- a/api/oss/src/apis/fastapi/environments/models.py
+++ b/api/oss/src/apis/fastapi/environments/models.py
@@ -1,6 +1,8 @@
 from typing import Optional, List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from oss.src.core.git.dtos import RevisionGrouping, validate_revision_grouping
 
 from oss.src.core.shared.dtos import (
     Windowing,
@@ -141,7 +143,28 @@ class EnvironmentRevisionQueryRequest(BaseModel):
     #
     include_archived: Optional[bool] = None
     #
+    grouping: Optional[RevisionGrouping] = Field(
+        default=None,
+        description=(
+            "Divide matching revisions by artifact or variant and select one "
+            "revision from each group."
+        ),
+    )
+    #
     windowing: Optional[Windowing] = None
+
+    @model_validator(mode="after")
+    def _validate_grouping(self):
+        validate_revision_grouping(
+            grouping=self.grouping,
+            artifact_refs=self.environment_refs,
+            variant_refs=self.environment_variant_refs,
+            revision_refs=self.environment_revision_refs,
+            windowing=self.windowing,
+        )
+        if self.grouping and self.references:
+            raise ValueError("grouping cannot be combined with environment references")
+        return self
 
 
 class EnvironmentRevisionCommitRequest(BaseModel):

--- a/api/oss/src/apis/fastapi/environments/router.py
+++ b/api/oss/src/apis/fastapi/environments/router.py
@@ -1,7 +1,7 @@
 from typing import Optional
 from uuid import UUID
 
-from fastapi import APIRouter, Request, status, Depends, HTTPException
+from fastapi import APIRouter, Body, Request, status, Depends, HTTPException
 
 from oss.src.utils.common import is_ee
 from oss.src.utils.logging import get_module_logger
@@ -67,7 +67,6 @@ from oss.src.apis.fastapi.environments.utils import (
     parse_environment_variant_query_request_from_body,
     merge_environment_variant_query_requests,
     parse_environment_revision_query_request_from_params,
-    parse_environment_revision_query_request_from_body,
     merge_environment_revision_query_requests,
     ensure_environment_deploy_allowed,
 )
@@ -1062,6 +1061,7 @@ class EnvironmentsRouter:
         query_request_params: Optional[EnvironmentRevisionQueryRequest] = Depends(
             parse_environment_revision_query_request_from_params
         ),
+        query_request_body: Optional[EnvironmentRevisionQueryRequest] = Body(None),
     ) -> EnvironmentRevisionsResponse:
         if not await check_action_access(  # type: ignore
             user_uid=request.state.user_id,
@@ -1069,24 +1069,6 @@ class EnvironmentsRouter:
             permission=Permission.VIEW_ENVIRONMENTS,  # type: ignore
         ):
             raise FORBIDDEN_EXCEPTION  # type: ignore
-
-        body_json = None
-        query_request_body = None
-
-        try:
-            body_json = await request.json()
-
-            if body_json:
-                query_request_body = parse_environment_revision_query_request_from_body(
-                    **body_json
-                )
-
-        except Exception as exc:
-            # Ignore JSON parsing issues and proceed without a body filter.
-            log.debug(
-                "Failed to parse environment revision query request body as JSON: %s",
-                exc,
-            )
 
         environment_revision_query_request = merge_environment_revision_query_requests(
             query_request_params,
@@ -1105,6 +1087,8 @@ class EnvironmentsRouter:
             references=environment_revision_query_request.references,
             #
             include_archived=environment_revision_query_request.include_archived,
+            #
+            grouping=environment_revision_query_request.grouping,
             #
             windowing=environment_revision_query_request.windowing,
         )

--- a/api/oss/src/apis/fastapi/environments/utils.py
+++ b/api/oss/src/apis/fastapi/environments/utils.py
@@ -1,4 +1,5 @@
 from typing import Optional, Literal, List
+from oss.src.core.git.dtos import RevisionGrouping
 from uuid import UUID
 from datetime import datetime
 
@@ -552,31 +553,20 @@ def parse_environment_revision_query_request_from_body(
     #
     include_archived: Optional[bool] = None,
     #
+    grouping: Optional[RevisionGrouping] = None,
+    #
     windowing: Optional[Windowing] = None,
 ) -> EnvironmentRevisionQueryRequest:
-    environment_revision_query_request = None
-
-    try:
-        environment_revision_query_request = EnvironmentRevisionQueryRequest(
-            environment_revision=environment_revision,
-            #
-            environment_refs=environment_refs,
-            environment_variant_refs=environment_variant_refs,
-            environment_revision_refs=environment_revision_refs,
-            #
-            references=references,
-            #
-            include_archived=include_archived,
-            #
-            windowing=windowing,
-        )
-
-    except Exception as e:  # pylint: disable=broad-except
-        log.warn(e)
-
-        environment_revision_query_request = EnvironmentRevisionQueryRequest()
-
-    return environment_revision_query_request
+    return EnvironmentRevisionQueryRequest(
+        environment_revision=environment_revision,
+        environment_refs=environment_refs,
+        environment_variant_refs=environment_variant_refs,
+        environment_revision_refs=environment_revision_refs,
+        references=references,
+        include_archived=include_archived,
+        grouping=grouping,
+        windowing=windowing,
+    )
 
 
 def merge_environment_revision_query_requests(
@@ -608,6 +598,8 @@ def merge_environment_revision_query_requests(
                 if query_request_body.include_archived is not None
                 else query_request_params.include_archived
             ),
+            #
+            grouping=query_request_body.grouping or query_request_params.grouping,
             #
             windowing=query_request_body.windowing or query_request_params.windowing,
         )

--- a/api/oss/src/apis/fastapi/evaluators/models.py
+++ b/api/oss/src/apis/fastapi/evaluators/models.py
@@ -1,6 +1,8 @@
 from typing import Optional, List, Dict, Any
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from oss.src.core.git.dtos import RevisionGrouping, validate_revision_grouping
 
 from oss.src.core.shared.dtos import (
     Windowing,
@@ -261,10 +263,29 @@ class EvaluatorRevisionQueryRequest(BaseModel):
         description="When true, include soft-deleted revisions.",
     )
     #
+    grouping: Optional[RevisionGrouping] = Field(
+        default=None,
+        description=(
+            "Divide matching revisions by artifact or variant and select one "
+            "revision from each group."
+        ),
+    )
+    #
     windowing: Optional[Windowing] = Field(
         default=None,
         description="Cursor-based pagination controls.",
     )
+
+    @model_validator(mode="after")
+    def _validate_grouping(self):
+        validate_revision_grouping(
+            grouping=self.grouping,
+            artifact_refs=self.evaluator_refs,
+            variant_refs=self.evaluator_variant_refs,
+            revision_refs=self.evaluator_revision_refs,
+            windowing=self.windowing,
+        )
+        return self
 
 
 class EvaluatorRevisionCommitRequest(BaseModel):

--- a/api/oss/src/apis/fastapi/evaluators/router.py
+++ b/api/oss/src/apis/fastapi/evaluators/router.py
@@ -1608,6 +1608,8 @@ class EvaluatorsRouter:
             #
             include_archived=evaluator_revision_query_request.include_archived,
             #
+            grouping=evaluator_revision_query_request.grouping,
+            #
             windowing=evaluator_revision_query_request.windowing,
         )
 

--- a/api/oss/src/apis/fastapi/queries/models.py
+++ b/api/oss/src/apis/fastapi/queries/models.py
@@ -1,6 +1,8 @@
 from typing import Optional, List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from oss.src.core.git.dtos import RevisionGrouping, validate_revision_grouping
 
 from oss.src.core.shared.dtos import (
     Reference,
@@ -135,7 +137,26 @@ class QueryRevisionQueryRequest(BaseModel):
     #
     include_archived: Optional[bool] = None
     #
+    grouping: Optional[RevisionGrouping] = Field(
+        default=None,
+        description=(
+            "Divide matching revisions by artifact or variant and select one "
+            "revision from each group."
+        ),
+    )
+    #
     windowing: Optional[Windowing] = None
+
+    @model_validator(mode="after")
+    def _validate_grouping(self):
+        validate_revision_grouping(
+            grouping=self.grouping,
+            artifact_refs=self.query_refs,
+            variant_refs=self.query_variant_refs,
+            revision_refs=self.query_revision_refs,
+            windowing=self.windowing,
+        )
+        return self
 
 
 class QueryRevisionCommitRequest(BaseModel):

--- a/api/oss/src/apis/fastapi/queries/router.py
+++ b/api/oss/src/apis/fastapi/queries/router.py
@@ -912,6 +912,8 @@ class QueriesRouter:
             #
             include_archived=query_revision_query_request.include_archived,
             #
+            grouping=query_revision_query_request.grouping,
+            #
             windowing=query_revision_query_request.windowing,
         )
 

--- a/api/oss/src/apis/fastapi/testsets/models.py
+++ b/api/oss/src/apis/fastapi/testsets/models.py
@@ -1,6 +1,8 @@
 from typing import Optional, List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from oss.src.core.git.dtos import RevisionGrouping, validate_revision_grouping
 
 from oss.src.core.shared.dtos import (
     Windowing,
@@ -229,10 +231,29 @@ class TestsetRevisionQueryRequest(BaseModel):
         description="Include full testcase objects for each returned revision. Defaults to true.",
     )
     #
+    grouping: Optional[RevisionGrouping] = Field(
+        default=None,
+        description=(
+            "Divide matching revisions by artifact or variant and select one "
+            "revision from each group."
+        ),
+    )
+    #
     windowing: Optional[Windowing] = Field(
         default=None,
         description="Cursor-based pagination. See the Query Pattern guide.",
     )
+
+    @model_validator(mode="after")
+    def _validate_grouping(self):
+        validate_revision_grouping(
+            grouping=self.grouping,
+            artifact_refs=self.testset_refs,
+            variant_refs=self.testset_variant_refs,
+            revision_refs=self.testset_revision_refs,
+            windowing=self.windowing,
+        )
+        return self
 
 
 class TestsetRevisionCommitRequest(BaseModel):

--- a/api/oss/src/apis/fastapi/testsets/router.py
+++ b/api/oss/src/apis/fastapi/testsets/router.py
@@ -1420,6 +1420,8 @@ class TestsetsRouter:
             include_archived=testset_revision_query_request.include_archived,
             include_testcases=testset_revision_query_request.include_testcases,
             #
+            grouping=testset_revision_query_request.grouping,
+            #
             windowing=testset_revision_query_request.windowing,
         )
 

--- a/api/oss/src/apis/fastapi/workflows/models.py
+++ b/api/oss/src/apis/fastapi/workflows/models.py
@@ -1,6 +1,8 @@
 from typing import Any, Literal, Optional, List
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
+
+from oss.src.core.git.dtos import RevisionGrouping, validate_revision_grouping
 
 from oss.src.core.shared.dtos import (
     Windowing,
@@ -253,10 +255,31 @@ class WorkflowRevisionQueryRequest(BaseModel):
         description="When true, include archived revisions.",
     )
     #
+    grouping: Optional[RevisionGrouping] = Field(
+        default=None,
+        description=(
+            "Divide matching revisions by artifact or variant and select one "
+            "revision from each group."
+        ),
+    )
+    #
     windowing: Optional[Windowing] = Field(
         default=None,
         description="Cursor-based pagination controls.",
     )
+
+    @model_validator(mode="after")
+    def _validate_grouping(self):
+        validate_revision_grouping(
+            grouping=self.grouping,
+            artifact_refs=self.workflow_refs,
+            variant_refs=self.workflow_variant_refs,
+            revision_refs=self.workflow_revision_refs,
+            windowing=self.windowing,
+        )
+        if self.grouping and self.workflow_revision and self.workflow_revision.flags:
+            raise ValueError("grouping cannot be combined with workflow revision flags")
+        return self
 
 
 class WorkflowRevisionCommitRequest(BaseModel):

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -1582,11 +1582,23 @@ class WorkflowsRouter:
             windowing=workflow_revision_query_request.windowing,
         )
 
-        next_windowing = compute_next_windowing(
-            entities=workflow_revisions,
-            attribute="id",
-            windowing=workflow_revision_query_request.windowing,
-            order="descending",
+        # A latest-per-workflow result is COMPLETE — one row per matching workflow, not a window
+        # into a longer list — so there is no next page, and handing back a cursor built from the
+        # last row would invite a caller to page through a set that has already ended.
+        latest_per_workflow = bool(
+            workflow_revision_query_request.workflow_revision
+            and workflow_revision_query_request.workflow_revision.latest_per_artifact
+        )
+
+        next_windowing = (
+            None
+            if latest_per_workflow
+            else compute_next_windowing(
+                entities=workflow_revisions,
+                attribute="id",
+                windowing=workflow_revision_query_request.windowing,
+                order="descending",
+            )
         )
 
         await publish_revision_event(

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -2,7 +2,7 @@ from inspect import isawaitable
 from typing import Any, Optional
 from uuid import UUID, uuid4
 
-from fastapi import APIRouter, Request, status, HTTPException, Depends
+from fastapi import APIRouter, Body, Request, status, HTTPException, Depends
 
 from oss.src.utils.env import env
 from oss.src.utils.logging import get_module_logger
@@ -90,7 +90,6 @@ from oss.src.apis.fastapi.workflows.utils import (
     parse_workflow_variant_query_request_from_body,
     merge_workflow_variant_query_requests,
     parse_workflow_revision_query_request_from_params,
-    parse_workflow_revision_query_request_from_body,
     merge_workflow_revision_query_requests,
 )
 from oss.src.apis.fastapi.environments.utils import (
@@ -1542,21 +1541,8 @@ class WorkflowsRouter:
         query_request_params: Optional[WorkflowRevisionQueryRequest] = Depends(
             parse_workflow_revision_query_request_from_params
         ),
+        query_request_body: Optional[WorkflowRevisionQueryRequest] = Body(None),
     ) -> WorkflowRevisionsResponse:
-        body_json = None
-        query_request_body = None
-
-        try:
-            body_json = await request.json()
-
-            if body_json:
-                query_request_body = parse_workflow_revision_query_request_from_body(
-                    **body_json
-                )
-
-        except Exception:  # pylint: disable=bare-except
-            pass
-
         workflow_revision_query_request = merge_workflow_revision_query_requests(
             query_request_params, query_request_body
         )
@@ -1579,20 +1565,14 @@ class WorkflowsRouter:
             #
             include_archived=workflow_revision_query_request.include_archived,
             #
+            grouping=workflow_revision_query_request.grouping,
+            #
             windowing=workflow_revision_query_request.windowing,
-        )
-
-        # A latest-per-workflow result is COMPLETE — one row per matching workflow, not a window
-        # into a longer list — so there is no next page, and handing back a cursor built from the
-        # last row would invite a caller to page through a set that has already ended.
-        latest_per_workflow = bool(
-            workflow_revision_query_request.workflow_revision
-            and workflow_revision_query_request.workflow_revision.latest_per_artifact
         )
 
         next_windowing = (
             None
-            if latest_per_workflow
+            if workflow_revision_query_request.grouping
             else compute_next_windowing(
                 entities=workflow_revisions,
                 attribute="id",

--- a/api/oss/src/apis/fastapi/workflows/utils.py
+++ b/api/oss/src/apis/fastapi/workflows/utils.py
@@ -1,4 +1,5 @@
 from typing import Optional, Literal, List
+from oss.src.core.git.dtos import RevisionGrouping
 from uuid import UUID
 from datetime import datetime
 
@@ -519,29 +520,19 @@ def parse_workflow_revision_query_request_from_body(
     #
     include_archived: Optional[bool] = None,
     #
+    grouping: Optional[RevisionGrouping] = None,
+    #
     windowing: Optional[Windowing] = None,
 ) -> WorkflowRevisionQueryRequest:
-    workflow_revision_query_request = None
-
-    try:
-        workflow_revision_query_request = WorkflowRevisionQueryRequest(
-            workflow_revision=workflow_revision,
-            #
-            workflow_refs=workflow_refs,
-            workflow_variant_refs=workflow_variant_refs,
-            workflow_revision_refs=workflow_revision_refs,
-            #
-            include_archived=include_archived,
-            #
-            windowing=windowing,
-        )
-
-    except Exception as e:  # pylint: disable=broad-except
-        log.warn(e)
-
-        workflow_revision_query_request = WorkflowRevisionQueryRequest()
-
-    return workflow_revision_query_request
+    return WorkflowRevisionQueryRequest(
+        workflow_revision=workflow_revision,
+        workflow_refs=workflow_refs,
+        workflow_variant_refs=workflow_variant_refs,
+        workflow_revision_refs=workflow_revision_refs,
+        include_archived=include_archived,
+        grouping=grouping,
+        windowing=windowing,
+    )
 
 
 def merge_workflow_revision_query_requests(
@@ -571,6 +562,8 @@ def merge_workflow_revision_query_requests(
                 if query_request_body.include_archived is not None
                 else query_request_params.include_archived
             ),
+            #
+            grouping=query_request_body.grouping or query_request_params.grouping,
             #
             windowing=query_request_body.windowing or query_request_params.windowing,
         )

--- a/api/oss/src/core/applications/service.py
+++ b/api/oss/src/core/applications/service.py
@@ -1,4 +1,5 @@
 from typing import Optional, List, TYPE_CHECKING
+from oss.src.core.git.dtos import RevisionGrouping
 from uuid import UUID, uuid4
 
 if TYPE_CHECKING:
@@ -806,6 +807,8 @@ class ApplicationsService:
         #
         include_archived: Optional[bool] = None,
         #
+        grouping: Optional[RevisionGrouping] = None,
+        #
         windowing: Optional[Windowing] = None,
     ) -> List[ApplicationRevision]:
         workflow_revision_query = (
@@ -828,6 +831,8 @@ class ApplicationsService:
             workflow_revision_refs=application_revision_refs,
             #
             include_archived=include_archived,
+            #
+            grouping=grouping,
             #
             windowing=windowing,
         )

--- a/api/oss/src/core/environments/service.py
+++ b/api/oss/src/core/environments/service.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, List, Optional
+from oss.src.core.git.dtos import RevisionGrouping
 from uuid import UUID, uuid4
 
 from pydantic import BaseModel
@@ -1007,6 +1008,8 @@ class EnvironmentsService:
         #
         include_archived: Optional[bool] = None,
         #
+        grouping: Optional[RevisionGrouping] = None,
+        #
         windowing: Optional[Windowing] = None,
     ) -> List[EnvironmentRevision]:
         revision_query = (
@@ -1031,6 +1034,8 @@ class EnvironmentsService:
             references=references,
             #
             include_archived=include_archived,
+            #
+            grouping=grouping,
             #
             windowing=windowing,
         )

--- a/api/oss/src/core/evaluators/service.py
+++ b/api/oss/src/core/evaluators/service.py
@@ -1,4 +1,5 @@
 from typing import Any, Dict, Optional, List
+from oss.src.core.git.dtos import RevisionGrouping
 from uuid import UUID, uuid4
 
 from oss.src.core.events.utils import publish_revision_event
@@ -802,6 +803,8 @@ class EvaluatorsService:
         #
         include_archived: Optional[bool] = None,
         #
+        grouping: Optional[RevisionGrouping] = None,
+        #
         windowing: Optional[Windowing] = None,
     ) -> List[EvaluatorRevision]:
         workflow_revision_query = (
@@ -824,6 +827,8 @@ class EvaluatorsService:
             workflow_revision_refs=evaluator_revision_refs,
             #
             include_archived=include_archived,
+            #
+            grouping=grouping,
             #
             windowing=windowing,
         )

--- a/api/oss/src/core/git/dtos.py
+++ b/api/oss/src/core/git/dtos.py
@@ -92,6 +92,17 @@ class RevisionQuery(Header, Metadata):
 
     message: Optional[str] = None
 
+    # Return only the newest revision of each artifact the query matches, instead of every
+    # revision of every one. A caller that wants one fact per artifact ("is this an agent?")
+    # otherwise has to download the whole history to compute it.
+    #
+    # It lives here, on the SHARED query, and not on a domain subclass: the domain services
+    # downcast their query to this type before calling the DAO, and this model does not set
+    # `extra`, so Pydantic's `extra="ignore"` default would drop a subclass-only field at that
+    # boundary without an error. "Newest per artifact" is generic artifact semantics anyway, so
+    # every domain on this DAO gets it.
+    latest_per_artifact: Optional[bool] = None
+
 
 class RevisionCommit(Slug, Header, Metadata):
     data: Optional[Data] = None

--- a/api/oss/src/core/git/dtos.py
+++ b/api/oss/src/core/git/dtos.py
@@ -1,4 +1,4 @@
-from typing import Dict, Optional, List
+from typing import Dict, Literal, Optional, List
 from uuid import UUID
 from datetime import datetime
 
@@ -15,6 +15,7 @@ from oss.src.core.shared.dtos import (
     Commit,
     FolderScope,
     Reference,
+    Windowing,
 )
 
 
@@ -80,6 +81,31 @@ class RevisionEdit(Identifier, Header, Metadata):
     pass
 
 
+class RevisionGrouping(BaseModel):
+    by: Literal["artifact", "variant"]
+    get: Literal["latest"]
+
+
+def validate_revision_grouping(
+    *,
+    grouping: Optional[RevisionGrouping],
+    artifact_refs: Optional[List[Reference]],
+    variant_refs: Optional[List[Reference]],
+    revision_refs: Optional[List[Reference]],
+    windowing: Optional[Windowing],
+) -> None:
+    if not grouping:
+        return
+    if windowing:
+        raise ValueError("grouping cannot be combined with windowing")
+    if revision_refs:
+        raise ValueError("grouping cannot be combined with revision references")
+    if grouping.by == "artifact" and not artifact_refs:
+        raise ValueError("artifact grouping requires artifact references")
+    if grouping.by == "variant" and not (artifact_refs or variant_refs):
+        raise ValueError("variant grouping requires artifact or variant references")
+
+
 class RevisionQuery(Header, Metadata):
     slug: Optional[str] = None
     slugs: Optional[List[str]] = None
@@ -91,17 +117,6 @@ class RevisionQuery(Header, Metadata):
     dates: Optional[List[datetime]] = None
 
     message: Optional[str] = None
-
-    # Return only the newest revision of each artifact the query matches, instead of every
-    # revision of every one. A caller that wants one fact per artifact ("is this an agent?")
-    # otherwise has to download the whole history to compute it.
-    #
-    # It lives here, on the SHARED query, and not on a domain subclass: the domain services
-    # downcast their query to this type before calling the DAO, and this model does not set
-    # `extra`, so Pydantic's `extra="ignore"` default would drop a subclass-only field at that
-    # boundary without an error. "Newest per artifact" is generic artifact semantics anyway, so
-    # every domain on this DAO gets it.
-    latest_per_artifact: Optional[bool] = None
 
 
 class RevisionCommit(Slug, Header, Metadata):

--- a/api/oss/src/core/git/interfaces.py
+++ b/api/oss/src/core/git/interfaces.py
@@ -19,6 +19,7 @@ from oss.src.core.git.dtos import (
     RevisionCreate,
     RevisionEdit,
     RevisionQuery,
+    RevisionGrouping,
     RevisionCommit,
 )
 
@@ -273,6 +274,7 @@ class GitDAOInterface(ABC):
         project_id: UUID,
         #
         revision_query: RevisionQuery,
+        grouping: Optional[RevisionGrouping] = None,
         #
         artifact_refs: Optional[List[Reference]] = None,
         variant_refs: Optional[List[Reference]] = None,

--- a/api/oss/src/core/queries/service.py
+++ b/api/oss/src/core/queries/service.py
@@ -1,4 +1,5 @@
 from typing import Optional, List, TYPE_CHECKING, Any, Dict
+from oss.src.core.git.dtos import RevisionGrouping
 from uuid import UUID, uuid4
 from collections import defaultdict
 
@@ -902,6 +903,8 @@ class QueriesService:
         #
         include_archived: Optional[bool] = None,
         #
+        grouping: Optional[RevisionGrouping] = None,
+        #
         windowing: Optional[Windowing] = None,
     ) -> List[QueryRevision]:
         _revision_query = (
@@ -922,6 +925,8 @@ class QueriesService:
             revision_refs=query_revision_refs,
             #
             include_archived=include_archived,
+            #
+            grouping=grouping,
             #
             windowing=windowing,
         )

--- a/api/oss/src/core/testsets/service.py
+++ b/api/oss/src/core/testsets/service.py
@@ -1,4 +1,5 @@
 from typing import Dict, Optional, List, Any
+from oss.src.core.git.dtos import RevisionGrouping
 from uuid import UUID, uuid4
 
 from oss.src.utils.logging import get_module_logger
@@ -937,6 +938,8 @@ class TestsetsService:
         include_archived: Optional[bool] = None,
         include_testcases: Optional[bool] = None,
         #
+        grouping: Optional[RevisionGrouping] = None,
+        #
         windowing: Optional[Windowing] = None,
     ) -> List[TestsetRevision]:
         revision_query = (
@@ -959,6 +962,8 @@ class TestsetsService:
             revision_refs=testset_revision_refs,
             #
             include_archived=include_archived,
+            #
+            grouping=grouping,
             #
             windowing=windowing,
         )

--- a/api/oss/src/core/workflows/service.py
+++ b/api/oss/src/core/workflows/service.py
@@ -1,5 +1,6 @@
 import json
 from typing import Any, Awaitable, Callable, Dict, Optional, List, Union, TYPE_CHECKING
+from oss.src.core.git.dtos import RevisionGrouping
 from uuid import UUID, uuid4
 
 import httpx
@@ -2131,6 +2132,8 @@ class WorkflowsService:
         #
         include_archived: Optional[bool] = None,
         #
+        grouping: Optional[RevisionGrouping] = None,
+        #
         windowing: Optional[Windowing] = None,
     ) -> List[WorkflowRevision]:
         _revision_query = (
@@ -2163,6 +2166,8 @@ class WorkflowsService:
             revision_refs=workflow_revision_refs,
             #
             include_archived=include_archived,
+            #
+            grouping=grouping,
             #
             windowing=windowing,
         )

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -38,6 +38,7 @@ from oss.src.core.git.dtos import (
     RevisionCreate,
     RevisionEdit,
     RevisionQuery,
+    RevisionGrouping,
     RevisionCommit,
 )
 
@@ -1363,6 +1364,7 @@ class GitDAO(GitDAOInterface):
         project_id: UUID,
         #
         revision_query: RevisionQuery,
+        grouping: Optional[RevisionGrouping] = None,
         #
         artifact_refs: Optional[List[Reference]] = None,
         variant_refs: Optional[List[Reference]] = None,
@@ -1375,15 +1377,8 @@ class GitDAO(GitDAOInterface):
         windowing: Optional[Windowing] = None,
     ) -> List[Revision]:
         async with self.engine.session() as session:
-            stmt = (
-                select(self.RevisionDBE)
-                .options(
-                    selectinload(self.RevisionDBE.artifact),  # type: ignore
-                    selectinload(self.RevisionDBE.variant),  # type: ignore
-                )
-                .filter(
-                    self.RevisionDBE.project_id == project_id,  # type: ignore
-                )
+            stmt = select(self.RevisionDBE).filter(
+                self.RevisionDBE.project_id == project_id,  # type: ignore
             )
 
             if artifact_refs:
@@ -1526,37 +1521,35 @@ class GitDAO(GitDAOInterface):
                     self.RevisionDBE.deleted_at.is_(None),  # type: ignore
                 )
 
-            # `revision_refs` names exact revisions, so collapsing to one per artifact would
-            # silently drop revisions the caller asked for by id. The explicit list wins.
-            latest_per_artifact = (
-                bool(revision_query.latest_per_artifact) and not revision_refs
-            )
-
-            if latest_per_artifact:
-                # Skip empty placeholder revisions — version "0" carrying no data and no flags.
-                # Nothing committed them, and on a multi-variant artifact one can hold a NEWER id
-                # than the real head, which would resolve the artifact to a row with no flags.
-                # A first commit lands ON version 0 and DOES carry data, so the data/flags arms
-                # are what keep a single-revision artifact from disappearing here.
+            if grouping:
+                # Seed rows carry version 0 but no committed content. A first real commit can
+                # also be version 0, so only exclude rows whose content fields are all empty.
                 stmt = stmt.filter(
                     or_(
                         self.RevisionDBE.version.is_(None),  # type: ignore
                         self.RevisionDBE.version != "0",  # type: ignore
                         self.RevisionDBE.data.isnot(None),  # type: ignore
                         self.RevisionDBE.flags.isnot(None),  # type: ignore
+                        self.RevisionDBE.tags.isnot(None),  # type: ignore
+                        self.RevisionDBE.meta.isnot(None),  # type: ignore
                     )
                 )
 
-                # Newest per artifact, by `id`, NEVER by `version`. Two reasons, both load-bearing:
-                #   - `version` is a nullable String column, so ordering by it is lexicographic —
-                #     "9" sorts above "10", which is wrong past nine commits.
-                #   - `version` counts revisions WITHIN a variant, so "max version per artifact"
-                #     is not even well defined for a multi-variant artifact.
-                # Ids are UUID7, so id order is commit order, and within a variant it is exactly
-                # version order.
-                stmt = stmt.distinct(self.RevisionDBE.artifact_id).order_by(  # type: ignore
-                    self.RevisionDBE.artifact_id,  # type: ignore
-                    self.RevisionDBE.id.desc(),  # type: ignore
+                group_column = (
+                    self.RevisionDBE.artifact_id
+                    if grouping.by == "artifact"
+                    else self.RevisionDBE.variant_id
+                )
+                selected_ids = (
+                    stmt.with_only_columns(self.RevisionDBE.id)
+                    .distinct(group_column)
+                    .order_by(group_column, self.RevisionDBE.id.desc())
+                    .subquery()
+                )
+                stmt = (
+                    select(self.RevisionDBE)
+                    .filter(self.RevisionDBE.id.in_(select(selected_ids.c.id)))
+                    .order_by(self.RevisionDBE.id.desc())
                 )
 
             elif windowing:
@@ -1567,6 +1560,11 @@ class GitDAO(GitDAOInterface):
                     order="descending",  # jobs-style
                     windowing=windowing,
                 )
+
+            stmt = stmt.options(
+                selectinload(self.RevisionDBE.artifact),  # type: ignore
+                selectinload(self.RevisionDBE.variant),  # type: ignore
+            )
 
             result = await session.execute(stmt)
 

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -1533,11 +1533,11 @@ class GitDAO(GitDAOInterface):
             )
 
             if latest_per_artifact:
-                # The empty placeholder a variant is seeded with (version "0", no data, no flags)
-                # is not a revision anyone committed, and every client-side "latest" picker skips
-                # it. `DISTINCT ON` would not: a variant added later carries a placeholder with a
-                # NEWER id than the first variant's real head, so a multi-variant artifact would
-                # resolve to the placeholder and lose its flags. Exclude them before picking.
+                # Skip empty placeholder revisions — version "0" carrying no data and no flags.
+                # Nothing committed them, and on a multi-variant artifact one can hold a NEWER id
+                # than the real head, which would resolve the artifact to a row with no flags.
+                # A first commit lands ON version 0 and DOES carry data, so the data/flags arms
+                # are what keep a single-revision artifact from disappearing here.
                 stmt = stmt.filter(
                     or_(
                         self.RevisionDBE.version.is_(None),  # type: ignore

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -1526,7 +1526,40 @@ class GitDAO(GitDAOInterface):
                     self.RevisionDBE.deleted_at.is_(None),  # type: ignore
                 )
 
-            if windowing:
+            # `revision_refs` names exact revisions, so collapsing to one per artifact would
+            # silently drop revisions the caller asked for by id. The explicit list wins.
+            latest_per_artifact = (
+                bool(revision_query.latest_per_artifact) and not revision_refs
+            )
+
+            if latest_per_artifact:
+                # The empty placeholder a variant is seeded with (version "0", no data, no flags)
+                # is not a revision anyone committed, and every client-side "latest" picker skips
+                # it. `DISTINCT ON` would not: a variant added later carries a placeholder with a
+                # NEWER id than the first variant's real head, so a multi-variant artifact would
+                # resolve to the placeholder and lose its flags. Exclude them before picking.
+                stmt = stmt.filter(
+                    or_(
+                        self.RevisionDBE.version.is_(None),  # type: ignore
+                        self.RevisionDBE.version != "0",  # type: ignore
+                        self.RevisionDBE.data.isnot(None),  # type: ignore
+                        self.RevisionDBE.flags.isnot(None),  # type: ignore
+                    )
+                )
+
+                # Newest per artifact, by `id`, NEVER by `version`. Two reasons, both load-bearing:
+                #   - `version` is a nullable String column, so ordering by it is lexicographic —
+                #     "9" sorts above "10", which is wrong past nine commits.
+                #   - `version` counts revisions WITHIN a variant, so "max version per artifact"
+                #     is not even well defined for a multi-variant artifact.
+                # Ids are UUID7, so id order is commit order, and within a variant it is exactly
+                # version order.
+                stmt = stmt.distinct(self.RevisionDBE.artifact_id).order_by(  # type: ignore
+                    self.RevisionDBE.artifact_id,  # type: ignore
+                    self.RevisionDBE.id.desc(),  # type: ignore
+                )
+
+            elif windowing:
                 stmt = apply_windowing(
                     stmt=stmt,
                     DBE=self.RevisionDBE,

--- a/api/oss/tests/pytest/acceptance/workflows/test_workflow_revision_grouping.py
+++ b/api/oss/tests/pytest/acceptance/workflows/test_workflow_revision_grouping.py
@@ -133,13 +133,13 @@ def _query(authed_api, **body):
     return response.json()
 
 
-class TestWorkflowRevisionsLatestPerWorkflow:
+class TestWorkflowRevisionsGrouping:
     def test_returns_one_revision_per_workflow(self, authed_api, mock_data):
         # ACT ------------------------------------------------------------------
         response = _query(
             authed_api,
             workflow_refs=[{"id": w["workflow_id"]} for w in mock_data["plain"]],
-            workflow_revision={"latest_per_artifact": True},
+            grouping={"by": "artifact", "get": "latest"},
         )
         # ----------------------------------------------------------------------
 
@@ -152,7 +152,7 @@ class TestWorkflowRevisionsLatestPerWorkflow:
         assert response.get("windowing") is None
         # ----------------------------------------------------------------------
 
-    def test_without_the_flag_every_revision_comes_back(self, authed_api, mock_data):
+    def test_without_grouping_every_revision_comes_back(self, authed_api, mock_data):
         # The behaviour this flag exists to avoid: no windowing means no LIMIT.
 
         # ACT ------------------------------------------------------------------
@@ -174,7 +174,7 @@ class TestWorkflowRevisionsLatestPerWorkflow:
         response = _query(
             authed_api,
             workflow_refs=[{"id": mock_data["deep"]["workflow_id"]}],
-            workflow_revision={"latest_per_artifact": True},
+            grouping={"by": "artifact", "get": "latest"},
         )
         # ----------------------------------------------------------------------
 
@@ -194,7 +194,7 @@ class TestWorkflowRevisionsLatestPerWorkflow:
         response = _query(
             authed_api,
             workflow_refs=[{"id": mock_data["multi"]["workflow_id"]}],
-            workflow_revision={"latest_per_artifact": True},
+            grouping={"by": "artifact", "get": "latest"},
         )
         # ----------------------------------------------------------------------
 
@@ -216,7 +216,7 @@ class TestWorkflowRevisionsLatestPerWorkflow:
         response = _query(
             authed_api,
             workflow_refs=[{"id": mock_data["v0"]["workflow_id"]}],
-            workflow_revision={"latest_per_artifact": True},
+            grouping={"by": "artifact", "get": "latest"},
         )
         # ----------------------------------------------------------------------
 
@@ -227,25 +227,40 @@ class TestWorkflowRevisionsLatestPerWorkflow:
         assert revision["flags"]["is_agent"] is True
         # ----------------------------------------------------------------------
 
-    def test_explicit_revision_refs_win(self, authed_api, mock_data):
-        # Naming exact revisions is a stronger statement than "the latest one" —
-        # collapsing here would silently drop revisions the caller asked for.
+    def test_rejects_explicit_revision_refs(self, authed_api, mock_data):
         revisions = mock_data["plain"][0]["revisions"]
 
-        # ACT ------------------------------------------------------------------
+        response = authed_api(
+            "POST",
+            "/workflows/revisions/query",
+            json={
+                "workflow_revision_refs": [{"id": revisions[0]["id"]}],
+                "grouping": {"by": "artifact", "get": "latest"},
+            },
+        )
+
+        assert response.status_code == 422
+
+    def test_rejects_grouping_without_get(self, authed_api, mock_data):
+        response = authed_api(
+            "POST",
+            "/workflows/revisions/query",
+            json={
+                "workflow_refs": [{"id": mock_data["plain"][0]["workflow_id"]}],
+                "grouping": {"by": "artifact"},
+            },
+        )
+
+        assert response.status_code == 422
+
+    def test_returns_latest_revision_per_variant(self, authed_api, mock_data):
         response = _query(
             authed_api,
-            workflow_revision_refs=[{"id": r["id"]} for r in revisions[:2]],
-            workflow_revision={"latest_per_artifact": True},
+            workflow_refs=[{"id": mock_data["multi"]["workflow_id"]}],
+            grouping={"by": "variant", "get": "latest"},
         )
-        # ----------------------------------------------------------------------
 
-        # ASSERT ---------------------------------------------------------------
         assert response["count"] == 2
-        assert {r["id"] for r in response["workflow_revisions"]} == {
-            r["id"] for r in revisions[:2]
-        }
-        # ----------------------------------------------------------------------
 
     def test_archived_head_falls_back_unless_included(self, authed_api, mock_data):
         workflow = mock_data["plain"][1]
@@ -259,7 +274,7 @@ class TestWorkflowRevisionsLatestPerWorkflow:
             response = _query(
                 authed_api,
                 workflow_refs=[{"id": workflow["workflow_id"]}],
-                workflow_revision={"latest_per_artifact": True},
+                grouping={"by": "artifact", "get": "latest"},
             )
             # ------------------------------------------------------------------
 
@@ -273,7 +288,7 @@ class TestWorkflowRevisionsLatestPerWorkflow:
                 authed_api,
                 include_archived=True,
                 workflow_refs=[{"id": workflow["workflow_id"]}],
-                workflow_revision={"latest_per_artifact": True},
+                grouping={"by": "artifact", "get": "latest"},
             )
             # ------------------------------------------------------------------
 

--- a/api/oss/tests/pytest/acceptance/workflows/test_workflow_revisions_latest_per_workflow.py
+++ b/api/oss/tests/pytest/acceptance/workflows/test_workflow_revisions_latest_per_workflow.py
@@ -1,0 +1,253 @@
+from uuid import uuid4
+
+import pytest
+
+
+def _create_workflow(authed_api, marker):
+    slug = uuid4()
+
+    response = authed_api(
+        "POST",
+        "/workflows/",
+        json={
+            "workflow": {
+                "slug": f"workflow-{slug}",
+                "name": f"Workflow {slug}",
+                "flags": {
+                    "is_application": True,
+                    "is_evaluator": False,
+                    "is_snippet": False,
+                },
+                "tags": {"_marker": marker},
+            }
+        },
+    )
+
+    assert response.status_code == 200
+
+    return response.json()["workflow"]["id"]
+
+
+def _create_variant(authed_api, workflow_id):
+    """Creating a variant seeds it with an EMPTY version-0 placeholder revision."""
+    slug = uuid4()
+
+    response = authed_api(
+        "POST",
+        "/workflows/variants/",
+        json={
+            "workflow_variant": {
+                "slug": f"workflow-variant-{slug}",
+                "name": f"Workflow Variant {slug}",
+                "flags": {
+                    "is_application": True,
+                    "is_evaluator": False,
+                    "is_snippet": False,
+                },
+                "workflow_id": workflow_id,
+            }
+        },
+    )
+
+    assert response.status_code == 200
+
+    return response.json()["workflow_variant"]["id"]
+
+
+def _commit(authed_api, workflow_id, variant_id, marker, *, is_agent=False):
+    slug = uuid4()
+
+    response = authed_api(
+        "POST",
+        "/workflows/revisions/commit",
+        json={
+            "workflow_revision": {
+                "slug": f"workflow-revision-{slug}",
+                "name": f"Workflow Revision {slug}",
+                "tags": {"_marker": marker},
+                "flags": {"is_custom": True, "is_agent": is_agent},
+                "data": {"uri": "agenta:builtin:chat:v0"},
+                "workflow_id": workflow_id,
+                "workflow_variant_id": variant_id,
+            }
+        },
+    )
+
+    assert response.status_code == 200
+
+    return response.json()["workflow_revision"]
+
+
+@pytest.fixture(scope="class")
+def mock_data(authed_api):
+    marker = uuid4().hex[:8]
+
+    # Two plain workflows, three real revisions each.
+    plain = []
+    for _ in range(2):
+        workflow_id = _create_workflow(authed_api, marker)
+        variant_id = _create_variant(authed_api, workflow_id)
+        revisions = [
+            _commit(authed_api, workflow_id, variant_id, marker) for _ in range(3)
+        ]
+        plain.append({"workflow_id": workflow_id, "revisions": revisions})
+
+    # One workflow past nine commits, so "9" vs "10" separates an id sort from a
+    # lexicographic sort of the (String) version column.
+    deep_workflow_id = _create_workflow(authed_api, marker)
+    deep_variant_id = _create_variant(authed_api, deep_workflow_id)
+    deep_revisions = [
+        _commit(authed_api, deep_workflow_id, deep_variant_id, marker)
+        for _ in range(11)
+    ]
+
+    # One workflow with a SECOND variant that only ever got its placeholder. That
+    # placeholder's id is newer than the first variant's real head.
+    multi_workflow_id = _create_workflow(authed_api, marker)
+    multi_variant_id = _create_variant(authed_api, multi_workflow_id)
+    multi_head = _commit(
+        authed_api, multi_workflow_id, multi_variant_id, marker, is_agent=True
+    )
+    _create_variant(authed_api, multi_workflow_id)
+
+    return {
+        "_marker": marker,
+        "plain": plain,
+        "deep": {"workflow_id": deep_workflow_id, "revisions": deep_revisions},
+        "multi": {"workflow_id": multi_workflow_id, "head": multi_head},
+    }
+
+
+def _query(authed_api, **body):
+    response = authed_api("POST", "/workflows/revisions/query", json=body)
+    assert response.status_code == 200
+    return response.json()
+
+
+class TestWorkflowRevisionsLatestPerWorkflow:
+    def test_returns_one_revision_per_workflow(self, authed_api, mock_data):
+        # ACT ------------------------------------------------------------------
+        response = _query(
+            authed_api,
+            workflow_refs=[{"id": w["workflow_id"]} for w in mock_data["plain"]],
+            workflow_revision={"latest_per_artifact": True},
+        )
+        # ----------------------------------------------------------------------
+
+        # ASSERT ---------------------------------------------------------------
+        assert response["count"] == 2
+        assert {r["id"] for r in response["workflow_revisions"]} == {
+            w["revisions"][-1]["id"] for w in mock_data["plain"]
+        }
+        # A complete result, not a window — so no cursor to page with.
+        assert response["windowing"] is None
+        # ----------------------------------------------------------------------
+
+    def test_without_the_flag_every_revision_comes_back(self, authed_api, mock_data):
+        # ACT ------------------------------------------------------------------
+        response = _query(
+            authed_api,
+            workflow_refs=[{"id": w["workflow_id"]} for w in mock_data["plain"]],
+        )
+        # ----------------------------------------------------------------------
+
+        # ASSERT ---------------------------------------------------------------
+        # 3 commits + the variant's version-0 placeholder, twice over.
+        assert response["count"] == 8
+        # ----------------------------------------------------------------------
+
+    def test_picks_version_11_over_version_9(self, authed_api, mock_data):
+        # `version` is a nullable String column, so a `ORDER BY version DESC` would
+        # answer "9" here. Ordering by the UUID7 id is what makes this pass.
+
+        # ACT ------------------------------------------------------------------
+        response = _query(
+            authed_api,
+            workflow_refs=[{"id": mock_data["deep"]["workflow_id"]}],
+            workflow_revision={"latest_per_artifact": True},
+        )
+        # ----------------------------------------------------------------------
+
+        # ASSERT ---------------------------------------------------------------
+        assert response["count"] == 1
+        revision = response["workflow_revisions"][0]
+        assert revision["id"] == mock_data["deep"]["revisions"][-1]["id"]
+        assert str(revision["version"]) == "11"
+        # ----------------------------------------------------------------------
+
+    def test_skips_a_second_variants_empty_placeholder(self, authed_api, mock_data):
+        # The newest revision by id belongs to the second variant and is an empty
+        # placeholder. Returning it would strip the workflow of its flags — an agent
+        # would stop reading as one.
+
+        # ACT ------------------------------------------------------------------
+        response = _query(
+            authed_api,
+            workflow_refs=[{"id": mock_data["multi"]["workflow_id"]}],
+            workflow_revision={"latest_per_artifact": True},
+        )
+        # ----------------------------------------------------------------------
+
+        # ASSERT ---------------------------------------------------------------
+        assert response["count"] == 1
+        revision = response["workflow_revisions"][0]
+        assert revision["id"] == mock_data["multi"]["head"]["id"]
+        assert revision["flags"]["is_agent"] is True
+        # ----------------------------------------------------------------------
+
+    def test_explicit_revision_refs_win(self, authed_api, mock_data):
+        # Naming exact revisions is a stronger statement than "the latest one" —
+        # collapsing here would silently drop revisions the caller asked for.
+        revisions = mock_data["plain"][0]["revisions"]
+
+        # ACT ------------------------------------------------------------------
+        response = _query(
+            authed_api,
+            workflow_revision_refs=[{"id": r["id"]} for r in revisions[:2]],
+            workflow_revision={"latest_per_artifact": True},
+        )
+        # ----------------------------------------------------------------------
+
+        # ASSERT ---------------------------------------------------------------
+        assert response["count"] == 2
+        assert {r["id"] for r in response["workflow_revisions"]} == {
+            r["id"] for r in revisions[:2]
+        }
+        # ----------------------------------------------------------------------
+
+    def test_archived_head_falls_back_unless_included(self, authed_api, mock_data):
+        workflow = mock_data["plain"][1]
+        head, previous = workflow["revisions"][-1], workflow["revisions"][-2]
+
+        response = authed_api("POST", f"/workflows/revisions/{head['id']}/archive")
+        assert response.status_code == 200
+
+        try:
+            # ACT ------------------------------------------------------------------
+            response = _query(
+                authed_api,
+                workflow_refs=[{"id": workflow["workflow_id"]}],
+                workflow_revision={"latest_per_artifact": True},
+            )
+            # ----------------------------------------------------------------------
+
+            # ASSERT — archived head excluded, so the one before it is now latest ---
+            assert response["count"] == 1
+            assert response["workflow_revisions"][0]["id"] == previous["id"]
+            # ----------------------------------------------------------------------
+
+            # ACT ------------------------------------------------------------------
+            response = _query(
+                authed_api,
+                include_archived=True,
+                workflow_refs=[{"id": workflow["workflow_id"]}],
+                workflow_revision={"latest_per_artifact": True},
+            )
+            # ----------------------------------------------------------------------
+
+            # ASSERT ---------------------------------------------------------------
+            assert response["count"] == 1
+            assert response["workflow_revisions"][0]["id"] == head["id"]
+            # ----------------------------------------------------------------------
+        finally:
+            authed_api("POST", f"/workflows/revisions/{head['id']}/unarchive")

--- a/api/oss/tests/pytest/acceptance/workflows/test_workflow_revisions_latest_per_workflow.py
+++ b/api/oss/tests/pytest/acceptance/workflows/test_workflow_revisions_latest_per_workflow.py
@@ -3,6 +3,10 @@ from uuid import uuid4
 import pytest
 
 
+AGENT_URI = "agenta:builtin:agent:v0"
+CHAT_URI = "agenta:builtin:chat:v0"
+
+
 def _create_workflow(authed_api, marker):
     slug = uuid4()
 
@@ -29,7 +33,6 @@ def _create_workflow(authed_api, marker):
 
 
 def _create_variant(authed_api, workflow_id):
-    """Creating a variant seeds it with an EMPTY version-0 placeholder revision."""
     slug = uuid4()
 
     response = authed_api(
@@ -54,7 +57,8 @@ def _create_variant(authed_api, workflow_id):
     return response.json()["workflow_variant"]["id"]
 
 
-def _commit(authed_api, workflow_id, variant_id, marker, *, is_agent=False):
+def _commit(authed_api, workflow_id, variant_id, nonce, *, uri=CHAT_URI):
+    """One revision. `nonce` keeps the data distinct — an unchanged commit is a no-op."""
     slug = uuid4()
 
     response = authed_api(
@@ -64,9 +68,7 @@ def _commit(authed_api, workflow_id, variant_id, marker, *, is_agent=False):
             "workflow_revision": {
                 "slug": f"workflow-revision-{slug}",
                 "name": f"Workflow Revision {slug}",
-                "tags": {"_marker": marker},
-                "flags": {"is_custom": True, "is_agent": is_agent},
-                "data": {"uri": "agenta:builtin:chat:v0"},
+                "data": {"uri": uri, "parameters": {"nonce": nonce}},
                 "workflow_id": workflow_id,
                 "workflow_variant_id": variant_id,
             }
@@ -82,39 +84,46 @@ def _commit(authed_api, workflow_id, variant_id, marker, *, is_agent=False):
 def mock_data(authed_api):
     marker = uuid4().hex[:8]
 
-    # Two plain workflows, three real revisions each.
+    # Two plain workflows, three revisions each.
     plain = []
     for _ in range(2):
         workflow_id = _create_workflow(authed_api, marker)
         variant_id = _create_variant(authed_api, workflow_id)
         revisions = [
-            _commit(authed_api, workflow_id, variant_id, marker) for _ in range(3)
+            _commit(authed_api, workflow_id, variant_id, nonce) for nonce in range(3)
         ]
         plain.append({"workflow_id": workflow_id, "revisions": revisions})
 
-    # One workflow past nine commits, so "9" vs "10" separates an id sort from a
+    # One workflow past nine revisions, so "9" vs "10" separates an id sort from a
     # lexicographic sort of the (String) version column.
     deep_workflow_id = _create_workflow(authed_api, marker)
     deep_variant_id = _create_variant(authed_api, deep_workflow_id)
     deep_revisions = [
-        _commit(authed_api, deep_workflow_id, deep_variant_id, marker)
-        for _ in range(11)
+        _commit(authed_api, deep_workflow_id, deep_variant_id, nonce)
+        for nonce in range(12)
     ]
 
-    # One workflow with a SECOND variant that only ever got its placeholder. That
-    # placeholder's id is newer than the first variant's real head.
+    # One workflow with two variants: an agent on the first, a chat committed later on
+    # the second. Grain is the WORKFLOW, so the newest across both wins.
     multi_workflow_id = _create_workflow(authed_api, marker)
-    multi_variant_id = _create_variant(authed_api, multi_workflow_id)
-    multi_head = _commit(
-        authed_api, multi_workflow_id, multi_variant_id, marker, is_agent=True
-    )
-    _create_variant(authed_api, multi_workflow_id)
+    multi_variant_a = _create_variant(authed_api, multi_workflow_id)
+    _commit(authed_api, multi_workflow_id, multi_variant_a, 0, uri=AGENT_URI)
+    multi_variant_b = _create_variant(authed_api, multi_workflow_id)
+    multi_head = _commit(authed_api, multi_workflow_id, multi_variant_b, 1)
+
+    # One workflow whose only revision is version "0" — the first commit lands on
+    # version 0, so a naive "skip every v0" rule would lose the workflow entirely.
+    v0_workflow_id = _create_workflow(authed_api, marker)
+    v0_variant_id = _create_variant(authed_api, v0_workflow_id)
+    v0_head = _commit(authed_api, v0_workflow_id, v0_variant_id, 0, uri=AGENT_URI)
+    assert str(v0_head["version"]) == "0"
 
     return {
         "_marker": marker,
         "plain": plain,
         "deep": {"workflow_id": deep_workflow_id, "revisions": deep_revisions},
         "multi": {"workflow_id": multi_workflow_id, "head": multi_head},
+        "v0": {"workflow_id": v0_workflow_id, "head": v0_head},
     }
 
 
@@ -140,10 +149,12 @@ class TestWorkflowRevisionsLatestPerWorkflow:
             w["revisions"][-1]["id"] for w in mock_data["plain"]
         }
         # A complete result, not a window — so no cursor to page with.
-        assert response["windowing"] is None
+        assert response.get("windowing") is None
         # ----------------------------------------------------------------------
 
     def test_without_the_flag_every_revision_comes_back(self, authed_api, mock_data):
+        # The behaviour this flag exists to avoid: no windowing means no LIMIT.
+
         # ACT ------------------------------------------------------------------
         response = _query(
             authed_api,
@@ -152,13 +163,12 @@ class TestWorkflowRevisionsLatestPerWorkflow:
         # ----------------------------------------------------------------------
 
         # ASSERT ---------------------------------------------------------------
-        # 3 commits + the variant's version-0 placeholder, twice over.
-        assert response["count"] == 8
+        assert response["count"] == 6
         # ----------------------------------------------------------------------
 
     def test_picks_version_11_over_version_9(self, authed_api, mock_data):
-        # `version` is a nullable String column, so a `ORDER BY version DESC` would
-        # answer "9" here. Ordering by the UUID7 id is what makes this pass.
+        # `version` is a nullable String column, so `ORDER BY version DESC` would answer
+        # "9" here. Ordering by the UUID7 id is what makes this pass.
 
         # ACT ------------------------------------------------------------------
         response = _query(
@@ -175,10 +185,10 @@ class TestWorkflowRevisionsLatestPerWorkflow:
         assert str(revision["version"]) == "11"
         # ----------------------------------------------------------------------
 
-    def test_skips_a_second_variants_empty_placeholder(self, authed_api, mock_data):
-        # The newest revision by id belongs to the second variant and is an empty
-        # placeholder. Returning it would strip the workflow of its flags — an agent
-        # would stop reading as one.
+    def test_grain_is_the_workflow_not_the_variant(self, authed_api, mock_data):
+        # Two variants, one row: the newest revision the WORKFLOW has, whichever
+        # variant it sits on. Variant grain would return two rows and leave the caller
+        # to break the tie — which is the tie-break this flag exists to remove.
 
         # ACT ------------------------------------------------------------------
         response = _query(
@@ -190,8 +200,30 @@ class TestWorkflowRevisionsLatestPerWorkflow:
 
         # ASSERT ---------------------------------------------------------------
         assert response["count"] == 1
+        assert (
+            response["workflow_revisions"][0]["id"] == mock_data["multi"]["head"]["id"]
+        )
+        # ----------------------------------------------------------------------
+
+    def test_a_version_0_revision_that_carries_data_still_counts(
+        self, authed_api, mock_data
+    ):
+        # The placeholder guard skips version-0 rows with NO data and NO flags. A first
+        # commit lands on version 0 WITH data, and dropping it would make a
+        # single-revision agent vanish from the Agents group.
+
+        # ACT ------------------------------------------------------------------
+        response = _query(
+            authed_api,
+            workflow_refs=[{"id": mock_data["v0"]["workflow_id"]}],
+            workflow_revision={"latest_per_artifact": True},
+        )
+        # ----------------------------------------------------------------------
+
+        # ASSERT ---------------------------------------------------------------
+        assert response["count"] == 1
         revision = response["workflow_revisions"][0]
-        assert revision["id"] == mock_data["multi"]["head"]["id"]
+        assert revision["id"] == mock_data["v0"]["head"]["id"]
         assert revision["flags"]["is_agent"] is True
         # ----------------------------------------------------------------------
 
@@ -223,31 +255,31 @@ class TestWorkflowRevisionsLatestPerWorkflow:
         assert response.status_code == 200
 
         try:
-            # ACT ------------------------------------------------------------------
+            # ACT --------------------------------------------------------------
             response = _query(
                 authed_api,
                 workflow_refs=[{"id": workflow["workflow_id"]}],
                 workflow_revision={"latest_per_artifact": True},
             )
-            # ----------------------------------------------------------------------
+            # ------------------------------------------------------------------
 
-            # ASSERT — archived head excluded, so the one before it is now latest ---
+            # ASSERT — archived head excluded, so the one before it is now latest
             assert response["count"] == 1
             assert response["workflow_revisions"][0]["id"] == previous["id"]
-            # ----------------------------------------------------------------------
+            # ------------------------------------------------------------------
 
-            # ACT ------------------------------------------------------------------
+            # ACT --------------------------------------------------------------
             response = _query(
                 authed_api,
                 include_archived=True,
                 workflow_refs=[{"id": workflow["workflow_id"]}],
                 workflow_revision={"latest_per_artifact": True},
             )
-            # ----------------------------------------------------------------------
+            # ------------------------------------------------------------------
 
-            # ASSERT ---------------------------------------------------------------
+            # ASSERT -----------------------------------------------------------
             assert response["count"] == 1
             assert response["workflow_revisions"][0]["id"] == head["id"]
-            # ----------------------------------------------------------------------
+            # ------------------------------------------------------------------
         finally:
             authed_api("POST", f"/workflows/revisions/{head['id']}/unarchive")

--- a/api/oss/tests/pytest/unit/git/test_revision_grouping_models.py
+++ b/api/oss/tests/pytest/unit/git/test_revision_grouping_models.py
@@ -1,0 +1,72 @@
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from oss.src.apis.fastapi.applications.models import ApplicationRevisionQueryRequest
+from oss.src.apis.fastapi.environments.models import EnvironmentRevisionQueryRequest
+from oss.src.apis.fastapi.evaluators.models import EvaluatorRevisionQueryRequest
+from oss.src.apis.fastapi.queries.models import QueryRevisionQueryRequest
+from oss.src.apis.fastapi.testsets import models as testset_models
+from oss.src.apis.fastapi.workflows.models import WorkflowRevisionQueryRequest
+
+
+REQUEST_MODELS = [
+    (ApplicationRevisionQueryRequest, "application"),
+    (EnvironmentRevisionQueryRequest, "environment"),
+    (EvaluatorRevisionQueryRequest, "evaluator"),
+    (QueryRevisionQueryRequest, "query"),
+    (testset_models.TestsetRevisionQueryRequest, "testset"),
+    (WorkflowRevisionQueryRequest, "workflow"),
+]
+
+
+@pytest.mark.parametrize(("request_model", "prefix"), REQUEST_MODELS)
+def test_explicit_latest_per_artifact_is_supported(request_model, prefix):
+    request = request_model.model_validate(
+        {
+            f"{prefix}_refs": [{"id": str(uuid4())}],
+            "grouping": {"by": "artifact", "get": "latest"},
+        }
+    )
+
+    assert request.grouping.by == "artifact"
+    assert request.grouping.get == "latest"
+
+
+@pytest.mark.parametrize(("request_model", "prefix"), REQUEST_MODELS)
+def test_grouping_requires_a_selection_rule(request_model, prefix):
+    with pytest.raises(ValidationError):
+        request_model.model_validate(
+            {
+                f"{prefix}_refs": [{"id": str(uuid4())}],
+                "grouping": {"by": "artifact"},
+            }
+        )
+
+
+@pytest.mark.parametrize(("request_model", "prefix"), REQUEST_MODELS)
+def test_grouping_rejects_windowing(request_model, prefix):
+    with pytest.raises(ValidationError, match="grouping cannot be combined with windowing"):
+        request_model.model_validate(
+            {
+                f"{prefix}_refs": [{"id": str(uuid4())}],
+                "grouping": {"by": "artifact", "get": "latest"},
+                "windowing": {"limit": 1},
+            }
+        )
+
+
+@pytest.mark.parametrize(("request_model", "prefix"), REQUEST_MODELS)
+def test_grouping_rejects_explicit_revision_references(request_model, prefix):
+    with pytest.raises(
+        ValidationError,
+        match="grouping cannot be combined with revision references",
+    ):
+        request_model.model_validate(
+            {
+                f"{prefix}_refs": [{"id": str(uuid4())}],
+                f"{prefix}_revision_refs": [{"id": str(uuid4())}],
+                "grouping": {"by": "artifact", "get": "latest"},
+            }
+        )

--- a/docs/design/revision-query-grouping/README.md
+++ b/docs/design/revision-query-grouping/README.md
@@ -1,0 +1,27 @@
+# Per-parent grouping on revision queries
+
+This folder plans one change to the Agenta API. The change lets a caller ask for the
+newest revisions of each parent, instead of every revision of every parent.
+
+## Reading order
+
+| File | Question it answers |
+| --- | --- |
+| `context.md` | What breaks today, and why we want to change it. |
+| `research.md` | What the code does now, with measurements. |
+| `api-design.md` | The interface we propose, and the shapes we rejected. |
+| `plan.md` | What to build, in what order. |
+| `status.md` | Where the work stands, and what is still open. |
+
+## Words used in this folder
+
+- **artifact**: the parent entity that owns a line of history. A workflow, a testset, an
+  evaluator, an environment, an application, or a query.
+- **variant**: a branch of an artifact.
+- **revision**: one committed version of a variant. An artifact has many revisions.
+- **git DAO**: the shared database layer at `api/oss/src/dbs/postgres/git/dao.py`. Six
+  entity families store their artifacts, variants, and revisions through it.
+- **windowing**: the shared request object that says which slice of an ordered result to
+  return. It carries a time range, a cursor, a limit, and a sort order.
+- **event loop**: the single thread inside each API worker that serves every request on
+  that worker. Work that does not yield blocks every other request on the same worker.

--- a/docs/design/revision-query-grouping/README.md
+++ b/docs/design/revision-query-grouping/README.md
@@ -1,7 +1,7 @@
 # Per-parent grouping on revision queries
 
-This folder plans one change to the Agenta API. The change lets a caller ask for the
-newest revisions of each parent, instead of every revision of every parent.
+This folder defines one change to the Agenta API. The change lets a caller group
+revisions by parent and explicitly get the latest revision from every group.
 
 ## Reading order
 

--- a/docs/design/revision-query-grouping/api-design.md
+++ b/docs/design/revision-query-grouping/api-design.md
@@ -1,0 +1,192 @@
+# The interface
+
+## The role this field plays
+
+Classify the field before naming it. "Return the newest revision of each workflow" is a
+result-shaping instruction. It says how to fold the result set. It is not a filter on a
+revision's own fields, it is not a scope reference, and it is not a policy.
+
+The request object already separates those roles:
+
+| Field | Role |
+| --- | --- |
+| `<entity>_revision` | attribute filter |
+| `<entity>_refs`, `<entity>_variant_refs`, `<entity>_revision_refs` | scope |
+| `include_archived` | policy |
+| `windowing` | result shaping |
+
+The new field belongs with `windowing`, as a sibling.
+
+## The proposed shape
+
+```jsonc
+POST /workflows/revisions/query
+{
+  "workflow_refs": [{"id": "..."}, {"id": "..."}, {"id": "..."}],
+  "windowing": { "order": "descending", "limit": 50 },
+  "grouping":  { "by": "artifact" }
+}
+```
+
+```python
+class RevisionGrouping(BaseModel):
+    by: Literal["artifact", "variant"] = Field(
+        description="Return the newest eligible revision within each parent.",
+    )
+```
+
+The first release carries `by` and nothing else. It returns at most one revision per
+requested parent. We dropped a `limit` field for "the newest N per parent", because no
+caller asks for it today, and it forces a second SQL branch plus a page cursor over
+parents that we cannot define yet. The section "What we removed after review" explains
+that decision.
+
+Each entity request model gains one optional field:
+
+```python
+grouping: Optional[RevisionGrouping] = Field(
+    default=None,
+    description=(
+        "Return the newest revisions within each parent instead of a flat list. "
+        "When set, `windowing.limit` and `windowing.next` count parents, not revisions."
+    ),
+)
+```
+
+The two limits compose, and that is a sign the split is correct. `grouping.limit` says how
+many revisions to keep inside each parent. `windowing.limit` still caps how many parents
+come back. They answer different questions, so they sit side by side.
+
+## Rules the contract must state
+
+1. When `grouping` is absent, behavior does not change at all.
+2. `grouping` needs a non-empty list of parent references, and the API caps how many.
+   The result is then bounded by the number of parents the caller named.
+3. Selection order is fixed by the server, and `windowing.order` does not change it.
+   Ascending order would otherwise select the oldest revision inside each parent, which
+   contradicts the name of the feature.
+4. `grouping` with `windowing.next`, `windowing.newest`, or `windowing.oldest` returns a
+   client error. A revision cursor cannot page over parents. See the next section.
+5. `grouping` with the environments `references` filter returns a client error. That
+   filter compares neighboring rows in a history, so it needs the history intact.
+6. A parent with no eligible revision produces no row. It does not produce an empty one.
+7. `grouping.by: "variant"` groups by the variant that owns the revision.
+   `grouping.by: "artifact"` groups by the artifact above the variant.
+
+## Why the cursor is rejected rather than redefined
+
+An earlier draft said `windowing.next` would page over parents. That does not work, and
+the failure is easy to reach.
+
+The response cursor is built from the last returned revision's id, in
+`apis/fastapi/shared/utils.py`. Take parent A with revisions 100 and 80, and parent B with
+revision 90. Page one folds to A/100 and sets the cursor to 100. Page two applies `id < 100`
+before the fold, so it returns B/90, and a later page returns A/80. Parent A appears twice.
+
+Paging over parents needs a parent-keyed cursor and a response contract that several of
+the six endpoints do not have today. No caller needs it, so the first release rejects the
+combination instead of half-supporting it.
+
+## What "newest" must mean
+
+The frontend does not treat the newest row as the latest revision.
+`selectMostRecentWorkflowRevision` in `web/packages/agenta-entities/src/workflow/api/api.ts`
+skips version 0 and ranks by `created_at`. Version 0 is an auto-created placeholder.
+
+A fold that picks the newest row by id can therefore pick a placeholder that the frontend
+then discards, and the parent disappears from the result. That is a regression, not a
+speed-up.
+
+So the server must decide eligibility before it selects, and the rule has to be written
+down. Version 0 is not automatically excluded: `WorkflowsService` distinguishes an empty
+placeholder from a configured revision that happens to be version 0.
+
+The same question applies to flags. `WorkflowsService` sends some flags to SQL, drops
+server-owned flags from that filter, builds the revisions, then matches the requested
+flags again in Python. Folding first can drop a parent whose older revision would have
+matched. The contract must say which of these it means:
+
+- the newest revision that matches the filter, or
+- the newest revision, returned only when it matches.
+
+Until that is settled per endpoint, `grouping` combined with post-SQL flag matching
+returns a client error.
+
+## Naming
+
+`by` takes `artifact` or `variant`, not the entity's own name. The git DAO calls the
+parent levels artifact and variant, and one shared DTO serves six entity families. A
+value of `workflow` would not read correctly inside a testset request.
+
+The field names use `lower_snake_case`, which matches the rest of the request.
+
+## Shapes we rejected
+
+### Extending the shared `Windowing`
+
+```jsonc
+"windowing": { "limit": 1, "order": "descending", "group_by": "artifact" }
+```
+
+`Windowing` already carries folding concepts, `interval` and `rate`, so this looks
+consistent at first. It fails on reach. 87 request models embed `Windowing`, and only six
+have a parent column. The other 81 would accept `group_by` and ignore it, and a caller
+could not tell the difference between a field that worked and a field that did nothing.
+
+It also breaks the meaning of `next`. That token is a cursor over one flat stream.
+Grouping changes what the stream contains.
+
+### A limit on the reference
+
+```jsonc
+"workflow_refs": [{"id": "...", "limit": 1}]
+```
+
+`Reference` is an identity type carrying `id`, `slug`, and `version`. Result shaping is
+not identity. No reader would predict finding a limit there.
+
+This shape is not hypothetical. The testsets batch fetcher in
+`web/packages/agenta-entities/src/testset/api/api.ts` already sent it, and the API silently
+dropped it. That dead code is now removed, along with a docstring that described a
+`ReferenceWithLimit` feature which never existed.
+
+### An `is_latest` query flag
+
+```jsonc
+"workflow_revision": { "flags": { "is_latest": true } }
+```
+
+Rejected for meaning and for effect.
+
+On meaning: the flags describe what a revision *is*. Some are derived from its own fields,
+some are user-declared, and some are merged from the artifact during a read. None of them
+depend on the revision's position in its own history. "Newest among its siblings" does,
+and it changes when a sibling arrives.
+
+On effect: flags are matched in Python after each model is built. A flag filter would
+still cut the serialization and compression cost, so it is not useless, but it would keep
+the database transfer and the model construction. Those are 531 ms of the 1916 ms we
+measured. Selecting in SQL removes all of it.
+
+## Where the DTO lives
+
+`RevisionGrouping` goes next to `RevisionQuery` in the git core DTOs, because the git DAO
+serves all six entity families and one implementation should serve all of them.
+
+All six request models get the field in the same change. Adding it to workflows alone
+would split a family that is identical today, and consistency across the six is worth
+more than a smaller diff.
+
+## What we removed after review
+
+Three things left the first release. Each added a branch of implementation and testing
+that no caller needs today.
+
+**The `limit` field, for the newest N per parent.** Every caller we found wants exactly
+one. Supporting N forces a second SQL path with `ROW_NUMBER`, and it makes the result size
+unbounded again, which is the problem we set out to fix.
+
+**Paging over parents.** Explained above. It needs a cursor the six endpoints do not have.
+
+**Grouping on unbounded queries.** `grouping` needs explicit parent references. Without
+them the fold still scans every revision in the project.

--- a/docs/design/revision-query-grouping/api-design.md
+++ b/docs/design/revision-query-grouping/api-design.md
@@ -1,192 +1,185 @@
 # The interface
 
-## The role this field plays
+## What the caller asks for
 
-Classify the field before naming it. "Return the newest revision of each workflow" is a
-result-shaping instruction. It says how to fold the result set. It is not a filter on a
-revision's own fields, it is not a scope reference, and it is not a policy.
+A grouped revision query makes two choices:
 
-The request object already separates those roles:
+1. `by` divides matching revisions by their parent.
+2. `get` selects one revision from each group.
 
-| Field | Role |
-| --- | --- |
-| `<entity>_revision` | attribute filter |
-| `<entity>_refs`, `<entity>_variant_refs`, `<entity>_revision_refs` | scope |
-| `include_archived` | policy |
-| `windowing` | result shaping |
-
-The new field belongs with `windowing`, as a sibling.
-
-## The proposed shape
+Both fields shape the result set, so they belong in one top-level `grouping` object beside
+`windowing`. They do not belong in `<entity>_revision`, which filters attributes of an
+individual revision.
 
 ```jsonc
 POST /workflows/revisions/query
 {
-  "workflow_refs": [{"id": "..."}, {"id": "..."}, {"id": "..."}],
-  "windowing": { "order": "descending", "limit": 50 },
-  "grouping":  { "by": "artifact" }
+  "workflow_refs": [{"id": "..."}, {"id": "..."}],
+  "grouping": {
+    "by": "artifact",
+    "get": "latest"
+  }
 }
 ```
 
-```python
-class RevisionGrouping(BaseModel):
-    by: Literal["artifact", "variant"] = Field(
-        description="Return the newest eligible revision within each parent.",
-    )
+This reads as: group revisions by workflow and get the latest eligible revision from each
+group. The response remains a flat list.
+
+For the latest revision of each variant under the requested workflows:
+
+```jsonc
+{
+  "workflow_refs": [{"id": "..."}],
+  "grouping": {
+    "by": "variant",
+    "get": "latest"
+  }
+}
 ```
 
-The first release carries `by` and nothing else. It returns at most one revision per
-requested parent. We dropped a `limit` field for "the newest N per parent", because no
-caller asks for it today, and it forces a second SQL branch plus a page cursor over
-parents that we cannot define yet. The section "What we removed after review" explains
-that decision.
+## Request model
 
-Each entity request model gains one optional field:
+```python
+class RevisionGrouping(BaseModel):
+    by: Literal["artifact", "variant"]
+    get: Literal["latest"]
+```
+
+`get` is required. `grouping.by` alone would leave the selection rule implicit. It could
+reasonably mean a nested response, an aggregate, or a first row. Requiring both fields makes
+the operation explicit and leaves room for another selection rule when a caller needs one.
+
+Each of the six revision-query request models gains:
 
 ```python
 grouping: Optional[RevisionGrouping] = Field(
     default=None,
     description=(
-        "Return the newest revisions within each parent instead of a flat list. "
-        "When set, `windowing.limit` and `windowing.next` count parents, not revisions."
+        "Divide matching revisions by artifact or variant and select one revision "
+        "from each group."
     ),
 )
 ```
 
-The two limits compose, and that is a sign the split is correct. `grouping.limit` says how
-many revisions to keep inside each parent. `windowing.limit` still caps how many parents
-come back. They answer different questions, so they sit side by side.
+## Query order
 
-## Rules the contract must state
+The server evaluates a grouped query in this order:
 
-1. When `grouping` is absent, behavior does not change at all.
-2. `grouping` needs a non-empty list of parent references, and the API caps how many.
-   The result is then bounded by the number of parents the caller named.
-3. Selection order is fixed by the server, and `windowing.order` does not change it.
-   Ascending order would otherwise select the oldest revision inside each parent, which
-   contradicts the name of the feature.
-4. `grouping` with `windowing.next`, `windowing.newest`, or `windowing.oldest` returns a
-   client error. A revision cursor cannot page over parents. See the next section.
-5. `grouping` with the environments `references` filter returns a client error. That
-   filter compares neighboring rows in a history, so it needs the history intact.
-6. A parent with no eligible revision produces no row. It does not produce an empty one.
-7. `grouping.by: "variant"` groups by the variant that owns the revision.
-   `grouping.by: "artifact"` groups by the artifact above the variant.
+1. Apply project scope, parent references, revision attribute filters, and archive policy.
+2. Exclude empty seed revisions. A configured revision whose version is `"0"` remains
+   eligible.
+3. Divide the eligible rows by `artifact_id` or `variant_id`.
+4. For `get: "latest"`, select the row with the greatest UUID7 revision id in each group.
+5. Return the selected rows as a flat list ordered by revision id, newest first.
 
-## Why the cursor is rejected rather than redefined
+The UUID7 id records commit order. The `version` column cannot define latest because it is a
+string and restarts for every variant. Ordering it descending puts `"9"` before `"10"`, and
+two variants can both have the same version.
 
-An earlier draft said `windowing.next` would page over parents. That does not work, and
-the failure is easy to reach.
+An empty seed revision is version `"0"` with no `data`, `flags`, `tags`, or `meta`. A first
+real commit can also be version `"0"`, but it carries at least one of those fields and remains
+eligible.
 
-The response cursor is built from the last returned revision's id, in
-`apis/fastapi/shared/utils.py`. Take parent A with revisions 100 and 80, and parent B with
-revision 90. Page one folds to A/100 and sets the cursor to 100. Page two applies `id < 100`
-before the fold, so it returns B/90, and a later page returns A/80. Parent A appears twice.
+Filters apply before selection. Therefore a grouped query means "the latest eligible revision
+that matches the request", not "the absolute latest revision, if it matches". This follows the
+normal query rule that filters determine the candidate rows before result shaping occurs.
 
-Paging over parents needs a parent-keyed cursor and a response contract that several of
-the six endpoints do not have today. No caller needs it, so the first release rejects the
-combination instead of half-supporting it.
+## Supported combinations
 
-## What "newest" must mean
+1. Omitting `grouping` preserves existing behavior.
+2. `grouping.by: "artifact"` requires non-empty artifact references.
+3. `grouping.by: "variant"` requires non-empty artifact or variant references.
+4. A parent with no eligible matching revision contributes no row.
+5. `grouping` cannot be combined with `windowing` in the first release.
+6. `grouping` cannot be combined with explicit revision references. Exact revision references
+   already select rows, so applying another selection rule would silently discard requested
+   revisions.
+7. A grouped request rejects any domain filter that is evaluated after the SQL query. This
+   includes server-owned revision flags and the environment `references` history filter.
+8. Malformed or unsupported grouping returns a client error. A parser must never swallow the
+   error and broaden the query.
 
-The frontend does not treat the newest row as the latest revision.
-`selectMostRecentWorkflowRevision` in `web/packages/agenta-entities/src/workflow/api/api.ts`
-skips version 0 and ranks by `created_at`. Version 0 is an auto-created placeholder.
+## Why grouped windowing is rejected
 
-A fold that picks the newest row by id can therefore pick a placeholder that the frontend
-then discards, and the parent disappears from the result. That is a regression, not a
-speed-up.
+The current cursor identifies a revision in one flat stream. It cannot page groups correctly.
 
-So the server must decide eligibility before it selects, and the rule has to be written
-down. Version 0 is not automatically excluded: `WorkflowsService` distinguishes an empty
-placeholder from a configured revision that happens to be version 0.
+Take workflow A with revisions 100 and 80, and workflow B with revision 90. A first page could
+select A/100 and use 100 as its cursor. The next page applies `id < 100` before grouping and
+returns B/90 and A/80. Workflow A now appears twice.
 
-The same question applies to flags. `WorkflowsService` sends some flags to SQL, drops
-server-owned flags from that filter, builds the revisions, then matches the requested
-flags again in Python. Folding first can drop a parent whose older revision would have
-matched. The contract must say which of these it means:
+Paging groups needs a cursor based on the group and a response contract shared by all six
+endpoints. No current caller needs it, so this release rejects every `windowing` field when
+`grouping` is present.
 
-- the newest revision that matches the filter, or
-- the newest revision, returned only when it matches.
+## Shared scope
 
-Until that is settled per endpoint, `grouping` combined with post-SQL flag matching
-returns a client error.
+`RevisionGrouping` lives beside `RevisionQuery` in the git core DTOs. The shared git DAO serves
+these endpoints:
 
-## Naming
+- `/workflows/revisions/query`
+- `/testsets/revisions/query`
+- `/evaluators/revisions/query`
+- `/environments/revisions/query`
+- `/applications/revisions/query`
+- `/queries/revisions/query`
 
-`by` takes `artifact` or `variant`, not the entity's own name. The git DAO calls the
-parent levels artifact and variant, and one shared DTO serves six entity families. A
-value of `workflow` would not read correctly inside a testset request.
+In that layer, `artifact` is the common name for a workflow, testset, evaluator, environment,
+application, or saved query. `variant` is a branch of that artifact.
 
-The field names use `lower_snake_case`, which matches the rest of the request.
+## Shapes rejected
 
-## Shapes we rejected
-
-### Extending the shared `Windowing`
+### `workflow_revision.latest_per_artifact`
 
 ```jsonc
-"windowing": { "limit": 1, "order": "descending", "group_by": "artifact" }
+{
+  "workflow_revision": {"latest_per_artifact": true}
+}
 ```
 
-`Windowing` already carries folding concepts, `interval` and `rate`, so this looks
-consistent at first. It fails on reach. 87 request models embed `Windowing`, and only six
-have a parent column. The other 81 would accept `group_by` and ignore it, and a caller
-could not tell the difference between a field that worked and a field that did nothing.
+The behavior is clear, but the location is wrong. `workflow_revision` filters attributes of an
+individual row. Latest-per-parent shapes the whole result. The boolean also hard-codes artifact
+grouping and cannot express the variant case.
 
-It also breaks the meaning of `next`. That token is a cursor over one flat stream.
-Grouping changes what the stream contains.
-
-### A limit on the reference
+### `grouping.by` without `grouping.get`
 
 ```jsonc
-"workflow_refs": [{"id": "...", "limit": 1}]
+{"grouping": {"by": "artifact"}}
 ```
 
-`Reference` is an identity type carrying `id`, `slug`, and `version`. Result shaping is
-not identity. No reader would predict finding a limit there.
+This states how rows are divided but leaves the selection behavior implicit. Grouping does not
+inherently mean latest. Requiring `get: "latest"` states the complete operation.
 
-This shape is not hypothetical. The testsets batch fetcher in
-`web/packages/agenta-entities/src/testset/api/api.ts` already sent it, and the API silently
-dropped it. That dead code is now removed, along with a docstring that described a
-`ReferenceWithLimit` feature which never existed.
-
-### An `is_latest` query flag
+### Extending `Windowing`
 
 ```jsonc
-"workflow_revision": { "flags": { "is_latest": true } }
+{"windowing": {"limit": 1, "group_by": "artifact"}}
 ```
 
-Rejected for meaning and for effect.
+Eighty-seven request models embed `Windowing`, while only the six revision endpoints have the
+artifact and variant columns. Adding the field there would expose it on unrelated APIs. It also
+mixes a revision cursor with a per-parent selection operation.
 
-On meaning: the flags describe what a revision *is*. Some are derived from its own fields,
-some are user-declared, and some are merged from the artifact during a read. None of them
-depend on the revision's position in its own history. "Newest among its siblings" does,
-and it changes when a sibling arrives.
+### A limit on each reference
 
-On effect: flags are matched in Python after each model is built. A flag filter would
-still cut the serialization and compression cost, so it is not useless, but it would keep
-the database transfer and the model construction. Those are 531 ms of the 1916 ms we
-measured. Selecting in SQL removes all of it.
+```jsonc
+{"workflow_refs": [{"id": "...", "limit": 1}]}
+```
 
-## Where the DTO lives
+`Reference` identifies an entity through `id`, `slug`, or `version`. A result limit is not part
+of identity. The testset client previously sent this field, and Pydantic silently discarded it.
 
-`RevisionGrouping` goes next to `RevisionQuery` in the git core DTOs, because the git DAO
-serves all six entity families and one implementation should serve all of them.
+### An `is_latest` revision flag
 
-All six request models get the field in the same change. Adding it to workflows alone
-would split a family that is identical today, and consistency across the six is worth
-more than a smaller diff.
+```jsonc
+{"workflow_revision": {"flags": {"is_latest": true}}}
+```
 
-## What we removed after review
+A revision flag describes that revision. "Latest among siblings" changes whenever a sibling is
+created. Flags are also matched in Python in several services, after the expensive rows have
+already left PostgreSQL.
 
-Three things left the first release. Each added a branch of implementation and testing
-that no caller needs today.
+## Deferred behavior
 
-**The `limit` field, for the newest N per parent.** Every caller we found wants exactly
-one. Supporting N forces a second SQL path with `ROW_NUMBER`, and it makes the result size
-unbounded again, which is the problem we set out to fix.
-
-**Paging over parents.** Explained above. It needs a cursor the six endpoints do not have.
-
-**Grouping on unbounded queries.** `grouping` needs explicit parent references. Without
-them the fold still scans every revision in the project.
+The first release supports exactly one selection rule, `latest`, and one selected row per group.
+It does not support newest N per group or paging groups. Those features need a real caller and a
+group-aware cursor contract before we add them.

--- a/docs/design/revision-query-grouping/context.md
+++ b/docs/design/revision-query-grouping/context.md
@@ -1,0 +1,74 @@
+# Why this work exists
+
+## What a user sees today
+
+A user opens an agent session in the playground. The agent runs for a while. Then one turn
+fails with this message:
+
+```
+session <id> record log is unreadable; cannot rebuild the conversation
+```
+
+Nothing is wrong with the session. The record log is intact. The turn failed because the
+API did not answer a request within five seconds, and the runner gave up.
+
+The API did not answer because its event loop was blocked. One ordinary request to
+`POST /workflows/revisions/query` held the worker for about two seconds. Several of them
+arrived together.
+
+## How one request blocks a worker for two seconds
+
+The playground needs the newest revision of each of several workflows. The API cannot
+express that request. Its `windowing.limit` applies to the whole result, not to each
+parent. A limit of 5 over 5 workflows can return 5 revisions of the first workflow and
+none of the others.
+
+The frontend has no safe option, so it drops the limit and takes everything. The comment
+in `web/packages/agenta-entities/src/workflow/api/api.ts` says so:
+
+> When fetching for a single workflow, limit to 1 (latest) to reduce payload.
+> With multiple workflows the global limit would cut across all, so skip it.
+
+On the project we measured, two workflows hold 179 of 258 revisions. A batch over those
+two returns 177 revisions and a 76 MB response body. Building and compressing that
+response costs about 1.9 seconds of CPU, and none of it yields to the event loop.
+
+## Why the fix belongs in the API, not the client
+
+The client can work around it, but badly. A scoped single-workflow request with
+`windowing.limit: 1` does reach SQL as a real `LIMIT 1`, and the existing single-workflow
+fetcher already does that. So a list page with twenty workflows could make twenty small
+requests. That trades one slow request for twenty round trips, and it still leaves the
+batch endpoint unable to answer the question it exists to answer. It is a usable emergency
+mitigation, not a fix.
+
+The database can answer this question cheaply. Postgres `DISTINCT ON` returns the newest
+row per group in one pass. The repository already does exactly this in
+`RecordsDAO.latest_message_per_session`, for the same reason.
+
+## Goals
+
+1. Let a caller ask for the newest N revisions of each parent, in one request.
+2. Push the fold into SQL, so the discarded rows never reach Python.
+3. Keep the six revision query endpoints consistent with each other.
+4. Change nothing for callers that do not ask for the new behavior.
+
+## Non-goals
+
+1. We do not change how revisions are stored.
+2. We do not change the runner's five-second budget. That budget is reasonable. The API
+   must answer inside it.
+3. We do not fix the two other costs found in the same investigation: schema revalidation
+   on read, and gzip compression on the event loop. Those are tracked in `status.md`.
+   Shrinking the payload reduces both, but it does not remove them.
+
+## What success looks like
+
+A batch over five workflows returns five revisions instead of every revision those five
+workflows have. Measure the response in bytes, not only in rows: a single large revision
+can still be big, and this change bounds the row count, not the size of one row.
+
+Then check the API's per-minute latency probe under playground load. It sits at 0.01
+seconds normally and reached 4.90 seconds during the incident. This change removes one
+large source of blocking. It does not on its own keep one request from blocking others,
+and `status.md` records the gzip work that addresses that.

--- a/docs/design/revision-query-grouping/context.md
+++ b/docs/design/revision-query-grouping/context.md
@@ -48,7 +48,8 @@ row per group in one pass. The repository already does exactly this in
 
 ## Goals
 
-1. Let a caller ask for the newest N revisions of each parent, in one request.
+1. Let a caller explicitly group revisions by parent and get the latest revision from
+   each group in one request.
 2. Push the fold into SQL, so the discarded rows never reach Python.
 3. Keep the six revision query endpoints consistent with each other.
 4. Change nothing for callers that do not ask for the new behavior.

--- a/docs/design/revision-query-grouping/plan.md
+++ b/docs/design/revision-query-grouping/plan.md
@@ -1,0 +1,106 @@
+# Execution plan
+
+The whole feature ships in one release. We do not land the request field before the
+behavior works, and the reason is specific. See "Why we do not ship the field early".
+
+## Why we do not ship the field early
+
+An earlier draft planned to add the field first, accepted and ignored, so the shape could
+be reviewed on its own. That plan is unsafe here.
+
+The workflows and environments routers do not take a declared body model. They read
+`await request.json()` and expand it into a parser function with an explicit keyword
+signature, inside a bare `except Exception: pass`. Checked on the running API:
+
+```
+parse_workflow_revision_query_request_from_body(**{"workflow_refs": [...], "grouping": {...}})
+  -> TypeError: got an unexpected keyword argument 'grouping'
+```
+
+The router swallows that error and leaves the parsed body as `None`. The parent references
+go with it, so the query stops being scoped and returns every revision in the project. A
+client that adopted the field early would make the exact incident worse.
+
+So the parsers change in the same step as the models, and a malformed `grouping` returns a
+client error rather than a silently broader query.
+
+## Step 1: settle eligibility, then write it down
+
+Before any code, answer these per endpoint and record the answers in `api-design.md`:
+
+- Which revision counts as the newest one, given that version 0 can be either an empty
+  placeholder or a real configured revision.
+- Whether `grouping` means "the newest revision that matches the filter" or "the newest
+  revision, returned only if it matches".
+- Which combinations return a client error. The current list is a revision cursor, a time
+  range, the environments `references` filter, and post-SQL flag matching.
+
+This step exists because folding first changes which parents appear at all, not just how
+many rows come back.
+
+## Step 2: API, end to end, in one change
+
+- Add `RevisionGrouping` next to `RevisionQuery` in the git core DTOs.
+- Add `grouping` to all six request models: workflows, testsets, evaluators, environments,
+  applications, and queries.
+- Update the body and parameter parsers and the merge helpers in the `utils.py` of each
+  router that has them. Workflows and environments both parse by keyword expansion.
+- Make a malformed or unsupported `grouping` return a client error. Do not let it fall
+  through the bare `except` into an unscoped query.
+- Extend `GitDAOInterface.query_revisions`, the concrete `GitDAO`, and the six service
+  signatures. Applications and evaluators reach this through `WorkflowsService`.
+- Apply the fold in SQL with `DISTINCT ON`. Its expressions must lead the `ORDER BY`, so
+  the response order needs an outer ordering stage on top of the fold.
+
+## Step 3: clients and documentation
+
+- Check the OpenAPI schema actually describes the request body. The workflows handler reads
+  `Request.json()` rather than declaring a body model, and the generated Python client
+  exposes query parameters instead of the body. Regeneration alone will not fix that.
+- Regenerate both clients with `clients/scripts/generate.sh`: Python under
+  `clients/python/agenta_client`, TypeScript under `web/packages/agenta-api-client`.
+- Rebuild `@agentaai/api-client` so consumers see the new types.
+- Update the query and versioning guides with what "latest" means and which combinations
+  are rejected.
+
+## Step 4: move the three callers
+
+- `fetchWorkflowsBatch` in `web/packages/agenta-entities/src/workflow/api/api.ts` passes
+  `grouping` and drops the comment about the global limit.
+- `fetchLatestRevisionsBatch` in `web/packages/agenta-entities/src/testset/api/api.ts`
+  passes `grouping` and drops the client-side fold. Its immediate correctness fix already
+  landed. See `status.md`.
+- `fetchLatestRevisionsBatch` in `web/oss/src/state/entities/testset/revisionEntity.ts`
+  passes `grouping`. It uses `windowing: {limit: ids.length * 5}` today, so one testset
+  with many revisions can consume the whole allowance and starve the others. Its selection
+  rule is highest version with a fallback to version 0, and moving it needs the eligibility
+  decision from Step 1.
+
+Leave alone the queries that page revision history on purpose, such as the evaluator table
+in `web/oss/src/components/Evaluators/store/evaluatorsPaginatedStore.ts`. Grouping is not
+right for every batched query.
+
+## Tests
+
+Unit tests on the DAO are not enough. The dangerous failures are in parsing and in SQL.
+
+- Run the SQL against real PostgreSQL, not a mock.
+- Cover all six HTTP paths, using the existing acceptance tests in
+  `api/oss/tests/pytest/acceptance/workflows/test_workflow_revisions_queries.py` as the
+  starting point.
+- Cover a malformed `grouping`, and assert it returns a client error rather than a broader
+  result. This is the regression that would repeat the incident.
+- Cover project scope, archived revisions, several variants under one artifact, an empty
+  placeholder next to a configured version 0, and each rejected combination.
+- Cover the three batch callers.
+
+## How we check it worked
+
+Measure the same batch before and after on a project with many revisions, and record the
+response bytes rather than only the row count. Then run heavy revision queries and session
+record log requests together against the deployed stack, and measure event loop delay. The
+per-minute scheduler request is a usable probe: it sat at 0.01 s normally and reached
+4.90 s during the incident.
+
+Shrinking this payload removes one large source of blocking. It does not by itself keep one
+request from blocking others. The gzip work tracked in `status.md` is what addresses that.

--- a/docs/design/revision-query-grouping/plan.md
+++ b/docs/design/revision-query-grouping/plan.md
@@ -24,19 +24,11 @@ client that adopted the field early would make the exact incident worse.
 So the parsers change in the same step as the models, and a malformed `grouping` returns a
 client error rather than a silently broader query.
 
-## Step 1: settle eligibility, then write it down
+## Step 1: record the settled contract
 
-Before any code, answer these per endpoint and record the answers in `api-design.md`:
-
-- Which revision counts as the newest one, given that version 0 can be either an empty
-  placeholder or a real configured revision.
-- Whether `grouping` means "the newest revision that matches the filter" or "the newest
-  revision, returned only if it matches".
-- Which combinations return a client error. The current list is a revision cursor, a time
-  range, the environments `references` filter, and post-SQL flag matching.
-
-This step exists because folding first changes which parents appear at all, not just how
-many rows come back.
+Record `grouping: {by, get}`, eligibility, ordering, and rejected combinations in
+`api-design.md`. Both fields are required inside grouping. Filters and archive policy
+run before the server selects the latest eligible revision in each group.
 
 ## Step 2: API, end to end, in one change
 
@@ -47,6 +39,8 @@ many rows come back.
   router that has them. Workflows and environments both parse by keyword expansion.
 - Make a malformed or unsupported `grouping` return a client error. Do not let it fall
   through the bare `except` into an unscoped query.
+- Reject grouped requests with `windowing`, explicit revision references, or filters
+  evaluated after SQL.
 - Extend `GitDAOInterface.query_revisions`, the concrete `GitDAO`, and the six service
   signatures. Applications and evaluators reach this through `WorkflowsService`.
 - Apply the fold in SQL with `DISTINCT ON`. Its expressions must lead the `ORDER BY`, so
@@ -60,7 +54,7 @@ many rows come back.
 - Regenerate both clients with `clients/scripts/generate.sh`: Python under
   `clients/python/agenta_client`, TypeScript under `web/packages/agenta-api-client`.
 - Rebuild `@agentaai/api-client` so consumers see the new types.
-- Update the query and versioning guides with what "latest" means and which combinations
+- Update the query and versioning guides with what `by` and `get` mean and which combinations
   are rejected.
 
 ## Step 4: move the three callers

--- a/docs/design/revision-query-grouping/research.md
+++ b/docs/design/revision-query-grouping/research.md
@@ -1,0 +1,134 @@
+# What the code does now
+
+All findings below come from the running `agenta-oss-team` stack on images `v0.114.5`,
+and from the repository at the time of writing.
+
+## The six endpoints share one shape
+
+Six routers expose `POST /<entity>/revisions/query`:
+
+| Router | Request model |
+| --- | --- |
+| `apis/fastapi/workflows/router.py:418` | `WorkflowRevisionQueryRequest` |
+| `apis/fastapi/testsets/router.py:491` | `TestsetRevisionQueryRequest` |
+| `apis/fastapi/evaluators/router.py:402` | `EvaluatorRevisionQueryRequest` |
+| `apis/fastapi/environments/router.py:296` | `EnvironmentRevisionQueryRequest` |
+| `apis/fastapi/applications/router.py:376` | `ApplicationRevisionQueryRequest` |
+| `apis/fastapi/queries/router.py:290` | `QueryRevisionQueryRequest` |
+
+The six request models are the same shape with different entity names:
+
+```python
+class <Entity>RevisionQueryRequest(BaseModel):
+    <entity>_revision: Optional[<Entity>RevisionQuery]   # attribute filter
+    <entity>_refs: Optional[List[Reference]]             # scope
+    <entity>_variant_refs: Optional[List[Reference]]     # scope
+    <entity>_revision_refs: Optional[List[Reference]]    # scope
+    include_archived: Optional[bool]                     # policy
+    windowing: Optional[Windowing]                       # result shaping
+```
+
+All six reach the same method, `GitDAO.query_revisions` at
+`dbs/postgres/git/dao.py:1334`. Any change made in one place must be made in all six, or
+the family drifts apart.
+
+## `Windowing` shapes one flat stream
+
+`Windowing` lives in `core/shared/dtos.py`. Its fields are grouped by comment:
+
+```python
+class Windowing(BaseModel):
+    newest, oldest      # RANGE
+    next                # TOKEN
+    limit               # LIMIT
+    order               # ORDER
+    interval            # BUCKETS
+    rate                # SAMPLES
+```
+
+`apply_windowing` in `dbs/postgres/shared/utils.py` applies it over one ordered result,
+keyed on a time column or an id column. The `next` token is a cursor over that flat
+stream.
+
+87 request models across the API embed `Windowing`. Only the six above have a parent
+column to group by.
+
+## The frontend already reaches for this, twice
+
+`web/packages/agenta-entities/src/workflow/api/api.ts:1291` drops the limit on purpose,
+and says why in a comment.
+
+`web/packages/agenta-entities/src/testset/api/api.ts:193` tries a different shape:
+
+```js
+testset_refs: testsetIds.map((id) => ({id, limit: 1})),
+```
+
+That `limit` does nothing. `Reference` is `class Reference(Identifier, Slug, Version)`
+with no `model_config`, so pydantic ignores extra keys. We checked it on the running API:
+
+```
+Reference(**{"id": "...", "limit": 1})
+  -> version=None slug=None id=UUID('...')
+  -> dumped: {'id': UUID('...')}
+```
+
+The call therefore fetches every revision of every testset in the batch. It fails
+silently. On the project we measured, testsets hold only 2 revisions, so nothing hurts
+today. The defect is latent, not harmless.
+
+## Where the cost sits
+
+`WorkflowsService.query_workflow_revisions` at `core/workflows/service.py:2076` builds a
+model per row:
+
+```python
+workflow_revision = await self._normalize_revision_for_read(
+    project_id=project_id,
+    revision=WorkflowRevision(**revision.model_dump(mode="json")),
+    ...
+)
+if not self._matches_requested_flags(...):
+    continue
+```
+
+Two facts follow from that order. First, every returned row is fully built before
+anything is discarded. Second, `WorkflowRevisionData._validate` runs on construction, and
+it calls `jsonschema.check_schema` on every schema. A filter applied at this point would
+still save the later serialization and compression, but not the database transfer or the
+model construction.
+
+Measured on the project's real data, inside the API container:
+
+| Stage | 177 revisions (two workflows) |
+| --- | --- |
+| Build models, including `check_schema` | 385 ms |
+| `model_dump` | 146 ms |
+| Serialize to JSON | 92 ms, giving 76.4 MB |
+| gzip at level 5 | 1293 ms, giving 18.9 MB |
+| **Total, none of it yielding** | **1916 ms** |
+
+A single revision costs 2.2 ms to build. The project holds 19 workflows and 269
+revisions, and two of those workflows hold 179 revisions and 30 MB between them.
+
+## Why a query flag would not work
+
+Adding `is_latest` to `<Entity>RevisionQueryFlags` looks natural, because the flags model
+is rich. It fails for two reasons.
+
+The flags are matched in Python at `service.py:2085`, after each model is built. A flag
+filter would pay the full 2.2 ms per row and then throw the rows away. It removes no
+cost, and the cost is the reason for the change.
+
+The meaning is also wrong. The flags describe what a revision is. The code groups them as
+`uri-derived`, `interface-derived`, and `slug-derived`, and others are user-declared or
+merged from the artifact during a read. Not all of them are computed from the revision
+alone, but none of them depend on where the revision sits in its own history. "Newest among
+its siblings" does, and it changes when someone commits a new revision.
+
+## The pattern to copy
+
+`RecordsDAO.latest_message_per_session` at `dbs/postgres/sessions/records/dao.py:167`
+solves the same shape. It uses `DISTINCT ON` to get the newest row per group in one
+query, and it truncates the large column inside Postgres so the big value never leaves
+the database. Its docstring gives the same reason we give here.

--- a/docs/design/revision-query-grouping/status.md
+++ b/docs/design/revision-query-grouping/status.md
@@ -1,0 +1,78 @@
+# Status
+
+Last updated 2026-09-05.
+
+## Where the work stands
+
+Planning, with one small fix already landed. The API change is not written yet.
+
+The measurements in `research.md` come from the running `agenta-oss-team` stack on images
+`v0.114.5`. The design was reviewed by Codex (`gpt-6-astra`, medium effort) on 2026-09-05,
+and this document records what changed as a result.
+
+## Landed
+
+One correctness fix in `web/packages/agenta-entities/src/testset/api/api.ts`,
+`fetchLatestRevisionsBatch`. It was three separate problems in one function:
+
+1. It sent `{id, limit: 1}` inside a `Reference`, and the API drops unknown keys, so the
+   limit never applied.
+2. Its docstring described a `ReferenceWithLimit` feature with SQL window functions. No
+   such feature exists anywhere in the repository.
+3. It sent no `windowing`, and `query_revisions` applies an `ORDER BY` only when windowing
+   is present. So the rows came back in unspecified order, and the loop kept whichever
+   revision arrived last. A function named "latest" returned an arbitrary revision.
+
+The fix asks for newest first, keeps the first revision seen per testset, and prefers a
+configured revision over an auto-created version 0 placeholder. That last rule matches the
+sibling fetcher in `web/oss/src/state/entities/testset/revisionEntity.ts`.
+
+The fix does not stop the over-fetch. That needs the API change planned here.
+
+## Decisions made
+
+- The new field is a sibling of `windowing`, named `grouping`. Mahmoud chose this shape.
+- The first release carries `by` only, and returns at most one revision per parent. The
+  `limit` field for "newest N per parent" is dropped until a caller needs it.
+- Paging over parents is rejected, not redefined. `api-design.md` gives the worked example
+  where a revision cursor makes a parent appear on two pages.
+- All six revision query endpoints get the field in the same change.
+- Nothing ships until the behavior works end to end. The earlier plan to land the field
+  first, accepted and ignored, is unsafe here, and `plan.md` explains why.
+
+## Open questions
+
+- What counts as the newest revision when version 0 can be either an empty placeholder or a
+  real configured revision. This blocks Step 2.
+- Whether `grouping` means "the newest revision that matches the filter" or "the newest
+  revision, returned only if it matches". The two differ whenever a filter is present.
+- Whether any caller outside this repository depends on the current unbounded behavior. The
+  change is additive, so the risk is low, but the SDK is public.
+
+## Related work found in the same investigation
+
+Separate from this plan. The first one now looks more urgent than this change.
+
+**gzip on the event loop.** `api/entrypoints/routers.py:503` adds
+`GZipMiddleware(minimum_size=1000, compresslevel=5)`, which compresses synchronously. It
+was 1293 ms of the 1916 ms we measured, so about two thirds of the cost. Shrinking payloads
+reduces it, but only compression work moving off the request path removes it.
+
+There may be a simple answer. The OSS nginx config at
+`hosting/docker-compose/oss/nginx/nginx.conf` already sets `gzip on` and includes
+`application/json`, so in that deployment the API duplicates work the proxy can do. Note
+the stack where the incident happened runs Traefik, not nginx, so the proxies differ by
+deployment and each path needs checking before the middleware is removed.
+
+**Schema revalidation on read.** `WorkflowRevisionData._validate` in
+`sdks/python/agenta/sdk/models/workflows.py` runs `jsonschema.check_schema` on every model
+construction, so reads re-check schemas that were validated at write time. 2.2 ms per
+revision. Moving the check to the write boundaries needs an audit of creation, commit, and
+import paths first. Do not simply delete it from a shared SDK model.
+
+**The session record log has no pagination.** `RecordsDAO.get_records` returns every record
+for a session. 95 ms today, and it grows with every turn.
+
+**A fourth batch shape with the same gap.** `GitDAO.query_variants` takes artifact
+references with a global limit, so newest-variant-per-artifact has the same problem. No
+caller needs it today. Recorded so nobody has to rediscover it, not scheduled.

--- a/docs/design/revision-query-grouping/status.md
+++ b/docs/design/revision-query-grouping/status.md
@@ -1,10 +1,11 @@
 # Status
 
-Last updated 2026-09-05.
+Last updated 2026-09-10.
 
 ## Where the work stands
 
-Planning, with one small fix already landed. The API change is not written yet.
+The interface is settled and implementation is in progress. One related testset
+correctness fix has already landed.
 
 The measurements in `research.md` come from the running `agenta-oss-team` stack on images
 `v0.114.5`. The design was reviewed by Codex (`gpt-6-astra`, medium effort) on 2026-09-05,
@@ -31,23 +32,25 @@ The fix does not stop the over-fetch. That needs the API change planned here.
 
 ## Decisions made
 
-- The new field is a sibling of `windowing`, named `grouping`. Mahmoud chose this shape.
-- The first release carries `by` only, and returns at most one revision per parent. The
-  `limit` field for "newest N per parent" is dropped until a caller needs it.
-- Paging over parents is rejected, not redefined. `api-design.md` gives the worked example
-  where a revision cursor makes a parent appear on two pages.
+- The new field is a sibling of `windowing`, named `grouping`.
+- `grouping.by` defines the parent level and the required `grouping.get` defines which
+  revision to select. The first release accepts `artifact` or `variant` for `by` and
+  only `latest` for `get`.
+- Grouped requests reject all `windowing`. `api-design.md` gives the worked example
+  where a revision cursor makes one parent appear on two pages.
+- Filters and archive policy run before grouping. `latest` selects the greatest eligible
+  UUID7 revision id in every group.
+- Empty seed revisions do not count. Configured version 0 revisions remain eligible.
+- Explicit revision references and filters evaluated after SQL are rejected with grouping.
 - All six revision query endpoints get the field in the same change.
 - Nothing ships until the behavior works end to end. The earlier plan to land the field
   first, accepted and ignored, is unsafe here, and `plan.md` explains why.
 
-## Open questions
+## Remaining verification
 
-- What counts as the newest revision when version 0 can be either an empty placeholder or a
-  real configured revision. This blocks Step 2.
-- Whether `grouping` means "the newest revision that matches the filter" or "the newest
-  revision, returned only if it matches". The two differ whenever a filter is present.
-- Whether any caller outside this repository depends on the current unbounded behavior. The
-  change is additive, so the risk is low, but the SDK is public.
+- Confirm the generated clients expose the grouped request on all six endpoints.
+- Measure the response size and latency on the seeded project.
+- Exercise the sidebar against the deployed API on exe.dev.
 
 ## Related work found in the same investigation
 


### PR DESCRIPTION
Temporary deployment PR for validating revision grouping on exe.dev before updating #6569 with the implementation.

This PR will not be merged. It will be closed after the exact SHA is deployed and tested.
