### PR TITLE
[6742] fix(frontend): Stop the config pane resize from crashing /m

### DIFF
--- a/web/packages/agenta-sessions-ui/src/SessionTabStrip.tsx
+++ b/web/packages/agenta-sessions-ui/src/SessionTabStrip.tsx
@@ -32,8 +32,14 @@ const fadeMask = (left: boolean, right: boolean): string => {
 /** Footprint of the inline New session (+): the 28px button plus the 4px it sits off the last chip. */
 const INLINE_ADD_PX = 32
 
-/** Chips' own width. `scrollWidth` can't give it: the scroller is `flex-1`, so a strip with room to
- * spare reports `scrollWidth === clientWidth`, exactly like one filled to the millimetre. */
+/**
+ * The scroller's content width from LAYOUT geometry: the chips, plus the inline (+) while it is
+ * one of them. Never `scrollWidth`, for two reasons. The scroller is `flex-1`, so a strip with room
+ * to spare reports `scrollWidth === clientWidth`, exactly like one filled to the millimetre. And
+ * the chips are motion layout items: while one of their layout animations is in flight (the
+ * strip resized, a chip came or went) they sit on a translate that `scrollWidth` counts as
+ * overflow and offsets do not.
+ */
 const chipsWidth = (el: HTMLElement): number => {
     const first = el.firstElementChild as HTMLElement | null
     const last = el.lastElementChild as HTMLElement | null
@@ -99,13 +105,22 @@ export const SessionTabStrip = ({
     const measureFade = useCallback(() => {
         const el = stripElRef.current
         if (!el) return
-        const overflow = el.scrollWidth - el.clientWidth > 1
+        // ONE metric for every decision below. Reading overflow off `scrollWidth` and the un-pin
+        // slack off offsets let the two disagree whenever a chip layout animation was mid-flight:
+        // the translate made `scrollWidth` say overflow, so the (+) pinned; offsets then said
+        // there was room, so it came back inline; moving it re-projected the chips and the next
+        // measure — run synchronously from the effect below — flipped it again. Dozens of flips
+        // inside one commit chain, and React threw "Maximum update depth exceeded" (#6742).
+        const content = chipsWidth(el)
+        const overflow = content - el.clientWidth > 1
         const left = overflow && el.scrollLeft > 1
-        const right = overflow && el.scrollLeft < el.scrollWidth - el.clientWidth - 1
+        const right = overflow && el.scrollLeft < content - el.clientWidth - 1
         // Chips resize per frame while animating; bail on an unchanged mask to avoid re-rendering.
         setFade((prev) => (prev.left === left && prev.right === right ? prev : {left, right}))
-        // Pin once the chips overflow; un-pin once they leave the button's footprint spare.
-        const pin = pinAddRef.current ? el.clientWidth - chipsWidth(el) < INLINE_ADD_PX : overflow
+        // Pin once the chips overflow; un-pin once they leave the button's footprint spare. The
+        // pinned (+) sits outside the scroller, so `clientWidth` is already net of it: this is
+        // wider hysteresis than it reads, and the two states cannot each satisfy the other's rule.
+        const pin = pinAddRef.current ? el.clientWidth - content < INLINE_ADD_PX : overflow
         if (pin !== pinAddRef.current) {
             pinAddRef.current = pin
             setPinAdd(pin)

--- a/web/packages/agenta-sessions-ui/tests/unit/SessionTabStripPin.test.tsx
+++ b/web/packages/agenta-sessions-ui/tests/unit/SessionTabStripPin.test.tsx
@@ -1,0 +1,154 @@
+/**
+ * The inline / pinned decision for the New session (+) must read ONE geometry.
+ *
+ * #6742: resizing the config pane crashed `/m` with "Maximum update depth exceeded". The chips
+ * are motion layout items, and mid-animation they sit on a translate that `scrollWidth` counts
+ * as overflow while offsets do not. Overflow was read off `scrollWidth` (→ pin) and the un-pin
+ * slack off offsets (→ un-pin), so the (+) flapped between the two homes inside one synchronous
+ * effect chain until React threw. These pin the strip to layout offsets for both decisions.
+ */
+import {act, createElement} from "react"
+
+import {createRoot, type Root} from "react-dom/client"
+import {afterEach, beforeEach, describe, expect, it, vi} from "vitest"
+
+import {SessionTabStrip} from "../../src/SessionTabStrip"
+
+/** Per-element geometry jsdom does not compute: widths from `data-w`, the scroller's own box from
+ * the test, and `scrollWidth` deliberately INFLATED past the content, as an in-flight translate
+ * makes it. `offsetLeft` is the running sum of the earlier siblings' widths, so `chipsWidth` reads
+ * what a real flex row would give. */
+const geometry = {scroller: 500, scrollWidth: 800}
+const widthOf = (el: HTMLElement) => Number(el.dataset.w ?? 32)
+const descriptors: Record<string, PropertyDescriptor | undefined> = {}
+const define = (name: string, get: (this: HTMLElement) => number) => {
+    descriptors[name] = Object.getOwnPropertyDescriptor(HTMLElement.prototype, name)
+    Object.defineProperty(HTMLElement.prototype, name, {configurable: true, get})
+}
+const isScroller = (el: Element) => el.classList.contains("overflow-x-auto")
+
+/** jsdom has no ResizeObserver. The stub keeps the callbacks so a test can deliver a "resize"
+ * the way the browser does — after a stable mount, from outside React's commit. */
+const resizeCallbacks: ResizeObserverCallback[] = []
+class ResizeObserverStub {
+    constructor(callback: ResizeObserverCallback) {
+        resizeCallbacks.push(callback)
+    }
+    observe() {}
+    unobserve() {}
+    disconnect() {}
+}
+const fireResize = () => {
+    for (const callback of resizeCallbacks) callback([], {} as ResizeObserver)
+}
+
+let root: Root
+let host: HTMLDivElement
+let errors: string[]
+
+beforeEach(() => {
+    vi.stubGlobal("ResizeObserver", ResizeObserverStub)
+    vi.stubGlobal("IS_REACT_ACT_ENVIRONMENT", true)
+    define("clientWidth", function () {
+        return isScroller(this) ? geometry.scroller : widthOf(this)
+    })
+    define("scrollWidth", function () {
+        return isScroller(this) ? geometry.scrollWidth : widthOf(this)
+    })
+    define("offsetWidth", function () {
+        return widthOf(this)
+    })
+    define("offsetLeft", function () {
+        let left = 0
+        for (let prev = this.previousElementSibling; prev; prev = prev.previousElementSibling) {
+            left += widthOf(prev as HTMLElement)
+        }
+        return left
+    })
+    resizeCallbacks.length = 0
+    errors = []
+    vi.spyOn(console, "error").mockImplementation((...args: unknown[]) => {
+        errors.push(args.map(String).join(" "))
+    })
+    host = document.createElement("div")
+    document.body.appendChild(host)
+    root = createRoot(host)
+})
+
+afterEach(() => {
+    act(() => root.unmount())
+    host.remove()
+    vi.restoreAllMocks()
+    vi.unstubAllGlobals()
+    for (const [name, descriptor] of Object.entries(descriptors)) {
+        if (descriptor) Object.defineProperty(HTMLElement.prototype, name, descriptor)
+        else delete (HTMLElement.prototype as unknown as Record<string, unknown>)[name]
+    }
+})
+
+const chip = (w: number) => createElement("div", {"data-w": w, role: "tab"})
+
+/** Renders, then lets the effect chain and the observers settle: the flap under test ran in the
+ * measurement callbacks React flushes after the commit, so asserting straight after `render`
+ * looked at a strip that had not looped YET. Counts the (+)'s moves while waiting — a single
+ * settle is at most one pin, never a back-and-forth. */
+const render = (chips: number[]) => {
+    act(() => {
+        root.render(
+            createElement(
+                SessionTabStrip,
+                {onAdd: () => undefined, remeasureKey: chips.length},
+                ...chips.map(chip),
+            ),
+        )
+    })
+}
+
+/** Lets the effect chain and the observers settle — OUTSIDE `act`, which holds every update until
+ * its scope exits. Counts the (+)'s moves meanwhile: one settle is at most one pin, never a
+ * back-and-forth. */
+const settle = async () => {
+    let moves = 0
+    const observer = new MutationObserver((records) => {
+        for (const record of records) moves += record.addedNodes.length + record.removedNodes.length
+    })
+    observer.observe(host, {childList: true, subtree: true})
+    await new Promise((resolve) => setTimeout(resolve, 100))
+    observer.disconnect()
+    return moves
+}
+
+const addButton = () => host.querySelector('button[aria-label="New session"]')
+const scroller = () => host.querySelector(".overflow-x-auto")
+
+describe("SessionTabStrip (+) placement", () => {
+    it("keeps the (+) inline when the chips fit, however far a translate inflates scrollWidth", async () => {
+        // A strip that fits, settled inline.
+        geometry.scroller = 500
+        geometry.scrollWidth = 500
+        render([100, 100])
+        await settle()
+        expect(scroller()?.contains(addButton())).toBe(true)
+
+        // The pane drag: the strip resizes while the chips' layout animation holds them on a
+        // translate, so `scrollWidth` runs far past the content that still fits.
+        geometry.scrollWidth = 800
+        act(() => fireResize())
+        const moves = await settle()
+
+        expect(errors.filter((e) => /Maximum update depth/.test(e))).toEqual([])
+        expect(moves).toBe(0)
+        expect(scroller()?.contains(addButton())).toBe(true)
+    })
+
+    it("pins the (+) outside the scroller once the chips themselves overflow", async () => {
+        geometry.scroller = 500
+        geometry.scrollWidth = 500
+        render([300, 300])
+        await settle()
+
+        expect(errors.filter((e) => /Maximum update depth/.test(e))).toEqual([])
+        expect(addButton()).not.toBeNull()
+        expect(scroller()?.contains(addButton())).toBe(false)
+    })
+})


### PR DESCRIPTION
Fixes #6742 (AGE-4321).

## Context
Dragging the Configuration pane divider in `/m` could replace the page with "Application error: a client-side exception has occurred" (React error #185, "Maximum update depth exceeded"). It only hit at some widths, which made it look random.

The session tab strip decides where the New session (+) lives: inline after the last tab while the tabs fit, pinned to the right once they overflow. It read *overflow* from the scroller's `scrollWidth` but the *un-pin* slack from layout offsets. The tabs are motion layout items, and while the strip resizes their layout animation holds them on a translate. `scrollWidth` counts that translate, offsets do not. So at the width where the tabs just fit, the two rules contradicted each other: "overflow, pin" then "room, un-pin", and every move of the (+) re-projected the tabs and re-ran the measure synchronously. After about fifty flips React threw. The throw landed inside the (+) tooltip's trigger ref, which is why the console stack pointed at Radix `compose-refs` rather than at the strip.

Measured on a 1240px window with three open tabs, mid-drag:

```
scrollWidth=688  clientWidth=555  chips (offsets)=430  transform=translate3d(258px)
```

## Changes
`measureFade` in `SessionTabStrip` now derives overflow, the edge fade, and the pin decision from one transform-free number: the chips' layout width (`chipsWidth`, which already existed for the un-pin check). The hysteresis the code always intended now holds, because the pinned (+) sits outside the scroller and `clientWidth` is already net of it.

Before, two metrics:

```
overflow = scrollWidth - clientWidth > 1        // sees in-flight translates
unpin    = clientWidth - chipsWidth >= 32       // does not
```

After, one:

```
content  = chipsWidth(el)
overflow = content - clientWidth > 1
unpin    = clientWidth - content >= 32
```

## Tests
- New `SessionTabStripPin.test.tsx`: mounts a strip that fits, inflates `scrollWidth` the way an in-flight translate does, and delivers a resize through the captured ResizeObserver callback. On the old code it reproduces the exact "Maximum update depth exceeded" error; with the fix the (+) stays inline and the DOM does not churn. A second case checks that real overflow still pins it.
- `pnpm vitest run`, `eslint`, `prettier --check`, and `tsc --noEmit` in `packages/agenta-sessions-ui` pass.
- Reproduced in the browser on the local EE dev stack (`/m`, 1240px wide, three tabs, scripted divider drag from 360 to 619px): crash on the old code at the first move past the fit boundary, no crash and a correctly settled (+) with the fix.

## What to QA
- Open an agent session in `/m` on a laptop-width window with three or four session tabs open, so the tabs roughly fill the strip. Drag the Configuration pane divider slowly across its whole range, both directions. The page stays up and the (+) either trails the last tab or sits at the right edge, without flickering between the two.
- Open enough tabs to overflow the strip. The (+) is pinned at the right and the strip fades at the clipped edge; scroll the tabs with the wheel and the fade follows.
- Regression: close tabs until they fit again. The (+) comes back inline after the last tab.
