### PR TITLE
fix(runner): patch Jaeger header crash

### DIFF
--- a/services/runner/package.json
+++ b/services/runner/package.json
@@ -68,6 +68,7 @@
     },
     "overrides": {
       "@hono/node-server": "1.19.15",
+      "@opentelemetry/propagator-jaeger": "2.9.0",
       "brace-expansion": "5.0.9",
       "fast-uri": "3.1.6",
       "hono": "4.12.34",

--- a/services/runner/pnpm-lock.yaml
+++ b/services/runner/pnpm-lock.yaml
@@ -6,6 +6,7 @@ settings:
 
 overrides:
   '@hono/node-server': 1.19.15
+  '@opentelemetry/propagator-jaeger': 2.9.0
   brace-expansion: 5.0.9
   fast-uri: 3.1.6
   hono: 4.12.34
@@ -1037,8 +1038,8 @@ packages:
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
 
-  '@opentelemetry/propagator-jaeger@2.8.0':
-    resolution: {integrity: sha512-Xnz9zZvvQzUw+9DrOn0MomR7BxFCkA2pcfXBQuHC28ndJpSbjLs7knzYb05kw5SyCjSsEWombkZMgGcJSk8JVg==}
+  '@opentelemetry/propagator-jaeger@2.9.0':
+    resolution: {integrity: sha512-4mYGty27rYvSM0jtp1ZUOqd3LfVRCYg9H5G9OFzSx5HViYToU21MFhWfco7x1HwXr7ER8yGOiCIHZUwjPksc0Q==}
     engines: {node: ^18.19.0 || >=20.6.0}
     peerDependencies:
       '@opentelemetry/api': '>=1.0.0 <1.10.0'
@@ -3763,10 +3764,10 @@ snapshots:
       '@opentelemetry/api': 1.9.1
       '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
 
-  '@opentelemetry/propagator-jaeger@2.8.0(@opentelemetry/api@1.9.1)':
+  '@opentelemetry/propagator-jaeger@2.9.0(@opentelemetry/api@1.9.1)':
     dependencies:
       '@opentelemetry/api': 1.9.1
-      '@opentelemetry/core': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/core': 2.9.0(@opentelemetry/api@1.9.1)
 
   '@opentelemetry/resources@2.0.1(@opentelemetry/api@1.9.1)':
     dependencies:
@@ -3836,7 +3837,7 @@ snapshots:
       '@opentelemetry/otlp-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/otlp-grpc-exporter-base': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/propagator-b3': 2.8.0(@opentelemetry/api@1.9.1)
-      '@opentelemetry/propagator-jaeger': 2.8.0(@opentelemetry/api@1.9.1)
+      '@opentelemetry/propagator-jaeger': 2.9.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/resources': 2.8.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-logs': 0.219.0(@opentelemetry/api@1.9.1)
       '@opentelemetry/sdk-metrics': 2.8.0(@opentelemetry/api@1.9.1)


### PR DESCRIPTION
## Problem

Dependabot #978 / GHSA-45rx-2jwx-cxfr reports a high-severity crash in `@opentelemetry/propagator-jaeger` when it extracts a crafted `uber-trace-id` header. The runner receives version 2.8.0 through Daytona's OpenTelemetry SDK.

## Change

Pin the transitive Jaeger propagator to patched version 2.9.0 in the runner override set and regenerate its lockfile.

## Validation

- Frozen runner install passed.
- The lockfile resolves only `@opentelemetry/propagator-jaeger` 2.9.0.
- Runner extension build passed.
- All 3,121 runner unit tests passed.
- Runner TypeScript check passed.
- `pnpm audit` no longer reports the Jaeger advisory.

Base: `release/v0.118.1`
