### PR TITLE
[fix] release 117: grouped revision query 422 and scope, playground picker, sidebar waiting filter

### DIFF
--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -1573,7 +1573,9 @@ class ApplicationsRouter:
         )
 
     @intercept_exceptions()
-    @suppress_exceptions(default=ApplicationRevisionsResponse())
+    @suppress_exceptions(
+        default=ApplicationRevisionsResponse(), exclude=[HTTPException]
+    )
     async def query_application_revisions(
         self,
         request: Request,

--- a/api/oss/src/apis/fastapi/applications/router.py
+++ b/api/oss/src/apis/fastapi/applications/router.py
@@ -596,7 +596,7 @@ class ApplicationsRouter:
         )
 
     @intercept_exceptions()
-    @suppress_exceptions(default=ApplicationResponse())
+    @suppress_exceptions(default=ApplicationResponse(), exclude=[HTTPException])
     async def fetch_application(
         self,
         request: Request,
@@ -735,7 +735,7 @@ class ApplicationsRouter:
         )
 
     @intercept_exceptions()
-    @suppress_exceptions(default=ApplicationsResponse())
+    @suppress_exceptions(default=ApplicationsResponse(), exclude=[HTTPException])
     async def query_applications(
         self,
         request: Request,
@@ -1883,7 +1883,7 @@ class SimpleApplicationsRouter:
         return simple_application_response
 
     @intercept_exceptions()
-    @suppress_exceptions(default=SimpleApplicationResponse())
+    @suppress_exceptions(default=SimpleApplicationResponse(), exclude=[HTTPException])
     async def fetch_simple_application(
         self,
         request: Request,

--- a/api/oss/src/apis/fastapi/environments/router.py
+++ b/api/oss/src/apis/fastapi/environments/router.py
@@ -2,6 +2,8 @@ from typing import Optional
 from uuid import UUID
 
 from fastapi import APIRouter, Body, Request, status, Depends, HTTPException
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
 
 from oss.src.utils.common import is_ee
 from oss.src.utils.logging import get_module_logger
@@ -1070,10 +1072,20 @@ class EnvironmentsRouter:
         ):
             raise FORBIDDEN_EXCEPTION  # type: ignore
 
-        environment_revision_query_request = merge_environment_revision_query_requests(
-            query_request_params,
-            query_request_body,
-        )
+        try:
+            environment_revision_query_request = (
+                merge_environment_revision_query_requests(
+                    query_request_params,
+                    query_request_body,
+                )
+            )
+        except ValidationError as exc:
+            # Merging re-runs request validation, so an invalid params/body combination
+            # must reach the caller as 422 instead of being suppressed into an empty 200.
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=jsonable_encoder(exc.errors()),
+            ) from exc
 
         environment_revisions = await self.environments_service.query_environment_revisions(
             project_id=UUID(request.state.project_id),

--- a/api/oss/src/apis/fastapi/workflows/router.py
+++ b/api/oss/src/apis/fastapi/workflows/router.py
@@ -3,6 +3,8 @@ from typing import Any, Optional
 from uuid import UUID, uuid4
 
 from fastapi import APIRouter, Body, Request, status, HTTPException, Depends
+from fastapi.encoders import jsonable_encoder
+from pydantic import ValidationError
 
 from oss.src.utils.env import env
 from oss.src.utils.logging import get_module_logger
@@ -863,7 +865,7 @@ class WorkflowsRouter:
         edit_name = workflow_edit_request.workflow.name
         if edit_name is not None and not edit_name.strip():
             raise HTTPException(
-                status_code=status.HTTP_422_UNPROCESSABLE_ENTITY,
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
                 detail="workflow.name must contain a non-whitespace character.",
             )
 
@@ -1543,9 +1545,17 @@ class WorkflowsRouter:
         ),
         query_request_body: Optional[WorkflowRevisionQueryRequest] = Body(None),
     ) -> WorkflowRevisionsResponse:
-        workflow_revision_query_request = merge_workflow_revision_query_requests(
-            query_request_params, query_request_body
-        )
+        try:
+            workflow_revision_query_request = merge_workflow_revision_query_requests(
+                query_request_params, query_request_body
+            )
+        except ValidationError as exc:
+            # Merging re-runs request validation, so an invalid params/body combination
+            # must reach the caller as 422 instead of being suppressed into an empty 200.
+            raise HTTPException(
+                status_code=status.HTTP_422_UNPROCESSABLE_CONTENT,
+                detail=jsonable_encoder(exc.errors()),
+            ) from exc
 
         if not await check_action_access(  # type: ignore
             user_uid=request.state.user_id,

--- a/api/oss/src/dbs/postgres/git/dao.py
+++ b/api/oss/src/dbs/postgres/git/dao.py
@@ -1546,8 +1546,12 @@ class GitDAO(GitDAOInterface):
                     .order_by(group_column, self.RevisionDBE.id.desc())
                     .subquery()
                 )
+                # Rebuilding the statement drops every predicate, including the tenant
+                # scope. Restoring it also restores the leading column of every index on
+                # these tables, so the outer lookup seeks instead of scanning.
                 stmt = (
                     select(self.RevisionDBE)
+                    .filter(self.RevisionDBE.project_id == project_id)  # type: ignore
                     .filter(self.RevisionDBE.id.in_(select(selected_ids.c.id)))
                     .order_by(self.RevisionDBE.id.desc())
                 )

--- a/api/oss/tests/pytest/unit/git/test_query_revisions_statement_scope.py
+++ b/api/oss/tests/pytest/unit/git/test_query_revisions_statement_scope.py
@@ -1,0 +1,117 @@
+"""`query_revisions` must scope the statement it actually executes to the project.
+
+The grouped path rebuilds the outer statement from scratch around an `IN` over the
+grouped subquery, which drops the predicates the base statement carried. Every index on
+the revision tables leads with `project_id`, so an outer query without it cannot seek.
+
+The DAO runs against a fake engine that records the compiled statement and returns no
+rows, so no database is involved.
+"""
+
+from contextlib import asynccontextmanager
+from uuid import uuid4
+
+import pytest
+from sqlalchemy.dialects import postgresql
+
+import oss.src.models.db_models  # noqa: F401  registers the `projects` table
+from oss.src.core.git.dtos import RevisionGrouping, RevisionQuery
+from oss.src.core.shared.dtos import Reference
+from oss.src.dbs.postgres.git.dao import GitDAO
+from oss.src.dbs.postgres.workflows.dbes import (
+    WorkflowArtifactDBE,
+    WorkflowRevisionDBE,
+    WorkflowVariantDBE,
+)
+
+
+class _RecordingResult:
+    def scalars(self):
+        return self
+
+    def all(self):
+        return []
+
+
+class _RecordingSession:
+    def __init__(self):
+        self.statements = []
+
+    async def execute(self, statement):
+        self.statements.append(statement)
+        return _RecordingResult()
+
+    async def commit(self):
+        return None
+
+    async def rollback(self):
+        return None
+
+    async def close(self):
+        return None
+
+
+class _RecordingEngine:
+    def __init__(self):
+        self.last_session = None
+
+    @asynccontextmanager
+    async def session(self):
+        self.last_session = _RecordingSession()
+        yield self.last_session
+
+
+def _compile(statement) -> str:
+    return str(statement.compile(dialect=postgresql.dialect()))
+
+
+def _split_outer_where(sql: str) -> str:
+    """The outer WHERE clause, with the parenthesised subquery removed."""
+    depth = 0
+    outer = []
+    for character in sql:
+        if character == "(":
+            depth += 1
+        elif character == ")":
+            depth -= 1
+        elif depth == 0:
+            outer.append(character)
+    return "".join(outer)
+
+
+async def _run_query(*, grouping):
+    engine = _RecordingEngine()
+    dao = GitDAO(
+        ArtifactDBE=WorkflowArtifactDBE,
+        VariantDBE=WorkflowVariantDBE,
+        RevisionDBE=WorkflowRevisionDBE,
+        engine=engine,
+    )
+
+    await dao.query_revisions(
+        project_id=uuid4(),
+        revision_query=RevisionQuery(),
+        grouping=grouping,
+        artifact_refs=[Reference(id=uuid4())],
+    )
+
+    assert engine.last_session is not None
+    assert len(engine.last_session.statements) == 1
+    return _compile(engine.last_session.statements[0])
+
+
+@pytest.mark.asyncio
+async def test_grouped_query_scopes_the_outer_statement_to_the_project():
+    sql = await _run_query(grouping=RevisionGrouping(by="artifact", get="latest"))
+
+    assert "IN (SELECT" in sql, "expected the grouped subquery shape"
+
+    outer_where = _split_outer_where(sql)
+    assert "workflow_revisions.project_id = " in outer_where
+
+
+@pytest.mark.asyncio
+async def test_ungrouped_query_scopes_the_statement_to_the_project():
+    sql = await _run_query(grouping=None)
+
+    assert "workflow_revisions.project_id = " in _split_outer_where(sql)

--- a/api/oss/tests/pytest/unit/git/test_revision_query_route_validation.py
+++ b/api/oss/tests/pytest/unit/git/test_revision_query_route_validation.py
@@ -1,0 +1,176 @@
+"""Revision-query routes must report validation and permission failures, not swallow them.
+
+Both failures are invisible from the pydantic layer alone. Grouping and windowing are
+rejected by the request model, but the workflows and environments routes merge query
+params into the body model inside the handler, so that rejection happens under
+`suppress_exceptions` rather than under FastAPI's own body validation. The applications
+route takes a single body model and has no merge, so what it can lose is its 403.
+
+The routers are built with stub services and mounted on a bare app, so the real route
+registration, the real `Depends` param parsing and the real decorator stack all run.
+"""
+
+from uuid import uuid4
+
+import pytest
+from fastapi import FastAPI, Request
+from fastapi.testclient import TestClient
+
+from oss.src.apis.fastapi.applications import router as applications_router_module
+from oss.src.apis.fastapi.applications.router import ApplicationsRouter
+from oss.src.apis.fastapi.environments import router as environments_router_module
+from oss.src.apis.fastapi.environments.router import EnvironmentsRouter
+from oss.src.apis.fastapi.workflows import router as workflows_router_module
+from oss.src.apis.fastapi.workflows.router import WorkflowsRouter
+
+
+GROUPING = {"by": "artifact", "get": "latest"}
+
+
+class _StubService:
+    """Answers every revision query with an empty list."""
+
+    async def query_workflow_revisions(self, **_kwargs):
+        return []
+
+    async def query_environment_revisions(self, **_kwargs):
+        return []
+
+    async def query_application_revisions(self, **_kwargs):
+        return []
+
+
+def _build_client(monkeypatch, *, access_allowed: bool = True) -> TestClient:
+    async def _check_action_access(**_kwargs):
+        return access_allowed
+
+    async def _publish_revision_event(**_kwargs):
+        return None
+
+    stub_service = _StubService()
+
+    for module in (
+        workflows_router_module,
+        environments_router_module,
+        applications_router_module,
+    ):
+        monkeypatch.setattr(
+            module, "check_action_access", _check_action_access, raising=False
+        )
+        monkeypatch.setattr(
+            module, "publish_revision_event", _publish_revision_event, raising=False
+        )
+
+    app = FastAPI()
+
+    @app.middleware("http")
+    async def _inject_principal(request: Request, call_next):
+        request.state.user_id = str(uuid4())
+        request.state.project_id = str(uuid4())
+        return await call_next(request)
+
+    app.include_router(
+        WorkflowsRouter(
+            workflows_service=stub_service,
+            environments_service=stub_service,
+        ).router,
+        prefix="/workflows",
+    )
+    app.include_router(
+        EnvironmentsRouter(environments_service=stub_service).router,
+        prefix="/environments",
+    )
+    app.include_router(
+        ApplicationsRouter(
+            applications_service=stub_service,
+            environments_service=stub_service,
+        ).router,
+        prefix="/applications",
+    )
+
+    return TestClient(app)
+
+
+@pytest.mark.parametrize(
+    "prefix, refs_field",
+    [
+        ("/workflows", "workflow_refs"),
+        ("/environments", "environment_refs"),
+    ],
+)
+def test_grouping_in_body_with_windowing_in_params_returns_422(
+    monkeypatch, prefix, refs_field
+):
+    client = _build_client(monkeypatch)
+
+    response = client.post(
+        f"{prefix}/revisions/query?limit=1",
+        json={refs_field: [{"id": str(uuid4())}], "grouping": GROUPING},
+    )
+
+    assert response.status_code == 422
+    assert "grouping cannot be combined with windowing" in response.text
+
+
+@pytest.mark.parametrize(
+    "prefix, refs_field",
+    [
+        ("/workflows", "workflow_refs"),
+        ("/environments", "environment_refs"),
+    ],
+)
+def test_grouping_in_body_with_windowing_in_body_still_returns_422(
+    monkeypatch, prefix, refs_field
+):
+    client = _build_client(monkeypatch)
+
+    response = client.post(
+        f"{prefix}/revisions/query",
+        json={
+            refs_field: [{"id": str(uuid4())}],
+            "grouping": GROUPING,
+            "windowing": {"limit": 1},
+        },
+    )
+
+    assert response.status_code == 422
+    assert "grouping cannot be combined with windowing" in response.text
+
+
+@pytest.mark.parametrize(
+    "prefix, refs_field",
+    [
+        ("/workflows", "workflow_refs"),
+        ("/environments", "environment_refs"),
+        ("/applications", "application_refs"),
+    ],
+)
+def test_grouping_without_windowing_is_accepted(monkeypatch, prefix, refs_field):
+    client = _build_client(monkeypatch)
+
+    response = client.post(
+        f"{prefix}/revisions/query",
+        json={refs_field: [{"id": str(uuid4())}], "grouping": GROUPING},
+    )
+
+    assert response.status_code == 200
+    assert response.json()["count"] == 0
+
+
+@pytest.mark.parametrize(
+    "prefix, refs_field",
+    [
+        ("/workflows", "workflow_refs"),
+        ("/environments", "environment_refs"),
+        ("/applications", "application_refs"),
+    ],
+)
+def test_denied_access_returns_403(monkeypatch, prefix, refs_field):
+    client = _build_client(monkeypatch, access_allowed=False)
+
+    response = client.post(
+        f"{prefix}/revisions/query",
+        json={refs_field: [{"id": str(uuid4())}]},
+    )
+
+    assert response.status_code == 403

--- a/api/oss/tests/pytest/unit/git/test_revision_query_route_validation.py
+++ b/api/oss/tests/pytest/unit/git/test_revision_query_route_validation.py
@@ -1,10 +1,11 @@
-"""Revision-query routes must report validation and permission failures, not swallow them.
+"""Read routes must report validation and permission failures, not swallow them.
 
 Both failures are invisible from the pydantic layer alone. Grouping and windowing are
-rejected by the request model, but the workflows and environments routes merge query
-params into the body model inside the handler, so that rejection happens under
-`suppress_exceptions` rather than under FastAPI's own body validation. The applications
-route takes a single body model and has no merge, so what it can lose is its 403.
+rejected by the request model, but the workflows and environments revision-query routes
+merge query params into the body model inside the handler, so that rejection happens
+under `suppress_exceptions` rather than under FastAPI's own body validation. The
+applications routes take a single body model and have no merge, so what they can lose is
+their 403.
 
 The routers are built with stub services and mounted on a bare app, so the real route
 registration, the real `Depends` param parsing and the real decorator stack all run.
@@ -17,7 +18,10 @@ from fastapi import FastAPI, Request
 from fastapi.testclient import TestClient
 
 from oss.src.apis.fastapi.applications import router as applications_router_module
-from oss.src.apis.fastapi.applications.router import ApplicationsRouter
+from oss.src.apis.fastapi.applications.router import (
+    ApplicationsRouter,
+    SimpleApplicationsRouter,
+)
 from oss.src.apis.fastapi.environments import router as environments_router_module
 from oss.src.apis.fastapi.environments.router import EnvironmentsRouter
 from oss.src.apis.fastapi.workflows import router as workflows_router_module
@@ -28,7 +32,7 @@ GROUPING = {"by": "artifact", "get": "latest"}
 
 
 class _StubService:
-    """Answers every revision query with an empty list."""
+    """Answers every query with an empty list and every fetch with nothing."""
 
     async def query_workflow_revisions(self, **_kwargs):
         return []
@@ -38,6 +42,20 @@ class _StubService:
 
     async def query_application_revisions(self, **_kwargs):
         return []
+
+    async def query_applications(self, **_kwargs):
+        return []
+
+    async def fetch_application(self, **_kwargs):
+        return None
+
+    async def fetch(self, **_kwargs):
+        return None
+
+    @property
+    def applications_service(self):
+        # `SimpleApplicationsRouter` reads this off its service when it is constructed.
+        return self
 
 
 def _build_client(monkeypatch, *, access_allowed: bool = True) -> TestClient:
@@ -86,6 +104,10 @@ def _build_client(monkeypatch, *, access_allowed: bool = True) -> TestClient:
             environments_service=stub_service,
         ).router,
         prefix="/applications",
+    )
+    app.include_router(
+        SimpleApplicationsRouter(simple_applications_service=stub_service).router,
+        prefix="/simple/applications",
     )
 
     return TestClient(app)
@@ -172,5 +194,25 @@ def test_denied_access_returns_403(monkeypatch, prefix, refs_field):
         f"{prefix}/revisions/query",
         json={refs_field: [{"id": str(uuid4())}]},
     )
+
+    assert response.status_code == 403
+
+
+@pytest.mark.parametrize(
+    "method, path, body",
+    [
+        ("GET", "/applications/{application_id}", None),
+        ("POST", "/applications/query", {}),
+        ("GET", "/simple/applications/{application_id}", None),
+    ],
+)
+def test_denied_access_on_the_application_read_routes_returns_403(
+    monkeypatch, method, path, body
+):
+    """These share the revision-query route's decorator, so they share its defect."""
+    client = _build_client(monkeypatch, access_allowed=False)
+
+    url = path.format(application_id=str(uuid4()))
+    response = client.get(url) if method == "GET" else client.post(url, json=body)
 
     assert response.status_code == 403

--- a/web/mobile/src/features/chat/useSessionWatch.ts
+++ b/web/mobile/src/features/chat/useSessionWatch.ts
@@ -16,6 +16,18 @@ import {sessionWatchUrl, watchRetryDelayMs} from "./watchRelay"
 const MIN_INTERVAL_MS = 3_000
 
 /**
+ * The rail's head window, not its paging tail.
+ *
+ * Both live under the `sidebar-sessions` prefix, and the tail carries `"older"` in the third
+ * slot. Invalidating the tail re-reads every page the rail has loaded, one request each, so at
+ * twelve pages a single turn costs twelve requests and a turn start and settle both land here.
+ * The head alone is correct for a lifecycle event: it is ordered by last activity, so the session
+ * that just changed is inside its window by definition.
+ */
+export const isSidebarSessionHeadQuery = (queryKey: readonly unknown[]) =>
+    queryKey[0] === "sidebar-sessions" && queryKey[2] !== "older"
+
+/**
  * One EventSource per foregrounded chat screen (M3 live relay). Most events invalidate existing
  * queries; interaction events also carry committed row state for immediate gate retirement:
  *
@@ -82,7 +94,9 @@ export const useSessionWatch = ({
             })
             // The rail draws the same liveness on its own rows, off its own queries. Without
             // these its dot outlives the run you are watching finish, until the next poll.
-            void queryClient.invalidateQueries({queryKey: ["sidebar-sessions"]})
+            void queryClient.invalidateQueries({
+                predicate: (query) => isSidebarSessionHeadQuery(query.queryKey),
+            })
             void queryClient.invalidateQueries({queryKey: ["sidebar-sessions-pinned"]})
             void queryClient.invalidateQueries({queryKey: ["sidebar-sessions-waiting"]})
         }

--- a/web/mobile/tests/unit/sidebarSessionInvalidation.test.ts
+++ b/web/mobile/tests/unit/sidebarSessionInvalidation.test.ts
@@ -1,0 +1,57 @@
+/**
+ * A turn start and a turn settle both invalidate the rail's session queries. The rail's paging
+ * tail re-reads every page it has loaded, one request per page, so a prefix match on
+ * `sidebar-sessions` turned one lifecycle event into up to twelve requests. The matcher has to
+ * hit the head window and skip the tail.
+ */
+import {describe, expect, it} from "vitest"
+
+import {isSidebarSessionHeadQuery} from "@/features/chat/useSessionWatch"
+
+const PROJECT = "project-1"
+
+/** The head key, as `sessionsSource` builds it. */
+const headKey = ["sidebar-sessions", PROJECT, [] as string[], "all", "7d", "chat", null] as const
+
+/** The tail key. Same prefix, with the slot that tells them apart in position two. */
+const tailKey = [
+    "sidebar-sessions",
+    PROJECT,
+    "older",
+    [] as string[],
+    "all",
+    "7d",
+    "chat",
+    null,
+    3,
+    null,
+] as const
+
+describe("isSidebarSessionHeadQuery", () => {
+    it("matches the head window", () => {
+        expect(isSidebarSessionHeadQuery(headKey)).toBe(true)
+    })
+
+    it("skips the paging tail", () => {
+        expect(isSidebarSessionHeadQuery(tailKey)).toBe(false)
+    })
+
+    it("matches a head window under any facet, since only the tail marks that slot", () => {
+        expect(
+            isSidebarSessionHeadQuery([
+                "sidebar-sessions",
+                PROJECT,
+                ["agent-1"],
+                "waiting",
+                "24h",
+                "automation",
+                ["session-1"],
+            ]),
+        ).toBe(true)
+    })
+
+    it("leaves the rail's other query families alone", () => {
+        expect(isSidebarSessionHeadQuery(["sidebar-sessions-pinned", PROJECT])).toBe(false)
+        expect(isSidebarSessionHeadQuery(["sidebar-sessions-waiting", PROJECT])).toBe(false)
+    })
+})

--- a/web/packages/agenta-entities/src/secret/core/promptModelGroups.ts
+++ b/web/packages/agenta-entities/src/secret/core/promptModelGroups.ts
@@ -23,6 +23,7 @@ import {
     type ProviderConnection,
 } from "./connections"
 import {fromLitellmModelId, toLitellmModelId} from "./litellmModelId"
+import {SUBSCRIPTION_PROVIDER_KIND} from "./subscriptionConnections"
 import {SecretKind} from "./types"
 
 /** One option in a picker group. Structurally the `ProviderGroup` option `@agenta/ui` renders. */
@@ -214,6 +215,10 @@ export const buildConnectionModelGroups = ({
     const groups: PromptModelGroup[] = []
 
     for (const connection of connections) {
+        // A hosted subscription holds no API key, so it can never back a litellm-run prompt.
+        // Offering it here persists a credential the run then fails to resolve.
+        if ((connection.secretKind as string) === SUBSCRIPTION_PROVIDER_KIND) continue
+
         const isStandard = connection.secretKind === SecretKind.ProviderKey
         const models = modelsFor(connection, catalog, capabilities).filter((model) => !!model.value)
         if (!models.length) continue

--- a/web/packages/agenta-entities/src/session/api/api.ts
+++ b/web/packages/agenta-entities/src/session/api/api.ts
@@ -742,8 +742,12 @@ export async function querySessionsPage({
     return parseSessionsQueryResponse(data, "[querySessionsPage]")
 }
 
-/** Temporary list-only adapter for callers that have not migrated to the page envelope. */
-export async function querySessions({
+/**
+ * The flat params above against the page envelope, so a caller that pages can read the
+ * server's cursor (`windowing.next` plus the boundary it belongs with) off the response.
+ * `querySessions` is this function with the envelope thrown away.
+ */
+export async function querySessionsFlatPage({
     projectId,
     references,
     includeEnded = true,
@@ -763,8 +767,8 @@ export async function querySessions({
     newest,
     oldest,
     order,
-}: QuerySessionsParams): Promise<SessionStream[] | null> {
-    const page = await querySessionsPage({
+}: QuerySessionsParams): Promise<SessionsQueryResponse | null> {
+    return querySessionsPage({
         projectId,
         session:
             search !== undefined || flags !== undefined || origin !== undefined
@@ -794,6 +798,11 @@ export async function querySessions({
         abortSignal,
         lowPriority,
     })
+}
+
+/** Temporary list-only adapter for callers that have not migrated to the page envelope. */
+export async function querySessions(params: QuerySessionsParams): Promise<SessionStream[] | null> {
+    const page = await querySessionsFlatPage(params)
     return page?.sessions ?? null
 }
 

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -16,6 +16,7 @@ export {
     isInteractionConflict,
     querySessionStreams,
     querySessionsPage,
+    querySessionsFlatPage,
     querySessions,
     setSessionHeader,
     fetchSessionStream,

--- a/web/packages/agenta-entities/tests/unit/prompt-model-groups.test.ts
+++ b/web/packages/agenta-entities/tests/unit/prompt-model-groups.test.ts
@@ -1,6 +1,7 @@
 import {describe, expect, it} from "vitest"
 
 import type {ProviderConnection} from "../../src/secret/core/connections"
+import {toProviderConnections} from "../../src/secret/core/connections"
 import {
     CURRENT_SELECTION_GROUP_KEY,
     buildConnectionModelGroups,
@@ -12,6 +13,7 @@ import {
     withCurrentSelectionGroup,
     withoutSlugBoundGroups,
 } from "../../src/secret/core/promptModelGroups"
+import {SUBSCRIPTION_PROVIDER_KIND} from "../../src/secret/core/subscriptionConnections"
 import {SecretKind} from "../../src/secret/core/types"
 
 const CATALOG = {
@@ -461,6 +463,43 @@ describe("buildConnectionModelGroups", () => {
         })
 
         expect(groups.map((group) => group.label)).toEqual(["My gateway"])
+    })
+
+    it("skips a hosted subscription, which holds no key a litellm run could use", () => {
+        const connections = toProviderConnections([
+            {
+                id: "sub-1",
+                slug: "chatgpt",
+                type: SUBSCRIPTION_PROVIDER_KIND,
+                displayName: "ChatGPT",
+                models: ["gpt-4o"],
+                subscription: {provider: "chatgpt", loginState: "ready", hasLogin: true},
+            },
+        ] as any) as ProviderConnection[]
+
+        expect(connections[0].secretKind).toBe(SUBSCRIPTION_PROVIDER_KIND)
+
+        expect(buildConnectionModelGroups({connections, catalog: CATALOG})).toEqual([])
+    })
+
+    it("keeps the key-backed connections when a subscription sits beside them", () => {
+        const connections = [
+            standard(),
+            {
+                id: "sub-1",
+                slug: "chatgpt",
+                name: "ChatGPT",
+                kind: "openai",
+                title: "ChatGPT",
+                secretKind: SUBSCRIPTION_PROVIDER_KIND as unknown as SecretKind,
+                models: ["gpt-4o"],
+                source: {},
+            } as ProviderConnection,
+        ]
+
+        const groups = buildConnectionModelGroups({connections, catalog: CATALOG})
+
+        expect(groups.map((group) => group.label)).toEqual(["OpenAI"])
     })
 })
 

--- a/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
+++ b/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
@@ -183,7 +183,11 @@ const sidebarWaitingIdsQueryAtomFamily = atomFamily((scopeId: string) =>
                     actionableOnly: true,
                     abortSignal: signal,
                 })
-                return [...new Set((rows ?? []).map((row) => row.session_id))]
+                // The interactions query applies no ORDER BY, so row order is not stable between
+                // executions. Both session queries put this array in their cache key, and a pure
+                // reorder would re-key them on every poll and re-fetch the whole tail. The server
+                // sorts the id list anyway, so ordering it here costs nothing.
+                return [...new Set((rows ?? []).map((row) => row.session_id))].sort()
             },
             enabled: Boolean(projectId) && (needed || scopeGroups(scopeId)),
             staleTime: 10_000,

--- a/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
+++ b/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
@@ -153,6 +153,12 @@ const queryByAgents = async (
  */
 const MAX_SESSION_QUERY_LIMIT = 200
 
+/**
+ * The longest `session_ids` list the sessions query accepts. Above it the server answers 422 and
+ * the request returns nothing, so the id push-down has to stay inside it.
+ */
+const MAX_SESSION_IDS_PER_QUERY = 500
+
 interface SessionPageWalkParams {
     projectId: string
     references: {id: string}[] | undefined
@@ -255,7 +261,15 @@ const sidebarWaitingIdsQueryAtomFamily = atomFamily((scopeId: string) =>
                 // executions. Both session queries put this array in their cache key, and a pure
                 // reorder would re-key them on every poll and re-fetch the whole tail. The server
                 // sorts the id list anyway, so ordering it here costs nothing.
-                return [...new Set((rows ?? []).map((row) => row.session_id))].sort()
+                //
+                // Truncated because the id push-down is the filter: a longer list is a 422 and the
+                // rail would show nothing at all rather than a subset. Sorting first makes which
+                // ids survive stable across polls. Paging closes on its own once the capped set
+                // runs out, since a short page ends the walk. Past 500 sessions gated at once the
+                // rail lists 500 of them; there is no server predicate to narrow it further.
+                return [...new Set((rows ?? []).map((row) => row.session_id))]
+                    .sort()
+                    .slice(0, MAX_SESSION_IDS_PER_QUERY)
             },
             enabled: Boolean(projectId) && (needed || scopeGroups(scopeId)),
             staleTime: 10_000,

--- a/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
+++ b/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
@@ -147,6 +147,20 @@ const queryByAgents = async (
     return [...byId.values()].sort((a, b) => activity(b) - activity(a))
 }
 
+/** `queryByAgents` over tail reads: any agent with more below it means the rail has more. */
+const walkByAgents = async (
+    agentIds: readonly string[],
+    run: (references: {id: string}[] | undefined) => Promise<SessionPageWalk>,
+): Promise<SessionPageWalk> => {
+    let more = false
+    const rows = await queryByAgents(agentIds, async (references) => {
+        const walk = await run(references)
+        more = more || walk.more
+        return walk.rows
+    })
+    return {rows: rows ?? [], more}
+}
+
 /**
  * The largest `windowing.limit` the sessions query accepts. Above it the server answers 422, so a
  * request that widens past this returns nothing at all rather than a truncated page.
@@ -158,6 +172,18 @@ const MAX_SESSION_QUERY_LIMIT = 200
  * the request returns nothing, so the id push-down has to stay inside it.
  */
 const MAX_SESSION_IDS_PER_QUERY = 500
+
+/**
+ * A tail read: the rows, and whether the server has more below the last one.
+ *
+ * `more` cannot be inferred from `rows.length`. Row validation drops a row the frontend schema
+ * does not know yet, so a full page can arrive short, and a length test would close paging one
+ * page early on the same unknown enum value that used to end the walk.
+ */
+interface SessionPageWalk {
+    rows: SessionStream[]
+    more: boolean
+}
 
 interface SessionPageWalkParams {
     projectId: string
@@ -191,11 +217,11 @@ const walkSessionPages = async ({
     pageSize,
     newest,
     ...rest
-}: SessionPageWalkParams): Promise<SessionStream[] | null> => {
+}: SessionPageWalkParams): Promise<SessionPageWalk> => {
     const limit = Math.min(pageSize, MAX_SESSION_QUERY_LIMIT)
     const rows: SessionStream[] = []
     let cursor: {newest?: string; next?: string} = {newest}
-    let answered = false
+    let more = false
 
     for (let page = 0; page < pages; page++) {
         const result = await querySessionsFlatPage({
@@ -206,18 +232,22 @@ const walkSessionPages = async ({
             order: "descending",
             lowPriority: true,
         })
-        // A failed request mid-walk keeps the rows already read; failing on the first loses
-        // nothing, and null is what the caller reads as "no answer".
-        if (!result) return answered ? rows : null
-        answered = true
+        // Throwing rather than returning what was read so far: a partial tail returned as a
+        // success is stored as the whole list and never retried, which silently loses every row
+        // below the page that failed.
+        if (!result) throw new Error(`Session page ${page + 1} of ${pages} failed`)
         rows.push(...result.sessions)
 
         const nextCursor = result.windowing
-        if (result.sessions.length < limit || !nextCursor?.next) break
-        cursor = {newest: nextCursor.newest ?? undefined, next: nextCursor.next}
+        // `count` is what the server returned; `sessions` is what survived row validation, which
+        // drops a row the frontend schema does not know yet. Reading the survivors here would
+        // read one dropped row in a full page as the end of the list.
+        more = result.count >= limit && Boolean(nextCursor?.next)
+        if (!more) break
+        cursor = {newest: nextCursor!.newest ?? undefined, next: nextCursor!.next!}
     }
 
-    return rows
+    return {rows, more}
 }
 
 /**
@@ -227,12 +257,10 @@ const walkSessionPages = async ({
  * group does not blink empty mid-interaction; the second must not, because those rows belong to a
  * project you just left.
  */
-const keepPreviousDataWithinProject = (scopeId: string, projectId: string | null) =>
+const keepPreviousDataWithinProject = <T>(scopeId: string, projectId: string | null) =>
     scopeGroups(scopeId)
-        ? (
-              previous: SessionStream[] | null | undefined,
-              previousQuery?: {queryKey: readonly unknown[]},
-          ) => (previousQuery?.queryKey[1] === projectId ? previous : undefined)
+        ? (previous: T | undefined, previousQuery?: {queryKey: readonly unknown[]}) =>
+              previousQuery?.queryKey[1] === projectId ? previous : undefined
         : undefined
 
 /**
@@ -322,7 +350,10 @@ const sidebarSessionsQueryAtomFamily = atomFamily((scopeId: string) =>
             // Without this every facet click is a cache miss that empties the group
             // mid-interaction. Held ONLY within a project: the key carries the project id too, so
             // an unconditional carry-over shows the previous project's sessions in a new one.
-            placeholderData: keepPreviousDataWithinProject(scopeId, projectId),
+            placeholderData: keepPreviousDataWithinProject<SessionStream[] | null>(
+                scopeId,
+                projectId,
+            ),
             staleTime: 30_000,
             refetchInterval: (query) => livePollInterval(query.state.data),
             refetchOnWindowFocus: true,
@@ -416,7 +447,7 @@ const oldestActivity = (rows: readonly SessionStream[]): string | undefined => {
  * dedupe to the fresh one above.
  */
 const sidebarSessionsOlderQueryAtomFamily = atomFamily((scopeId: string) =>
-    atomWithQuery<SessionStream[] | null>((get) => {
+    atomWithQuery<SessionPageWalk>((get) => {
         const projectId = get(projectIdAtom)
         const filters = get(sidebarSessionFiltersAtomFamily(scopeId))
         const pages = get(sidebarSessionPageCountAtomFamily(scopeId))
@@ -442,7 +473,7 @@ const sidebarSessionsOlderQueryAtomFamily = atomFamily((scopeId: string) =>
                 waiting ? waitingIds : null,
             ],
             queryFn: ({signal}) =>
-                queryByAgents(agentIds, (references) =>
+                walkByAgents(agentIds, (references) =>
                     walkSessionPages({
                         projectId: projectId ?? "",
                         references,
@@ -467,7 +498,7 @@ const sidebarSessionsOlderQueryAtomFamily = atomFamily((scopeId: string) =>
                 pages > 0 &&
                 Boolean(boundary) &&
                 (!waiting || waitingIds !== null),
-            placeholderData: keepPreviousDataWithinProject(scopeId, projectId),
+            placeholderData: keepPreviousDataWithinProject<SessionPageWalk>(scopeId, projectId),
             staleTime: 30_000,
             refetchOnWindowFocus: false,
         }
@@ -488,10 +519,9 @@ export const sidebarSessionPagingAtomFamily = atomFamily((scopeId: string) =>
         const older = get(sidebarSessionsOlderQueryAtomFamily(scopeId))
         const pageSize = scopeLimit(scopeId)
         const headFull = (head.data?.length ?? 0) >= pageSize
-        // A short page is the end of the list; a full one means there is probably another.
-        const olderFull = (older.data?.length ?? 0) >= pageSize * pages
         return {
-            hasMore: pages < MAX_SESSION_PAGES && (pages === 0 ? headFull : olderFull),
+            hasMore:
+                pages < MAX_SESSION_PAGES && (pages === 0 ? headFull : Boolean(older.data?.more)),
             isLoadingMore: older.isFetching,
             isError: older.isError,
         }
@@ -557,7 +587,10 @@ const sidebarPinnedSessionsQueryAtomFamily = atomFamily((scopeId: string) =>
                 ),
             enabled:
                 Boolean(projectId) && pinnedIds.length > 0 && (!waiting || waitingIds !== null),
-            placeholderData: keepPreviousDataWithinProject(scopeId, projectId),
+            placeholderData: keepPreviousDataWithinProject<SessionStream[] | null>(
+                scopeId,
+                projectId,
+            ),
             staleTime: 30_000,
             refetchInterval: (query) => livePollInterval(query.state.data),
             refetchOnWindowFocus: true,
@@ -718,9 +751,9 @@ const sidebarSessionRefsAtomFamily = atomFamily((scopeId: string) =>
 
         // Pages past the head. They trail it, and `uniqueBySession` keeps the head's copy of any
         // row that has since climbed back into it.
-        const olderRows = (get(sidebarSessionsOlderQueryAtomFamily(scopeId)).data ?? []).filter(
-            (row) => !pinned.has(row.session_id),
-        )
+        const olderRows = (
+            get(sidebarSessionsOlderQueryAtomFamily(scopeId)).data?.rows ?? []
+        ).filter((row) => !pinned.has(row.session_id))
 
         const isRef = (ref: SessionSidebarRef | null): ref is SessionSidebarRef => ref !== null
         const server = [

--- a/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
+++ b/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
@@ -318,6 +318,9 @@ const sidebarSessionsOlderQueryAtomFamily = atomFamily((scopeId: string) =>
         const {agentIds, flags, includeArchived, origin, excludeOrigin, oldest} =
             requestFilters(filters)
         const boundary = get(sidebarSessionBoundaryAtomFamily(scopeId))
+        const waiting = filters.status === "waiting"
+        const waitingQuery = get(sidebarWaitingIdsQueryAtomFamily(scopeId))
+        const waitingIds = waitingQuery.data ?? null
         return {
             // `projectId` stays at index 1: `keepPreviousDataWithinProject` reads that slot to
             // tell a facet change from a project switch.
@@ -331,6 +334,7 @@ const sidebarSessionsOlderQueryAtomFamily = atomFamily((scopeId: string) =>
                 filters.type,
                 boundary ?? null,
                 pages,
+                waiting ? waitingIds : null,
             ],
             queryFn: ({signal}) =>
                 queryByAgents(agentIds, (references) =>
@@ -344,6 +348,9 @@ const sidebarSessionsOlderQueryAtomFamily = atomFamily((scopeId: string) =>
                         // The activity floor still applies; the boundary only narrows it further.
                         oldest,
                         newest: boundary,
+                        // The same id push-down the head does. Without it the tail asks for every
+                        // session older than the boundary, and the filter leaks on the second page.
+                        sessionIds: waiting ? (waitingIds ?? []) : undefined,
                         limit: scopeLimit(scopeId) * pages,
                         order: "descending",
                         abortSignal: signal,
@@ -351,7 +358,11 @@ const sidebarSessionsOlderQueryAtomFamily = atomFamily((scopeId: string) =>
                     }),
                 ),
             // Nothing to page until the head has landed, and no pages asked for yet.
-            enabled: Boolean(projectId) && pages > 0 && Boolean(boundary),
+            enabled:
+                Boolean(projectId) &&
+                pages > 0 &&
+                Boolean(boundary) &&
+                (!waiting || waitingIds !== null),
             placeholderData: keepPreviousDataWithinProject(scopeId, projectId),
             staleTime: 30_000,
             refetchOnWindowFocus: false,

--- a/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
+++ b/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
@@ -2,6 +2,7 @@ import {
     livenessPollInterval,
     queryInteractions,
     querySessions,
+    querySessionsFlatPage,
     type SessionStream,
 } from "@agenta/entities/session"
 import {
@@ -147,6 +148,73 @@ const queryByAgents = async (
 }
 
 /**
+ * The largest `windowing.limit` the sessions query accepts. Above it the server answers 422, so a
+ * request that widens past this returns nothing at all rather than a truncated page.
+ */
+const MAX_SESSION_QUERY_LIMIT = 200
+
+interface SessionPageWalkParams {
+    projectId: string
+    references: {id: string}[] | undefined
+    flags: {is_alive?: boolean; is_running?: boolean; is_attached?: boolean} | undefined
+    includeArchived: boolean | undefined
+    origin: Parameters<typeof querySessionsFlatPage>[0]["origin"]
+    excludeOrigin: Parameters<typeof querySessionsFlatPage>[0]["excludeOrigin"]
+    oldest: string | undefined
+    newest: string | undefined
+    sessionIds: string[] | undefined
+    pages: number
+    pageSize: number
+    abortSignal: AbortSignal | undefined
+}
+
+/**
+ * Read `pages` windows below `newest`, one fixed-size request at a time.
+ *
+ * The tail used to ask for `pageSize * pages` rows in a single request. Past the cap that is a
+ * 422, so the fifth page at size 50 came back empty, the rail collapsed to its head window, and
+ * no project with more than 250 sessions could reach an older one. Walking the server's own
+ * cursor (`windowing.next` with the boundary it belongs to) keeps every request inside the cap.
+ *
+ * Still one read of the WHOLE tail per load, not an appended page, because that is what lets a
+ * row archived elsewhere disappear from it. A short page means the list ended, so stop there
+ * rather than spending the remaining round trips on nothing.
+ */
+const walkSessionPages = async ({
+    pages,
+    pageSize,
+    newest,
+    ...rest
+}: SessionPageWalkParams): Promise<SessionStream[] | null> => {
+    const limit = Math.min(pageSize, MAX_SESSION_QUERY_LIMIT)
+    const rows: SessionStream[] = []
+    let cursor: {newest?: string; next?: string} = {newest}
+    let answered = false
+
+    for (let page = 0; page < pages; page++) {
+        const result = await querySessionsFlatPage({
+            ...rest,
+            newest: cursor.newest,
+            next: cursor.next,
+            limit,
+            order: "descending",
+            lowPriority: true,
+        })
+        // A failed request mid-walk keeps the rows already read; failing on the first loses
+        // nothing, and null is what the caller reads as "no answer".
+        if (!result) return answered ? rows : null
+        answered = true
+        rows.push(...result.sessions)
+
+        const nextCursor = result.windowing
+        if (result.sessions.length < limit || !nextCursor?.next) break
+        cursor = {newest: nextCursor.newest ?? undefined, next: nextCursor.next}
+    }
+
+    return rows
+}
+
+/**
  * Carry the previous rows through a key change, but only inside the same project.
  *
  * A facet click and a project switch both change the key. The first wants the old rows held so the
@@ -248,12 +316,25 @@ const sidebarSessionsQueryAtomFamily = atomFamily((scopeId: string) =>
     }),
 )
 
-/** Each page widens one request, so the last one is the most expensive — stop before it hurts. */
+/** Each page is one more round trip on every tail read — stop before it hurts. */
 const MAX_SESSION_PAGES = 12
 
-/** The predicate a page count belongs to — change it and the count is meaningless. */
-const filtersKey = (filters: SidebarSessionFilters) =>
-    [filters.agentIds.join(","), filters.status, filters.activity, filters.type].join("|")
+/**
+ * What a page count and its frozen boundary belong to — change it and both are meaningless.
+ *
+ * The project is part of it. A count kept across a project switch renders the new project's whole
+ * list at once, and a boundary kept across one freezes the tail at a timestamp from a list you are
+ * no longer looking at. Both readers and the writer take it as a parameter rather than reading a
+ * project atom of their own, so a site left behind fails to compile instead of drifting.
+ */
+const filtersKey = (filters: SidebarSessionFilters, projectId: string | null) =>
+    [
+        projectId ?? "",
+        filters.agentIds.join(","),
+        filters.status,
+        filters.activity,
+        filters.type,
+    ].join("|")
 
 const sessionPageCountStateAtomFamily = atomFamily((_scopeId: string) =>
     atom<{key: string; pages: number; boundary?: string}>({key: "", pages: 0}),
@@ -270,11 +351,17 @@ export const sidebarSessionPageCountAtomFamily = atomFamily((scopeId: string) =>
     atom(
         (get) => {
             const state = get(sessionPageCountStateAtomFamily(scopeId))
-            const key = filtersKey(get(sidebarSessionFiltersAtomFamily(scopeId)))
+            const key = filtersKey(
+                get(sidebarSessionFiltersAtomFamily(scopeId)),
+                get(projectIdAtom),
+            )
             return state.key === key ? state.pages : 0
         },
         (get, set, next: {pages: number; boundary?: string}) => {
-            const key = filtersKey(get(sidebarSessionFiltersAtomFamily(scopeId)))
+            const key = filtersKey(
+                get(sidebarSessionFiltersAtomFamily(scopeId)),
+                get(projectIdAtom),
+            )
             set(sessionPageCountStateAtomFamily(scopeId), {key, ...next})
         },
     ),
@@ -290,7 +377,7 @@ export const sidebarSessionPageCountAtomFamily = atomFamily((scopeId: string) =>
 const sidebarSessionBoundaryAtomFamily = atomFamily((scopeId: string) =>
     atom((get) => {
         const state = get(sessionPageCountStateAtomFamily(scopeId))
-        const key = filtersKey(get(sidebarSessionFiltersAtomFamily(scopeId)))
+        const key = filtersKey(get(sidebarSessionFiltersAtomFamily(scopeId)), get(projectIdAtom))
         return state.key === key ? state.boundary : undefined
     }),
 )
@@ -342,7 +429,7 @@ const sidebarSessionsOlderQueryAtomFamily = atomFamily((scopeId: string) =>
             ],
             queryFn: ({signal}) =>
                 queryByAgents(agentIds, (references) =>
-                    querySessions({
+                    walkSessionPages({
                         projectId: projectId ?? "",
                         references,
                         flags,
@@ -355,10 +442,9 @@ const sidebarSessionsOlderQueryAtomFamily = atomFamily((scopeId: string) =>
                         // The same id push-down the head does. Without it the tail asks for every
                         // session older than the boundary, and the filter leaks on the second page.
                         sessionIds: waiting ? (waitingIds ?? []) : undefined,
-                        limit: scopeLimit(scopeId) * pages,
-                        order: "descending",
+                        pages,
+                        pageSize: scopeLimit(scopeId),
                         abortSignal: signal,
-                        lowPriority: true,
                     }),
                 ),
             // Nothing to page until the head has landed, and no pages asked for yet.
@@ -377,8 +463,9 @@ const sidebarSessionsOlderQueryAtomFamily = atomFamily((scopeId: string) =>
 /**
  * What the rail needs to page: whether more exist, whether a page is in flight, and how to ask.
  *
- * `loadMore` widens the window rather than appending a cursor page, so every reload re-reads the
- * whole tail — which is also what lets a row archived elsewhere disappear from it.
+ * `loadMore` asks for one more page rather than appending a cursor page to the rows already held,
+ * so every reload re-reads the whole tail. That is what lets a row archived elsewhere disappear
+ * from it. `walkSessionPages` does the re-read as one fixed-size request per page.
  */
 export const sidebarSessionPagingAtomFamily = atomFamily((scopeId: string) =>
     atom((get) => {

--- a/web/packages/agenta-navigation/tests/unit/sessionsSourcePaging.test.ts
+++ b/web/packages/agenta-navigation/tests/unit/sessionsSourcePaging.test.ts
@@ -263,6 +263,82 @@ describe("session rail paging past the server's limit", () => {
         unsubscribe()
     })
 
+    it("keeps walking when a row in a full page fails validation", async () => {
+        const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
+        const {sidebarSessionPagingAtomFamily} = await import("../../src/dynamic/sessionsSource")
+        const scope = MAIN_SIDEBAR_SCOPE_ID
+
+        const serve = project(1_000)
+        queryInteractions.mockResolvedValue([])
+        querySessions.mockImplementation(async (args: PageRequest) => {
+            const page = await serve(args)
+            return page ? page.sessions : null
+        })
+        // `parseSessionsQueryResponse` drops a row the frontend schema does not know yet and
+        // leaves `count` alone, so a full page can arrive one row short. Reading the survivors
+        // rather than `count` would take that for the end of the list.
+        querySessionsFlatPage.mockImplementation(async (args: PageRequest) => {
+            const page = await serve(args)
+            if (!page || page.sessions.length < args.limit) return page
+            return {...page, sessions: page.sessions.slice(0, -1)}
+        })
+
+        const store = newStore()
+        const unsubscribe = store.sub(sidebarSessionPagingAtomFamily(scope), () => {})
+        store.get(sidebarSessionPagingAtomFamily(scope))
+        await settle()
+
+        await pageTo(store, scope, 5)
+
+        const cursors = querySessionsFlatPage.mock.calls
+            .map(([args]) => (args as PageRequest).next)
+            .filter(Boolean)
+        expect(cursors.length).toBeGreaterThan(0)
+        const deepest = Math.max(...cursors.map((next) => Number(next!.replace("row-", ""))))
+        // One dropped row per page must not end the walk after the first page.
+        expect(deepest).toBe(MAIN_PAGE_SIZE * 5 - 1)
+        unsubscribe()
+    })
+
+    it("fails the tail query when a request mid-walk fails", async () => {
+        const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
+        const {loadMoreSidebarSessionsAtomFamily, sidebarSessionPagingAtomFamily} =
+            await import("../../src/dynamic/sessionsSource")
+        const scope = MAIN_SIDEBAR_SCOPE_ID
+
+        const serve = project(1_000)
+        queryInteractions.mockResolvedValue([])
+        querySessions.mockImplementation(async (args: PageRequest) => {
+            const page = await serve(args)
+            return page ? page.sessions : null
+        })
+
+        querySessionsFlatPage.mockImplementation(serve)
+
+        const store = newStore()
+        const unsubscribe = store.sub(sidebarSessionPagingAtomFamily(scope), () => {})
+        store.get(sidebarSessionPagingAtomFamily(scope))
+        await settle()
+
+        await pageTo(store, scope, 2)
+        expect(store.get(sidebarSessionPagingAtomFamily(scope)).isError).toBe(false)
+
+        // From here every request past the walk's second page answers with nothing. Keyed on the
+        // cursor rather than a call counter so it fails at the same depth on every read.
+        // Returning the pages read so far as a success would store a truncated list that React
+        // Query treats as complete and never retries.
+        const failFrom = `row-${MAIN_PAGE_SIZE * 3 - 1}`
+        querySessionsFlatPage.mockImplementation(async (args: PageRequest) =>
+            args.next === failFrom ? null : serve(args),
+        )
+
+        store.set(loadMoreSidebarSessionsAtomFamily(scope))
+        await settle()
+
+        expect(store.get(sidebarSessionPagingAtomFamily(scope)).isError).toBe(true)
+        unsubscribe()
+    })
+
     it("drops the page count and the frozen boundary when the project changes", async () => {
         const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
         const {projectIdAtom} = await import("@agenta/shared/state")

--- a/web/packages/agenta-navigation/tests/unit/sessionsSourcePaging.test.ts
+++ b/web/packages/agenta-navigation/tests/unit/sessionsSourcePaging.test.ts
@@ -1,0 +1,300 @@
+/**
+ * The session rail's tail used to ask for `pageSize * pages` rows in one request. The sessions
+ * query caps `windowing.limit` at 200 and answers 422 above it, so the fifth page at size 50 came
+ * back empty, the rail collapsed from 250 rows to its head window of 50, and no project with more
+ * than 250 sessions could reach an older one. The narrow scope hit the same wall at its eleventh
+ * page, 220 rows at size 20.
+ *
+ * These tests pin the walk: every request stays at one page size, the pages accumulate, and the
+ * page count belongs to a project so a switch does not start the new one deep in the list.
+ */
+import {QueryClient} from "@tanstack/react-query"
+import {createStore} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+const querySessions = vi.fn()
+const querySessionsFlatPage = vi.fn()
+const queryInteractions = vi.fn()
+
+vi.mock("@agenta/entities/session", () => ({
+    querySessions: (...args: unknown[]) => querySessions(...args),
+    querySessionsFlatPage: (...args: unknown[]) => querySessionsFlatPage(...args),
+    queryInteractions: (...args: unknown[]) => queryInteractions(...args),
+    livenessPollInterval: () => false,
+}))
+
+vi.mock("@agenta/entities/workflow", async () => {
+    const {atom} = await import("jotai")
+    return {
+        agentWorkflowsListQueryStateAtom: atom({data: [], isPending: false}),
+        appWorkflowsListQueryAtom: atom({data: {refs: []}}),
+        workflowMolecule: {selectors: {artifactName: () => atom(null)}},
+    }
+})
+
+vi.mock("@agenta/sessions/row", () => ({
+    isAutomationSession: () => false,
+    sessionOpenTarget: (row: {session_id: string}) => ({appId: `app-${row.session_id}`}),
+}))
+
+vi.mock("@agenta/sessions/state", async () => {
+    const {atom} = await import("jotai")
+    return {pinnedSessionIdsAtom: atom([] as string[])}
+})
+
+vi.mock("@agenta/shared/state", async () => {
+    const {atom} = await import("jotai")
+    return {idleReadyAtom: atom(true), projectIdAtom: atom("project-1" as string | null)}
+})
+
+// The real filters atom is storage-backed, which does not round-trip under `node`.
+vi.mock("../../src/dynamic/sessionFilters", async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>
+    const {atom} = await import("jotai")
+    const {atomFamily} = await import("jotai-family")
+    const base = atomFamily((_scopeId: string) =>
+        atom({
+            agentIds: [] as string[],
+            status: "all",
+            activity: "7d",
+            type: "chat",
+            groupBy: "date",
+        } as any),
+    )
+    return {
+        ...actual,
+        sidebarSessionFiltersAtomFamily: atomFamily((scopeId: string) =>
+            atom(
+                (get) => get(base(scopeId)),
+                (get, set, next: Record<string, unknown>) =>
+                    set(base(scopeId), {...(get(base(scopeId)) as object), ...next} as any),
+            ),
+        ),
+    }
+})
+
+const memory = new Map<string, string>()
+;(globalThis as unknown as {localStorage: unknown}).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => void memory.set(key, value),
+    removeItem: (key: string) => void memory.delete(key),
+    clear: () => memory.clear(),
+    key: (index: number) => [...memory.keys()][index] ?? null,
+    get length() {
+        return memory.size
+    },
+}
+
+/** What the server refuses above. A request over this answers 422 and returns no rows at all. */
+const SERVER_LIMIT = 200
+
+const BASE_TIME = Date.UTC(2026, 8, 1)
+
+/** Newest first, one minute apart, so an index is also a position in the list. */
+const row = (index: number) => ({
+    id: `row-${index}`,
+    session_id: `s${index}`,
+    created_at: new Date(BASE_TIME - index * 60_000).toISOString(),
+    updated_at: new Date(BASE_TIME - index * 60_000).toISOString(),
+    flags: {is_alive: true, is_running: false},
+})
+
+interface PageRequest {
+    limit: number
+    next?: string
+    newest?: string
+    order?: string
+}
+
+/**
+ * A project holding `total` sessions, answering the way the real endpoint does: at most `limit`
+ * rows, and a cursor on the last row whenever the page came back full.
+ */
+const project = (total: number) => {
+    const all = Array.from({length: total}, (_, index) => row(index))
+    return async (args: PageRequest) => {
+        // The 422 the real endpoint answers above the cap. The client reads a rejected query as
+        // no answer, which is what emptied the tail and collapsed the rail.
+        if (args.limit > SERVER_LIMIT) return null
+        let start = 0
+        if (args.next) {
+            const at = all.findIndex((entry) => entry.id === args.next)
+            start = at >= 0 ? at + 1 : all.length
+        } else if (args.newest) {
+            const at = all.findIndex((entry) => entry.updated_at < args.newest!)
+            start = at >= 0 ? at : all.length
+        }
+        const sessions = all.slice(start, start + args.limit)
+        const last = sessions[sessions.length - 1]
+        const full = sessions.length === args.limit && last
+        return {
+            count: sessions.length,
+            sessions,
+            windowing: full
+                ? {next: last.id, newest: last.updated_at, limit: args.limit}
+                : {limit: args.limit},
+        }
+    }
+}
+
+const settle = async (ticks = 20) => {
+    for (let index = 0; index < ticks; index++)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+const newStore = () => {
+    const store = createStore()
+    store.set(
+        queryClientAtom,
+        new QueryClient({defaultOptions: {queries: {retry: false, gcTime: 0}}}),
+    )
+    return store
+}
+
+/** The main rail reads 50 rows a page; every other scope reads 20. */
+const MAIN_PAGE_SIZE = 50
+const NARROW_PAGE_SIZE = 20
+const NARROW_SCOPE = "test-narrow-scope"
+
+const pageTo = async (store: any, scope: string, target: number) => {
+    const {loadMoreSidebarSessionsAtomFamily, sidebarSessionPagingAtomFamily} =
+        await import("../../src/dynamic/sessionsSource")
+    for (let page = 0; page < target; page++) {
+        expect(store.get(sidebarSessionPagingAtomFamily(scope)).hasMore).toBe(true)
+        store.set(loadMoreSidebarSessionsAtomFamily(scope))
+        await settle()
+    }
+}
+
+describe("session rail paging past the server's limit", () => {
+    beforeEach(() => {
+        querySessions.mockReset()
+        querySessionsFlatPage.mockReset()
+        queryInteractions.mockReset()
+        memory.clear()
+    })
+
+    it.each([
+        ["the main rail", undefined, MAIN_PAGE_SIZE, 5],
+        ["the narrow rail", NARROW_SCOPE, NARROW_PAGE_SIZE, 11],
+    ])(
+        "keeps every %s request inside the server limit while paging past it",
+        async (_label, scopeOverride, pageSize, pages) => {
+            const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
+            const {sidebarSessionPagingAtomFamily} =
+                await import("../../src/dynamic/sessionsSource")
+            const scope = scopeOverride ?? MAIN_SIDEBAR_SCOPE_ID
+
+            const serve = project(1_000)
+            queryInteractions.mockResolvedValue([])
+            querySessions.mockImplementation(async (args: PageRequest) => {
+                const page = await serve(args)
+                return page ? page.sessions : null
+            })
+            querySessionsFlatPage.mockImplementation(serve)
+
+            const store = newStore()
+            const unsubscribe = store.sub(sidebarSessionPagingAtomFamily(scope), () => {})
+            store.get(sidebarSessionPagingAtomFamily(scope))
+            await settle()
+
+            await pageTo(store, scope, pages)
+
+            const requests = querySessionsFlatPage.mock.calls.map(([args]) => args as PageRequest)
+            expect(requests.length).toBeGreaterThan(0)
+
+            // The whole point: no single request may cross the cap, at either page size.
+            const widest = Math.max(...requests.map((request) => request.limit))
+            expect(widest).toBe(pageSize)
+            expect(widest).toBeLessThanOrEqual(SERVER_LIMIT)
+
+            // The last read walks one request per page, and every one after the first carries a
+            // cursor rather than a wider window. A read starts at the one request with no cursor.
+            // A read opens with one cursor-less request and then follows the server's cursor.
+            expect(requests.some((request) => request.next === undefined)).toBe(true)
+
+            // How deep the walk actually got. The head holds the first window and the tail walks
+            // `pages` more, so the last cursor names row `pageSize * pages - 1`. Reaching it is
+            // the proof that rows past the cap are fetched rather than thrown away: the single
+            // widening request answered 422 from `pageSize * 5` upward and returned nothing.
+            const deepest = Math.max(
+                ...requests
+                    .map((request) => Number(request.next?.replace("row-", "") ?? -1))
+                    .filter((index) => index >= 0),
+            )
+            expect(deepest).toBe(pageSize * pages - 1)
+            expect(deepest).toBeGreaterThan(SERVER_LIMIT)
+
+            // Rows already scrolled past are still held: `hasMore` needs a full tail, which past
+            // the cap is exactly what the single widening request could not return.
+            expect(store.get(sidebarSessionPagingAtomFamily(scope)).hasMore).toBe(true)
+            unsubscribe()
+        },
+    )
+
+    it("stops walking when the list ends instead of spending the remaining requests", async () => {
+        const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
+        const {sidebarSessionPagingAtomFamily} = await import("../../src/dynamic/sessionsSource")
+        const scope = MAIN_SIDEBAR_SCOPE_ID
+
+        // 170 rows: the head takes 50, so the tail ends part-way through its third page.
+        const serve = project(170)
+        queryInteractions.mockResolvedValue([])
+        querySessions.mockImplementation(async (args: PageRequest) => {
+            const page = await serve(args)
+            return page ? page.sessions : null
+        })
+        querySessionsFlatPage.mockImplementation(serve)
+
+        const store = newStore()
+        const unsubscribe = store.sub(sidebarSessionPagingAtomFamily(scope), () => {})
+        store.get(sidebarSessionPagingAtomFamily(scope))
+        await settle()
+
+        await pageTo(store, scope, 3)
+
+        const lastRead = querySessionsFlatPage.mock.calls
+            .map(([args]) => args as PageRequest)
+            .slice(-3)
+        expect(lastRead.length).toBeLessThanOrEqual(3)
+        // A short page is the end of the list, so `hasMore` closes rather than asking again.
+        expect(store.get(sidebarSessionPagingAtomFamily(scope)).hasMore).toBe(false)
+        unsubscribe()
+    })
+
+    it("drops the page count and the frozen boundary when the project changes", async () => {
+        const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
+        const {projectIdAtom} = await import("@agenta/shared/state")
+        const {sidebarSessionPageCountAtomFamily, sidebarSessionPagingAtomFamily} =
+            await import("../../src/dynamic/sessionsSource")
+        const scope = MAIN_SIDEBAR_SCOPE_ID
+
+        const serve = project(1_000)
+        queryInteractions.mockResolvedValue([])
+        querySessions.mockImplementation(async (args: PageRequest) => {
+            const page = await serve(args)
+            return page ? page.sessions : null
+        })
+        querySessionsFlatPage.mockImplementation(serve)
+
+        const store = newStore()
+        const unsubscribe = store.sub(sidebarSessionPagingAtomFamily(scope), () => {})
+        store.get(sidebarSessionPagingAtomFamily(scope))
+        await settle()
+
+        await pageTo(store, scope, 3)
+        expect(store.get(sidebarSessionPageCountAtomFamily(scope))).toBe(3)
+
+        store.set(projectIdAtom, "project-2")
+        await settle()
+
+        // Otherwise the new project renders several hundred rows at once, and its tail is frozen
+        // at a boundary taken from a list the user has left.
+        expect(store.get(sidebarSessionPageCountAtomFamily(scope))).toBe(0)
+
+        store.set(projectIdAtom, "project-1")
+        expect(store.get(sidebarSessionPageCountAtomFamily(scope))).toBe(3)
+        unsubscribe()
+    })
+})

--- a/web/packages/agenta-navigation/tests/unit/sessionsSourceWaitingFilter.test.ts
+++ b/web/packages/agenta-navigation/tests/unit/sessionsSourceWaitingFilter.test.ts
@@ -97,11 +97,9 @@ const settle = async (ticks = 12) => {
 
 const newStore = () => {
     const store = createStore()
-    store.set(
-        queryClientAtom,
-        new QueryClient({defaultOptions: {queries: {retry: false, gcTime: 0}}}),
-    )
-    return store
+    const queryClient = new QueryClient({defaultOptions: {queries: {retry: false, gcTime: 0}}})
+    store.set(queryClientAtom, queryClient)
+    return {store, queryClient}
 }
 
 describe("Awaiting input sidebar filter and the paging tail", () => {
@@ -124,7 +122,7 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
             (args.sessionIds ?? waitingIds).slice(0, PAGE_SIZE).map(sessionRow),
         )
 
-        const store = newStore()
+        const {store} = newStore()
         const scope = MAIN_SIDEBAR_SCOPE_ID
         store.set(sidebarSessionFiltersAtomFamily(scope), {status: "waiting"})
 
@@ -134,7 +132,7 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
 
         const headCalls = querySessions.mock.calls.map(([args]) => args)
         expect(headCalls.length).toBeGreaterThan(0)
-        expect(headCalls[0].sessionIds).toEqual(waitingIds)
+        expect(headCalls[0].sessionIds).toEqual([...waitingIds].sort())
         expect(store.get(sidebarSessionPagingAtomFamily(scope)).hasMore).toBe(true)
 
         querySessions.mockClear()
@@ -144,9 +142,50 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
         const tailCalls = querySessions.mock.calls.map(([args]) => args)
         expect(tailCalls.length).toBeGreaterThan(0)
         const tail = tailCalls[tailCalls.length - 1]
-        expect(tail.sessionIds).toEqual(waitingIds)
+        expect(tail.sessionIds).toEqual([...waitingIds].sort())
         expect(tail.newest).toBeTruthy()
         expect(tail.limit).toBe(PAGE_SIZE)
+
+        unsubscribe()
+    })
+
+    it("keys on a stable id order, so a reordered poll refetches nothing", async () => {
+        const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
+        const {sidebarSessionFiltersAtomFamily} = await import("../../src/dynamic/sessionFilters")
+        const {sidebarSessionPagingAtomFamily, loadMoreSidebarSessionsAtomFamily} =
+            await import("../../src/dynamic/sessionsSource")
+
+        const waitingIds = Array.from({length: 60}, (_, index) => `s${index}`)
+        const sorted = [...waitingIds].sort()
+        // The interactions endpoint applies no ORDER BY, so consecutive polls can answer with the
+        // same ids in a different order.
+        queryInteractions
+            .mockResolvedValueOnce(waitingIds.map((id) => ({session_id: id})))
+            .mockResolvedValue([...waitingIds].reverse().map((id) => ({session_id: id})))
+        querySessions.mockImplementation(async (args: {sessionIds?: string[]}) =>
+            (args.sessionIds ?? sorted).slice(0, PAGE_SIZE).map(sessionRow),
+        )
+
+        const {store, queryClient} = newStore()
+        const scope = MAIN_SIDEBAR_SCOPE_ID
+        store.set(sidebarSessionFiltersAtomFamily(scope), {status: "waiting"})
+
+        const unsubscribe = store.sub(sidebarSessionPagingAtomFamily(scope), () => {})
+        store.get(sidebarSessionPagingAtomFamily(scope))
+        await settle()
+        store.set(loadMoreSidebarSessionsAtomFamily(scope))
+        await settle()
+
+        const before = querySessions.mock.calls.length
+        expect(before).toBeGreaterThan(0)
+
+        await queryClient.refetchQueries({queryKey: ["sidebar-sessions-waiting"]})
+        await settle()
+
+        expect(queryInteractions.mock.calls.length).toBeGreaterThan(1)
+        // The reordered poll must not re-key either session query. Without the sort both the head
+        // and the tail refetch, and the tail asks for up to twelve pages.
+        expect(querySessions.mock.calls.length).toBe(before)
 
         unsubscribe()
     })
@@ -161,7 +200,7 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
         queryInteractions.mockResolvedValue([])
         querySessions.mockImplementation(async () => allIds.slice(0, PAGE_SIZE).map(sessionRow))
 
-        const store = newStore()
+        const {store} = newStore()
         const scope = MAIN_SIDEBAR_SCOPE_ID
         store.set(sidebarSessionFiltersAtomFamily(scope), {status: "all"})
 
@@ -193,7 +232,7 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
             (args.sessionIds ?? []).map(sessionRow),
         )
 
-        const store = newStore()
+        const {store} = newStore()
         const scope = MAIN_SIDEBAR_SCOPE_ID
         store.set(sidebarSessionFiltersAtomFamily(scope), {status: "waiting"})
 

--- a/web/packages/agenta-navigation/tests/unit/sessionsSourceWaitingFilter.test.ts
+++ b/web/packages/agenta-navigation/tests/unit/sessionsSourceWaitingFilter.test.ts
@@ -85,6 +85,9 @@ const memory = new Map<string, string>()
 
 const PAGE_SIZE = 50
 
+/** `session_ids` is capped at this length by the request model; a longer list is a 422. */
+const MAX_SESSION_IDS = 500
+
 const sessionRow = (id: string) => ({
     session_id: id,
     created_at: "2026-09-01T00:00:00Z",
@@ -199,6 +202,43 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
         // The reordered poll must not re-key either session query. Without the sort both the head
         // and the tail refetch, and the tail walks every page again.
         expect(requests()).toBe(before)
+
+        unsubscribe()
+    })
+
+    it("truncates the waiting set to the longest id list the server accepts", async () => {
+        const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
+        const {sidebarSessionFiltersAtomFamily} = await import("../../src/dynamic/sessionFilters")
+        const {sidebarSessionPagingAtomFamily, loadMoreSidebarSessionsAtomFamily} =
+            await import("../../src/dynamic/sessionsSource")
+
+        // More sessions awaiting input than the request model allows in one `session_ids` list.
+        const waitingIds = Array.from({length: 620}, (_, index) => `s${index}`)
+        const kept = [...waitingIds].sort().slice(0, MAX_SESSION_IDS)
+        queryInteractions.mockResolvedValue(waitingIds.map((id) => ({session_id: id})))
+        querySessions.mockImplementation(async (args: {sessionIds?: string[]}) =>
+            (args.sessionIds ?? []).slice(0, PAGE_SIZE).map(sessionRow),
+        )
+        querySessionsFlatPage.mockImplementation(servePage(kept))
+
+        const {store} = newStore()
+        const scope = MAIN_SIDEBAR_SCOPE_ID
+        store.set(sidebarSessionFiltersAtomFamily(scope), {status: "waiting"})
+
+        const unsubscribe = store.sub(sidebarSessionPagingAtomFamily(scope), () => {})
+        store.get(sidebarSessionPagingAtomFamily(scope))
+        await settle()
+
+        const head = querySessions.mock.calls.map(([args]) => args)[0]
+        // Sending all 620 is a 422, which shows the user an empty list rather than a subset.
+        expect(head.sessionIds).toHaveLength(MAX_SESSION_IDS)
+        expect(head.sessionIds).toEqual(kept)
+
+        store.set(loadMoreSidebarSessionsAtomFamily(scope))
+        await settle()
+
+        const tail = querySessionsFlatPage.mock.calls.map(([args]) => args).at(-1)
+        expect(tail.sessionIds).toHaveLength(MAX_SESSION_IDS)
 
         unsubscribe()
     })

--- a/web/packages/agenta-navigation/tests/unit/sessionsSourceWaitingFilter.test.ts
+++ b/web/packages/agenta-navigation/tests/unit/sessionsSourceWaitingFilter.test.ts
@@ -10,10 +10,12 @@ import {queryClientAtom} from "jotai-tanstack-query"
 import {beforeEach, describe, expect, it, vi} from "vitest"
 
 const querySessions = vi.fn()
+const querySessionsFlatPage = vi.fn()
 const queryInteractions = vi.fn()
 
 vi.mock("@agenta/entities/session", () => ({
     querySessions: (...args: unknown[]) => querySessions(...args),
+    querySessionsFlatPage: (...args: unknown[]) => querySessionsFlatPage(...args),
     queryInteractions: (...args: unknown[]) => queryInteractions(...args),
     livenessPollInterval: () => false,
 }))
@@ -90,6 +92,13 @@ const sessionRow = (id: string) => ({
     flags: {is_alive: true, is_running: false},
 })
 
+/** The tail walks the cursor, so its stub answers with the page envelope, not a bare list. */
+const servePage = (pool: string[]) => async (args: {sessionIds?: string[]; limit: number}) => {
+    const ids = args.sessionIds ?? pool
+    const sessions = ids.slice(0, args.limit).map(sessionRow)
+    return {count: sessions.length, sessions, windowing: {limit: args.limit}}
+}
+
 const settle = async (ticks = 12) => {
     for (let index = 0; index < ticks; index++)
         await new Promise((resolve) => setTimeout(resolve, 0))
@@ -105,6 +114,7 @@ const newStore = () => {
 describe("Awaiting input sidebar filter and the paging tail", () => {
     beforeEach(() => {
         querySessions.mockReset()
+        querySessionsFlatPage.mockReset()
         queryInteractions.mockReset()
     })
 
@@ -121,6 +131,7 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
         querySessions.mockImplementation(async (args: {sessionIds?: string[]}) =>
             (args.sessionIds ?? waitingIds).slice(0, PAGE_SIZE).map(sessionRow),
         )
+        querySessionsFlatPage.mockImplementation(servePage(waitingIds))
 
         const {store} = newStore()
         const scope = MAIN_SIDEBAR_SCOPE_ID
@@ -135,11 +146,10 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
         expect(headCalls[0].sessionIds).toEqual([...waitingIds].sort())
         expect(store.get(sidebarSessionPagingAtomFamily(scope)).hasMore).toBe(true)
 
-        querySessions.mockClear()
         store.set(loadMoreSidebarSessionsAtomFamily(scope))
         await settle()
 
-        const tailCalls = querySessions.mock.calls.map(([args]) => args)
+        const tailCalls = querySessionsFlatPage.mock.calls.map(([args]) => args)
         expect(tailCalls.length).toBeGreaterThan(0)
         const tail = tailCalls[tailCalls.length - 1]
         expect(tail.sessionIds).toEqual([...waitingIds].sort())
@@ -165,6 +175,7 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
         querySessions.mockImplementation(async (args: {sessionIds?: string[]}) =>
             (args.sessionIds ?? sorted).slice(0, PAGE_SIZE).map(sessionRow),
         )
+        querySessionsFlatPage.mockImplementation(servePage(sorted))
 
         const {store, queryClient} = newStore()
         const scope = MAIN_SIDEBAR_SCOPE_ID
@@ -176,7 +187,9 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
         store.set(loadMoreSidebarSessionsAtomFamily(scope))
         await settle()
 
-        const before = querySessions.mock.calls.length
+        const requests = () =>
+            querySessions.mock.calls.length + querySessionsFlatPage.mock.calls.length
+        const before = requests()
         expect(before).toBeGreaterThan(0)
 
         await queryClient.refetchQueries({queryKey: ["sidebar-sessions-waiting"]})
@@ -184,8 +197,8 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
 
         expect(queryInteractions.mock.calls.length).toBeGreaterThan(1)
         // The reordered poll must not re-key either session query. Without the sort both the head
-        // and the tail refetch, and the tail asks for up to twelve pages.
-        expect(querySessions.mock.calls.length).toBe(before)
+        // and the tail refetch, and the tail walks every page again.
+        expect(requests()).toBe(before)
 
         unsubscribe()
     })
@@ -199,6 +212,7 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
         const allIds = Array.from({length: 60}, (_, index) => `s${index}`)
         queryInteractions.mockResolvedValue([])
         querySessions.mockImplementation(async () => allIds.slice(0, PAGE_SIZE).map(sessionRow))
+        querySessionsFlatPage.mockImplementation(servePage(allIds))
 
         const {store} = newStore()
         const scope = MAIN_SIDEBAR_SCOPE_ID
@@ -210,11 +224,10 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
 
         expect(store.get(sidebarSessionPagingAtomFamily(scope)).hasMore).toBe(true)
 
-        querySessions.mockClear()
         store.set(loadMoreSidebarSessionsAtomFamily(scope))
         await settle()
 
-        const tailCalls = querySessions.mock.calls.map(([args]) => args)
+        const tailCalls = querySessionsFlatPage.mock.calls.map(([args]) => args)
         expect(tailCalls.length).toBeGreaterThan(0)
         expect(tailCalls[tailCalls.length - 1].sessionIds).toBeUndefined()
 
@@ -231,6 +244,7 @@ describe("Awaiting input sidebar filter and the paging tail", () => {
         querySessions.mockImplementation(async (args: {sessionIds?: string[]}) =>
             (args.sessionIds ?? []).map(sessionRow),
         )
+        querySessionsFlatPage.mockImplementation(servePage(waitingIds))
 
         const {store} = newStore()
         const scope = MAIN_SIDEBAR_SCOPE_ID

--- a/web/packages/agenta-navigation/tests/unit/sessionsSourceWaitingFilter.test.ts
+++ b/web/packages/agenta-navigation/tests/unit/sessionsSourceWaitingFilter.test.ts
@@ -1,0 +1,207 @@
+/**
+ * "Awaiting input" has no server predicate: the sidebar resolves the gated session ids itself and
+ * pushes them down as an explicit id list. The head query did that; the tail query the rail loads
+ * on scroll did not, so from the second page on the server answered with every session older than
+ * the boundary and the filter leaked. These tests pin the id set onto both requests.
+ */
+import {QueryClient} from "@tanstack/react-query"
+import {createStore} from "jotai"
+import {queryClientAtom} from "jotai-tanstack-query"
+import {beforeEach, describe, expect, it, vi} from "vitest"
+
+const querySessions = vi.fn()
+const queryInteractions = vi.fn()
+
+vi.mock("@agenta/entities/session", () => ({
+    querySessions: (...args: unknown[]) => querySessions(...args),
+    queryInteractions: (...args: unknown[]) => queryInteractions(...args),
+    livenessPollInterval: () => false,
+}))
+
+vi.mock("@agenta/entities/workflow", async () => {
+    const {atom} = await import("jotai")
+    return {
+        agentWorkflowsListQueryStateAtom: atom({data: [], isPending: false}),
+        appWorkflowsListQueryAtom: atom({data: {refs: []}}),
+        workflowMolecule: {selectors: {artifactName: () => atom(null)}},
+    }
+})
+
+vi.mock("@agenta/sessions/row", () => ({
+    isAutomationSession: () => false,
+    sessionOpenTarget: (row: {session_id: string}) => ({appId: `app-${row.session_id}`}),
+}))
+
+vi.mock("@agenta/sessions/state", async () => {
+    const {atom} = await import("jotai")
+    return {pinnedSessionIdsAtom: atom([] as string[])}
+})
+
+vi.mock("@agenta/shared/state", async () => {
+    const {atom} = await import("jotai")
+    return {idleReadyAtom: atom(true), projectIdAtom: atom("project-1" as string | null)}
+})
+
+// The real filters atom is storage-backed, which does not round-trip under `node`. Swap it for a
+// plain writable atom so the test and the source read the same instance.
+vi.mock("../../src/dynamic/sessionFilters", async (importOriginal) => {
+    const actual = (await importOriginal()) as Record<string, unknown>
+    const {atom} = await import("jotai")
+    const {atomFamily} = await import("jotai-family")
+    const base = atomFamily((_scopeId: string) =>
+        atom({
+            agentIds: [] as string[],
+            status: "all",
+            activity: "7d",
+            type: "chat",
+            groupBy: "date",
+        } as any),
+    )
+    return {
+        ...actual,
+        sidebarSessionFiltersAtomFamily: atomFamily((scopeId: string) =>
+            atom(
+                (get) => get(base(scopeId)),
+                (get, set, next: Record<string, unknown>) =>
+                    set(base(scopeId), {...(get(base(scopeId)) as object), ...next} as any),
+            ),
+        ),
+    }
+})
+
+const memory = new Map<string, string>()
+;(globalThis as unknown as {localStorage: unknown}).localStorage = {
+    getItem: (key: string) => (memory.has(key) ? memory.get(key)! : null),
+    setItem: (key: string, value: string) => void memory.set(key, value),
+    removeItem: (key: string) => void memory.delete(key),
+    clear: () => memory.clear(),
+    key: (index: number) => [...memory.keys()][index] ?? null,
+    get length() {
+        return memory.size
+    },
+}
+
+const PAGE_SIZE = 50
+
+const sessionRow = (id: string) => ({
+    session_id: id,
+    created_at: "2026-09-01T00:00:00Z",
+    updated_at: `2026-09-0${(Number(id.slice(1)) % 9) + 1}T00:00:00Z`,
+    flags: {is_alive: true, is_running: false},
+})
+
+const settle = async (ticks = 12) => {
+    for (let index = 0; index < ticks; index++)
+        await new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+const newStore = () => {
+    const store = createStore()
+    store.set(
+        queryClientAtom,
+        new QueryClient({defaultOptions: {queries: {retry: false, gcTime: 0}}}),
+    )
+    return store
+}
+
+describe("Awaiting input sidebar filter and the paging tail", () => {
+    beforeEach(() => {
+        querySessions.mockReset()
+        queryInteractions.mockReset()
+    })
+
+    it("carries the waiting id set on the tail request, not only on the head", async () => {
+        const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
+        const {sidebarSessionFiltersAtomFamily} = await import("../../src/dynamic/sessionFilters")
+        const {sidebarSessionPagingAtomFamily, loadMoreSidebarSessionsAtomFamily} =
+            await import("../../src/dynamic/sessionsSource")
+
+        // A full head window is what unlocks paging, so the leak needs at least that many gated
+        // sessions to be reachable at all.
+        const waitingIds = Array.from({length: 60}, (_, index) => `s${index}`)
+        queryInteractions.mockResolvedValue(waitingIds.map((id) => ({session_id: id})))
+        querySessions.mockImplementation(async (args: {sessionIds?: string[]}) =>
+            (args.sessionIds ?? waitingIds).slice(0, PAGE_SIZE).map(sessionRow),
+        )
+
+        const store = newStore()
+        const scope = MAIN_SIDEBAR_SCOPE_ID
+        store.set(sidebarSessionFiltersAtomFamily(scope), {status: "waiting"})
+
+        const unsubscribe = store.sub(sidebarSessionPagingAtomFamily(scope), () => {})
+        store.get(sidebarSessionPagingAtomFamily(scope))
+        await settle()
+
+        const headCalls = querySessions.mock.calls.map(([args]) => args)
+        expect(headCalls.length).toBeGreaterThan(0)
+        expect(headCalls[0].sessionIds).toEqual(waitingIds)
+        expect(store.get(sidebarSessionPagingAtomFamily(scope)).hasMore).toBe(true)
+
+        querySessions.mockClear()
+        store.set(loadMoreSidebarSessionsAtomFamily(scope))
+        await settle()
+
+        const tailCalls = querySessions.mock.calls.map(([args]) => args)
+        expect(tailCalls.length).toBeGreaterThan(0)
+        const tail = tailCalls[tailCalls.length - 1]
+        expect(tail.sessionIds).toEqual(waitingIds)
+        expect(tail.newest).toBeTruthy()
+        expect(tail.limit).toBe(PAGE_SIZE)
+
+        unsubscribe()
+    })
+
+    it("leaves the tail request unfiltered by id under any other status", async () => {
+        const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
+        const {sidebarSessionFiltersAtomFamily} = await import("../../src/dynamic/sessionFilters")
+        const {sidebarSessionPagingAtomFamily, loadMoreSidebarSessionsAtomFamily} =
+            await import("../../src/dynamic/sessionsSource")
+
+        const allIds = Array.from({length: 60}, (_, index) => `s${index}`)
+        queryInteractions.mockResolvedValue([])
+        querySessions.mockImplementation(async () => allIds.slice(0, PAGE_SIZE).map(sessionRow))
+
+        const store = newStore()
+        const scope = MAIN_SIDEBAR_SCOPE_ID
+        store.set(sidebarSessionFiltersAtomFamily(scope), {status: "all"})
+
+        const unsubscribe = store.sub(sidebarSessionPagingAtomFamily(scope), () => {})
+        store.get(sidebarSessionPagingAtomFamily(scope))
+        await settle()
+
+        expect(store.get(sidebarSessionPagingAtomFamily(scope)).hasMore).toBe(true)
+
+        querySessions.mockClear()
+        store.set(loadMoreSidebarSessionsAtomFamily(scope))
+        await settle()
+
+        const tailCalls = querySessions.mock.calls.map(([args]) => args)
+        expect(tailCalls.length).toBeGreaterThan(0)
+        expect(tailCalls[tailCalls.length - 1].sessionIds).toBeUndefined()
+
+        unsubscribe()
+    })
+
+    it("cannot page at all when fewer than one window of sessions are awaiting input", async () => {
+        const {MAIN_SIDEBAR_SCOPE_ID} = await import("../../src/constants")
+        const {sidebarSessionFiltersAtomFamily} = await import("../../src/dynamic/sessionFilters")
+        const {sidebarSessionPagingAtomFamily} = await import("../../src/dynamic/sessionsSource")
+
+        const waitingIds = ["a", "b", "c"]
+        queryInteractions.mockResolvedValue(waitingIds.map((id) => ({session_id: id})))
+        querySessions.mockImplementation(async (args: {sessionIds?: string[]}) =>
+            (args.sessionIds ?? []).map(sessionRow),
+        )
+
+        const store = newStore()
+        const scope = MAIN_SIDEBAR_SCOPE_ID
+        store.set(sidebarSessionFiltersAtomFamily(scope), {status: "waiting"})
+
+        const unsubscribe = store.sub(sidebarSessionPagingAtomFamily(scope), () => {})
+        store.get(sidebarSessionPagingAtomFamily(scope))
+        await settle()
+
+        expect(store.get(sidebarSessionPagingAtomFamily(scope)).hasMore).toBe(false)
+        unsubscribe()
+    })
+})

--- a/web/packages/agenta-sessions-ui/src/renameCache.ts
+++ b/web/packages/agenta-sessions-ui/src/renameCache.ts
@@ -13,11 +13,11 @@ export const NAMED_SESSION_QUERY_KEYS = [
 /**
  * Rewrites one session's name wherever a cached list holds it.
  *
- * Four shapes carry sessions: the rail's flat `SessionStream[]`, a single query page
- * (`{sessions}`), an infinite query's `{pages}`, and one bare session. Anything else is handed
- * back untouched, so an unrecognised cache entry is left alone rather than corrupted. Returns the
- * SAME object when the session is not in it — a fresh identity would re-render every list that
- * never held it.
+ * Five shapes carry sessions: the rail's flat `SessionStream[]`, a single query page
+ * (`{sessions}`), the rail's paging tail (`{rows, more}`), an infinite query's `{pages}`, and one
+ * bare session. Anything else is handed back untouched, so an unrecognised cache entry is left
+ * alone rather than corrupted. Returns the SAME object when the session is not in it — a fresh
+ * identity would re-render every list that never held it.
  */
 export const withRenamedSession = (data: unknown, sessionId: string, name: string): unknown => {
     if (Array.isArray(data)) {
@@ -31,7 +31,11 @@ export const withRenamedSession = (data: unknown, sessionId: string, name: strin
         return changed ? next : data
     }
     if (!data || typeof data !== "object") return data
-    const {pages, sessions} = data as {pages?: unknown; sessions?: unknown}
+    const {pages, sessions, rows} = data as {
+        pages?: unknown
+        sessions?: unknown
+        rows?: unknown
+    }
     if (Array.isArray(pages)) {
         const next = pages.map((page) => withRenamedSession(page, sessionId, name))
         return next.some((page, index) => page !== pages[index]) ? {...data, pages: next} : data
@@ -39,6 +43,12 @@ export const withRenamedSession = (data: unknown, sessionId: string, name: strin
     if (Array.isArray(sessions)) {
         const next = withRenamedSession(sessions, sessionId, name)
         return next === sessions ? data : {...data, sessions: next}
+    }
+    // The rail's paging tail. It carries `more` beside its rows because whether another page
+    // exists cannot be read off a row count, so the rows are not the cache entry itself.
+    if (Array.isArray(rows)) {
+        const next = withRenamedSession(rows, sessionId, name)
+        return next === rows ? data : {...data, rows: next}
     }
     // One session on its own, the shape `/m`'s per-session stream query caches.
     if ((data as {session_id?: string}).session_id === sessionId) return {...data, name}

--- a/web/packages/agenta-sessions-ui/tests/unit/renameCache.test.ts
+++ b/web/packages/agenta-sessions-ui/tests/unit/renameCache.test.ts
@@ -26,6 +26,25 @@ describe("withRenamedSession", () => {
         })
     })
 
+    // The rail's paging tail caches `{rows, more}`, not a bare array: whether another page exists
+    // cannot be read off a row count once response validation can drop a row. A rename of a
+    // session below the first page reaches the rail only through this branch, because rename
+    // deliberately patches the cache instead of refetching.
+    it("renames inside the rail's paging tail", () => {
+        const data = {rows: [row("s1", "old"), row("s2", "other")], more: true}
+
+        expect(withRenamedSession(data, "s1", "new")).toEqual({
+            rows: [row("s1", "new"), row("s2", "other")],
+            more: true,
+        })
+    })
+
+    it("hands back the same tail when the session is not in it", () => {
+        const data = {rows: [row("s2", "other")], more: false}
+
+        expect(withRenamedSession(data, "s1", "new")).toBe(data)
+    })
+
     it("renames inside an infinite query's pages", () => {
         const data = {pageParams: [null], pages: [{sessions: [row("s1", "old")]}]}
 


### PR DESCRIPTION
Four confirmed regressions found while verifying release/v0.117.0. Each is one commit with a test that fails on the release branch and passes here. Full verification write-up: the release run's `qa/code-verification.md`.

## Grouped revision query returned an empty 200 instead of a 422

Sending a `grouping` object in the body with a windowing parameter in the query string (`?limit=1`) answered `200 {"count": 0, "workflow_revisions": []}`. The same combination sent entirely in the body correctly answers 422, so a client got two different answers for one invalid request and read the empty list as "nothing matched".

The workflows and environments routes parse windowing from query params and merge it into the body model inside the handler. Building the merged model re-runs the request validator, which raises `grouping cannot be combined with windowing`. That happens under `@suppress_exceptions`, which catches bare `Exception` and returns its default. Both routes now catch the `ValidationError` around the merge and re-raise it as an `HTTPException(422)` carrying the validator's message, which both decorators already let through.

Before: `POST /workflows/revisions/query?limit=1` with grouping in the body returns `200 {"count":0,...}`
After: the same request returns `422` with `Value error, grouping cannot be combined with windowing`

The applications revision-query route had the same decorator with no `exclude`, so its permission denial was swallowed the same way. A caller without `VIEW_APPLICATIONS` got `200` with an empty list instead of a `403`. That is the one-line half of this commit.

## Grouped revision query was not scoped to the project

The grouped path in `query_revisions` rebuilds the outer statement as a bare `SELECT ... WHERE id IN (grouped subquery)`. Rebuilding drops every predicate the base statement carried, `project_id` included.

Results were never wrong, because the inner subquery is project-scoped and no cross-project row id can reach the `IN` list. The cost is the plan. Every index on the revision tables leads with `project_id` (the composite primary key, the slug unique key, and both secondary indexes) and none leads with `id`, so the outer lookup cannot seek and past a size threshold the planner prefers a sequential scan.

The outer statement now filters on `project_id` again, which restores the leading column and makes the tenant scope explicit on the query that actually returns rows.

## Subscription connections showed up in the prompt playground model picker

A project with a ChatGPT subscription saw a "ChatGPT" provider group in the prompt playground and LLM-as-a-judge model pickers, under the OpenAI icon. Picking a model from it wrote `connectionSlug: "chatgpt"` and `provider: "openai"` into the prompt config, and the run then failed at run time resolving a credential that holds no API key.

`toProviderConnections` maps a subscription row onto its provider family, so the connection reaches the picker looking like an OpenAI key. `buildConnectionModelGroups` had no subscription guard, and because `isStandard` is false for that kind its options were not marked slug-bound either, so `withoutSlugBoundGroups` did not drop them from pickers that cannot persist a slug.

The builder now skips any connection of kind `subscription_provider`. The guard sits in the builder rather than in `useLLMProviderConfig`, so it covers every caller. A hosted subscription can never back a litellm-run prompt.

## "Awaiting input" sidebar filter leaked ordinary sessions on scroll

With the sidebar filtered to "Awaiting input", scrolling far enough to load a second page mixed in sessions that were not awaiting input at all.

There is no server predicate for a human gate, so the sidebar resolves the gated session ids itself and pushes them down as an explicit id list. The head query did that. The tail query the rail loads on scroll sent `projectId`, `references`, `flags`, `oldest`, `newest`, `limit` and `order` but no `sessionIds`, and under this filter it emits no flags either, so it asked the server for every non-archived chat session older than the boundary. Nothing narrowed those rows on the client.

The tail query now reads the waiting set the same way the head does, sends `sessionIds`, carries the set in its cache key so a changed gate set re-keys it, and stays disabled until the set resolves.

Reaching this needed at least fifty sessions awaiting input at once, because paging only unlocks on a full head window. A project with a handful of gated sessions could not reproduce it.

## Tests

Every test below fails on `release/v0.117.0` and passes on this branch.

API, `cd api && uv run --no-sync python -m pytest oss/tests/pytest/unit/git oss/tests/pytest/unit/workflows oss/tests/pytest/unit/environments oss/tests/pytest/unit/applications -q`:

```
734 passed, 24 skipped
```

The 24 skips are the pre-existing Postgres-dependent DAO concurrency tests, which skip without a reachable database.

Two new API test files:

- `test_revision_query_route_validation.py` builds the three real routers with stub services on a bare app, so the real route registration, `Depends` param parsing and decorator stack all run. It asserts the 422 for grouping plus a windowing param, the 422 for the body-only combination, a 200 for grouping alone, and a 403 on all three routes when access is denied. Against the release branch, 3 of its 10 cases fail: both 422-via-params cases and the applications 403.
- `test_query_revisions_statement_scope.py` runs the DAO against a fake engine that records the compiled statement, then asserts `project_id` appears in the outer `WHERE` with the grouped subquery excised. No database involved.

Web:

```
cd web/packages/agenta-entities && npx vitest run     # 115 files, 1659 tests passed
cd web/packages/agenta-navigation && npx vitest run   # 4 files, 99 tests passed
```

Two new cases in `prompt-model-groups.test.ts` cover a subscription alone and a subscription beside a key-backed connection. Both fail on the release branch. A new `sessionsSourceWaitingFilter.test.ts` drives the real atoms with `querySessions` mocked, seeds 60 gated sessions, unlocks paging and asserts the tail request carries the id set. Its first case fails on the release branch. Two guard cases cover the other statuses and the short-window case where paging never unlocks.

`pnpm lint-fix` in `web` and `ruff format` plus `ruff check --fix` in `api` are clean, and both touched web packages pass `tsc --noEmit`.

## What to QA

- Filter the sidebar to "Awaiting input" in a project with more than fifty gated sessions, then scroll past the first page. Every row still shows a gate. This needs the volume; a small project cannot page at all.
- Connect a ChatGPT subscription, then open the prompt playground model picker. No "ChatGPT" group appears. The same holds in the LLM-as-a-judge evaluator picker.
- Regression: with an OpenAI API key connection in the same project, its group still appears with its models.
- Item E from the verification report is not in this PR. A `self_managed` connection carrying a slug returns a rejection naming ChatGPT with `provider 'unknown'`. It is only reachable by switching an agent's harness after picking a subscription model, and it gets its own issue.

https://claude.ai/code/session_01SaN5pYGkaoCsVd48Qcqm3L
