### PR TITLE
docs: add Agents API guide

### DIFF
--- a/docs/docs/reference/agents/00-overview.mdx
+++ b/docs/docs/reference/agents/00-overview.mdx
@@ -1,0 +1,63 @@
+---
+title: "Agents API overview"
+sidebar_label: "Overview"
+description: "Run configurable agents in managed sessions through the Agenta agent service."
+sidebar_position: 1
+---
+
+The Agenta agent service lets an application run AI agents through HTTP. Agenta manages the harness loop, sessions, tools, approvals, tracing, and sandbox lifecycle. Your application supplies a task and either references a stored agent or sends an inline configuration.
+
+## Start here
+
+- [Quickstart](/reference/agents/quickstart) runs a stored agent and consumes its stream.
+- [Agent configuration](/reference/agents/agent-configuration) defines every agent-template field.
+- [Invoke an agent](/reference/agents/invoke-an-agent) documents the complete HTTP contract.
+- [Chat message format](/reference/agents/chat-message-format) defines messages and stream frames.
+
+## Core concepts
+
+- **Agent:** instructions, model, harness, tools, skills, permissions, and sandbox configuration.
+- **Sandbox:** the local or Daytona environment where the agent works with commands and files.
+- **Session:** conversation state and a working directory that continue across turns.
+- **Interaction:** an approval, user-input request, or client tool call that pauses a turn.
+
+## Lifecycle
+
+1. Reference a stored workflow revision or send `data.parameters.agent` inline.
+2. Post messages to `/services/agent/v0/invoke`.
+3. Read one JSON response, SSE frames, or NDJSON frames.
+4. Answer any pending interaction.
+5. Reuse `session_id` for the next turn.
+
+The service supports Pi, Claude Code, and Codex harnesses; local and Daytona sandboxes; connected applications; code and client tools; referenced workflows; HTTP MCP servers; and reusable skills. Availability depends on the deployment and harness.
+
+## Minimal inline request
+
+```bash
+curl -N -X POST \
+  "$AGENTA_HOST/services/agent/v0/invoke?project_id=$PROJECT_ID" \
+  -H "Authorization: ApiKey $AGENTA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d '{
+    "data": {
+      "inputs": {"messages": [{"role": "user", "content": "Summarize this repository."}]},
+      "parameters": {
+        "agent": {
+          "instructions": {"agents_md": "Read before answering."},
+          "llm": {"provider": "openai", "model": "gpt-5.6-luna"},
+          "tools": [],
+          "harness": {"kind": "pi_core"},
+          "runner": {"kind": "sidecar", "permissions": {"default": "allow_reads"}},
+          "sandbox": {"kind": "local"}
+        }
+      }
+    }
+  }'
+```
+
+Harness built-ins are always active and are not listed in `tools`. Store the returned `x-ag-session-id` and reuse it to continue the session.
+
+## Data location
+
+Agenta Cloud has US and EU hosts. The chosen host determines where prompts, configurations, traces, files, and secrets are stored. Self-hosted deployments use the infrastructure you configure. See [Data regions](/administration/security/data-regions) and [Privacy](/administration/security/privacy).

--- a/docs/docs/reference/agents/01-agent-configuration.mdx
+++ b/docs/docs/reference/agents/01-agent-configuration.mdx
@@ -2,6 +2,7 @@
 title: "Agent configuration"
 sidebar_label: "Agent configuration"
 description: "Every field of the Agenta agent template: type, default, and allowed values."
+sidebar_position: 4
 ---
 
 An agent's configuration is one JSON object, the **agent template**. It is stored on a workflow revision and travels on the wire at `data.parameters.agent`.
@@ -20,38 +21,38 @@ For what these parts mean, see [Agents](/concepts/agents), [Instructions](/conce
 
 Every field is optional. An omitted field falls back to the default in the table.
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `instructions` | object | No | `{"agents_md": "<built-in text>"}` | The agent's instruction documents. |
-| `llm` | object | No | see [llm](#llm) | The model the agent runs on, its provider, and its credential connection. |
-| `tools` | array | No | `[]` | Tools the agent can call. Each entry is one of the tool objects below. |
-| `mcps` | array | No | `[]` | MCP servers exposed to the agent. |
-| `skills` | array | No | `[]` | Skills the agent ships with. |
-| `harness` | object | No | see [harness](#harness) | The coding agent to drive, plus its gating posture. |
-| `runner` | object | No | see [runner](#runner) | The engine that drives the harness loop, plus the tool execution policy. |
-| `sandbox` | object | No | see [sandbox](#sandbox) | Where the agent runs, plus its security boundary. |
+| Field          | Type   | Required | Default                            | Description                                                               |
+| -------------- | ------ | -------- | ---------------------------------- | ------------------------------------------------------------------------- |
+| `instructions` | object | No       | `{"agents_md": "<built-in text>"}` | The agent's instruction documents.                                        |
+| `llm`          | object | No       | see [llm](#llm)                    | The model the agent runs on, its provider, and its credential connection. |
+| `tools`        | array  | No       | `[]`                               | Tools the agent can call. Each entry is one of the tool objects below.    |
+| `mcps`         | array  | No       | `[]`                               | MCP servers exposed to the agent.                                         |
+| `skills`       | array  | No       | `[]`                               | Skills the agent ships with.                                              |
+| `harness`      | object | No       | see [harness](#harness)            | The coding agent to drive, plus its gating posture.                       |
+| `runner`       | object | No       | see [runner](#runner)              | The engine that drives the harness loop, plus the tool execution policy.  |
+| `sandbox`      | object | No       | see [sandbox](#sandbox)            | Where the agent runs, plus its security boundary.                         |
 
 ## instructions
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `agents_md` | string | No | A built-in hello-world text | The agent's system prompt. The harness receives it as `AGENTS.md`. |
+| Field       | Type   | Required | Default                     | Description                                                        |
+| ----------- | ------ | -------- | --------------------------- | ------------------------------------------------------------------ |
+| `agents_md` | string | No       | A built-in hello-world text | The agent's system prompt. The harness receives it as `AGENTS.md`. |
 
 ## llm
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `model` | string | No | `"gpt-5.6-luna"` | Model id in the provider's namespace. A `provider/model` string also parses, split on the first `/`. |
-| `provider` | string or `null` | No | `null` | Model provider. When unset, resolution infers it from a matching stored connection, and fails with an error when it cannot. |
-| `connection` | object or `null` | No | `null` | Where the model credential comes from. Omit for the project default. |
-| `extras` | object | No | `{}` | Model knobs passed through unchanged, for example `reasoning_effort`. |
+| Field        | Type             | Required | Default          | Description                                                                                                                 |
+| ------------ | ---------------- | -------- | ---------------- | --------------------------------------------------------------------------------------------------------------------------- |
+| `model`      | string           | No       | `"gpt-5.6-luna"` | Model id in the provider's namespace. A `provider/model` string also parses, split on the first `/`.                        |
+| `provider`   | string or `null` | No       | `null`           | Model provider. When unset, resolution infers it from a matching stored connection, and fails with an error when it cannot. |
+| `connection` | object or `null` | No       | `null`           | Where the model credential comes from. Omit for the project default.                                                        |
+| `extras`     | object           | No       | `{}`             | Model knobs passed through unchanged, for example `reasoning_effort`.                                                       |
 
 ### llm.connection
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `mode` | `"agenta"` \| `"self_managed"` | No | `"agenta"` | `agenta` uses a connection stored in the project. `self_managed` injects no credential; the harness signs itself in. |
-| `slug` | string or `null` | No | `null` | The named stored connection. Valid only with `mode: "agenta"`. Omit for the project default. Setting it with `self_managed` is rejected. |
+| Field  | Type                           | Required | Default    | Description                                                                                                                              |
+| ------ | ------------------------------ | -------- | ---------- | ---------------------------------------------------------------------------------------------------------------------------------------- |
+| `mode` | `"agenta"` \| `"self_managed"` | No       | `"agenta"` | `agenta` uses a connection stored in the project. `self_managed` injects no credential; the harness signs itself in.                     |
+| `slug` | string or `null`               | No       | `null`     | The named stored connection. Valid only with `mode: "agenta"`. Omit for the project default. Setting it with `self_managed` is rejected. |
 
 Which providers, deployments, and connection modes each harness can reach is served per harness:
 
@@ -63,195 +64,211 @@ In the shipped table, `pi_core` reaches `openai`, `anthropic`, `gemini`, `mistra
 
 ## tools
 
-Each entry in `tools` is an object discriminated by `type`. Every entry also accepts the two shared fields below.
+Each entry in `tools` is an object discriminated by `type`. Code, client, and reference tools accept the shared fields below. A `gateway_connection` entry uses its own policy instead.
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `permission` | `"allow"` \| `"ask"` \| `"deny"` \| `null` | No | `null` | Per-tool override of the runner policy. Absent means inherit `runner.permissions.default`. On a `builtin` entry it is not enforceable, so it is dropped and logged. |
-| `render` | object or `null` | No | `null` | Display hint carried through to the client. |
+| Field        | Type                                       | Required | Default | Description                                                                                |
+| ------------ | ------------------------------------------ | -------- | ------- | ------------------------------------------------------------------------------------------ |
+| `permission` | `"allow"` \| `"ask"` \| `"deny"` \| `null` | No       | `null`  | Per-tool override of the runner policy. Absent means inherit `runner.permissions.default`. |
+| `render`     | object or `null`                           | No       | `null`  | Display hint carried through to the client.                                                |
 
-### type: builtin
+### Harness built-ins
 
-A tool the harness itself provides. Present means the agent has it. Absent means it does not exist for that agent.
+Harness built-ins are always active. Do not list them in `tools`. Pi provides `read`, `bash`, `edit`, `write`, `grep`, `find`, and `ls`; the runner treats `read`, `grep`, `find`, and `ls` as read-only.
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `type` | `"builtin"` | Yes | | |
-| `name` | string | Yes | | Built-in tool name. |
+`{"type": "builtin", "name": "read"}` is a legacy shape. Agenta accepts and ignores it while older revisions migrate.
 
-Pi built-in names are `read`, `bash`, `edit`, `write`, `grep`, `find`, and `ls`. `read`, `grep`, `find`, and `ls` are read-only for permission purposes. Claude Code has no Pi built-ins; its Agenta tools are delivered over MCP.
+### type: gateway_connection
 
-### type: gateway
+One connected application, including all actions that its integration advertises.
 
-One action from a built-in integration.
+| Field                        | Type                                            | Required | Default      | Description                                |
+| ---------------------------- | ----------------------------------------------- | -------- | ------------ | ------------------------------------------ |
+| `type`                       | `"gateway_connection"`                          | Yes      |              |                                            |
+| `connection.provider`        | `"composio"`                                    | No       | `"composio"` | Integration gateway.                       |
+| `connection.integration`     | string                                          | Yes      |              | Connected app key, such as `github`.       |
+| `connection.slug`            | string                                          | Yes      |              | Existing project connection slug.          |
+| `policy.permissions.default` | `"inherit"` \| `"allow"` \| `"ask"` \| `"deny"` | No       | `"inherit"`  | Default for actions on this connection.    |
+| `policy.permissions.tools`   | object                                          | No       | `{}`         | Per-action decisions keyed by action name. |
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `type` | `"gateway"` | Yes | | |
-| `provider` | string | No | The built-in integrations gateway | Which gateway serves the action. |
-| `integration` | string | Yes | | The connected app. |
-| `action` | string | Yes | | The single action to expose. |
-| `connection` | string | Yes | | The account connection the action runs as. |
-| `name` | string or `null` | No | `null` | Model-visible tool name. |
+```json
+{
+  "type": "gateway_connection",
+  "connection": {
+    "provider": "composio",
+    "integration": "github",
+    "slug": "github-primary"
+  },
+  "policy": {
+    "permissions": {
+      "default": "allow",
+      "tools": { "DELETE_REPOSITORY": "deny" }
+    }
+  }
+}
+```
+
+The connection slug must already exist. A second `gateway_connection` for the same provider and integration is rejected.
+
+The per-action `gateway` shape is legacy. Preserve it when reading an older revision, but use `gateway_connection` for new configurations.
 
 ### type: code
 
 A script the runner executes.
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `type` | `"code"` | Yes | | |
-| `name` | string | Yes | | Model-visible tool name. |
-| `description` | string or `null` | No | `null` | What the tool does. |
-| `runtime` | `"python"` \| `"node"` | No | `"python"` | Script runtime. |
-| `script` | string | Yes | | The script source. |
-| `input_schema` | object | No | `{"type": "object", "properties": {}}` | JSON Schema for the tool's arguments. |
-| `secrets` | array of string | No | `[]` | Names of secrets injected into the script's environment. |
+| Field          | Type                   | Required | Default                                | Description                                              |
+| -------------- | ---------------------- | -------- | -------------------------------------- | -------------------------------------------------------- |
+| `type`         | `"code"`               | Yes      |                                        |                                                          |
+| `name`         | string                 | Yes      |                                        | Model-visible tool name.                                 |
+| `description`  | string or `null`       | No       | `null`                                 | What the tool does.                                      |
+| `runtime`      | `"python"` \| `"node"` | No       | `"python"`                             | Script runtime.                                          |
+| `script`       | string                 | Yes      |                                        | The script source.                                       |
+| `input_schema` | object                 | No       | `{"type": "object", "properties": {}}` | JSON Schema for the tool's arguments.                    |
+| `secrets`      | array of string        | No       | `[]`                                   | Names of secrets injected into the script's environment. |
 
 ### type: client
 
 A tool the calling client fulfils instead of the server.
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `type` | `"client"` | Yes | | |
-| `name` | string | Yes | | Model-visible tool name. |
-| `description` | string or `null` | No | `null` | What the tool does. |
-| `input_schema` | object | No | `{"type": "object", "properties": {}}` | JSON Schema for the tool's arguments. |
+| Field          | Type             | Required | Default                                | Description                           |
+| -------------- | ---------------- | -------- | -------------------------------------- | ------------------------------------- |
+| `type`         | `"client"`       | Yes      |                                        |                                       |
+| `name`         | string           | Yes      |                                        | Model-visible tool name.              |
+| `description`  | string or `null` | No       | `null`                                 | What the tool does.                   |
+| `input_schema` | object           | No       | `{"type": "object", "properties": {}}` | JSON Schema for the tool's arguments. |
 
 ### type: reference
 
 Another workflow exposed to the agent as a tool. Agenta runs it server-side.
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `type` | `"reference"` | Yes | | |
-| `ref_by` | `"variant"` \| `"environment"` | No | `"variant"` | Which axis selects the workflow revision. |
-| `slug` | string | Yes | | The workflow slug to reference. |
-| `environment` | string or `null` | No | `null` | Environment slug. Required when `ref_by` is `"environment"`, rejected otherwise. |
-| `version` | string or `null` | No | `null` | Pin a revision. Valid only with `ref_by: "variant"`. Absent means the latest revision. |
-| `name` | string or `null` | No | `null` | Model-visible tool name. Defaults to `slug`. |
-| `description` | string or `null` | No | `null` | What the tool does. |
-| `input_schema` | object | No | `{"type": "object", "properties": {}}` | JSON Schema for the tool's arguments. |
+| Field          | Type                           | Required | Default                                | Description                                                                            |
+| -------------- | ------------------------------ | -------- | -------------------------------------- | -------------------------------------------------------------------------------------- |
+| `type`         | `"reference"`                  | Yes      |                                        |                                                                                        |
+| `ref_by`       | `"variant"` \| `"environment"` | No       | `"variant"`                            | Which axis selects the workflow revision.                                              |
+| `slug`         | string                         | Yes      |                                        | The workflow slug to reference.                                                        |
+| `environment`  | string or `null`               | No       | `null`                                 | Environment slug. Required when `ref_by` is `"environment"`, rejected otherwise.       |
+| `version`      | string or `null`               | No       | `null`                                 | Pin a revision. Valid only with `ref_by: "variant"`. Absent means the latest revision. |
+| `name`         | string or `null`               | No       | `null`                                 | Legacy display-name copy. It does not change the model-visible name.                   |
+| `description`  | string or `null`               | No       | `null`                                 | What the tool does.                                                                    |
+| `input_schema` | object                         | No       | `{"type": "object", "properties": {}}` | JSON Schema for the tool's arguments.                                                  |
 
-### type: platform
+The workflow slug becomes the model-visible tool name.
 
-An existing Agenta endpoint exposed as a tool. The catalog owns its description, endpoint, and request schema.
+### Platform tools
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `type` | `"platform"` | Yes | | |
-| `op` | string | Yes | | Which catalog operation to expose, for example `discover_tools`. |
+Agenta can inject platform operations such as `discover_tools` into a run. Do not add a `type: "platform"` entry to the stored template. The commit API rejects authored platform tools.
 
 ## mcps
 
 Each entry declares one MCP server. See [Tools and integrations](/concepts/tools-and-integrations).
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `name` | string | Yes | | 1 to 128 characters matching `^[A-Za-z0-9._-]+$`. The name `agenta-tools` is reserved and rejected. |
-| `connection` | object | Yes | | How Agenta reaches the server. |
-| `policy` | object | No | `{"tools": {"mode": "all", "names": []}}` | Which of the server's tools are exposed, and at what permission. |
+| Field        | Type   | Required | Default                                   | Description                                                                                         |
+| ------------ | ------ | -------- | ----------------------------------------- | --------------------------------------------------------------------------------------------------- |
+| `name`       | string | Yes      |                                           | 1 to 128 characters matching `^[A-Za-z0-9._-]+$`. The name `agenta-tools` is reserved and rejected. |
+| `connection` | object | Yes      |                                           | How Agenta reaches the server.                                                                      |
+| `policy`     | object | No       | `{"tools": {"mode": "all", "names": []}}` | Which of the server's tools are exposed, and at what permission.                                    |
 
 ### mcps[].connection
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `type` | `"http"` | No | `"http"` | Transport. `http` is the only value. |
-| `url` | string | Yes | | The server URL. |
-| `headers` | object of string | No | `{}` | Static request headers. |
-| `credentials` | object | No | `{"type": "none"}` | Either `{"type": "none"}` or `{"type": "header_secret_refs", "headers": {"<header>": "<secret-name>"}}`. Secret values resolve at run time and are never stored in the configuration. |
+| Field         | Type             | Required | Default            | Description                                                                                                                                                                           |
+| ------------- | ---------------- | -------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `type`        | `"http"`         | No       | `"http"`           | Transport. `http` is the only value.                                                                                                                                                  |
+| `url`         | string           | Yes      |                    | The server URL.                                                                                                                                                                       |
+| `headers`     | object of string | No       | `{}`               | Static request headers.                                                                                                                                                               |
+| `credentials` | object           | No       | `{"type": "none"}` | Either `{"type": "none"}` or `{"type": "header_secret_refs", "headers": {"<header>": "<secret-name>"}}`. Secret values resolve at run time and are never stored in the configuration. |
 
 ### mcps[].policy
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `tools.mode` | `"all"` \| `"include"` | No | `"all"` | `all` exposes every tool the server advertises. `include` exposes only `tools.names`. |
-| `tools.names` | array of string | No | `[]` | Tool names to expose. Required with `include`, rejected with `all`. |
-| `permission` | `"allow"` \| `"ask"` \| `"deny"` \| `null` | No | `null` | Permission applied to this server's tools. Absent means inherit `runner.permissions.default`. |
+| Field         | Type                                       | Required | Default | Description                                                                                   |
+| ------------- | ------------------------------------------ | -------- | ------- | --------------------------------------------------------------------------------------------- |
+| `tools.mode`  | `"all"` \| `"include"`                     | No       | `"all"` | `all` exposes every tool the server advertises. `include` exposes only `tools.names`.         |
+| `tools.names` | array of string                            | No       | `[]`    | Tool names to expose. Required with `include`, rejected with `all`.                           |
+| `permission`  | `"allow"` \| `"ask"` \| `"deny"` \| `null` | No       | `null`  | Permission applied to this server's tools. Absent means inherit `runner.permissions.default`. |
 
 ## skills
 
 Each entry is an inline skill package. See [Skills](/concepts/skills).
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `name` | string | Yes | | 1 to 64 characters matching `^[a-z0-9]+(-[a-z0-9]+)*$`. |
-| `description` | string | Yes | | 1 to 1024 characters. This is what the agent sees at the start of a session, and what decides when the skill loads. |
-| `body` | string | Yes | | 1 to 50,000 characters. The skill's `SKILL.md` content after the frontmatter. |
-| `files` | array | No | `[]` | Files laid beside `SKILL.md`. |
-| `disable_model_invocation` | boolean | No | `false` | Hide the skill from the prompt so it loads only when invoked by name. |
-| `allow_executable_files` | boolean | No | `false` | Allow bundled files to be marked executable. Sandbox policy must also allow it. |
+| Field                      | Type    | Required | Default | Description                                                                                                         |
+| -------------------------- | ------- | -------- | ------- | ------------------------------------------------------------------------------------------------------------------- |
+| `name`                     | string  | Yes      |         | 1 to 64 characters matching `^[a-z0-9]+(-[a-z0-9]+)*$`.                                                             |
+| `description`              | string  | Yes      |         | 1 to 1024 characters. This is what the agent sees at the start of a session, and what decides when the skill loads. |
+| `body`                     | string  | Yes      |         | 1 to 50,000 characters. The skill's `SKILL.md` content after the frontmatter.                                       |
+| `files`                    | array   | No       | `[]`    | Files laid beside `SKILL.md`.                                                                                       |
+| `disable_model_invocation` | boolean | No       | `false` | Hide the skill from the prompt so it loads only when invoked by name.                                               |
+| `allow_executable_files`   | boolean | No       | `false` | Allow bundled files to be marked executable. Sandbox policy must also allow it.                                     |
 
 ### skills[].files[]
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `path` | string | Yes | | 1 to 255 characters. Relative POSIX path. A leading `/`, a backslash, a `..` segment, or a root-level `SKILL.md` is rejected. |
-| `content` | string | Yes | | UTF-8 text, up to 200,000 characters. |
-| `executable` | boolean | No | `false` | Mark the file executable when it is written out. |
+| Field        | Type    | Required | Default | Description                                                                                                                   |
+| ------------ | ------- | -------- | ------- | ----------------------------------------------------------------------------------------------------------------------------- |
+| `path`       | string  | Yes      |         | 1 to 255 characters. Relative POSIX path. A leading `/`, a backslash, a `..` segment, or a root-level `SKILL.md` is rejected. |
+| `content`    | string  | Yes      |         | UTF-8 text, up to 200,000 characters.                                                                                         |
+| `executable` | boolean | No       | `false` | Mark the file executable when it is written out.                                                                              |
 
 ## harness
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `kind` | `"pi_core"` \| `"claude"` \| `"codex"` | No | `"pi_core"` | Which coding agent to drive. |
-| `permissions` | object | No | see [harness.permissions](#harnesspermissions) | Tool-use gating posture, applied by harnesses that gate. |
-| `extras` | object | No | `{}` | Per-harness knobs passed through unchanged. For Pi, `system` replaces the base system prompt and `append_system` adds to it. Both are independent of `instructions.agents_md`. |
+| Field         | Type                                   | Required | Default                                        | Description                                                                                                                                                                    |
+| ------------- | -------------------------------------- | -------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `kind`        | `"pi_core"` \| `"claude"` \| `"codex"` | No       | `"pi_core"`                                    | Which coding agent to drive.                                                                                                                                                   |
+| `permissions` | object                                 | No       | see [harness.permissions](#harnesspermissions) | Tool-use gating posture, applied by harnesses that gate.                                                                                                                       |
+| `extras`      | object                                 | No       | `{}`                                           | Per-harness knobs passed through unchanged. For Pi, `system` replaces the base system prompt and `append_system` adds to it. Both are independent of `instructions.agents_md`. |
 
-| `kind` | Display name | Versioned slug |
-|---|---|---|
-| `pi_core` | Pi | `agenta:harness:pi_core:v0` |
-| `claude` | Claude Code | `agenta:harness:claude:v0` |
-| `codex` | Codex | `agenta:harness:codex:v0` |
+| `kind`    | Display name | Versioned slug              |
+| --------- | ------------ | --------------------------- |
+| `pi_core` | Pi           | `agenta:harness:pi_core:v0` |
+| `claude`  | Claude Code  | `agenta:harness:claude:v0`  |
+| `codex`   | Codex        | `agenta:harness:codex:v0`   |
 
 `pi_agenta` was an experimental Pi variant, removed in August 2026. A stored config that still carries the value runs as `pi_core`.
 
 ### harness.permissions
 
-Applied by harnesses that gate tool use. Claude Code renders it into `.claude/settings.json` in the session working directory. Pi does not gate and leaves it empty. Codex renders no per-tool rules of its own; its tool gating comes from [runner.permissions](#runnerpermissions) and the `permission` on each tool entry.
+Applied by harnesses that gate tool use. Claude Code renders it into `.claude/settings.json` in the session working directory. Pi uses these rules for its built-in tools. Codex renders no per-tool rules of its own; its tool gating comes from [runner.permissions](#runnerpermissions) and the `permission` on each tool entry.
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `default_mode` | `"default"` \| `"acceptEdits"` \| `"plan"` \| `"bypassPermissions"` \| `null` | No | `null` | The harness's own default permission mode. |
-| `allow` | array of string | No | `[]` | Per-tool rules approved without prompting. |
-| `ask` | array of string | No | `[]` | Per-tool rules that raise a prompt. |
-| `deny` | array of string | No | `[]` | Per-tool rules always rejected. |
+| Field          | Type                                                                          | Required | Default | Description                                |
+| -------------- | ----------------------------------------------------------------------------- | -------- | ------- | ------------------------------------------ |
+| `default_mode` | `"default"` \| `"acceptEdits"` \| `"plan"` \| `"bypassPermissions"` \| `null` | No       | `null`  | The harness's own default permission mode. |
+| `allow`        | array of string                                                               | No       | `[]`    | Per-tool rules approved without prompting. |
+| `ask`          | array of string                                                               | No       | `[]`    | Per-tool rules that raise a prompt.        |
+| `deny`         | array of string                                                               | No       | `[]`    | Per-tool rules always rejected.            |
 
 ## runner
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `kind` | `"sidecar"` | No | `"sidecar"` | The engine that drives the harness loop. `sidecar` is the only value. |
-| `permissions` | object | No | `{"default": "allow_reads"}` | The runner-enforced tool execution policy. |
-| `extras` | object | No | `{}` | Per-runner knobs passed through unchanged. |
+| Field         | Type        | Required | Default                      | Description                                                           |
+| ------------- | ----------- | -------- | ---------------------------- | --------------------------------------------------------------------- |
+| `kind`        | `"sidecar"` | No       | `"sidecar"`                  | The engine that drives the harness loop. `sidecar` is the only value. |
+| `permissions` | object      | No       | `{"default": "allow_reads"}` | The runner-enforced tool execution policy.                            |
+| `extras`      | object      | No       | `{}`                         | Per-runner knobs passed through unchanged.                            |
 
 ### runner.permissions
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `default` | `"allow"` \| `"ask"` \| `"deny"` \| `"allow_reads"` | No | `"allow_reads"` | `allow` runs every tool without asking. `ask` requires approval for every tool. `deny` refuses every tool. `allow_reads` runs read-hinted tools and asks for everything else. |
+| Field     | Type                                                | Required | Default         | Description                                                                                                                                                                   |
+| --------- | --------------------------------------------------- | -------- | --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `default` | `"allow"` \| `"ask"` \| `"deny"` \| `"allow_reads"` | No       | `"allow_reads"` | `allow` runs every tool without asking. `ask` requires approval for every tool. `deny` refuses every tool. `allow_reads` runs read-hinted tools and asks for everything else. |
 
 A value outside that set is rejected. A `permission` set on a single tool entry overrides this default for that tool.
 
 ## sandbox
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `kind` | `"local"` \| `"daytona"` | No | `"local"` | Where the agent runs. |
-| `permissions` | object or `null` | No | `null` | The declared security boundary. Unset means no declared boundary, and the field never reaches the wire. |
-| `extras` | object | No | `{}` | Per-sandbox knobs passed through unchanged, for example a Daytona snapshot. |
+| Field         | Type                     | Required | Default   | Description                                                                                             |
+| ------------- | ------------------------ | -------- | --------- | ------------------------------------------------------------------------------------------------------- |
+| `kind`        | `"local"` \| `"daytona"` | No       | `"local"` | Where the agent runs.                                                                                   |
+| `credentials` | array                    | No       | `[]`      | Project secret references bound to environment variables in the sandbox.                                |
+| `permissions` | object or `null`         | No       | `null`    | The declared security boundary. Unset means no declared boundary, and the field never reaches the wire. |
+| `extras`      | object                   | No       | `{}`      | Per-sandbox knobs passed through unchanged, for example a Daytona snapshot.                             |
+
+Each credential entry has `secret.slug` and a binding shaped as `{"type": "env", "name": "VARIABLE_NAME"}`.
 
 A deployment restricts which sandbox providers it accepts. A request naming a provider the deployment has not enabled is refused before the run starts.
 
 ### sandbox.permissions
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `network.mode` | `"on"` \| `"off"` \| `"allowlist"` | No | `"on"` | Outbound network policy. |
-| `network.allowlist` | array of string | No | `[]` | CIDR ranges allowed when `network.mode` is `"allowlist"`. |
-| `filesystem` | `"on"` \| `"readonly"` \| `"off"` \| `null` | No | `null` | Declared only. Not enforced. |
-| `enforcement` | `"strict"` \| `"best_effort"` | No | `"strict"` | `strict` fails the run when the boundary cannot be applied. |
+| Field               | Type                                        | Required | Default    | Description                                                 |
+| ------------------- | ------------------------------------------- | -------- | ---------- | ----------------------------------------------------------- |
+| `network.mode`      | `"on"` \| `"off"` \| `"allowlist"`          | No       | `"on"`     | Outbound network policy.                                    |
+| `network.allowlist` | array of string                             | No       | `[]`       | CIDR ranges allowed when `network.mode` is `"allowlist"`.   |
+| `filesystem`        | `"on"` \| `"readonly"` \| `"off"` \| `null` | No       | `null`     | Declared only. Not enforced.                                |
+| `enforcement`       | `"strict"` \| `"best_effort"`               | No       | `"strict"` | `strict` fails the run when the boundary cannot be applied. |
 
 ## The default template
 
@@ -266,32 +283,27 @@ This is the value a new agent starts with. It is also the `default` on the agent
     "provider": "openai",
     "model": "gpt-5.6-luna"
   },
-  "tools": [
-    {"type": "builtin", "name": "read"},
-    {"type": "builtin", "name": "bash"},
-    {"type": "builtin", "name": "edit"},
-    {"type": "builtin", "name": "write"}
-  ],
+  "tools": [],
   "mcps": [],
-  "harness": {"kind": "pi_core"},
-  "runner": {"kind": "sidecar", "permissions": {"default": "allow_reads"}},
-  "sandbox": {"kind": "local"}
+  "harness": { "kind": "pi_core" },
+  "runner": { "kind": "sidecar", "permissions": { "default": "allow_reads" } },
+  "sandbox": { "kind": "local" }
 }
 ```
 
-An empty `tools` array grants no built-ins at all. The four entries above are what a new agent ships with.
+An empty `tools` array adds no configured tools. The harness built-ins remain active.
 
 ## Rejected shapes
 
 The parser returns HTTP `400` instead of falling back to a default when:
 
-| Sent | Error | Use instead |
-|---|---|---|
-| A flat `model` key on the template | Pre-migration flat key | `llm.model` |
-| A flat `agents_md` key on the template | Pre-migration flat key | `instructions.agents_md` |
-| `harness` or `sandbox` as a bare string | Pre-migration flat selector | `{"kind": "..."}` |
-| A key other than `kind`, `permissions`, or `extras` inside `harness`, `runner`, or `sandbox` | Unknown selector key | One of the three allowed keys |
-| A `runner.permissions.default` outside the four modes | Invalid permission default | `allow`, `ask`, `deny`, or `allow_reads` |
+| Sent                                                                                         | Error                       | Use instead                              |
+| -------------------------------------------------------------------------------------------- | --------------------------- | ---------------------------------------- |
+| A flat `model` key on the template                                                           | Pre-migration flat key      | `llm.model`                              |
+| A flat `agents_md` key on the template                                                       | Pre-migration flat key      | `instructions.agents_md`                 |
+| `harness` or `sandbox` as a bare string                                                      | Pre-migration flat selector | `{"kind": "..."}`                        |
+| A key other than `kind`, `permissions`, or `extras` inside `harness`, `runner`, or `sandbox` | Unknown selector key        | One of the three allowed keys            |
+| A `runner.permissions.default` outside the four modes                                        | Invalid permission default  | `allow`, `ask`, `deny`, or `allow_reads` |
 
 ## Embed references
 
@@ -300,8 +312,8 @@ A `tools` or `skills` entry can be an `@ag.embed` reference instead of an inline
 ```json
 {
   "@ag.embed": {
-    "@ag.references": {"workflow": {"slug": "pdf-report"}},
-    "@ag.selector": {"path": "parameters.skill"}
+    "@ag.references": { "workflow": { "slug": "pdf-report" } },
+    "@ag.selector": { "path": "parameters.skill" }
   }
 }
 ```

--- a/docs/docs/reference/agents/02-invoke-an-agent.mdx
+++ b/docs/docs/reference/agents/02-invoke-an-agent.mdx
@@ -2,6 +2,7 @@
 title: "Invoke an agent"
 sidebar_label: "Invoke an agent"
 description: "The endpoint, request body, headers, and response shapes for running one agent turn over HTTP."
+sidebar_position: 5
 ---
 
 One turn of an agent conversation is one HTTP request.
@@ -12,37 +13,37 @@ POST {AGENTA_HOST}/services/agent/v0/invoke?project_id={PROJECT_ID}
 
 This is the endpoint the playground drives. It is served by the agent workflow service, not by the `/api` surface, so it is not in the [API Reference](/reference/api/category).
 
-| Deployment | Host |
-|---|---|
-| Cloud (US) | `https://us.cloud.agenta.ai` |
-| Cloud (EU) | `https://eu.cloud.agenta.ai` |
-| Self-hosted | your Agenta origin |
+| Deployment  | Host                         |
+| ----------- | ---------------------------- |
+| Cloud (US)  | `https://us.cloud.agenta.ai` |
+| Cloud (EU)  | `https://eu.cloud.agenta.ai` |
+| Self-hosted | your Agenta origin           |
 
 The same service also serves `POST /services/agent/v0/inspect`, which returns the agent workflow's resolved revision plus a ready-made invoke request.
 
 ## Authentication
 
-| Item | Value |
-|---|---|
-| Header | `Authorization: ApiKey {API_KEY}` |
-| Query parameter | `project_id={PROJECT_ID}` |
+| Item            | Value                             |
+| --------------- | --------------------------------- |
+| Header          | `Authorization: ApiKey {API_KEY}` |
+| Query parameter | `project_id={PROJECT_ID}`         |
 
 The project is not read from the request body. The service checks the credential against the Agenta API before the run starts, and returns `401` for an invalid credential or `403` when the key may not run services in that project.
 
 ## Request headers
 
-| Header | Values | Effect |
-|---|---|---|
-| `Content-Type` | `application/json` | Required. |
-| `Accept` | `application/json` | One JSON response after the turn finishes. |
-| | `text/event-stream` | Server-sent events. |
-| | `application/x-ndjson`, `application/jsonl` | Newline-delimited JSON. |
-| | absent or `*/*` | The server picks the format that matches what the handler produced. |
-| `x-ag-messages-format` | `vercel` | Messages and frames use the Vercel AI SDK representation. Absent means the Agenta representation. |
-| `x-ag-messages-transcript` | `last` \| `full` | `last` trims the output to the trailing unit of the turn. `full` returns the whole message list. |
-| `x-ag-session-control` | `force` | Take over or attach to an existing run on the session. |
-| `x-ag-workflow-embeds` | `resolve` | Resolve `@ag.embed` references in the configuration. |
-| `x-ag-session-id` | a session id | Used when the body carries no `session_id`. |
+| Header                     | Values                                      | Effect                                                                                            |
+| -------------------------- | ------------------------------------------- | ------------------------------------------------------------------------------------------------- |
+| `Content-Type`             | `application/json`                          | Required.                                                                                         |
+| `Accept`                   | `application/json`                          | One JSON response after the turn finishes.                                                        |
+|                            | `text/event-stream`                         | Server-sent events.                                                                               |
+|                            | `application/x-ndjson`, `application/jsonl` | Newline-delimited JSON.                                                                           |
+|                            | absent or `*/*`                             | The server picks the format that matches what the handler produced.                               |
+| `x-ag-messages-format`     | `vercel`                                    | Messages and frames use the Vercel AI SDK representation. Absent means the Agenta representation. |
+| `x-ag-messages-transcript` | `last` \| `full`                            | `last` trims the output to the trailing unit of the turn. `full` returns the whole message list.  |
+| `x-ag-session-control`     | `force`                                     | Take over or attach to an existing run on the session.                                            |
+| `x-ag-workflow-embeds`     | `resolve`                                   | Resolve `@ag.embed` references in the configuration.                                              |
+| `x-ag-session-id`          | a session id                                | Used when the body carries no `session_id`.                                                       |
 
 Each of the last four headers maps onto a field in the body's `flags` object (`stream`, `trim`, `force`, `resolve`). A value in `flags` wins over the header.
 
@@ -50,30 +51,33 @@ See [Chat message format](/reference/agents/chat-message-format) for what each r
 
 ## Request body
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `data` | object | No | `null` | The turn's payload. See below. |
-| `session_id` | string | No | server-minted | 1 to 128 characters matching `^[A-Za-z0-9._:-]{1,128}$`. When absent, the server mints one and returns it. An invalid value returns `400`. |
-| `references` | object | No | `null` | Points the run at a stored configuration. See [Running a stored agent](#running-a-stored-agent). |
-| `flags` | object | No | `null` | `stream`, `trim`, `force`, `resolve`. Each is a boolean. |
-| `tags` | object | No | `null` | Free-form key-value pairs recorded on the trace. |
-| `meta` | object | No | `null` | Free-form key-value pairs recorded on the trace. |
-| `links` | object | No | `null` | `{trace_id, span_id}` pairs linking this run to another trace. |
-| `selector` | object | No | `null` | `{key, path}`, used when resolving a reference through an environment. |
-| `secrets` | object | No | `null` | Per-request secret values. |
-| `credentials` | string | No | `null` | Credential passed to the run. |
-| `version` | string | No | `"2025.07.14"` | Request contract version. |
+| Field         | Type                                 | Required | Default        | Description                                                                                                                                |
+| ------------- | ------------------------------------ | -------- | -------------- | ------------------------------------------------------------------------------------------------------------------------------------------ |
+| `data`        | object                               | No       | `null`         | The turn's payload. See below.                                                                                                             |
+| `session_id`  | string                               | No       | server-minted  | 1 to 128 characters matching `^[A-Za-z0-9._:-]{1,128}$`. When absent, the server mints one and returns it. An invalid value returns `400`. |
+| `on_busy`     | `"reject"` \| `"queue"` \| `"steer"` | No       | `null`         | Policy when this session already has an active execution. Requires `session_id`.                                                           |
+| `references`  | object                               | No       | `null`         | Points the run at a stored configuration. See [Running a stored agent](#running-a-stored-agent).                                           |
+| `flags`       | object                               | No       | `null`         | `stream`, `trim`, `force`, `resolve`. Each is a boolean.                                                                                   |
+| `tags`        | object                               | No       | `null`         | Free-form key-value pairs recorded on the trace.                                                                                           |
+| `meta`        | object                               | No       | `null`         | Free-form key-value pairs recorded on the trace.                                                                                           |
+| `links`       | object                               | No       | `null`         | `{trace_id, span_id}` pairs linking this run to another trace.                                                                             |
+| `selector`    | object                               | No       | `null`         | `{key, path}`, used when resolving a reference through an environment.                                                                     |
+| `secrets`     | object                               | No       | `null`         | Per-request secret values.                                                                                                                 |
+| `credentials` | string                               | No       | `null`         | Credential passed to the run.                                                                                                              |
+| `version`     | string                               | No       | `"2025.07.14"` | Request contract version.                                                                                                                  |
+
+Use only letters, numbers, underscores, and hyphens when your client also calls the `/api/sessions` management endpoints. Their current session ID contract is narrower than the invoke contract.
 
 ### data
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `inputs` | object | No | `null` | For an agent, `{"messages": [...]}`. |
-| `parameters` | object | No | `null` | For an agent, `{"agent": {...}}`, the [agent template](/reference/agents/agent-configuration). |
-| `revision` | object | No | `null` | An inline workflow revision. |
-| `testcase` | object | No | `null` | A test case supplying the inputs. |
-| `trace` | object | No | `null` | Trace context for the run. |
-| `outputs` | any | No | `null` | Reserved. |
+| Field        | Type   | Required | Default | Description                                                                                    |
+| ------------ | ------ | -------- | ------- | ---------------------------------------------------------------------------------------------- |
+| `inputs`     | object | No       | `null`  | For an agent, `{"messages": [...]}`.                                                           |
+| `parameters` | object | No       | `null`  | For an agent, `{"agent": {...}}`, the [agent template](/reference/agents/agent-configuration). |
+| `revision`   | object | No       | `null`  | An inline workflow revision.                                                                   |
+| `testcase`   | object | No       | `null`  | A test case supplying the inputs.                                                              |
+| `trace`      | object | No       | `null`  | Trace context for the run.                                                                     |
+| `outputs`    | any    | No       | `null`  | Reserved.                                                                                      |
 
 ## Running an inline configuration
 
@@ -101,10 +105,7 @@ curl -N -X POST \
             "model": "gpt-5.6-luna",
             "connection": {"mode": "agenta"}
           },
-          "tools": [
-            {"type": "builtin", "name": "bash"},
-            {"type": "builtin", "name": "read"}
-          ],
+          "tools": [],
           "mcps": [],
           "skills": [],
           "harness": {"kind": "pi_core"},
@@ -124,11 +125,13 @@ Send `references` instead of `data.parameters`. Agenta fetches the stored revisi
 {
   "session_id": "019d952f-0000-0000-0000-000000000001",
   "references": {
-    "workflow_revision": {"id": "019d952f-0000-0000-0000-000000000002"}
+    "workflow_revision": { "id": "019d952f-0000-0000-0000-000000000002" }
   },
   "data": {
     "inputs": {
-      "messages": [{"role": "user", "content": "Draft this week's changelog."}]
+      "messages": [
+        { "role": "user", "content": "Draft this week's changelog." }
+      ]
     }
   }
 }
@@ -136,11 +139,11 @@ Send `references` instead of `data.parameters`. Agenta fetches the stored revisi
 
 A reference is `{id, slug, version}`; supply whichever you have. `id` is always sufficient.
 
-| Family | Keys |
-|---|---|
-| Workflow | `workflow`, `workflow_variant`, `workflow_revision` |
+| Family      | Keys                                                         |
+| ----------- | ------------------------------------------------------------ |
+| Workflow    | `workflow`, `workflow_variant`, `workflow_revision`          |
 | Application | `application`, `application_variant`, `application_revision` |
-| Evaluator | `evaluator`, `evaluator_variant`, `evaluator_revision` |
+| Evaluator   | `evaluator`, `evaluator_variant`, `evaluator_revision`       |
 | Environment | `environment`, `environment_variant`, `environment_revision` |
 
 Two rules govern this object:
@@ -155,16 +158,30 @@ With `Accept: application/json` the response arrives once, after the turn finish
 ```json
 {
   "version": "2025.07.14",
-  "status": {"code": 200, "message": "Success"},
+  "status": { "code": 200, "message": "Success" },
   "trace_id": "019d952f000000000000000000000003",
   "span_id": "019d952f00000004",
   "session_id": "019d952f-0000-0000-0000-000000000001",
   "data": {
     "outputs": {
       "messages": [
-        {"role": "tool", "content": "", "tool_call_id": "call_019d952f", "tool_name": "bash", "input": {"command": "ls"}},
-        {"role": "tool", "content": "AGENTS.md\nREADME.md\n", "tool_call_id": "call_019d952f", "is_error": false},
-        {"role": "assistant", "content": "Two files: AGENTS.md and README.md."}
+        {
+          "role": "tool",
+          "content": "",
+          "tool_call_id": "call_019d952f",
+          "tool_name": "bash",
+          "input": { "command": "ls" }
+        },
+        {
+          "role": "tool",
+          "content": "AGENTS.md\nREADME.md\n",
+          "tool_call_id": "call_019d952f",
+          "is_error": false
+        },
+        {
+          "role": "assistant",
+          "content": "Two files: AGENTS.md and README.md."
+        }
       ],
       "stop_reason": "end_turn"
     }
@@ -172,19 +189,19 @@ With `Accept: application/json` the response arrives once, after the turn finish
 }
 ```
 
-| Field | Type | Description |
-|---|---|---|
-| `version` | string | Response contract version. |
-| `status.code` | integer | Repeated as the HTTP status code. |
-| `status.message` | string | Status text. |
-| `status.type` | string or `null` | Error type, when the run failed. |
-| `status.stacktrace` | string, array of string, or `null` | Present on some failures. |
-| `trace_id` | string or `null` | The run's trace. |
-| `span_id` | string or `null` | The run's span. |
-| `session_id` | string or `null` | The resolved session id. |
-| `data.outputs.messages` | array | The folded turn. |
-| `data.outputs.stop_reason` | string | Present when the turn produced one. `paused` means the run stopped for an approval. |
-| `data.outputs.pending_interaction` | object | Present when `stop_reason` is `paused`. Carries the interaction `id`, `kind`, `payload`, and the derived `tool` name. |
+| Field                              | Type                               | Description                                                                                                           |
+| ---------------------------------- | ---------------------------------- | --------------------------------------------------------------------------------------------------------------------- |
+| `version`                          | string                             | Response contract version.                                                                                            |
+| `status.code`                      | integer                            | Repeated as the HTTP status code.                                                                                     |
+| `status.message`                   | string                             | Status text.                                                                                                          |
+| `status.type`                      | string or `null`                   | Error type, when the run failed.                                                                                      |
+| `status.stacktrace`                | string, array of string, or `null` | Present on some failures.                                                                                             |
+| `trace_id`                         | string or `null`                   | The run's trace.                                                                                                      |
+| `span_id`                          | string or `null`                   | The run's span.                                                                                                       |
+| `session_id`                       | string or `null`                   | The resolved session id.                                                                                              |
+| `data.outputs.messages`            | array                              | The folded turn.                                                                                                      |
+| `data.outputs.stop_reason`         | string                             | Present when the turn produced one. `paused` means the run stopped for an approval.                                   |
+| `data.outputs.pending_interaction` | object                             | Present when `stop_reason` is `paused`. Carries the interaction `id`, `kind`, `payload`, and the derived `tool` name. |
 
 Fields that are `null` are omitted from the response.
 
@@ -196,15 +213,15 @@ Add `x-ag-messages-format: vercel` for the Vercel AI SDK UI Message Stream, whic
 
 ## Response headers
 
-| Header | Present when |
-|---|---|
-| `x-ag-version` | always |
-| `x-ag-trace-id` | the run produced a trace |
-| `x-ag-span-id` | the run produced a span |
-| `x-ag-session-id` | a session is in play |
-| `baggage` | a session is in play, carrying `ag.session.id=<id>` |
-| `traceparent` | both a trace id and a span id exist |
-| `x-vercel-ai-ui-message-stream: v1`, `x-ag-messages-format: vercel`, `x-ag-messages-version: v1` | the Vercel UI Message Stream was requested |
+| Header                                                                                           | Present when                                        |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------- |
+| `x-ag-version`                                                                                   | always                                              |
+| `x-ag-trace-id`                                                                                  | the run produced a trace                            |
+| `x-ag-span-id`                                                                                   | the run produced a span                             |
+| `x-ag-session-id`                                                                                | a session is in play                                |
+| `baggage`                                                                                        | a session is in play, carrying `ag.session.id=<id>` |
+| `traceparent`                                                                                    | both a trace id and a span id exist                 |
+| `x-vercel-ai-ui-message-stream: v1`, `x-ag-messages-format: vercel`, `x-ag-messages-version: v1` | the Vercel UI Message Stream was requested          |
 
 ## Continuing a conversation
 
@@ -222,21 +239,21 @@ POST /api/sessions/interactions/{interaction_id}/respond
 
 with a body of `{"answer": {...}}`. Related endpoints:
 
-| Method and path | Purpose |
-|---|---|
-| `POST /api/sessions/interactions/query` | List interactions for a session. |
-| `GET /api/sessions/interactions/{interaction_id}` | Fetch one interaction. |
-| `POST /api/sessions/interactions/{interaction_id}/respond` | Answer a pending interaction. |
-| `POST /api/sessions/interactions/transition` | Move an interaction to another status. |
+| Method and path                                            | Purpose                                |
+| ---------------------------------------------------------- | -------------------------------------- |
+| `POST /api/sessions/interactions/query`                    | List interactions for a session.       |
+| `GET /api/sessions/interactions/{interaction_id}`          | Fetch one interaction.                 |
+| `POST /api/sessions/interactions/{interaction_id}/respond` | Answer a pending interaction.          |
+| `POST /api/sessions/interactions/transition`               | Move an interaction to another status. |
 
 An interaction has a `kind` of `user_approval`, `user_input`, or `client_tool`, and a `status` of `pending`, `responded`, `resolved`, or `cancelled`. Responding to an interaction that is not `pending` returns `409`.
 
 ## Errors
 
-| Status | Cause |
-|---|---|
-| `400` | The agent template uses a pre-migration flat key, or an unknown key inside `harness`, `runner`, or `sandbox`. The `runner.permissions.default` value is not one of the four modes. The `session_id` does not match the allowed pattern. Two execution reference families are populated at once. |
-| `401` | Missing or invalid credential. |
-| `403` | The credential may not run services in that project. |
-| `406` | `Accept` asked for a stream but the handler produced a batch response, or the reverse. |
-| `4xx` / `5xx` in `status.code` | A run that fails returns a JSON body with the real status, even when a stream was requested. |
+| Status                         | Cause                                                                                                                                                                                                                                                                                           |
+| ------------------------------ | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `400`                          | The agent template uses a pre-migration flat key, or an unknown key inside `harness`, `runner`, or `sandbox`. The `runner.permissions.default` value is not one of the four modes. The `session_id` does not match the allowed pattern. Two execution reference families are populated at once. |
+| `401`                          | Missing or invalid credential.                                                                                                                                                                                                                                                                  |
+| `403`                          | The credential may not run services in that project.                                                                                                                                                                                                                                            |
+| `406`                          | `Accept` asked for a stream but the handler produced a batch response, or the reverse.                                                                                                                                                                                                          |
+| `4xx` / `5xx` in `status.code` | A run that fails returns a JSON body with the real status, even when a stream was requested.                                                                                                                                                                                                    |

--- a/docs/docs/reference/agents/03-batch-runs.mdx
+++ b/docs/docs/reference/agents/03-batch-runs.mdx
@@ -2,6 +2,7 @@
 title: "Batch runs"
 sidebar_label: "Batch runs"
 description: "Agenta has no batch endpoint for agents. Run an agent over many inputs by sending one invoke request per input."
+sidebar_position: 6
 ---
 
 Agenta has no endpoint that accepts a list of inputs and runs an agent once per entry. `POST /services/agent/v0/invoke` takes one message list and produces one turn. The request body carries `data.inputs` as a single object, not an array.
@@ -77,34 +78,33 @@ Field-by-field detail for the request and the response is in [Invoke an agent](/
 
 The `session_id` decides whether the runs share a conversation.
 
-| Pattern | Effect |
-|---|---|
-| A fresh `session_id` per input | Each input runs as its own conversation, with its own session folder. Nothing carries over. |
-| One `session_id` for every input, with the growing history in `data.inputs.messages` | One conversation. Each turn sees the previous ones, and the session folder persists across them. |
-| No `session_id` | The server mints one per request and returns it in `session_id` and in the `x-ag-session-id` response header. |
-
+| Pattern                                                                              | Effect                                                                                                        |
+| ------------------------------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------- |
+| A fresh `session_id` per input                                                       | Each input runs as its own conversation, with its own session folder. Nothing carries over.                   |
+| One `session_id` for every input, with the growing history in `data.inputs.messages` | One conversation. Each turn sees the previous ones, and the session folder persists across them.              |
+| No `session_id`                                                                      | The server mints one per request and returns it in `session_id` and in the `x-ag-session-id` response header. |
 
 ## What the client handles
 
-| Concern | Behaviour |
-|---|---|
-| Concurrency | There is no server-side queue for these requests. Bound the fan-out in your own code. |
-| Failures | Each run reports its own outcome in `status.code`. A failed run does not affect the others. |
-| Approvals | Under a `runner.permissions.default` of `ask` or `allow_reads`, a run can stop with `stop_reason: "paused"` and wait for an approval. A default of `allow` never pauses. See [Permissions](/concepts/permissions). |
-| Ordering | Concurrent runs complete in any order. |
+| Concern     | Behaviour                                                                                                                                                                                                          |
+| ----------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| Concurrency | There is no server-side queue for these requests. Bound the fan-out in your own code.                                                                                                                              |
+| Failures    | Each run reports its own outcome in `status.code`. A failed run does not affect the others.                                                                                                                        |
+| Approvals   | Under a `runner.permissions.default` of `ask` or `allow_reads`, a run can stop with `stop_reason: "paused"` and wait for an approval. A default of `allow` never pauses. See [Permissions](/concepts/permissions). |
+| Ordering    | Concurrent runs complete in any order.                                                                                                                                                                             |
 
 ## Evaluation runs
 
 Agenta has a separate fan-out engine for evaluations. An evaluation run takes a testset revision and a workflow revision, and invokes the workflow once per testcase, bounded by `data.concurrency.batch_size`. It stores each result and computes metrics.
 
-| Method and path | Purpose |
-|---|---|
-| `POST /api/simple/testsets/` | Create a testset and its rows in one call. The response carries the `revision_id`. |
-| `POST /api/simple/evaluations/` | Create an evaluation run. This also starts it. |
-| `GET /api/simple/evaluations/{evaluation_id}` | Read the run's status at `data.status`. |
-| `POST /api/simple/evaluations/{evaluation_id}/stop` | Stop a running evaluation. |
-| `POST /api/evaluations/results/query` | Read the per-testcase results. |
-| `POST /api/evaluations/metrics/query` | Read the run's metrics. |
+| Method and path                                     | Purpose                                                                            |
+| --------------------------------------------------- | ---------------------------------------------------------------------------------- |
+| `POST /api/simple/testsets/`                        | Create a testset and its rows in one call. The response carries the `revision_id`. |
+| `POST /api/simple/evaluations/`                     | Create an evaluation run. This also starts it.                                     |
+| `GET /api/simple/evaluations/{evaluation_id}`       | Read the run's status at `data.status`.                                            |
+| `POST /api/simple/evaluations/{evaluation_id}/stop` | Stop a running evaluation.                                                         |
+| `POST /api/evaluations/results/query`               | Read the per-testcase results.                                                     |
+| `POST /api/evaluations/metrics/query`               | Read the run's metrics.                                                            |
 
 The run's steps are revision ids:
 
@@ -113,10 +113,10 @@ The run's steps are revision ids:
   "evaluation": {
     "name": "Ticket summaries",
     "data": {
-      "testset_steps": {"019d952f-0000-0000-0000-000000000010": "auto"},
-      "application_steps": {"019d952f-0000-0000-0000-000000000002": "auto"},
+      "testset_steps": { "019d952f-0000-0000-0000-000000000010": "auto" },
+      "application_steps": { "019d952f-0000-0000-0000-000000000002": "auto" },
       "repeats": 1,
-      "concurrency": {"batch_size": 10, "max_retries": 0, "retry_delay": 0}
+      "concurrency": { "batch_size": 10, "max_retries": 0, "retry_delay": 0 }
     }
   }
 }

--- a/docs/docs/reference/agents/04-chat-message-format.mdx
+++ b/docs/docs/reference/agents/04-chat-message-format.mdx
@@ -2,14 +2,15 @@
 title: "Chat message format"
 sidebar_label: "Chat message format"
 description: "Message roles, content blocks, tool calls, and the streamed frame types an Agenta agent produces."
+sidebar_position: 7
 ---
 
 Messages travel in and out of an agent at `data.inputs.messages` and `data.outputs.messages`. Two wire representations exist, selected by a request header.
 
-| `x-ag-messages-format` | Representation |
-|---|---|
-| absent, or `agenta` | Agenta messages and Agenta event frames |
-| `vercel` | Vercel AI SDK `UIMessage` objects and UI Message Stream parts |
+| `x-ag-messages-format` | Representation                                                |
+| ---------------------- | ------------------------------------------------------------- |
+| absent, or `agenta`    | Agenta messages and Agenta event frames                       |
+| `vercel`               | Vercel AI SDK `UIMessage` objects and UI Message Stream parts |
 
 The header is independent of `Accept`, which selects the transport. See [Invoke an agent](/reference/agents/invoke-an-agent).
 
@@ -17,13 +18,13 @@ The header is independent of `Accept`, which selects the transport. See [Invoke 
 
 The agent runtime reads two fields from every inbound message.
 
-| Field | Type | Required | Default | Description |
-|---|---|---|---|---|
-| `role` | string | Yes | | The message author. A message with no `role` is dropped. |
-| `content` | string or array of content blocks | No | `""` | The message body. A bare string is treated as a single `text` block. |
+| Field     | Type                              | Required | Default | Description                                                          |
+| --------- | --------------------------------- | -------- | ------- | -------------------------------------------------------------------- |
+| `role`    | string                            | Yes      |         | The message author. A message with no `role` is dropped.             |
+| `content` | string or array of content blocks | No       | `""`    | The message body. A bare string is treated as a single `text` block. |
 
 ```json
-{"role": "user", "content": "Summarize the release notes for 0.106."}
+{ "role": "user", "content": "Summarize the release notes for 0.106." }
 ```
 
 The agent workflow's inputs schema declares `messages` as the `messages` catalog type, whose roles are `developer`, `system`, `user`, `assistant`, `tool`, and `function`. Fetch it with `GET /api/workflows/catalog/types/messages`.
@@ -32,18 +33,18 @@ The agent workflow's inputs schema declares `messages` as the `messages` catalog
 
 A content block is an object with a `type` and the fields that type uses. Keys are camelCase on the wire; the parser also accepts the snake_case spellings.
 
-| Field | Type | Used by | Description |
-|---|---|---|---|
-| `type` | string | all | `text`, `image`, `resource`, `tool_call`, or `tool_result`. |
-| `text` | string | `text` | The text. |
-| `data` | string | `image`, `resource` | Base64 payload. |
-| `mimeType` | string | `image`, `resource` | Media type. |
-| `uri` | string | `image`, `resource` | Location of the payload. |
-| `toolCallId` | string | `tool_call`, `tool_result` | Ties a call to its result. |
-| `toolName` | string | `tool_call`, `tool_result` | The tool's name. |
-| `input` | any | `tool_call` | The arguments the model produced. |
-| `output` | any | `tool_result` | What the tool returned. |
-| `isError` | boolean | `tool_result` | `true` when the call failed. |
+| Field        | Type    | Used by                    | Description                                                 |
+| ------------ | ------- | -------------------------- | ----------------------------------------------------------- |
+| `type`       | string  | all                        | `text`, `image`, `resource`, `tool_call`, or `tool_result`. |
+| `text`       | string  | `text`                     | The text.                                                   |
+| `data`       | string  | `image`, `resource`        | Base64 payload.                                             |
+| `mimeType`   | string  | `image`, `resource`        | Media type.                                                 |
+| `uri`        | string  | `image`, `resource`        | Location of the payload.                                    |
+| `toolCallId` | string  | `tool_call`, `tool_result` | Ties a call to its result.                                  |
+| `toolName`   | string  | `tool_call`, `tool_result` | The tool's name.                                            |
+| `input`      | any     | `tool_call`                | The arguments the model produced.                           |
+| `output`     | any     | `tool_result`              | What the tool returned.                                     |
+| `isError`    | boolean | `tool_result`              | `true` when the call failed.                                |
 
 Unset fields are omitted rather than sent as `null`.
 
@@ -51,8 +52,19 @@ Unset fields are omitted rather than sent as `null`.
 {
   "role": "assistant",
   "content": [
-    {"type": "tool_call", "toolCallId": "call_019d952f", "toolName": "bash", "input": {"command": "ls docs"}},
-    {"type": "tool_result", "toolCallId": "call_019d952f", "toolName": "bash", "output": "index.md\n", "isError": false}
+    {
+      "type": "tool_call",
+      "toolCallId": "call_019d952f",
+      "toolName": "bash",
+      "input": { "command": "ls docs" }
+    },
+    {
+      "type": "tool_result",
+      "toolCallId": "call_019d952f",
+      "toolName": "bash",
+      "output": "index.md\n",
+      "isError": false
+    }
   ]
 }
 ```
@@ -63,33 +75,33 @@ A `tool_call` block followed by its `tool_result` block is how a completed tool 
 
 With `x-ag-messages-format: vercel`, inbound messages are Vercel AI SDK `UIMessage` objects.
 
-| Field | Type | Required | Description |
-|---|---|---|---|
-| `id` | string | No | Message id. When the last message is an `assistant` message, its `id` is reused as the reply's `messageId`. |
-| `role` | string | Yes | The message author. |
-| `parts` | array | Yes | The message body. A message with no `parts` falls back to the Agenta message shape. |
+| Field   | Type   | Required | Description                                                                                                 |
+| ------- | ------ | -------- | ----------------------------------------------------------------------------------------------------------- |
+| `id`    | string | No       | Message id. When the last message is an `assistant` message, its `id` is reused as the reply's `messageId`. |
+| `role`  | string | Yes      | The message author.                                                                                         |
+| `parts` | array  | Yes      | The message body. A message with no `parts` falls back to the Agenta message shape.                         |
 
 Agenta converts each part to content blocks before the run:
 
-| Inbound part `type` | Becomes |
-|---|---|
-| `text` | a `text` block |
-| `file` | an `image` block when `mediaType` starts with `image/`, otherwise a `resource` block |
-| `tool-<name>`, `dynamic-tool` | a `tool_call` block, plus a `tool_result` block when the part carries `output`, `errorText`, or an approval decision |
-| `tool-output-available`, `tool-output-error`, `tool-output-denied` | a `tool_result` block |
-| `tool-approval-response` | a `tool_result` block keyed by `toolCallId` |
-| `tool-approval-request` | dropped |
-| anything else, including `reasoning` | dropped |
+| Inbound part `type`                                                | Becomes                                                                                                              |
+| ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------------------- |
+| `text`                                                             | a `text` block                                                                                                       |
+| `file`                                                             | an `image` block when `mediaType` starts with `image/`, otherwise a `resource` block                                 |
+| `tool-<name>`, `dynamic-tool`                                      | a `tool_call` block, plus a `tool_result` block when the part carries `output`, `errorText`, or an approval decision |
+| `tool-output-available`, `tool-output-error`, `tool-output-denied` | a `tool_result` block                                                                                                |
+| `tool-approval-response`                                           | a `tool_result` block keyed by `toolCallId`                                                                          |
+| `tool-approval-request`                                            | dropped                                                                                                              |
+| anything else, including `reasoning`                               | dropped                                                                                                              |
 
 A tool part's `state` decides the result block:
 
-| `state` | Result |
-|---|---|
-| `output-available` | `tool_result` with `output`, `isError: false` |
-| `output-error` | `tool_result` with `output` set to `errorText`, `isError: true` |
-| `output-denied` | `tool_result` carrying `{"approved": false}` |
+| `state`              | Result                                                                              |
+| -------------------- | ----------------------------------------------------------------------------------- |
+| `output-available`   | `tool_result` with `output`, `isError: false`                                       |
+| `output-error`       | `tool_result` with `output` set to `errorText`, `isError: true`                     |
+| `output-denied`      | `tool_result` carrying `{"approved": false}`                                        |
 | `approval-responded` | `tool_result` carrying `{"approved": <bool>}` and, when present, `interactionToken` |
-| `input-available` | `tool_call` only, no result |
+| `input-available`    | `tool_call` only, no result                                                         |
 
 ## Answering an approval
 
@@ -103,9 +115,12 @@ When a tool call needs approval the turn ends and the stream carries a `tool-app
     {
       "type": "tool-bash",
       "toolCallId": "call_019d952f",
-      "input": {"command": "rm -rf build"},
+      "input": { "command": "rm -rf build" },
       "state": "approval-responded",
-      "approval": {"id": "019d952f-0000-0000-0000-000000000001", "approved": true}
+      "approval": {
+        "id": "019d952f-0000-0000-0000-000000000001",
+        "approved": true
+      }
     }
   ]
 }
@@ -117,11 +132,11 @@ Replay every part of the paused message, not only the gated one. The runner fing
 
 With `Accept: application/json`, `data.outputs.messages` is the folded turn. Every message carries a `role` and a `content`.
 
-| Produced by | Shape |
-|---|---|
-| assistant text | `{"role": "assistant", "content": "<text>"}` |
-| a tool call | `{"role": "tool", "content": "", "tool_call_id": "...", "tool_name": "...", "input": {...}}` |
-| a tool result | `{"role": "tool", "content": "<output>", "tool_call_id": "...", "is_error": false}` |
+| Produced by    | Shape                                                                                        |
+| -------------- | -------------------------------------------------------------------------------------------- |
+| assistant text | `{"role": "assistant", "content": "<text>"}`                                                 |
+| a tool call    | `{"role": "tool", "content": "", "tool_call_id": "...", "tool_name": "...", "input": {...}}` |
+| a tool result  | `{"role": "tool", "content": "<output>", "tool_call_id": "...", "is_error": false}`          |
 
 Reasoning, usage, file, and data events produce no message.
 
@@ -142,25 +157,25 @@ data: {"type": "done", "data": {"stopReason": "end_turn"}}
 
 With `Accept: application/x-ndjson` or `application/jsonl` the same objects are newline-delimited JSON instead.
 
-| `type` | `data` fields |
-|---|---|
-| `message` | `text` |
-| `message_start` | `id` |
-| `message_delta` | `id`, `delta` |
-| `message_end` | `id` |
-| `thought` | `text` |
-| `thought_start` | `id` |
-| `thought_delta` | `id`, `delta` |
-| `thought_end` | `id` |
-| `tool_call` | `id`, `name`, `input`, `rawInput`, `render` |
-| `tool_result` | `id`, `output`, `data`, `isError`, `denied`, `render` |
-| `interaction_request` | `id`, `kind` (`user_approval`, `user_input`, or `client_tool`), `payload` |
-| `interaction_response` | `id`, `kind`, `payload` |
-| `data` | `name`, `data`, `transient` |
-| `file` | `url`, `mediaType` |
-| `usage` | `input`, `output`, `total`, `cost` |
-| `error` | `message` |
-| `done` | `stopReason`, `traceId` |
+| `type`                 | `data` fields                                                             |
+| ---------------------- | ------------------------------------------------------------------------- |
+| `message`              | `text`                                                                    |
+| `message_start`        | `id`                                                                      |
+| `message_delta`        | `id`, `delta`                                                             |
+| `message_end`          | `id`                                                                      |
+| `thought`              | `text`                                                                    |
+| `thought_start`        | `id`                                                                      |
+| `thought_delta`        | `id`, `delta`                                                             |
+| `thought_end`          | `id`                                                                      |
+| `tool_call`            | `id`, `name`, `input`, `rawInput`, `render`                               |
+| `tool_result`          | `id`, `output`, `data`, `isError`, `denied`, `render`                     |
+| `interaction_request`  | `id`, `kind` (`user_approval`, `user_input`, or `client_tool`), `payload` |
+| `interaction_response` | `id`, `kind`, `payload`                                                   |
+| `data`                 | `name`, `data`, `transient`                                               |
+| `file`                 | `url`, `mediaType`                                                        |
+| `usage`                | `input`, `output`, `total`, `cost`                                        |
+| `error`                | `message`                                                                 |
+| `done`                 | `stopReason`, `traceId`                                                   |
 
 A `tool_call` may be emitted more than once for the same `id`. The first carries the announcement; a later one refreshes the arguments. Prefer `rawInput` over `input` when it is present.
 
@@ -170,27 +185,27 @@ With `Accept: text/event-stream` and `x-ag-messages-format: vercel`, each frame 
 
 Response headers on this path include `x-vercel-ai-ui-message-stream: v1`, `x-ag-messages-format: vercel`, and `x-ag-messages-version: v1`.
 
-| Part `type` | Fields |
-|---|---|
-| `start` | `messageId`, `messageMetadata.sessionId` |
-| `start-step` | |
-| `text-start` / `text-delta` / `text-end` | `id`; `delta` on the delta part |
-| `reasoning-start` / `reasoning-delta` / `reasoning-end` | `id`; `delta` on the delta part |
-| `tool-input-start` | `toolCallId`, `toolName` |
-| `tool-input-available` | `toolCallId`, `toolName`, `input` |
-| `tool-output-available` | `toolCallId`, `output` |
-| `tool-output-error` | `toolCallId`, `errorText` |
-| `tool-output-denied` | `toolCallId` |
-| `tool-approval-request` | `approvalId`, `toolCallId` |
-| `data-input-request` | `id`, `data` |
-| `data-interaction` | `id`, `data.kind`, `data.payload` |
-| `data-render` | `data.toolCallId`, `data.render` |
-| `data-committed-revision` | `data.variantId`, `data.revisionId`, `data.version` |
-| `data-<name>` | `data`, `transient` |
-| `file` | `url`, `mediaType` |
-| `error` | `errorText` |
-| `finish-step` | |
-| `finish` | `finishReason`, `messageMetadata.usage`, `messageMetadata.traceId` |
+| Part `type`                                             | Fields                                                             |
+| ------------------------------------------------------- | ------------------------------------------------------------------ |
+| `start`                                                 | `messageId`, `messageMetadata.sessionId`                           |
+| `start-step`                                            |                                                                    |
+| `text-start` / `text-delta` / `text-end`                | `id`; `delta` on the delta part                                    |
+| `reasoning-start` / `reasoning-delta` / `reasoning-end` | `id`; `delta` on the delta part                                    |
+| `tool-input-start`                                      | `toolCallId`, `toolName`                                           |
+| `tool-input-available`                                  | `toolCallId`, `toolName`, `input`                                  |
+| `tool-output-available`                                 | `toolCallId`, `output`                                             |
+| `tool-output-error`                                     | `toolCallId`, `errorText`                                          |
+| `tool-output-denied`                                    | `toolCallId`                                                       |
+| `tool-approval-request`                                 | `approvalId`, `toolCallId`                                         |
+| `data-input-request`                                    | `id`, `data`                                                       |
+| `data-interaction`                                      | `id`, `data.kind`, `data.payload`                                  |
+| `data-render`                                           | `data.toolCallId`, `data.render`                                   |
+| `data-committed-revision`                               | `data.variantId`, `data.revisionId`, `data.version`                |
+| `data-<name>`                                           | `data`, `transient`                                                |
+| `file`                                                  | `url`, `mediaType`                                                 |
+| `error`                                                 | `errorText`                                                        |
+| `finish-step`                                           |                                                                    |
+| `finish`                                                | `finishReason`, `messageMetadata.usage`, `messageMetadata.traceId` |
 
 A turn always opens with `start` and `start-step` and always closes with `finish-step` and `finish`, including when it fails. A turn that produced no content parts emits an `error` part reading `The agent produced no output.`
 
@@ -200,13 +215,13 @@ A turn always opens with `start` and `start-step` and always closes with `finish
 
 The model's raw stop reason is mapped onto the AI SDK set before it is sent.
 
-| Raw stop reason | `finishReason` |
-|---|---|
-| `end_turn`, `stop_sequence` | `stop` |
-| `max_tokens` | `length` |
-| `tool_use`, `tool_calls`, `function_call` | `tool-calls` |
-| `refusal`, `content_filter` | `content-filter` |
-| `paused`, `cancelled` | `other` |
-| anything else | `unknown` |
+| Raw stop reason                           | `finishReason`   |
+| ----------------------------------------- | ---------------- |
+| `end_turn`, `stop_sequence`               | `stop`           |
+| `max_tokens`                              | `length`         |
+| `tool_use`, `tool_calls`, `function_call` | `tool-calls`     |
+| `refusal`, `content_filter`               | `content-filter` |
+| `paused`, `cancelled`                     | `other`          |
+| anything else                             | `unknown`        |
 
 Values already in the set (`stop`, `length`, `content-filter`, `tool-calls`, `error`, `other`, `unknown`) pass through unchanged. A turn paused for an approval finishes with `other`.

--- a/docs/docs/reference/agents/05-quickstart.mdx
+++ b/docs/docs/reference/agents/05-quickstart.mdx
@@ -37,7 +37,7 @@ Send another request with the same revision and `session_id`:
 
 ```json
 {
-  "session_id": "customer-case-4821",
+  "session_id": "<x-ag-session-id from the first response>",
   "references": {
     "workflow_revision": { "id": "019d952f-0000-0000-0000-000000000002" }
   },
@@ -51,6 +51,6 @@ Send another request with the same revision and `session_id`:
 }
 ```
 
-If a turn pauses, answer its pending interaction before continuing. See [Tools and interactions](/reference/agents/tools-and-interactions). To stop an active execution, call `POST /api/sessions/{session_id}/stop`.
+If a turn pauses, answer its pending interaction before continuing. See [Tools and interactions](/reference/agents/tools-and-interactions). To stop an active execution, call `POST /api/sessions/{session_id}/cancel`.
 
 For a non-streaming result, send `Accept: application/json`. For Vercel AI SDK frames, also send `x-ag-messages-format: vercel`.

--- a/docs/docs/reference/agents/05-quickstart.mdx
+++ b/docs/docs/reference/agents/05-quickstart.mdx
@@ -1,0 +1,56 @@
+---
+title: "Quickstart"
+sidebar_label: "Quickstart"
+description: "Invoke a stored Agenta agent, read its stream, and continue its session."
+sidebar_position: 2
+---
+
+This example invokes an existing workflow revision. You need an Agenta host, project ID, API key, and workflow revision ID.
+
+```bash
+export AGENTA_HOST="https://eu.cloud.agenta.ai"
+export PROJECT_ID="019d952f-0000-0000-0000-000000000000"
+export REVISION_ID="019d952f-0000-0000-0000-000000000002"
+```
+
+## Run the first turn
+
+```bash
+curl -iN -X POST \
+  "$AGENTA_HOST/services/agent/v0/invoke?project_id=$PROJECT_ID" \
+  -H "Authorization: ApiKey $AGENTA_API_KEY" \
+  -H "Content-Type: application/json" \
+  -H "Accept: text/event-stream" \
+  -d "{
+    \"references\": {\"workflow_revision\": {\"id\": \"$REVISION_ID\"}},
+    \"data\": {\"inputs\": {\"messages\": [
+      {\"role\": \"user\", \"content\": \"Inspect the project and explain how to run its tests.\"}
+    ]}}
+  }"
+```
+
+Response headers include `x-ag-session-id`, `x-ag-trace-id`, and `x-ag-span-id`. Each SSE `data:` line contains an Agenta event. A final `done` event reports the stop reason.
+
+## Continue the session
+
+Send another request with the same revision and `session_id`:
+
+```json
+{
+  "session_id": "customer-case-4821",
+  "references": {
+    "workflow_revision": { "id": "019d952f-0000-0000-0000-000000000002" }
+  },
+  "data": {
+    "inputs": {
+      "messages": [
+        { "role": "user", "content": "Now run the smallest relevant test." }
+      ]
+    }
+  }
+}
+```
+
+If a turn pauses, answer its pending interaction before continuing. See [Tools and interactions](/reference/agents/tools-and-interactions). To stop an active execution, call `POST /api/sessions/{session_id}/stop`.
+
+For a non-streaming result, send `Accept: application/json`. For Vercel AI SDK frames, also send `x-ag-messages-format: vercel`.

--- a/docs/docs/reference/agents/06-architecture.mdx
+++ b/docs/docs/reference/agents/06-architecture.mdx
@@ -1,0 +1,37 @@
+---
+title: "Architecture"
+sidebar_label: "Architecture"
+description: "How an API request moves through the Agenta agent service, runner, harness, and sandbox."
+sidebar_position: 3
+---
+
+An agent request crosses five boundaries:
+
+1. **Your application** sends messages, a project ID, and a stored or inline configuration.
+2. **Agent workflow service** authenticates the request, resolves references and embeds, and normalizes the response.
+3. **Runner** manages the loop, sessions, tools, permissions, interactions, and events.
+4. **Harness** drives Pi, Claude Code, or Codex and calls the selected model.
+5. **Sandbox** provides the working directory, command runtime, skill files, and output files.
+
+## Stored and inline agents
+
+A stored run sends `references.workflow_revision`. Agenta fetches the versioned workflow configuration. An inline run sends `data.parameters.agent`; this takes precedence when both are present.
+
+## State boundaries
+
+| State                            | Lifetime                               |
+| -------------------------------- | -------------------------------------- |
+| Request messages                 | one invocation unless replayed         |
+| Session records and interactions | session                                |
+| Warm harness process             | while retained by the runner           |
+| Session working directory        | session according to sandbox retention |
+| Workflow configuration           | versioned project resource             |
+| Traces                           | observability retention policy         |
+
+A session can continue after a harness restart because Agenta reconstructs model-visible history from durable records. Warm continuation is faster and preserves in-process state, but clients must not depend on it.
+
+## Deployment responsibility
+
+Agenta Cloud operates the agent service, runner, and configured sandbox providers. In self-hosted deployments, you operate those components and choose which model connections, sandbox providers, and network policies are available.
+
+See [Sessions and turns](/reference/agents/sessions-and-turns) for continuation behavior and [Sandboxes and security](/reference/agents/sandboxes-and-security) for trust boundaries.

--- a/docs/docs/reference/agents/07-sessions-and-turns.mdx
+++ b/docs/docs/reference/agents/07-sessions-and-turns.mdx
@@ -1,0 +1,50 @@
+---
+title: "Sessions and turns"
+sidebar_label: "Sessions and turns"
+description: "Start, continue, steer, pause, resume, and stop agent sessions."
+sidebar_position: 8
+---
+
+A call to `/services/agent/v0/invoke` creates one turn. Reusing `session_id` associates later turns with the same conversation and sandbox workspace.
+
+## Start and continue
+
+Omit `session_id` to let Agenta mint one, then store `x-ag-session-id` from the response. Supply that ID on every later invoke request.
+
+When your client also uses `/api/sessions`, keep IDs to letters, numbers, underscores, and hyphens. The management API currently accepts a narrower character set than invoke.
+
+## Busy sessions
+
+Set top-level `on_busy` when a session already has an active execution:
+
+| Value    | Behavior                                                            |
+| -------- | ------------------------------------------------------------------- |
+| `reject` | Refuse overlapping work.                                            |
+| `queue`  | Queue the new input behind the active execution.                    |
+| `steer`  | Deliver input to the active execution when the harness supports it. |
+
+`on_busy` requires an explicit `session_id`.
+
+## Pause and resume
+
+A gated tool, user-input request, or client tool can end a turn with `stop_reason: "paused"`. The response contains `pending_interaction`; durable session APIs also expose the interaction.
+
+Resume in either way:
+
+- replay the paused assistant message with the answer represented as a tool result; or
+- call `POST /api/sessions/interactions/{interaction_id}/respond`.
+
+Do not answer the same interaction twice. A non-pending interaction returns `409`.
+
+## Stop an execution
+
+```http
+POST /api/sessions/{session_id}/stop
+Authorization: ApiKey {API_KEY}
+```
+
+Stopping targets active work; it does not delete the session. Use the session management endpoints to archive or delete stored session data.
+
+## Warm state and replay
+
+Agenta may retain a warm harness and sandbox between turns. If that state is unavailable, it reconstructs conversation history from session records. Applications should persist the session ID and complete message or interaction data, not assume a specific process remains alive.

--- a/docs/docs/reference/agents/07-sessions-and-turns.mdx
+++ b/docs/docs/reference/agents/07-sessions-and-turns.mdx
@@ -39,7 +39,7 @@ Do not answer the same interaction twice. A non-pending interaction returns `409
 ## Stop an execution
 
 ```http
-POST /api/sessions/{session_id}/stop
+POST /api/sessions/{session_id}/cancel
 Authorization: ApiKey {API_KEY}
 ```
 

--- a/docs/docs/reference/agents/08-session-events.mdx
+++ b/docs/docs/reference/agents/08-session-events.mdx
@@ -1,0 +1,37 @@
+---
+title: "Session events"
+sidebar_label: "Session events"
+description: "Read per-turn streams and reconnect to durable agent session events."
+sidebar_position: 9
+---
+
+Agenta exposes two event scopes: the invoke response for one turn and a durable event reader for a session.
+
+## Turn stream
+
+Request `Accept: text/event-stream` from `/services/agent/v0/invoke`. Agenta-format frames are SSE `data:` lines containing objects such as `message_delta`, `tool_call`, `tool_result`, `interaction_request`, `usage`, `error`, and `done`.
+
+Use `Accept: application/x-ndjson` for the same objects as newline-delimited JSON. Use `x-ag-messages-format: vercel` for Vercel UI Message Stream parts. See [Chat message format](/reference/agents/chat-message-format#streamed-frames-agenta-format).
+
+## Durable session reader
+
+```http
+GET /api/sessions/{session_id}/events?after=0
+Accept: text/event-stream
+Authorization: ApiKey {API_KEY}
+```
+
+Each event has a monotonically increasing cursor. Persist the latest cursor and reconnect with `after=<cursor>` to replay later durable events before joining the live stream.
+
+Durable records cover execution lifecycle, completed messages and tools, and interaction lifecycle. Incremental token deltas are turn-stream data and should not be treated as durable records.
+
+## Reconnection
+
+- Ignore SSE comment lines; they are heartbeats.
+- Process duplicate events idempotently.
+- Advance the stored cursor only after processing an event.
+- Reconnect with the last committed cursor after a network failure.
+
+The durable reader can return `404` when the deployment has not enabled the shared session reader and `403` when the caller lacks session-view access.
+
+`/api/sessions/streams/watch` is a low-frequency change-notification stream for list refreshes. It is not a replayable transcript of an agent turn.

--- a/docs/docs/reference/agents/09-manage-sessions.mdx
+++ b/docs/docs/reference/agents/09-manage-sessions.mdx
@@ -13,7 +13,7 @@ Session management endpoints use the authenticated project from the request cont
 | Inspect a session    | `GET /api/sessions/{session_id}`                          |
 | Rename               | `PATCH /api/sessions/{session_id}`                        |
 | Archive or unarchive | `POST /api/sessions/{session_id}/archive` or `/unarchive` |
-| Stop active work     | `POST /api/sessions/{session_id}/stop`                    |
+| Cancel active work   | `POST /api/sessions/{session_id}/cancel`                  |
 | Delete               | `DELETE /api/sessions/{session_id}`                       |
 | Query interactions   | `POST /api/sessions/interactions/query`                   |
 | Query queued inputs  | `POST /api/sessions/inputs/query`                         |

--- a/docs/docs/reference/agents/09-manage-sessions.mdx
+++ b/docs/docs/reference/agents/09-manage-sessions.mdx
@@ -1,0 +1,47 @@
+---
+title: "Manage sessions"
+sidebar_label: "Manage sessions"
+description: "Query, inspect, rename, archive, stop, and delete agent sessions."
+sidebar_position: 10
+---
+
+Session management endpoints use the authenticated project from the request context.
+
+| Operation            | Endpoint                                                  |
+| -------------------- | --------------------------------------------------------- |
+| Query sessions       | `POST /api/sessions/query`                                |
+| Inspect a session    | `GET /api/sessions/{session_id}`                          |
+| Rename               | `PATCH /api/sessions/{session_id}`                        |
+| Archive or unarchive | `POST /api/sessions/{session_id}/archive` or `/unarchive` |
+| Stop active work     | `POST /api/sessions/{session_id}/stop`                    |
+| Delete               | `DELETE /api/sessions/{session_id}`                       |
+| Query interactions   | `POST /api/sessions/interactions/query`                   |
+| Query queued inputs  | `POST /api/sessions/inputs/query`                         |
+
+## Query
+
+```json
+{
+  "session": {
+    "search": "support",
+    "origins": ["manual"]
+  },
+  "include_ended": true,
+  "include_archived": false,
+  "include_total": true,
+  "expand": ["last_message", "trigger"],
+  "windowing": { "limit": 50, "order": "descending" }
+}
+```
+
+Use `include_ended` to include inactive sessions and `archived_only` to restrict results to archived sessions. Cursor fields in `windowing` paginate without relying on mutable offsets.
+
+## Archive versus delete
+
+Archiving hides a session from ordinary queries but preserves its records. Unarchiving restores it. Deletion is destructive and should only follow explicit user intent.
+
+Stopping and archiving are independent: stop active execution before destructive cleanup when necessary.
+
+## Interactions
+
+Interactions have kinds `user_approval`, `user_input`, or `client_tool`, and statuses `pending`, `responded`, `resolved`, or `cancelled`. Fetch the pending interaction before responding so the client can validate its current status and payload.

--- a/docs/docs/reference/agents/10-files-and-attachments.mdx
+++ b/docs/docs/reference/agents/10-files-and-attachments.mdx
@@ -1,0 +1,45 @@
+---
+title: "Files and attachments"
+sidebar_label: "Files and attachments"
+description: "Upload input files, attach them to a session, and consume files produced by an agent."
+sidebar_position: 11
+---
+
+Files enter an agent through session attachments and leave through file events or tool results. The sandbox working directory is separate from the attachment API.
+
+## Upload and reference
+
+Upload an attachment through the session attachment endpoint, then associate returned attachment IDs with a session:
+
+```json
+{
+  "session_id": "customer-case-4821",
+  "attachment_ids": ["019d952f-0000-0000-0000-000000000010"]
+}
+```
+
+The reference request accepts at most 100 attachment IDs. The API validates project access before exposing file content to a session.
+
+When sending messages, use image or resource blocks with a URI and MIME type, or the equivalent Vercel `file` part. See [Chat message format](/reference/agents/chat-message-format#content-blocks).
+
+## Generated files
+
+An agent can create files in its sandbox. A streamed `file` event carries:
+
+```json
+{
+  "type": "file",
+  "data": {
+    "url": "https://example.invalid/download/report.pdf",
+    "mediaType": "application/pdf"
+  }
+}
+```
+
+Treat returned URLs according to their expiry and authorization rules. Download files promptly when your application needs durable ownership.
+
+## Working-directory persistence
+
+Files written in the sandbox can persist between turns in the same session, depending on sandbox retention. They are not a substitute for application storage: a cold reconstruction can restore message history without guaranteeing an expired sandbox filesystem.
+
+Do not place credentials in uploaded files or message blocks. Use project secrets, connected applications, MCP secret references, or sandbox credential bindings.

--- a/docs/docs/reference/agents/11-tools-and-interactions.mdx
+++ b/docs/docs/reference/agents/11-tools-and-interactions.mdx
@@ -1,0 +1,62 @@
+---
+title: "Tools and interactions"
+sidebar_label: "Tools and interactions"
+description: "Configure agent tools, resolve permissions, and answer paused interactions."
+sidebar_position: 12
+---
+
+Agents can use harness built-ins, connected applications, code tools, client tools, referenced workflows, MCP tools, and platform tools injected by Agenta.
+
+## Tool types
+
+| Type                 | Execution location                          |
+| -------------------- | ------------------------------------------- |
+| Harness built-in     | Harness and sandbox; do not list in `tools` |
+| `gateway_connection` | Connected application through the gateway   |
+| `code`               | Runner-provided Python or Node runtime      |
+| `client`             | Your application                            |
+| `reference`          | Another Agenta workflow, server-side        |
+| MCP                  | Configured HTTP MCP server                  |
+
+A connected application is one `gateway_connection` entry for the whole integration. The older per-action `gateway` shape is legacy.
+
+## Client tools
+
+```json
+{
+  "type": "client",
+  "name": "lookup_account",
+  "description": "Find an account by email.",
+  "input_schema": {
+    "type": "object",
+    "properties": { "email": { "type": "string" } },
+    "required": ["email"]
+  },
+  "permission": "allow"
+}
+```
+
+When called, the turn pauses with a `client_tool` interaction. Post the result to `POST /api/sessions/interactions/{interaction_id}/respond`:
+
+```json
+{
+  "answer": {
+    "tool_call_id": "call_019d952f",
+    "outcome": "completed",
+    "output": { "account_id": "acct_4821", "name": "Example Company" }
+  }
+}
+```
+
+Use `outcome: "error"` and an error output when the client action fails.
+
+## Permission resolution
+
+1. A code, client, or reference tool's `permission` wins.
+2. A connected app uses `policy.permissions.tools[tool_key]`, then its connection default.
+3. `inherit` uses `runner.permissions.default`.
+4. `allow_reads` allows read-hinted tools and asks for the rest.
+
+The final result is `allow`, `ask`, or `deny`. `ask` creates a `user_approval` interaction; `deny` returns a tool error. Pi built-ins also use `harness.permissions` rules.
+
+After a disconnect, query interactions by session and answer only records still marked `pending`.

--- a/docs/docs/reference/agents/12-mcp-servers.mdx
+++ b/docs/docs/reference/agents/12-mcp-servers.mdx
@@ -1,0 +1,48 @@
+---
+title: "MCP servers"
+sidebar_label: "MCP servers"
+description: "Connect an agent to an HTTP MCP server with tool filters and secret-backed headers."
+sidebar_position: 13
+---
+
+Add MCP servers to `parameters.agent.mcps`. Each entry has a unique name, an HTTP connection, and an optional tool policy.
+
+```json
+{
+  "name": "internal-search",
+  "connection": {
+    "type": "http",
+    "url": "https://mcp.example.com/mcp",
+    "headers": { "X-Tenant": "acme" },
+    "credentials": {
+      "type": "header_secret_refs",
+      "headers": { "Authorization": "internal-mcp-token" }
+    }
+  },
+  "policy": {
+    "tools": { "mode": "include", "names": ["search_docs"] },
+    "permission": "allow"
+  }
+}
+```
+
+## Connection fields
+
+- `type` is `http`; local stdio servers are not part of this configuration surface.
+- `url` is required.
+- `headers` stores non-secret static values.
+- `header_secret_refs.headers` maps HTTP header names to project secret slugs. Secret values resolve at run time and are not stored in the template.
+
+## Tool policy
+
+`tools.mode: "all"` exposes every advertised tool and requires an empty names list. `tools.mode: "include"` exposes only `tools.names`. `permission` is `allow`, `ask`, `deny`, or `null`; `null` inherits the runner policy.
+
+The name must match `^[A-Za-z0-9._-]+$`, be no longer than 128 characters, and must not be `agenta-tools`, which is reserved.
+
+## Troubleshooting
+
+- A connection failure usually means DNS, TLS, network policy, or server availability.
+- An authorization failure means the referenced project secret is absent, expired, or mapped to the wrong header.
+- A missing tool can be excluded by `policy.tools`, absent from server discovery, or unsupported by the selected harness.
+
+See [Add an MCP server](/guides/add-an-mcp-server) for the configuration workflow.

--- a/docs/docs/reference/agents/13-subagents.mdx
+++ b/docs/docs/reference/agents/13-subagents.mdx
@@ -1,0 +1,49 @@
+---
+title: "Subagents and delegation"
+sidebar_label: "Subagents"
+description: "Expose another Agenta workflow to an agent as a reference tool."
+sidebar_position: 14
+---
+
+Agenta models delegation as a `reference` tool. The parent agent calls it like any other tool; Agenta invokes the referenced workflow server-side and returns its result.
+
+## Follow the latest variant revision
+
+```json
+{
+  "type": "reference",
+  "ref_by": "variant",
+  "slug": "release-reviewer",
+  "description": "Review release notes for omissions and risky claims.",
+  "input_schema": {
+    "type": "object",
+    "properties": { "draft": { "type": "string" } },
+    "required": ["draft"]
+  },
+  "permission": "allow"
+}
+```
+
+Without `version`, `ref_by: "variant"` resolves the latest revision. Set `version` to pin a specific revision.
+
+## Follow an environment deployment
+
+```json
+{
+  "type": "reference",
+  "ref_by": "environment",
+  "slug": "release-reviewer",
+  "environment": "production",
+  "description": "Review release notes using the production reviewer."
+}
+```
+
+Environment references run the revision deployed in that environment and cannot also set `version`.
+
+The workflow `slug` is the model-visible tool name. The optional `name` field is retained only for compatibility with older stored references.
+
+## Concurrency and permissions
+
+Reference tools use normal runner tool scheduling and permission resolution. Agenta does not expose a separate `max_concurrent_subagents` setting. Use the parent agent's instructions and tool permission to control when delegation occurs.
+
+Connections and secrets required by the child workflow remain server-side and are resolved from the child's configuration.

--- a/docs/docs/reference/agents/14-skills.mdx
+++ b/docs/docs/reference/agents/14-skills.mdx
@@ -1,0 +1,38 @@
+---
+title: "Skills and reusable setup"
+sidebar_label: "Skills"
+description: "Package reusable instructions and supporting files with an Agenta agent."
+sidebar_position: 15
+---
+
+A skill is a named instruction package rendered beside the agent's `AGENTS.md`. Its description tells the model when to load it.
+
+```json
+{
+  "name": "release-qa",
+  "description": "Use when checking release notes before publication.",
+  "body": "Check every version, link, migration step, and compatibility claim against source.",
+  "files": [
+    {
+      "path": "checklists/release.md",
+      "content": "- Version is correct\n- Links resolve\n- Breaking changes are explicit\n"
+    }
+  ]
+}
+```
+
+## Constraints
+
+- `name` uses lowercase letters, digits, and single hyphens, up to 64 characters.
+- `description` is 1 to 1,024 characters.
+- `body` is up to 50,000 characters.
+- File paths are relative POSIX paths; absolute paths, backslashes, `..`, and root `SKILL.md` are rejected.
+- Set both `allow_executable_files: true` and an executable file entry to ship a runnable helper. Sandbox policy must also permit execution.
+
+Set `disable_model_invocation: true` to hide a skill from ordinary model selection and make it explicitly invokable only in supported harnesses.
+
+## Stored skills
+
+A `skills` entry can be an `@ag.embed` reference to a stored skill workflow. Follow the skill workflow slug for the latest revision or pin a workflow revision version. Agenta resolves embeds before the runner starts.
+
+Skills package instructions and files. They do not implicitly add an MCP server or connected application; configure those separately.

--- a/docs/docs/reference/agents/15-credentials-and-secrets.mdx
+++ b/docs/docs/reference/agents/15-credentials-and-secrets.mdx
@@ -1,0 +1,51 @@
+---
+title: "Credentials and secrets"
+sidebar_label: "Credentials and secrets"
+description: "Choose model credentials and provide secrets to tools, MCP servers, and sandboxes without storing values in agent templates."
+sidebar_position: 16
+---
+
+Agent templates should contain references to credentials, not secret values.
+
+## Model connections
+
+```json
+{
+  "llm": {
+    "provider": "openai",
+    "model": "gpt-5.6-luna",
+    "connection": { "mode": "agenta", "slug": "openai-production" }
+  }
+}
+```
+
+`mode: "agenta"` resolves a project connection; omit `slug` to use the project default. `mode: "self_managed"` tells Agenta not to inject a model credential and cannot be combined with a slug.
+
+## Connected applications
+
+A `gateway_connection` tool stores the provider, integration key, and existing project connection slug. OAuth tokens and API keys stay in the project connection and are resolved by the gateway.
+
+## Code tools
+
+A code tool's `secrets` array lists secret names. At execution time the resolver injects available values into the script environment. Missing-secret behavior depends on the service policy and can fail resolution.
+
+## MCP headers
+
+Use `connection.credentials.type: "header_secret_refs"` and map each HTTP header to a project secret slug. Do not put bearer tokens in static `headers`.
+
+## Sandbox credentials
+
+Bind a project secret into the sandbox explicitly:
+
+```json
+{
+  "secret": { "slug": "package-registry-token" },
+  "binding": { "type": "env", "name": "NPM_TOKEN" }
+}
+```
+
+The binding name must be a valid environment variable name.
+
+## Per-request fields
+
+Invoke requests also accept `secrets` and `credentials`. These are sensitive runtime inputs, not a place to persist credentials in client logs or source control. Prefer project-managed references for reusable agents.

--- a/docs/docs/reference/agents/16-sandboxes-and-security.mdx
+++ b/docs/docs/reference/agents/16-sandboxes-and-security.mdx
@@ -1,0 +1,45 @@
+---
+title: "Sandboxes and security"
+sidebar_label: "Sandboxes and security"
+description: "Select an agent sandbox and declare its network, filesystem, and enforcement policy."
+sidebar_position: 17
+---
+
+The sandbox is where an agent reads and writes files, runs commands, and loads skill assets. Agenta supports `local` and `daytona`; a deployment can restrict either provider.
+
+```json
+{
+  "sandbox": {
+    "kind": "daytona",
+    "permissions": {
+      "network": {
+        "mode": "allowlist",
+        "allowlist": ["203.0.113.0/24"]
+      },
+      "filesystem": "readonly",
+      "enforcement": "strict"
+    },
+    "extras": {}
+  }
+}
+```
+
+## Permission fields
+
+| Field          | Values                          | Notes                                                       |
+| -------------- | ------------------------------- | ----------------------------------------------------------- |
+| `network.mode` | `on`, `off`, `allowlist`        | `allowlist` uses CIDR ranges in `network.allowlist`.        |
+| `filesystem`   | `on`, `readonly`, `off`, `null` | Currently declared but not enforced.                        |
+| `enforcement`  | `strict`, `best_effort`         | `strict` fails when the provider cannot apply the boundary. |
+
+An omitted `permissions` object means no declared boundary. It is not equivalent to an explicit deny policy.
+
+## Layers of control
+
+Sandbox permissions limit the environment. `runner.permissions` controls whether resolved tools execute. `harness.permissions` controls supported harness built-ins. Apply all three layers according to the task's risk.
+
+## Persistence
+
+A session can reuse its sandbox working directory across turns, but retention depends on provider and deployment configuration. Persist important outputs outside the sandbox using attachment or application storage APIs.
+
+For self-hosted deployments, the operator is responsible for network routing, runner isolation, sandbox provider credentials, retention, and host access. See the self-hosting guides for provider setup.

--- a/docs/docs/reference/agents/17-traces-and-usage.mdx
+++ b/docs/docs/reference/agents/17-traces-and-usage.mdx
@@ -1,0 +1,44 @@
+---
+title: "Agent traces and usage"
+sidebar_label: "Traces and usage"
+description: "Find an agent trace and interpret harness, model, tool, token, and cost spans."
+sidebar_position: 18
+---
+
+Every invocation can return trace context in headers, response fields, and stream events.
+
+| Location      | Value                              |
+| ------------- | ---------------------------------- |
+| Header        | `x-ag-trace-id` and `x-ag-span-id` |
+| JSON response | `trace_id` and `span_id`           |
+| Agenta stream | `done.data.traceId`                |
+| Vercel stream | `finish.messageMetadata.traceId`   |
+
+Store `trace_id` with your application's session or job record. The session ID groups turns; the trace ID identifies one invocation.
+
+## Fetch a trace
+
+```bash
+curl \
+  "$AGENTA_HOST/api/traces/019d952f000000000000000000000003" \
+  -H "Authorization: ApiKey $AGENTA_API_KEY"
+```
+
+The response contains a nested span tree. Span names can repeat, so sibling values can be arrays. See [Tracing](/reference/api-guide/tracing) for complete query and response schemas.
+
+## Agent spans
+
+| `ag.type.span`              | Work recorded         |
+| --------------------------- | --------------------- |
+| `workflow`                  | Root invoke operation |
+| `agent`                     | Harness loop          |
+| `llm`, `chat`, `completion` | Model request         |
+| `tool`                      | Tool execution        |
+
+Inspect errors on the narrowest failed span before the root summary. Tool spans can distinguish a permission denial, client pause, remote integration error, and sandbox execution failure.
+
+## Usage
+
+Streaming runs can emit a `usage` event with `input`, `output`, `total`, and `cost`. Vercel output places usage in `finish.messageMetadata.usage`. Provider reporting varies, so fields can be absent even when the run succeeds.
+
+Use trace links when one workflow invokes another. A reference-tool child has its own execution context while preserving correlation to the parent.

--- a/docs/docs/reference/agents/18-automate-agent-runs.mdx
+++ b/docs/docs/reference/agents/18-automate-agent-runs.mdx
@@ -1,0 +1,65 @@
+---
+title: "Automate agent runs"
+sidebar_label: "Automate agent runs"
+description: "Run an agent from a cron schedule or a connected provider event."
+sidebar_position: 19
+---
+
+Agenta automations start agent runs on a schedule or when a connected provider emits an event. They are not session-completion webhooks.
+
+## Scheduled run
+
+Create a trigger schedule with a five-field UTC cron expression:
+
+```json
+{
+  "schedule": {
+    "name": "Weekday support digest",
+    "description": "Summarize new support work every weekday.",
+    "data": {
+      "event_key": "weekday-support-digest",
+      "schedule": "0 8 * * 1-5",
+      "inputs_fields": {
+        "messages": [
+          {
+            "role": "user",
+            "content": "Prepare today's support digest."
+          }
+        ],
+        "payload": "$.event.attributes"
+      }
+    }
+  }
+}
+```
+
+`start_time` and `end_time` optionally bound the active UTC window. The schedule binds to a workflow revision when it is created.
+
+## Provider event
+
+A subscription requires a ready provider connection, an event key from the trigger catalog, and event-specific `trigger_config`:
+
+```json
+{
+  "subscription": {
+    "name": "Triage new issues",
+    "connection_id": "019d952f-0000-0000-0000-000000000020",
+    "data": {
+      "event_key": "github_issue_created",
+      "trigger_config": { "owner": "acme", "repo": "product" },
+      "inputs_fields": {
+        "messages": [{ "role": "user", "content": "Triage this new issue." }],
+        "payload": "$.event.attributes"
+      }
+    }
+  }
+}
+```
+
+Confirm the catalog event's integration and description before saving it. Event matching is provider-specific.
+
+## Input mapping
+
+A leaf beginning with `$` is a JSONPath selector over the fire context; a leaf beginning with `/` is a JSON Pointer. Other strings pass through literally. Unmatched selectors resolve to `null`; selectors are not interpolated inside larger strings.
+
+Include an explicit imperative `messages` entry and map the provider payload under a sibling key. See [Automations](/concepts/automations) for setup and delivery monitoring.

--- a/docs/docs/reference/agents/18-automate-agent-runs.mdx
+++ b/docs/docs/reference/agents/18-automate-agent-runs.mdx
@@ -33,7 +33,9 @@ Create a trigger schedule with a five-field UTC cron expression:
 }
 ```
 
-`start_time` and `end_time` optionally bound the active UTC window. The schedule binds to a workflow revision when it is created.
+`start_time` and `end_time` optionally bound the active UTC window. When the agent creates a schedule with the `create_schedule` platform tool, Agenta binds it to the current workflow variant. The dispatcher resolves that variant's latest revision each time the schedule fires, so later commits change future runs.
+
+To keep execution stable, create the schedule through `POST /api/triggers/schedules/` and set `schedule.data.references.workflow_revision` to a specific revision `id` or `version`. A `workflow_revision` reference remains pinned; a `workflow` or `workflow_variant` reference tracks its latest revision.
 
 ## Provider event
 

--- a/docs/docs/reference/agents/_category_.json
+++ b/docs/docs/reference/agents/_category_.json
@@ -1,0 +1,8 @@
+{
+  "label": "Agents API",
+  "position": 4,
+  "link": {
+    "type": "doc",
+    "id": "reference/agents/overview"
+  }
+}


### PR DESCRIPTION
## Summary

- add a task-focused Agents API reference covering quickstart, architecture, sessions, events, files, tools, MCP, subagents, skills, credentials, sandboxes, traces, and automations
- update agent configuration examples to the current built-in and `gateway_connection` tool model
- document session continuation, interaction responses, stream formats, and busy-session behavior

## Validation

- `corepack pnpm@10.30.0 exec prettier --check 'docs/reference/agents/*.{mdx,json}'`
- `corepack pnpm@10.30.0 build`
- `git diff --check`

The Docusaurus build passes. It reports only the repository's existing duplicate redirect and deprecated `onBrokenMarkdownLinks` warnings.