### PR TITLE
[5414] fix(api): Reuse one aiohttp session for object-store reads

### DIFF
--- a/api/entrypoints/routers.py
+++ b/api/entrypoints/routers.py
@@ -348,6 +348,8 @@ async def lifespan(*args, **kwargs):
     for adapter in _composio_triggers_adapters.values():
         await adapter.close()
 
+    await store.close()
+
     await _transactions_engine.close()
     await _analytics_engine.close()
     await _streams_engine.close()

--- a/api/oss/src/core/store/storage.py
+++ b/api/oss/src/core/store/storage.py
@@ -1,3 +1,4 @@
+import asyncio
 from datetime import datetime, timezone
 from hashlib import sha256
 from io import BytesIO
@@ -89,6 +90,9 @@ class ObjectStore:
         self._region = region
         self._sts_endpoint_url = sts_endpoint_url
         self._signing_key = signing_key
+        # ClientSession binds to the running loop; this object is built at import time.
+        self._session: Optional[aiohttp.ClientSession] = None
+        self._session_lock = asyncio.Lock()
 
     @property
     def enabled(self) -> bool:
@@ -128,6 +132,23 @@ class ObjectStore:
             secure=secure,
             region=self._region,
         )
+
+    async def _http_session(self) -> aiohttp.ClientSession:
+        session = self._session
+        if session is not None and not session.closed:
+            return session
+        async with self._session_lock:
+            session = self._session
+            if session is None or session.closed:
+                self._session = aiohttp.ClientSession()
+            return self._session
+
+    async def close(self) -> None:
+        async with self._session_lock:
+            session = self._session
+            self._session = None
+        if session is not None and not session.closed:
+            await session.close()
 
     async def ensure_bucket(self, *, bucket: str) -> None:
         """Create the store bucket if absent (master key).
@@ -422,19 +443,20 @@ class ObjectStore:
         key: str,
     ) -> bytes:
         client = self._client()
-        # get_object needs an explicit aiohttp session (miniopy-async 1.21 signature) and hands
-        # back a streaming ClientResponse; own the session so it outlives the body read.
-        async with aiohttp.ClientSession() as session:
-            try:
-                resp = await client.get_object(bucket, key, session)
-            except S3Error as e:
-                if e.code in ("NoSuchKey", "NoSuchObject", "NoSuchBucket"):
-                    raise MountFileNotFound() from e
-                raise
-            try:
-                return await resp.content.read()
-            finally:
-                await resp.release()
+        # miniopy-async 1.21 requires a caller-supplied session and returns a live
+        # ClientResponse. Reuse one session so archive reads keep the TCP/TLS
+        # connection instead of handshaking per object.
+        session = await self._http_session()
+        try:
+            resp = await client.get_object(bucket, key, session)
+        except S3Error as e:
+            if e.code in ("NoSuchKey", "NoSuchObject", "NoSuchBucket"):
+                raise MountFileNotFound() from e
+            raise
+        try:
+            return await resp.content.read()
+        finally:
+            await resp.release()
 
     async def put_object(
         self,

--- a/api/oss/tests/pytest/unit/test_mounts_injection.py
+++ b/api/oss/tests/pytest/unit/test_mounts_injection.py
@@ -713,14 +713,21 @@ class TestGetObjectSessionReuse:
         await _object_store().close()
 
     async def test_missing_key_still_maps_to_not_found(self, monkeypatch):
+        import oss.src.core.store.storage as storage_mod
         from miniopy_async.error import S3Error
 
         from oss.src.core.mounts.types import MountFileNotFound
 
         store = _object_store()
-        err = S3Error.__new__(S3Error)
-        err.code = "NoSuchKey"
+        created = []
+        monkeypatch.setattr(
+            storage_mod.aiohttp,
+            "ClientSession",
+            lambda: _TrackSession(created),
+        )
+        err = S3Error("NoSuchKey", "not found", "missing", "req", "host", object())
         monkeypatch.setattr(store, "_client", lambda: _FakeMinio(error=err))
 
         with pytest.raises(MountFileNotFound):
             await store.get_object(bucket=_BUCKET, key="missing")
+        await store.close()

--- a/api/oss/tests/pytest/unit/test_mounts_injection.py
+++ b/api/oss/tests/pytest/unit/test_mounts_injection.py
@@ -11,6 +11,7 @@ live against the docker-compose SeaweedFS in the acceptance suite; the fakes her
 the service-side derivation (prefix, bucket, policy scope, XML parsing, master-key isolation).
 """
 
+import asyncio
 from typing import Dict, Optional
 from urllib.parse import parse_qs
 from uuid import uuid4, uuid5, NAMESPACE_DNS
@@ -583,3 +584,143 @@ class TestMountsCredentialsTtlConfig:
         else:
             monkeypatch.setenv("AGENTA_MOUNTS_CREDENTIALS_TTL_SECONDS", value)
         assert MountsConfig().credentials_ttl_seconds == expected
+
+
+# ---------------------------------------------------------------------------
+# get_object session reuse (storage layer)
+# ---------------------------------------------------------------------------
+
+
+class _FakeBody:
+    def __init__(self, data: bytes):
+        self._data = data
+
+    async def read(self):
+        return self._data
+
+
+class _FakeObjectResponse:
+    def __init__(self, data: bytes = b"payload"):
+        self.content = _FakeBody(data)
+        self.released = False
+
+    async def release(self):
+        self.released = True
+
+
+class _FakeMinio:
+    def __init__(self, *, error=None):
+        self.calls = []
+        self.responses = []
+        self._error = error
+
+    async def get_object(self, bucket, key, session):
+        self.calls.append((bucket, key, session))
+        if self._error is not None:
+            raise self._error
+        resp = _FakeObjectResponse()
+        self.responses.append(resp)
+        return resp
+
+
+class _TrackSession:
+    def __init__(self, created):
+        self.closed = False
+        created.append(self)
+
+    async def close(self):
+        self.closed = True
+
+
+def _object_store():
+    from oss.src.core.store.storage import ObjectStore
+
+    return ObjectStore(
+        endpoint_url="https://s3.eu-central-1.amazonaws.com",
+        access_key=_MASTER_KEY,
+        secret_key=_MASTER_SECRET,
+        region="eu-central-1",
+    )
+
+
+@pytest.mark.asyncio
+class TestGetObjectSessionReuse:
+    async def test_reuses_one_session_across_reads(self, monkeypatch):
+        import oss.src.core.store.storage as storage_mod
+
+        store = _object_store()
+        client = _FakeMinio()
+        created = []
+        monkeypatch.setattr(store, "_client", lambda: client)
+        monkeypatch.setattr(
+            storage_mod.aiohttp,
+            "ClientSession",
+            lambda: _TrackSession(created),
+        )
+
+        assert await store.get_object(bucket=_BUCKET, key="a") == b"payload"
+        assert await store.get_object(bucket=_BUCKET, key="b") == b"payload"
+
+        assert len(created) == 1
+        assert [session for _, _, session in client.calls] == [created[0], created[0]]
+        assert all(resp.released for resp in client.responses)
+        assert created[0].closed is False
+
+    async def test_concurrent_first_reads_share_one_session(self, monkeypatch):
+        import oss.src.core.store.storage as storage_mod
+
+        store = _object_store()
+        client = _FakeMinio()
+        created = []
+        monkeypatch.setattr(store, "_client", lambda: client)
+        monkeypatch.setattr(
+            storage_mod.aiohttp,
+            "ClientSession",
+            lambda: _TrackSession(created),
+        )
+
+        await asyncio.gather(
+            store.get_object(bucket=_BUCKET, key="a"),
+            store.get_object(bucket=_BUCKET, key="b"),
+            store.get_object(bucket=_BUCKET, key="c"),
+        )
+
+        assert len(created) == 1
+        assert {session for _, _, session in client.calls} == {created[0]}
+
+    async def test_close_then_next_read_opens_another_session(self, monkeypatch):
+        import oss.src.core.store.storage as storage_mod
+
+        store = _object_store()
+        client = _FakeMinio()
+        created = []
+        monkeypatch.setattr(store, "_client", lambda: client)
+        monkeypatch.setattr(
+            storage_mod.aiohttp,
+            "ClientSession",
+            lambda: _TrackSession(created),
+        )
+
+        await store.get_object(bucket=_BUCKET, key="a")
+        await store.close()
+        assert created[0].closed is True
+
+        await store.get_object(bucket=_BUCKET, key="b")
+        assert len(created) == 2
+        assert client.calls[1][2] is created[1]
+
+    async def test_close_is_safe_when_no_read_happened(self):
+        await _object_store().close()
+
+    async def test_missing_key_still_maps_to_not_found(self, monkeypatch):
+        from miniopy_async.error import S3Error
+
+        from oss.src.core.mounts.types import MountFileNotFound
+
+        store = _object_store()
+        err = S3Error.__new__(S3Error)
+        err.code = "NoSuchKey"
+        monkeypatch.setattr(store, "_client", lambda: _FakeMinio(error=err))
+
+        with pytest.raises(MountFileNotFound):
+            await store.get_object(bucket=_BUCKET, key="missing")


### PR DESCRIPTION
## Summary
`ObjectStore.get_object` used to open a new `aiohttp.ClientSession` on every read. The download-all archive path reads many files through that method, so remote S3 paid a TCP/TLS handshake per object (about 47s for ~5000 files at 8-way concurrency in #5414).

This change keeps one long-lived session on `ObjectStore`, creates it lazily on first `get_object`, shares it across concurrent first reads, and closes it on app shutdown via FastAPI lifespan. Listing and STS signing are unchanged on purpose.

Closes #5414

## Testing
### Verified locally
Ran:
pytest oss/tests/pytest/unit/test_mounts_injection.py 

oss/tests/pytest/unit/sessions/test_watchdog_lifespan_wiring.py -n0
Result: 33 passed.

### Added or updated tests
Updated `api/oss/tests/pytest/unit/test_mounts_injection.py` to cover:
- sequential reads reuse one session
- concurrent first reads share one session
- close then reopen
- missing key still maps to `MountFileNotFound`

### QA follow-up
N/A for UI. Optional maintainer check: remote S3 download-all on a large mount to confirm handshake cost drops.

## Demo
Backend-only change (no UI). Demo is the local unit-test run for session reuse / close / missing-key behavior:
<img width="1200" height="432" alt="b2945b98c871808dfa11a9746b95fe45" src="https://github.com/user-attachments/assets/2ab93bde-0ecc-4a2d-96c6-31e391eede52" />


## Checklist
- [x] Demo shows the real app running this branch (not a mock-up or recreated UI), or is marked N/A
- [x] Relevant tests pass locally
- [x] Relevant linting and formatting pass locally
- [x] I have signed the CLA, or I will sign it when the bot prompts me
