### PR TITLE
[6548] fix(frontend): Keep the working pulse visible for the whole run on /m

### DIFF
--- a/web/mobile/src/features/chat/LiveConversation.tsx
+++ b/web/mobile/src/features/chat/LiveConversation.tsx
@@ -63,7 +63,11 @@ import {selectedRevisionAtomFamily} from "./selectedRevision"
 import {ChatLoading} from "./states/ChatStates"
 import {cancelledStopAction} from "./stopHereState"
 import {TurnRow} from "./TurnRow"
-import {deriveMobileRemoteTurnPresentation, showTrailingWorkingPulse} from "./turnStatus"
+import {
+    deriveMobileRemoteTurnPresentation,
+    showTrailingWorkingPulse,
+    showTurnWorkingPulse,
+} from "./turnStatus"
 import {TurnStatusLine} from "./TurnStatusLine"
 import {useApprovalActions, type ApprovalActions} from "./useApprovalActions"
 import {useSessionWatch} from "./useSessionWatch"
@@ -625,6 +629,9 @@ export const LiveConversation = ({
                         workflowId={agentId}
                         key={turn.message.id}
                         turn={turn}
+                        working={showTurnWorkingPulse(turn, {
+                            waitingForInput: conversation.hitlPending,
+                        })}
                         onClientToolOutput={conversation.sendToolOutput}
                         onRewind={handleRewind}
                         sessionId={sessionId}

--- a/web/mobile/src/features/chat/TurnRow.tsx
+++ b/web/mobile/src/features/chat/TurnRow.tsx
@@ -39,6 +39,7 @@ import {AssistantMarkdown} from "./AssistantMarkdown"
 import {continuationRetryAction} from "./continuationRetry"
 import {isLiveReasoningPart, isLiveTextItem} from "./markdownStream"
 import {ToolLine} from "./ToolLine"
+import {TurnStatusLine} from "./TurnStatusLine"
 
 type ToolsItem = Extract<TurnViewModel["items"][number], {kind: "tools"}>
 
@@ -188,12 +189,18 @@ const downloadAttachment = (url: string, name: string) => {
  */
 const TurnRowInner = ({
     turn,
+    working = false,
     onClientToolOutput,
     onRewind,
     sessionId,
     workflowId,
 }: {
     turn: TurnViewModel
+    /** The run is still working on this turn: keep the pulse under its content, so reasoning,
+     * tool runs and the pauses between paragraphs never read as a finished reply (#6548). Only
+     * the turn being generated gets it, and only once it has content — before that the loading
+     * bubble is the indicator. See `showTurnWorkingPulse`. */
+    working?: boolean
     /** Settles a browser-fulfilled tool (elicitation, connect) back into the run. Optional because
      * the read-only transcript screen has no engine to settle into — and it passes no client-tool
      * predicate either, so it never produces one of these items to begin with. */
@@ -296,6 +303,10 @@ const TurnRowInner = ({
                     )}
                 />
             ) : null}
+            {/* Under the content, in the content's own column: the desktop's meta line. The
+                trailing line after the list covers the gap before this turn exists, and the
+                loading bubble covers it while it is empty, so exactly one pulse shows at a time. */}
+            {working ? <TurnStatusLine working waitingForInput={false} className="h-5" /> : null}
         </div>
     )
 

--- a/web/mobile/src/features/chat/TurnStatusLine.tsx
+++ b/web/mobile/src/features/chat/TurnStatusLine.tsx
@@ -11,9 +11,13 @@ import {Hourglass} from "lucide-react"
 export const TurnStatusLine = ({
     working,
     waitingForInput,
+    className,
 }: {
     working: boolean
     waitingForInput: boolean
+    /** Sizes the pulse for where it sits: the trailing line keeps the bubble height, a line under
+     * a turn's own content sits tighter. */
+    className?: string
 }) => {
     if (waitingForInput) {
         return (
@@ -30,7 +34,7 @@ export const TurnStatusLine = ({
     if (working) {
         return (
             <span role="status" aria-label="Agent is working" className="px-1 py-0.5">
-                <ChatTypingDots />
+                <ChatTypingDots className={className} />
             </span>
         )
     }

--- a/web/mobile/src/features/chat/turnStatus.ts
+++ b/web/mobile/src/features/chat/turnStatus.ts
@@ -16,6 +16,20 @@ export const showTrailingWorkingPulse = (
     turns: {isUser: boolean; isStreamingTurn: boolean}[],
 ): boolean => streaming && !turns.some((turn) => !turn.isUser && turn.isStreamingTurn)
 
+/**
+ * Should this turn carry the working pulse under its content?
+ *
+ * The turn being generated shows its own loading bubble until it has content, and nothing after
+ * that — so reasoning, tool runs and the pauses between paragraphs read as an idle agent for most
+ * of a run (#6548). The desktop keeps a working line under the streaming turn for the WHOLE busy
+ * period; this is that rule. A parked run (a pending approval) hands the line to the hourglass
+ * instead, which the trailing status line renders.
+ */
+export const showTurnWorkingPulse = (
+    turn: {isUser: boolean; isStreamingTurn: boolean; status: {hasContent: boolean}},
+    {waitingForInput}: {waitingForInput: boolean},
+): boolean => !turn.isUser && turn.isStreamingTurn && turn.status.hasContent && !waitingForInput
+
 export const showRunningElsewhere = ({
     running,
     localStatus,

--- a/web/mobile/tests/unit/turnStatus.test.ts
+++ b/web/mobile/tests/unit/turnStatus.test.ts
@@ -5,6 +5,7 @@ import {
     deriveMobileRemoteTurnPresentation,
     showRunningElsewhere,
     showTrailingWorkingPulse,
+    showTurnWorkingPulse,
 } from "@/features/chat/turnStatus"
 
 const userTurn = {isUser: true, isStreamingTurn: false}
@@ -28,6 +29,38 @@ describe("showTrailingWorkingPulse", () => {
     it("shows nothing when the run is not active", () => {
         expect(showTrailingWorkingPulse(false, [userTurn, settledAssistant])).toBe(false)
         expect(showTrailingWorkingPulse(false, [])).toBe(false)
+    })
+})
+
+describe("showTurnWorkingPulse", () => {
+    const withContent = (
+        turn: {isUser: boolean; isStreamingTurn: boolean},
+        hasContent: boolean,
+    ) => ({
+        ...turn,
+        status: {hasContent},
+    })
+    const live = {waitingForInput: false}
+
+    // The regression (#6548): the pulse vanished the moment the reply had any content, so the
+    // rest of the run — reasoning, tool calls, pauses between paragraphs — read as idle.
+    it("keeps the pulse on the streaming turn once it has content", () => {
+        expect(showTurnWorkingPulse(withContent(streamingAssistant, true), live)).toBe(true)
+    })
+
+    it("leaves an empty streaming turn to its loading bubble", () => {
+        expect(showTurnWorkingPulse(withContent(streamingAssistant, false), live)).toBe(false)
+    })
+
+    it("never marks a user turn or a settled turn", () => {
+        expect(showTurnWorkingPulse(withContent(userTurn, true), live)).toBe(false)
+        expect(showTurnWorkingPulse(withContent(settledAssistant, true), live)).toBe(false)
+    })
+
+    it("yields to the hourglass while the run is parked on the user", () => {
+        expect(
+            showTurnWorkingPulse(withContent(streamingAssistant, true), {waitingForInput: true}),
+        ).toBe(false)
     })
 })
 


### PR DESCRIPTION
Fixes #6548

## Context
In `/m`, the three-dot working pulse shows only while the assistant turn is still empty. The loading bubble is gated on "no content yet" and the trailing status line on "no streaming assistant turn", so the first thought or the first token retires both, and nothing shows the run is still working for the rest of it. Reasoning, tool runs and the pauses between paragraphs read as an idle agent. The desktop keeps a working line under the streaming turn for the whole busy period.

Sampled every 300 ms on the local EE stack while a five-paragraph reply streamed: the pulse was visible in 0 of 25 samples where the reply text grew.

## Changes
`showTurnWorkingPulse` in the mobile turn-status module is the desktop's rule for `/m`: the turn being generated, once it has content, unless the run is parked on the user. The conversation passes it per turn and the turn row renders the existing `TurnStatusLine` under its content when it is set, in the content's own column. The loading bubble still owns the empty turn and the trailing line still owns the gap before the assistant turn exists, so exactly one pulse shows at a time, and the hourglass wins while an approval is pending. `TurnStatusLine` takes a `className` so the in-turn pulse sits tighter than the trailing one.

## Tests
- Unit tests for `showTurnWorkingPulse`: streaming turn with content shows it, empty streaming turn defers to the bubble, user and settled turns never show it, a parked run yields to the hourglass. `eslint`, `prettier --check`, and `tsc --noEmit` pass in `mobile`.
- Browser, `/m`, same sampler after the change: pulse visible in 24 of 24 samples while the reply streamed, and gone once the run settled.

## What to QA
- `/m`: ask an agent for a long reply that thinks first. The pulse appears under the reply as soon as text starts, stays through the whole answer including pauses, and disappears when the run ends.
- `/m`: trigger an approval gate mid-run. The hourglass "Waiting for your input" shows and no dots do; after approving, the pulse is back under the continuing turn.
- Regression: the moment after sending, before any reply text, there is still exactly one pulse (the loading bubble), never two.
