### PR TITLE
[feat] Redesign the mobile agent overview

### DIFF
--- a/web/mobile/src/features/agents/AgentActivityFilterMenu.tsx
+++ b/web/mobile/src/features/agents/AgentActivityFilterMenu.tsx
@@ -1,0 +1,117 @@
+import {useMemo} from "react"
+
+import {useSessionFilters, type SessionStatusFilter} from "@agenta/sessions/state"
+import {FilterMenu, type FilterMenuSection} from "@agenta/ui/filter-menu"
+import {CalendarBlank, Clock, Minus, Rows, SquaresFour, Waveform} from "@phosphor-icons/react"
+
+import type {SessionActivityWindow} from "../sessions/sessionListView"
+
+import {
+    isDefaultAgentActivityView,
+    type AgentActivityGrouping,
+    type AgentActivityView,
+} from "./agentActivityView"
+
+const ICON = 14
+
+/** The status filters get the dot a row paints, so the filter and the row read alike. */
+const StatusDot = ({className}: {className: string}) => (
+    <span aria-hidden className={`size-1.5 rounded-full ${className}`} />
+)
+
+/**
+ * The overview list's view control — the sessions page's menu minus the rows the page already
+ * answers: no Type (the tabs are the type) and no Agent (every row is this agent's).
+ *
+ * Status is the shared session atom, so a status set here is the one the sessions page shows
+ * too; the window and the grouping are this screen's own.
+ */
+export const AgentActivityFilterMenu = ({
+    view,
+    onChange,
+    waitingCount,
+    onReset,
+}: {
+    view: AgentActivityView
+    onChange: (view: AgentActivityView) => void
+    waitingCount?: number
+    onReset: () => void
+}) => {
+    const {status, setStatus, archivedOnly, includeArchived} = useSessionFilters()
+
+    const sections = useMemo<FilterMenuSection[]>(
+        () => [
+            {
+                key: "status",
+                label: "Status",
+                icon: <Waveform size={ICON} />,
+                value: status,
+                options: [
+                    {value: "all", label: "All", icon: <SquaresFour size={ICON} />},
+                    {
+                        value: "waiting",
+                        label: waitingCount ? `Waiting ${waitingCount}` : "Waiting",
+                        icon: <StatusDot className="bg-[var(--ag-run-status-warning)]" />,
+                    },
+                    {
+                        value: "running",
+                        label: "Running",
+                        icon: <StatusDot className="bg-[var(--ag-run-status-success)]" />,
+                    },
+                    {
+                        value: "idle",
+                        label: "Idle",
+                        icon: <StatusDot className="bg-[var(--ag-run-status-default)]" />,
+                    },
+                ],
+                onChange: (value) => setStatus(value as SessionStatusFilter),
+            },
+            {
+                key: "activity",
+                label: "Last activity",
+                icon: <Clock size={ICON} />,
+                value: view.activity,
+                options: [
+                    {value: "all", label: "All", icon: <SquaresFour size={ICON} />},
+                    {value: "24h", label: "Today", icon: <Clock size={ICON} />},
+                    {value: "7d", label: "Last 7 days", icon: <Clock size={ICON} />},
+                    {value: "30d", label: "Last 30 days", icon: <Clock size={ICON} />},
+                ],
+                onChange: (value) => onChange({...view, activity: value as SessionActivityWindow}),
+            },
+            {
+                key: "group",
+                label: "Group by",
+                icon: <Rows size={ICON} />,
+                block: "sort",
+                value: view.group,
+                // The default first, as the Status and window rows lead with theirs.
+                options: [
+                    {value: "none", label: "None", icon: <Minus size={ICON} />},
+                    {value: "date", label: "Date", icon: <CalendarBlank size={ICON} />},
+                    {value: "status", label: "Status", icon: <Waveform size={ICON} />},
+                ],
+                onChange: (value) => onChange({...view, group: value as AgentActivityGrouping}),
+            },
+        ],
+        [onChange, setStatus, status, view, waitingCount],
+    )
+
+    // The archived atoms narrow this query too, set from the sessions page — so they dot the
+    // trigger here, and Reset is the way back.
+    const active =
+        status !== "all" || archivedOnly || includeArchived || !isDefaultAgentActivityView(view)
+
+    return (
+        <FilterMenu
+            sections={sections}
+            align="end"
+            label={null}
+            triggerAriaLabel="Filter and group activity"
+            size="icon-sm"
+            active={active}
+            onReset={onReset}
+            resetDisabled={!active}
+        />
+    )
+}

--- a/web/mobile/src/features/agents/AgentActivityRowCells.tsx
+++ b/web/mobile/src/features/agents/AgentActivityRowCells.tsx
@@ -1,0 +1,136 @@
+import {useCallback, useMemo, type MouseEvent as ReactMouseEvent} from "react"
+
+import {
+    sessionAutomationKindLabel,
+    type SessionRowStatusMeta,
+    type SessionRowVm,
+} from "@agenta/sessions/row"
+import {InlineRenameInput, useInlineRename, type SessionMenuEntry} from "@agenta/sessions-ui"
+import {timeAgo} from "@agenta/shared/utils"
+import {ClockClockwise, Lightning} from "@phosphor-icons/react"
+
+import {cn} from "@/lib/utils"
+
+import {SessionRowMenu} from "../sessions/SessionRowMenu"
+
+/** Archived is a state the reader chose. The kebab keeps full weight; unarchiving lives there. */
+const FADED = "opacity-60"
+
+/** Filled while something is happening, a hollow ring when not. The word is in the tooltip. */
+const StatusDot = ({status}: {status: SessionRowStatusMeta}) => {
+    const live = status.status === "waiting" || status.status === "running"
+    return (
+        <span
+            role="img"
+            aria-label={status.label}
+            title={status.label}
+            className={cn(
+                "box-border size-[7px] shrink-0 rounded-full border-[1.5px] border-solid",
+                live ? `${status.dotClassName} border-transparent` : "border-colorBorder",
+            )}
+        />
+    )
+}
+
+/** The automations page's two tints: orange for "when something happens", purple for a schedule. */
+const KIND_CHIP: Record<"subscription" | "schedule", string> = {
+    subscription: "bg-[var(--ag-preset-orange-bg)] text-[var(--ag-preset-orange-text)]",
+    schedule: "bg-[var(--ag-preset-purple-bg)] text-[var(--ag-preset-purple-text)]",
+}
+
+/** A run's tile: the automations page's kind mark, a bolt for an event and a clock for a schedule. */
+const RunTile = ({vm}: {vm: SessionRowVm}) => {
+    // A run whose trigger record is gone still ran from one; the neutral tile says "a run".
+    const kind = vm.automation?.kind ?? null
+    return (
+        <span
+            role="img"
+            aria-label={`${kind ? sessionAutomationKindLabel(kind) : "Automation run"} · ${vm.status.label}`}
+            title={vm.status.label}
+            className={cn(
+                "flex size-6 shrink-0 items-center justify-center rounded-md",
+                kind ? KIND_CHIP[kind] : "bg-muted text-muted-foreground",
+            )}
+        >
+            {kind === "schedule" ? (
+                <ClockClockwise size={13} aria-hidden />
+            ) : (
+                <Lightning size={13} aria-hidden />
+            )}
+        </span>
+    )
+}
+
+/**
+ * One activity row's cells, in column order: the mark, the title (or its rename editor), the
+ * time, the kebab. The sessions page's narrow row, with a run tile where the tab is runs.
+ */
+export const AgentActivityRowCells = ({
+    vm,
+    entries,
+    onMenuSelect,
+    onRenameRow,
+}: {
+    vm: SessionRowVm
+    entries: SessionMenuEntry[]
+    onMenuSelect: (vm: SessionRowVm, key: string) => void
+    onRenameRow: (vm: SessionRowVm, name: string) => Promise<boolean>
+}) => {
+    const onCommit = useCallback((name: string) => onRenameRow(vm, name), [onRenameRow, vm])
+    const rename = useInlineRename({current: vm.title, onCommit})
+
+    const onSelect = useCallback(
+        (key: string) => {
+            // Deferred, not run here: the editor must not mount inside the menu's focus trap.
+            if (key === "rename") return () => rename.start()
+            onMenuSelect(vm, key)
+        },
+        [onMenuSelect, rename, vm],
+    )
+
+    // The row opens the session; every control on it has to say so itself.
+    const swallow = useCallback((event: ReactMouseEvent) => event.stopPropagation(), [])
+
+    const archived = Boolean(vm.stream.archived_at)
+    const updated = useMemo(
+        () => (vm.activityAt ? timeAgo(Date.parse(vm.activityAt)) : "—"),
+        [vm.activityAt],
+    )
+
+    return (
+        <>
+            <span className={cn("flex min-w-0 items-center gap-2.5", archived && FADED)}>
+                {vm.isAutomation ? <RunTile vm={vm} /> : <StatusDot status={vm.status} />}
+                {rename.renaming ? (
+                    <span className="min-w-0 flex-1" onClick={swallow}>
+                        <InlineRenameInput
+                            rename={rename}
+                            className="h-6 w-full min-w-0 rounded-md border border-solid border-input bg-background px-2 text-[14px] leading-none text-foreground shadow-xs outline-none transition-[color,box-shadow] [font-family:inherit] selection:bg-primary selection:text-primary-foreground focus:border-ring focus:ring-[3px] focus:ring-ring/50 dark:bg-input/30"
+                        />
+                    </span>
+                ) : (
+                    <span className="min-w-0 truncate text-[14px] text-foreground" title={vm.title}>
+                        {vm.title}
+                    </span>
+                )}
+            </span>
+
+            <span
+                className={cn(
+                    "truncate text-right text-[13px] text-muted-foreground",
+                    archived && FADED,
+                )}
+            >
+                {updated}
+            </span>
+
+            <span className="flex justify-end" onClick={swallow}>
+                <SessionRowMenu
+                    entries={entries}
+                    onSelect={onSelect}
+                    label={vm.title || "Untitled session"}
+                />
+            </span>
+        </>
+    )
+}

--- a/web/mobile/src/features/agents/AgentActivityTable.tsx
+++ b/web/mobile/src/features/agents/AgentActivityTable.tsx
@@ -1,0 +1,160 @@
+import {useCallback, useMemo, useState} from "react"
+
+import type {SessionRowVm} from "@agenta/sessions/row"
+import {
+    rowsFromPages,
+    useSessionFilters,
+    useSessionList,
+    useSessionsList,
+} from "@agenta/sessions/state"
+import {SessionListLoadMore} from "@agenta/sessions-ui"
+import {ListTable, type ListTableColumn, type ListTableGroup} from "@agenta/ui/list-table"
+
+import type {SessionRowVerbs} from "../sessions/SessionListTable"
+import {deriveSessionGroups} from "../sessions/sessionListView"
+import {SessionsError} from "../sessions/states/SessionsError"
+import {SessionsNoMatch} from "../sessions/states/SessionsNoMatch"
+
+import {AgentActivityRowCells} from "./AgentActivityRowCells"
+import {
+    agentActivityPolicy,
+    type AgentActivityTab,
+    type AgentActivityView,
+} from "./agentActivityView"
+import {AgentActivityEmpty} from "./states/AgentActivityEmpty"
+
+/** The sessions page's phone columns: the title takes the row, the time sits against the kebab. */
+const columnsFor = (tab: AgentActivityTab): ListTableColumn[] => [
+    {key: "title", label: tab === "runs" ? "Run" : "Session", width: "minmax(160px,1fr)"},
+    {key: "updated", label: "Updated", width: "64px", headerClassName: "text-right"},
+    {key: "actions", label: "Actions", srOnly: true, width: "24px"},
+]
+const MIN_WIDTH = 272
+
+/**
+ * One agent's activity, in the frame the sessions page uses: the tab pins the origin, the menu
+ * cuts and narrows the rest. Pins stay their own group at the top whatever the grouping is.
+ */
+export const AgentActivityTable = ({
+    agentId,
+    view,
+    activityFloor,
+    verbs,
+    onClearSearch,
+    onResetView,
+}: {
+    agentId: string
+    view: AgentActivityView
+    /** ISO floor from the Last activity facet; undefined = no bound. */
+    activityFloor?: string
+    verbs: SessionRowVerbs
+    onClearSearch: () => void
+    onResetView: () => void
+}) => {
+    const policy = useMemo(() => agentActivityPolicy(view.tab), [view.tab])
+    const columns = useMemo(() => columnsFor(view.tab), [view.tab])
+    const list = useSessionsList({
+        agentId,
+        activityFloor,
+        defaultPolicy: policy,
+        automationPolicy: policy,
+    })
+    // The APPLIED term, so the empty state can never name a search that has not run yet.
+    const term = useSessionFilters().search.trim()
+
+    const [collapsed, setCollapsed] = useState<Set<string>>(() => new Set())
+    const toggleGroup = useCallback(
+        (key: string) =>
+            setCollapsed((current) => {
+                const next = new Set(current)
+                if (!next.delete(key)) next.add(key)
+                return next
+            }),
+        [],
+    )
+
+    const groups = useMemo<ListTableGroup<SessionRowVm>[]>(() => {
+        const out: ListTableGroup<SessionRowVm>[] = []
+        for (const source of list.groups) {
+            if (source.key === "pinned") {
+                out.push({key: source.key, label: source.label ?? null, rows: source.rows})
+                continue
+            }
+            // Flat under "none": the tab already names what the rows are.
+            if (view.group === "none") {
+                if (source.rows.length) out.push({key: source.key, label: null, rows: source.rows})
+                continue
+            }
+            for (const derived of deriveSessionGroups(source.rows, view.group))
+                out.push({...derived, key: `${source.key}:${derived.key}`})
+        }
+        return out
+    }, [list.groups, view.group])
+
+    // Does this agent have ANY session of this kind? The page cannot tell "none yet" from
+    // "the filters hid them" out of what it holds, so it asks — the sessions page's own probe,
+    // scoped to the agent. Runs only while the list is empty.
+    const probe = useSessionList({
+        agentId,
+        originPolicy: policy.origin,
+        expansions: [],
+        includeArchived: true,
+        limit: 1,
+        enabled: list.isEmpty && !list.isPlaceholder && !list.isPending,
+    })
+    const agentHasRows = rowsFromPages(probe.data?.pages).length > 0
+
+    if (list.isError) return <SessionsError onRetry={list.refetch} />
+
+    return (
+        <div aria-busy={list.isPlaceholder || undefined}>
+            <div
+                className={
+                    list.isPlaceholder ? "opacity-50 transition-opacity" : "transition-opacity"
+                }
+            >
+                <ListTable
+                    columns={columns}
+                    minWidth={MIN_WIDTH}
+                    stickyHeader
+                    // The tab above already names the rows; a header row said it twice.
+                    hideHeader
+                    density="compact"
+                    loading={list.isPending}
+                    groups={groups}
+                    rowKey={(vm) => vm.id}
+                    onOpenRow={verbs.open}
+                    collapsedKeys={collapsed}
+                    onToggleGroup={toggleGroup}
+                    empty={
+                        // Nothing while unsettled: the rows may be a previous query's, or the
+                        // probe may not have said yet. A guess here tells a reader with sessions
+                        // that they have none.
+                        list.isPlaceholder || probe.isPending ? null : agentHasRows ? (
+                            <SessionsNoMatch
+                                term={term || undefined}
+                                onClear={term ? onClearSearch : onResetView}
+                            />
+                        ) : (
+                            <AgentActivityEmpty tab={view.tab} />
+                        )
+                    }
+                    renderRow={(vm) => (
+                        <AgentActivityRowCells
+                            vm={vm}
+                            entries={verbs.menuFor(vm)}
+                            onMenuSelect={verbs.onMenuSelect}
+                            onRenameRow={verbs.onRenameRow}
+                        />
+                    )}
+                />
+                {list.paging.hasNext ? (
+                    <SessionListLoadMore
+                        loading={list.paging.isLoadingNext}
+                        onClick={list.paging.loadNext}
+                    />
+                ) : null}
+            </div>
+        </div>
+    )
+}

--- a/web/mobile/src/features/agents/AgentActivityTabs.tsx
+++ b/web/mobile/src/features/agents/AgentActivityTabs.tsx
@@ -1,0 +1,50 @@
+import type {ReactNode} from "react"
+
+import {FOCUS_RING} from "@/lib/interactive"
+import {cn} from "@/lib/utils"
+
+import type {AgentActivityTab} from "./agentActivityView"
+
+const TAB_BASE =
+    "box-border cursor-pointer appearance-none border-0 border-b-2 border-solid bg-transparent px-0.5 pb-2.5 font-[inherit] text-[15px] leading-none outline-none transition-colors " +
+    FOCUS_RING
+const TAB_ON = "border-b-foreground font-semibold text-foreground"
+const TAB_OFF = "border-b-transparent font-normal text-muted-foreground hover:text-foreground"
+
+const TABS: {key: AgentActivityTab; label: string}[] = [
+    {key: "sessions", label: "Sessions"},
+    // Co-equal with Sessions, not a filter of it: a run is one the user configured but did not start.
+    {key: "runs", label: "Automations"},
+]
+
+/** The activity list's rail: two tabs on a rule, Home's tab language, with the list's control at the far end. */
+export const AgentActivityTabs = ({
+    tab,
+    onChange,
+    actions,
+}: {
+    tab: AgentActivityTab
+    onChange: (tab: AgentActivityTab) => void
+    /** The filter menu, sitting on the rule's right. */
+    actions?: ReactNode
+}) => (
+    <div
+        role="tablist"
+        className="mb-1.5 flex items-end gap-6 border-0 border-b border-solid border-b-[var(--ag-colorSplit)]"
+    >
+        {TABS.map((entry) => (
+            <button
+                key={entry.key}
+                type="button"
+                role="tab"
+                aria-selected={entry.key === tab}
+                onClick={() => onChange(entry.key)}
+                // `-mb-px` sits the active rule on the rail's rule, not above it.
+                className={cn(TAB_BASE, "-mb-px", entry.key === tab ? TAB_ON : TAB_OFF)}
+            >
+                {entry.label}
+            </button>
+        ))}
+        {actions ? <span className="mb-2 ml-auto flex items-center">{actions}</span> : null}
+    </div>
+)

--- a/web/mobile/src/features/agents/AgentAutomationsCard.tsx
+++ b/web/mobile/src/features/agents/AgentAutomationsCard.tsx
@@ -1,0 +1,61 @@
+import {useUpcomingTriggers} from "@agenta/entity-ui/agent"
+import {Clock, Lightning} from "@phosphor-icons/react"
+import {useRouter} from "next/router"
+
+import {AgentOverviewCard} from "./AgentOverviewCard"
+import {AgentOverviewCardRow} from "./AgentOverviewCardRow"
+import {AgentOverviewCardError} from "./states/AgentOverviewCardError"
+import {AgentOverviewCardSkeleton} from "./states/AgentOverviewCardSkeleton"
+
+const ICON = 16
+
+/**
+ * What is going to run, soonest first — the agent's schedules and event subscriptions. Runs that
+ * HAPPENED are in the activity list; this answers "is anything coming".
+ */
+export const AgentAutomationsCard = ({
+    agentId,
+    agentNames,
+    base,
+}: {
+    agentId: string
+    agentNames?: ReadonlyMap<string, string>
+    /** `/w/:workspace/p/:project` — a row opens its automation's screen. */
+    base: string
+}) => {
+    const router = useRouter()
+    const {rows, isLoading, hasError, retry} = useUpcomingTriggers({agentId, agentNames})
+
+    return (
+        <AgentOverviewCard title="Automations">
+            {isLoading ? (
+                <AgentOverviewCardSkeleton rows={2} />
+            ) : hasError ? (
+                <AgentOverviewCardError message="Couldn't load automations." onRetry={retry} />
+            ) : rows.length === 0 ? (
+                <p className="m-0 py-2 text-[13px] text-muted-foreground">
+                    No automations bound to this agent yet.
+                </p>
+            ) : (
+                rows.map((row) => (
+                    <AgentOverviewCardRow
+                        key={row.id}
+                        // A clock for a schedule, a bolt for an event: the two kinds of trigger.
+                        icon={
+                            row.kind === "schedule" ? (
+                                <Clock size={ICON} />
+                            ) : (
+                                <Lightning size={ICON} weight="fill" />
+                            )
+                        }
+                        label={row.name}
+                        detail={row.detail}
+                        title={row.tooltip}
+                        onClick={() => void router.push(`${base}/automations/${row.id}`)}
+                        className="text-[13.5px]"
+                    />
+                ))
+            )}
+        </AgentOverviewCard>
+    )
+}

--- a/web/mobile/src/features/agents/AgentComposer.tsx
+++ b/web/mobile/src/features/agents/AgentComposer.tsx
@@ -51,9 +51,10 @@ export const AgentComposer = ({
     return (
         <HomeTaskComposer
             fixedAgentId={agentId}
-            placeholder={`Ask ${agentName}… — starts a new session`}
             attachments={attachments}
             onStart={start}
+            // Home's composer, mic and all — this is the same start-a-session control.
+            voice
         />
     )
 }

--- a/web/mobile/src/features/agents/AgentConfigCard.tsx
+++ b/web/mobile/src/features/agents/AgentConfigCard.tsx
@@ -1,0 +1,130 @@
+import {useMemo} from "react"
+
+import {composioLogo, PROVIDERS} from "@agenta/entities/workflow"
+import {agentConfigSummary, agentLatestRevisionAtomFamily} from "@agenta/entity-ui/agent"
+import {humanizeActionKey} from "@agenta/shared/utils"
+import {LogoMarks} from "@agenta/ui/components/presentational"
+import {Cpu, FileText, GraduationCap, Plugs, Wrench} from "@phosphor-icons/react"
+import {useAtomValue} from "jotai"
+
+import {AgentOverviewCard} from "./AgentOverviewCard"
+import {AgentOverviewCardRow} from "./AgentOverviewCardRow"
+import {AgentOverviewCardError} from "./states/AgentOverviewCardError"
+import {AgentOverviewCardSkeleton} from "./states/AgentOverviewCardSkeleton"
+
+const ICON = 16
+const INSTRUCTIONS_FILE = "AGENTS.md"
+/** Marks past this collapse to "+N" — a phone row cannot hold a longer run. */
+const MAX_MARKS = 4
+
+/** `openrouter/deepseek/deepseek-v4-flash` → `deepseek-v4-flash`: the row is for the model, and the
+ * route and provider in front of it are what pushed the model off the end. The full id stays in
+ * the tooltip. */
+const modelName = (id: string): string => id.split("/").filter(Boolean).pop() ?? id
+
+/** What this agent IS: the playground's config sections, one row each, less the permission default. */
+export const AgentConfigCard = ({
+    agentId,
+    onEdit,
+}: {
+    agentId: string
+    /** Opens the config for editing; every row leads there too. */
+    onEdit: () => void
+}) => {
+    // Configuration lives on a revision, not on the artifact.
+    const revisionAtom = useMemo(() => agentLatestRevisionAtomFamily(agentId), [agentId])
+    const revision = useAtomValue(revisionAtom)
+    const summary = useMemo(
+        () => agentConfigSummary(revision.data?.data?.parameters),
+        [revision.data],
+    )
+
+    const marks = useMemo(
+        () =>
+            summary.integrationKeys.map((key) => ({
+                key,
+                name: PROVIDERS[key]?.label ?? humanizeActionKey(key),
+                logo: PROVIDERS[key]?.logo ?? composioLogo(key),
+            })),
+        [summary.integrationKeys],
+    )
+
+    // User MCP servers are a Claude-harness feature; on any other harness the row only offers a
+    // setting the runtime ignores — unless a server is already configured, which is worth saying.
+    const showMcp = summary.mcps > 0 || Boolean(summary.harness?.toLowerCase().includes("claude"))
+
+    const skills =
+        summary.skillNames.length > 0
+            ? summary.skillNames.join(", ")
+            : summary.skills
+              ? `${summary.skills} ${summary.skills === 1 ? "skill" : "skills"}`
+              : "No skills"
+
+    return (
+        <AgentOverviewCard title="Configuration" action="Edit" onAction={onEdit}>
+            {revision.isPending ? (
+                <AgentOverviewCardSkeleton rows={4} />
+            ) : revision.isError ? (
+                <AgentOverviewCardError
+                    message="Couldn't load this agent's configuration."
+                    onRetry={() => void revision.refetch()}
+                />
+            ) : (
+                <>
+                    <AgentOverviewCardRow
+                        icon={<Cpu size={ICON} />}
+                        label="Model"
+                        detail={summary.model ? modelName(summary.model) : "Choose a model"}
+                        title={summary.model ?? undefined}
+                        onClick={onEdit}
+                    />
+                    <AgentOverviewCardRow
+                        icon={<FileText size={ICON} />}
+                        label="Instructions"
+                        detail={
+                            summary.instructions
+                                ? `${INSTRUCTIONS_FILE} · ${summary.instructionWords}w`
+                                : "Add instructions"
+                        }
+                        onClick={onEdit}
+                    />
+                    <AgentOverviewCardRow
+                        icon={<Wrench size={ICON} />}
+                        label="Integrations"
+                        detail={
+                            marks.length > 0 ? (
+                                <LogoMarks
+                                    items={marks}
+                                    size={16}
+                                    max={MAX_MARKS}
+                                    stacked
+                                    label="Integrations"
+                                />
+                            ) : summary.tools ? (
+                                `${summary.tools} enabled`
+                            ) : (
+                                "No integrations"
+                            )
+                        }
+                        onClick={onEdit}
+                    />
+                    {showMcp ? (
+                        <AgentOverviewCardRow
+                            icon={<Plugs size={ICON} />}
+                            label="MCP servers"
+                            detail={summary.mcps ? `${summary.mcps} connected` : "Connect a server"}
+                            onClick={onEdit}
+                        />
+                    ) : null}
+                    <AgentOverviewCardRow
+                        icon={<GraduationCap size={ICON} />}
+                        label="Skills"
+                        detail={skills}
+                        title={summary.skillNames.join(", ") || undefined}
+                        onClick={onEdit}
+                    />
+                </>
+            )}
+        </AgentOverviewCard>
+    )
+}

--- a/web/mobile/src/features/agents/AgentDriveCard.tsx
+++ b/web/mobile/src/features/agents/AgentDriveCard.tsx
@@ -1,0 +1,111 @@
+import {useMemo, useState} from "react"
+
+import {AGENT_FILES_DIR, agentMountQueryFamily, useSessionDrive} from "@agenta/entities/drive"
+import {latestMountFilesQueryFamily, type MountFile} from "@agenta/entities/session"
+import {File, Folder} from "@phosphor-icons/react"
+import {useAtomValue} from "jotai"
+import dynamic from "next/dynamic"
+
+import {AgentOverviewCard} from "./AgentOverviewCard"
+import {AgentOverviewCardRow} from "./AgentOverviewCardRow"
+import {AgentOverviewCardSkeleton} from "./states/AgentOverviewCardSkeleton"
+
+// The whole drive explorer, pulled in only once the drawer is actually opened.
+const FilesDrawer = dynamic(
+    () => import("@agenta/entity-ui/drive").then((mod) => mod.FilesDrawer),
+    {ssr: false},
+)
+
+const ICON = 14
+/** The card shows this many, newest first, and never more: the drawer is where the whole drive lives. */
+const LIMIT = 5
+
+const formatSize = (bytes: number | null | undefined): string | null => {
+    if (bytes == null) return null
+    if (bytes < 1024) return `${bytes} B`
+    if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`
+    return `${(bytes / (1024 * 1024)).toFixed(1)} MB`
+}
+
+const fileDetail = (file: MountFile): string | null =>
+    file.is_folder
+        ? file.item_count != null
+            ? `${file.item_count} item${file.item_count === 1 ? "" : "s"}`
+            : null
+        : formatSize(file.size)
+
+/**
+ * The agent's OWN drive — the files it carries between runs, not a session's scratch mount. The
+ * same mount and file queries the shared card reads, so this and the drawer share one cache.
+ */
+export const AgentDriveCard = ({agentId}: {agentId: string}) => {
+    const [openPath, setOpenPath] = useState<string | null>(null)
+    const [open, setOpen] = useState(false)
+
+    const mountsAtom = useMemo(() => agentMountQueryFamily(agentId), [agentId])
+    const mounts = useAtomValue(mountsAtom)
+    const mountId = mounts.data?.id ?? ""
+
+    const filesAtom = useMemo(
+        () => latestMountFilesQueryFamily({mountId, limit: LIMIT, order: "recent"}),
+        [mountId],
+    )
+    const files = useAtomValue(filesAtom)
+    // No session id: only the agent mount loads, and only once the drawer is open.
+    const drive = useSessionDrive("", open ? agentId : undefined)
+
+    const rows: MountFile[] = files.data?.files ?? []
+    const isPending = mounts.isPending || (Boolean(mountId) && files.isPending)
+
+    const openDrive = (path: string | null) => {
+        setOpenPath(path)
+        setOpen(true)
+    }
+
+    return (
+        <AgentOverviewCard
+            title="Files"
+            action={mountId ? "Open files" : undefined}
+            onAction={() => openDrive(null)}
+        >
+            {isPending ? (
+                <AgentOverviewCardSkeleton rows={3} />
+            ) : rows.length === 0 ? (
+                <p className="m-0 py-2 text-[13px] text-muted-foreground">
+                    {mountId
+                        ? "This agent isn't carrying any files yet."
+                        : "This agent has no drive yet."}
+                </p>
+            ) : (
+                rows.map((file) => (
+                    <AgentOverviewCardRow
+                        key={file.path}
+                        icon={file.is_folder ? <Folder size={ICON} /> : <File size={ICON} />}
+                        label={file.path.split("/").filter(Boolean).pop() || file.path}
+                        detail={fileDetail(file)}
+                        title={file.path}
+                        // The drive folds the agent mount in under `agent-files/`.
+                        onClick={() => openDrive(`${AGENT_FILES_DIR}/${file.path}`)}
+                        className="py-1.5"
+                    />
+                ))
+            )}
+
+            {open ? (
+                <FilesDrawer
+                    open={open}
+                    onClose={() => {
+                        setOpen(false)
+                        setOpenPath(null)
+                    }}
+                    drive={drive}
+                    scope="app"
+                    initialPath={openPath}
+                    driveIds={
+                        mountId ? [{key: "mount", label: "Drive ID", value: mountId}] : undefined
+                    }
+                />
+            ) : null}
+        </AgentOverviewCard>
+    )
+}

--- a/web/mobile/src/features/agents/AgentOverviewBody.tsx
+++ b/web/mobile/src/features/agents/AgentOverviewBody.tsx
@@ -1,0 +1,138 @@
+import {useCallback, useMemo} from "react"
+
+import {AgentOverviewLayout} from "@agenta/entity-ui/agent"
+import {resetSessionFiltersAtom, sessionSearchAtom, useSessionsList} from "@agenta/sessions/state"
+import {useFilterMenuView} from "@agenta/ui/filter-menu"
+import {useSetAtom} from "jotai"
+
+import {useScrollFade} from "@/lib/useScrollFade"
+
+import type {SessionRowVerbs} from "../sessions/SessionListTable"
+import {activityFloorIso} from "../sessions/sessionListView"
+
+import {AgentActivityFilterMenu} from "./AgentActivityFilterMenu"
+import {AgentActivityTable} from "./AgentActivityTable"
+import {AgentActivityTabs} from "./AgentActivityTabs"
+import {
+    agentActivityPolicy,
+    DEFAULT_AGENT_ACTIVITY_VIEW,
+    type AgentActivityView,
+} from "./agentActivityView"
+import {AgentAutomationsCard} from "./AgentAutomationsCard"
+import {AgentComposer} from "./AgentComposer"
+import {AgentConfigCard} from "./AgentConfigCard"
+import {AgentDriveCard} from "./AgentDriveCard"
+
+/**
+ * The overview's body, on the shared two-column arrangement: the composer over the activity
+ * tabs on the left, the agent's own state as three soft cards on the right — Configuration,
+ * Files, Automations — and the two stacked below `lg`.
+ */
+export const AgentOverviewBody = ({
+    agentId,
+    agentName,
+    base,
+    agentNames,
+    verbs,
+    onEditConfig,
+}: {
+    agentId: string
+    agentName: string
+    /** `/w/:workspace/p/:project` */
+    base: string
+    agentNames: ReadonlyMap<string, string>
+    verbs: SessionRowVerbs
+    onEditConfig: () => void
+}) => {
+    // The grouping is a preference; the tab, the window and the status are the question of the moment.
+    const [view, setView] = useFilterMenuView<AgentActivityView>({
+        key: "agenta:agent-overview:view",
+        fallback: DEFAULT_AGENT_ACTIVITY_VIEW,
+        persist: ["group"],
+    })
+    // Once per facet change, never per render — a `Date.now()` floor would re-key the query forever.
+    const activityFloor = useMemo(() => activityFloorIso(view.activity), [view.activity])
+
+    // The SAME arguments the table passes, so both resolve to one query; here only for the count.
+    const policy = useMemo(() => agentActivityPolicy(view.tab), [view.tab])
+    const list = useSessionsList({
+        agentId,
+        activityFloor,
+        defaultPolicy: policy,
+        automationPolicy: policy,
+    })
+
+    // Home's edge fade: the list says there is more above or below instead of ending in a line.
+    const fade = useScrollFade<HTMLDivElement>()
+
+    const setSearch = useSetAtom(sessionSearchAtom)
+    const resetFilters = useSetAtom(resetSessionFiltersAtom)
+    const clearSearch = useCallback(() => setSearch(""), [setSearch])
+    const resetView = useCallback(() => {
+        resetFilters()
+        setView({...DEFAULT_AGENT_ACTIVITY_VIEW, tab: view.tab})
+    }, [resetFilters, setView, view.tab])
+    const setTab = useCallback(
+        (tab: AgentActivityView["tab"]) => setView({...view, tab}),
+        [setView, view],
+    )
+
+    return (
+        <AgentOverviewLayout
+            // The rows' hover fill bleeds 12px past the tabs on both sides, as on the agents
+            // page. The scroller is this frame, and a scrollport clips at its padding box, so
+            // 12px of the page gutter lives here rather than on the screen's column.
+            className="px-3"
+            // The page never scrolls: the composer and the tabs stay put and the list beneath
+            // them takes what is left of the screen and scrolls on its own.
+            scroll="columns"
+            main={
+                <>
+                    <AgentComposer agentId={agentId} agentName={agentName} base={base} />
+                    <div className="mt-3 flex min-h-0 flex-1 flex-col">
+                        <AgentActivityTabs
+                            tab={view.tab}
+                            onChange={setTab}
+                            actions={
+                                <AgentActivityFilterMenu
+                                    view={view}
+                                    onChange={setView}
+                                    waitingCount={list.waitingCount}
+                                    onReset={resetView}
+                                />
+                            }
+                        />
+                        {/* The one scroller. `-mx-3 px-3` is net zero on the content and gives
+                            the rows' 12px hover bleed somewhere to land — a scrollport clips at
+                            its padding box. */}
+                        <div
+                            ref={fade.ref}
+                            onScroll={fade.onScroll}
+                            style={fade.style}
+                            className="-mx-3 min-h-0 flex-1 overflow-y-auto px-3"
+                        >
+                            <AgentActivityTable
+                                agentId={agentId}
+                                view={view}
+                                activityFloor={activityFloor}
+                                verbs={verbs}
+                                onClearSearch={clearSearch}
+                                onResetView={resetView}
+                            />
+                        </div>
+                    </div>
+                </>
+            }
+            rail={
+                // Only as a side rail. Below `lg` the layout would stack the cards under the
+                // list, where three of them read as a second page; the agent's own state is a
+                // tap away in the session workspace.
+                <div className="hidden w-full flex-col gap-3.5 lg:flex">
+                    <AgentConfigCard agentId={agentId} onEdit={onEditConfig} />
+                    <AgentDriveCard agentId={agentId} />
+                    <AgentAutomationsCard agentId={agentId} agentNames={agentNames} base={base} />
+                </div>
+            }
+        />
+    )
+}

--- a/web/mobile/src/features/agents/AgentOverviewCard.tsx
+++ b/web/mobile/src/features/agents/AgentOverviewCard.tsx
@@ -1,0 +1,41 @@
+import type {ReactNode} from "react"
+
+import {cn} from "@/lib/utils"
+
+/** The rail card's action link: 13px, secondary, no chrome — a word at the title's right. */
+const ACTION_CLASS =
+    "m-0 shrink-0 cursor-pointer appearance-none border-0 bg-transparent p-0 font-[inherit] text-[13px] leading-none text-muted-foreground outline-none transition-colors hover:text-foreground focus-visible:text-foreground"
+
+/**
+ * One card of the agent overview's rail — Configuration, Files, Automations. A soft fill on the
+ * page, no border, so the three read as one column of the agent's own state rather than three
+ * framed panels competing with the activity list beside them.
+ */
+export const AgentOverviewCard = ({
+    title,
+    action,
+    onAction,
+    children,
+    className,
+}: {
+    title: string
+    /** The one verb the card offers — "Edit", "Open drive". */
+    action?: string
+    onAction?: () => void
+    children: ReactNode
+    className?: string
+}) => (
+    <section className={cn("rounded-[10px] bg-muted/50 px-4 pb-2.5 pt-3.5", className)}>
+        <div className="mb-1.5 flex items-center gap-2.5">
+            <h2 className="m-0 min-w-0 flex-1 truncate text-[14px] font-medium leading-[1.4] text-foreground">
+                {title}
+            </h2>
+            {action && onAction ? (
+                <button type="button" onClick={onAction} className={ACTION_CLASS}>
+                    {action}
+                </button>
+            ) : null}
+        </div>
+        {children}
+    </section>
+)

--- a/web/mobile/src/features/agents/AgentOverviewCardRow.tsx
+++ b/web/mobile/src/features/agents/AgentOverviewCardRow.tsx
@@ -1,0 +1,72 @@
+import type {ReactNode} from "react"
+
+import {cn} from "@/lib/utils"
+
+/** A rail card's row: a mark, a label, and the fact at the right. Rows bleed 8px into the card's padding so the hover fill has room. */
+export const AgentOverviewCardRow = ({
+    icon,
+    label,
+    detail,
+    onClick,
+    title,
+    className,
+}: {
+    icon: ReactNode
+    label: ReactNode
+    /** The fact on the right — text, or a run of marks. */
+    detail?: ReactNode
+    /** Absent ⇒ the row is a fact, not a control. */
+    onClick?: () => void
+    title?: string
+    className?: string
+}) => {
+    const body = (
+        <>
+            <span className="flex size-4 shrink-0 items-center justify-center text-muted-foreground">
+                {icon}
+            </span>
+            {/* The label takes what the fact leaves: a long file or automation name truncates,
+                while a long model id stops at just over half the row so the label stays whole. */}
+            <span className="min-w-0 flex-1 truncate text-left text-[14px] text-foreground">
+                {label}
+            </span>
+            {typeof detail === "string" ? (
+                <span className="max-w-[55%] shrink-0 truncate text-right text-[13px] text-muted-foreground">
+                    {detail}
+                </span>
+            ) : detail ? (
+                <span className="flex shrink-0 items-center justify-end">{detail}</span>
+            ) : null}
+        </>
+    )
+    const shared = cn(
+        "-mx-2 box-border flex w-[calc(100%+16px)] items-center gap-3 rounded-lg px-2 py-[7px]",
+        className,
+    )
+    // A div with the button role, not a <button>: the Integrations row's fact is a list of
+    // marks, which a real button cannot contain. Enter and Space still open it.
+    return onClick ? (
+        <div
+            role="button"
+            tabIndex={0}
+            title={title}
+            onClick={onClick}
+            onKeyDown={(event) => {
+                if (event.key === "Enter" || event.key === " ") {
+                    event.preventDefault()
+                    onClick()
+                }
+            }}
+            className={cn(
+                shared,
+                "cursor-pointer outline-none transition-colors hover:bg-accent focus-visible:bg-accent",
+            )}
+        >
+            {body}
+        </div>
+    ) : (
+        <div title={title} className={shared}>
+            {body}
+        </div>
+    )
+}

--- a/web/mobile/src/features/agents/AgentOverviewScreen.tsx
+++ b/web/mobile/src/features/agents/AgentOverviewScreen.tsx
@@ -2,16 +2,11 @@ import {useCallback, useMemo} from "react"
 
 import {chatPanelMaximizedAtom, configPanelCollapsedAtom} from "@agenta/chat/state"
 import {agentWorkflowsListQueryStateAtom, type Workflow} from "@agenta/entities/workflow"
-import {AgentActionsMenu, AgentIdentity, AgentOverviewBody} from "@agenta/entity-ui/agent"
-import {UsageCard} from "@agenta/home-ui"
-import {sessionRouteModes} from "@agenta/sessions/state"
 import {pageContentWidthClass} from "@agenta/ui/components/page-width"
 import {useAtomValue, useSetAtom} from "jotai"
 
 import {PageTitle} from "@/components/PageTitle"
 import {ScreenScaffold} from "@/components/ScreenScaffold"
-import {Skeleton} from "@/components/ui/skeleton"
-import {AGENT_CONFIG_INTEGRATIONS_COPY} from "@/lib/integrationsCopy"
 
 import {useStartBlankSession} from "../chat/useStartBlankSession"
 import {useBindProjectContext} from "../context/useBindProjectContext"
@@ -20,9 +15,10 @@ import {NavDrawer} from "../nav/NavDrawer"
 import {SessionAutomationDrawers} from "../sessions/SessionAutomationDrawers"
 import {useSessionRowMenu} from "../sessions/useSessionRowMenu"
 
-import {AgentComposer} from "./AgentComposer"
+import {AgentOverviewBody} from "./AgentOverviewBody"
+import {AgentOverviewTitle} from "./AgentOverviewTitle"
 
-/** One agent's overview: the desktop page's shared cards, with a config card for its rail. */
+/** One agent's overview: who it is, a composer, its activity in tabs, and its own state in a rail. */
 export const AgentOverviewScreen = ({
     workspaceId,
     projectId,
@@ -39,17 +35,28 @@ export const AgentOverviewScreen = ({
     const agents = useMemo<Workflow[]>(() => agentsQuery.data ?? [], [agentsQuery.data])
     const agent = agents.find((candidate) => candidate.id === agentId)
     const name = agent?.name || agent?.slug || "Agent"
+    const description = agent?.description?.trim() || null
     const agentNames = useMemo(
         () => new Map(agents.map((entry) => [entry.id, entry.name || entry.slug || "Agent"])),
         [agents],
     )
 
+    // The shared row verbs — rename, pin, archive, delete — bound here, resolved by the rows.
     const sessionMenu = useSessionRowMenu(base)
+    const verbs = useMemo(
+        () => ({
+            open: sessionMenu.open,
+            menuFor: sessionMenu.menuFor,
+            onMenuSelect: sessionMenu.onMenuSelect,
+            onRenameRow: sessionMenu.onRenameRow,
+        }),
+        [sessionMenu.menuFor, sessionMenu.onMenuSelect, sessionMenu.onRenameRow, sessionMenu.open],
+    )
 
-    // Configuration is edited in the session workspace here, so this lands on a blank session
-    // with this agent and puts the config pane on screen. BOTH panel flags are written because
-    // either one alone leaves the pane hidden — the pair `resolveSessionPanes` reads.
     const startBlank = useStartBlankSession(base)
+    const openChat = useCallback(() => startBlank(agentId), [agentId, startBlank])
+    // Configuration is edited in the session workspace here, so this lands on a blank session
+    // with the config pane on screen. BOTH flags are written — either alone leaves it hidden.
     const setChatMaximized = useSetAtom(chatPanelMaximizedAtom)
     const setConfigCollapsed = useSetAtom(configPanelCollapsedAtom)
     const onEditConfig = useCallback(() => {
@@ -65,89 +72,37 @@ export const AgentOverviewScreen = ({
                 <ScreenScaffold
                     fill
                     header={
-                        // The rule is phone chrome — a pinned strip over a scroller — so it stops
-                        // at `lg`, where a full-bleed line would run edge to edge across a page
-                        // whose content is a centred column, cutting it off from its own title.
-                        // Same border story as the sessions bar.
-                        //
-                        // Horizontal padding sits on the inner column, not here: on the outer box
-                        // it insets the box the column centres in, and the header's left edge
-                        // drifts off the body's by half the padding.
-                        <div className="border-border shrink-0 border-b pb-3 pt-2 lg:border-b-0 lg:pb-4 lg:pt-14">
+                        // Phone chrome: a pinned strip over a scroller, whose rule stops at `lg`
+                        // where the page is a centred column. Padding sits on the inner column so
+                        // the header's left edge stays on the body's.
+                        <div className="border-border shrink-0 border-b pb-3 pt-2 lg:border-b-0 lg:pb-5 lg:pt-14">
                             <div
-                                className={`${pageContentWidthClass} flex items-center gap-2 px-2 lg:px-16`}
+                                className={`${pageContentWidthClass} flex items-start gap-2 px-4 lg:px-16`}
                             >
-                                {/* Nav is the drawer, as on every other screen — not a per-screen
-                                    back button. Home is one drawer entry away. */}
                                 <NavDrawer workspaceId={workspaceId} projectId={projectId} />
-                                {/* THE shared identity the session top bar renders: icon picker +
-                                    inline rename. Neither is agent CONFIG, which /m still only
-                                    reads, and the kebab beside it already offers this rename. */}
-                                {/* No `flex-1`: the title sizes to its text so the kebab sits
-                                    beside it, as on the desktop, instead of being pushed to the
-                                    far edge. `min-w-0` still lets a long name truncate. */}
-                                {/* The placeholder stands in while the roster is in flight; the
-                                    "Agent" fallback is for an agent that never resolves. */}
-                                <AgentIdentity
-                                    workflowId={agentId}
+                                <AgentOverviewTitle
+                                    agentId={agentId}
                                     name={name}
-                                    size="title"
-                                    namePlaceholder={
-                                        agentsQuery.isPending && !agent ? (
-                                            <Skeleton className="h-8 w-40 shrink-0" />
-                                        ) : undefined
-                                    }
+                                    description={description}
+                                    pending={agentsQuery.isPending && !agent}
+                                    onOpenChat={openChat}
                                 />
-                                {/* The same verbs the desktop header offers; rename and delete
-                                    fall through to the shared implementations here, since /m has
-                                    no app-management modals of its own.
-
-                                    Held back until the record lands, like every other agent fact
-                                    on this screen: until then `name` is the "Agent" placeholder,
-                                    so a rename would open seeded with it and the destructive
-                                    verbs would act on an agent whose name and slug are unknown. */}
-                                {agent ? (
-                                    <AgentActionsMenu
-                                        agent={{id: agentId, name, slug: agent.slug}}
-                                        align="end"
-                                    />
-                                ) : null}
                             </div>
                         </div>
                     }
                 >
-                    {/* THE shared overview body — the same cards, order and chrome the desktop
-                        page renders. */}
-                    {/* The shared page column (`pageContentWidthClass`), same as Sessions and
-                        Agents: this page used to opt out of the cap at `lg` and stretched ~300px
-                        wider than every other screen, which also inflated the body's right rail
-                        past the width its rows are designed for. */}
-                    {/* `min-h-0 flex-1` is load-bearing: the body IS the scroller, so it needs a
-                        definite height to scroll within. */}
+                    {/* `min-h-0 flex-1` is load-bearing: the body IS the scroller. */}
                     <div
-                        className={`${pageContentWidthClass} flex min-h-0 flex-1 flex-col px-2 pb-4 pt-2 lg:px-16 lg:pb-6 lg:pt-5`}
+                        // The header's gutter less the 12px the body's scroller carries itself (see the body).
+                        className={`${pageContentWidthClass} flex min-h-0 flex-1 flex-col px-1 pb-4 pt-3 lg:px-[52px] lg:pb-6 lg:pt-2`}
                     >
-                        {/* `sessionsHref` is the PROJECT-wide list — /m has no agent-scoped
-                            sessions route — hence no `sessionsHrefScopesAgent`: the cards hand
-                            this agent over as a filter, or "View all" lands on a list of
-                            everyone else's sessions too. */}
                         <AgentOverviewBody
-                            alwaysShowPin
-                            composer={
-                                <AgentComposer agentId={agentId} agentName={name} base={base} />
-                            }
                             agentId={agentId}
+                            agentName={name}
+                            base={base}
                             agentNames={agentNames}
-                            // This app says "Integrations" where oss/ee still say "Tools".
-                            configCopy={AGENT_CONFIG_INTEGRATIONS_COPY}
-                            usage={<UsageCard appId={agentId} />}
-                            sessionsHref={`${base}/sessions`}
-                            automationSessionsHref={`${base}/sessions?mode=${sessionRouteModes.automation}`}
+                            verbs={verbs}
                             onEditConfig={onEditConfig}
-                            onOpenRow={sessionMenu.open}
-                            menuFor={sessionMenu.menuFor}
-                            onMenuSelect={sessionMenu.onMenuSelect}
-                            onRenameRow={sessionMenu.onRenameRow}
                         />
                     </div>
                 </ScreenScaffold>

--- a/web/mobile/src/features/agents/AgentOverviewTitle.tsx
+++ b/web/mobile/src/features/agents/AgentOverviewTitle.tsx
@@ -5,12 +5,16 @@ import {
     AgentChip,
     AgentIconPopover,
     useRenameAgent,
+    useUpdateAgentDescription,
 } from "@agenta/entity-ui/agent"
 import {InlineRenameInput, useDeferredMenuSelect, useInlineRename} from "@agenta/sessions-ui"
+import {useMediaQuery} from "@agenta/ui/hooks"
 import {ChatCircleDots} from "@phosphor-icons/react"
 
 import {Button} from "@/components/ui/button"
 import {Skeleton} from "@/components/ui/skeleton"
+import {FOCUS_RING} from "@/lib/interactive"
+import {cn} from "@/lib/utils"
 
 /**
  * Who the agent is, as the overview's header row: the roster's tile (icon picker behind it), the
@@ -41,21 +45,39 @@ export const AgentOverviewTitle = ({
         onCommit,
         errorText: "Couldn't rename this agent",
     })
+    // The description edits the same way, one line under the name. Blank is a real value here:
+    // it is how a description is removed.
+    const updateDescription = useUpdateAgentDescription()
+    const onCommitDescription = useCallback(
+        (next: string) => updateDescription(agentId, next),
+        [agentId, updateDescription],
+    )
+    const describe = useInlineRename({
+        current: description ?? "",
+        onCommit: onCommitDescription,
+        errorText: "Couldn't update this agent's description",
+        allowEmpty: true,
+    })
     // The editor must not mount inside the menu's focus trap, so the verb runs from the close.
     const {handleSelect, handleCloseAutoFocus} = useDeferredMenuSelect((key) => {
         if (key === "rename") return () => rename.start()
+        if (key === "describe") return () => describe.start()
     })
+    // Tailwind's `lg`, where the rail sits beside the list and the header has room for the rest.
+    const wide = useMediaQuery("(min-width: 1024px)")
 
     return (
         <>
             {/* The row is top-aligned so a two-line description hangs under the title rather
-                than pushing everything to its middle. On a phone each control nudges down so its
-                centre sits on the title line; from `sm` the tile's top edge sits on the title's. */}
+                than pushing everything to its middle. Below `lg` each control nudges down so its
+                centre sits on the title line; from `lg` the tile's top edge sits on the title's
+                glyphs. */}
             <AgentIconPopover workflowId={agentId}>
-                {/* The playground bar's 24px on a phone, the roster's 32 from `sm`. */}
-                <AgentChip workflowId={agentId} box="mt-1 size-6 sm:mt-0 sm:size-8" glyph={16} />
+                {/* The playground bar's 24px below `lg`, the roster's 32 beside the rail. `mt-1` puts
+                    its top on the title's cap height, not on the line box above it. */}
+                <AgentChip workflowId={agentId} box="mt-1 size-6 lg:size-8" glyph={16} />
             </AgentIconPopover>
-            <div className="flex min-w-0 flex-1 flex-col gap-0.5 pt-1 sm:pt-0">
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5 pt-1 lg:pt-0">
                 {pending ? (
                     <Skeleton className="h-7 w-40" />
                 ) : rename.renaming ? (
@@ -73,19 +95,41 @@ export const AgentOverviewTitle = ({
                         {name}
                     </h1>
                 )}
-                {description ? (
-                    <p className="m-0 line-clamp-2 text-[13px] leading-snug text-muted-foreground sm:text-[14px]">
-                        {description}
-                    </p>
-                ) : null}
+                {/* Only from `lg`, beside the rail. One line, never wider than the composer
+                    column beneath it: the rail takes a third of the page plus the 40px gap, so
+                    the line stops there. Below `lg` the header is the name alone. */}
+                {pending || !wide ? null : describe.renaming ? (
+                    <InlineRenameInput
+                        rename={describe}
+                        ariaLabel="Agent description"
+                        className="h-6 w-full min-w-0 rounded-md border border-solid border-input bg-background px-2 text-[13px] leading-none text-foreground shadow-xs outline-none transition-[color,box-shadow] [font-family:inherit] selection:bg-primary selection:text-primary-foreground focus:border-ring focus:ring-[3px] focus:ring-ring/50 dark:bg-input/30 lg:max-w-[calc(66.667%-40px)]"
+                    />
+                ) : (
+                    // A button either way: the text is its own edit affordance, and an agent
+                    // with no description gets the same line as a prompt, so the header keeps
+                    // one shape.
+                    <button
+                        type="button"
+                        onClick={describe.start}
+                        title={description ?? "Add a description"}
+                        className={cn(
+                            "m-0 min-w-0 cursor-text truncate border-0 bg-transparent p-0 text-left font-[inherit] text-[13px] leading-snug outline-none sm:text-[14px] lg:max-w-[calc(66.667%-40px)]",
+                            FOCUS_RING,
+                            description ? "text-muted-foreground" : "text-placeholder",
+                        )}
+                    >
+                        {description ?? "Add a description"}
+                    </button>
+                )}
             </div>
-            {/* A phone's header has no room beside the name; the composer below is the same verb. */}
+            {/* Only beside the rail: a narrower header has no room, and the composer is the same verb. */}
             <Button
                 type="button"
                 variant="outline"
-                size="xs"
+                // `sm` is 32px — the filter trigger's height, and what the other page headers use.
+                size="sm"
                 onClick={onOpenChat}
-                className="hidden shrink-0 sm:inline-flex"
+                className="hidden shrink-0 lg:inline-flex"
             >
                 <ChatCircleDots aria-hidden />
                 Open chat
@@ -98,8 +142,9 @@ export const AgentOverviewTitle = ({
                     agent={{id: agentId, name}}
                     align="end"
                     onRename={() => handleSelect("rename")}
+                    onEditDescription={wide ? () => handleSelect("describe") : undefined}
                     onCloseAutoFocus={handleCloseAutoFocus}
-                    className="mt-0.5 sm:-mt-0.5"
+                    className="mt-0.5 lg:mt-0.5"
                 />
             )}
         </>

--- a/web/mobile/src/features/agents/AgentOverviewTitle.tsx
+++ b/web/mobile/src/features/agents/AgentOverviewTitle.tsx
@@ -1,0 +1,107 @@
+import {useCallback} from "react"
+
+import {
+    AgentActionsMenu,
+    AgentChip,
+    AgentIconPopover,
+    useRenameAgent,
+} from "@agenta/entity-ui/agent"
+import {InlineRenameInput, useDeferredMenuSelect, useInlineRename} from "@agenta/sessions-ui"
+import {ChatCircleDots} from "@phosphor-icons/react"
+
+import {Button} from "@/components/ui/button"
+import {Skeleton} from "@/components/ui/skeleton"
+
+/**
+ * Who the agent is, as the overview's header row: the roster's tile (icon picker behind it), the
+ * name renaming in place the way a roster row does, the description under it, then Open chat
+ * and the shared kebab. The kebab's Rename starts the editor here rather than a modal.
+ */
+export const AgentOverviewTitle = ({
+    agentId,
+    name,
+    description,
+    pending,
+    onOpenChat,
+}: {
+    agentId: string
+    name: string
+    description: string | null
+    /** The roster is still in flight and the record has not landed. */
+    pending: boolean
+    onOpenChat: () => void
+}) => {
+    const renameAgent = useRenameAgent()
+    const onCommit = useCallback(
+        (next: string) => renameAgent(agentId, next),
+        [agentId, renameAgent],
+    )
+    const rename = useInlineRename({
+        current: name,
+        onCommit,
+        errorText: "Couldn't rename this agent",
+    })
+    // The editor must not mount inside the menu's focus trap, so the verb runs from the close.
+    const {handleSelect, handleCloseAutoFocus} = useDeferredMenuSelect((key) => {
+        if (key === "rename") return () => rename.start()
+    })
+
+    return (
+        <>
+            {/* The row is top-aligned so a two-line description hangs under the title rather
+                than pushing everything to its middle. On a phone each control nudges down so its
+                centre sits on the title line; from `sm` the tile's top edge sits on the title's. */}
+            <AgentIconPopover workflowId={agentId}>
+                {/* The playground bar's 24px on a phone, the roster's 32 from `sm`. */}
+                <AgentChip workflowId={agentId} box="mt-1 size-6 sm:mt-0 sm:size-8" glyph={16} />
+            </AgentIconPopover>
+            <div className="flex min-w-0 flex-1 flex-col gap-0.5 pt-1 sm:pt-0">
+                {pending ? (
+                    <Skeleton className="h-7 w-40" />
+                ) : rename.renaming ? (
+                    <InlineRenameInput
+                        rename={rename}
+                        ariaLabel="Agent name"
+                        className="h-7 w-full min-w-0 rounded-md border border-solid border-input bg-background px-2 text-[16px] font-semibold leading-none text-foreground shadow-xs outline-none transition-[color,box-shadow] [font-family:inherit] selection:bg-primary selection:text-primary-foreground focus:border-ring focus:ring-[3px] focus:ring-ring/50 dark:bg-input/30"
+                    />
+                ) : (
+                    <h1
+                        className="m-0 min-w-0 truncate text-[16px] font-semibold leading-[1.5] text-foreground sm:text-[18px] sm:leading-[1.3]"
+                        title={name}
+                        onDoubleClick={rename.start}
+                    >
+                        {name}
+                    </h1>
+                )}
+                {description ? (
+                    <p className="m-0 line-clamp-2 text-[13px] leading-snug text-muted-foreground sm:text-[14px]">
+                        {description}
+                    </p>
+                ) : null}
+            </div>
+            {/* A phone's header has no room beside the name; the composer below is the same verb. */}
+            <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                onClick={onOpenChat}
+                className="hidden shrink-0 sm:inline-flex"
+            >
+                <ChatCircleDots aria-hidden />
+                Open chat
+            </Button>
+            {/* Held back until the record lands: until then the destructive verbs would act on
+                an agent whose name is unknown. No slug on purpose: the menu offers Copy Slug only
+                when it has one, and this screen does not want it. */}
+            {pending ? null : (
+                <AgentActionsMenu
+                    agent={{id: agentId, name}}
+                    align="end"
+                    onRename={() => handleSelect("rename")}
+                    onCloseAutoFocus={handleCloseAutoFocus}
+                    className="mt-0.5 sm:-mt-0.5"
+                />
+            )}
+        </>
+    )
+}

--- a/web/mobile/src/features/agents/agentActivityView.ts
+++ b/web/mobile/src/features/agents/agentActivityView.ts
@@ -1,0 +1,36 @@
+import type {SessionListRequestPolicy} from "@agenta/sessions/state"
+
+import type {SessionActivityWindow, SessionGrouping} from "../sessions/sessionListView"
+
+/** The two lists the overview's tabs switch between. */
+export type AgentActivityTab = "sessions" | "runs"
+
+/** How the overview's rows are cut. No "agent": every row here is this agent's. */
+export type AgentActivityGrouping = Exclude<SessionGrouping, "agent">
+
+export interface AgentActivityView {
+    tab: AgentActivityTab
+    group: AgentActivityGrouping
+    activity: SessionActivityWindow
+}
+
+/** Flat and unbounded: the page is one agent's whole history, not a project-wide search. */
+export const DEFAULT_AGENT_ACTIVITY_VIEW: AgentActivityView = {
+    tab: "sessions",
+    group: "none",
+    activity: "all",
+}
+
+/** The tab is the subject, not a filter — it never counts as "narrowed". */
+export const isDefaultAgentActivityView = (view: AgentActivityView): boolean =>
+    view.group === DEFAULT_AGENT_ACTIVITY_VIEW.group &&
+    view.activity === DEFAULT_AGENT_ACTIVITY_VIEW.activity
+
+/**
+ * The origin policy a tab pins. Passed as BOTH policies to `useSessionsList` so the tab, not the
+ * shared Type facet, decides what this list shows — the sessions page's mode must not leak here.
+ */
+export const agentActivityPolicy = (tab: AgentActivityTab): SessionListRequestPolicy =>
+    tab === "runs"
+        ? {origin: "trigger-only", expansions: ["trigger"]}
+        : {origin: "exclude-trigger", expansions: []}

--- a/web/mobile/src/features/agents/states/AgentActivityEmpty.tsx
+++ b/web/mobile/src/features/agents/states/AgentActivityEmpty.tsx
@@ -1,0 +1,34 @@
+import {ChatCircleDots, Lightning} from "@phosphor-icons/react"
+
+import type {AgentActivityTab} from "../agentActivityView"
+
+const COPY: Record<AgentActivityTab, {title: string; body: string}> = {
+    sessions: {
+        title: "No sessions yet",
+        body: "Conversations with this agent will show up here. Start one from the composer above.",
+    },
+    runs: {
+        title: "No automation runs yet",
+        body: "Runs from automations bound to this agent will show up here.",
+    },
+}
+
+/** The tab's list has nothing in it — under a header row that is still true, so no frame of its own. */
+export const AgentActivityEmpty = ({tab}: {tab: AgentActivityTab}) => {
+    const copy = COPY[tab]
+    return (
+        <div className="flex flex-col items-center justify-center gap-2.5 px-8 py-12 text-center">
+            <span className="inline-flex size-10 shrink-0 items-center justify-center rounded-[10px] bg-muted text-muted-foreground">
+                {tab === "runs" ? (
+                    <Lightning aria-hidden size={19} />
+                ) : (
+                    <ChatCircleDots aria-hidden size={19} />
+                )}
+            </span>
+            <p className="m-0 text-[14px] font-medium text-foreground">{copy.title}</p>
+            <p className="m-0 max-w-[42ch] text-[13px] leading-snug text-muted-foreground">
+                {copy.body}
+            </p>
+        </div>
+    )
+}

--- a/web/mobile/src/features/agents/states/AgentOverviewCardError.tsx
+++ b/web/mobile/src/features/agents/states/AgentOverviewCardError.tsx
@@ -1,0 +1,22 @@
+import {RefreshCw} from "lucide-react"
+
+/** A rail card whose section failed to load: one line and the way back, inside the card's own fill. */
+export const AgentOverviewCardError = ({
+    message,
+    onRetry,
+}: {
+    message: string
+    onRetry: () => void
+}) => (
+    <div className="flex items-center gap-3 py-2">
+        <p className="m-0 min-w-0 flex-1 text-[13px] text-muted-foreground">{message}</p>
+        <button
+            type="button"
+            onClick={onRetry}
+            className="inline-flex shrink-0 cursor-pointer appearance-none items-center gap-1 border-0 bg-transparent p-0 font-[inherit] text-[13px] text-foreground outline-none hover:underline"
+        >
+            <RefreshCw className="size-3" aria-hidden />
+            Retry
+        </button>
+    </div>
+)

--- a/web/mobile/src/features/agents/states/AgentOverviewCardSkeleton.tsx
+++ b/web/mobile/src/features/agents/states/AgentOverviewCardSkeleton.tsx
@@ -1,0 +1,10 @@
+import {Skeleton} from "@/components/ui/skeleton"
+
+/** Rows in flight, at the row's own 34px rhythm so the facts land without a shift. */
+export const AgentOverviewCardSkeleton = ({rows = 3}: {rows?: number}) => (
+    <div className="flex flex-col gap-2 py-1.5">
+        {Array.from({length: rows}, (_, index) => (
+            <Skeleton key={index} className="h-[26px] w-full" />
+        ))}
+    </div>
+)

--- a/web/mobile/src/lib/integrationsCopy.ts
+++ b/web/mobile/src/lib/integrationsCopy.ts
@@ -47,11 +47,3 @@ export const INTEGRATIONS_SECTION_COPY = {
     emptyBody: "Connect an integration to let your agents call it.",
     noMatch: (term: string) => `No integrations match “${term}”`,
 } as const
-
-/** Copy for the agent overview's config card, whose tools row says "Tools" for oss/ee. */
-export const AGENT_CONFIG_INTEGRATIONS_COPY = {
-    toolsTitle: "Integrations",
-    toolsCount: (count: number) => `${count} enabled`,
-    toolsAdd: "Add integrations",
-    toolsNone: "None enabled",
-} as const

--- a/web/mobile/src/lib/useScrollFade.ts
+++ b/web/mobile/src/lib/useScrollFade.ts
@@ -1,0 +1,42 @@
+import {useCallback, useEffect, useRef, useState, type CSSProperties} from "react"
+
+/**
+ * The list's own scroll state, as an edge fade — Home's list region, extracted. A hard edge at
+ * the bottom of a capped box reads as the end of the list; the fade is the signal that there is
+ * more below, and the top one that there is more above.
+ *
+ * Measured on every render, not only on scroll: content height changes under a capped box
+ * without resizing it, so a list that overflows on arrival has to show the fade before it is
+ * ever touched (a ResizeObserver on the scroller never fires for that).
+ */
+export const useScrollFade = <T extends HTMLElement>() => {
+    const ref = useRef<T>(null)
+    const [mask, setMask] = useState<string>("none")
+
+    const readScroll = useCallback(() => {
+        const el = ref.current
+        if (!el) return
+        const max = el.scrollHeight - el.clientHeight
+        const top = el.scrollTop > 4
+        const bottom = max > 4 && el.scrollTop < max - 4
+        const next =
+            !top && !bottom
+                ? "none"
+                : `linear-gradient(to bottom, transparent 0, #000 ${top ? "26px" : "0"}, #000 ${
+                      bottom ? "calc(100% - 34px)" : "100%"
+                  }, transparent 100%)`
+        // Idempotent, so this is safe to call on every render.
+        setMask((current) => (current === next ? current : next))
+    }, [])
+
+    useEffect(readScroll)
+
+    // The window's width changes how many rows fit; the height they occupy is what the mask reads.
+    useEffect(() => {
+        window.addEventListener("resize", readScroll)
+        return () => window.removeEventListener("resize", readScroll)
+    }, [readScroll])
+
+    const style: CSSProperties = {maskImage: mask, WebkitMaskImage: mask}
+    return {ref, onScroll: readScroll, style}
+}

--- a/web/packages/agenta-entities/src/workflow/agentTemplates.ts
+++ b/web/packages/agenta-entities/src/workflow/agentTemplates.ts
@@ -94,9 +94,10 @@ export interface AgentStarterTemplate {
     requiredIntegrations: RequiredIntegration[]
 }
 
-/** Provider slug → display label + brand logo URL (Composio logo CDN, the tool catalog's source). */
-const composioLogo = (slug: string) => `https://logos.composio.dev/api/${slug}`
+/** An integration slug's brand logo URL (Composio logo CDN, the tool catalog's source). */
+export const composioLogo = (slug: string) => `https://logos.composio.dev/api/${slug}`
 
+/** Provider slug → display label + brand logo URL. */
 export const PROVIDERS: Record<string, {label: string; logo: string}> = {
     github: {label: "GitHub", logo: composioLogo("github")},
     gitlab: {label: "GitLab", logo: composioLogo("gitlab")},

--- a/web/packages/agenta-entities/src/workflow/api/api.ts
+++ b/web/packages/agenta-entities/src/workflow/api/api.ts
@@ -1057,8 +1057,10 @@ export async function updateWorkflow(
     projectId: string,
     payload: UpdateWorkflowPayload,
 ): Promise<Workflow> {
-    // Update workflow metadata if non-data fields changed
-    const hasMetadataChanges = payload.name || payload.description || payload.flags || payload.tags
+    // Update workflow metadata if non-data fields changed. Description is checked for presence,
+    // not truth: an empty string is how a description is cleared.
+    const hasMetadataChanges =
+        payload.name || payload.description !== undefined || payload.flags || payload.tags
     if (hasMetadataChanges) {
         await axios.put(
             `${getAgentaApiUrl()}/workflows/${payload.id}`,

--- a/web/packages/agenta-entities/src/workflow/index.ts
+++ b/web/packages/agenta-entities/src/workflow/index.ts
@@ -490,6 +490,7 @@ export {
     agentTemplateSeed,
     categoryFromSlug,
     categorySlug,
+    composioLogo,
     templateBuilderMessage,
     templateCategories,
     templateProviderSlugs,

--- a/web/packages/agenta-entity-ui/src/agent/AgentActionsMenu.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentActionsMenu.tsx
@@ -5,7 +5,14 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from "@agenta/ui/ui"
-import {Archive, Copy, DotsThreeVertical, Note, PencilSimple} from "@phosphor-icons/react"
+import {
+    Archive,
+    Copy,
+    DotsThreeVertical,
+    Note,
+    PencilSimple,
+    TextAlignLeft,
+} from "@phosphor-icons/react"
 
 import {useAgentActions, type AgentActionTarget} from "./useAgentActions"
 
@@ -21,6 +28,8 @@ export interface AgentActionsMenuProps {
      * cache), so it passes them; a host without one falls through to [[useAgentActions]].
      */
     onRename?: () => void
+    /** Edits the description in place. Absent means no item: the desktop edits it in its rename modal. */
+    onEditDescription?: () => void
     /** Named for the prop's history; the verb it stands for is Archive. */
     onDelete?: () => void
     /** Custom-workflow "Configure" — only the desktop has that flow, so absent means no item. */
@@ -42,6 +51,7 @@ export const AgentActionsMenu = ({
     agent,
     onOpen,
     onRename,
+    onEditDescription,
     onDelete,
     onConfigure,
     align = "start",
@@ -86,6 +96,12 @@ export const AgentActionsMenu = ({
                         Rename
                     </DropdownMenuItem>
                 )}
+                {onEditDescription ? (
+                    <DropdownMenuItem onSelect={onEditDescription}>
+                        <TextAlignLeft size={16} />
+                        Edit description
+                    </DropdownMenuItem>
+                ) : null}
                 {agent.slug ? (
                     <DropdownMenuItem onSelect={() => void actions.copy(agent.slug!, "Slug")}>
                         <Copy size={16} />

--- a/web/packages/agenta-entity-ui/src/agent/AgentOverviewLayout.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/AgentOverviewLayout.tsx
@@ -10,6 +10,13 @@ export interface AgentOverviewLayoutProps {
     rail: ReactNode
     /** Host spacing — the stacked gap below lg is content rhythm, not layout. */
     className?: string
+    /**
+     * Who scrolls. `frame` (default): this frame is the one scroller and both columns move
+     * together. `columns`: the frame stays put and each column owns its own height — the host
+     * gives one child of `main` a `min-h-0 flex-1 overflow-y-auto` and that is what scrolls,
+     * with everything above it (a composer, a tab rail) pinned.
+     */
+    scroll?: "frame" | "columns"
 }
 
 /**
@@ -27,16 +34,38 @@ export interface AgentOverviewLayoutProps {
  * height (the desktop page asks the layout for its full-height frame, mobile's `ScreenScaffold`
  * takes `fill`), or `flex-1` has no space to resolve against.
  */
-export const AgentOverviewLayout = ({main, rail, className}: AgentOverviewLayoutProps) => (
-    <div
-        className={clsx(
-            "flex min-h-0 w-full flex-1 flex-col items-start gap-10 overflow-y-auto lg:flex-row",
-            className,
-        )}
-    >
-        <div className="flex w-full min-w-0 flex-col gap-6 lg:flex-1">{main}</div>
-        <div className="flex w-full shrink-0 grow-0 flex-col lg:w-1/3 lg:min-w-[340px] lg:max-w-[520px]">
-            {rail}
+export const AgentOverviewLayout = ({
+    main,
+    rail,
+    className,
+    scroll = "frame",
+}: AgentOverviewLayoutProps) => {
+    const columns = scroll === "columns"
+    return (
+        <div
+            className={clsx(
+                "flex min-h-0 w-full flex-1 flex-col gap-10 lg:flex-row",
+                // Stretched, so a column has the frame's height to hand down to its scroller.
+                columns ? "items-stretch overflow-hidden" : "items-start overflow-y-auto",
+                className,
+            )}
+        >
+            <div
+                className={clsx(
+                    "flex w-full min-w-0 flex-col gap-6 lg:flex-1",
+                    columns && "min-h-0 flex-1",
+                )}
+            >
+                {main}
+            </div>
+            <div
+                className={clsx(
+                    "flex w-full shrink-0 grow-0 flex-col lg:w-1/3 lg:min-w-[340px] lg:max-w-[520px]",
+                    columns && "min-h-0 overflow-y-auto",
+                )}
+            >
+                {rail}
+            </div>
         </div>
-    </div>
-)
+    )
+}

--- a/web/packages/agenta-entity-ui/src/agent/NextTriggersSection.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/NextTriggersSection.tsx
@@ -1,162 +1,16 @@
-import {useCallback, useMemo} from "react"
-
-import {
-    describeCron,
-    nextCronRuns,
-    triggerBoundAgentId,
-    useTriggerSchedules,
-    useTriggerSubscriptions,
-} from "@agenta/entities/gatewayTrigger"
-import {nowTickAtom} from "@agenta/shared/state"
-import {dayjs} from "@agenta/shared/utils"
 import {PanelSection} from "@agenta/ui/components/presentational"
 import {SkeletonBlock} from "@agenta/ui/ui"
 import {LightningIcon} from "@phosphor-icons/react"
-import {useAtomValue} from "jotai"
 
 import {SectionLoadError} from "./SectionLoadError"
 import {Tip} from "./Tip"
+import {useUpcomingTriggers, type UseUpcomingTriggersArgs} from "./useUpcomingTriggers"
 
-const LIST_SIZE = 5
+export type NextTriggersSectionProps = UseUpcomingTriggersArgs
 
-/** `formatDay` renders in UTC; a next-run time is only meaningful in the reader's own day. */
-const formatNextRun = (at: Date) => {
-    const run = dayjs(at)
-    const days = run.startOf("day").diff(dayjs().startOf("day"), "day")
-    if (days === 0) return run.format("HH:mm")
-    if (days === 1) return `tomorrow ${run.format("HH:mm")}`
-    if (days < 7) return run.format("ddd HH:mm")
-    return run.format("D MMM HH:mm")
-}
-
-/**
- * What is going to fire, soonest first.
- *
- * Automations already appear on these pages as runs that HAPPENED. That answers "did it work",
- * never "is anything coming" — a schedule that silently stopped firing looks identical to one
- * that has simply not come round yet. Schedules project forward from their own cron expression;
- * event subscriptions have no next time by nature, so they say what they are instead and sort
- * after everything dated.
- */
-interface UpcomingTrigger {
-    id: string
-    /** What it does. Falls back to the cadence in words, never to a cron expression. */
-    name: string
-    /** Which agent runs it, and how often. */
-    subtitle: string
-    detail: string
-    /** Absent for event subscriptions — they fire when the world does. */
-    at: Date | null
-    tooltip: string
-}
-
-export interface NextTriggersSectionProps {
-    /** Scope to one agent's triggers. On that agent's own page the binding is the premise, so
-     * rows drop the agent name and lead with the cadence instead. */
-    agentId?: string
-    /** Agent display names by workflow id. The classified agents list is app state, so the app
-     * hands the names over; an unknown id reads as "Unassigned agent". */
-    agentNames?: ReadonlyMap<string, string>
-}
-
+/** What is going to fire, soonest first — the rows `useUpcomingTriggers` derives, in the rail's panel chrome. */
 export const NextTriggersSection = ({agentId, agentNames}: NextTriggersSectionProps = {}) => {
-    const {
-        schedules,
-        isLoading: schedulesLoading,
-        error: schedulesError,
-        refetch: refetchSchedules,
-    } = useTriggerSchedules()
-    const {
-        subscriptions,
-        isLoading: subscriptionsLoading,
-        error: subscriptionsError,
-        refetch: refetchSubscriptions,
-    } = useTriggerSubscriptions()
-    // The shared minute clock: a projected next-run time that never re-computes freezes and ends
-    // up in the past.
-    const nowTick = useAtomValue(nowTickAtom)
-
-    const rows = useMemo<UpcomingTrigger[]>(() => {
-        const describeAgent = (references: unknown) => {
-            const boundId = triggerBoundAgentId(references as never)
-            return (boundId && agentNames?.get(boundId)) || "Unassigned agent"
-        }
-        const isInScope = (references: unknown) =>
-            !agentId || triggerBoundAgentId(references as never) === agentId
-
-        const scheduled = schedules
-            .filter(
-                (schedule) =>
-                    schedule.flags?.is_active !== false &&
-                    !schedule.deleted_at &&
-                    isInScope(schedule.data?.references),
-            )
-            .map((schedule, index) => {
-                const expression = schedule.data?.schedule ?? ""
-                const [next] = nextCronRuns(expression, 1)
-                const cadence = describeCron(expression)
-                const agent = describeAgent(schedule.data?.references)
-                return {
-                    id: schedule.id ?? `schedule-${index}`,
-                    // An unnamed schedule reads as its cadence, never as "5 * * * *".
-                    name: schedule.name || cadence,
-                    // Scoped to one agent, an unnamed schedule's title already IS the cadence.
-                    subtitle: agentId
-                        ? schedule.name
-                            ? cadence
-                            : ""
-                        : schedule.name
-                          ? `${agent} · ${cadence}`
-                          : agent,
-                    detail: next ? formatNextRun(next) : "—",
-                    at: next ?? null,
-                    tooltip: cadence,
-                }
-            })
-
-        const evented = subscriptions
-            .filter(
-                (subscription) =>
-                    subscription.flags?.is_active !== false &&
-                    isInScope(subscription.data?.references),
-            )
-            .map((subscription, index) => {
-                const eventKey = subscription.data?.event_key ?? ""
-                const agent = describeAgent(subscription.data?.references)
-                return {
-                    id: subscription.id ?? `subscription-${index}`,
-                    name: subscription.name || eventKey || "Event automation",
-                    subtitle: agentId
-                        ? subscription.name
-                            ? eventKey
-                            : ""
-                        : eventKey && subscription.name
-                          ? `${agent} · ${eventKey}`
-                          : agent,
-                    detail: "on event",
-                    at: null,
-                    tooltip: eventKey ? `Fires on ${eventKey}` : "Fires when its event arrives",
-                }
-            })
-
-        // Dated first and soonest-first; undated (event) triggers keep their own order after them.
-        return [...scheduled, ...evented]
-            .sort((a, b) => {
-                if (a.at && b.at) return a.at.getTime() - b.at.getTime()
-                if (a.at) return -1
-                if (b.at) return 1
-                return 0
-            })
-            .slice(0, LIST_SIZE)
-        // nowTick is a dep on purpose: it is what re-projects the next runs each minute.
-    }, [schedules, subscriptions, agentNames, agentId, nowTick])
-
-    const isLoading = schedulesLoading || subscriptionsLoading
-    const hasError = Boolean(schedulesError || subscriptionsError)
-    const retry = useCallback(() => {
-        if (schedulesError) void refetchSchedules()
-        if (subscriptionsError) void refetchSubscriptions()
-    }, [schedulesError, subscriptionsError, refetchSchedules, refetchSubscriptions])
+    const {rows, isLoading, hasError, retry} = useUpcomingTriggers({agentId, agentNames})
 
     return (
         <PanelSection title="Automations">

--- a/web/packages/agenta-entity-ui/src/agent/agentConfigSummary.ts
+++ b/web/packages/agenta-entity-ui/src/agent/agentConfigSummary.ts
@@ -16,6 +16,9 @@ export interface AgentConfigSummary {
     /** The brief itself, raw — `InstructionsFileRow` derives its own preview from the markdown. */
     instructions: string | null
     tools: number
+    /** The integration behind each gateway-connection tool (`linear`, `github`), in tool order,
+     * deduplicated — so an overview can show the marks rather than only the count. */
+    integrationKeys: string[]
     mcps: number
     skills: number
     /** Display names of the agent's skills (embed refs by their sibling name/slug, inline
@@ -45,6 +48,12 @@ const skillName = (entry: unknown): string | null => {
     return slug
 }
 
+/** A gateway-connection tool's integration key; null for a custom or builtin tool. */
+const integrationKey = (entry: unknown): string | null =>
+    isRecord(entry) && entry.type === "gateway_connection"
+        ? str(nested(entry, "connection")?.integration)
+        : null
+
 const nested = (parent: unknown, key: string): Record<string, unknown> | null => {
     if (!isRecord(parent)) return null
     const child = parent[key]
@@ -70,6 +79,13 @@ export function agentConfigSummary(parameters: unknown): AgentConfigSummary {
         instructionWords: instructions ? instructions.split(/\s+/).filter(Boolean).length : null,
         instructions,
         tools: count(agent.tools),
+        integrationKeys: Array.isArray(agent.tools)
+            ? [
+                  ...new Set(
+                      agent.tools.map(integrationKey).filter((key): key is string => Boolean(key)),
+                  ),
+              ]
+            : [],
         mcps: count(agent.mcps),
         skills: count(agent.skills),
         skillNames: Array.isArray(agent.skills)

--- a/web/packages/agenta-entity-ui/src/agent/index.ts
+++ b/web/packages/agenta-entity-ui/src/agent/index.ts
@@ -48,5 +48,10 @@ export {
 export {AgentIconPopover} from "./AgentIconPopover"
 export {AgentIdentity, type AgentIdentityProps, type AgentIdentitySize} from "./AgentIdentity"
 export {AGENT_CHIP_BOX, AGENT_CHIP_FALLBACK, AGENT_FOCUS_RING} from "./chrome"
-export {useAgentActions, useRenameAgent, type AgentActionTarget} from "./useAgentActions"
+export {
+    useAgentActions,
+    useRenameAgent,
+    useUpdateAgentDescription,
+    type AgentActionTarget,
+} from "./useAgentActions"
 export {AgentIntroCard, capabilityLabel} from "./AgentIntroCard"

--- a/web/packages/agenta-entity-ui/src/agent/index.ts
+++ b/web/packages/agenta-entity-ui/src/agent/index.ts
@@ -21,6 +21,11 @@ export {
 } from "./AgentPicker"
 export {NextTriggersSection, type NextTriggersSectionProps} from "./NextTriggersSection"
 export {
+    useUpcomingTriggers,
+    type UpcomingTrigger,
+    type UseUpcomingTriggersArgs,
+} from "./useUpcomingTriggers"
+export {
     AgentConfigSummaryCard,
     type AgentConfigSummaryCardProps,
     type AgentConfigSummaryCopy,

--- a/web/packages/agenta-entity-ui/src/agent/useAgentActions.tsx
+++ b/web/packages/agenta-entity-ui/src/agent/useAgentActions.tsx
@@ -34,6 +34,27 @@ export const useRenameAgent = () => {
     )
 }
 
+/** The description write on its own, for an inline editor. An empty string clears it. */
+export const useUpdateAgentDescription = () => {
+    const queryClient = useQueryClient()
+    const projectId = useAtomValue(projectIdAtom) ?? ""
+
+    return useCallback(
+        async (id: string, description: string): Promise<boolean> => {
+            try {
+                await updateWorkflow(projectId, {id, description})
+            } catch {
+                message.error("Couldn't update this agent's description")
+                return false
+            }
+            void queryClient.invalidateQueries({queryKey: ["workflows"]})
+            void queryClient.invalidateQueries({queryKey: ["agent-workflows"]})
+            return true
+        },
+        [projectId, queryClient],
+    )
+}
+
 /**
  * Everything you can do to an agent from its own surfaces, defined once — the same shape
  * [[useSessionActions]] gives sessions.

--- a/web/packages/agenta-entity-ui/src/agent/useUpcomingTriggers.ts
+++ b/web/packages/agenta-entity-ui/src/agent/useUpcomingTriggers.ts
@@ -1,0 +1,164 @@
+import {useCallback, useMemo} from "react"
+
+import {
+    describeCron,
+    nextCronRuns,
+    triggerBoundAgentId,
+    useTriggerSchedules,
+    useTriggerSubscriptions,
+} from "@agenta/entities/gatewayTrigger"
+import {nowTickAtom} from "@agenta/shared/state"
+import {dayjs} from "@agenta/shared/utils"
+import {useAtomValue} from "jotai"
+
+const LIST_SIZE = 5
+
+/** `formatDay` renders in UTC; a next-run time is only meaningful in the reader's own day. */
+const formatNextRun = (at: Date) => {
+    const run = dayjs(at)
+    const days = run.startOf("day").diff(dayjs().startOf("day"), "day")
+    if (days === 0) return run.format("HH:mm")
+    if (days === 1) return `tomorrow ${run.format("HH:mm")}`
+    if (days < 7) return run.format("ddd HH:mm")
+    return run.format("D MMM HH:mm")
+}
+
+/**
+ * What is going to fire, soonest first.
+ *
+ * Automations already appear on these pages as runs that HAPPENED. That answers "did it work",
+ * never "is anything coming" — a schedule that silently stopped firing looks identical to one
+ * that has simply not come round yet. Schedules project forward from their own cron expression;
+ * event subscriptions have no next time by nature, so they say what they are instead and sort
+ * after everything dated.
+ */
+export interface UpcomingTrigger {
+    id: string
+    /** A schedule or an event subscription — the mark a row leads with. */
+    kind: "schedule" | "event"
+    /** What it does. Falls back to the cadence in words, never to a cron expression. */
+    name: string
+    /** Which agent runs it, and how often. */
+    subtitle: string
+    detail: string
+    /** Absent for event subscriptions — they fire when the world does. */
+    at: Date | null
+    tooltip: string
+}
+
+export interface UseUpcomingTriggersArgs {
+    /** Scope to one agent's triggers. On that agent's own page the binding is the premise, so
+     * rows drop the agent name and lead with the cadence instead. */
+    agentId?: string
+    /** Agent display names by workflow id. The classified agents list is app state, so the app
+     * hands the names over; an unknown id reads as "Unassigned agent". */
+    agentNames?: ReadonlyMap<string, string>
+}
+
+/**
+ * The rows behind the Automations rail card — derived once here so the desktop panel and a host
+ * with its own card chrome list the same triggers in the same order.
+ */
+export const useUpcomingTriggers = ({agentId, agentNames}: UseUpcomingTriggersArgs = {}) => {
+    const {
+        schedules,
+        isLoading: schedulesLoading,
+        error: schedulesError,
+        refetch: refetchSchedules,
+    } = useTriggerSchedules()
+    const {
+        subscriptions,
+        isLoading: subscriptionsLoading,
+        error: subscriptionsError,
+        refetch: refetchSubscriptions,
+    } = useTriggerSubscriptions()
+    // The shared minute clock: a projected next-run time that never re-computes freezes and ends
+    // up in the past.
+    const nowTick = useAtomValue(nowTickAtom)
+
+    const rows = useMemo<UpcomingTrigger[]>(() => {
+        const describeAgent = (references: unknown) => {
+            const boundId = triggerBoundAgentId(references as never)
+            return (boundId && agentNames?.get(boundId)) || "Unassigned agent"
+        }
+        const isInScope = (references: unknown) =>
+            !agentId || triggerBoundAgentId(references as never) === agentId
+
+        const scheduled = schedules
+            .filter(
+                (schedule) =>
+                    schedule.flags?.is_active !== false &&
+                    !schedule.deleted_at &&
+                    isInScope(schedule.data?.references),
+            )
+            .map((schedule, index): UpcomingTrigger => {
+                const expression = schedule.data?.schedule ?? ""
+                const [next] = nextCronRuns(expression, 1)
+                const cadence = describeCron(expression)
+                const agent = describeAgent(schedule.data?.references)
+                return {
+                    id: schedule.id ?? `schedule-${index}`,
+                    kind: "schedule",
+                    // An unnamed schedule reads as its cadence, never as "5 * * * *".
+                    name: schedule.name || cadence,
+                    // Scoped to one agent, an unnamed schedule's title already IS the cadence.
+                    subtitle: agentId
+                        ? schedule.name
+                            ? cadence
+                            : ""
+                        : schedule.name
+                          ? `${agent} · ${cadence}`
+                          : agent,
+                    detail: next ? formatNextRun(next) : "—",
+                    at: next ?? null,
+                    tooltip: cadence,
+                }
+            })
+
+        const evented = subscriptions
+            .filter(
+                (subscription) =>
+                    subscription.flags?.is_active !== false &&
+                    isInScope(subscription.data?.references),
+            )
+            .map((subscription, index): UpcomingTrigger => {
+                const eventKey = subscription.data?.event_key ?? ""
+                const agent = describeAgent(subscription.data?.references)
+                return {
+                    id: subscription.id ?? `subscription-${index}`,
+                    kind: "event",
+                    name: subscription.name || eventKey || "Event automation",
+                    subtitle: agentId
+                        ? subscription.name
+                            ? eventKey
+                            : ""
+                        : eventKey && subscription.name
+                          ? `${agent} · ${eventKey}`
+                          : agent,
+                    detail: "on event",
+                    at: null,
+                    tooltip: eventKey ? `Fires on ${eventKey}` : "Fires when its event arrives",
+                }
+            })
+
+        // Dated first and soonest-first; undated (event) triggers keep their own order after them.
+        return [...scheduled, ...evented]
+            .sort((a, b) => {
+                if (a.at && b.at) return a.at.getTime() - b.at.getTime()
+                if (a.at) return -1
+                if (b.at) return 1
+                return 0
+            })
+            .slice(0, LIST_SIZE)
+        // nowTick is a dep on purpose: it is what re-projects the next runs each minute.
+    }, [schedules, subscriptions, agentNames, agentId, nowTick])
+
+    const isLoading = schedulesLoading || subscriptionsLoading
+    const hasError = Boolean(schedulesError || subscriptionsError)
+    const retry = useCallback(() => {
+        if (schedulesError) void refetchSchedules()
+        if (subscriptionsError) void refetchSubscriptions()
+    }, [schedulesError, subscriptionsError, refetchSchedules, refetchSubscriptions])
+
+    return {rows, isLoading, hasError, retry}
+}

--- a/web/packages/agenta-entity-ui/tests/unit/agentConfigSummary.test.ts
+++ b/web/packages/agenta-entity-ui/tests/unit/agentConfigSummary.test.ts
@@ -24,6 +24,7 @@ describe("agentConfigSummary", () => {
             instructionWords: 10,
             instructions: "You are a friendly agent.\n\n- Greet the user warmly.",
             tools: 2,
+            integrationKeys: [],
             mcps: 0,
             skills: 0,
             skillNames: [],
@@ -71,6 +72,23 @@ describe("agentConfigSummary", () => {
         expect(prettifyKind("claude_code")).toBe("Claude code")
         expect(prettifyKind("some-future-kind")).toBe("Some future kind")
         expect(prettifyKind(null)).toBeNull()
+    })
+})
+
+describe("integrationKeys", () => {
+    it("names the integration behind each gateway connection, once", () => {
+        const summary = agentConfigSummary({
+            agent: {
+                tools: [
+                    {type: "gateway_connection", connection: {integration: "linear"}},
+                    {type: "gateway_connection", connection: {integration: "github"}},
+                    {type: "gateway_connection", connection: {integration: "linear"}},
+                    {name: "bash"},
+                ],
+            },
+        })
+        expect(summary.tools).toBe(4)
+        expect(summary.integrationKeys).toEqual(["linear", "github"])
     })
 })
 

--- a/web/packages/agenta-sessions-ui/src/useInlineRename.ts
+++ b/web/packages/agenta-sessions-ui/src/useInlineRename.ts
@@ -9,6 +9,8 @@ export interface InlineRenameOptions {
     onCommit: (name: string) => Promise<boolean>
     /** What a failed commit says. Defaults to the session wording this started as. */
     errorText?: string
+    /** Let a blank draft commit — for a field that can be cleared, like a description. */
+    allowEmpty?: boolean
 }
 
 export interface InlineRename {
@@ -35,6 +37,7 @@ export const useInlineRename = ({
     current,
     onCommit,
     errorText = "Couldn't rename this session",
+    allowEmpty = false,
 }: InlineRenameOptions): InlineRename => {
     const [renaming, setRenaming] = useState(false)
     const [draft, setDraft] = useState("")
@@ -56,9 +59,9 @@ export const useInlineRename = ({
         committedRef.current = true
         const name = draft.trim()
         setRenaming(false)
-        if (!name || name === (current ?? "")) return
+        if ((!name && !allowEmpty) || name === (current ?? "")) return
         if (!(await onCommit(name))) message.error(errorText)
-    }, [current, draft, errorText, onCommit])
+    }, [allowEmpty, current, draft, errorText, onCommit])
 
     return {renaming, draft, setDraft, start, commit, cancel}
 }

--- a/web/packages/agenta-ui/src/list-table/ListTable.tsx
+++ b/web/packages/agenta-ui/src/list-table/ListTable.tsx
@@ -31,6 +31,9 @@ const SKELETON_WIDTHS = ["w-4/5", "w-3/5", "w-2/3", "w-1/2", "w-3/4"]
  */
 const STICKY = {height: "h-9", groupTop: "top-9"} as const
 
+/** With no visible header, a stuck group heading sits at the scroller's own top. */
+const groupTop = (hideHeader: boolean) => (hideHeader ? "top-0" : STICKY.groupTop)
+
 /**
  * The list frame every table-shaped screen in this app shares: a header row, optional group
  * headings that collapse, and rows that open.
@@ -58,6 +61,7 @@ export const ListTable = <Row,>({
     onToggleGroup,
     empty,
     stickyHeader = false,
+    hideHeader = false,
     density = "default",
     className,
 }: ListTableProps<Row>) => {
@@ -80,21 +84,27 @@ export const ListTable = <Row,>({
             <div style={{minWidth}}>
                 <div
                     role="row"
+                    // The sr-only header carries none of the visual classes: `sticky`/`h-9`
+                    // would win over its `absolute` and leave a 36px blank strip.
                     className={cn(
-                        // No horizontal inset, here or on the rows or the group headings: every
-                        // one of them reads from the table's own edge, which is the line the page
-                        // title and the toolbar above already keep. Dropping it from ALL of them
-                        // together is what matters — the header's content box has to stay
-                        // identical to a row's, or their grid tracks resolve differently and
-                        // every column but the first drifts off its cells.
-                        "grid gap-3 border-0 border-b border-solid border-border/40 text-[13px] font-medium text-muted-foreground",
-                        // Opaque, or the rows read straight through it as they pass under. A
-                        // stated height rather than padding, so the group headings below can be
-                        // stuck directly beneath it without measuring anything — and the margin
-                        // goes, or a 4px slot of rows would show through the gap.
-                        stickyHeader
-                            ? `sticky top-0 z-20 ${STICKY.height} items-center bg-background`
-                            : "mb-1 py-2",
+                        hideHeader
+                            ? "sr-only"
+                            : [
+                                  // No horizontal inset, here or on the rows or the group headings: every
+                                  // one of them reads from the table's own edge, which is the line the page
+                                  // title and the toolbar above already keep. Dropping it from ALL of them
+                                  // together is what matters — the header's content box has to stay
+                                  // identical to a row's, or their grid tracks resolve differently and
+                                  // every column but the first drifts off its cells.
+                                  "grid gap-3 border-0 border-b border-solid border-border/40 text-[13px] font-medium text-muted-foreground",
+                                  // Opaque, or the rows read straight through it as they pass under. A
+                                  // stated height rather than padding, so the group headings below can be
+                                  // stuck directly beneath it without measuring anything — and the margin
+                                  // goes, or a 4px slot of rows would show through the gap.
+                                  stickyHeader
+                                      ? `sticky top-0 z-20 ${STICKY.height} items-center bg-background`
+                                      : "mb-1 py-2",
+                              ],
                     )}
                     style={{gridTemplateColumns: grid}}
                 >
@@ -175,7 +185,7 @@ export const ListTable = <Row,>({
                                             // Stuck directly under the column header, so a long
                                             // run still says which group you are reading.
                                             stickyHeader &&
-                                                `sticky ${STICKY.groupTop} z-10 bg-background`,
+                                                `sticky ${groupTop(hideHeader)} z-10 bg-background`,
                                             FOCUS_RING,
                                         )}
                                     >
@@ -194,7 +204,7 @@ export const ListTable = <Row,>({
                                         className={cn(
                                             "m-0 pb-1.5 pt-3.5 text-[13px] text-muted-foreground",
                                             stickyHeader &&
-                                                `sticky ${STICKY.groupTop} z-10 bg-background`,
+                                                `sticky ${groupTop(hideHeader)} z-10 bg-background`,
                                         )}
                                     >
                                         {group.label}

--- a/web/packages/agenta-ui/src/list-table/types.ts
+++ b/web/packages/agenta-ui/src/list-table/types.ts
@@ -68,6 +68,12 @@ export interface ListTableProps<Row> {
      */
     stickyHeader?: boolean
     /**
+     * Keep the column names for screen readers only. For a list whose surroundings already say
+     * what the rows are — a tab named "Sessions" over a single-column list — where a header row
+     * only repeats the tab.
+     */
+    hideHeader?: boolean
+    /**
      * Row rhythm. `compact` is for the long lists — a sessions page runs to hundreds of rows, and
      * 13px above and below each one is a screen of air per hundred. The default suits a list a
      * reader scans once.


### PR DESCRIPTION
## Context
The mobile agent overview still rendered the desktop page's shared body: two stacked cards for sessions and automation runs with "View all" links, and a bordered rail of six config rows plus a usage card. The Agent Overview design reads differently: one activity list under tabs, the agent's own state as three quiet cards, and a header that names the agent and offers a chat. This PR rebuilds the `/m` overview to that design. Desktop rendering does not change.

Stacked on `feat/mobile-sessions-compact-rows`; this diff is only the top lane.

## Changes
The screen is now composed in `web/mobile` from the pieces the automation and sessions lanes already built, instead of the shared `AgentOverviewBody`.

**Header.** The roster's agent tile (icon picker behind it), the name renaming in place from the kebab or a double-click (no modal), the description under it, then Open chat and the shared kebab. Open chat is hidden below `sm`; the composer is the same verb.

**Activity.** Home's composer with voice, then `Sessions | Automations` tabs over one `ListTable` scoped to the agent. The tab pins the origin policy itself (`exclude-trigger` / `trigger-only`), so the sessions page's Type mode cannot leak in. The shared `FilterMenu` narrows it: Status, Last activity (default 7 days), Group by (None, Date, Status). The column header row is gone; the tab already names the rows.

**Rail.** Three soft cards this app owns: Configuration (Model, Instructions, Integrations as stacked logos, MCP servers only on a Claude harness, Skills), Files with "Open drive", Automations with a clock or bolt per trigger. The rail is hidden below `sm`. The Usage card is dropped, as designed.

**Packages, additive only.**
- `agentConfigSummary` gains `integrationKeys`, the integration behind each gateway-connection tool.
- `NextTriggersSection`'s row derivation moves into a `useUpcomingTriggers` hook; the desktop panel calls it and renders exactly what it did.
- `composioLogo` is exported from `@agenta/entities/workflow` for keys outside `PROVIDERS`.
- `ListTable` gains `hideHeader` (column names stay for screen readers; stuck group headings move to the top).

## Tests
- `agentConfigSummary.test.ts` covers `integrationKeys` (dedup, non-connection tools ignored).
- Mobile lint and `types:check`, entity-ui and agenta-ui `tsc` and eslint all pass.
- Checked on `/m` at 375px (light and dark) and at 1280px: tab switch, grouping, no-match and reset, inline rename, the filter dot.

## What to QA
- Open an agent from Agents on a phone. Header shows the tile, name and kebab; the rail cards are absent; the list under Sessions is flush with the tabs and has no header row.
- Kebab → Rename. The name turns into an input in place; Enter commits, Esc cancels.
- Switch to Automations. Rows lead with a bolt tile; the tile tints amber on a waiting run.
- Filter → Last activity → Today on an agent with older sessions. "No session matches these filters" with a Reset button; Reset restores the list.
- Widen past `sm`. Open chat appears in the header and the three cards sit under (or beside, from `lg`) the list; Configuration shows stacked integration logos and no MCP row on a non-Claude harness.
- Regression: the desktop agent overview and the mobile Sessions page look and filter as before.
