### PR TITLE
[feat] Add Kbd keycaps and shortcut prop to the @agenta/ui tooltip

### DIFF
--- a/web/mobile/src/styles/theme.generated.css
+++ b/web/mobile/src/styles/theme.generated.css
@@ -45,7 +45,7 @@
     --colorErrorBorder: #d94c4a;
     --controlItemBgHover: rgba(36, 36, 36, 0.02);
     --controlItemBgActive: #f0efed;
-    --colorBgSpotlight: rgba(36, 36, 36, 0.9);
+    --colorBgSpotlight: #242424;
     --colorTextLightSolid: #ffffff;
     --colorSplit: #f0efed;
     --colorInfo: #113955;

--- a/web/oss/src/styles/theme/antd-overrides.generated.ts
+++ b/web/oss/src/styles/theme/antd-overrides.generated.ts
@@ -69,7 +69,7 @@ export const LIGHT_TOKEN_OVERRIDES = {
     colorBgLayout: "#f6f5f3",
     colorBgBase: "#ffffff",
     colorBgMask: "rgba(36, 36, 36, 0.45)",
-    colorBgSpotlight: "rgba(36, 36, 36, 0.9)",
+    colorBgSpotlight: "#242424",
     colorBgContainerDisabled: "rgba(36, 36, 36, 0.04)",
     colorBorderBg: "#ffffff",
     colorWhite: "#ffffff",

--- a/web/oss/src/styles/theme/palette.ts
+++ b/web/oss/src/styles/theme/palette.ts
@@ -62,7 +62,7 @@ export const surface = {
     container: {light: "#ffffff", dark: "#141414"}, // [absorbs] --ag-c-FFFFFF, the #141414 literals
     elevated: {light: "#ffffff", dark: "#242424"}, // [override] [absorbs] 25+ light surfaces → one dark
     layout: {light: GROUND, dark: "#000000"}, // the warm page ground behind white cards
-    spotlight: {light: "rgba(36, 36, 36, 0.9)", dark: "#424242"},
+    spotlight: {light: "#242424", dark: "#424242"},
     mask: {light: "rgba(36, 36, 36, 0.45)", dark: "rgba(0, 0, 0, 0.45)"},
     containerDisabled: {light: "rgba(36, 36, 36, 0.04)", dark: "rgba(255, 255, 255, 0.08)"},
     infoBg: {light: "#e5f1f9", dark: "#111a2c"}, // antd's colorInfoBg (unified with antd render)

--- a/web/packages/agenta-ui/src/components/ui/index.ts
+++ b/web/packages/agenta-ui/src/components/ui/index.ts
@@ -29,7 +29,14 @@ export {
     type SelectTriggerProps,
 } from "./select"
 export {Popover, PopoverTrigger, PopoverAnchor, PopoverContent} from "./popover"
-export {Tooltip, TooltipTrigger, TooltipContent, TooltipProvider} from "./tooltip"
+export {
+    Tooltip,
+    TooltipTrigger,
+    TooltipContent,
+    TooltipProvider,
+    type TooltipShortcut,
+} from "./tooltip"
+export {Kbd, KbdGroup, kbdVariants, type KbdProps} from "./kbd"
 export {SimpleTooltip, type SimpleTooltipProps} from "./tooltip-composed"
 export {RadioGroup, RadioGroupItem, type RadioGroupProps} from "./radio-group"
 export {

--- a/web/packages/agenta-ui/src/components/ui/kbd.tsx
+++ b/web/packages/agenta-ui/src/components/ui/kbd.tsx
@@ -1,0 +1,49 @@
+import * as React from "react"
+
+import {cva, type VariantProps} from "class-variance-authority"
+
+import {cn} from "./utils"
+
+/**
+ * Kbd — shadcn's keycap in @agenta/ui (no `forwardRef`, `data-slot`). Re-skinned to the chip
+ * surface (`ag-surface-chip` + colorTextSecondary). `tone="inverse"` sits on a dark or filled
+ * surface (a primary button); inside a `TooltipContent` the cap flips to that tone on its own via
+ * the `[data-slot=tooltip-content]` ancestor selector, so tooltip callers never pass it.
+ */
+const kbdVariants = cva(
+    "pointer-events-none inline-flex w-fit select-none items-center justify-center gap-1 rounded font-sans font-medium leading-none whitespace-nowrap [&_svg:not([class*='size-'])]:size-3",
+    {
+        variants: {
+            tone: {
+                chip: "ag-surface-chip text-[var(--ag-colorTextSecondary)] [[data-slot=tooltip-content]_&]:border-transparent [[data-slot=tooltip-content]_&]:bg-white/20 [[data-slot=tooltip-content]_&]:text-inherit",
+                inverse: "bg-white/20 text-inherit",
+            },
+            size: {
+                // Fixed height = min-width, so a single glyph is a square cap and a word
+                // (`Esc`) grows only sideways.
+                sm: "h-4 min-w-4 px-1 text-[10px]",
+                md: "h-5 min-w-5 px-1.5 text-[11px]",
+            },
+        },
+        defaultVariants: {tone: "chip", size: "sm"},
+    },
+)
+
+export interface KbdProps extends React.ComponentProps<"kbd">, VariantProps<typeof kbdVariants> {}
+
+function Kbd({className, tone, size, ...props}: KbdProps) {
+    return <kbd data-slot="kbd" className={cn(kbdVariants({tone, size}), className)} {...props} />
+}
+
+/** Lays several caps out as one chord, e.g. `⌘` `K`. */
+function KbdGroup({className, ...props}: React.ComponentProps<"div">) {
+    return (
+        <kbd
+            data-slot="kbd-group"
+            className={cn("inline-flex items-center gap-0.5 align-middle", className)}
+            {...props}
+        />
+    )
+}
+
+export {Kbd, KbdGroup, kbdVariants}

--- a/web/packages/agenta-ui/src/components/ui/tooltip-composed.tsx
+++ b/web/packages/agenta-ui/src/components/ui/tooltip-composed.tsx
@@ -1,11 +1,19 @@
 import * as React from "react"
 
-import {Tooltip, TooltipContent, TooltipProvider, TooltipTrigger} from "./tooltip"
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    type TooltipShortcut,
+    TooltipTrigger,
+} from "./tooltip"
 
 export interface SimpleTooltipProps {
     /** Tooltip body. Empty/undefined renders the child bare — antd `Tooltip title` semantics. */
     title?: React.ReactNode
     side?: React.ComponentProps<typeof TooltipContent>["side"]
+    /** Keyboard shortcut printed after `title` as `Kbd` caps, e.g. `["⌘", "K"]`. */
+    shortcut?: TooltipShortcut
     className?: string
     /** Must accept a forwarded ref (the trigger renders asChild). */
     children: React.ReactElement
@@ -31,13 +39,13 @@ export interface SimpleTooltipProps {
  *   (`dispatchSetState ← setRef ← … ← safelyDetachRef ← commitDeletionEffectsOnFiber`).
  *   Unresolved — do not assume the un-nesting above closed it.
  */
-export function SimpleTooltip({title, side, className, children}: SimpleTooltipProps) {
+export function SimpleTooltip({title, side, shortcut, className, children}: SimpleTooltipProps) {
     if (title == null || title === "") return children
     return (
         <TooltipProvider delayDuration={300}>
             <Tooltip>
                 <TooltipTrigger asChild>{children}</TooltipTrigger>
-                <TooltipContent side={side} className={className}>
+                <TooltipContent side={side} shortcut={shortcut} className={className}>
                     {title}
                 </TooltipContent>
             </Tooltip>

--- a/web/packages/agenta-ui/src/components/ui/tooltip.tsx
+++ b/web/packages/agenta-ui/src/components/ui/tooltip.tsx
@@ -2,6 +2,7 @@ import * as React from "react"
 
 import * as TooltipPrimitive from "@radix-ui/react-tooltip"
 
+import {Kbd, KbdGroup} from "./kbd"
 import {cn} from "./utils"
 
 /**
@@ -9,7 +10,26 @@ import {cn} from "./utils"
  * Re-skinned to antd's overlay: colorBgSpotlight bg, white text, borderRadius (8px), the
  * overlay shadow. antd → @agenta/ui: `title`→children, `placement`→`side`+`align`, `open`→`open`,
  * `getPopupContainer`→`container`.
+ *
+ * Body copy is always the small step (`text-field-sm`, 12px). Pass `shortcut` to print a
+ * keyboard chord after the label as `Kbd` caps in the inverse tone.
  */
+
+/** One key or a chord, e.g. `"Esc"` or `["⌘", "K"]`. Each entry becomes one cap. */
+export type TooltipShortcut = string | string[]
+
+/** Renders a `TooltipShortcut` as caps; `null` when there is nothing to print. */
+function TooltipShortcutKeys({shortcut}: {shortcut?: TooltipShortcut}) {
+    const keys = shortcut == null ? [] : Array.isArray(shortcut) ? shortcut : [shortcut]
+    if (keys.length === 0) return null
+    return (
+        <KbdGroup data-slot="tooltip-shortcut" className="ml-1.5">
+            {keys.map((key, index) => (
+                <Kbd key={`${key}-${index}`}>{key}</Kbd>
+            ))}
+        </KbdGroup>
+    )
+}
 
 function TooltipProvider({
     delayDuration = 0,
@@ -36,12 +56,15 @@ function TooltipContent({
     className,
     sideOffset = 4,
     container,
+    shortcut,
     children,
     ...props
 }: React.ComponentProps<typeof TooltipPrimitive.Content> & {
     /** Portal target. Defaults to document.body; pass an element to render inline (e.g. inside
      * a modal/scroll container, or a forced-open parity story). */
     container?: HTMLElement | null
+    /** Keyboard shortcut printed after the body as `Kbd` caps. */
+    shortcut?: TooltipShortcut
 }) {
     return (
         <TooltipPrimitive.Portal container={container}>
@@ -51,8 +74,9 @@ function TooltipContent({
                 className={cn(
                     // font-portal: portaled to <body>, escaping the app font scope (preflight off).
                     // antd tooltip is borderless with the overlay shadow (boxShadowSecondary),
-                    // colorBgSpotlight bg + white text, borderRadius (8px), 6px×8px padding.
-                    "z-50 box-border w-fit rounded-control bg-colorBgSpotlight px-2 py-1.5 text-field-md text-colorTextLightSolid shadow-overlay font-portal",
+                    // colorBgSpotlight bg + white text. Deliberately more compact than antd:
+                    // 12px/16px type, 6px×10px padding, 6px radius — a 28px single-line pill.
+                    "z-50 box-border w-fit rounded-control-sm bg-colorBgSpotlight px-2.5 py-1.5 text-field-sm leading-4 text-colorTextLightSolid shadow-overlay font-portal",
                     // Soft width cap (matches antd's default tooltip max width) — not a control dim.
                     // break-words: the cap alone can't contain an unbreakable token (an event key,
                     // an id, a URL), which otherwise runs straight out of the tooltip's background.
@@ -62,6 +86,7 @@ function TooltipContent({
                 {...props}
             >
                 {children}
+                <TooltipShortcutKeys shortcut={shortcut} />
                 {/* Same fill as bg; Radix renders it as an SVG triangle. */}
                 <TooltipPrimitive.Arrow className="fill-colorBgSpotlight" />
             </TooltipPrimitive.Content>

--- a/web/packages/agenta-ui/src/shortcuts/ShortcutKeys.tsx
+++ b/web/packages/agenta-ui/src/shortcuts/ShortcutKeys.tsx
@@ -15,6 +15,7 @@ import {
     type ShortcutModifier,
 } from "@agenta/shared/utils"
 
+import {Kbd, type KbdProps} from "../components/ui/kbd"
 import {cn} from "../components/ui/utils"
 
 export interface ShortcutKeysProps {
@@ -25,25 +26,12 @@ export interface ShortcutKeysProps {
     /** Also print the shortcut's mirror chord, e.g. `Alt Z` and `Alt X`. */
     showAlt?: boolean
     /** `chip` sits on a surface; `inverse` sits inside a dark tooltip or a filled button. */
-    tone?: "chip" | "inverse"
-    size?: "sm" | "md"
+    tone?: KbdProps["tone"]
+    size?: KbdProps["size"]
     /** Hide from assistive tech where an adjacent label already names the action. */
     "aria-hidden"?: boolean
     className?: string
 }
-
-const capBase =
-    "inline-flex items-center justify-center rounded font-medium leading-none whitespace-nowrap"
-
-const capTone = {
-    chip: "ag-surface-chip text-[var(--ag-colorTextSecondary)]",
-    inverse: "bg-white/20 text-inherit",
-} as const
-
-const capSize = {
-    sm: "min-w-4 px-1 py-0.5 text-[11px]",
-    md: "min-w-5 px-1.5 py-1 text-[12px]",
-} as const
 
 /** Reads the platform once on mount. Exported so a parent can print many caps from one read. */
 export const useIsMacPlatform = (): boolean => {
@@ -58,14 +46,14 @@ const Caps = ({
     size,
 }: {
     faces: string[]
-    tone: keyof typeof capTone
-    size: keyof typeof capSize
+    tone: KbdProps["tone"]
+    size: KbdProps["size"]
 }) => (
     <>
         {faces.map((face, index) => (
-            <kbd key={`${face}-${index}`} className={cn(capBase, capTone[tone], capSize[size])}>
+            <Kbd key={`${face}-${index}`} tone={tone} size={size}>
                 {face}
-            </kbd>
+            </Kbd>
         ))}
     </>
 )

--- a/web/packages/agenta-ui/src/styles/theme-variables.css
+++ b/web/packages/agenta-ui/src/styles/theme-variables.css
@@ -20,7 +20,7 @@
     --ag-colorBgElevated: #ffffff;
     --ag-colorBgLayout: #f6f5f3;
     --ag-colorBgBase: #ffffff;
-    --ag-colorBgSpotlight: rgba(36, 36, 36, 0.9);
+    --ag-colorBgSpotlight: #242424;
     --ag-colorBgMask: rgba(36, 36, 36, 0.45);
     --ag-colorBorder: #d7d7d7;
     --ag-colorBorderSecondary: #e5e5e3;

--- a/web/packages/agenta-ui/tests/unit/TooltipShortcut.render.test.tsx
+++ b/web/packages/agenta-ui/tests/unit/TooltipShortcut.render.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment jsdom
+import {cleanup, render, screen} from "@testing-library/react"
+import {afterEach, describe, expect, it} from "vitest"
+
+import {Kbd} from "../../src/components/ui/kbd"
+import {ShortcutKeys} from "../../src/shortcuts/ShortcutKeys"
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipProvider,
+    TooltipTrigger,
+} from "../../src/components/ui/tooltip"
+
+// jsdom has no ResizeObserver; Radix measures the arrow with one.
+class StubResizeObserver {
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+globalThis.ResizeObserver ??= StubResizeObserver as unknown as typeof ResizeObserver
+
+afterEach(cleanup)
+
+describe("Tooltip shortcut", () => {
+    it("renders caps inside the forced-open content", () => {
+        render(
+            <TooltipProvider>
+                <Tooltip open>
+                    <TooltipTrigger asChild>
+                        <button type="button">go</button>
+                    </TooltipTrigger>
+                    <TooltipContent shortcut="Esc">Close</TooltipContent>
+                </Tooltip>
+            </TooltipProvider>,
+        )
+        const content = document.querySelector('[data-slot="tooltip-content"]')
+        expect(content).not.toBeNull()
+        expect(content!.className).toContain("text-field-sm")
+        expect(content!.className).not.toContain("text-field-md")
+        const caps = content!.querySelectorAll('[data-slot="kbd"]')
+        expect(Array.from(caps).map((c) => c.textContent)).toEqual(["Esc"])
+    })
+
+    it("prints nothing for an empty chord", () => {
+        render(
+            <TooltipProvider>
+                <Tooltip open>
+                    <TooltipTrigger asChild>
+                        <button type="button">go</button>
+                    </TooltipTrigger>
+                    <TooltipContent shortcut={[]}>Close</TooltipContent>
+                </Tooltip>
+            </TooltipProvider>,
+        )
+        expect(document.querySelector('[data-slot="tooltip-shortcut"]')).toBeNull()
+    })
+
+    it("ShortcutKeys prints Kbd caps", () => {
+        render(<ShortcutKeys chord={{modifiers: ["mod"], key: "k"}} tone="inverse" size="md" />)
+        const caps = document.querySelectorAll('[data-slot="kbd"]')
+        expect(caps.length).toBe(2)
+        expect(caps[0].className).toContain("bg-white/20")
+        expect(caps[0].className).toContain("h-5")
+    })
+
+    it("Kbd flips to the inverse tone only under tooltip content", () => {
+        render(<Kbd>K</Kbd>)
+        expect(screen.getByText("K").className).toContain(
+            "[[data-slot=tooltip-content]_&]:bg-white/20",
+        )
+    })
+})


### PR DESCRIPTION
## Context
The `@agenta/ui` tooltip rendered at body size (14px, 8px radius, 32px tall) and its background was `rgba(36,36,36,0.9)` in light mode, so content bled through. There was no shared keycap primitive either: `ShortcutKeys` carried its own `<kbd>` styling, and the caps it printed inside tooltips were taller than they were wide.

## Changes
Tooltip is now a compact pill: 12px/16px type, 6px by 10px padding, 6px radius (28px single line). `TooltipContent` and `SimpleTooltip` take a `shortcut` prop (`"Esc"` or `["⌘", "K"]`) and print it after the label as keycaps.

New `Kbd` / `KbdGroup` in `@agenta/ui/ui`, following shadcn's source. Two variants: `tone` (`chip` on a surface, `inverse` on a dark or filled one) and `size` (`sm` 16px, `md` 20px). Height equals min-width, so a single glyph is a square cap and only a word like `Esc` grows sideways. Under a `TooltipContent` the chip tone flips to inverse on its own. `ShortcutKeys` now renders `Kbd` instead of its own `<kbd>`; its API is unchanged, so the ten call sites need no edits.

`colorBgSpotlight` is now opaque `#242424` in light mode (dark was already `#424242`). Changed in `palette.ts` and regenerated; antd tooltips pick this up too.

Before: `Hide configuration` with 15px by 16px caps in a 32px translucent tooltip.
After: same label with 16px square caps in a 28px opaque tooltip.

## Tests
- `tests/unit/TooltipShortcut.render.test.tsx` covers the `shortcut` prop, the empty chord, the `text-field-sm` swap, and `ShortcutKeys` rendering `Kbd` with `tone`/`size` passed through.
- `pnpm test:tsc` and eslint pass in `packages/agenta-ui`.
- Demo outstanding: no local capture yet.

## What to QA
- Agent playground: hover the collapse-config chevron. The tooltip reads "Hide configuration" with two square keycaps, compact, fully opaque.
- Sessions tab rail: hover the new-session button. Same treatment for `New session` and its shortcut.
- Dark mode: the tooltip is `#424242` with the usual 1px elevation ring; caps are `white/20` on it.
- Regression: any antd `Tooltip` (e.g. the observability table headers) is now opaque instead of 90% black; confirm nothing relied on the see-through look.
