### PR TITLE
fix(sdk): strip /api only from the URL path when deriving the host

### DIFF
--- a/sdks/python/agenta/sdk/engines/tracing/tracing.py
+++ b/sdks/python/agenta/sdk/engines/tracing/tracing.py
@@ -17,6 +17,7 @@ from opentelemetry.sdk.trace import Span, SpanLimits, Tracer, TracerProvider
 from opentelemetry.sdk.resources import Resource
 
 
+from agenta.sdk.utils.helpers import strip_trailing_api_segment
 from agenta.sdk.utils.singleton import Singleton
 from agenta.sdk.utils.exceptions import suppress
 from agenta.sdk.utils.logging import get_module_logger
@@ -384,7 +385,7 @@ class Tracing(metaclass=Singleton):
             )
 
         api_url = ag.DEFAULT_AGENTA_SINGLETON_INSTANCE.api_url
-        web_url = api_url.replace("/api", "") if api_url else None
+        web_url = strip_trailing_api_segment(api_url) if api_url else None
 
         (organization_id, workspace_id, project_id) = (
             ag.DEFAULT_AGENTA_SINGLETON_INSTANCE.resolve_scopes()

--- a/sdks/python/agenta/sdk/utils/helpers.py
+++ b/sdks/python/agenta/sdk/utils/helpers.py
@@ -2,6 +2,7 @@ import os
 import importlib.metadata
 import re
 from typing import Dict, Tuple
+from urllib.parse import urlsplit, urlunsplit
 
 
 def get_current_version():
@@ -45,6 +46,24 @@ def parse_url(url: str) -> str:
         return url
 
     return url
+
+
+def strip_trailing_api_segment(url: str) -> str:
+    """Return the origin of an API base URL.
+
+    Only a trailing ``/api`` *path* segment is removed. Scheme, host, and port
+    stay intact, so a host literally named ``api`` (``http://api:8000``) is not
+    cut inside the authority the way ``str.rsplit("/api")`` / ``str.replace``
+    would.
+    """
+
+    parsed = urlsplit(url)
+    path = parsed.path.rstrip("/")
+    if path.endswith("/api"):
+        path = path[: -len("/api")]
+    return urlunsplit(
+        (parsed.scheme, parsed.netloc, path, parsed.query, parsed.fragment)
+    ).rstrip("/")
 
 
 _PLACEHOLDER_RE = re.compile(r"\{\{\s*(.*?)\s*\}\}")

--- a/sdks/python/agenta/sdk/utils/init.py
+++ b/sdks/python/agenta/sdk/utils/init.py
@@ -6,7 +6,7 @@ import httpx
 from agenta.client import AgentaApi, AsyncAgentaApi
 from agenta.sdk.engines.tracing import Tracing
 from agenta.sdk.utils.globals import set_global
-from agenta.sdk.utils.helpers import parse_url
+from agenta.sdk.utils.helpers import parse_url, strip_trailing_api_segment
 from agenta.sdk.utils.logging import get_module_logger
 
 log = get_module_logger(__name__)
@@ -96,7 +96,7 @@ class AgentaSingleton:
 
         if _api_url:
             _api_url = parse_url(url=_api_url)
-            _host = _api_url.rsplit("/api", 1)[0]
+            _host = strip_trailing_api_segment(_api_url)
         elif _host:
             _host = parse_url(url=_host)
             _api_url = _host + "/api"

--- a/sdks/python/oss/tests/pytest/unit/test_init_api_origin.py
+++ b/sdks/python/oss/tests/pytest/unit/test_init_api_origin.py
@@ -1,0 +1,109 @@
+"""Regression: host/origin derivation must not match '/api' inside the URL authority.
+
+``AgentaSingleton.init`` used to do ``api_url.rsplit("/api", 1)[0]``. That is not
+anchored to a path segment, so a host literally named ``api`` is cut inside the
+scheme:
+
+    http://api:8000  →  http:/   →  traces at http://api/otlp/v1/traces
+
+The runner then rejects the endpoint (port mismatch) and every turn fails.
+See https://github.com/Agenta-AI/agenta/issues/6787.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from agenta.sdk.engines.tracing.tracing import Tracing
+from agenta.sdk.utils.helpers import strip_trailing_api_segment
+from agenta.sdk.utils.init import AgentaSingleton
+
+
+def _reset_singleton() -> None:
+    AgentaSingleton._instance = None
+    AgentaSingleton._initialized = False
+
+
+@pytest.fixture
+def fresh_singleton(monkeypatch):
+    _reset_singleton()
+    for name in (
+        "AGENTA_API_INTERNAL_URL",
+        "AGENTA_API_URL",
+        "AGENTA_HOST",
+        "AGENTA_API_KEY",
+        "DOCKER_NETWORK_MODE",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    yield
+    _reset_singleton()
+
+
+def _init(api_url: str):
+    with (
+        patch("agenta.sdk.utils.init.Tracing") as tracing_cls,
+        patch("agenta.sdk.utils.init.AgentaApi"),
+        patch("agenta.sdk.utils.init.AsyncAgentaApi"),
+        patch("agenta.sdk.utils.init.version", return_value="0"),
+    ):
+        singleton = AgentaSingleton()
+        singleton.tracing = None
+        singleton.api = None
+        singleton.async_api = None
+        singleton.init(api_url=api_url)
+        return singleton, tracing_cls
+
+
+@pytest.mark.parametrize(
+    ("api_url", "origin"),
+    [
+        ("http://api:8000", "http://api:8000"),
+        ("http://agenta-api:8000", "http://agenta-api:8000"),
+        ("http://api:8000/api", "http://api:8000"),
+        ("http://agenta-api:8000/api", "http://agenta-api:8000"),
+        ("https://cloud.agenta.ai/api", "https://cloud.agenta.ai"),
+        ("https://cloud.agenta.ai/api/", "https://cloud.agenta.ai"),
+    ],
+)
+def test_strip_trailing_api_segment_only_touches_path(api_url, origin):
+    assert strip_trailing_api_segment(api_url) == origin
+
+
+def test_strip_trailing_api_segment_leaves_non_trailing_api_path():
+    assert (
+        strip_trailing_api_segment("https://example.com/api/v1")
+        == "https://example.com/api/v1"
+    )
+
+
+@pytest.mark.parametrize(
+    ("api_url", "origin"),
+    [
+        ("http://api:8000", "http://api:8000"),
+        ("http://agenta-api:8000", "http://agenta-api:8000"),
+        ("http://api:8000/api", "http://api:8000"),
+        ("https://cloud.agenta.ai/api", "https://cloud.agenta.ai"),
+    ],
+)
+def test_init_derives_origin_and_otlp_endpoint_from_path_only(
+    fresh_singleton, api_url, origin
+):
+    singleton, tracing_cls = _init(api_url)
+
+    assert singleton.host == origin
+    assert singleton.api_url == api_url.rstrip("/")
+    tracing_cls.assert_called_once()
+    assert tracing_cls.call_args.kwargs["url"] == f"{origin}/api/otlp/v1/traces"
+
+
+def test_get_trace_url_does_not_cut_host_named_api():
+    tracing = Tracing.__new__(Tracing)
+    singleton = MagicMock()
+    singleton.api_url = "http://api:8000/api"
+    singleton.resolve_scopes.return_value = ("org", "ws", "proj")
+
+    with patch("agenta.sdk.engines.tracing.tracing.ag") as ag:
+        ag.DEFAULT_AGENTA_SINGLETON_INSTANCE = singleton
+        url = tracing.get_trace_url(trace_id="abc")
+
+    assert url == "http://api:8000/w/ws/p/proj/observability?trace=abc"


### PR DESCRIPTION
## Summary
- `AgentaSingleton.init` derived the host with `_api_url.rsplit("/api", 1)[0]`. That match is not a path segment, so a host literally named `api` is cut inside the authority: `http://api:8000` became `http:/`, and the OTLP endpoint became `http://api/otlp/v1/traces` (port lost). The runner then rejected the endpoint.
- The same unanchored `/api` match lived in `Tracing.get_trace_url` (`api_url.replace("/api", "")`), which turned `http://api:8000/api` into `http:/:8000`.
- Both call sites now share `strip_trailing_api_segment`, which uses `urlsplit` and only removes a trailing `/api` path segment.

Fixes #6787

## Test plan
- [x] Red: `uv run pytest oss/tests/pytest/unit/test_init_api_origin.py` failed on `http://api:8000` → host `http:/` before the fix
- [x] Green: the same file, 12 tests, after the fix
- [x] `ruff==0.15.12 check` and `ruff format --check` on the four changed files
- [ ] Optional: self-host with `AGENTA_API_INTERNAL_URL=http://api:8000` (no `/api` suffix) and confirm a turn's traces reach the platform

Made with [Cursor](https://cursor.com)