### PR TITLE
[fix] ci: clear CodeQL 322 and unblock the web acceptance suite

### DIFF
--- a/hosting/kubernetes/helm/tests/test_existing_secret.py
+++ b/hosting/kubernetes/helm/tests/test_existing_secret.py
@@ -17,9 +17,7 @@ Requires the `helm` binary on PATH.
 
 from __future__ import annotations
 
-import re
 import subprocess
-import sys
 from pathlib import Path
 
 import yaml
@@ -108,13 +106,8 @@ def secret_references(docs: list[dict]) -> list[tuple[str, str, str]]:
     return refs
 
 
-def redact_failure_line(line: str) -> str:
-    """Redact potentially sensitive values from failure output."""
-    # Replace quoted values (for example secret names shown with !r) with a marker.
-    return re.sub(r"'[^']*'", "'<redacted>'", line)
-
-
-def main() -> int:
+def collect_failures() -> list[str]:
+    """Every way the rendered chart fails to honor `secrets.existingSecret`."""
     failures: list[str] = []
     docs = render()
 
@@ -172,21 +165,29 @@ def main() -> int:
                 f"{workload}: agentRunner.auth.tokenSecretRef ignored, reads {name!r}"
             )
 
-    if failures:
-        print("FAIL: secrets.existingSecret is not honored:", file=sys.stderr)
-        for line in failures:
-            print(f"  - {redact_failure_line(line)}", file=sys.stderr)
-        return 1
+    return failures
 
-    print("OK: every Secret reference honors secrets.existingSecret.")
-    print(f"  runner token sources: {len(token_refs)} workload(s)")
-    return 0
+
+def failure_report(failures: list[str]) -> str:
+    return "secrets.existingSecret is not honored:\n" + "\n".join(
+        f"  - {failure}" for failure in failures
+    )
 
 
 def test_existing_secret_is_honored() -> None:
-    """pytest entry point. The module also runs standalone; both call main()."""
-    assert main() == 0, "secrets.existingSecret is honored"
+    """pytest entry point. The module also runs standalone; both call collect_failures().
+
+    The offending workload and Secret names belong in the assertion, not in a log line. They
+    are Kubernetes Secret RESOURCE names rather than secret material, and a failure is
+    unactionable without them: whoever reads it needs to know which reference points at the
+    wrong Secret.
+    """
+    failures = collect_failures()
+    assert not failures, failure_report(failures)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    _failures = collect_failures()
+    if _failures:
+        raise SystemExit(failure_report(_failures))
+    print("OK: every Secret reference honors secrets.existingSecret.")

--- a/hosting/kubernetes/helm/tests/test_runner_secret_absence.py
+++ b/hosting/kubernetes/helm/tests/test_runner_secret_absence.py
@@ -19,7 +19,6 @@ Requires the `helm` binary on PATH.
 from __future__ import annotations
 
 import subprocess
-import sys
 from pathlib import Path
 
 import yaml
@@ -198,7 +197,8 @@ def check(names: list[str]) -> list[str]:
     return failures
 
 
-def main() -> int:
+def collect_failures() -> list[str]:
+    """Every way the rendered chart widens the runner's environment."""
     failures: list[str] = []
 
     # Default deployment: the token comes from the platform Secret, env still narrow.
@@ -262,23 +262,31 @@ def main() -> int:
             "custom runner securityContext suppresses the /dev/fuse hostPath"
         )
 
-    if failures:
-        print("FAIL: runner environment is not narrow:", file=sys.stderr)
-        for line in failures:
-            print(f"  - {line}", file=sys.stderr)
-        return 1
+    return failures
 
-    print(
-        "OK: internal-services key is limited to API/Services; runner env remains narrow."
+
+def failure_report(failures: list[str]) -> str:
+    return "runner environment is not narrow:\n" + "\n".join(
+        f"  - {failure}" for failure in failures
     )
-    print(f"  default env: {sorted(names)}")
-    return 0
 
 
 def test_runner_env_stays_narrow() -> None:
-    """pytest entry point. The module also runs standalone; both call main()."""
-    assert main() == 0, "the runner environment stays narrow"
+    """pytest entry point. The module also runs standalone; both call collect_failures().
+
+    The offending variable names belong in the assertion, not in a log line. They are
+    environment variable NAMES read out of a rendered manifest rather than any value, and a
+    failure is unactionable without them: whoever reads it needs to know which variable
+    widened the runner.
+    """
+    failures = collect_failures()
+    assert not failures, failure_report(failures)
 
 
 if __name__ == "__main__":
-    raise SystemExit(main())
+    _failures = collect_failures()
+    if _failures:
+        raise SystemExit(failure_report(_failures))
+    print(
+        "OK: internal-services key is limited to API/Services; runner env remains narrow."
+    )

--- a/web/oss/tests/playwright/acceptance/mobile-gate/gate.spec.ts
+++ b/web/oss/tests/playwright/acceptance/mobile-gate/gate.spec.ts
@@ -6,12 +6,20 @@ const IPHONE_UA =
 const gateEnabled = process.env.AGENTA_MOBILE_GATE !== "false"
 const reverseGateEnabled = process.env.AGENTA_MOBILE_REVERSE_GATE !== "false"
 
+/**
+ * A genuinely empty context. `storageState: undefined` reads as "no session" but does not clear
+ * anything: an option set to undefined falls back to the config value, so these tests inherited
+ * the shared signed-in state, including the `agenta-mobile-optout` cookie that switches the very
+ * gate they assert on off. Both directions decide on the request, before any session matters.
+ */
+const NO_SESSION = {cookies: [], origins: []}
+
 test.describe("mobile gate: forward direction", () => {
     test.skip(!gateEnabled, "mobile gate opted out (AGENTA_MOBILE_GATE=false)")
     test.use({
         userAgent: IPHONE_UA,
         extraHTTPHeaders: {"sec-ch-ua-mobile": "?1"},
-        storageState: undefined,
+        storageState: NO_SESSION,
     })
 
     test("mobile UA on a desktop route lands in /m", async ({page}) => {
@@ -45,7 +53,7 @@ test.describe("mobile gate: reverse direction", () => {
         !reverseGateEnabled,
         "reverse mobile gate opted out (AGENTA_MOBILE_REVERSE_GATE=false)",
     )
-    test.use({storageState: undefined})
+    test.use({storageState: NO_SESSION})
 
     test("desktop UA on /m is sent to the desktop app", async ({page}) => {
         await page.goto("/m/")

--- a/web/tests/playwright/global-setup.ts
+++ b/web/tests/playwright/global-setup.ts
@@ -881,6 +881,66 @@ async function authenticateUserImpl({
     await waitForSettledAuthenticatedPage(page, timeout)
 }
 
+/**
+ * Storage keys owned by `@agenta/shared`'s classicMode state. Copied rather than imported: the
+ * test package does not depend on the web packages, and the values run inside `page.evaluate`.
+ * Source of truth: `web/packages/agenta-shared/src/state/classicMode.ts`.
+ */
+const ACTIVE_USER_ID_KEY = "agenta:onboarding:active-user-id"
+const navSimplifiedOverrideKey = (userId: string) =>
+    `agenta:onboarding:${userId}:nav-simplified-override`
+
+/**
+ * Put the shared storage state on the full desktop app, the way the Classic mode switch does.
+ *
+ * Every account this setup creates is new enough to fall in the simplified cohort, so Classic
+ * mode is off by default. That costs the desktop suites twice: the gate redirects them into `/m`,
+ * where none of the desktop paths they assert on exist, and the desktop sidebar hides its
+ * advanced areas (Prompts, Evaluations), which several specs navigate through.
+ *
+ * Turning Classic mode on fixes both. The override is what the Preferences switch writes, and it
+ * outranks the signup-era default everywhere it is read, so the client-side gate stands down and
+ * the cookie sync publishes `agenta-classic-mode=1` for the middleware. `?view=desktop` on top is
+ * the product's own escape hatch: it sets `agenta-mobile-optout`, which both gates honour ahead of
+ * everything else, and it clears any `agenta-classic-mode=0` the signup flow already wrote.
+ *
+ * The mobile-gate spec runs with `storageState: undefined`, so it still exercises the gate itself.
+ */
+async function pinDesktopView(page: Page, rootURL: string, timeout: number): Promise<void> {
+    try {
+        // Navigate first: localStorage is per-origin, and a context that has not left about:blank
+        // has none to write to.
+        await page.goto(`${rootURL}/w?view=desktop`, {timeout, waitUntil: "domcontentloaded"})
+
+        const userId = await page.evaluate((key) => localStorage.getItem(key), ACTIVE_USER_ID_KEY)
+        if (userId) {
+            await page.evaluate(
+                (key) => localStorage.setItem(key, "false"),
+                navSimplifiedOverrideKey(userId),
+            )
+        } else {
+            console.warn(
+                "[global-setup] No active user id in storage; Classic mode stays at its default",
+            )
+        }
+
+        const optedOut = (await page.context().cookies()).some(
+            (cookie) => cookie.name === "agenta-mobile-optout",
+        )
+        if (!optedOut) {
+            console.warn(
+                "[global-setup] agenta-mobile-optout cookie was not set; desktop tests may be redirected to /m",
+            )
+            return
+        }
+        console.log(
+            "[global-setup] Pinned the desktop view (Classic mode on, mobile gate opted out)",
+        )
+    } catch (error) {
+        console.warn("[global-setup] Could not pin the desktop view:", error)
+    }
+}
+
 async function globalSetup() {
     console.log("[global-setup] Starting global setup for authentication")
 
@@ -932,6 +992,8 @@ async function globalSetup() {
             testmail,
         })
 
+        await pinDesktopView(authenticatedPage, rootURL, timeout)
+
         mkdirSync(dirname(storageState), {recursive: true})
         await authenticatedPage.context().storageState({path: storageState})
         await maybeCreateEphemeralProject(authenticatedPage, baseURL)
@@ -942,6 +1004,9 @@ async function globalSetup() {
             )
             const cachedContext = await browser.newContext({storageState})
             const cachedPage = await cachedContext.newPage()
+            // A state saved before this pin existed still redirects to /m; refresh it.
+            await pinDesktopView(cachedPage, rootURL, timeout)
+            await cachedContext.storageState({path: storageState})
             await cachedPage.goto(`${rootURL}/apps`, {timeout, waitUntil: "domcontentloaded"})
             await maybeCreateEphemeralProject(cachedPage, baseURL)
             await cachedContext.close()


### PR DESCRIPTION
Two CI blockers on the 0.117.0 release branch, one real and one pre-existing.

## CodeQL alert 322

`hosting/kubernetes/helm/tests/test_existing_secret.py` prints its failure lines to stderr, and CodeQL reads the Secret names in them as clear-text logging of sensitive data. The previous attempt at this (a24cfeb) added a redaction helper, which only moved the alert from line 171 to line 178 and made the output useless: the helper replaces every quoted value with `'<redacted>'`, including the workload names you need to act on the failure.

The values are Kubernetes Secret **resource** names, not secret material. They belong in the assertion, where pytest shows them on failure and where there is no logging sink to flag.

Before, on a failure:

```
FAIL: secrets.existingSecret is not honored:
  - existing-secret-test-runner: AGENTA_RUNNER_TOKEN reads Secret '<redacted>', expected '<redacted>'
```

After:

```
AssertionError: secrets.existingSecret is not honored:
  - existing-secret-test-runner: AGENTA_RUNNER_TOKEN reads Secret 'existing-secret-test-agenta', expected 'my-agenta-secret'
```

The standalone entry point keeps its exit code and prints the same one-line summary on success. Verified both paths locally with `uv run hosting/kubernetes/helm/tests/test_existing_secret.py`.

## `tests / run-web-tests (acceptance)`

Five specs fail because the browser never stays in the desktop app. The evaluations route is the clearest case:

```
Expected: "/w/{ws}/p/{proj}/apps/{appId}/evaluations"
Received: "/m/w/{ws}/p/{proj}/agents/{appId}"
```

The global setup signs up a brand-new account for every run. Any account created after 2026-08-01 is in the simplified cohort, which means Classic mode is off, which costs the desktop suites twice. The gate redirects them into `/m`, where the paths they assert on do not exist, and the desktop sidebar hides its advanced areas, which several specs navigate through. The "AI providers" heading failure is the same cause with one extra turn: the gate drops the query string, so `?tab=llms` is lost and `/m` renders Preferences instead.

The fix turns Classic mode on in the shared storage state, the way the Preferences switch does, and then takes the product's own `?view=desktop` escape hatch so both gates stand down. The mobile-gate spec runs with an empty storage state, so it still exercises the gate itself.

**This is not a 0.117.0 regression.** None of the 171 commits in `main..release/v0.117.0` touch the gate; the implicated files are byte-identical to `main`. The redirect shipped in v0.115.4 (#6261), and the same five specs fail on unrelated branches cut from main, for example runs 34505714417 and 34506034867.

One test had to change with it. `mobile-gate/gate.spec.ts` asks for `storageState: undefined`, which reads as "no session" but clears nothing: a Playwright option set to undefined falls back to the config value, so those tests were running signed in, and the desktop opt-out cookie then switched off the very gate they assert on. They now get an empty cookies/origins object, which is what they always meant.

## Result

| Run | Outcome |
| --- | --- |
| Before, on a24cfeb | 1 passed, 5 failed, 11 skipped, 63 never ran |
| After the storage-state pin | 47 passed, 3 failed, 30 skipped |
| After the gate-spec fix | 50 passed, 0 failed, 30 skipped |

All 67 checks on this PR pass. CodeQL uses GitHub's default setup, which only analyzes pull requests targeting `main`, so alert 322 will clear on #6748 once this lands rather than here.

Worth a conscious call rather than an assumption: the product behaviour here is that every account created after 2026-08-01 lands in `/m` on a desktop browser by default. That is the stated intent of #6261, but it is indistinguishable from a regression on first sight.

https://claude.ai/code/session_01SaN5pYGkaoCsVd48Qcqm3L