### PR TITLE
[6778][6776] fix(frontend): Show working dots and the new session as soon as a message is sent

### DIFF
--- a/web/mobile/src/features/chat/LiveConversation.tsx
+++ b/web/mobile/src/features/chat/LiveConversation.tsx
@@ -29,7 +29,11 @@ import {
     type TurnViewModel,
 } from "@agenta/chat/model"
 import {getSessionTurnId} from "@agenta/chat/state"
-import {cancelSessionExecution} from "@agenta/entities/session"
+import {
+    cancelSessionExecution,
+    isSessionFresh,
+    registerLocalSessionAtom,
+} from "@agenta/entities/session"
 import {AgentIntroCard} from "@agenta/entity-ui/agent"
 import {SecretRequestDock} from "@agenta/entity-ui/clientTools"
 import {isOnScreen, isOverlayOpen} from "@agenta/shared/utils"
@@ -192,7 +196,25 @@ export const LiveConversation = ({
     const sendPendingTask = useSetAtom(sendPendingTaskAtom)
     const failPendingTask = useSetAtom(failPendingTaskAtom)
     const pendingTaskError = pendingTask?.delivery === "failed"
-    const {isHydrating, revalidate, send, stop, voidPendingResume} = conversation
+    const {
+        isHydrating,
+        revalidate,
+        send: sendToConversation,
+        stop,
+        voidPendingResume,
+    } = conversation
+    // A fresh session becomes real on the server only once this first message is admitted, which
+    // can take seconds on a cold runner. Note it locally first, so the rail lists it now (#6776).
+    const registerLocalSession = useSetAtom(registerLocalSessionAtom)
+    const send = useCallback(
+        async (input: Parameters<typeof sendToConversation>[0]) => {
+            if (isSessionFresh(sessionId)) {
+                registerLocalSession({sessionId, agentId: agentId ?? null, name: input.text})
+            }
+            await sendToConversation(input)
+        },
+        [agentId, registerLocalSession, sendToConversation, sessionId],
+    )
     useEffect(() => {
         if (!pendingTask || pendingTask.delivery) return
         const decision = pendingTaskDecision({
@@ -240,7 +262,11 @@ export const LiveConversation = ({
         readerReady: conversation.readerReady,
         ownedContinuation: conversation.acceptedRunPending,
     })
-    const showingTurnActivity = streamingHere || remoteTurn.showActivity
+    // `sendInFlight` covers the gap the other two cannot: the message has left the composer, and
+    // neither `useChat` (the server-owned path never moves its status) nor liveness (a poll away)
+    // knows yet. Without it the pulse arrived a runner accept plus a poll after the send (#6778).
+    const showingTurnActivity =
+        streamingHere || conversation.sendInFlight || remoteTurn.showActivity
     const streamingHereRef = useRef(streamingHere)
     streamingHereRef.current = streamingHere
     const hitlPendingRef = useRef(conversation.hitlPending)
@@ -784,7 +810,7 @@ export const LiveConversation = ({
                                 // An open edit rewrites its held message instead of sending. The
                                 // input clears on submit, so the displaced draft goes back after.
                                 if (!conversation.editingId) {
-                                    await conversation.send({text, parts})
+                                    await send({text, parts})
                                     return
                                 }
                                 const draft = await conversation.commitEdit({

--- a/web/mobile/src/features/nav/localSessionRefs.ts
+++ b/web/mobile/src/features/nav/localSessionRefs.ts
@@ -1,0 +1,63 @@
+import {useEffect} from "react"
+
+import {sessionStatusAtomFamily} from "@agenta/chat/state"
+import {forgetLocalSessionsAtom, localSessionsAtom} from "@agenta/entities/session"
+import {
+    localSessionRefsAtom,
+    sidebarServerSessionIdsAtomFamily,
+    type SessionSidebarRef,
+} from "@agenta/navigation"
+import {pinnedSessionIdsAtom} from "@agenta/sessions/state"
+import {atom, useAtomValue, useSetAtom} from "jotai"
+
+/**
+ * Mobile's binding for `@agenta/navigation`'s local-session seam — the desktop feeds it from its
+ * playground tab cache; mobile has no tab cache, so it feeds it from the sessions this client
+ * created and sent into (`localSessionsAtom`, written by the chat screen on a fresh session's
+ * first send).
+ *
+ * The server lists a session only once its first turn is admitted, which on a cold runner takes
+ * seconds. Until then this is the row's only way into the rail (#6776). `withLocalSessions` lets
+ * the server row win the moment it exists.
+ */
+export const localMobileSessionRefsAtom = atom<SessionSidebarRef[]>((get) => {
+    const pinned = get(pinnedSessionIdsAtom)
+    return Object.values(get(localSessionsAtom)).map((session) => {
+        const status = get(sessionStatusAtomFamily(session.sessionId))
+        return {
+            id: session.sessionId,
+            sessionId: session.sessionId,
+            name: session.name,
+            // Mobile rows link by session id alone; `appId` is the open target the server resolves.
+            appId: null,
+            agentId: session.agentId,
+            pinned: pinned.includes(session.sessionId),
+            alive: false,
+            activityAt: new Date(session.createdAt).toISOString(),
+            archived: false,
+            // A chat you typed into is never a trigger run.
+            isAutomation: false,
+            running: status === "running",
+            waiting: status === "awaiting",
+        }
+    })
+})
+
+/**
+ * Mirror the derived rows into the package's writable seam, and retire local copies the server
+ * has caught up with. Mounted with the rail: a rail that is not rendered has nothing to reconcile.
+ */
+export const useSyncLocalSessionRefs = (scopeId: string) => {
+    const refs = useAtomValue(localMobileSessionRefsAtom)
+    const setLocalRefs = useSetAtom(localSessionRefsAtom)
+    useEffect(() => {
+        setLocalRefs(refs)
+    }, [refs, setLocalRefs])
+
+    const serverIds = useAtomValue(sidebarServerSessionIdsAtomFamily(scopeId))
+    const forget = useSetAtom(forgetLocalSessionsAtom)
+    useEffect(() => {
+        const known = refs.filter((ref) => serverIds.has(ref.sessionId)).map((ref) => ref.sessionId)
+        if (known.length) forget(known)
+    }, [refs, serverIds, forget])
+}

--- a/web/mobile/src/features/nav/useMobileNavItems.tsx
+++ b/web/mobile/src/features/nav/useMobileNavItems.tsx
@@ -39,6 +39,8 @@ import {
 import {atom, useAtomValue, useSetAtom} from "jotai"
 import {unwrap} from "jotai/utils"
 
+import {useSyncLocalSessionRefs} from "./localSessionRefs"
+
 /** The drawer's scope id — its open-groups persistence bucket. */
 export const MOBILE_NAV_SCOPE_ID = "mobile-main"
 
@@ -110,6 +112,8 @@ const mobileSessionsEntity = defineSidebarEntity<SessionSidebarRef>(
  * forking a component.
  */
 export const useMobileNavItems = (projectURL: string): SidebarConfig[] => {
+    // Sessions this client created ride the shared local seam until the server lists them.
+    useSyncLocalSessionRefs(MOBILE_NAV_SCOPE_ID)
     const rawSource = useAtomValue(mobileSessionsEntity.activeSourceAtom)
     const loadMoreSessions = useSetAtom(loadMoreSidebarSessionsAtomFamily(MOBILE_NAV_SCOPE_ID))
     const groups = useAtomValue(sidebarSessionGroupsAtomFamily(MOBILE_NAV_SCOPE_ID))

--- a/web/mobile/tests/unit/localSessionRefs.test.ts
+++ b/web/mobile/tests/unit/localSessionRefs.test.ts
@@ -1,0 +1,48 @@
+/**
+ * Mobile's binding of the rail's local-session seam (#6776): a session this client sent into
+ * shows as a row — under its agent, spinning while it runs — until the server lists it.
+ */
+import {sessionStatusAtomFamily, setSessionStatusAtom} from "@agenta/chat/state"
+import {registerLocalSessionAtom} from "@agenta/entities/session"
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {localMobileSessionRefsAtom} from "@/features/nav/localSessionRefs"
+
+describe("localMobileSessionRefsAtom", () => {
+    it("lists nothing until a session is registered", () => {
+        expect(createStore().get(localMobileSessionRefsAtom)).toEqual([])
+    })
+
+    it("turns a registered session into a rail row that follows its run status", () => {
+        const store = createStore()
+        store.set(registerLocalSessionAtom, {
+            sessionId: "s1",
+            agentId: "agent-1",
+            name: "Write a file",
+            now: Date.UTC(2026, 8, 12, 10, 0, 0),
+        })
+        store.set(setSessionStatusAtom, {id: "s1", status: "running"})
+        expect(store.get(sessionStatusAtomFamily("s1"))).toBe("running")
+        expect(store.get(localMobileSessionRefsAtom)).toEqual([
+            {
+                id: "s1",
+                sessionId: "s1",
+                name: "Write a file",
+                appId: null,
+                agentId: "agent-1",
+                pinned: false,
+                alive: false,
+                activityAt: "2026-09-12T10:00:00.000Z",
+                archived: false,
+                isAutomation: false,
+                running: true,
+                waiting: false,
+            },
+        ])
+
+        store.set(setSessionStatusAtom, {id: "s1", status: "awaiting"})
+        const [row] = store.get(localMobileSessionRefsAtom)
+        expect(row).toMatchObject({running: false, waiting: true})
+    })
+})

--- a/web/packages/agenta-chat/src/assets/pendingSendEchoes.ts
+++ b/web/packages/agenta-chat/src/assets/pendingSendEchoes.ts
@@ -112,6 +112,18 @@ export const retirePendingSendEchoes = (
 }
 
 /** Disposable user rows; the id prefix keeps rewind from finding an echo in the AI SDK array. */
+/**
+ * Is a send still on its way to the runner, or streaming as an echo this client owns?
+ *
+ * Every echo that is not refused and not parked in the queue is a turn THIS client started and is
+ * still waiting on: from the moment it leaves the composer until its durable row retires it. That
+ * is the local "submitted" signal the AI SDK's `status` carries on the direct path, which the
+ * server-owned send path never sets — without it the working indicator waited for the next
+ * liveness poll to notice the run (#6778).
+ */
+export const pendingSendsInFlight = (pending: readonly PendingSendEcho[]): boolean =>
+    pending.some((echo) => !echo.failed && !echo.parkedInputId)
+
 export const pendingSendEchoMessages = (pending: readonly PendingSendEcho[]): UIMessage[] =>
     pending.map(
         (item) =>

--- a/web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentChatQueue.ts
@@ -584,6 +584,10 @@ export const useAgentChatQueue = ({
         queued: [...(server?.queued ?? []), ...queued],
         /** Sent-but-not-yet-saved user rows; merge with `mergePendingSendEchoRows`. */
         pendingSendRows: echoes.rows,
+        /** A send of this mount is on its way: admitted, not yet named by the runner or refused.
+         * The server-owned path never moves `useChat`'s `status` off "ready", so this is the only
+         * local evidence a turn was just submitted. */
+        sendInFlight: echoes.inFlight,
         submit,
         steer,
         removeQueued,

--- a/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
+++ b/web/packages/agenta-chat/src/hooks/useAgentConversation.ts
@@ -174,6 +174,12 @@ export interface AgentConversation {
     turns: TurnViewModel[]
     /** Send a user message (routes through the queue: sends now, or holds while busy/paused). */
     send: (input: SendInput) => Promise<void>
+    /**
+     * A send this mount admitted is still on its way: the runner has neither named its turn nor
+     * refused it. `status` stays "ready" on the server-owned send path, so a skin that wants to
+     * show work from the moment the message leaves the composer reads this alongside it.
+     */
+    sendInFlight: boolean
     /** Prevent an approval decision still being recorded from starting its delayed resume. */
     voidPendingResume: () => void
     /** Abort the in-flight stream and tag the last assistant turn as user-stopped. */
@@ -770,6 +776,7 @@ export const useAgentConversation = ({
         cancelEdit,
         commitEdit,
         pendingSendRows,
+        sendInFlight,
     } = useAgentChatQueue({
         status,
         messages,
@@ -961,10 +968,11 @@ export const useAgentConversation = ({
 
     // Publish this session's run state (single source of truth for session-list status dots).
     // Precedence error > awaiting approval > running > idle.
+    // `sendInFlight` too: the dot goes live when the message leaves, not when a poll notices.
     const runStatus = deriveSessionRunStatus({
         error: !!errorBoundary.runError,
         hitlPending,
-        busy: busy || acceptedRunPending || ownsContinuation,
+        busy: busy || acceptedRunPending || ownsContinuation || sendInFlight,
     })
     useEffect(() => {
         setSessionStatus({id: sessionId, status: runStatus})
@@ -1332,6 +1340,7 @@ export const useAgentConversation = ({
         connectionWarning: errorBoundary.connectionWarning,
         turns,
         send,
+        sendInFlight,
         voidPendingResume,
         stop: handleStop,
         regenerate: regenerateTurn,

--- a/web/packages/agenta-chat/src/hooks/usePendingSendEchoes.ts
+++ b/web/packages/agenta-chat/src/hooks/usePendingSendEchoes.ts
@@ -8,6 +8,7 @@ import {
     durableUserTurnIds,
     nextPendingSendCoverage,
     pendingSendEchoMessages,
+    pendingSendsInFlight,
     retirePendingSendEchoes,
     type PendingSendEcho,
 } from "../assets/pendingSendEchoes"
@@ -21,6 +22,8 @@ export interface PendingSendEchoInput {
 export interface PendingSendEchoes {
     /** Disposable user rows to render between the saved transcript and the live answer. */
     rows: UIMessage[]
+    /** A send left the composer and the runner has neither named its turn's row nor refused it. */
+    inFlight: boolean
     /** Show a send immediately, before its request leaves. */
     add: (input: PendingSendEchoInput) => void
     /** The server named the turn this send started; from here it retires on that id alone. */
@@ -152,6 +155,7 @@ export const usePendingSendEchoes = ({
     }, [])
 
     const rows = useMemo(() => pendingSendEchoMessages(visible), [visible])
+    const inFlight = useMemo(() => pendingSendsInFlight(visible), [visible])
 
-    return {rows, add, markAccepted, markParked, markFailed, drop}
+    return {rows, inFlight, add, markAccepted, markParked, markFailed, drop}
 }

--- a/web/packages/agenta-chat/tests/unit/pendingSendsInFlight.test.ts
+++ b/web/packages/agenta-chat/tests/unit/pendingSendsInFlight.test.ts
@@ -1,0 +1,33 @@
+/**
+ * The local "submitted" signal behind #6778. On the server-owned send path `useChat`'s status
+ * never leaves "ready", so an echo that is neither refused nor parked is the only evidence that
+ * a turn of ours is on its way — and the working indicator must read it.
+ */
+import {describe, expect, it} from "vitest"
+
+import {pendingSendsInFlight, type PendingSendEcho} from "../../src/assets/pendingSendEchoes"
+
+const echo = (patch: Partial<PendingSendEcho> = {}): PendingSendEcho => ({
+    id: "e1",
+    text: "hello",
+    coveredAtUserCount: 1,
+    createdAtUserCount: 0,
+    ...patch,
+})
+
+describe("pendingSendsInFlight", () => {
+    it("is false with nothing pending", () => {
+        expect(pendingSendsInFlight([])).toBe(false)
+    })
+
+    it("is true from the moment a send is admitted, and still after the runner named it", () => {
+        expect(pendingSendsInFlight([echo()])).toBe(true)
+        expect(pendingSendsInFlight([echo({executionId: "x1"})])).toBe(true)
+    })
+
+    it("ignores refused sends and sends parked in the queue", () => {
+        expect(pendingSendsInFlight([echo({failed: true})])).toBe(false)
+        expect(pendingSendsInFlight([echo({parkedInputId: "in1"})])).toBe(false)
+        expect(pendingSendsInFlight([echo({failed: true}), echo({id: "e2"})])).toBe(true)
+    })
+})

--- a/web/packages/agenta-entities/src/session/core/localSessions.ts
+++ b/web/packages/agenta-entities/src/session/core/localSessions.ts
@@ -1,0 +1,73 @@
+import {atom} from "jotai"
+
+/**
+ * A session this client created and the server cannot list yet.
+ *
+ * A session becomes real on the backend only once its first turn is admitted — a slow runner can
+ * take seconds — but the client minted its id and knows the agent and the first message from the
+ * moment that message left the composer. Session lists read this registry so a brand-new session
+ * appears the instant it is sent, not when the next list refetch happens to carry it (#6776).
+ *
+ * Sibling of `freshSessions`: that one is a synchronous predicate for "no durable records yet",
+ * read during render; this one is reactive, so a list can subscribe to it.
+ */
+export interface LocalSession {
+    sessionId: string
+    /** The owning agent's workflow id, where the creating surface knows it. */
+    agentId: string | null
+    /** The first message, until the server names the session itself. */
+    name: string | null
+    /** ms epoch, so the row can take its place in a date-ordered list. */
+    createdAt: number
+}
+
+export const localSessionsAtom = atom<Record<string, LocalSession>>({})
+
+/** Longest a first message can reasonably be a title. */
+const LOCAL_SESSION_NAME_MAX = 120
+
+export const localSessionNameFromText = (text: string | null | undefined): string | null => {
+    const line = (text ?? "").trim().split("\n")[0]?.trim() ?? ""
+    if (!line) return null
+    return line.length > LOCAL_SESSION_NAME_MAX ? `${line.slice(0, LOCAL_SESSION_NAME_MAX)}…` : line
+}
+
+/**
+ * Note a session this client just sent a message into. Idempotent: a repeat keeps the first
+ * message as the name and only fills in an agent it did not know before.
+ */
+export const registerLocalSessionAtom = atom(
+    null,
+    (
+        get,
+        set,
+        input: {sessionId: string; agentId?: string | null; name?: string | null; now?: number},
+    ) => {
+        const current = get(localSessionsAtom)
+        const existing = current[input.sessionId]
+        const name = existing?.name ?? localSessionNameFromText(input.name)
+        const agentId = existing?.agentId ?? input.agentId ?? null
+        if (existing && existing.name === name && existing.agentId === agentId) return
+        set(localSessionsAtom, {
+            ...current,
+            [input.sessionId]: {
+                sessionId: input.sessionId,
+                agentId,
+                name,
+                createdAt: existing?.createdAt ?? input.now ?? Date.now(),
+            },
+        })
+    },
+)
+
+/** The server lists these now (or they were deleted): the local copies have done their job. */
+export const forgetLocalSessionsAtom = atom(null, (get, set, ids: Iterable<string>) => {
+    const current = get(localSessionsAtom)
+    let next: Record<string, LocalSession> | null = null
+    for (const id of ids) {
+        if (!(id in current)) continue
+        next ??= {...current}
+        delete next[id]
+    }
+    if (next) set(localSessionsAtom, next)
+})

--- a/web/packages/agenta-entities/src/session/index.ts
+++ b/web/packages/agenta-entities/src/session/index.ts
@@ -206,3 +206,10 @@ export {
     isSessionFresh,
     markSessionFresh,
 } from "./core/freshSessions"
+export {
+    forgetLocalSessionsAtom,
+    localSessionNameFromText,
+    localSessionsAtom,
+    registerLocalSessionAtom,
+    type LocalSession,
+} from "./core/localSessions"

--- a/web/packages/agenta-entities/tests/unit/session-local-sessions.test.ts
+++ b/web/packages/agenta-entities/tests/unit/session-local-sessions.test.ts
@@ -1,0 +1,68 @@
+/**
+ * The client-created session registry behind #6776: a session the server cannot list yet is
+ * noted at its first send, keeps its first message as its name, and retires once the server
+ * carries it.
+ */
+import {createStore} from "jotai"
+import {describe, expect, it} from "vitest"
+
+import {
+    forgetLocalSessionsAtom,
+    localSessionNameFromText,
+    localSessionsAtom,
+    registerLocalSessionAtom,
+} from "../../src/session"
+
+describe("localSessions", () => {
+    it("registers a session with its first message as the name", () => {
+        const store = createStore()
+        store.set(registerLocalSessionAtom, {
+            sessionId: "s1",
+            agentId: "a1",
+            name: "  Write a file named qa.html \n second line",
+            now: 1_000,
+        })
+        expect(store.get(localSessionsAtom)).toEqual({
+            s1: {
+                sessionId: "s1",
+                agentId: "a1",
+                name: "Write a file named qa.html",
+                createdAt: 1_000,
+            },
+        })
+    })
+
+    it("keeps the first name and creation time on a repeat, only filling a missing agent", () => {
+        const store = createStore()
+        store.set(registerLocalSessionAtom, {sessionId: "s1", name: "first", now: 1_000})
+        const before = store.get(localSessionsAtom)
+        store.set(registerLocalSessionAtom, {sessionId: "s1", name: "second", now: 2_000})
+        // Nothing changed, so the same object comes back — no spurious list re-render.
+        expect(store.get(localSessionsAtom)).toBe(before)
+        store.set(registerLocalSessionAtom, {sessionId: "s1", agentId: "a1", name: "third"})
+        expect(store.get(localSessionsAtom).s1).toEqual({
+            sessionId: "s1",
+            agentId: "a1",
+            name: "first",
+            createdAt: 1_000,
+        })
+    })
+
+    it("forgets only the ids it holds and leaves the map untouched otherwise", () => {
+        const store = createStore()
+        store.set(registerLocalSessionAtom, {sessionId: "s1", name: "one", now: 1})
+        store.set(registerLocalSessionAtom, {sessionId: "s2", name: "two", now: 2})
+        const before = store.get(localSessionsAtom)
+        store.set(forgetLocalSessionsAtom, ["missing"])
+        expect(store.get(localSessionsAtom)).toBe(before)
+        store.set(forgetLocalSessionsAtom, ["s1", "missing"])
+        expect(Object.keys(store.get(localSessionsAtom))).toEqual(["s2"])
+    })
+
+    it("derives a title from the first line, bounded, or none from blank text", () => {
+        expect(localSessionNameFromText("  hi \n there")).toBe("hi")
+        expect(localSessionNameFromText("   \n  ")).toBeNull()
+        expect(localSessionNameFromText(undefined)).toBeNull()
+        expect(localSessionNameFromText("x".repeat(200))).toBe(`${"x".repeat(120)}…`)
+    })
+})

--- a/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
+++ b/web/packages/agenta-navigation/src/dynamic/sessionsSource.ts
@@ -725,6 +725,24 @@ const uniqueBySession = (refs: readonly SessionSidebarRef[]): SessionSidebarRef[
 }
 
 /**
+ * The ids the SERVER lists for this scope, pins and pages included. A host reconciles its local
+ * rows against it: a session the server carries no longer needs the local seam, and a local row
+ * that outlived its server twin would resurface the session whenever it aged out of the window.
+ */
+export const sidebarServerSessionIdsAtomFamily = atomFamily((scopeId: string) =>
+    atom<ReadonlySet<string>>((get) => {
+        const ids = new Set<string>()
+        for (const row of get(sidebarPinnedSessionsQueryAtomFamily(scopeId)).data ?? [])
+            ids.add(row.session_id)
+        for (const row of get(sidebarSessionsQueryAtomFamily(scopeId)).data ?? [])
+            ids.add(row.session_id)
+        for (const row of get(sidebarSessionsOlderQueryAtomFamily(scopeId)).data?.rows ?? [])
+            ids.add(row.session_id)
+        return ids
+    }),
+)
+
+/**
  * Pinned sessions first, then the rest by activity.
  *
  * Pins are pulled to the top rather than left in place because a pinned conversation is one you

--- a/web/packages/agenta-navigation/src/index.ts
+++ b/web/packages/agenta-navigation/src/index.ts
@@ -22,6 +22,7 @@ export {
     sidebarSessionSearchOpenAtom,
     sidebarSessionSearchQueryAtom,
     sidebarSessionSearchResultsAtom,
+    sidebarServerSessionIdsAtomFamily,
     withLocalSessions,
     type SessionSidebarRef,
 } from "./dynamic/sessionsSource"


### PR DESCRIPTION
Fixes #6778
Fixes #6776

Linear: AGE-4334, AGE-4332.

## Context
Two delays Mahmoud reported together, and they do share a cause. Both reproduce on `/m`; the desktop playground was checked too and does not show the dots delay, so it is untouched.

When you send a chat message in `/m`, the message shows at once but the working dots arrive later, and when the message is the first one of a new session, the session shows up in the sidebar later still. Measured on the local EE stack with a scripted send (times from Enter):

| | message shown | working dots | session in sidebar |
|---|---|---|---|
| warm runner | ~100 ms | 356 ms | 563 ms |
| cold runner | ~130 ms | 2,591 ms | 2,882 ms |

The send does not go through the AI SDK's `sendMessage`. The queue hands it to `useServerSessionInputs`, which does its own `fetch` to the invoke URL and shows the message as a local "echo" row. So `useChat`'s `status` stays `ready` for the whole turn, and the only "a run is happening" signal the screen had was the session liveness poll. That poll can only see the run once the runner has admitted it, and it runs on its own cadence. The sidebar has the same dependency: the server lists a new session only once its first turn is admitted (absent at 86 ms, present at 269 ms warm, seconds on a cold runner), and the list refetches after that.

## Changes
Both surfaces now read what the client already knows at submit time.

**Working dots (#6778).** The echo state machine in `usePendingSendEchoes` already tracks each send from "left the composer" through "runner named the turn" to "row persisted". It now exposes `inFlight` (an echo that is neither refused nor parked), `useAgentChatQueue` returns it as `sendInFlight`, and `useAgentConversation` folds it into the published run status and returns it. The `/m` conversation treats it as activity, next to the SDK status and the liveness-derived remote turn. The session's status dot goes live at the same moment.

**Sidebar (#6776).** `@agenta/entities/session` gains a small reactive registry of sessions this client created and sent into (`localSessionsAtom`, with the agent and the first message as the name). The `/m` conversation registers the session on the first send of a fresh session. The navigation package already had a host seam for exactly this (`localSessionRefsAtom`, fed on the desktop from its playground tab cache); `/m` never fed it. A mobile binding now derives rows from the registry, mirrors them into the seam, and retires a local row once the server lists that id, using a new `sidebarServerSessionIdsAtomFamily` export. The existing merge lets the server row win the moment it exists, so the row the agent later renames is the same row.

## Tests
- Unit: the in-flight predicate (`pendingSendsInFlight`), the registry atoms (register, idempotent rename, forget), and the mobile row derivation following the session's run status. All pass; `eslint`, `prettier --check`, and `tsc --noEmit` pass in entities, chat, navigation, and mobile.
- Browser, `/m`, same scripted send after the change: working dots at 73 ms in an existing session; in a new session the sidebar row appears at 86 ms and the dots at 102 ms, both before the invoke request has even returned. After the run settles there is exactly one row for the session, carrying the server's name.
- Desktop: timed the same send in the agent playground with the new signal switched off and on; the dots appear as the request leaves either way (185 ms and 209 ms), so the desktop gate is left as is. `sendInFlight` is available from `useAgentChatQueue` if a desktop surface ever needs it.

## What to QA
- `/m`: open an existing session, send a message. The three dots appear under your message in the same instant it does, and stay until the reply starts.
- `/m`: press + for a new session, send a first message. Your message text is the top row in the sidebar's Sessions list immediately, with the running spinner. When the agent renames the session, the row's label updates in place and there is only one row for it.
- `/m`: send from Home's composer instead of a session page. Same two checks.
- Regression: queue a second message while a run is going (it parks). No extra dots for the parked one, and the session row does not duplicate.



## Review follow-up (second commit)
Addresses Mahmoud's two findings and the `sendInFlight` one.

- **Failed first send left its row.** The local session record now has a lifecycle: `submitting` from the send, `accepted` once the chat queue reports admission (a turn id, or a parked input), dropped on any failure while still `submitting`, and retired by the server list as before. The queue gained `onSendAccepted` and `onSendFailed`, fired on the rejected promise and on the late refusal alike; `useAgentConversation` passes them through and `/m` wires them to the registry. An accepted session keeps its row through a later failure, since that failure belongs to a later message.
- **Rows leaked across projects.** `LocalSession` now carries `projectId`, and the mobile selector filters by the active project (`projectIdAtom`, the value `ContextSync` owns).
- **`busyRef` missed `sendInFlight`.** The write moved after the queue hook and includes it, so a navigation in the window between the message leaving and the turn being accepted no longer releases and stops the chat.

Tests: registry lifecycle (drop while submitting, keep once accepted, ignore unknown ids), project-switch filtering, and queue callbacks for a rejected send and a late refusal. Entities 7, mobile 3, chat 102 pass; tsc clean in entities, chat, and mobile.

Extra QA:
- `/m`, new session, send with the runner unreachable (or a model key missing so the send is refused). The message comes back as not sent, and no row for that session stays in the sidebar.
- `/m`, send a first message in project A, switch to project B before the reply. B's sidebar does not show A's pending row; switching back shows it.
